### PR TITLE
Add initial runtime support for packet routing

### DIFF
--- a/runtime_lib/airhost/include/air_host.h
+++ b/runtime_lib/airhost/include/air_host.h
@@ -174,7 +174,8 @@ hsa_status_t air_packet_shimdma_status(dispatch_packet_t *pkt, uint8_t col);
 hsa_status_t
 air_packet_nd_memcpy(dispatch_packet_t *pkt, uint16_t herd_id, uint8_t col,
                      uint8_t direction, uint8_t channel, uint8_t burst_len,
-                     uint8_t memory_space, uint64_t phys_addr,
+                     uint8_t memory_space, uint8_t packet_type,
+                     uint8_t packet_id, uint64_t phys_addr,
                      uint32_t transfer_length1d, uint32_t transfer_length2d,
                      uint32_t transfer_stride2d, uint32_t transfer_length3d,
                      uint32_t transfer_stride3d, uint32_t transfer_length4d,

--- a/runtime_lib/airhost/memory.cpp
+++ b/runtime_lib/airhost/memory.cpp
@@ -269,8 +269,10 @@ void air_shim_memcpy4d_queue_impl(uint32_t id, uint64_t x, uint64_t y, void* t,
   uint64_t packet_id = wr_idx % _air_host_active_herd.q->size;
 
   dispatch_packet_t *pkt = (dispatch_packet_t*)(_air_host_active_herd.q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan, /*burst_len=*/4, /*memory_space=*/2,
-                       _air_host_bram_paddr, length*sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S,
+                       shim_chan, /*burst_len=*/4, /*memory_space=*/2,
+                       /*packet_type=*/0, /*packet_id=*/0, _air_host_bram_paddr,
+                       length * sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
   //if (s) {
   //  // TODO: don't block here
   //  air_queue_dispatch_and_wait(_air_host_active_herd.q, wr_idx, pkt);
@@ -330,8 +332,11 @@ void air_shim_memcpy2d_queue_impl(uint32_t id, uint64_t x, uint64_t y, void* t,
   uint64_t packet_id = wr_idx % _air_host_active_herd.q->size;
 
   dispatch_packet_t *pkt = (dispatch_packet_t*)(_air_host_active_herd.q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan, /*burst_len=*/4, /*memory_space=*/2,
-                       _air_host_bram_paddr, length*sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S,
+                       shim_chan,
+                       /*burst_len=*/4, /*memory_space=*/2,
+                       /*packet_type=*/0, /*packet_id=*/0, _air_host_bram_paddr,
+                       length * sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
   //if (s) {
   //  // TODO: don't block here
   //  air_queue_dispatch_and_wait(_air_host_active_herd.q, wr_idx, pkt);
@@ -380,8 +385,10 @@ void air_shim_memcpy_queue_impl(signal_t *s, uint32_t id, uint64_t x,
   uint64_t packet_id = wr_idx % _air_host_active_herd.q->size;
 
   dispatch_packet_t *pkt = (dispatch_packet_t*)(_air_host_active_herd.q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan, /*burst_len=*/4, /*memory_space=*/2,
-                       _air_host_bram_paddr, length*sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S,
+                       shim_chan, /*burst_len=*/4, /*memory_space=*/2,
+                       /*packet_type=*/0, /*packet_id=*/0, _air_host_bram_paddr,
+                       length * sizeof(uint32_t), 1, 0, 1, 0, 1, 0);
   if (s) {
     // TODO: don't block here
     air_queue_dispatch_and_wait(_air_host_active_herd.q, wr_idx, pkt);
@@ -533,7 +540,8 @@ void air_mem_shim_nd_memcpy_queue_impl(signal_t *s, uint32_t id, uint64_t x,
     dispatch_packet_t *pkt = (dispatch_packet_t*)(_air_host_active_herd.q->base_address_vaddr) + packet_id;
     air_packet_nd_memcpy(
         pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan,
-        /*burst_len=*/4, /*memory_space=*/space, (uint64_t)t->data + offset,
+        /*burst_len=*/4, /*memory_space=*/space,
+        /*packet_type=*/0, /*packet_id=*/0, (uint64_t)t->data + offset,
         length_1d * sizeof(T), length_2d, stride_2d * sizeof(T), length_3d,
         stride_3d * sizeof(T), length_4d, stride_4d * sizeof(T));
     if (s) {
@@ -590,8 +598,11 @@ void air_mem_shim_nd_memcpy_queue_impl(signal_t *s, uint32_t id, uint64_t x,
     uint64_t packet_id = wr_idx % _air_host_active_herd.q->size;
 
     dispatch_packet_t *pkt = (dispatch_packet_t*)(_air_host_active_herd.q->base_address_vaddr) + packet_id;
-    air_packet_nd_memcpy(pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan, /*burst_len=*/4, /*memory_space=*/2,
-                         _air_host_bram_paddr, length*sizeof(T), 1, 0, 1, 0, 1, 0);
+    air_packet_nd_memcpy(
+        pkt, /*herd_id=*/0, shim_col, /*direction=*/isMM2S, shim_chan,
+        /*burst_len=*/4, /*memory_space=*/2,
+        /*packet_type=*/0, /*packet_id=*/0, _air_host_bram_paddr,
+        length * sizeof(T), 1, 0, 1, 0, 1, 0);
     if (s) {
       // TODO: don't block here
       air_queue_dispatch_and_wait(_air_host_active_herd.q, wr_idx, pkt);

--- a/runtime_lib/airhost/queue.cpp
+++ b/runtime_lib/airhost/queue.cpp
@@ -411,7 +411,8 @@ hsa_status_t air_packet_aie_lock_range(dispatch_packet_t *pkt, uint16_t herd_id,
 hsa_status_t
 air_packet_nd_memcpy(dispatch_packet_t *pkt, uint16_t herd_id, uint8_t col,
                      uint8_t direction, uint8_t channel, uint8_t burst_len,
-                     uint8_t memory_space, uint64_t phys_addr,
+                     uint8_t memory_space, uint8_t packet_type,
+                     uint8_t packet_id, uint64_t phys_addr,
                      uint32_t transfer_length1d, uint32_t transfer_length2d,
                      uint32_t transfer_stride2d, uint32_t transfer_length3d,
                      uint32_t transfer_stride3d, uint32_t transfer_length4d,
@@ -420,6 +421,8 @@ air_packet_nd_memcpy(dispatch_packet_t *pkt, uint16_t herd_id, uint8_t col,
   initialize_packet(pkt);
 
   pkt->arg[0] = 0;
+  pkt->arg[0] |= ((uint64_t)packet_id & 0x1f);
+  pkt->arg[0] |= ((uint64_t)packet_type & 0x7) << 5;
   pkt->arg[0] |= ((uint64_t)memory_space) << 16;
   pkt->arg[0] |= ((uint64_t)channel) << 24;
   pkt->arg[0] |= ((uint64_t)col) << 32;

--- a/test/10_mb_shim_dma_to_tile_dma/test.cpp
+++ b/test/10_mb_shim_dma_to_tile_dma/test.cpp
@@ -104,7 +104,8 @@ main(int argc, char *argv[])
 
   dispatch_packet_t *pkt =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt, 0, col, 1, 0, 4, 2, air_dev_mem_get_pa(dram_ptr),
+  air_packet_nd_memcpy(pkt, 0, col, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(dram_ptr),
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt);
 

--- a/test/11_mb_shim_dma_from_tile_dma/test.cpp
+++ b/test/11_mb_shim_dma_from_tile_dma/test.cpp
@@ -116,9 +116,9 @@ main(int argc, char *argv[])
 
   dispatch_packet_t *cpypkt0 =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(cpypkt0, 0, col, 0, 0, 8, 2,
-                       air_dev_mem_get_pa(dram_ptr), DMA_COUNT * sizeof(float),
-                       1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(cpypkt0, 0, col, 0, 0, 8, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(dram_ptr),
+                       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, cpypkt0);
 
   uint32_t errs = 0;

--- a/test/12_dual_channel_shim_dma/test.cpp
+++ b/test/12_dual_channel_shim_dma/test.cpp
@@ -118,7 +118,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2,
+  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0,
                        air_dev_mem_get_pa(dram_ptr_1) /*BRAM_ADDR*/,
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_a);
@@ -128,7 +129,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_b, 0, col, 1, 1, 4, 2,
+      pkt_b, 0, col, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(dram_ptr_2) /*BRAM_ADDR+(DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_b);
@@ -140,7 +141,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, col, 0, 0, 4, 2,
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(dram_ptr_3) /*BRAM_ADDR+(2*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_c);
@@ -150,7 +151,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_d, 0, col, 0, 1, 4, 2,
+      pkt_d, 0, col, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(dram_ptr_4) /*BRAM_ADDR+(3*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_d);

--- a/test/13_mb_add_one/test.cpp
+++ b/test/13_mb_add_one/test.cpp
@@ -119,7 +119,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt, 0, col, 1, 0, 4, 2, air_dev_mem_get_pa(src),
+  air_packet_nd_memcpy(pkt, 0, col, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(src),
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt);
 
@@ -131,7 +132,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt2 =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt2, 0, col, 0, 0, 4, 2, air_dev_mem_get_pa(dst),
+  air_packet_nd_memcpy(pkt2, 0, col, 0, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(dst),
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt2);
 

--- a/test/14_multi_shim_dma/test.cpp
+++ b/test/14_multi_shim_dma/test.cpp
@@ -120,7 +120,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 18, 1, 0, 4, 2,
+  air_packet_nd_memcpy(pkt_a, 0, 18, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0,
                        air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_a);
@@ -130,7 +131,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_b, 0, 11, 1, 0, 4, 2,
+      pkt_b, 0, 11, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -143,7 +144,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, 18, 0, 0, 4, 2,
+      pkt_c, 0, 18, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_3) /*AIR_BBUFF_BASE+(2*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -154,7 +155,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_d, 0, 11, 0, 0, 4, 2,
+      pkt_d, 0, 11, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_4) /*AIR_BBUFF_BASE+(3*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);

--- a/test/15_dual_mb_dual_herd_add_one/test.cpp
+++ b/test/15_dual_mb_dual_herd_add_one/test.cpp
@@ -136,7 +136,8 @@ main(int argc, char *argv[])
   wr_idx = queue_add_write_index(q, 1);
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt1 = (dispatch_packet_t*)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt1, 0, 7, 1, 0, 4, 2, air_dev_mem_get_pa(bram_ptr),
+  air_packet_nd_memcpy(pkt1, 0, 7, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(bram_ptr),
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   //
@@ -146,10 +147,10 @@ main(int argc, char *argv[])
   wr_idx = queue_add_write_index(q, 1);
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt2 = (dispatch_packet_t*)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt2, 0, 7, 0, 0, 4, 2,
-                       air_dev_mem_get_pa(bram_ptr) +
-                           (DMA_COUNT * sizeof(float)),
-                       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(
+      pkt2, 0, 7, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(bram_ptr) + (DMA_COUNT * sizeof(float)),
+      DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   //
   // send the data
@@ -158,7 +159,8 @@ main(int argc, char *argv[])
   wr_idx2 = queue_add_write_index(q2, 1);
   packet_id2 = wr_idx2 % q2->size;
   dispatch_packet_t *pkt12 = (dispatch_packet_t*)(q2->base_address_vaddr) + packet_id2;
-  air_packet_nd_memcpy(pkt12, 0, 34, 1, 0, 4, 2, air_dev_mem_get_pa(bram_ptr),
+  air_packet_nd_memcpy(pkt12, 0, 34, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, air_dev_mem_get_pa(bram_ptr),
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   //
@@ -168,10 +170,10 @@ main(int argc, char *argv[])
   wr_idx2 = queue_add_write_index(q2, 1);
   packet_id2 = wr_idx2 % q2->size;
   dispatch_packet_t *pkt22 = (dispatch_packet_t*)(q2->base_address_vaddr) + packet_id2;
-  air_packet_nd_memcpy(pkt22, 0, 34, 0, 0, 4, 2,
-                       air_dev_mem_get_pa(bram_ptr) +
-                           (2 * DMA_COUNT * sizeof(float)),
-                       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(
+      pkt22, 0, 34, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(bram_ptr) + (2 * DMA_COUNT * sizeof(float)),
+      DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   air_queue_dispatch(q, wr_idx, pkt2);
   air_queue_dispatch_and_wait(q2, wr_idx2, pkt22);

--- a/test/16_multi_shim_dma_all_channels/test.cpp
+++ b/test/16_multi_shim_dma_all_channels/test.cpp
@@ -126,7 +126,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_e =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_e, 0, 18, 1, 1, 4, 2,
+  air_packet_nd_memcpy(pkt_e, 0, 18, 1, 1, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0,
                        air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
@@ -135,7 +136,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_f =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_f, 0, 11, 1, 1, 4, 2,
+      pkt_f, 0, 11, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -147,7 +148,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_g =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_g, 0, 18, 0, 1, 4, 2,
+      pkt_g, 0, 18, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_5) /*AIR_BBUFF_BASE+(4*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -157,7 +158,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_h =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_h, 0, 11, 0, 1, 4, 2,
+      pkt_h, 0, 11, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_6) /*AIR_BBUFF_BASE+(5*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -168,7 +169,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 18, 1, 0, 4, 2,
+  air_packet_nd_memcpy(pkt_a, 0, 18, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0,
                        air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
                        DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
@@ -177,7 +179,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_b, 0, 11, 1, 0, 4, 2,
+      pkt_b, 0, 11, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -189,7 +191,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, 18, 0, 0, 4, 2,
+      pkt_c, 0, 18, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_3) /*AIR_BBUFF_BASE+(2*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -199,7 +201,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_d, 0, 11, 0, 0, 4, 2,
+      pkt_d, 0, 11, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_4) /*AIR_BBUFF_BASE+(3*DMA_COUNT*sizeof(float))*/,
       DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);

--- a/test/17_packet_bcast/aie.mlir
+++ b/test/17_packet_bcast/aie.mlir
@@ -1,0 +1,303 @@
+module @aie.partition_0 {
+  %0 = AIE.tile(7, 2)
+  %1 = AIE.tile(8, 2)
+  %2 = AIE.tile(7, 3)
+  %3 = AIE.tile(8, 3)
+  %4 = AIE.tile(2, 0)
+  %5 = AIE.tile(3, 0)
+  %6 = AIE.tile(6, 0)
+  %7 = AIE.lock(%0, 3)
+  %8 = AIE.lock(%0, 2)
+  %9 = AIE.lock(%0, 1)
+  %10 = AIE.lock(%0, 0)
+  %11 = AIE.lock(%1, 3)
+  %12 = AIE.lock(%1, 2)
+  %13 = AIE.lock(%1, 1)
+  %14 = AIE.lock(%1, 0)
+  %15 = AIE.lock(%2, 3)
+  %16 = AIE.lock(%2, 2)
+  %17 = AIE.lock(%2, 1)
+  %18 = AIE.lock(%2, 0)
+  %19 = AIE.lock(%3, 3)
+  %20 = AIE.lock(%3, 2)
+  %21 = AIE.lock(%3, 1)
+  %22 = AIE.lock(%3, 0)
+  %23 = AIE.buffer(%3) {sym_name = "buf11"} : memref<32x32xi32, 2>
+  %24 = AIE.buffer(%3) {sym_name = "buf10"} : memref<32x32xi32, 2>
+  %25 = AIE.buffer(%3) {sym_name = "buf9"} : memref<32x32xi32, 2>
+  %26 = AIE.buffer(%2) {sym_name = "buf8"} : memref<32x32xi32, 2>
+  %27 = AIE.buffer(%2) {sym_name = "buf7"} : memref<32x32xi32, 2>
+  %28 = AIE.buffer(%2) {sym_name = "buf6"} : memref<32x32xi32, 2>
+  %29 = AIE.buffer(%1) {sym_name = "buf5"} : memref<32x32xi32, 2>
+  %30 = AIE.buffer(%1) {sym_name = "buf4"} : memref<32x32xi32, 2>
+  %31 = AIE.buffer(%1) {sym_name = "buf3"} : memref<32x32xi32, 2>
+  %32 = AIE.buffer(%0) {sym_name = "buf2"} : memref<32x32xi32, 2>
+  %33 = AIE.buffer(%0) {sym_name = "buf1"} : memref<32x32xi32, 2>
+  %34 = AIE.buffer(%0) {sym_name = "buf0"} : memref<32x32xi32, 2>
+  memref.global "public" @__air_herd_arg_9 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_10 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_11 : memref<64x64xi32>
+  %35 = AIE.mem(%3) {
+    %43 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb6)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%22, Acquire, 0)
+    AIE.dmaBd(<%23 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%22, Release, 1)
+    cf.br ^bb1
+  ^bb2:  // pred: ^bb3
+    AIE.end
+  ^bb3:  // pred: ^bb6
+    %44 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
+  ^bb4:  // 2 preds: ^bb3, ^bb5
+    AIE.useLock(%21, Acquire, 0)
+    AIE.dmaBd(<%24 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%21, Release, 1)
+    cf.br ^bb5
+  ^bb5:  // pred: ^bb4
+    AIE.useLock(%20, Acquire, 0)
+    AIE.dmaBd(<%25 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%20, Release, 1)
+    cf.br ^bb4
+  ^bb6:  // pred: ^bb0
+    %45 = AIE.dmaStart(MM2S, 0, ^bb7, ^bb3)
+  ^bb7:  // 2 preds: ^bb6, ^bb7
+    AIE.useLock(%19, Acquire, 1)
+    AIE.dmaBd(<%23 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%19, Release, 0)
+    cf.br ^bb7
+  }
+  %36 = AIE.core(%3) {
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c0 = arith.constant 0 : index
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    AIE.useLock(%19, Acquire, 0)
+    AIE.useLock(%22, Acquire, 1)
+    AIE.useLock(%20, Acquire, 1)
+    AIE.useLock(%21, Acquire, 1)
+    affine.for %arg1 = 0 to 32 {
+      affine.for %arg2 = 0 to 32 {
+        %43 = affine.load %24[%arg1, %arg2] : memref<32x32xi32, 2>
+        %44 = affine.load %25[%arg1, %arg2] : memref<32x32xi32, 2>
+        %45 = affine.load %23[%arg1, %arg2] : memref<32x32xi32, 2>
+        %46 = arith.muli %43, %44 : i32
+        %47 = arith.addi %45, %46 : i32
+        affine.store %47, %23[%arg1, %arg2] : memref<32x32xi32, 2>
+      }
+    }
+    AIE.useLock(%21, Release, 0)
+    AIE.useLock(%20, Release, 0)
+    AIE.useLock(%22, Release, 0)
+    AIE.useLock(%19, Release, 1)
+    AIE.end
+  } {elf_file = "partition_0_core_8_3.elf"}
+  memref.global "public" @__air_herd_arg_6 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_7 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_8 : memref<64x64xi32>
+  %37 = AIE.mem(%2) {
+    %43 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb6)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%18, Acquire, 0)
+    AIE.dmaBd(<%26 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%18, Release, 1)
+    cf.br ^bb1
+  ^bb2:  // pred: ^bb3
+    AIE.end
+  ^bb3:  // pred: ^bb6
+    %44 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
+  ^bb4:  // 2 preds: ^bb3, ^bb5
+    AIE.useLock(%17, Acquire, 0)
+    AIE.dmaBd(<%27 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%17, Release, 1)
+    cf.br ^bb5
+  ^bb5:  // pred: ^bb4
+    AIE.useLock(%16, Acquire, 0)
+    AIE.dmaBd(<%28 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%16, Release, 1)
+    cf.br ^bb4
+  ^bb6:  // pred: ^bb0
+    %45 = AIE.dmaStart(MM2S, 0, ^bb7, ^bb3)
+  ^bb7:  // 2 preds: ^bb6, ^bb7
+    AIE.useLock(%15, Acquire, 1)
+    AIE.dmaBd(<%26 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%15, Release, 0)
+    cf.br ^bb7
+  }
+  %38 = AIE.core(%2) {
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c0 = arith.constant 0 : index
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    AIE.useLock(%15, Acquire, 0)
+    AIE.useLock(%18, Acquire, 1)
+    AIE.useLock(%16, Acquire, 1)
+    AIE.useLock(%17, Acquire, 1)
+    affine.for %arg1 = 0 to 32 {
+      affine.for %arg2 = 0 to 32 {
+        %43 = affine.load %27[%arg1, %arg2] : memref<32x32xi32, 2>
+        %44 = affine.load %28[%arg1, %arg2] : memref<32x32xi32, 2>
+        %45 = affine.load %26[%arg1, %arg2] : memref<32x32xi32, 2>
+        %46 = arith.muli %43, %44 : i32
+        %47 = arith.addi %45, %46 : i32
+        affine.store %47, %26[%arg1, %arg2] : memref<32x32xi32, 2>
+      }
+    }
+    AIE.useLock(%17, Release, 0)
+    AIE.useLock(%16, Release, 0)
+    AIE.useLock(%18, Release, 0)
+    AIE.useLock(%15, Release, 1)
+    AIE.end
+  } {elf_file = "partition_0_core_7_3.elf"}
+  memref.global "public" @__air_herd_arg_3 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_4 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_5 : memref<64x64xi32>
+  %39 = AIE.mem(%1) {
+    %43 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb6)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%14, Acquire, 0)
+    AIE.dmaBd(<%29 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%14, Release, 1)
+    cf.br ^bb1
+  ^bb2:  // pred: ^bb3
+    AIE.end
+  ^bb3:  // pred: ^bb6
+    %44 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
+  ^bb4:  // 2 preds: ^bb3, ^bb5
+    AIE.useLock(%13, Acquire, 0)
+    AIE.dmaBd(<%30 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%13, Release, 1)
+    cf.br ^bb5
+  ^bb5:  // pred: ^bb4
+    AIE.useLock(%12, Acquire, 0)
+    AIE.dmaBd(<%31 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%12, Release, 1)
+    cf.br ^bb4
+  ^bb6:  // pred: ^bb0
+    %45 = AIE.dmaStart(MM2S, 0, ^bb7, ^bb3)
+  ^bb7:  // 2 preds: ^bb6, ^bb7
+    AIE.useLock(%11, Acquire, 1)
+    AIE.dmaBd(<%29 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%11, Release, 0)
+    cf.br ^bb7
+  }
+  %40 = AIE.core(%1) {
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c0 = arith.constant 0 : index
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    AIE.useLock(%11, Acquire, 0)
+    AIE.useLock(%14, Acquire, 1)
+    AIE.useLock(%12, Acquire, 1)
+    AIE.useLock(%13, Acquire, 1)
+    affine.for %arg1 = 0 to 32 {
+      affine.for %arg2 = 0 to 32 {
+        %43 = affine.load %30[%arg1, %arg2] : memref<32x32xi32, 2>
+        %44 = affine.load %31[%arg1, %arg2] : memref<32x32xi32, 2>
+        %45 = affine.load %29[%arg1, %arg2] : memref<32x32xi32, 2>
+        %46 = arith.muli %43, %44 : i32
+        %47 = arith.addi %45, %46 : i32
+        affine.store %47, %29[%arg1, %arg2] : memref<32x32xi32, 2>
+      }
+    }
+    AIE.useLock(%13, Release, 0)
+      AIE.useLock(%12, Release, 0)
+    AIE.useLock(%14, Release, 0)
+    AIE.useLock(%11, Release, 1)
+    AIE.end
+  } {elf_file = "partition_0_core_8_2.elf"}
+  memref.global "public" @__air_herd_arg_0 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_1 : memref<64x64xi32>
+  memref.global "public" @__air_herd_arg_2 : memref<64x64xi32>
+  %41 = AIE.mem(%0) {
+    %43 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb6)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%10, Acquire, 0)
+    AIE.dmaBd(<%32 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%10, Release, 1)
+    cf.br ^bb1
+  ^bb2:  // pred: ^bb3
+    AIE.end
+  ^bb3:  // pred: ^bb6
+    %44 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
+  ^bb4:  // 2 preds: ^bb3, ^bb5
+    AIE.useLock(%9, Acquire, 0)
+    AIE.dmaBd(<%33 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%9, Release, 1)
+    cf.br ^bb5
+  ^bb5:  // pred: ^bb4
+    AIE.useLock(%8, Acquire, 0)
+    AIE.dmaBd(<%34 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%8, Release, 1)
+    cf.br ^bb4
+  ^bb6:  // pred: ^bb0
+    %45 = AIE.dmaStart(MM2S, 0, ^bb7, ^bb3)
+  ^bb7:  // 2 preds: ^bb6, ^bb7
+    AIE.useLock(%7, Acquire, 1)
+    AIE.dmaBd(<%32 : memref<32x32xi32, 2>, 0, 1024>, 0)
+    AIE.useLock(%7, Release, 0)
+    cf.br ^bb7
+  }
+  %42 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c0 = arith.constant 0 : index
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    AIE.useLock(%7, Acquire, 0)
+    AIE.useLock(%10, Acquire, 1)
+    AIE.useLock(%8, Acquire, 1)
+    AIE.useLock(%9, Acquire, 1)
+    affine.for %arg1 = 0 to 32 {
+      affine.for %arg2 = 0 to 32 {
+        %43 = affine.load %33[%arg1, %arg2] : memref<32x32xi32, 2>
+        %44 = affine.load %34[%arg1, %arg2] : memref<32x32xi32, 2>
+        %45 = affine.load %32[%arg1, %arg2] : memref<32x32xi32, 2>
+        %46 = arith.muli %43, %44 : i32
+        %47 = arith.addi %45, %46 : i32
+        affine.store %47, %32[%arg1, %arg2] : memref<32x32xi32, 2>
+      }
+    }
+    AIE.useLock(%9, Release, 0)
+    AIE.useLock(%8, Release, 0)
+    AIE.useLock(%10, Release, 0)
+    AIE.useLock(%7, Release, 1)
+    AIE.end
+  } {elf_file = "partition_0_core_7_2.elf"}
+  AIE.flow(%3, DMA : 0, %4, DMA : 0)
+  AIE.flow(%2, DMA : 0, %4, DMA : 1)
+  AIE.flow(%1, DMA : 0, %5, DMA : 0)
+  AIE.flow(%0, DMA : 0, %5, DMA : 1)
+  AIE.broadcast_packet(%4, DMA : 0) {
+    AIE.bp_id(4) {
+      AIE.bp_dest<%0, DMA : 1>
+      AIE.bp_dest<%1, DMA : 1>
+    }
+    AIE.bp_id(5) {
+      AIE.bp_dest<%2, DMA : 1>
+      AIE.bp_dest<%3, DMA : 1>
+    }
+    AIE.bp_id(3) {
+      AIE.bp_dest<%1, DMA : 1>
+      AIE.bp_dest<%3, DMA : 1>
+    }
+    AIE.bp_id(2) {
+      AIE.bp_dest<%0, DMA : 1>
+      AIE.bp_dest<%2, DMA : 1>
+    }
+  }
+  AIE.flow(%5, DMA : 0, %3, DMA : 0)
+  AIE.flow(%5, DMA : 1, %2, DMA : 0)
+  AIE.flow(%6, DMA : 0, %1, DMA : 0)
+  AIE.flow(%6, DMA : 1, %0, DMA : 0)
+}

--- a/test/17_packet_bcast/run.lit
+++ b/test/17_packet_bcast/run.lit
@@ -1,0 +1,10 @@
+//===- run.lit ------------------------------------------------------------===//
+//
+// Copyright (C) 2022, Xilinx Inc.
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: %run_on_board %T/test.elf

--- a/test/17_packet_bcast/test.cpp
+++ b/test/17_packet_bcast/test.cpp
@@ -1,0 +1,293 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2020-2022, Xilinx Inc.
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "air_host.h"
+#include "test_library.h"
+
+#include "aie_inc.cpp"
+
+#define TILE_WIDTH 32
+#define TILE_HEIGHT 32
+#define TILE_SIZE (TILE_WIDTH * TILE_HEIGHT)
+
+int main(int argc, char *argv[]) {
+  uint64_t col = 7;
+  uint64_t row = 2;
+
+  auto init_ret = air_init();
+  assert(init_ret == HSA_STATUS_SUCCESS);
+
+  std::vector<air_agent_t> agents;
+  auto get_agents_ret = air_iterate_agents(
+      [](air_agent_t a, void *d) {
+        auto *v = static_cast<std::vector<air_agent_t> *>(d);
+        v->push_back(a);
+        return HSA_STATUS_SUCCESS;
+      },
+      (void *)&agents);
+  assert(get_agents_ret == HSA_STATUS_SUCCESS && agents.size() &&
+         "failed to get agents!");
+
+  std::cout << "Found " << agents.size() << " agents" << std::endl;
+
+  std::vector<queue_t *> queues;
+  for (auto agent : agents) {
+    // create the queue
+    queue_t *q = nullptr;
+    auto create_queue_ret =
+        air_queue_create(MB_QUEUE_SIZE, HSA_QUEUE_TYPE_SINGLE, &q, agent.handle,
+                         0 /* device_id (optional) */);
+    assert(create_queue_ret == 0 && "failed to create queue!");
+    queues.push_back(q);
+  }
+
+  aie_libxaie_ctx_t *xaie = (aie_libxaie_ctx_t *)air_get_libxaie_ctx();
+  if (xaie == NULL) {
+    std::cout << "Error initializing libxaie" << std::endl;
+    return -1;
+  }
+
+  // Want to initializing the device memory allocator
+  if (air_init_dev_mem_allocator(0x8000 /* dev_mem_size */,
+                                 0 /* device_id (optional)*/)) {
+    std::cout << "Error creating device memory allocator" << std::endl;
+    return -1;
+  }
+
+  uint64_t wr_idx = queue_add_write_index(queues[0], 1);
+  uint64_t packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *herd_pkt =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_herd_init(herd_pkt, 0, col, 2, row, 2);
+  air_queue_dispatch_and_wait(queues[0], wr_idx, herd_pkt);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *shim_pkt =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_device_init(shim_pkt, XAIE_NUM_COLS);
+  air_queue_dispatch_and_wait(queues[0], wr_idx, shim_pkt);
+
+  XAie_Finish(&(xaie->DevInst));
+  XAie_CfgInitialize(&(xaie->DevInst), &(xaie->AieConfigPtr));
+  XAie_PmRequestTiles(&(xaie->DevInst), NULL, 0);
+
+  mlir_aie_configure_cores(xaie);
+  mlir_aie_configure_switchboxes(xaie);
+  mlir_aie_initialize_locks(xaie);
+  mlir_aie_configure_dmas(xaie);
+  mlir_aie_start_cores(xaie);
+
+  // overwrite the tile memory buffers
+  for (int i = 0; i < TILE_SIZE; i++) {
+    mlir_aie_write_buffer_buf0(xaie, i, 0xdeadbeef);
+    mlir_aie_write_buffer_buf1(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf2(xaie, i, 0xdeadbeef);
+    mlir_aie_write_buffer_buf3(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf4(xaie, i, 0xdeadbeef);
+    mlir_aie_write_buffer_buf5(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf6(xaie, i, 0xdeadbeef);
+    mlir_aie_write_buffer_buf7(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf8(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf9(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf10(xaie, i, 0xfeedface);
+    mlir_aie_write_buffer_buf11(xaie, i, 0xfeedface);
+  }
+
+  uint32_t *dram_ptr_1 =
+      (uint32_t *)air_dev_mem_alloc(TILE_SIZE * sizeof(uint32_t));
+  uint32_t *dram_ptr_2 =
+      (uint32_t *)air_dev_mem_alloc(TILE_SIZE * sizeof(uint32_t));
+  uint32_t *dram_ptr_3 =
+      (uint32_t *)air_dev_mem_alloc(TILE_SIZE * sizeof(uint32_t));
+  uint32_t *dram_ptr_4 =
+      (uint32_t *)air_dev_mem_alloc(TILE_SIZE * sizeof(uint32_t));
+  uint32_t *dram_ptr_5 =
+      (uint32_t *)air_dev_mem_alloc(TILE_SIZE * sizeof(uint32_t));
+
+  if (dram_ptr_1 == NULL || dram_ptr_2 == NULL || dram_ptr_3 == NULL ||
+      dram_ptr_4 == NULL || dram_ptr_5 == NULL) {
+    std::cout << "Couldn't allocate device memory" << std::endl;
+    return -1;
+  }
+
+  for (int i = 0; i < TILE_SIZE; i++) {
+    dram_ptr_1[i] = 1;
+    dram_ptr_2[i] = 2;
+    dram_ptr_3[i] = 3;
+    dram_ptr_4[i] = 4;
+    dram_ptr_5[i] = 5;
+  }
+
+  // Send the packet to write the tiles
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_a =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_a, /*herd_id*/ 0, /*col*/ 2, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 2, /*id*/ 2,
+                       air_dev_mem_get_pa(dram_ptr_2) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_b =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_b, /*herd_id*/ 0, /*col*/ 2, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 3, /*id*/ 3,
+                       air_dev_mem_get_pa(dram_ptr_3) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_c =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_c, /*herd_id*/ 0, /*col*/ 2, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 4, /*id*/ 4,
+                       air_dev_mem_get_pa(dram_ptr_4) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_d =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_d, /*herd_id*/ 0, /*col*/ 2, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 5, /*id*/ 5,
+                       air_dev_mem_get_pa(dram_ptr_5) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_d);
+  printf("finished broadcast\n");
+
+  printf("7,2 a : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf0(xaie, i));
+  }
+  printf("\n7,2 b : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf1(xaie, i));
+  }
+  printf("\n8,2 a : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf3(xaie, i));
+  }
+  printf("\n8,2 b : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf4(xaie, i));
+  }
+  printf("\n7,3 a : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf6(xaie, i));
+  }
+  printf("\n7,3 b : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf7(xaie, i));
+  }
+  printf("\n8,3 a : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf9(xaie, i));
+  }
+  printf("\n8,3 b : ");
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    printf("%x ", mlir_aie_read_buffer_buf10(xaie, i));
+  }
+  printf("\n");
+
+  // c
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_e =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_e, /*herd_id*/ 0, /*col*/ 3, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 0, /*id*/ 0,
+                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_f =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_f, /*herd_id*/ 0, /*col*/ 3, /*direction*/ 1,
+                       /*channel*/ 1, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 0, /*id*/ 0,
+                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_g =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_g, /*herd_id*/ 0, /*col*/ 6, /*direction*/ 1,
+                       /*channel*/ 0, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 0, /*id*/ 0,
+                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  wr_idx = queue_add_write_index(queues[0], 1);
+  packet_id = wr_idx % queues[0]->size;
+  dispatch_packet_t *pkt_h =
+      (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
+  air_packet_nd_memcpy(pkt_h, /*herd_id*/ 0, /*col*/ 6, /*direction*/ 1,
+                       /*channel*/ 1, /*burst_len*/ 4, /*space*/ 2,
+                       /*type*/ 0, /*id*/ 0,
+                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+                       TILE_WIDTH * sizeof(uint32_t), TILE_HEIGHT,
+                       TILE_WIDTH * sizeof(uint32_t), 1, 0, 1, 0);
+
+  air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_h);
+  printf("finished copies\n");
+
+  sleep(1);
+
+  uint32_t errs = 0;
+  for (int i = 0; i < TILE_WIDTH; i++) {
+    if (mlir_aie_read_buffer_buf2(xaie, i) != 9)
+      errs++;
+    if (mlir_aie_read_buffer_buf5(xaie, i) != 13)
+      errs++;
+    if (mlir_aie_read_buffer_buf8(xaie, i) != 11)
+      errs++;
+    if (mlir_aie_read_buffer_buf11(xaie, i) != 16)
+      errs++;
+  }
+
+  air_dev_mem_allocator_free();
+
+  if (errs == 0) {
+    printf("PASS!\n");
+    return 0;
+  } else {
+    printf("fail.\n");
+    return -1;
+  }
+}

--- a/test/273_barrier_add_two/test.cpp
+++ b/test/273_barrier_add_two/test.cpp
@@ -142,7 +142,8 @@ main(int argc, char *argv[])
       wr_idx = queue_add_write_index(queues[0], 1);
       packet_id = wr_idx % queues[0]->size;
       dispatch_packet_t *pkt1 = (dispatch_packet_t*)(queues[0]->base_address_vaddr) + packet_id;
-      air_packet_nd_memcpy(pkt1, 0, 2 + i, 1, 0 + j, 4, 2,
+      air_packet_nd_memcpy(pkt1, 0, 2 + i, 1, 0 + j, 4, 2, /*packet_id=*/0,
+                           /*packet_type=*/0,
                            air_dev_mem_get_pa(bram_ptr) +
                                ((2 * i + j) * DMA_COUNT * sizeof(float)),
                            DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
@@ -154,11 +155,11 @@ main(int argc, char *argv[])
       wr_idx = queue_add_write_index(queues[0], 1);
       packet_id = wr_idx % queues[0]->size;
       dispatch_packet_t *pkt2 = (dispatch_packet_t*)(queues[0]->base_address_vaddr) + packet_id;
-      air_packet_nd_memcpy(pkt2, 0, 2 + i, 0, 0 + j, 4, 2,
-                           air_dev_mem_get_pa(bram_ptr) +
-                               (4 * DMA_COUNT * sizeof(float)) +
-                               ((2 * i + j) * DMA_COUNT * sizeof(float)),
-                           DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
+      air_packet_nd_memcpy(
+          pkt2, 0, 2 + i, 0, 0 + j, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+          air_dev_mem_get_pa(bram_ptr) + (4 * DMA_COUNT * sizeof(float)) +
+              ((2 * i + j) * DMA_COUNT * sizeof(float)),
+          DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
       signal_create(1, 0, NULL, (signal_t *)&pkt2->completion_signal);
 
       uint64_t s = queue_paddr_from_index(
@@ -190,10 +191,10 @@ main(int argc, char *argv[])
   wr_idx2 = queue_add_write_index(queues[1], 1);
   packet_id2 = wr_idx2 % queues[1]->size;
   dispatch_packet_t *pkt12 = (dispatch_packet_t*)(queues[1]->base_address_vaddr) + packet_id2;
-  air_packet_nd_memcpy(pkt12, 0, 6, 1, 0, 4, 2,
-                       air_dev_mem_get_pa(bram_ptr) +
-                           4 * DMA_COUNT * sizeof(float),
-                       4 * DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(
+      pkt12, 0, 6, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(bram_ptr) + 4 * DMA_COUNT * sizeof(float),
+      4 * DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   //
   // read the data
@@ -202,10 +203,10 @@ main(int argc, char *argv[])
   wr_idx2 = queue_add_write_index(queues[1], 1);
   packet_id2 = wr_idx2 % queues[1]->size;
   dispatch_packet_t *pkt22 = (dispatch_packet_t*)(queues[1]->base_address_vaddr) + packet_id2;
-  air_packet_nd_memcpy(pkt22, 0, 6, 0, 0, 4, 2,
-                       air_dev_mem_get_pa(bram_ptr) +
-                           (8 * DMA_COUNT * sizeof(float)),
-                       4 * DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
+  air_packet_nd_memcpy(
+      pkt22, 0, 6, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(bram_ptr) + (8 * DMA_COUNT * sizeof(float)),
+      4 * DMA_COUNT * sizeof(float), 1, 0, 1, 0, 1, 0);
 
   // start herd 1 (waiting on barrier)
   air_queue_dispatch(queues[1], wr_idx2, pkt22);

--- a/test/290_mb_matrix_add_ddr/test.cpp
+++ b/test/290_mb_matrix_add_ddr/test.cpp
@@ -124,7 +124,12 @@ main(int argc, char *argv[])
   wr_idx = queue_add_write_index(q, 1);
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt_c = (dispatch_packet_t*)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_c, 0, col, 0, 0, 4, 2, DDR_ADDR+(2*IMAGE_SIZE*sizeof(float)), TILE_WIDTH*sizeof(float), TILE_HEIGHT, IMAGE_WIDTH*sizeof(float), NUM_3D, TILE_WIDTH*sizeof(float), NUM_4D, IMAGE_WIDTH*TILE_HEIGHT*sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      DDR_ADDR + (2 * IMAGE_SIZE * sizeof(float)), TILE_WIDTH * sizeof(float),
+      TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), NUM_3D,
+      TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   //
   // packet to send the input matrices
@@ -133,12 +138,21 @@ main(int argc, char *argv[])
   wr_idx = queue_add_write_index(q, 1);
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt_a = (dispatch_packet_t*)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2, DDR_ADDR, TILE_WIDTH*sizeof(float), TILE_HEIGHT, IMAGE_WIDTH*sizeof(float), NUM_3D, TILE_WIDTH*sizeof(float), NUM_4D, IMAGE_WIDTH*TILE_HEIGHT*sizeof(float));
+  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0, DDR_ADDR, TILE_WIDTH * sizeof(float),
+                       TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), NUM_3D,
+                       TILE_WIDTH * sizeof(float), NUM_4D,
+                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   wr_idx = queue_add_write_index(q, 1);
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt_b = (dispatch_packet_t*)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_b, 0, col, 1, 1, 4, 2, DDR_ADDR+(IMAGE_SIZE*sizeof(float)), TILE_WIDTH*sizeof(float), TILE_HEIGHT, IMAGE_WIDTH*sizeof(float), NUM_3D, TILE_WIDTH*sizeof(float), NUM_4D, IMAGE_WIDTH*TILE_HEIGHT*sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_b, 0, col, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      DDR_ADDR + (IMAGE_SIZE * sizeof(float)), TILE_WIDTH * sizeof(float),
+      TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), NUM_3D,
+      TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   //
   // dispatch the packets to the MB

--- a/test/29_mb_matrix_add/test.cpp
+++ b/test/29_mb_matrix_add/test.cpp
@@ -149,7 +149,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, col, 0, 0, 4, 2,
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(dram_ptr_3) /*BRAM_ADDR+(2*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
       NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
@@ -164,9 +164,10 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_a, 0, col, 1, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_1) /*BRAM_ADDR*/,
-      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
-      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*BRAM_ADDR*/, TILE_WIDTH * sizeof(float),
+      TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), NUM_3D,
+      TILE_WIDTH * sizeof(float), NUM_4D,
       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   wr_idx = queue_add_write_index(queues[0], 1);
@@ -174,7 +175,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_b, 0, col, 1, 1, 4, 2,
+      pkt_b, 0, col, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(dram_ptr_2) /*BRAM_ADDR+(IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
       NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,

--- a/test/30_2d_mb_shim_dma/test.cpp
+++ b/test/30_2d_mb_shim_dma/test.cpp
@@ -118,7 +118,8 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2,
+  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0,
+                       /*packet_type=*/0,
                        air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
                        TILE_WIDTH * sizeof(float), TILE_HEIGHT,
                        IMAGE_WIDTH * sizeof(float), 1, 0, 1, 0);
@@ -129,7 +130,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, col, 0, 0, 4, 2,
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), 1,

--- a/test/31_3d_mb_shim_dma/test.cpp
+++ b/test/31_3d_mb_shim_dma/test.cpp
@@ -121,9 +121,9 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_a, 0, col, 1, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_1),
-      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
-      NUM_3D, TILE_WIDTH * sizeof(float), 1, 0);
+      pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), 1, 0);
 
   // Send the packet to read from the tiles
   wr_idx = queue_add_write_index(queues[0], 1);
@@ -131,9 +131,9 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, col, 0, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_2),
-      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
-      NUM_3D, TILE_WIDTH * sizeof(float), 1, 0);
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_2), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), 1, 0);
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_c);
 
   uint32_t errs = 0;

