### PR TITLE
Updates to env_setup.sh

### DIFF
--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##===- utils/env_setup.sh - Setup mlir-aie env post build to compile mlir-aie designs --*- Script -*-===##
 # 
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
@@ -8,16 +7,15 @@
 ##===----------------------------------------------------------------------===##
 #
 # This script sets up the environment to run the mlir-aie build tools.
+# It must be sourced, not executed.
 #
-# source env_setup.sh <mlir-aie install dir> <llvm install dir>
-#
-# e.g. source env_setup.sh /scratch/mlir-aie/install /scratch/llvm/install
+# e.g. source env_setup.sh /scratch/mlir-air/install /scratch/mlir-aie/install /scratch/llvm/install
 #
 ##===----------------------------------------------------------------------===##
 
 if [ "$#" -ne 3 ]; then
-    echo "ERROR: Needs 3 arguments for <mlir-air install dir> <mlir-aie install dir> and <llvm install dir>"
-    exit 1
+	echo "ERROR: Needs 3 arguments for <mlir-air install dir> <mlir-aie install dir> and <llvm install dir>"
+	return
 fi
 
 export MLIR_AIR_INSTALL_DIR=$1
@@ -27,4 +25,3 @@ export LLVM_INSTALL_DIR=$3
 export PATH=${MLIR_AIR_INSTALL_DIR}/bin:${MLIR_AIE_INSTALL_DIR}/bin:${LLVM_INSTALL_DIR}/bin:${PATH} 
 export PYTHONPATH=${MLIR_AIR_INSTALL_DIR}/python:${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH} 
 export LD_LIBRARY_PATH=${MLIR_AIR_INSTALL_DIR}/lib:${MLIR_AIE_INSTALL_DIR}/lib:${LLVM_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
-


### PR DESCRIPTION
This script is intended to be sourced, not executed. Therefore, it should not have the executable attribute in the file system and not start with the #! for executing scripts.

If a user is connected over ssh and does not provide the correct number of parameters while sourcing this script, 'exit' will close the ssh connection which is quite a harsh punishment. Use 'return' instead to give the user another chance.

Signed-off-by: Joel Nider <joel.nider@xilinx.com>