### PR TITLE
Make some dialect updates

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -29,6 +29,7 @@
 include "mlir/IR/OpBase.td"
 include "air/Dialect/AIR/AIROpBase.td"
 
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -41,24 +42,24 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
                                      IsolatedFromAbove,
                                      AffineScope,
                                      SingleBlockImplicitTerminator<"LaunchTerminatorOp">]>,
-                        Arguments<(ins OptionalAttr<SymbolRefAttr>:$symbol,
-                                       Variadic<air_AsyncToken>:$asyncDependencies,
-                                       Variadic<Index>:$sizes,
-                                       Variadic<AnyType>:$operands)>,
-                        Results<(outs Optional<air_AsyncToken>:$asyncToken)> {
+                          Arguments<(ins OptionalAttr<SymbolRefAttr>:$symbol,
+                                         Variadic<air_AsyncToken>:$async_dependencies,
+                                         Variadic<Index>:$sizes,
+                                         Variadic<AnyType>:$operands)>,
+                          Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Launch";
   let description = [{
     Launch
   }];
 
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernelOperands)>,
-    OpBuilder<(ins "ValueRange":$asyncDependencies,
-      "ValueRange":$sizes,"ValueRange":$kernelOperands, 
-      CArg<"bool", "false">:$isAsync)>
+    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernel_operands)>,
+    OpBuilder<(ins "ValueRange":$async_dependencies,
+      "ValueRange":$sizes,"ValueRange":$kernel_operands, 
+      CArg<"bool", "false">:$is_async)>
   ];
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
@@ -81,41 +82,42 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
 }
 
 def air_LaunchTerminatorOp : air_Op<"launch_terminator", [HasParent<"LaunchOp">,
-                                                      NoSideEffect, Terminator]>,
-    Arguments<(ins)>, Results<(outs)> {
-  let summary = "Terminator for air launch regions.";
+                                                          NoSideEffect,
+                                                          Terminator]>,
+                                    Arguments<(ins)>, Results<(outs)> {
+  let summary = "Terminator for `air.launch`.";
   let description = [{
-    A terminator operation for regions that appear in the body of
-    `air.launch` operation.  These regions are not expected to return any
-    value so the terminator takes no operands.
+    A terminator operation for the body of `air.launch` operations.
+    `air.launch` operations are not expected to return any value so the
+    terminator takes no operands.
   }];
   let assemblyFormat = "attr-dict";
 }
 
 def air_PartitionOp : air_Op<"partition", [air_AsyncOpInterface,
-                                     air_HierarchyInterface,
-                                     AttrSizedOperandSegments,
-                                     IsolatedFromAbove,
-                                     AffineScope,
-                                     SingleBlockImplicitTerminator<"PartitionTerminatorOp">]>,
+                                           air_HierarchyInterface,
+                                           AttrSizedOperandSegments,
+                                           IsolatedFromAbove,
+                                           AffineScope,
+                                           SingleBlockImplicitTerminator<"PartitionTerminatorOp">]>,
                         Arguments<(ins OptionalAttr<SymbolRefAttr>:$symbol,
-                                       Variadic<air_AsyncToken>:$asyncDependencies,
+                                       Variadic<air_AsyncToken>:$async_dependencies,
                                        Variadic<Index>:$sizes,
                                        Variadic<AnyType>:$operands)>,
-                        Results<(outs Optional<air_AsyncToken>:$asyncToken)> {
+                        Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Partition";
   let description = [{
     Partition
   }];
 
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernelOperands)>,
-    OpBuilder<(ins "ValueRange":$asyncDependencies,
-      "ValueRange":$sizes,"ValueRange":$kernelOperands, 
-      CArg<"bool", "false">:$isAsync)>
+    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernel_operands)>,
+    OpBuilder<(ins "ValueRange":$async_dependencies,
+      "ValueRange":$sizes,"ValueRange":$kernel_operands, 
+      CArg<"bool", "false">:$is_async)>
   ];
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
@@ -142,38 +144,38 @@ def air_PartitionTerminatorOp : air_Op<"partition_terminator", [HasParent<"Parti
     Arguments<(ins)>, Results<(outs)> {
   let summary = "Terminator for air partition regions.";
   let description = [{
-    A terminator operation for regions that appear in the body of
-    `air.partition` operation.  These regions are not expected to return any
-    value so the terminator takes no operands.
+    A terminator operation for the body of `air.partition` operations.
+    `air.partition` operations are not expected to return any value so the
+    terminator takes no operands.
   }];
   let assemblyFormat = "attr-dict";
 }
 
 def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
-                                              air_HierarchyInterface,
-                                              AttrSizedOperandSegments,
-                                              IsolatedFromAbove,
-                                              AffineScope,
-                                              SingleBlockImplicitTerminator<"HerdTerminatorOp">]>,
+                                 air_HierarchyInterface,
+                                 AttrSizedOperandSegments,
+                                 IsolatedFromAbove,
+                                 AffineScope,
+                                 SingleBlockImplicitTerminator<"HerdTerminatorOp">]>,
                         Arguments<(ins OptionalAttr<SymbolRefAttr>:$symbol,
-                                       Variadic<air_AsyncToken>:$asyncDependencies,
+                                       Variadic<air_AsyncToken>:$async_dependencies,
                                        Variadic<Index>:$sizes,
                                        Variadic<AnyType>:$operands)>,
-                        Results<(outs Optional<air_AsyncToken>:$asyncToken)> {
+                        Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Herd";
   let description = [{
     Define and run a 1D or 2D array of tiles as an AIR Herd.
   }];
 
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernelOperands)>,
-    OpBuilder<(ins "ValueRange":$asyncDependencies,
+    OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernel_operands)>,
+    OpBuilder<(ins "ValueRange":$async_dependencies,
       "ValueRange":$sizes,
-      "ValueRange":$kernelOperands,
-      CArg<"bool", "false">:$isAsync
+      "ValueRange":$kernel_operands,
+      CArg<"bool", "false">:$is_async
     )>
   ];
   let hasCustomAssemblyFormat = 1;
@@ -214,12 +216,12 @@ def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
 
 def air_HerdTerminatorOp : air_Op<"herd_terminator", [HasParent<"HerdOp">,
                                                       NoSideEffect, Terminator]>,
