### PR TITLE
make a naming convention of command line variables in mlir passes

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -143,13 +143,12 @@ def AIRAutomaticTiling: Pass<"air-automatic-tiling", "func::FuncOp"> {
     ListOption<"loopTileSizes", "loop-tile-sizes", "unsigned",
                "A list of multi-dimensional loop tile sizes",
                "llvm::cl::ZeroOrMore">,
-    Option<"tileSeparate", "tile-separate", "bool", /*default=*/"false",
+    Option<"clTileSeparate", "tile-separate", "bool", /*default=*/"false",
            "AIR loop tiling separates full and partial tiles">,
-    Option<"AIRLabel", "air-label", "std::string", /*default=*/"",
+    Option<"clLabel", "air-label", "std::string", /*default=*/"",
            "Transform loops with the given label">,
-    Option<"AIRPostLabel", "air-post-label", "std::string", 
-            /*default=*/"",
-            "Label to apply to transformed loop nest">
+    Option<"clPostLabel", "air-post-label", "std::string", /*default=*/"",
+           "Label to apply to transformed loop nest">
   ];
 }
 
@@ -163,14 +162,14 @@ def AIRHerdPlacementPass : Pass<"air-place-herds", "ModuleOp"> {
   let constructor = "xilinx::air::createAIRHerdPlacementPass()";
 
   let options = [
-    Option<"numRows", "num-rows", "int", /*default=*/"8",
-          "Number of rows of AIE tiles in a partition">,
-    Option<"numCols", "num-cols", "int", /*default=*/"10",
-          "Number of columns of AIE tiles in a partition">,
-    Option<"anchorPointRow", "row-anchor", "int", /*default=*/"0",
-          "Anchoring row number of partition">,
-    Option<"anchorPointCol", "col-anchor", "int", /*default=*/"0",
-          "Anchoring column number of a partition">
+    Option<"clNumRows", "num-rows", "int", /*default=*/"8",
+           "Number of rows of AIE tiles in a partition">,
+    Option<"clNumCols", "num-cols", "int", /*default=*/"10",
+           "Number of columns of AIE tiles in a partition">,
+    Option<"clAnchorPointRow", "row-anchor", "int", /*default=*/"0",
+           "Anchoring row number of partitions">,
+    Option<"clAnchorPointCol", "col-anchor", "int", /*default=*/"0",
+           "Anchoring column number of partitions">
   ];
 
   let description = [{
@@ -300,7 +299,7 @@ def AIRLinalgCodegen : Pass<"air-linalg-codegen", "ModuleOp"> {
     Option<"clInputFilter", "input-filter", "std::string", 
             /*default=*/"",
             "Input filter for linalg transformations">,
-    Option<"AIRLinalgCodegenTestPatterns", "test-patterns", "bool",
+    Option<"clLinalgCodegenTestPatterns", "test-patterns", "bool",
             "false", "test patterns">
 
   ];
@@ -499,9 +498,9 @@ def AIRLoopPermutation: Pass<"air-loop-permutation", "func::FuncOp"> {
     ListOption<"loopOrder", "loop-order", "unsigned",
                "The target loop permutation ordering",
                "llvm::cl::OneOrMore">,
-    Option<"AIRLabel", "air-label", "std::string", /*default=*/"",
+    Option<"clLabel", "air-label", "std::string", /*default=*/"",
            "Transform loops with the given label">,
-    Option<"AIRPostLabel", "air-post-label", "std::string", 
+    Option<"clPostLabel", "air-post-label", "std::string", 
             /*default=*/"",
             "Label to apply to transformed loop nest">
   ];

--- a/mlir/lib/Transform/AIRAutomaticTilingPass.cpp
+++ b/mlir/lib/Transform/AIRAutomaticTilingPass.cpp
@@ -85,8 +85,8 @@ void AIRAutomaticTilingPass::runOnOperation() {
     for (auto tileSize: optTileSizes) {
       // Bands of loops to tile
       std::vector<SmallVector<AffineForOp, 6>> bands;
-      xilinx::air::getTileableBands(func, bands, 
-                       AIRAutomaticTilingPass::affineOptAttrName, AIRLabel);
+      xilinx::air::getTileableBands(
+          func, bands, AIRAutomaticTilingPass::affineOptAttrName, clLabel);
 
       tileLoopsManually(bands, tileSize);
 
@@ -100,8 +100,8 @@ void AIRAutomaticTilingPass::runOnOperation() {
   } else { 
     // Find the optimal tile sizes automatically.
     std::vector<SmallVector<AffineForOp, 6>> bands;
-    xilinx::air::getTileableBands(func, bands, 
-                     AIRAutomaticTilingPass::affineOptAttrName, AIRLabel);
+    xilinx::air::getTileableBands(
+        func, bands, AIRAutomaticTilingPass::affineOptAttrName, clLabel);
 
     // Normalize every loop before tiling.
     for (auto band: bands) 
@@ -113,8 +113,8 @@ void AIRAutomaticTilingPass::runOnOperation() {
 
     // Normalize every loop after tiling.
     bands.clear();
-    xilinx::air::getTileableBands(func, bands, 
-                     AIRAutomaticTilingPass::affineOptAttrName, AIRLabel);
+    xilinx::air::getTileableBands(
+        func, bands, AIRAutomaticTilingPass::affineOptAttrName, clLabel);
     for (auto band: bands) 
       for (AffineForOp affineFor: band) 
         if (failed(normalizeAffineFor(affineFor)))
@@ -279,8 +279,10 @@ void AIRAutomaticTilingPass::tileLoopsAutomatically(
     auto stringAttr = band[0]->getAttrOfType<StringAttr>(
         AIRAutomaticTilingPass::affineOptAttrName);
     if (stringAttr) {
-      StringAttr postLabel = AIRPostLabel.empty() ? 
-        stringAttr:StringAttr::get(AIRPostLabel, stringAttr.getType());
+      StringAttr postLabel =
+          clPostLabel.empty()
+              ? stringAttr
+              : StringAttr::get(clPostLabel, stringAttr.getType());
       tiledLoops[0]->setAttr(
           AIRAutomaticTilingPass::affineOptAttrName, postLabel);
     }
@@ -302,7 +304,7 @@ void AIRAutomaticTilingPass::tileLoopsManually(
       return signalPassFailure();
 
     // Separate full and partial tiles.
-    if (tileSeparate) {
+    if (clTileSeparate) {
       auto intraTileLoops =
           MutableArrayRef<AffineForOp>(tiledNest).drop_front(band.size());
       (void)separateFullTiles(intraTileLoops);
@@ -313,8 +315,10 @@ void AIRAutomaticTilingPass::tileLoopsManually(
     // StringRef originalLabel = band[0]->getAttrOfType<StringRef>(
     //   AIRAutomaticTilingPass::affineOptAttrName);
     if (stringAttr) {
-      StringAttr postLabel = AIRPostLabel.empty() ? 
-        stringAttr:StringAttr::get(AIRPostLabel, stringAttr.getType());
+      StringAttr postLabel =
+          clPostLabel.empty()
+              ? stringAttr
+              : StringAttr::get(clPostLabel, stringAttr.getType());
       tiledNest[0]->setAttr(
           AIRAutomaticTilingPass::affineOptAttrName, postLabel);
     }

--- a/mlir/lib/Transform/AIRHerdPlacementPass.cpp
+++ b/mlir/lib/Transform/AIRHerdPlacementPass.cpp
@@ -180,8 +180,8 @@ public:
 
   void runOnOperation() override {
 
-    if (numRows < 0 || numCols < 0 || anchorPointRow < 0 ||
-        anchorPointCol < 0) {
+    if (clNumRows < 0 || clNumCols < 0 || clAnchorPointRow < 0 ||
+        clAnchorPointCol < 0) {
       llvm::errs() << "Ensure all input parameters are greater than zero.\n";
       return;
     }
@@ -223,7 +223,7 @@ public:
       });
     }
     std::unique_ptr<Partition> partition = std::make_unique<Partition>(
-        numRows, numCols, anchorPointRow, anchorPointCol);
+        clNumRows, clNumCols, clAnchorPointRow, clAnchorPointCol);
     std::sort(unplacedHerds.begin(), unplacedHerds.end(), HerdComparision());
     std::vector<std::unique_ptr<Herd>> placedHerds;
     naivePlacement(partition, unplacedHerds, placedHerds);

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -1450,7 +1450,7 @@ public:
     //RewritePatternSet prePatterns(&getContext());
     //prePatterns.insert<RemoveAllocLinalgOpCopyPattern>(&getContext());
     //(void)applyPatternsAndFoldGreedily(f, std::move(prePatterns));
-    if (!AIRLinalgCodegenTestPatterns) {
+    if (!clLinalgCodegenTestPatterns) {
       runMatmulPatterns(f);
       runConv2dPatterns(f);
       runGenericPatterns(f);

--- a/mlir/lib/Transform/AIRLoopPermutationPass.cpp
+++ b/mlir/lib/Transform/AIRLoopPermutationPass.cpp
@@ -70,9 +70,8 @@ void AIRLoopPermutationPass::runOnOperation() {
   
   // Bands of loops to tile
   std::vector<SmallVector<AffineForOp, 6>> bands;
-  xilinx::air::getTileableBands(func, bands, 
-                                AIRLoopPermutationPass::affineOptAttrName,
-                                AIRLabel);
+  xilinx::air::getTileableBands(
+      func, bands, AIRLoopPermutationPass::affineOptAttrName, clLabel);
 
   for (auto band: bands) {
     // Save and erase the previous label
@@ -81,9 +80,11 @@ void AIRLoopPermutationPass::runOnOperation() {
     
     unsigned newOutermost = permuteLoops(band, loopOrder);
 
-    if (stringAttr) { 
-      StringAttr postLabel = AIRPostLabel.empty() ? 
-        stringAttr:StringAttr::get(AIRPostLabel, stringAttr.getType());
+    if (stringAttr) {
+      StringAttr postLabel =
+          clPostLabel.empty()
+              ? stringAttr
+              : StringAttr::get(clPostLabel, stringAttr.getType());
       band[newOutermost]->setAttr(
           AIRLoopPermutationPass::affineOptAttrName, postLabel);
     }


### PR DESCRIPTION
They all start with `cl`, like `clTileSize`