--- a/test/32_4d_mb_shim_dma/test.cpp
+++ b/test/32_4d_mb_shim_dma/test.cpp
@@ -121,12 +121,12 @@ main(int argc, char *argv[])
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, col, 1, 0, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_a, 0, col, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Sending the packet to read from the tiles
   wr_idx = queue_add_write_index(queues[0], 1);
@@ -134,7 +134,7 @@ main(int argc, char *argv[])
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, col, 0, 0, 4, 2,
+      pkt_c, 0, col, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),

--- a/test/36_4d_mb_multi_shim_dma_all_channels/test.cpp
+++ b/test/36_4d_mb_multi_shim_dma_all_channels/test.cpp
@@ -142,11 +142,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 7, 1, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_1),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_a, 0, 7, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_a);
 
   // Core 7,4
@@ -156,11 +156,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_b, 0, 7, 1, 1, 4, 2, air_dev_mem_get_pa(dram_ptr_1),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_b, 0, 7, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_b);
 
   // Core 8,2
@@ -170,11 +170,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_e =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_e, 0, 6, 1, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_1),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_e, 0, 6, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_e);
 
   // Core 8,4
@@ -184,11 +184,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_f =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_f, 0, 6, 1, 1, 4, 2, air_dev_mem_get_pa(dram_ptr_1),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_f, 0, 6, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_f);
 
   // Core 7,2