-    Arguments<(ins)>, Results<(outs)> {
-  let summary = "Terminator for air launch_herd regions.";
+                                   Arguments<(ins)>, Results<(outs)> {
+  let summary = "Terminator for air herd regions.";
   let description = [{
-    A terminator operation for regions that appear in the body of
-    `air.launch_herd` operation.  These regions are not expected to return any
-    value so the terminator takes no operands.
+    A terminator operation for the body of `air.herd` operations.
+    `air.herd` operations are not expected to return any value so the
+    terminator takes no operands.
   }];
   let assemblyFormat = "attr-dict";
 }
@@ -233,7 +235,7 @@ def air_HerdPipelineOp : air_Op<"pipeline", [HasParent<"HerdOp">,
     Define a pipeline within an AIR Herd.
   }];
 
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
   let hasVerifier = 1;
   let assemblyFormat = [{
     attr-dict-with-keyword $body
@@ -247,7 +249,7 @@ def air_HerdPipelineOp : air_Op<"pipeline", [HasParent<"HerdOp">,
 def air_PipelineStageOp : air_Op<"pipeline.stage", [HasParent<"HerdPipelineOp">]>,
     Arguments<(ins Variadic<AnyType>:$opers)>, Results<(outs Variadic<AnyType>:$results)> {
   let summary = "Pipeline stage";
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
   let description = [{
     Pipeline stage.
   }];
@@ -259,12 +261,14 @@ def air_PipelineStageOp : air_Op<"pipeline.stage", [HasParent<"HerdPipelineOp">]
 }
 
 def air_PipelineYieldOp : air_Op<"pipeline.yield", [HasParent<"PipelineStageOp">,
-                                          NoSideEffect, ReturnLike, Terminator]>,
-    Arguments<(ins Variadic<AnyType>:$opers)>, Results<(outs)> {
+                                                    NoSideEffect, ReturnLike, Terminator]>,
+                                 Arguments<(ins Variadic<AnyType>:$opers)>, Results<(outs)> {
   let summary = "Yield for air pipeline stages.";
   let description = [{
     A terminator operation for regions that appear in the body of 
-    `air.pipeline.stage` operation.
+    `air.pipeline.stage` operation. The operation takes variable number of
+    operands and produces no results. The operand number and types must
+    match the signature of the `air.pipeline` that contains the operation.
   }];
   let assemblyFormat = [{
     ($opers^)? attr-dict (`:` type($opers)^)?
@@ -312,7 +316,7 @@ def air_DmaMemcpyNdOp: air_Op<"dma_memcpy_nd",
                          AttrSizedOperandSegments]> {
   let summary = "dma operator";
   let arguments = (
-    ins Variadic<air_AsyncToken>:$asyncDependencies,
+    ins Variadic<air_AsyncToken>:$async_dependencies,
         AnyMemRef:$dst,
         Variadic<Index>:$dst_offsets,
         Variadic<Index>:$dst_sizes,
@@ -322,9 +326,9 @@ def air_DmaMemcpyNdOp: air_Op<"dma_memcpy_nd",
         Variadic<Index>:$src_sizes,
         Variadic<Index>:$src_strides
   );
-  let results = (outs Optional<air_AsyncToken>:$asyncToken);
+  let results = (outs Optional<air_AsyncToken>:$async_token);
   let assemblyFormat = [{
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) 
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) 
     `(` $dst `[` ($dst_offsets^)? `]``[` ($dst_sizes^)? `]``[` ($dst_strides^)? `]` `,` 
         $src `[` ($src_offsets^)? `]``[` ($src_sizes^)? `]``[` ($src_strides^)? `]` `)`  attr-dict `:`
     `(` type($dst) `,` type($src) `)`
@@ -349,9 +353,9 @@ def air_DmaMemcpyNdOp: air_Op<"dma_memcpy_nd",
 }
 
 def air_WaitAllOp: air_Op<"wait_all", [air_AsyncOpInterface]> {
-  let arguments = (ins Variadic<air_AsyncToken>:$asyncDependencies);
+  let arguments = (ins Variadic<air_AsyncToken>:$async_dependencies);
   let results = (
-    outs Optional<air_AsyncToken>:$asyncToken
+    outs Optional<air_AsyncToken>:$async_token
   );
 
   let summary = "wait for all operator";
@@ -359,7 +363,7 @@ def air_WaitAllOp: air_Op<"wait_all", [air_AsyncOpInterface]> {
     Wait for all async tokens before preceding.
   }];
   let assemblyFormat = [{
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) attr-dict
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) attr-dict
   }];
   let extraClassDeclaration = [{
     int32_t getId() {
@@ -374,11 +378,11 @@ def air_WaitAllOp: air_Op<"wait_all", [air_AsyncOpInterface]> {
 def air_AllocOp: air_Op<"alloc", [air_AsyncOpInterface]> {
   let summary = "alloc operator";
   let arguments = (
-    ins Variadic<air_AsyncToken>:$asyncDependencies
+    ins Variadic<air_AsyncToken>:$async_dependencies
   );
-  let results = (outs Optional<air_AsyncToken>:$asyncToken, AnyMemRef:$result);
+  let results = (outs Optional<air_AsyncToken>:$async_token, AnyMemRef:$result);
   let assemblyFormat = [{
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) attr-dict `:` type($result)
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) attr-dict `:` type($result)
   }];
   let description = [{
     Allocate memory
@@ -388,11 +392,11 @@ def air_AllocOp: air_Op<"alloc", [air_AsyncOpInterface]> {
 def air_DeallocOp: air_Op<"dealloc", [air_AsyncOpInterface]> {
   let summary = "dealloc operator";
   let arguments = (
-    ins Variadic<air_AsyncToken>:$asyncDependencies, AnyMemRef:$memref
+    ins Variadic<air_AsyncToken>:$async_dependencies, AnyMemRef:$memref
   );
-  let results = (outs Optional<air_AsyncToken>:$asyncToken);
+  let results = (outs Optional<air_AsyncToken>:$async_token);
   let assemblyFormat = [{
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) $memref attr-dict `:` type($memref)
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) $memref attr-dict `:` type($memref)
   }];
   let description = [{
     Deallocate memory
@@ -401,12 +405,12 @@ def air_DeallocOp: air_Op<"dealloc", [air_AsyncOpInterface]> {
 
 // AIR channel
 
-def air_ChannelOp : air_Op<"channel", []>,
-    Arguments<(ins FlatSymbolRefAttr:$name, 
+def air_ChannelOp : air_Op<"channel", [Symbol]>,
+    Arguments<(ins SymbolNameAttr:$sym_name, 
         ConfinedAttr<I32Attr, [IntMinValue<0>]>:$countx,
         ConfinedAttr<I32Attr, [IntMinValue<0>]>:$county)> {
   let assemblyFormat = [{
-    $name `{` `count_x` `=` $countx `,` `count_y` `=` $county `}` attr-dict 
+    $sym_name `{` `count_x` `=` $countx `,` `count_y` `=` $county `}` attr-dict 
   }];
   let summary = "Channel for data movement.";
   let description = [{
@@ -440,7 +444,7 @@ def air_DistributeOp : air_Op<"distribute", []>,
 }
 
 def air_PushOp : air_Op<"push", [air_AsyncOpInterface, AttrSizedOperandSegments]>,
-    Arguments<(ins Variadic<air_AsyncToken>:$asyncDependencies, 
+    Arguments<(ins Variadic<air_AsyncToken>:$async_dependencies, 
         FlatSymbolRefAttr:$chan_name, 
         Index:$chan_idx,
         Index:$chan_idy,
@@ -448,21 +452,21 @@ def air_PushOp : air_Op<"push", [air_AsyncOpInterface, AttrSizedOperandSegments]
         Variadic<Index>:$src_offsets,
         Variadic<Index>:$src_sizes,
         Variadic<Index>:$src_strides)>, 
-    Results<(outs Optional<air_AsyncToken>:$asyncToken)> {
+    Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Push for air channels.";
   let description = [{
     Experimental operation to represent copying data into a channel.
   }];
   let assemblyFormat = [{
     $chan_name `(` $chan_idx `,` $chan_idy `)`
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) 
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) 
     `(` $src `[` ($src_offsets^)? `]``[` ($src_sizes^)? `]``[` ($src_strides^)? `]` `)`  attr-dict `:`
     `(` type($src) `)`
   }];
 }
 
 def air_PopOp : air_Op<"pop", [air_AsyncOpInterface, AttrSizedOperandSegments]>,
-    Arguments<(ins Variadic<air_AsyncToken>:$asyncDependencies, 
+    Arguments<(ins Variadic<air_AsyncToken>:$async_dependencies, 
         FlatSymbolRefAttr:$chan_name, 
         Index:$chan_idx,
         Index:$chan_idy,
@@ -470,14 +474,14 @@ def air_PopOp : air_Op<"pop", [air_AsyncOpInterface, AttrSizedOperandSegments]>,
         Variadic<Index>:$dst_offsets,
         Variadic<Index>:$dst_sizes,
         Variadic<Index>:$dst_strides)>, 
-    Results<(outs Optional<air_AsyncToken>:$asyncToken)> {
+    Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Pop for air channels.";
   let description = [{
     Experimental operation to represent copying data out of a channel.
   }];
   let assemblyFormat = [{
     $chan_name `(` $chan_idx `,` $chan_idy `)`
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) 
+    custom<AsyncDependencies>(type($async_token), $async_dependencies) 
     `(` $dst `[` ($dst_offsets^)? `]``[` ($dst_sizes^)? `]``[` ($dst_strides^)? `]` `)`  attr-dict `:`
     `(` type($dst) `)`
   }];
@@ -485,24 +489,25 @@ def air_PopOp : air_Op<"pop", [air_AsyncOpInterface, AttrSizedOperandSegments]>,
 
 // AIR asynchronous region for dynamic event dispatching.
 
-def air_ExecuteOp : air_Op<"execute", [air_AsyncOpInterface, AffineScope]> {
+def air_ExecuteOp : air_Op<"execute", [SingleBlockImplicitTerminator<"ExecuteTerminatorOp">,
+                                       air_AsyncOpInterface]> {
   let arguments = (
-    ins Variadic<AnyType>:$asyncDependencies
+    ins Variadic<air_AsyncToken>:$async_dependencies
   );
   let results = (
-    outs  air_AsyncToken:$asyncToken,
-          Optional<AnyType>:$valOut
+    outs air_AsyncToken:$async_token,
+         Variadic<AnyType>:$results
   );
   let summary = "Asynchronous code region";
-  let regions = (region AnyRegion:$body);
+  let regions = (region SizedRegion<1>:$body);
   let description = [{
     Defines a code region to be dispatched asynchronously at runtime. All operations in
     the region must be executed sequentially.
   }];
 
   let assemblyFormat = [{
-    custom<AsyncDependencies>(type($asyncToken), $asyncDependencies) (`:` 
-    `(` type($asyncDependencies)^ `)`)? regions attr-dict (`:` `(` type($valOut)^ `)`)?
+    (` ``[` $async_dependencies^ `]`)?
+    (`->` `(` type($results)^ `)`)? regions attr-dict
   }];
   let extraClassDeclaration = [{
     int32_t getId() {
@@ -518,11 +523,12 @@ def air_ExecuteOp : air_Op<"execute", [air_AsyncOpInterface, AffineScope]> {
 
 def air_ExecuteTerminatorOp : air_Op<"execute_terminator", [HasParent<"ExecuteOp">,
                                                       NoSideEffect, ReturnLike, Terminator]>{
-  let summary = "Terminator for air regions.";
+  let summary = "Terminator for air execute.";
   let description = [{
-    A terminator operation for regions that appear in the body of
-    `air.execute` operation.  These regions are not expected to return any
-    value so the terminator takes no operands.
+    A terminator operation for code regions that appear in the body of
+    `air.execute` operation. The operation takes variable number of
+    operands and produces no results. The operand number and types must
+    match the signature of the `air.execute` that contains the operation.
   }];
 
   let arguments = (ins Variadic<AnyType>:$results);

--- a/mlir/test/Conversion/AIRToAIE/lower_air_execute_pattern.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_air_execute_pattern.mlir
@@ -44,16 +44,16 @@ module attributes {torch.debug_module_name = "mmult"} {
       %c32 = arith.constant 32 : index
       // CHECK: affine.apply #map()[%{{.*}}]
       // CHECK-NEXT: [[T0:%.*]] = air.wait_all async
-      %asyncToken, %valOut = air.execute async  {
+      %asyncToken, %valOut = air.execute -> (index) {
         %6 = affine.apply #map()[%arg3]
         air.execute_terminator %6 : index
-      } {id = 5 : i32} : (index)
+      } {id = 5 : i32}
       // CHECK-NEXT: affine.apply #map()[%{{.*}}]
       // CHECK-NEXT: [[T1:%.*]] = air.wait_all async
-      %asyncToken_0, %valOut_1 = air.execute async  {
+      %asyncToken_0, %valOut_1 = air.execute -> (index) {
         %6 = affine.apply #map()[%arg4]
         air.execute_terminator %6 : index
-      } {id = 6 : i32} : (index)
+      } {id = 6 : i32}
       // CHECK-NEXT: air.wait_all async [[[T0]], [[T1]]]
       %2 = air.wait_all async [%asyncToken, %asyncToken_0] 
       %6 = memref.alloc() : memref<32x32xi32, 2>
@@ -62,9 +62,8 @@ module attributes {torch.debug_module_name = "mmult"} {
       %4 = air.dma_memcpy_nd async [%2] (%6[] [] [], %arg9[%valOut, %valOut_1] [%c32, %c32] [%c64, %c1]) {id = 3 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32>)
       %5 = air.dma_memcpy_nd async [%4] (%arg9[%valOut, %valOut_1] [%c32, %c32] [%c64, %c1], %6[] [] []) {id = 4 : i32} : (memref<64x64xi32>, memref<32x32xi32, 2>)
       // CHECK: air.wait_all [[[T2]], [[T3]]]
-      %asyncToken_4 = air.execute async [%4, %5]  : (!air.async.token, !air.async.token) {
+      %asyncToken_4 = air.execute [%4, %5] {
         memref.dealloc %6 : memref<32x32xi32, 2>
-        air.execute_terminator
       } {id = 15 : i32}
       air.herd_terminator
     }

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -53,40 +53,40 @@ module attributes {torch.debug_module_name = "mmult"} {
       %c0 = arith.constant 0 : index
       %c64 = arith.constant 64 : index
       %c32 = arith.constant 32 : index
-      %asyncToken, %valOut = air.execute async  {
+      %asyncToken, %valOut = air.execute -> (index) {
         %6 = affine.apply #map()[%arg3]
         air.execute_terminator %6 : index
-      } {id = 5 : i32} : (index)
-      %asyncToken_0, %valOut_1 = air.execute async  {
+      } {id = 5 : i32}
+      %asyncToken_0, %valOut_1 = air.execute -> (index) {
         %6 = affine.apply #map()[%arg4]
         air.execute_terminator %6 : index
-      } {id = 6 : i32} : (index)
+      } {id = 6 : i32}
       %2 = air.wait_all async [%asyncToken, %asyncToken_0] 
-      %asyncToken_2, %valOut_3 = air.execute async  {
+      %asyncToken_2, %valOut_3 = air.execute -> (memref<32x32xi32, 2>) {
         %6 = memref.alloc() : memref<32x32xi32, 2>
         air.execute_terminator %6 : memref<32x32xi32, 2>
-      } {id = 9 : i32} : (memref<32x32xi32, 2>)
+      } {id = 9 : i32}
       %3 = air.dma_memcpy_nd async [%2, %asyncToken_2] (%valOut_3[] [] [], %arg9[%valOut, %valOut_1] [%c32, %c32] [%c64, %c1]) {id = 3 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32>)
       %4 = scf.for %arg10 = %c0 to %c64 step %c32 iter_args(%arg11 = %3) -> (!air.async.token) {
-        %asyncToken_5, %valOut_6 = air.execute async [%arg11]  : (!air.async.token) {
+        %asyncToken_5, %valOut_6 = air.execute [%arg11] -> (memref<32x32xi32, 2>) {
           %9 = memref.alloc() : memref<32x32xi32, 2>
           air.execute_terminator %9 : memref<32x32xi32, 2>
-        } {id = 7 : i32} : (memref<32x32xi32, 2>)
-        %asyncToken_7, %valOut_8 = air.execute async [%arg11]  : (!air.async.token) {
+        } {id = 7 : i32}
+        %asyncToken_7, %valOut_8 = air.execute [%arg11] -> (memref<32x32xi32, 2>) {
           %9 = memref.alloc() : memref<32x32xi32, 2>
           air.execute_terminator %9 : memref<32x32xi32, 2>
-        } {id = 8 : i32} : (memref<32x32xi32, 2>)
+        } {id = 8 : i32}
         %6 = air.dma_memcpy_nd async [%asyncToken_5, %arg11] (%valOut_6[] [] [], %arg7[%valOut, %arg10] [%c32, %c32] [%c64, %c1]) {id = 1 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32>)
         %7 = air.dma_memcpy_nd async [%asyncToken_7, %arg11] (%valOut_8[] [] [], %arg8[%arg10, %valOut_1] [%c32, %c32] [%c64, %c1]) {id = 2 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32>)
-        %asyncToken_9 = air.execute async [%7, %arg11, %6]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_9 = air.execute [%7, %arg11, %6] {
           linalg.matmul ins(%valOut_6, %valOut_8 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%valOut_3 : memref<32x32xi32, 2>)
           air.execute_terminator
         } {id = 12 : i32}
-        %asyncToken_10 = air.execute async [%asyncToken_9]  : (!air.async.token) {
+        %asyncToken_10 = air.execute [%asyncToken_9] {
           memref.dealloc %valOut_6 : memref<32x32xi32, 2>
           air.execute_terminator
         } {id = 13 : i32}
-        %asyncToken_11 = air.execute async [%asyncToken_9]  : (!air.async.token) {
+        %asyncToken_11 = air.execute [%asyncToken_9] {
           memref.dealloc %valOut_8 : memref<32x32xi32, 2>
           air.execute_terminator
         } {id = 14 : i32}
@@ -94,7 +94,7 @@ module attributes {torch.debug_module_name = "mmult"} {
         scf.yield %8 : !air.async.token
       }
       %5 = air.dma_memcpy_nd async [%4] (%arg9[%valOut, %valOut_1] [%c32, %c32] [%c64, %c1], %valOut_3[] [] []) {id = 4 : i32} : (memref<64x64xi32>, memref<32x32xi32, 2>)
-      %asyncToken_4 = air.execute async [%5]  : (!air.async.token) {
+      %asyncToken_4 = air.execute [%5] {
         memref.dealloc %valOut_3 : memref<32x32xi32, 2>
         air.execute_terminator
       } {id = 15 : i32}

--- a/mlir/test/Conversion/AIRToAIE/lower_scf_air_token.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_scf_air_token.mlir
@@ -36,7 +36,7 @@ module attributes {torch.debug_module_name = "mmult"} {
       %0 = air.wait_all async
       // CHECK: scf.for %{{.*}} = %c0 to %c64 step %c32 {
       %1 = scf.for %arg10 = %c0 to %c64 step %c32 iter_args(%arg11 = %0) -> (!air.async.token) {
-        %asyncToken = air.execute async [%arg11]  : (!air.async.token) {
+        %asyncToken = air.execute [%arg11] {
           linalg.matmul ins(%arg7, %arg8 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%arg9 : memref<32x32xi32, 2>)
           air.execute_terminator
         } {id = 1 : i32}

--- a/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
+++ b/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
@@ -36,7 +36,7 @@ module  {
       %c0_1 = arith.constant 0 : index
       %c1_1 = arith.constant 1 : index
       %1 = memref.alloc() : memref<512xi32, 3>
-      // CHECK: %[[EVENT1:.*]], %[[VAL1:.*]] = air.execute async
+      // CHECK: %[[EVENT1:.*]], %[[VAL1:.*]] = air.execute
       air.dma_memcpy_nd (%1[][][], %arg4[%c0_1][%c0_1][%c0_1]) {id = 1 : i32} : (memref<512xi32, 3>, memref<1024xi32>)
       // CHECK: %[[EVENT2:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}]
       air.partition unroll (%arg5, %arg6) in (%size_x2 = %c1_1, %size_y2 = %c1_1) args(%arg7 = %1) : memref<512xi32, 3> {
@@ -44,26 +44,26 @@ module  {
         %c0_2 = arith.constant 0 : index
         %c1_2 = arith.constant 1 : index
         %2 = memref.alloc() : memref<256xi32, 2>
-        // CHECK: %[[EVENT4:.*]], %[[VAL4:.*]] = air.execute async
+        // CHECK: %[[EVENT4:.*]], %[[VAL4:.*]] = air.execute
         air.dma_memcpy_nd (%2[][][], %arg7[%c0_2][%c0_2][%c0_2]) {id = 2 : i32} : (memref<256xi32, 2>, memref<512xi32, 3>)
         // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT4]]{{.*}}]
         air.herd tile (%arg8, %arg9) in (%arg10=%c1_2, %arg11=%c1_2) args(%arg12=%2) : memref<256xi32, 2> {
         // CHECK: %[[EVENT6:.*]] = air.herd async [{{.*}}%[[EVENT5]]{{.*}}]{{.*}}tile
           %c0_3 = arith.constant 0 : index
           %3 = memref.alloc() : memref<128xi32, 1>
-          // CHECK: %[[EVENT7:.*]], %[[VAL7:.*]] = air.execute async
+          // CHECK: %[[EVENT7:.*]], %[[VAL7:.*]] = air.execute
           air.dma_memcpy_nd (%3[][][], %arg12[%c0_3][%c0_3][%c0_3]) {id = 3 : i32} : (memref<128xi32, 1>, memref<256xi32, 2>)
           // CHECK: %[[EVENT8:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT7]]{{.*}}]
           memref.dealloc %3 : memref<128xi32, 1>
-          // CHECK: %[[EVENT9:.*]] = air.execute async [{{.*}}%[[EVENT8]]{{.*}}]
+          // CHECK: %[[EVENT9:.*]] = air.execute [{{.*}}%[[EVENT8]]{{.*}}]
           air.herd_terminator
         }
         memref.dealloc %2 : memref<256xi32, 2>
-        // CHECK: %[[EVENT10:.*]] = air.execute async [{{.*}}%[[EVENT6]]{{.*}}]
+        // CHECK: %[[EVENT10:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
         air.partition_terminator
       }
       memref.dealloc %1 : memref<512xi32, 3>
-      // CHECK: %[[EVENT11:.*]] = air.execute async [{{.*}}%[[EVENT3]]{{.*}}]
+      // CHECK: %[[EVENT11:.*]] = air.execute [{{.*}}%[[EVENT3]]{{.*}}]
       air.launch_terminator
     }
     return

--- a/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
@@ -38,19 +38,16 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.launch @memcpy_nd async
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
-    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
     // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
-    // CHECK: %[[EVENT7:.*]] = air.execute async [{{.*}}%[[EVENT6]]{{.*}}]
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
     air.launch_terminator
   }
   return

--- a/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
@@ -38,19 +38,16 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.partition @memcpy_nd async unroll
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
-    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
     // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
-    // CHECK: %[[EVENT7:.*]] = air.execute async [{{.*}}%[[EVENT6]]{{.*}}]
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
     air.partition_terminator
   }
   return

--- a/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
@@ -38,19 +38,16 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.herd @memcpy_nd async
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
-    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg5[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
     // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
     air.dma_memcpy_nd (%arg5[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
-    // CHECK: %[[EVENT7:.*]] = air.execute async [{{.*}}%[[EVENT6]]{{.*}}]
-    // CHECK: air.execute_terminator
+    // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
     air.herd_terminator
   }
   return

--- a/mlir/test/Transform/AIRDependency/linalg_generic.mlir
+++ b/mlir/test/Transform/AIRDependency/linalg_generic.mlir
@@ -26,7 +26,7 @@
 
 // A single async air.execute op should be created around linalg.generic
 // No air.execute op should be created inside of linalg.generic block
-// CHECK: %[[EVENT0:.*]] = air.execute async [
+// CHECK: %[[EVENT0:.*]] = air.execute [
 // CHECK-NEXT: linalg.generic {
 // CHECK-NEXT: ^bb0(
 // CHECK-NEXT: %[[VALUE1:.*]] = linalg.index

--- a/mlir/test/Transform/AIRDependency/matmul_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_nd.mlir
@@ -33,25 +33,23 @@ module attributes {torch.debug_module_name = "mmult"}  {
     %c64 = arith.constant 64 : index
     %c1 = arith.constant 1 : index
     %0 = memref.alloc() : memref<64x64xi32>
-    // CHECK: = air.execute async
+    // CHECK: = air.execute
     // CHECK: air.execute_terminator
     linalg.fill ins(%c0_i32 : i32) outs(%0 : memref<64x64xi32>)
-    // CHECK: = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: = air.execute
     %1 = memref.cast %arg2 : memref<?x?xi32> to memref<64x64xi32>
-    // CHECK: = air.execute async
+    // CHECK: = air.execute
     // CHECK: air.execute_terminator
     linalg.copy ins(%0 : memref<64x64xi32>) outs(%1 : memref<64x64xi32>)
-    // CHECK: = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: = air.execute
     %2 = memref.alloc() : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
+    // CHECK: = air.execute
     // CHECK: air.execute_terminator
     %3 = memref.alloc() : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
+    // CHECK: = air.execute
     // CHECK: air.execute_terminator
     %4 = memref.alloc() : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
+    // CHECK: = air.execute
     // CHECK: air.execute_terminator
     air.dma_memcpy_nd (%2[] [] [], %arg0[%c0, %c0] [%c64, %c64] [%c64, %c1]) {id = 1 : i32} : (memref<64x64xi32, 1>, memref<64x64xi32>)
     // CHECK: = air.dma_memcpy_nd async
@@ -66,10 +64,10 @@ module attributes {torch.debug_module_name = "mmult"}  {
       %c64_1 = arith.constant 64 : index
       %c1_2 = arith.constant 1 : index
       %5 = arith.muli %arg3, %c32 : index
-      // CHECK: = air.execute async
+      // CHECK: = air.execute
       // CHECK: air.execute_terminator
       %6 = arith.muli %arg4, %c32 : index
-      // CHECK: = air.execute async
+      // CHECK: = air.execute
       // CHECK: air.execute_terminator
       // CHECK: = air.wait_all async
       scf.for %arg10 = %c0_0 to %c64_1 step %c32 {
@@ -83,19 +81,15 @@ module attributes {torch.debug_module_name = "mmult"}  {
         air.dma_memcpy_nd (%9[] [] [], %arg9[%5, %6] [%c32, %c32] [%c64_1, %c1_2]) {id = 6 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32, 1>)
         // CHECK: = air.dma_memcpy_nd async
         linalg.matmul ins(%7, %8 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%9 : memref<32x32xi32, 2>)
-        // CHECK: = air.execute async
-        // CHECK: air.execute_terminator
+        // CHECK: = air.execute
         air.dma_memcpy_nd (%arg9[%5, %6] [%c32, %c32] [%c64_1, %c1_2], %9[] [] []) {id = 7 : i32} : (memref<64x64xi32, 1>, memref<32x32xi32, 2>)
         // CHECK: = air.dma_memcpy_nd async
         memref.dealloc %7 : memref<32x32xi32, 2>
-        // CHECK: = air.execute async
-        // CHECK: air.execute_terminator
+        // CHECK: = air.execute
         memref.dealloc %8 : memref<32x32xi32, 2>
-        // CHECK: = air.execute async
-        // CHECK: air.execute_terminator
+        // CHECK: = air.execute
         memref.dealloc %9 : memref<32x32xi32, 2>
-        // CHECK: = air.execute async
-        // CHECK: air.execute_terminator
+        // CHECK: = air.execute
       }
       air.herd_terminator
       // CHECK: air.herd_terminator
@@ -103,14 +97,11 @@ module attributes {torch.debug_module_name = "mmult"}  {
     air.dma_memcpy_nd (%1[%c0, %c0] [%c64, %c64] [%c64, %c1], %4[] [] []) {id = 8 : i32} : (memref<64x64xi32>, memref<64x64xi32, 1>)
     // CHECK: = air.dma_memcpy_nd async
     memref.dealloc %2 : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: = air.execute
     memref.dealloc %3 : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: = air.execute
     memref.dealloc %4 : memref<64x64xi32, 1>
-    // CHECK: = air.execute async
-    // CHECK: air.execute_terminator
+    // CHECK: = air.execute
     return
   }
 }

--- a/mlir/test/Transform/AIRDependency/matmul_parallel.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_parallel.mlir
@@ -29,7 +29,7 @@
 // It should also generate an scf.reduce at the end of its body
 // CHECK: %[[EVENT0:.*]] = scf.parallel
 // CHECK: scf.reduce
-// CHECK: %[[EVENT1:.*]] = air.execute async [{{.*}}%[[EVENT0]]{{.*}}]
+// CHECK: %[[EVENT1:.*]] = air.execute [{{.*}}%[[EVENT0]]{{.*}}]
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module attributes {torch.debug_module_name = "mmult"} {

--- a/mlir/test/Transform/AIRDependency/matmul_parallel_with_L2.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_parallel_with_L2.mlir
@@ -29,7 +29,7 @@
 // It should also generate an scf.reduce at the end of its body
 // CHECK: %[[EVENT0:.*]] = scf.parallel
 // CHECK: scf.reduce
-// CHECK: %[[EVENT1:.*]] = air.execute async [{{.*}}%[[EVENT0]]{{.*}}]
+// CHECK: %[[EVENT1:.*]] = air.execute [{{.*}}%[[EVENT0]]{{.*}}]
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module attributes {torch.debug_module_name = "mmult"} {

--- a/mlir/test/Transform/AIRDependency/parallel_herds.mlir
+++ b/mlir/test/Transform/AIRDependency/parallel_herds.mlir
@@ -27,7 +27,8 @@
 // The second herd should not depend on the first
 
 // CHECK: %[[EVENT0:.*]] = scf.for
-// CHECK: } {id = 14 : i32} : (index)
+// CHECK: air.execute_terminator {{.*}} : index
+// CHECK: } {id = 14 : i32}
 // CHECK-NOT: %[[EVENT1:.*]] = air.wait_all async [{{.*}}%[[EVENT0]]
 // CHECK: %[[EVENT2:.*]] = scf.for
 

--- a/mlir/test/Transform/AIRDependencyCanonicalization/prune_redundant_edges.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/prune_redundant_edges.mlir
@@ -29,9 +29,9 @@
 // CHECK: %[[EVENT0:.*]] = air.partition async
 // CHECK: %[[EVENT1:.*]] = air.herd async
 // CHECK: %[[EVENT2:.*]] = air.dma_memcpy_nd async{{.*}}id = 3
-// CHECK-NEXT: %[[EVENT3:.*]] = air.execute async [%[[EVENT2]]]
-// CHECK: %[[EVENT4:.*]] = air.execute async [%[[EVENT1]]]
-// CHECK: %[[EVENT5:.*]] = air.execute async [%[[EVENT0]]]
+// CHECK-NEXT: %[[EVENT3:.*]] = air.execute [%[[EVENT2]]]
+// CHECK: %[[EVENT4:.*]] = air.execute [%[[EVENT1]]]
+// CHECK: %[[EVENT5:.*]] = air.execute [%[[EVENT0]]]
 
 module {
   func.func @foo(%arg0: memref<1024xi32>) {
@@ -40,39 +40,39 @@ module {
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<1024xi32> attributes {id = 3 : i32} {
       %c0_0 = arith.constant 0 : index
       %c1_1 = arith.constant 1 : index
-      %asyncToken, %valOut = air.execute async  {
+      %asyncToken, %valOut = air.execute -> (memref<512xi32, 3>){
         %3 = memref.alloc() : memref<512xi32, 3>
         air.execute_terminator %3 : memref<512xi32, 3>
-      } {id = 1 : i32} : (memref<512xi32, 3>)
+      } {id = 1 : i32}
       %1 = air.dma_memcpy_nd async [%asyncToken] (%valOut[] [] [], %arg5[%c0_0] [%c0_0] [%c0_0]) {id = 1 : i32} : (memref<512xi32, 3>, memref<1024xi32>)
       %2 = air.partition async [%1]  unroll(%arg6, %arg7) in (%arg8=%c1_1, %arg9=%c1_1) args(%arg10=%valOut) : memref<512xi32, 3> attributes {id = 2 : i32} {
         %c0_3 = arith.constant 0 : index
         %c1_4 = arith.constant 1 : index
-        %asyncToken_5, %valOut_6 = air.execute async  {
+        %asyncToken_5, %valOut_6 = air.execute -> (memref<256xi32, 2>) {
           %5 = memref.alloc() : memref<256xi32, 2>
           air.execute_terminator %5 : memref<256xi32, 2>
-        } {id = 2 : i32} : (memref<256xi32, 2>)
+        } {id = 2 : i32}
         %3 = air.dma_memcpy_nd async [%asyncToken_5] (%valOut_6[] [] [], %arg10[%c0_3] [%c0_3] [%c0_3]) {id = 2 : i32} : (memref<256xi32, 2>, memref<512xi32, 3>)
         %4 = air.herd async [%3]  tile (%arg11, %arg12) in (%arg13=%c1_4, %arg14=%c1_4) args(%arg15=%valOut_6) : memref<256xi32, 2> attributes {id = 1 : i32} {
           %c0_8 = arith.constant 0 : index
-          %asyncToken_9, %valOut_10 = air.execute async  {
+          %asyncToken_9, %valOut_10 = air.execute -> (memref<128xi32, 1>){
             %6 = memref.alloc() : memref<128xi32, 1>
             air.execute_terminator %6 : memref<128xi32, 1>
-          } {id = 3 : i32} : (memref<128xi32, 1>)
+          } {id = 3 : i32}
           %5 = air.dma_memcpy_nd async [%asyncToken_9] (%valOut_10[] [] [], %arg15[%c0_8] [%c0_8] [%c0_8]) {id = 3 : i32} : (memref<128xi32, 1>, memref<256xi32, 2>)
-          %asyncToken_11 = air.execute async [%5, %asyncToken_9]  : (!air.async.token, !air.async.token) {
+          %asyncToken_11 = air.execute [%5, %asyncToken_9] {
             memref.dealloc %valOut_10 : memref<128xi32, 1>
             air.execute_terminator
           } {id = 4 : i32}
           air.herd_terminator
         }
-        %asyncToken_7 = air.execute async [%4, %asyncToken_5, %3]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_7 = air.execute [%4, %asyncToken_5, %3] {
           memref.dealloc %valOut_6 : memref<256xi32, 2>
           air.execute_terminator
         } {id = 5 : i32}
         air.partition_terminator
       }
-      %asyncToken_2 = air.execute async [%2, %1]  : (!air.async.token, !air.async.token) {
+      %asyncToken_2 = air.execute [%2, %1] {
         memref.dealloc %valOut : memref<512xi32, 3>
         air.execute_terminator
       } {id = 6 : i32}

--- a/mlir/test/Transform/AIRDependencyCanonicalization/renumber.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/renumber.mlir
@@ -40,39 +40,39 @@ module {
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<1024xi32> attributes {id = 13 : i32} {
       %c0_0 = arith.constant 0 : index
       %c1_1 = arith.constant 1 : index
-      %asyncToken, %valOut = air.execute async  {
+      %asyncToken, %valOut = air.execute -> (memref<512xi32, 3>) {
         %3 = memref.alloc() : memref<512xi32, 3>
         air.execute_terminator %3 : memref<512xi32, 3>
-      } {id = 1 : i32} : (memref<512xi32, 3>)
+      } {id = 1 : i32}
       %1 = air.dma_memcpy_nd async [%asyncToken] (%valOut[] [] [], %arg5[%c0_0] [%c0_0] [%c0_0]) {id = 81 : i32} : (memref<512xi32, 3>, memref<1024xi32>)
       %2 = air.partition async [%1]  unroll(%arg6, %arg7) in (%arg8=%c1_1, %arg9=%c1_1) args(%arg10=%valOut) : memref<512xi32, 3> attributes {id = 82 : i32} {
         %c0_3 = arith.constant 0 : index
         %c1_4 = arith.constant 1 : index
-        %asyncToken_5, %valOut_6 = air.execute async  {
+        %asyncToken_5, %valOut_6 = air.execute -> (memref<256xi32, 2>) {
           %5 = memref.alloc() : memref<256xi32, 2>
           air.execute_terminator %5 : memref<256xi32, 2>
-        } {id = 2 : i32} : (memref<256xi32, 2>)
+        } {id = 2 : i32}
         %3 = air.dma_memcpy_nd async [%asyncToken_5] (%valOut_6[] [] [], %arg10[%c0_3] [%c0_3] [%c0_3]) {id = 72 : i32} : (memref<256xi32, 2>, memref<512xi32, 3>)
         %4 = air.herd async [%3]  tile (%arg11, %arg12) in (%arg13=%c1_4, %arg14=%c1_4) args(%arg15=%valOut_6) : memref<256xi32, 2> attributes {id = 15 : i32} {
           %c0_8 = arith.constant 0 : index
-          %asyncToken_9, %valOut_10 = air.execute async  {
+          %asyncToken_9, %valOut_10 = air.execute -> (memref<128xi32, 1>) {
             %6 = memref.alloc() : memref<128xi32, 1>
             air.execute_terminator %6 : memref<128xi32, 1>
-          } {id = 3 : i32} : (memref<128xi32, 1>)
+          } {id = 3 : i32}
           %5 = air.dma_memcpy_nd async [%asyncToken_9] (%valOut_10[] [] [], %arg15[%c0_8] [%c0_8] [%c0_8]) {id = 43 : i32} : (memref<128xi32, 1>, memref<256xi32, 2>)
-          %asyncToken_11 = air.execute async [%5, %asyncToken_9]  : (!air.async.token, !air.async.token) {
+          %asyncToken_11 = air.execute [%5, %asyncToken_9] {
             memref.dealloc %valOut_10 : memref<128xi32, 1>
             air.execute_terminator
           } {id = 4 : i32}
           air.herd_terminator
         }
-        %asyncToken_7 = air.execute async [%4, %asyncToken_5, %3]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_7 = air.execute [%4, %asyncToken_5, %3] {
           memref.dealloc %valOut_6 : memref<256xi32, 2>
           air.execute_terminator
         } {id = 5 : i32}
         air.partition_terminator
       }
-      %asyncToken_2 = air.execute async [%2, %1]  : (!air.async.token, !air.async.token) {
+      %asyncToken_2 = air.execute [%2, %1] {
         memref.dealloc %valOut : memref<512xi32, 3>
         air.execute_terminator
       } {id = 6 : i32}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
@@ -85,7 +85,7 @@ module attributes {torch.debug_module_name = "model"} {
             linalg.yield %16 : bf16
           }
           // CHECK: %[[EVENT4:.*]] = air.dma_memcpy_nd async 
-          // CHECK: %[[EVENT5:.*]] = air.execute async [%[[EVENT4]]]
+          // CHECK: %[[EVENT5:.*]] = air.execute [%[[EVENT4]]]
           air.dma_memcpy_nd (%arg19[%7, %8] [%c32, %c32] [%c64_1, %c1_0], %10[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
           memref.dealloc %9 : memref<32x32xbf16, 2>
           memref.dealloc %10 : memref<32x32xbf16, 2>

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast.mlir
@@ -51,28 +51,28 @@ module {
     %c0 = arith.constant 0 : index
     %c512 = arith.constant 512 : index
     %c64 = arith.constant 64 : index
-    %asyncToken, %valOut = air.execute async  {
+    %asyncToken, %valOut = air.execute -> (memref<512x512xbf16>){
       %1 = memref.alloc() {alignment = 128 : i64} : memref<512x512xbf16>
       air.execute_terminator %1 : memref<512x512xbf16>
-    } {id = 1 : i32} : (memref<512x512xbf16>)
-    %asyncToken_0 = air.execute async [%asyncToken]  : (!air.async.token) {
+    } {id = 1 : i32} 
+    %asyncToken_0 = air.execute[%asyncToken] {
       memref.copy %arg2, %valOut : memref<512x512xbf16> to memref<512x512xbf16>
       air.execute_terminator
     } {id = 2 : i32}
     %0 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c512, %c512) step (%c64, %c64) init (%asyncToken_0) -> !air.async.token {
       %1 = scf.for %arg5 = %c0 to %c512 step %c64 iter_args(%arg6 = %asyncToken_0) -> (!air.async.token) {
-        %asyncToken_1, %valOut_2 = air.execute async [%arg6]  : (!air.async.token) {
+        %asyncToken_1, %valOut_2 = air.execute[%arg6] -> (memref<64x64xbf16, 1>) {
           %8 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %8 : memref<64x64xbf16, 1>
-        } {id = 3 : i32} : (memref<64x64xbf16, 1>)
-        %asyncToken_3, %valOut_4 = air.execute async [%arg6]  : (!air.async.token) {
+        } {id = 3 : i32}
+        %asyncToken_3, %valOut_4 = air.execute[%arg6] -> (memref<64x64xbf16, 1>) {
           %8 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %8 : memref<64x64xbf16, 1>
-        } {id = 4 : i32} : (memref<64x64xbf16, 1>)
-        %asyncToken_5, %valOut_6 = air.execute async [%arg6]  : (!air.async.token) {
+        } {id = 4 : i32}
+        %asyncToken_5, %valOut_6 = air.execute[%arg6] -> (memref<64x64xbf16, 1>) {
           %8 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %8 : memref<64x64xbf16, 1>
-        } {id = 5 : i32} : (memref<64x64xbf16, 1>)
+        } {id = 5 : i32}
         %2 = air.dma_memcpy_nd async [%asyncToken_1] (%valOut_2[] [] [], %arg0[%arg3, %arg5] [%c64, %c64] [%c512, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
         %3 = air.dma_memcpy_nd async [%asyncToken_3] (%valOut_4[] [] [], %arg1[%arg5, %arg4] [%c64, %c64] [%c512, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
         %4 = air.dma_memcpy_nd async [%asyncToken_5, %arg6] (%valOut_6[] [] [], %valOut[%arg3, %arg4] [%c64, %c64] [%c512, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
@@ -81,40 +81,40 @@ module {
           %c64_11 = arith.constant 64 : index
           %c32 = arith.constant 32 : index
           %c0_12 = arith.constant 0 : index
-          %asyncToken_13, %valOut_14 = air.execute async  {
+          %asyncToken_13, %valOut_14 = air.execute -> (index) {
             %12 = affine.apply #map()[%arg7]
             air.execute_terminator %12 : index
-          } {id = 6 : i32} : (index)
-          %asyncToken_15, %valOut_16 = air.execute async  {
+          } {id = 6 : i32}
+          %asyncToken_15, %valOut_16 = air.execute -> (index) {
             %12 = affine.apply #map()[%arg8]
             air.execute_terminator %12 : index
-          } {id = 7 : i32} : (index)
+          } {id = 7 : i32}
           %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-          %asyncToken_17, %valOut_18 = air.execute async  {
+          %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16, 2>) {
             %12 = memref.alloc() : memref<32x32xbf16, 2>
             air.execute_terminator %12 : memref<32x32xbf16, 2>
-          } {id = 10 : i32} : (memref<32x32xbf16, 2>)
+          } {id = 10 : i32}
           %9 = air.dma_memcpy_nd async [%8, %asyncToken_17] (%valOut_18[] [] [], %arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
           %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %9) -> (!air.async.token) {
-            %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+            %asyncToken_20, %valOut_21 = air.execute[%arg15] -> (memref<32x32xbf16, 2>) {
               %15 = memref.alloc() : memref<32x32xbf16, 2>
               air.execute_terminator %15 : memref<32x32xbf16, 2>
-            } {id = 8 : i32} : (memref<32x32xbf16, 2>)
-            %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+            } {id = 8 : i32}
+            %asyncToken_22, %valOut_23 = air.execute[%arg15] -> (memref<32x32xbf16, 2>) {
               %15 = memref.alloc() : memref<32x32xbf16, 2>
               air.execute_terminator %15 : memref<32x32xbf16, 2>
-            } {id = 9 : i32} : (memref<32x32xbf16, 2>)
+            } {id = 9 : i32}
             %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
             %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set1, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-            %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+            %asyncToken_24 = air.execute[%13, %arg15, %12] {
               linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%valOut_18 : memref<32x32xbf16, 2>)
               air.execute_terminator
             } {id = 11 : i32}
-            %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_25 = air.execute[%asyncToken_24] {
               memref.dealloc %valOut_21 : memref<32x32xbf16, 2>
               air.execute_terminator
             } {id = 12 : i32}
-            %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_26 = air.execute[%asyncToken_24] {
               memref.dealloc %valOut_23 : memref<32x32xbf16, 2>
               air.execute_terminator
             } {id = 13 : i32}
@@ -122,22 +122,22 @@ module {
             scf.yield %14 : !air.async.token
           }
           %11 = air.dma_memcpy_nd async [%10] (%arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10], %valOut_18[] [] []) {broadcast = "both", id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-          %asyncToken_19 = air.execute async [%11]  : (!air.async.token) {
+          %asyncToken_19 = air.execute[%11] {
             memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
             air.execute_terminator
           } {id = 14 : i32}
           air.herd_terminator
         }
         %6 = air.dma_memcpy_nd async [%5] (%valOut[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %valOut_6[] [] []) {id = 8 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
-        %asyncToken_7 = air.execute async [%5]  : (!air.async.token) {
+        %asyncToken_7 = air.execute[%5] {
           memref.dealloc %valOut_2 : memref<64x64xbf16, 1>
           air.execute_terminator
         } {id = 15 : i32}
-        %asyncToken_8 = air.execute async [%5]  : (!air.async.token) {
+        %asyncToken_8 = air.execute[%5] {
           memref.dealloc %valOut_4 : memref<64x64xbf16, 1>
           air.execute_terminator
         } {id = 16 : i32}
-        %asyncToken_9 = air.execute async [%6]  : (!air.async.token) {
+        %asyncToken_9 = air.execute[%6] {
           memref.dealloc %valOut_6 : memref<64x64xbf16, 1>
           air.execute_terminator
         } {id = 17 : i32}

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_4x4.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_4x4.mlir
@@ -68,57 +68,57 @@ module {
     %c0 = arith.constant 0 : index
     %c512 = arith.constant 512 : index
     %c64 = arith.constant 64 : index
-    %asyncToken_1, %valOut_2 = air.execute async {
+    %asyncToken_1, %valOut_2 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 3 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_3, %valOut_4 = air.execute async {
+    } {id = 3 : i32} 
+    %asyncToken_3, %valOut_4 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 4 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_5, %valOut_6 = air.execute async {
+    } {id = 4 : i32}
+    %asyncToken_5, %valOut_6 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 5 : i32} : (memref<64x64xbf16, 1>)
+    } {id = 5 : i32}
     %5 = air.herd async [%asyncToken_1, %asyncToken_3, %asyncToken_5]  tile (%arg7, %arg8) in (%arg9=%c4, %arg10=%c4) args(%arg11=%valOut_2, %arg12=%valOut_4, %arg13=%valOut_6) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 1 : i32, sym_name = "herd_0"} {
       %c1_10 = arith.constant 1 : index
       %c64_11 = arith.constant 64 : index
       %c32 = arith.constant 32 : index
       %c0_12 = arith.constant 0 : index
-      %asyncToken_13, %valOut_14 = air.execute async  {
+      %asyncToken_13, %valOut_14 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg7]
         air.execute_terminator %12 : index
-      } {id = 6 : i32} : (index)
-      %asyncToken_15, %valOut_16 = air.execute async  {
+      } {id = 6 : i32}
+      %asyncToken_15, %valOut_16 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg8]
         air.execute_terminator %12 : index
-      } {id = 7 : i32} : (index)
+      } {id = 7 : i32}
       %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-      %asyncToken_17, %valOut_18 = air.execute async  {
+      %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16, 2>) {
         %12 = memref.alloc() : memref<32x32xbf16, 2>
         air.execute_terminator %12 : memref<32x32xbf16, 2>
-      } {id = 10 : i32} : (memref<32x32xbf16, 2>)
+      } {id = 10 : i32}
       %9 = air.dma_memcpy_nd async [%8, %asyncToken_17] (%valOut_18[] [] [], %arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
       %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %9) -> (!air.async.token) {
-        %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+        %asyncToken_20, %valOut_21 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 8 : i32} : (memref<32x32xbf16, 2>)
-        %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+        } {id = 8 : i32}
+        %asyncToken_22, %valOut_23 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 9 : i32} : (memref<32x32xbf16, 2>)
+        } {id = 9 : i32}
         %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
         %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set1, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-        %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_24 = air.execute [%13, %arg15, %12] {
           linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%valOut_18 : memref<32x32xbf16, 2>)
           air.execute_terminator
         } {id = 11 : i32}
-        %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_25 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_21 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 12 : i32}
-        %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_26 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_23 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 13 : i32}
@@ -126,7 +126,7 @@ module {
         scf.yield %14 : !air.async.token
       }
       %11 = air.dma_memcpy_nd async [%10] (%arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10], %valOut_18[] [] []) {broadcast = "both", id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-      %asyncToken_19 = air.execute async [%11]  : (!air.async.token) {
+      %asyncToken_19 = air.execute [%11] {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_affine_offset.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_affine_offset.mlir
@@ -65,62 +65,62 @@ module {
         %c64_11 = arith.constant 64 : index
         %c32 = arith.constant 32 : index
         %c0_12 = arith.constant 0 : index
-        %newAsyncToken_0, %newValOut_0 = air.execute async  {
+        %newAsyncToken_0, %newValOut_0 = air.execute -> (index) {
             %12 = affine.apply #map0()[%arg7]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_1, %newValOut_1 = air.execute async [%newAsyncToken_0]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_1, %newValOut_1 = air.execute [%newAsyncToken_0] -> (index) {
             %12 = affine.apply #map1()[%newValOut_0]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_2, %newValOut_2 = air.execute async [%newAsyncToken_1]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_2, %newValOut_2 = air.execute [%newAsyncToken_1] -> (index) {
             %12 = affine.apply #map2()[%newValOut_1]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_3, %newValOut_3 = air.execute async [%newAsyncToken_2]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_3, %newValOut_3 = air.execute [%newAsyncToken_2] -> (index) {
             %12 = affine.apply #map3()[%newValOut_2]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %asyncToken_13, %valOut_14 = air.execute async [%newAsyncToken_3]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %asyncToken_13, %valOut_14 = air.execute [%newAsyncToken_3] -> (index) {
             %12 = affine.apply #map4()[%newValOut_3]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %asyncToken_15, %valOut_16 = air.execute async  {
+        } {id = 6 : i32}
+        %asyncToken_15, %valOut_16 = air.execute -> (index) {
             %12 = affine.apply #map5()[%arg8]
             air.execute_terminator %12 : index
-        } {id = 7 : i32} : (index)
+        } {id = 7 : i32}
         %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-        %asyncToken_17, %valOut_18 = air.execute async  {
+        %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16>) {
             %12 = memref.alloc() : memref<32x32xbf16>
             air.execute_terminator %12 : memref<32x32xbf16>
-        } {id = 10 : i32} : (memref<32x32xbf16>)
+        } {id = 10 : i32}
         %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %8) -> (!air.async.token) {
-            %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+            %asyncToken_20, %valOut_21 = air.execute [%arg15] -> (memref<32x32xbf16>){
                 %15 = memref.alloc() : memref<32x32xbf16>
                 air.execute_terminator %15 : memref<32x32xbf16>
-            } {id = 8 : i32} : (memref<32x32xbf16>)
-            %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+            } {id = 8 : i32}
+            %asyncToken_22, %valOut_23 = air.execute [%arg15] -> (memref<32x32xbf16>){
                 %15 = memref.alloc() : memref<32x32xbf16>
                 air.execute_terminator %15 : memref<32x32xbf16>
-            } {id = 9 : i32} : (memref<32x32xbf16>)
+            } {id = 9 : i32}
             %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16>, memref<64x64xbf16>)
             %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set1, id = 5 : i32} : (memref<32x32xbf16>, memref<64x64xbf16>)
-            %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+            %asyncToken_24 = air.execute [%13, %arg15, %12] {
                 linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16>, memref<32x32xbf16>) outs(%valOut_18 : memref<32x32xbf16>)
                 air.execute_terminator
             } {id = 11 : i32}
-            %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_25 = air.execute [%asyncToken_24] {
                 memref.dealloc %valOut_21 : memref<32x32xbf16>
                 air.execute_terminator
             } {id = 12 : i32}
-            %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_26 = air.execute [%asyncToken_24] {
                 memref.dealloc %valOut_23 : memref<32x32xbf16>
                 air.execute_terminator
             } {id = 13 : i32}
             %14 = air.wait_all async [%asyncToken_24, %asyncToken_25, %asyncToken_26] 
             scf.yield %14 : !air.async.token
         }
-        %asyncToken_19 = air.execute async [%10] : (!air.async.token) {
+        %asyncToken_19 = air.execute [%10] {
             memref.dealloc %valOut_18 : memref<32x32xbf16>
             air.execute_terminator
         } {id = 14 : i32}

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_arith_offset.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_arith_offset.mlir
@@ -62,62 +62,62 @@ module {
         %c64_11 = arith.constant 64 : index
         %c32 = arith.constant 32 : index
         %c0_12 = arith.constant 0 : index
-        %newAsyncToken_0, %newValOut_0 = air.execute async  {
+        %newAsyncToken_0, %newValOut_0 = air.execute -> (index) {
             %12 = affine.apply #map0()[%arg7]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_1, %newValOut_1 = air.execute async [%newAsyncToken_0]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_1, %newValOut_1 = air.execute [%newAsyncToken_0] -> (index) {
             %12 = affine.apply #map1()[%newValOut_0]
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_2, %newValOut_2 = air.execute async [%newAsyncToken_1]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_2, %newValOut_2 = air.execute [%newAsyncToken_1] -> (index) {
             %12 = arith.addi %newValOut_1, %c1_10 : index
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %newAsyncToken_3, %newValOut_3 = air.execute async [%newAsyncToken_2]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %newAsyncToken_3, %newValOut_3 = air.execute [%newAsyncToken_2] -> (index) {
             %12 = arith.addi %newValOut_2, %c64_11 : index
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %asyncToken_13, %valOut_14 = air.execute async [%newAsyncToken_3]  : (!air.async.token) {
+        } {id = 6 : i32}
+        %asyncToken_13, %valOut_14 = air.execute [%newAsyncToken_3] -> (index) {
             %12 = arith.muli %newValOut_3, %c32 : index
             air.execute_terminator %12 : index
-        } {id = 6 : i32} : (index)
-        %asyncToken_15, %valOut_16 = air.execute async  {
+        } {id = 6 : i32}
+        %asyncToken_15, %valOut_16 = air.execute -> (index) {
             %12 = affine.apply #map2()[%arg8]
             air.execute_terminator %12 : index
-        } {id = 7 : i32} : (index)
+        } {id = 7 : i32}
         %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-        %asyncToken_17, %valOut_18 = air.execute async  {
+        %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16>) {
             %12 = memref.alloc() : memref<32x32xbf16>
             air.execute_terminator %12 : memref<32x32xbf16>
-        } {id = 10 : i32} : (memref<32x32xbf16>)
+        } {id = 10 : i32}
         %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %8) -> (!air.async.token) {
-            %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+            %asyncToken_20, %valOut_21 = air.execute [%arg15] -> (memref<32x32xbf16>) {
                 %15 = memref.alloc() : memref<32x32xbf16>
                 air.execute_terminator %15 : memref<32x32xbf16>
-            } {id = 8 : i32} : (memref<32x32xbf16>)
-            %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+            } {id = 8 : i32}
+            %asyncToken_22, %valOut_23 = air.execute [%arg15] -> (memref<32x32xbf16>) {
                 %15 = memref.alloc() : memref<32x32xbf16>
                 air.execute_terminator %15 : memref<32x32xbf16>
-            } {id = 9 : i32} : (memref<32x32xbf16>)
+            } {id = 9 : i32}
             %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16>, memref<64x64xbf16>)
             %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set1, id = 5 : i32} : (memref<32x32xbf16>, memref<64x64xbf16>)
-            %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+            %asyncToken_24 = air.execute [%13, %arg15, %12] {
                 linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16>, memref<32x32xbf16>) outs(%valOut_18 : memref<32x32xbf16>)
                 air.execute_terminator
             } {id = 11 : i32}
-            %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_25 = air.execute [%asyncToken_24] {
                 memref.dealloc %valOut_21 : memref<32x32xbf16>
                 air.execute_terminator
             } {id = 12 : i32}
-            %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+            %asyncToken_26 = air.execute [%asyncToken_24] {
                 memref.dealloc %valOut_23 : memref<32x32xbf16>
                 air.execute_terminator
             } {id = 13 : i32}
             %14 = air.wait_all async [%asyncToken_24, %asyncToken_25, %asyncToken_26] 
             scf.yield %14 : !air.async.token
         }
-        %asyncToken_19 = air.execute async [%10] : (!air.async.token) {
+        %asyncToken_19 = air.execute [%10] {
             memref.dealloc %valOut_18 : memref<32x32xbf16>
             air.execute_terminator
         } {id = 14 : i32}

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_0.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_0.mlir
@@ -48,57 +48,57 @@ module {
     %c0 = arith.constant 0 : index
     %c512 = arith.constant 512 : index
     %c64 = arith.constant 64 : index
-    %asyncToken_1, %valOut_2 = air.execute async {
+    %asyncToken_1, %valOut_2 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 3 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_3, %valOut_4 = air.execute async {
+    } {id = 3 : i32}
+    %asyncToken_3, %valOut_4 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 4 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_5, %valOut_6 = air.execute async {
+    } {id = 4 : i32}
+    %asyncToken_5, %valOut_6 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 5 : i32} : (memref<64x64xbf16, 1>)
+    } {id = 5 : i32}
     %5 = air.herd async [%asyncToken_1, %asyncToken_3, %asyncToken_5]  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%valOut_2, %arg12=%valOut_4, %arg13=%valOut_6) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 1 : i32, sym_name = "herd_0"} {
       %c1_10 = arith.constant 1 : index
       %c64_11 = arith.constant 64 : index
       %c32 = arith.constant 32 : index
       %c0_12 = arith.constant 0 : index
-      %asyncToken_13, %valOut_14 = air.execute async  {
+      %asyncToken_13, %valOut_14 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg7]
         air.execute_terminator %12 : index
-      } {id = 6 : i32} : (index)
-      %asyncToken_15, %valOut_16 = air.execute async  {
+      } {id = 6 : i32}
+      %asyncToken_15, %valOut_16 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg8]
         air.execute_terminator %12 : index
-      } {id = 7 : i32} : (index)
+      } {id = 7 : i32}
       %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-      %asyncToken_17, %valOut_18 = air.execute async  {
+      %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16, 2>) {
         %12 = memref.alloc() : memref<32x32xbf16, 2>
         air.execute_terminator %12 : memref<32x32xbf16, 2>
-      } {id = 10 : i32} : (memref<32x32xbf16, 2>)
+      } {id = 10 : i32}
       %9 = air.dma_memcpy_nd async [%8, %asyncToken_17] (%valOut_18[] [] [], %arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
       %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %9) -> (!air.async.token) {
-        %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+        %asyncToken_20, %valOut_21 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 8 : i32} : (memref<32x32xbf16, 2>)
-        %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+        } {id = 8 : i32}
+        %asyncToken_22, %valOut_23 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 9 : i32} : (memref<32x32xbf16, 2>)
+        } {id = 9 : i32}
         %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
         %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-        %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_24 = air.execute [%13, %arg15, %12] {
           linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%valOut_18 : memref<32x32xbf16, 2>)
           air.execute_terminator
         } {id = 11 : i32}
-        %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_25 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_21 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 12 : i32}
-        %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_26 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_23 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 13 : i32}
@@ -106,7 +106,7 @@ module {
         scf.yield %14 : !air.async.token
       }
       %11 = air.dma_memcpy_nd async [%10] (%arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10], %valOut_18[] [] []) {broadcast = "both", id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-      %asyncToken_19 = air.execute async [%11]  : (!air.async.token) {
+      %asyncToken_19 = air.execute [%11] {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_1.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_1.mlir
@@ -61,57 +61,57 @@ module {
     %c0 = arith.constant 0 : index
     %c512 = arith.constant 512 : index
     %c64 = arith.constant 64 : index
-    %asyncToken_1, %valOut_2 = air.execute async {
+    %asyncToken_1, %valOut_2 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 3 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_3, %valOut_4 = air.execute async {
+    } {id = 3 : i32}
+    %asyncToken_3, %valOut_4 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 4 : i32} : (memref<64x64xbf16, 1>)
-    %asyncToken_5, %valOut_6 = air.execute async {
+    } {id = 4 : i32}
+    %asyncToken_5, %valOut_6 = air.execute -> (memref<64x64xbf16, 1>) {
       %8 = memref.alloc() : memref<64x64xbf16, 1>
       air.execute_terminator %8 : memref<64x64xbf16, 1>
-    } {id = 5 : i32} : (memref<64x64xbf16, 1>)
+    } {id = 5 : i32}
     %5 = air.herd async [%asyncToken_1, %asyncToken_3, %asyncToken_5]  tile (%arg7, %arg8) in (%arg9=%c4, %arg10=%c4) args(%arg11=%valOut_2, %arg12=%valOut_4, %arg13=%valOut_6) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 1 : i32, sym_name = "herd_0"} {
       %c1_10 = arith.constant 1 : index
       %c64_11 = arith.constant 64 : index
       %c32 = arith.constant 32 : index
       %c0_12 = arith.constant 0 : index
-      %asyncToken_13, %valOut_14 = air.execute async  {
+      %asyncToken_13, %valOut_14 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg7]
         air.execute_terminator %12 : index
-      } {id = 6 : i32} : (index)
-      %asyncToken_15, %valOut_16 = air.execute async  {
+      } {id = 6 : i32}
+      %asyncToken_15, %valOut_16 = air.execute -> (index) {
         %12 = affine.apply #map()[%arg8]
         air.execute_terminator %12 : index
-      } {id = 7 : i32} : (index)
+      } {id = 7 : i32}
       %8 = air.wait_all async [%asyncToken_13, %asyncToken_15] 
-      %asyncToken_17, %valOut_18 = air.execute async  {
+      %asyncToken_17, %valOut_18 = air.execute -> (memref<32x32xbf16, 2>) {
         %12 = memref.alloc() : memref<32x32xbf16, 2>
         air.execute_terminator %12 : memref<32x32xbf16, 2>
-      } {id = 10 : i32} : (memref<32x32xbf16, 2>)
+      } {id = 10 : i32}
       %9 = air.dma_memcpy_nd async [%8, %asyncToken_17] (%valOut_18[] [] [], %arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
       %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %9) -> (!air.async.token) {
-        %asyncToken_20, %valOut_21 = air.execute async [%arg15]  : (!air.async.token) {
+        %asyncToken_20, %valOut_21 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 8 : i32} : (memref<32x32xbf16, 2>)
-        %asyncToken_22, %valOut_23 = air.execute async [%arg15]  : (!air.async.token) {
+        } {id = 8 : i32}
+        %asyncToken_22, %valOut_23 = air.execute [%arg15] -> (memref<32x32xbf16, 2>){
           %15 = memref.alloc() : memref<32x32xbf16, 2>
           air.execute_terminator %15 : memref<32x32xbf16, 2>
-        } {id = 9 : i32} : (memref<32x32xbf16, 2>)
+        } {id = 9 : i32}
         %12 = air.dma_memcpy_nd async [%asyncToken_20, %arg15] (%valOut_21[] [] [], %arg11[%valOut_14, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
         %13 = air.dma_memcpy_nd async [%asyncToken_22, %arg15] (%valOut_23[] [] [], %arg12[%arg14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_pattern = #set0, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-        %asyncToken_24 = air.execute async [%13, %arg15, %12]  : (!air.async.token, !air.async.token, !air.async.token) {
+        %asyncToken_24 = air.execute [%13, %arg15, %12] {
           linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%valOut_21, %valOut_23 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%valOut_18 : memref<32x32xbf16, 2>)
           air.execute_terminator
         } {id = 11 : i32}
-        %asyncToken_25 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_25 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_21 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 12 : i32}
-        %asyncToken_26 = air.execute async [%asyncToken_24]  : (!air.async.token) {
+        %asyncToken_26 = air.execute [%asyncToken_24] {
           memref.dealloc %valOut_23 : memref<32x32xbf16, 2>
           air.execute_terminator
         } {id = 13 : i32}
@@ -119,7 +119,7 @@ module {
         scf.yield %14 : !air.async.token
       }
       %11 = air.dma_memcpy_nd async [%10] (%arg13[%valOut_14, %valOut_16] [%c32, %c32] [%c64_11, %c1_10], %valOut_18[] [] []) {broadcast = "both", id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-      %asyncToken_19 = air.execute async [%11]  : (!air.async.token) {
+      %asyncToken_19 = air.execute [%11] {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}


### PR DESCRIPTION
- remove camelcase from operand names
- make regions of launch, partition and herd SizedRegion<1>
- make air.execute have implicit terminator
- change air.execute syntax to be more like func.func and async.execute
- make air.channel a real symbol