### PR TITLE
AIR Dependency: Make canonicalization pass compatible with AIRBERT example

### DIFF
--- a/examples/matmul_gelu/matmul_gelu.py
+++ b/examples/matmul_gelu/matmul_gelu.py
@@ -84,6 +84,7 @@ with air.mlir.ir.Context():
         "air-dependency",
         "air-dependency-schedule-opt",
         "air-specialize-dma-broadcast",
+        "air-dependency-canonicalize{dump-graph=true output-dir=dot_graphs/}"
     ])
     pm = air.mlir.passmanager.PassManager.parse(pipeline)
     pm.run(air_module)

--- a/examples/matmul_gelu/output2.mlir
+++ b/examples/matmul_gelu/output2.mlir
@@ -35,195 +35,186 @@ module attributes {torch.debug_module_name = "mmult"} {
     %c16 = arith.constant 16 : index
     %c384 = arith.constant 384 : index
     %cst = arith.constant 0.000000e+00 : bf16
-    %asyncToken, %valOut = air.execute async  {
+    %async_token, %results = air.execute -> (memref<24576x1024xbf16>) {
       %2 = memref.alloc() {alignment = 128 : i64} : memref<24576x1024xbf16>
       air.execute_terminator %2 : memref<24576x1024xbf16>
-    } {id = 1 : i32} : (memref<24576x1024xbf16>)
-    %asyncToken_0 = air.execute async [%asyncToken]  : (!air.async.token) {
-      linalg.fill ins(%cst : bf16) outs(%valOut : memref<24576x1024xbf16>)
-      air.execute_terminator
-    } {id = 2 : i32}
-    %asyncToken_1, %valOut_2 = air.execute async  {
+    }
+    %async_token_0 = air.execute [%async_token] {
+      linalg.fill ins(%cst : bf16) outs(%results : memref<24576x1024xbf16>)
+    }
+    %async_token_1, %results_2 = air.execute -> (memref<24576x1024xbf16>) {
       %2 = memref.alloc() {alignment = 128 : i64} : memref<24576x1024xbf16>
       air.execute_terminator %2 : memref<24576x1024xbf16>
-    } {id = 3 : i32} : (memref<24576x1024xbf16>)
-    %asyncToken_3 = air.execute async [%asyncToken_1, %asyncToken_0]  : (!air.async.token, !air.async.token) {
-      memref.copy %valOut, %valOut_2 : memref<24576x1024xbf16> to memref<24576x1024xbf16>
-      air.execute_terminator
-    } {id = 4 : i32}
-    %0 = air.launch async [%asyncToken_3] (%arg2, %arg3) in (%arg4=%c384, %arg5=%c16) args(%arg6=%arg0, %arg7=%arg1, %arg8=%valOut_2) : memref<24576x1024xbf16>, memref<1024x1024xbf16>, memref<24576x1024xbf16> attributes {id = 3 : i32} {
+    }
+    %async_token_3 = air.execute [%async_token_1, %async_token_0] {
+      memref.copy %results, %results_2 : memref<24576x1024xbf16> to memref<24576x1024xbf16>
+    }
+    %0 = air.launch async [%async_token_3] (%arg2, %arg3) in (%arg4=%c384, %arg5=%c16) args(%arg6=%arg0, %arg7=%arg1, %arg8=%results_2) : memref<24576x1024xbf16>, memref<1024x1024xbf16>, memref<24576x1024xbf16> attributes {id = 1 : i32} {
       %2 = air.partition async  args(%arg9=%arg2, %arg10=%arg3, %arg11=%arg4, %arg12=%arg5, %arg13=%arg6, %arg14=%arg7, %arg15=%arg8) : index, index, index, index, memref<24576x1024xbf16>, memref<1024x1024xbf16>, memref<24576x1024xbf16> attributes {id = 2 : i32} {
         %c1 = arith.constant 1 : index
         %c2 = arith.constant 2 : index
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c64 = arith.constant 64 : index
-        %asyncToken_6, %valOut_7 = air.execute async  {
+        %async_token_6, %results_7 = air.execute -> (index) {
           %7 = affine.apply #map0()[%arg9]
           air.execute_terminator %7 : index
-        } {id = 5 : i32} : (index)
-        %asyncToken_8, %valOut_9 = air.execute async  {
+        }
+        %async_token_8, %results_9 = air.execute -> (index) {
           %7 = affine.apply #map0()[%arg10]
           air.execute_terminator %7 : index
-        } {id = 6 : i32} : (index)
-        %3 = air.wait_all async [%asyncToken_6, %asyncToken_8] 
-        %asyncToken_10, %valOut_11 = air.execute async  {
+        }
+        %3 = air.wait_all async [%async_token_8, %async_token_6] 
+        %async_token_10, %results_11 = air.execute -> (memref<64x64xbf16, 1>) {
           %7 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %7 : memref<64x64xbf16, 1>
-        } {id = 9 : i32} : (memref<64x64xbf16, 1>)
-        %4 = air.dma_memcpy_nd async [%3, %asyncToken_10] (%valOut_11[] [] [], %arg15[%valOut_7, %valOut_9] [%c64, %c64] [%c1024, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
+        }
+        %4 = air.dma_memcpy_nd async [%async_token_10, %3] (%results_11[] [] [], %arg15[%results_7, %results_9] [%c64, %c64] [%c1024, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
         %5 = scf.for %arg16 = %c0 to %c1024 step %c64 iter_args(%arg17 = %4) -> (!air.async.token) {
-          %asyncToken_13, %valOut_14 = air.execute async [%arg17]  : (!air.async.token) {
+          %async_token_13, %results_14 = air.execute [%arg17] -> (memref<64x64xbf16, 1>) {
             %11 = memref.alloc() : memref<64x64xbf16, 1>
             air.execute_terminator %11 : memref<64x64xbf16, 1>
-          } {id = 7 : i32} : (memref<64x64xbf16, 1>)
-          %asyncToken_15, %valOut_16 = air.execute async [%arg17]  : (!air.async.token) {
+          }
+          %async_token_15, %results_16 = air.execute [%arg17] -> (memref<64x64xbf16, 1>) {
             %11 = memref.alloc() : memref<64x64xbf16, 1>
             air.execute_terminator %11 : memref<64x64xbf16, 1>
-          } {id = 8 : i32} : (memref<64x64xbf16, 1>)
-          %7 = air.dma_memcpy_nd async [%asyncToken_13, %arg17] (%valOut_14[] [] [], %arg13[%valOut_7, %arg16] [%c64, %c64] [%c1024, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
-          %8 = air.dma_memcpy_nd async [%asyncToken_15, %arg17] (%valOut_16[] [] [], %arg14[%arg16, %valOut_9] [%c64, %c64] [%c1024, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<1024x1024xbf16>)
-          %9 = air.herd @herd_0 async [%8, %arg17, %7]  tile (%arg18, %arg19) in (%arg20=%c2, %arg21=%c2) args(%arg22=%valOut_14, %arg23=%valOut_16, %arg24=%valOut_11) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 1 : i32} {
+          }
+          %7 = air.dma_memcpy_nd async [%async_token_13] (%results_14[] [] [], %arg13[%results_7, %arg16] [%c64, %c64] [%c1024, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
+          %8 = air.dma_memcpy_nd async [%async_token_15] (%results_16[] [] [], %arg14[%arg16, %results_9] [%c64, %c64] [%c1024, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<1024x1024xbf16>)
+          %9 = air.herd @herd_0 async [%8, %7]  tile (%arg18, %arg19) in (%arg20=%c2, %arg21=%c2) args(%arg22=%results_14, %arg23=%results_16, %arg24=%results_11) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 3 : i32} {
             %c1_19 = arith.constant 1 : index
             %c0_20 = arith.constant 0 : index
             %c64_21 = arith.constant 64 : index
             %c32 = arith.constant 32 : index
-            %asyncToken_22, %valOut_23 = air.execute async  {
+            %async_token_22, %results_23 = air.execute -> (index) {
               %15 = affine.apply #map1()[%arg18]
               air.execute_terminator %15 : index
-            } {id = 10 : i32} : (index)
-            %asyncToken_24, %valOut_25 = air.execute async  {
+            }
+            %async_token_24, %results_25 = air.execute -> (index) {
               %15 = affine.apply #map1()[%arg19]
               air.execute_terminator %15 : index
-            } {id = 11 : i32} : (index)
-            %11 = air.wait_all async [%asyncToken_22, %asyncToken_24] 
-            %asyncToken_26, %valOut_27 = air.execute async  {
+            }
+            %11 = air.wait_all async [%async_token_24, %async_token_22] 
+            %async_token_26, %results_27 = air.execute -> (memref<32x32xbf16, 2>) {
               %15 = memref.alloc() : memref<32x32xbf16, 2>
               air.execute_terminator %15 : memref<32x32xbf16, 2>
-            } {id = 14 : i32} : (memref<32x32xbf16, 2>)
-            %12 = air.dma_memcpy_nd async [%11, %asyncToken_26] (%valOut_27[] [] [], %arg24[%valOut_23, %valOut_25] [%c32, %c32] [%c64_21, %c1_19]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+            }
+            %12 = air.dma_memcpy_nd async [%async_token_26, %11] (%results_27[] [] [], %arg24[%results_23, %results_25] [%c32, %c32] [%c64_21, %c1_19]) {id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
             %13 = scf.for %arg25 = %c0_20 to %c64_21 step %c32 iter_args(%arg26 = %12) -> (!air.async.token) {
-              %asyncToken_29, %valOut_30 = air.execute async [%arg26]  : (!air.async.token) {
+              %async_token_29, %results_30 = air.execute [%arg26] -> (memref<32x32xbf16, 2>) {
                 %18 = memref.alloc() : memref<32x32xbf16, 2>
                 air.execute_terminator %18 : memref<32x32xbf16, 2>
-              } {id = 12 : i32} : (memref<32x32xbf16, 2>)
-              %asyncToken_31, %valOut_32 = air.execute async [%arg26]  : (!air.async.token) {
+              }
+              %async_token_31, %results_32 = air.execute [%arg26] -> (memref<32x32xbf16, 2>) {
                 %18 = memref.alloc() : memref<32x32xbf16, 2>
                 air.execute_terminator %18 : memref<32x32xbf16, 2>
-              } {id = 13 : i32} : (memref<32x32xbf16, 2>)
+              }
               %15 = affine.if #set0()[%arg18, %arg19] -> !air.async.token {
                 %c0_36 = arith.constant 0 : index
-                %18 = air.dma_memcpy_nd async [%asyncToken_29, %arg26] (%valOut_30[] [] [], %arg22[%c0_36, %arg25] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set0} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+                %18 = air.dma_memcpy_nd async [%async_token_29] (%results_30[] [] [], %arg22[%c0_36, %arg25] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set0, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
                 affine.yield %18 : !air.async.token
               } else {
                 %c32_36 = arith.constant 32 : index
-                %18 = air.dma_memcpy_nd async [%asyncToken_29, %arg26] (%valOut_30[] [] [], %arg22[%c32_36, %arg25] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set1} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+                %18 = air.dma_memcpy_nd async [%async_token_29] (%results_30[] [] [], %arg22[%c32_36, %arg25] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set1, id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
                 affine.yield %18 : !air.async.token
               }
               %16 = affine.if #set2()[%arg18, %arg19] -> !air.async.token {
                 %c0_36 = arith.constant 0 : index
-                %18 = air.dma_memcpy_nd async [%asyncToken_31, %arg26] (%valOut_32[] [] [], %arg23[%arg25, %c0_36] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set2} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+                %18 = air.dma_memcpy_nd async [%async_token_31] (%results_32[] [] [], %arg23[%arg25, %c0_36] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set2, id = 7 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
                 affine.yield %18 : !air.async.token
               } else {
                 %c32_36 = arith.constant 32 : index
-                %18 = air.dma_memcpy_nd async [%asyncToken_31, %arg26] (%valOut_32[] [] [], %arg23[%arg25, %c32_36] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set3} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+                %18 = air.dma_memcpy_nd async [%async_token_31] (%results_32[] [] [], %arg23[%arg25, %c32_36] [%c32, %c32] [%c64_21, %c1_19]) {broadcast_set = #set3, id = 8 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
                 affine.yield %18 : !air.async.token
               }
-              %asyncToken_33 = air.execute async [%16, %arg26, %15]  : (!air.async.token, !air.async.token, !air.async.token) {
-                linalg.matmul ins(%valOut_30, %valOut_32 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%valOut_27 : memref<32x32xbf16, 2>)
-                air.execute_terminator
-              } {id = 15 : i32}
-              %asyncToken_34 = air.execute async [%asyncToken_33]  : (!air.async.token) {
-                memref.dealloc %valOut_30 : memref<32x32xbf16, 2>
-                air.execute_terminator
-              } {id = 16 : i32}
-              %asyncToken_35 = air.execute async [%asyncToken_33]  : (!air.async.token) {
-                memref.dealloc %valOut_32 : memref<32x32xbf16, 2>
-                air.execute_terminator
-              } {id = 17 : i32}
-              %17 = air.wait_all async [%asyncToken_33, %asyncToken_34, %asyncToken_35] 
+              %async_token_33 = air.execute [%16, %15] {
+                linalg.matmul ins(%results_30, %results_32 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%results_27 : memref<32x32xbf16, 2>)
+              }
+              %async_token_34 = air.execute [%async_token_33] {
+                memref.dealloc %results_30 : memref<32x32xbf16, 2>
+              }
+              %async_token_35 = air.execute [%async_token_33] {
+                memref.dealloc %results_32 : memref<32x32xbf16, 2>
+              }
+              %17 = air.wait_all async [%async_token_35, %async_token_34] 
               scf.yield %17 : !air.async.token
             }
-            %14 = air.dma_memcpy_nd async [%13] (%arg24[%valOut_23, %valOut_25] [%c32, %c32] [%c64_21, %c1_19], %valOut_27[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-            %asyncToken_28 = air.execute async [%14]  : (!air.async.token) {
-              memref.dealloc %valOut_27 : memref<32x32xbf16, 2>
-              air.execute_terminator
-            } {id = 18 : i32}
+            %14 = air.dma_memcpy_nd async [%13] (%arg24[%results_23, %results_25] [%c32, %c32] [%c64_21, %c1_19], %results_27[] [] []) {id = 9 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
+            %async_token_28 = air.execute [%14] {
+              memref.dealloc %results_27 : memref<32x32xbf16, 2>
+            }
             air.herd_terminator
           }
-          %asyncToken_17 = air.execute async [%9]  : (!air.async.token) {
-            memref.dealloc %valOut_14 : memref<64x64xbf16, 1>
-            air.execute_terminator
-          } {id = 19 : i32}
-          %asyncToken_18 = air.execute async [%9]  : (!air.async.token) {
-            memref.dealloc %valOut_16 : memref<64x64xbf16, 1>
-            air.execute_terminator
-          } {id = 20 : i32}
-          %10 = air.wait_all async [%9, %asyncToken_17, %asyncToken_18] 
+          %async_token_17 = air.execute [%9] {
+            memref.dealloc %results_14 : memref<64x64xbf16, 1>
+          }
+          %async_token_18 = air.execute [%9] {
+            memref.dealloc %results_16 : memref<64x64xbf16, 1>
+          }
+          %10 = air.wait_all async [%async_token_18, %async_token_17] 
           scf.yield %10 : !air.async.token
         }
-        %6 = air.dma_memcpy_nd async [%5] (%arg15[%valOut_7, %valOut_9] [%c64, %c64] [%c1024, %c1], %valOut_11[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
-        %asyncToken_12 = air.execute async [%6]  : (!air.async.token) {
-          memref.dealloc %valOut_11 : memref<64x64xbf16, 1>
-          air.execute_terminator
-        } {id = 21 : i32}
+        %6 = air.dma_memcpy_nd async [%5] (%arg15[%results_7, %results_9] [%c64, %c64] [%c1024, %c1], %results_11[] [] []) {id = 10 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
+        %async_token_12 = air.execute [%6] {
+          memref.dealloc %results_11 : memref<64x64xbf16, 1>
+        }
         air.partition_terminator
       }
       air.launch_terminator
     }
-    %asyncToken_4, %valOut_5 = air.execute async  {
+    %async_token_4, %results_5 = air.execute -> (memref<24576x1024xbf16>) {
       %2 = memref.alloc() {alignment = 128 : i64} : memref<24576x1024xbf16>
       air.execute_terminator %2 : memref<24576x1024xbf16>
-    } {id = 22 : i32} : (memref<24576x1024xbf16>)
-    %1 = air.launch async [%asyncToken_4, %0] (%arg2, %arg3) in (%arg4=%c384, %arg5=%c16) args(%arg6=%valOut_2, %arg7=%valOut_5) : memref<24576x1024xbf16>, memref<24576x1024xbf16> attributes {id = 6 : i32} {
+    }
+    %1 = air.launch async [%async_token_4, %0] (%arg2, %arg3) in (%arg4=%c384, %arg5=%c16) args(%arg6=%results_2, %arg7=%results_5) : memref<24576x1024xbf16>, memref<24576x1024xbf16> attributes {id = 4 : i32} {
       %2 = air.partition async  args(%arg8=%arg2, %arg9=%arg3, %arg10=%arg4, %arg11=%arg5, %arg12=%arg6, %arg13=%arg7) : index, index, index, index, memref<24576x1024xbf16>, memref<24576x1024xbf16> attributes {id = 5 : i32} {
         %c1 = arith.constant 1 : index
         %c1024 = arith.constant 1024 : index
         %c64 = arith.constant 64 : index
         %c2 = arith.constant 2 : index
-        %asyncToken_6, %valOut_7 = air.execute async  {
+        %async_token_6, %results_7 = air.execute -> (index) {
           %6 = affine.apply #map0()[%arg8]
           air.execute_terminator %6 : index
-        } {id = 23 : i32} : (index)
-        %asyncToken_8, %valOut_9 = air.execute async  {
+        }
+        %async_token_8, %results_9 = air.execute -> (index) {
           %6 = affine.apply #map0()[%arg9]
           air.execute_terminator %6 : index
-        } {id = 24 : i32} : (index)
-        %asyncToken_10, %valOut_11 = air.execute async  {
+        }
+        %async_token_10, %results_11 = air.execute -> (memref<64x64xbf16, 1>) {
           %6 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %6 : memref<64x64xbf16, 1>
-        } {id = 25 : i32} : (memref<64x64xbf16, 1>)
-        %asyncToken_12, %valOut_13 = air.execute async  {
+        }
+        %async_token_12, %results_13 = air.execute -> (memref<64x64xbf16, 1>) {
           %6 = memref.alloc() : memref<64x64xbf16, 1>
           air.execute_terminator %6 : memref<64x64xbf16, 1>
-        } {id = 26 : i32} : (memref<64x64xbf16, 1>)
-        %3 = air.dma_memcpy_nd async [%asyncToken_10, %asyncToken_8, %asyncToken_6] (%valOut_11[] [] [], %arg12[%valOut_7, %valOut_9] [%c64, %c64] [%c1024, %c1]) {id = 9 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
-        %4 = air.herd @herd_1 async [%3]  tile (%arg14, %arg15) in (%arg16=%c2, %arg17=%c2) args(%arg18=%valOut_11, %arg19=%valOut_13) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 4 : i32} {
+        }
+        %3 = air.dma_memcpy_nd async [%async_token_10, %async_token_8, %async_token_6] (%results_11[] [] [], %arg12[%results_7, %results_9] [%c64, %c64] [%c1024, %c1]) {id = 11 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
+        %4 = air.herd @herd_1 async [%async_token_12, %3]  tile (%arg14, %arg15) in (%arg16=%c2, %arg17=%c2) args(%arg18=%results_11, %arg19=%results_13) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 6 : i32} {
           %c1_16 = arith.constant 1 : index
           %c64_17 = arith.constant 64 : index
           %c32 = arith.constant 32 : index
           %cst_18 = arith.constant 2.000000e+00 : bf16
           %cst_19 = arith.constant 1.000000e+00 : bf16
           %cst_20 = arith.constant 5.000000e-01 : bf16
-          %asyncToken_21, %valOut_22 = air.execute async  {
+          %async_token_21, %results_22 = air.execute -> (index) {
             %8 = affine.apply #map1()[%arg14]
             air.execute_terminator %8 : index
-          } {id = 27 : i32} : (index)
-          %asyncToken_23, %valOut_24 = air.execute async  {
+          }
+          %async_token_23, %results_24 = air.execute -> (index) {
             %8 = affine.apply #map1()[%arg15]
             air.execute_terminator %8 : index
-          } {id = 28 : i32} : (index)
-          %asyncToken_25, %valOut_26 = air.execute async  {
+          }
+          %async_token_25, %results_26 = air.execute -> (memref<32x32xbf16, 2>) {
             %8 = memref.alloc() : memref<32x32xbf16, 2>
             air.execute_terminator %8 : memref<32x32xbf16, 2>
-          } {id = 29 : i32} : (memref<32x32xbf16, 2>)
-          %asyncToken_27, %valOut_28 = air.execute async  {
+          }
+          %async_token_27, %results_28 = air.execute -> (memref<32x32xbf16, 2>) {
             %8 = memref.alloc() : memref<32x32xbf16, 2>
             air.execute_terminator %8 : memref<32x32xbf16, 2>
-          } {id = 30 : i32} : (memref<32x32xbf16, 2>)
-          %6 = air.dma_memcpy_nd async [%asyncToken_25, %asyncToken_23, %asyncToken_21] (%valOut_26[] [] [], %arg18[%valOut_22, %valOut_24] [%c32, %c32] [%c64_17, %c1_16]) {id = 11 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-          %asyncToken_29 = air.execute async [%6]  : (!air.async.token) {
-            linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%valOut_26 : memref<32x32xbf16, 2>) outs(%valOut_28 : memref<32x32xbf16, 2>) {
+          }
+          %6 = air.dma_memcpy_nd async [%async_token_25, %async_token_23, %async_token_21] (%results_26[] [] [], %arg18[%results_22, %results_24] [%c32, %c32] [%c64_17, %c1_16]) {id = 12 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+          %async_token_29 = air.execute [%async_token_27, %6] {
+            linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%results_26 : memref<32x32xbf16, 2>) outs(%results_28 : memref<32x32xbf16, 2>) {
             ^bb0(%arg20: bf16, %arg21: bf16):
               %8 = math.sqrt %cst_18 : bf16
               %9 = arith.divf %arg20, %8 : bf16
@@ -233,32 +224,27 @@ module attributes {torch.debug_module_name = "mmult"} {
               %13 = arith.mulf %arg20, %12 : bf16
               linalg.yield %13 : bf16
             }
-            air.execute_terminator
-          } {id = 31 : i32}
-          %7 = air.dma_memcpy_nd async [%asyncToken_29] (%arg19[%valOut_22, %valOut_24] [%c32, %c32] [%c64_17, %c1_16], %valOut_28[] [] []) {id = 13 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-          %asyncToken_30 = air.execute async [%asyncToken_29]  : (!air.async.token) {
-            memref.dealloc %valOut_26 : memref<32x32xbf16, 2>
-            air.execute_terminator
-          } {id = 32 : i32}
-          %asyncToken_31 = air.execute async [%7]  : (!air.async.token) {
-            memref.dealloc %valOut_28 : memref<32x32xbf16, 2>
-            air.execute_terminator
-          } {id = 33 : i32}
+          }
+          %7 = air.dma_memcpy_nd async [%async_token_29] (%arg19[%results_22, %results_24] [%c32, %c32] [%c64_17, %c1_16], %results_28[] [] []) {id = 13 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
+          %async_token_30 = air.execute [%async_token_29] {
+            memref.dealloc %results_26 : memref<32x32xbf16, 2>
+          }
+          %async_token_31 = air.execute [%7] {
+            memref.dealloc %results_28 : memref<32x32xbf16, 2>
+          }
           air.herd_terminator
         }
-        %5 = air.dma_memcpy_nd async [%4] (%arg13[%valOut_7, %valOut_9] [%c64, %c64] [%c1024, %c1], %valOut_13[] [] []) {id = 14 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
-        %asyncToken_14 = air.execute async [%4]  : (!air.async.token) {
-          memref.dealloc %valOut_11 : memref<64x64xbf16, 1>
-          air.execute_terminator
-        } {id = 34 : i32}
-        %asyncToken_15 = air.execute async [%5]  : (!air.async.token) {
-          memref.dealloc %valOut_13 : memref<64x64xbf16, 1>
-          air.execute_terminator
-        } {id = 35 : i32}
+        %5 = air.dma_memcpy_nd async [%4] (%arg13[%results_7, %results_9] [%c64, %c64] [%c1024, %c1], %results_13[] [] []) {id = 14 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
+        %async_token_14 = air.execute [%4] {
+          memref.dealloc %results_11 : memref<64x64xbf16, 1>
+        }
+        %async_token_15 = air.execute [%5] {
+          memref.dealloc %results_13 : memref<64x64xbf16, 1>
+        }
         air.partition_terminator
       }
       air.launch_terminator
     }
-    return %valOut_5 : memref<24576x1024xbf16>
+    return %results_5 : memref<24576x1024xbf16>
   }
 }

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -768,7 +768,7 @@ def AIRDependencyScheduleOpt: Pass<"air-dependency-schedule-opt", "ModuleOp"> {
   }];
 }
 
-def AIRDependencyCanonicalize: Pass<"air-dependency-canonicalize", "func::FuncOp"> {
+def AIRDependencyCanonicalize: Pass<"air-dependency-canonicalize", "ModuleOp"> {
   let summary = "Canonicalize the dependency graph";
   let constructor = "xilinx::air::createAIRDependencyCanonicalizePass()";
   let description = [{
@@ -777,7 +777,10 @@ def AIRDependencyCanonicalize: Pass<"air-dependency-canonicalize", "func::FuncOp
   }];
   let options = [
     Option<"clDumpGraph", "dump-graph", "bool", /*default=*/"false",
-            "Dump post-canonicalization dot graphs.">
+            "Dump post-canonicalization dot graphs.">,
+    Option<"clDumpDir", "output-dir", "std::string", 
+            /*default=*/"\"\"",
+            "Target directory to dump dot graphs.">
   ];
 }
 

--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -163,14 +163,26 @@ class dependencyCanonicalizer {
 
 public:
   void parseCommandGraphs(func::FuncOp &toplevel, dependencyGraph &global_graph,
-                          dependencyContext &dep_ctx);
+                          dependencyContext &dep_ctx, bool dump_dot = false,
+                          std::string dump_dir = "");
   void canonicalizeGraphs(dependencyGraph &global_graph,
                           dependencyGraph &tr_graph,
                           vertex_to_vertex_map_tree &g_to_tr,
-                          bool dump_graph = false);
+                          bool dump_graph = false, std::string dump_dir = "");
   void updateDepList(func::FuncOp func, dependencyGraph &global_graph);
+  void removeDepListRepitition(func::FuncOp func);
+  void removeRedundantWaitAllOps(func::FuncOp func);
+  void dumpDotGraphFiles(dependencyGraph global_graph,
+                         std::string dump_dir = "");
 
 private:
+  void addVerticesInHerd(std::vector<dependencyGraph> &herd_subgraphs,
+                         air::HerdOp herd, dependencyContext &dep_ctx);
+  void addVerticesInPartition(std::vector<dependencyGraph> &part_subgraphs,
+                              air::PartitionOp partition,
+                              dependencyContext &dep_ctx);
+  void addVerticesInLaunch(std::vector<dependencyGraph> &launch_subgraphs,
+                           air::LaunchOp launch, dependencyContext &dep_ctx);
   Graph::vertex_descriptor addVertexFromOpImpls(Operation *op, Graph &G,
                                                 dependencyContext &dep_ctx);
   Graph::vertex_descriptor addVertexFromOp(Operation *op, uint64_t &id,
@@ -188,6 +200,8 @@ private:
   Graph::vertex_descriptor
   addVertexFromTerminatorOp(Operation *op, Graph &G,
                             dependencyContext &dep_ctx);
+  Graph::vertex_descriptor addVertexFromReduceOp(Operation *op, Graph &G,
+                                                 dependencyContext &dep_ctx);
   Graph::vertex_descriptor addVertexFromExecuteOp(xilinx::air::ExecuteOp op,
                                                   Graph &G,
                                                   dependencyContext &dep_ctx);
@@ -204,7 +218,7 @@ private:
                                   dependencyContext dep_ctx);
   void connectOpToItsDepList(Operation *op, SmallVector<Value, 1> dep_list,
                              Graph &g, dependencyContext dep_ctx);
-  std::vector<Operation *> traceOpFromToken(Value dep_token);
+  std::vector<Operation *> traceOpFromToken(Operation *op, Value dep_token);
   void connectTerminatorInGraph(Graph &g);
   void connectStartNodeInCommandGraph(dependencyGraph &G);
   void updatePointerFromGraphToHierarchyTerminator(dependencyGraph &G);

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -52,6 +52,8 @@ uint64_t getTensorVolume(const Type ty);
 
 scf::ForOp getForRegionIterArgsOwner(Value val);
 
+scf::ParallelOp getParallelRegionInitValsOwner(Operation *op, Value val);
+
 air::HerdOp getHerdArgOwner(Value val);
 
 air::HierarchyInterface getHierarchyArgOwner(Value val);
@@ -59,6 +61,8 @@ air::HierarchyInterface getHierarchyArgOwner(Value val);
 int getIdAttr(Operation *op);
 
 void renumberDmaOps(func::FuncOp func, std::string mode = "herd");
+
+std::string to_string(Operation *op);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -639,56 +639,6 @@ public:
         }
       });
     }
-
-    // Final traversal: Clean up
-    // Remove repetition in dependency list.
-    for (auto f : module.getOps<func::FuncOp>()) {
-      f.walk([&](Operation *op) {
-        if (auto async_op = dyn_cast<air::AsyncOpInterface>(op)) {
-          if (async_op.getAsyncDependencies().size() >= 1) {
-            auto dependency_list = async_op.getAsyncDependencies();
-            // Initialize repetition mask
-            std::vector<bool> hasRepeat;
-            for (auto i = dependency_list.begin(); i != dependency_list.end();
-                 ++i) {
-              hasRepeat.push_back(false);
-            }
-            // Iterate the dependency list
-            for (unsigned i = 0; i < dependency_list.size(); i++) {
-              for (unsigned j = i + 1; j < dependency_list.size(); j++) {
-                if (dependency_list[i] == dependency_list[j]) {
-                  hasRepeat[j] = true;
-                }
-              }
-            }
-            for (int i = dependency_list.size() - 1; i >= 0; i--) {
-              if (hasRepeat[i]) {
-                async_op.eraseAsyncDependency(i);
-              }
-            }
-          }
-        }
-      });
-    }
-
-    // Remove wait_all with single operand.
-    // Remove wait_all's id attribute.
-    for (auto f : module.getOps<func::FuncOp>()) {
-      f.walk([&](Operation *op) {
-        if (air::WaitAllOp wa_op = dyn_cast<air::WaitAllOp>(op)) {
-          if (wa_op.getAsyncDependencies().size() == 1) {
-            wa_op.getAsyncToken().replaceAllUsesWith(
-                wa_op.getAsyncDependencies()[0]);
-            wa_op.erase();
-          } else {
-            wa_op->removeAttr("id");
-          }
-        }
-      });
-    }
-
-    // Dump graph
-    dump_graph("out.dot");
   }
 
 private:

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -53,19 +53,25 @@ public:
   }
 
   void runOnOperation() override {
-    auto func = getOperation();
+    auto module = getOperation();
 
-    // Parse dependency graphs
-    hostGraph = dependencyGraph(func, true);
-    canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx);
+    for (auto func : module.getOps<func::FuncOp>()) {
+      // Parse dependency graphs
+      hostGraph = dependencyGraph(func, true);
+      canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx);
 
-    // Transitive reduction
-    xilinx::air::dependencyGraph trHostGraph;
-    canonicalizer.canonicalizeGraphs(hostGraph, trHostGraph, g_to_tr,
-                                     clDumpGraph);
+      // Transitive reduction
+      xilinx::air::dependencyGraph trHostGraph;
+      canonicalizer.canonicalizeGraphs(hostGraph, trHostGraph, g_to_tr,
+                                       clDumpGraph, clDumpDir);
 
-    // Update dependency list
-    canonicalizer.updateDepList(func, trHostGraph);
+      // Update dependency list
+      canonicalizer.updateDepList(func, trHostGraph);
+
+      // Clean up
+      canonicalizer.removeDepListRepitition(func);
+      canonicalizer.removeRedundantWaitAllOps(func);
+    }
   }
 
 private:

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -206,6 +206,17 @@ scf::ForOp getForRegionIterArgsOwner(Value val) {
   return dyn_cast<scf::ForOp>(containingOp);
 }
 
+// Get the parent scf.parallel op of an init_val
+scf::ParallelOp getParallelRegionInitValsOwner(Operation *op, Value val) {
+  if (auto parent_parallel_op = op->getParentOfType<scf::ParallelOp>()) {
+    for (auto init_val : parent_parallel_op.getInitVals()) {
+      if (init_val == val)
+        return parent_parallel_op;
+    }
+  }
+  return scf::ParallelOp();
+}
+
 // Get the parent air.launch_herd op of a tile id
 air::HerdOp getHerdArgOwner(Value val) {
   auto ivArg = val.dyn_cast<BlockArgument>();
@@ -261,6 +272,11 @@ void renumberDmaOps(func::FuncOp func, std::string mode = "herd") {
     }
   } else
     assert(false && "Unknown dma renumber mode. Supported modes: global, herd");
+}
+
+// Get op type as string
+std::string to_string(Operation *op) {
+  return op->getName().getStringRef().str();
 }
 
 } // namespace air

--- a/mlir/test/Transform/AIRDependencyCanonicalization/broadcast_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/broadcast_dma.mlir
@@ -1,0 +1,162 @@
+//===- broadcast_dma.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Xilinx Inc.
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
+
+// Prune redundant dependency edges when affine if-based broadcast pattern exists
+// CHECK: %[[EVENT0:.*]] = scf.for{{.*}}iter_args(%[[EVENT1:.*]] = 
+// CHECK: %[[EVENT2:.*]], %[[VALUE0:.*]] = air.execute [%[[EVENT1]]]
+// CHECK: %[[EVENT3:.*]], %[[VALUE1:.*]] = air.execute [%[[EVENT1]]]
+// CHECK: %[[EVENT4:.*]], %[[VALUE2:.*]] = air.execute [%[[EVENT1]]]
+// CHECK-NOT: %[[EVENT5:.*]] = air.dma_memcpy_nd async [%[[EVENT2]], %[[EVENT1]]]
+// CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [%[[EVENT2]]]
+// CHECK-NOT: %[[EVENT6:.*]] = air.dma_memcpy_nd async [%[[EVENT3]], %[[EVENT1]]]
+// CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [%[[EVENT3]]]
+// CHECK-NOT: %[[EVENT7:.*]] = air.dma_memcpy_nd async [%[[EVENT4]], %[[EVENT1]]]
+// CHECK: %[[EVENT7:.*]] = air.dma_memcpy_nd async [%[[EVENT4]]]
+
+#map = affine_map<()[s0] -> (s0 * 32)>
+#set0 = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
+#set1 = affine_set<()[s0, s1] : (s0 - 1 == 0, s1 >= 0, -s1 + 1 >= 0)>
+#set2 = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 1 >= 0, s1 == 0)>
+#set3 = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 1 >= 0, s1 - 1 == 0)>
+module {
+  func.func @matmul(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg2: memref<512x512xbf16>) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0 = arith.constant 0 : index
+    %c512 = arith.constant 512 : index
+    %c64 = arith.constant 64 : index
+    %async_token, %results = air.execute -> (memref<512x512xbf16>) {
+      %1 = memref.alloc() {alignment = 128 : i64} : memref<512x512xbf16>
+      air.execute_terminator %1 : memref<512x512xbf16>
+    } {id = 1 : i32}
+    %async_token_0 = air.execute [%async_token] {
+      memref.copy %arg2, %results : memref<512x512xbf16> to memref<512x512xbf16>
+    } {id = 2 : i32}
+    %0 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c512, %c512) step (%c64, %c64) init (%async_token_0) -> !air.async.token {
+      %1 = scf.for %arg5 = %c0 to %c512 step %c64 iter_args(%arg6 = %async_token_0) -> (!air.async.token) {
+        %async_token_1, %results_2 = air.execute [%arg6] -> (memref<64x64xbf16, 1>) {
+          %8 = memref.alloc() : memref<64x64xbf16, 1>
+          air.execute_terminator %8 : memref<64x64xbf16, 1>
+        } {id = 3 : i32}
+        %async_token_3, %results_4 = air.execute [%arg6] -> (memref<64x64xbf16, 1>) {
+          %8 = memref.alloc() : memref<64x64xbf16, 1>
+          air.execute_terminator %8 : memref<64x64xbf16, 1>
+        } {id = 4 : i32}
+        %async_token_5, %results_6 = air.execute [%arg6] -> (memref<64x64xbf16, 1>) {
+          %8 = memref.alloc() : memref<64x64xbf16, 1>
+          air.execute_terminator %8 : memref<64x64xbf16, 1>
+        } {id = 5 : i32}
+        %2 = air.dma_memcpy_nd async [%async_token_1] (%results_2[] [] [], %arg0[%arg3, %arg5] [%c64, %c64] [%c512, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+        %3 = air.dma_memcpy_nd async [%async_token_3] (%results_4[] [] [], %arg1[%arg5, %arg4] [%c64, %c64] [%c512, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+        %4 = air.dma_memcpy_nd async [%async_token_5, %arg6] (%results_6[] [] [], %results[%arg3, %arg4] [%c64, %c64] [%c512, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+        %5 = air.herd @herd_0 async [%3, %2, %4]  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results_2, %arg12=%results_4, %arg13=%results_6) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {id = 1 : i32} {
+          %c1_10 = arith.constant 1 : index
+          %c64_11 = arith.constant 64 : index
+          %c32 = arith.constant 32 : index
+          %c0_12 = arith.constant 0 : index
+          %async_token_13, %results_14 = air.execute -> (index) {
+            %12 = affine.apply #map()[%arg7]
+            air.execute_terminator %12 : index
+          } {id = 6 : i32}
+          %async_token_15, %results_16 = air.execute -> (index) {
+            %12 = affine.apply #map()[%arg8]
+            air.execute_terminator %12 : index
+          } {id = 7 : i32}
+          %8 = air.wait_all async [%async_token_13, %async_token_15] 
+          %async_token_17, %results_18 = air.execute -> (memref<32x32xbf16, 2>) {
+            %12 = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %12 : memref<32x32xbf16, 2>
+          } {id = 10 : i32}
+          %9 = air.dma_memcpy_nd async [%8, %async_token_17] (%results_18[] [] [], %arg13[%results_14, %results_16] [%c32, %c32] [%c64_11, %c1_10]) {id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+          %10 = scf.for %arg14 = %c0_12 to %c64_11 step %c32 iter_args(%arg15 = %9) -> (!air.async.token) {
+            %async_token_20, %results_21 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
+              %15 = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %15 : memref<32x32xbf16, 2>
+            } {id = 8 : i32}
+            %async_token_22, %results_23 = air.execute [%arg15] -> (memref<32x32xbf16, 2>) {
+              %15 = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %15 : memref<32x32xbf16, 2>
+            } {id = 9 : i32}
+            %12 = affine.if #set0()[%arg7, %arg8] -> !air.async.token {
+              %c0_27 = arith.constant 0 : index
+              %15 = air.dma_memcpy_nd async [%async_token_20, %arg15] (%results_21[] [] [], %arg11[%c0_27, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_set = #set0, id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+              affine.yield %15 : !air.async.token
+            } else {
+              %c32_27 = arith.constant 32 : index
+              %15 = air.dma_memcpy_nd async [%async_token_20, %arg15] (%results_21[] [] [], %arg11[%c32_27, %arg14] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_set = #set1, id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+              affine.yield %15 : !air.async.token
+            }
+            %13 = affine.if #set2()[%arg7, %arg8] -> !air.async.token {
+              %c0_27 = arith.constant 0 : index
+              %15 = air.dma_memcpy_nd async [%async_token_22, %arg15] (%results_23[] [] [], %arg12[%arg14, %c0_27] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_set = #set2, id = 7 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+              affine.yield %15 : !air.async.token
+            } else {
+              %c32_27 = arith.constant 32 : index
+              %15 = air.dma_memcpy_nd async [%async_token_22, %arg15] (%results_23[] [] [], %arg12[%arg14, %c32_27] [%c32, %c32] [%c64_11, %c1_10]) {broadcast_set = #set3, id = 8 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+              affine.yield %15 : !air.async.token
+            }
+            %async_token_24 = air.execute [%13, %arg15, %12] {
+              linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_21, %results_23 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%results_18 : memref<32x32xbf16, 2>)
+            } {id = 11 : i32}
+            %async_token_25 = air.execute [%async_token_24] {
+              memref.dealloc %results_21 : memref<32x32xbf16, 2>
+            } {id = 12 : i32}
+            %async_token_26 = air.execute [%async_token_24] {
+              memref.dealloc %results_23 : memref<32x32xbf16, 2>
+            } {id = 13 : i32}
+            %14 = air.wait_all async [%async_token_24, %async_token_25, %async_token_26] 
+            scf.yield %14 : !air.async.token
+          }
+          %11 = air.dma_memcpy_nd async [%10] (%arg13[%results_14, %results_16] [%c32, %c32] [%c64_11, %c1_10], %results_18[] [] []) {broadcast = "both", id = 9 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
+          %async_token_19 = air.execute [%11] {
+            memref.dealloc %results_18 : memref<32x32xbf16, 2>
+          } {id = 14 : i32}
+          air.herd_terminator
+        }
+        %6 = air.dma_memcpy_nd async [%5] (%results[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %results_6[] [] []) {id = 10 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
+        %async_token_7 = air.execute [%5] {
+          memref.dealloc %results_2 : memref<64x64xbf16, 1>
+        } {id = 15 : i32}
+        %async_token_8 = air.execute [%5] {
+          memref.dealloc %results_4 : memref<64x64xbf16, 1>
+        } {id = 16 : i32}
+        %async_token_9 = air.execute [%6] {
+          memref.dealloc %results_6 : memref<64x64xbf16, 1>
+        } {id = 17 : i32}
+        %7 = air.wait_all async [%async_token_7, %async_token_8, %async_token_9] 
+        scf.yield %7 : !air.async.token
+      }
+      scf.reduce(%1)  : !air.async.token {
+      ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+        %2 = air.wait_all async [%arg5, %arg6] 
+        scf.reduce.return %2 : !air.async.token
+      }
+      scf.yield
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyCanonicalization/herd_only.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/herd_only.mlir
@@ -1,0 +1,124 @@
+//===- herd_only.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Xilinx Inc.
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
+
+// Prune redundant dependency edges, when there are only air herds
+// CHECK: %[[EVENT0:.*]] = scf.for{{.*}}iter_args(%[[EVENT1:.*]] = 
+// CHECK: %[[EVENT2:.*]], %[[VALUE0:.*]] = air.execute [%[[EVENT1]]]
+// CHECK: %[[EVENT3:.*]], %[[VALUE1:.*]] = air.execute [%[[EVENT1]]]
+// CHECK: %[[EVENT4:.*]], %[[VALUE2:.*]] = air.execute [%[[EVENT1]]]
+// CHECK-NOT: %[[EVENT5:.*]] = air.dma_memcpy_nd async [%[[EVENT2]], %[[EVENT1]]]
+// CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [%[[EVENT2]]]
+// CHECK-NOT: %[[EVENT6:.*]] = air.dma_memcpy_nd async [%[[EVENT3]], %[[EVENT1]]]
+// CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [%[[EVENT3]]]
+// CHECK-NOT: %[[EVENT7:.*]] = air.dma_memcpy_nd async [%[[EVENT4]], %[[EVENT1]]]
+// CHECK: %[[EVENT7:.*]] = air.dma_memcpy_nd async [%[[EVENT4]]]
+
+#map0 = affine_map<()[s0] -> (s0 * 16)>
+#map1 = affine_map<()[s0] -> (s0 * 64)>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+module attributes {torch.debug_module_name = "MMult_Mult"} {
+  func.func @forward(%arg0: memref<128x128xf32>, %arg1: memref<128x128xf32>, %arg2: memref<128x128xf32>, %arg3: memref<128x128xf32>) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %async_token, %results = air.execute -> (memref<128x128xf32>) {
+      %2 = memref.alloc() {alignment = 128 : i64} : memref<128x128xf32>
+      air.execute_terminator %2 : memref<128x128xf32>
+    } {id = 1 : i32}
+    %async_token_0, %results_1 = air.execute -> (memref<128x128xf32>) {
+      %2 = memref.alloc() {alignment = 128 : i64} : memref<128x128xf32>
+      air.execute_terminator %2 : memref<128x128xf32>
+    } {id = 2 : i32}
+    %async_token_2, %results_3 = air.execute -> (memref<128x128xf32>) {
+      %2 = memref.alloc() {alignment = 128 : i64} : memref<128x128xf32>
+      air.execute_terminator %2 : memref<128x128xf32>
+    } {id = 3 : i32}
+    %async_token_4 = air.execute [%async_token_0] {
+      linalg.fill ins(%cst : f32) outs(%results_1 : memref<128x128xf32>)
+    } {id = 4 : i32}
+    %async_token_5 = air.execute [%async_token_2, %async_token_4] {
+      memref.copy %results_1, %results_3 : memref<128x128xf32> to memref<128x128xf32>
+    } {id = 5 : i32}
+    %0 = air.herd @herd_0 async [%async_token_5]  tile (%arg4, %arg5) in (%arg6=%c8, %arg7=%c2) args(%arg8=%arg1, %arg9=%arg2, %arg10=%results_3) : memref<128x128xf32>, memref<128x128xf32>, memref<128x128xf32> attributes {id = 1 : i32} {
+      %c64 = arith.constant 64 : index
+      %c1_7 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c128 = arith.constant 128 : index
+      %c0 = arith.constant 0 : index
+      %async_token_8, %results_9 = air.execute -> (index) {
+        %4 = affine.apply #map0()[%arg4]
+        air.execute_terminator %4 : index
+      } {id = 6 : i32}
+      %async_token_10, %results_11 = air.execute -> (index) {
+        %4 = affine.apply #map1()[%arg5]
+        air.execute_terminator %4 : index
+      } {id = 7 : i32}
+      %2 = air.wait_all async [%async_token_8, %async_token_10] 
+      %3 = scf.for %arg11 = %c0 to %c128 step %c32 iter_args(%arg12 = %2) -> (!air.async.token) {
+        %c16_12 = arith.constant 16 : index
+        %c32_13 = arith.constant 32 : index
+        %c128_14 = arith.constant 128 : index
+        %c1_15 = arith.constant 1 : index
+        %c64_16 = arith.constant 64 : index
+        %async_token_17, %results_18 = air.execute [%arg12] -> (memref<16x32xf32, 2>) {
+          %9 = memref.alloc() : memref<16x32xf32, 2>
+          air.execute_terminator %9 : memref<16x32xf32, 2>
+        } {id = 8 : i32}
+        %async_token_19, %results_20 = air.execute [%arg12] -> (memref<32x64xf32, 2>) {
+          %9 = memref.alloc() : memref<32x64xf32, 2>
+          air.execute_terminator %9 : memref<32x64xf32, 2>
+        } {id = 9 : i32}
+        %async_token_21, %results_22 = air.execute [%arg12] -> (memref<16x64xf32, 2>) {
+          %9 = memref.alloc() : memref<16x64xf32, 2>
+          air.execute_terminator %9 : memref<16x64xf32, 2>
+        } {id = 10 : i32}
+        %4 = air.dma_memcpy_nd async [%async_token_17, %arg12] (%results_18[] [] [], %arg8[%results_9, %arg11] [%c16_12, %c32_13] [%c128_14, %c1_15]) {id = 1 : i32} : (memref<16x32xf32, 2>, memref<128x128xf32>)
+        %5 = air.dma_memcpy_nd async [%async_token_19, %arg12] (%results_20[] [] [], %arg9[%arg11, %results_11] [%c32_13, %c64_16] [%c128_14, %c1_15]) {id = 2 : i32} : (memref<32x64xf32, 2>, memref<128x128xf32>)
+        %6 = air.dma_memcpy_nd async [%async_token_21, %arg12] (%results_22[] [] [], %arg10[%results_9, %results_11] [%c16_12, %c64_16] [%c128_14, %c1_15]) {id = 3 : i32} : (memref<16x64xf32, 2>, memref<128x128xf32>)
+        %async_token_23 = air.execute [%5, %6, %4] {
+          linalg.matmul ins(%results_18, %results_20 : memref<16x32xf32, 2>, memref<32x64xf32, 2>) outs(%results_22 : memref<16x64xf32, 2>)
+        } {id = 11 : i32}
+        %7 = air.dma_memcpy_nd async [%async_token_23] (%arg10[%results_9, %results_11] [%c16_12, %c64_16] [%c128_14, %c1_15], %results_22[] [] []) {id = 4 : i32} : (memref<128x128xf32>, memref<16x64xf32, 2>)
+        %async_token_24 = air.execute [%async_token_23] {
+          memref.dealloc %results_18 : memref<16x32xf32, 2>
+        } {id = 12 : i32}
+        %async_token_25 = air.execute [%async_token_23] {
+          memref.dealloc %results_20 : memref<32x64xf32, 2>
+        } {id = 13 : i32}
+        %async_token_26 = air.execute [%7] {
+          memref.dealloc %results_22 : memref<16x64xf32, 2>
+        } {id = 14 : i32}
+        %8 = air.wait_all async [%async_token_24, %async_token_25, %async_token_26] 
+        scf.yield %8 : !air.async.token
+      }
+      air.herd_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
@@ -49,8 +49,12 @@ module attributes {torch.debug_module_name = "model"} {
       air.dma_memcpy_nd (%5[] [] [], %arg6[%3, %4] [%c64, %c64] [%c1024, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
       air.dma_memcpy_nd (%6[] [] [], %arg7[%3, %4] [%c64, %c64] [%c1024, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
       air.partition args(%arg9=%arg2, %arg10=%arg3, %arg11=%arg4, %arg12=%arg5, %arg13=%5, %arg14=%6) : index, index, index, index, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> {
-      // CHECK: %[[EVENT0:.*]] = air.dma_memcpy_nd async 
-      // CHECK: %[[EVENT1:.*]] = air.partition async [%[[EVENT0]]]
+      // CHECK: %[[EVENT0:.*]], %[[VALUE0:.*]] = air.execute
+      // CHECK: %[[EVENT1:.*]], %[[VALUE1:.*]] = air.execute
+      // CHECK: %[[EVENT2:.*]], %[[VALUE2:.*]] = air.execute
+      // CHECK: %[[EVENT3:.*]], %[[VALUE3:.*]] = air.execute
+      // CHECK: %[[EVENT4:.*]] = air.dma_memcpy_nd async 
+      // CHECK: %[[EVENT5:.*]] = air.partition async [%[[EVENT0]], %[[EVENT1]], %[[EVENT3]], %[[EVENT4]]]
         %c1_1 = arith.constant 1 : index
         %c2_0 = arith.constant 2 : index
         %c64_2 = arith.constant 64 : index
@@ -60,8 +64,10 @@ module attributes {torch.debug_module_name = "model"} {
         air.dma_memcpy_nd (%new_0[] [] [], %arg13[%arg9, %arg10] [%c1_1, %c1_1] [%c1_1, %c1_1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<64x64xbf16, 1>)
         air.dma_memcpy_nd (%new_1[] [] [], %arg14[%arg9, %arg10] [%c1_1, %c1_1] [%c1_1, %c1_1]) {id = 4 : i32} : (memref<64x64xbf16, 1>, memref<64x64xbf16, 1>)
         air.herd  tile (%arg22, %arg23) in (%arg16=%c2_0, %arg17=%c2_0) args(%arg18=%new_0, %arg19=%new_1) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {sym_name = "herd_1"} {
-        // CHECK: %[[EVENT2:.*]] = air.dma_memcpy_nd async 
-        // CHECK: %[[EVENT3:.*]] = air.herd @herd_1 async [%[[EVENT2]]]
+        // CHECK: %[[EVENT6:.*]], %[[VALUE4:.*]] = air.execute
+        // CHECK: %[[EVENT7:.*]], %[[VALUE5:.*]] = air.execute
+        // CHECK: %[[EVENT8:.*]] = air.dma_memcpy_nd async 
+        // CHECK: %[[EVENT9:.*]] = air.herd @herd_1 async [%[[EVENT7]], %[[EVENT8]]]
           %c1_0 = arith.constant 1 : index
           %c64_1 = arith.constant 64 : index
           %c32 = arith.constant 32 : index
@@ -72,6 +78,7 @@ module attributes {torch.debug_module_name = "model"} {
           %8 = affine.apply #map1()[%arg23]
           %9 = memref.alloc() : memref<32x32xbf16, 2>
           %10 = memref.alloc() : memref<32x32xbf16, 2>
+          // CHECK: %[[EVENT10:.*]] = air.dma_memcpy_nd async 
           air.dma_memcpy_nd (%9[] [] [], %arg18[%7, %8] [%c32, %c32] [%c64_1, %c1_0]) {id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
           air.dma_memcpy_nd (%10[] [] [], %arg19[%7, %8] [%c32, %c32] [%c64_1, %c1_0]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
           linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%9 : memref<32x32xbf16, 2>) outs(%10 : memref<32x32xbf16, 2>) {
@@ -84,8 +91,8 @@ module attributes {torch.debug_module_name = "model"} {
             %16 = arith.mulf %arg20, %15 : bf16
             linalg.yield %16 : bf16
           }
-          // CHECK: %[[EVENT4:.*]] = air.dma_memcpy_nd async 
-          // CHECK: %[[EVENT5:.*]] = air.execute [%[[EVENT4]]]
+          // CHECK: %[[EVENT11:.*]] = air.dma_memcpy_nd async 
+          // CHECK: %[[EVENT12:.*]] = air.execute [%[[EVENT11]]]
           air.dma_memcpy_nd (%arg19[%7, %8] [%c32, %c32] [%c64_1, %c1_0], %10[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
           memref.dealloc %9 : memref<32x32xbf16, 2>
           memref.dealloc %10 : memref<32x32xbf16, 2>


### PR DESCRIPTION
- Support cases in which herd is the only hierarchy, with no launch or partition.
- Fixup issue between broadcast dma lowering and dependency canonicalization.
- Fixup issue with parsing scf.parallel ops.
- Unit tests.