@@ -198,11 +198,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_c, 0, 7, 0, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_2),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_c, 0, 7, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_2), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_c);
 
   // Core 7,4
@@ -212,11 +212,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_d, 0, 7, 0, 1, 4, 2, air_dev_mem_get_pa(dram_ptr_3),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_d, 0, 7, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_3), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_d);
 
   // Core 8,2
@@ -226,11 +226,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_g =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_g, 0, 6, 0, 0, 4, 2, air_dev_mem_get_pa(dram_ptr_4),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_g, 0, 6, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_4), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   // air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_g);
 
   // Core 8,4
@@ -239,11 +239,11 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_h =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_h, 0, 6, 0, 1, 4, 2, air_dev_mem_get_pa(dram_ptr_5),
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_h, 0, 6, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_5), TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+      IMAGE_WIDTH * sizeof(float), NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
   air_queue_dispatch_and_wait(queues[0], wr_idx, pkt_h);
 
   uint32_t errs = 0;

--- a/test/37_4d_mb_multi_shim_dma_broadcast/test.cpp
+++ b/test/37_4d_mb_multi_shim_dma_broadcast/test.cpp
@@ -135,12 +135,12 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 7, 1, 0, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_a, 0, 7, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Core 7,2
   // Start by sending the packet to read from the tiles
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, 7, 0, 0, 4, 2,
+      pkt_c, 0, 7, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_d, 0, 7, 0, 1, 4, 2,
+      pkt_d, 0, 7, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_3) /*AIR_BBUFF_BASE+(2*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_g =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_g, 0, 6, 0, 0, 4, 2,
+      pkt_g, 0, 6, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_4) /*AIR_BBUFF_BASE+(3*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_h =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_h, 0, 6, 0, 1, 4, 2,
+      pkt_h, 0, 6, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_5) /*AIR_BBUFF_BASE+(4*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),

--- a/test/38_4d_mb_shim_dma_channel_stress/test.cpp
+++ b/test/38_4d_mb_shim_dma_channel_stress/test.cpp
@@ -148,12 +148,12 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 7, 1, 0, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_a, 0, 7, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Core 7,4
   // Send the packet to write the tiles
@@ -161,12 +161,12 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_b =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_b, 0, 11, 1, 1, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_b, 0, 11, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Core 8,2
   // Send the packet to write the tiles
@@ -174,12 +174,12 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_e =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_e, 0, 6, 1, 0, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_e, 0, 6, 1, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Core 8,4
   // Send the packet to write the tiles
@@ -187,12 +187,12 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % queues[0]->size;
   dispatch_packet_t *pkt_f =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_f, 0, 10, 1, 1, 4, 2,
-                       air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), NUM_3D,
-                       TILE_WIDTH * sizeof(float), NUM_4D,
-                       IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
+  air_packet_nd_memcpy(
+      pkt_f, 0, 10, 1, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
+      air_dev_mem_get_pa(dram_ptr_1) /*AIR_BBUFF_BASE*/,
+      TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
+      NUM_3D, TILE_WIDTH * sizeof(float), NUM_4D,
+      IMAGE_WIDTH * TILE_HEIGHT * sizeof(float));
 
   // Core 7,2
   // Start by sending the packet to read from the tiles
