### PR TITLE
Make barrier packets accept zero

### DIFF
--- a/runtime_lib/controller/main.cpp
+++ b/runtime_lib/controller/main.cpp
@@ -1584,6 +1584,9 @@ inline signal_value_t signal_wait(volatile signal_t *signal,
                                   signal_value_t compare_value,
                                   uint64_t timeout_hint,
                                   signal_value_t default_value) {
+  if (signal == 0)
+    return default_value;
+
   if (signal->handle == 0)
     return default_value;
   signal_value_t ret = 0;


### PR DESCRIPTION
Barrier packets should accept signal values of 0.

http://hsafoundation.com/wp-content/uploads/2021/02/HSA-Runtime-1.2.pdf, section 2.6.5.9:
_Signals with a handle value of 0 are allowed and are interpreted by the packet processor as satisfied dependencies._