@@ -201,7 +201,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_c, 0, 3, 0, 0, 4, 2,
+      pkt_c, 0, 3, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_2) /*AIR_BBUFF_BASE+(IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -215,7 +215,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_d =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_d, 0, 19, 0, 1, 4, 2,
+      pkt_d, 0, 19, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_3) /*AIR_BBUFF_BASE+(2*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_g =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_g, 0, 26, 0, 0, 4, 2,
+      pkt_g, 0, 26, 0, 0, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_4) /*AIR_BBUFF_BASE+(3*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),
@@ -243,7 +243,7 @@ int main(int argc, char *argv[]) {
   dispatch_packet_t *pkt_h =
       (dispatch_packet_t *)(queues[0]->base_address_vaddr) + packet_id;
   air_packet_nd_memcpy(
-      pkt_h, 0, 18, 0, 1, 4, 2,
+      pkt_h, 0, 18, 0, 1, 4, 2, /*packet_id=*/0, /*packet_type=*/0,
       air_dev_mem_get_pa(
           dram_ptr_5) /*AIR_BBUFF_BASE+(4*IMAGE_SIZE*sizeof(float))*/,
       TILE_WIDTH * sizeof(float), TILE_HEIGHT, IMAGE_WIDTH * sizeof(float),

--- a/test/level2-tests/109_L2_DMA_1d_nd_memcpy_pkt/test.cpp
+++ b/test/level2-tests/109_L2_DMA_1d_nd_memcpy_pkt/test.cpp
@@ -107,8 +107,9 @@ int main(int argc, char *argv[]) {
     packet_id = wr_idx % q->size;
     pkt = (dispatch_packet_t *)(q->base_address_vaddr) + packet_id;
 
-    air_packet_nd_memcpy(pkt, 0, 7, 1, sel, 4, 1, 0, XFR_SZ * sizeof(float), 1,
-                         0, 1, 0, 1, 0);
+    air_packet_nd_memcpy(pkt, 0, 7, 1, sel, 4, 1, /*packet_id=*/0,
+                         /*packet_type=*/0, 0, XFR_SZ * sizeof(float), 1, 0, 1,
+                         0, 1, 0);
 
     //
     // read the data back
@@ -117,7 +118,8 @@ int main(int argc, char *argv[]) {
     packet_id = wr_idx % q->size;
     pkt = (dispatch_packet_t *)(q->base_address_vaddr) + packet_id;
 
-    air_packet_nd_memcpy(pkt, 0, 7, 0, sel, 4, 1, XFR_SZ * sizeof(float),
+    air_packet_nd_memcpy(pkt, 0, 7, 0, sel, 4, 1, /*packet_id=*/0,
+                         /*packet_type=*/0, XFR_SZ * sizeof(float),
                          XFR_SZ * sizeof(float), 1, 0, 1, 0, 1, 0);
   }
 

--- a/test/level2-tests/118_L2_DMA_2d_nd_memcpy_pkt/test.cpp
+++ b/test/level2-tests/118_L2_DMA_2d_nd_memcpy_pkt/test.cpp
@@ -113,9 +113,9 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt_a =
       (dispatch_packet_t *)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_a, 0, 7, 1, 0, 4, /*space*/ 1, 0,
-                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
-                       IMAGE_WIDTH * sizeof(float), 1, 0, 1, 0);
+  air_packet_nd_memcpy(pkt_a, 0, 7, 1, 0, 4, /*space=*/1, /*packet_id=*/0,
+                       /*packet_type=*/0, 0, TILE_WIDTH * sizeof(float),
+                       TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), 1, 0, 1, 0);
 
   //
   // read the data back
@@ -126,9 +126,10 @@ int main(int argc, char *argv[]) {
   packet_id = wr_idx % q->size;
   dispatch_packet_t *pkt_c =
       (dispatch_packet_t *)(q->base_address_vaddr) + packet_id;
-  air_packet_nd_memcpy(pkt_c, 0, 7, 0, 1, 4, /*space*/ 1,
-                       IMAGE_SIZE * sizeof(float), TILE_WIDTH * sizeof(float),
-                       TILE_HEIGHT, IMAGE_WIDTH * sizeof(float), 1, 0, 1, 0);
+  air_packet_nd_memcpy(pkt_c, 0, 7, 0, 1, 4, /*space=*/1, /*packet_id=*/0,
+                       /*packet_type=*/0, IMAGE_SIZE * sizeof(float),
+                       TILE_WIDTH * sizeof(float), TILE_HEIGHT,
+                       IMAGE_WIDTH * sizeof(float), 1, 0, 1, 0);
 
   air_queue_dispatch_and_wait(q, wr_idx, pkt_c);
 


### PR DESCRIPTION
This adds a type and id field to the nd memcpy packets.
