### PR TITLE
AIR ParseGraph: Parse and interpret AIR dependency graph as flattened boost graph

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -51,6 +51,8 @@ mlir::AffineIfOp getAffineIfInBlock(mlir::Block *block);
 
 air::DmaMemcpyNdOp getAIRDmaInBlock(mlir::Block *block);
 
+void eraseAIRHierarchyOperand(air::HierarchyInterface op, unsigned index);
+
 struct LinalgTransforms {
   static const StringLiteral kLinalgTransformMarker;
 };

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -50,9 +50,11 @@ public:
       canonicalizer.updateDepList(func, trHostGraph);
 
       // Clean up
-      canonicalizer.removeDepListRepitition(func);
       canonicalizer.removeUnusedExecuteOp(func);
       canonicalizer.removeRedundantWaitAllOps(func);
+      canonicalizer.removeRedundantAIRHierarchyArgs(func);
+      canonicalizer.canonicalizeAIRHierarchyDependency(func);
+      canonicalizer.removeDepListRepitition(func);
 
       if (clDumpGraph) {
         // Dump graphs

--- a/mlir/lib/Transform/AIRDependencyParseGraph.cpp
+++ b/mlir/lib/Transform/AIRDependencyParseGraph.cpp
@@ -39,10 +39,13 @@ public:
     for (auto func : module.getOps<func::FuncOp>()) {
       // Parse dependency graphs
       hostGraph = dependencyGraph(func, true);
-      canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx, true,
-                                       clDumpDir);
+      canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx);
       // Purge id attribute
       func.walk([&](Operation *op) { op->removeAttr("id"); });
+
+      // Visualize graph with flattened hierarchy
+      canonicalizer.copyDependencyGraphToFlatGraphAndVisualize(
+          func, hostGraph, dep_ctx, true, clDumpDir);
     }
   }
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -173,6 +173,42 @@ void traceDependentInductionVar(air::AsyncOpInterface async_op,
   }
 }
 
+// Recursively check for dependency to any control token (scf loop or wait all)
+void traceDependentScfLoopToken(air::AsyncOpInterface async_op,
+                                SmallVector<Value, 1> &control_token_history,
+                                std::vector<Operation *> &op_history) {
+
+  // Check for immediate dependency to control tokens
+  for (auto token : async_op.getAsyncDependencies()) {
+    if (auto for_op = getForRegionIterArgsOwner(token)) {
+      control_token_history.push_back(token);
+      return;
+    }
+    if (auto parallel_op =
+            getParallelRegionInitValsOwner(async_op.getOperation(), token)) {
+      control_token_history.push_back(token);
+      return;
+    }
+    if (token.getDefiningOp() &&
+        dyn_cast<air::WaitAllOp>(token.getDefiningOp())) {
+      control_token_history.push_back(token);
+      return;
+    }
+  }
+
+  // Recursively trace dependency to scf loop tokens
+  for (auto token : async_op.getAsyncDependencies()) {
+    if (token.getDefiningOp() &&
+        mlir::dyn_cast<air::AsyncOpInterface>(token.getDefiningOp())) {
+      auto ancestor_async_op =
+          dyn_cast<air::AsyncOpInterface>(token.getDefiningOp());
+      op_history.push_back(ancestor_async_op.getOperation());
+      traceDependentScfLoopToken(ancestor_async_op, control_token_history,
+                                 op_history);
+    }
+  }
+}
+
 void eraseAsyncDependencyFromAsyncOp(xilinx::air::AsyncOpInterface op,
                                      Value token) {
   assert(token && "input value is nullptr");
@@ -291,8 +327,6 @@ air::ChannelGetOp getTheOtherChannelOpThroughSymbol(air::ChannelPutOp put) {
 }
 air::ChannelPutOp getTheOtherChannelOpThroughSymbol(air::ChannelGetOp get) {
   auto module = get->getParentOfType<ModuleOp>();
-  // auto channel_op =
-  //     dyn_cast<air::ChannelOp>(module.lookupSymbol(get.getChanName()));
   auto channel_op = getChannelDeclarationThroughSymbol(
       dyn_cast<air::ChannelInterface>(get.getOperation()));
   auto attr =
@@ -394,6 +428,129 @@ void dependencyCanonicalizer::parseCommandGraphs(func::FuncOp &toplevel,
   if (dump_dot) {
     // Dump dot graphs
     dumpDotGraphFiles(global_graph, dump_dir);
+  }
+}
+
+void dependencyCanonicalizer::copyDependencyGraphToFlatGraphAndVisualize(
+    func::FuncOp &toplevel, dependencyGraph &global_graph,
+    dependencyContext &dep_ctx, bool dump_dot, std::string dump_dir) {
+  // Create FlatGraph
+  FlatGraph flat_g;
+  boost::get_property(flat_g, boost::graph_graph_attribute)["rankdir"] = "LR";
+  std::vector<vertex_to_flat_vertex_map> maps;
+
+  // Copy vertices and edges to flat graph
+  vertex_to_flat_vertex_map map;
+  copyFromDependencyGraphToFlatGraph(global_graph.g, flat_g, map, true);
+  maps.push_back(map);
+  for (auto &G_l : global_graph.subgraphs) {
+    vertex_to_flat_vertex_map map_l;
+    copyFromDependencyGraphToFlatGraph(G_l.g, flat_g, map_l);
+    maps.push_back(map_l);
+    for (auto &G_p : G_l.subgraphs) {
+      vertex_to_flat_vertex_map map_p;
+      copyFromDependencyGraphToFlatGraph(G_p.g, flat_g, map_p);
+      maps.push_back(map_p);
+      for (auto &G_h : G_p.subgraphs) {
+        vertex_to_flat_vertex_map map_h;
+        copyFromDependencyGraphToFlatGraph(G_h.g, flat_g, map_h);
+        maps.push_back(map_h);
+      }
+    }
+  }
+
+  // AIR channel dependency edges, overlayed as a (non-cluster) subgraph
+  ChannelMap channel_map;
+  unsigned index = 0;
+  collectAIRChannelPutAndGetInGraph(global_graph.g, maps[index++], channel_map);
+  for (auto &G_l : global_graph.subgraphs) {
+    collectAIRChannelPutAndGetInGraph(G_l.g, maps[index++], channel_map);
+    for (auto &G_p : G_l.subgraphs) {
+      collectAIRChannelPutAndGetInGraph(G_p.g, maps[index++], channel_map);
+      for (auto &G_h : G_p.subgraphs) {
+        collectAIRChannelPutAndGetInGraph(G_h.g, maps[index++], channel_map);
+      }
+    }
+  }
+  FlatGraph &flat_subg_chan = flat_g.create_subgraph();
+  for (auto &map : channel_map) {
+    if (map.second.first == std::numeric_limits<int>::max()) {
+      assert(false && "incomplete channel op map");
+    } else if (map.second.second == std::numeric_limits<int>::max()) {
+      assert(false && "incomplete channel op map");
+    }
+    auto a = add_vertex(map.second.first, flat_subg_chan);
+    auto b = add_vertex(map.second.second, flat_subg_chan);
+    auto e = add_edge(a, b, flat_subg_chan).first;
+    put(get(boost::edge_attribute, flat_subg_chan), e,
+        GraphvizAttributes{{"style", "dashed"}});
+  }
+
+  // Create subgraphs
+  boost::get_property(flat_g, boost::graph_name) = "host";
+  index = 1;
+  unsigned idx_l = 0;
+  unsigned idx_p = 0;
+  unsigned idx_h = 0;
+
+  auto vp = boost::vertices(global_graph.g);
+  for (auto vit = vp.first; vit != vp.second; ++vit) {
+    if (global_graph.g[*vit].asyncEventName == "LaunchOp") {
+      auto G_l = *global_graph.g[*vit].nextDependencyGraph;
+      FlatGraph &flat_subg_l = flat_g.create_subgraph();
+      updateSubgraphFromDependencyGraph(G_l.g, flat_subg_l, maps[index], true);
+      boost::get_property(flat_subg_l, boost::graph_name) =
+          "cluster" + std::to_string(index);
+      boost::get_property(flat_subg_l, boost::graph_graph_attribute)["label"] =
+          "launch" + std::to_string(idx_l++);
+      // Connect host "launch" graph nodes with "start" of launch subgraph
+      add_edge(maps[0][*vit], maps[index][G_l.start_vertex], flat_g);
+
+      auto map_idx_launch = index++;
+      auto vp_l = boost::vertices(G_l.g);
+      for (auto vit_l = vp_l.first; vit_l != vp_l.second; ++vit_l) {
+        if (G_l.g[*vit_l].asyncEventName == "PartitionOp") {
+          auto G_p = *G_l.g[*vit_l].nextDependencyGraph;
+          FlatGraph &flat_subg_p = flat_subg_l.create_subgraph();
+          updateSubgraphFromDependencyGraph(G_p.g, flat_subg_p, maps[index],
+                                            true);
+          boost::get_property(flat_subg_p, boost::graph_name) =
+              "cluster" + std::to_string(index);
+          boost::get_property(flat_subg_p,
+                              boost::graph_graph_attribute)["label"] =
+              "partition" + std::to_string(idx_p++);
+          // Connect host "launch" graph nodes with "start" of partition
+          // subgraph
+          add_edge(maps[map_idx_launch][*vit_l], maps[index][G_p.start_vertex],
+                   flat_g);
+
+          auto map_idx_partition = index++;
+          auto vp_p = boost::vertices(G_p.g);
+          for (auto vit_p = vp_p.first; vit_p != vp_p.second; ++vit_p) {
+            if (G_p.g[*vit_p].asyncEventName == "HerdOp") {
+              auto G_h = *G_p.g[*vit_p].nextDependencyGraph;
+              FlatGraph &flat_subg_h = flat_subg_p.create_subgraph();
+              updateSubgraphFromDependencyGraph(G_h.g, flat_subg_h, maps[index],
+                                                true);
+              boost::get_property(flat_subg_h, boost::graph_name) =
+                  "cluster" + std::to_string(index);
+              boost::get_property(flat_subg_h,
+                                  boost::graph_graph_attribute)["label"] =
+                  "herd" + std::to_string(idx_h++);
+              // Connect host "launch" graph nodes with "start" of herd subgraph
+              add_edge(maps[map_idx_partition][*vit_p],
+                       maps[index++][G_h.start_vertex], flat_g);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (dump_dot) {
+    // Dump dot graphs
+    std::ofstream ofs(dump_dir + "graph.dot", std::ofstream::out);
+    write_graphviz(ofs, flat_g);
   }
 }
 
@@ -526,8 +683,9 @@ Graph::vertex_descriptor dependencyCanonicalizer::addVertexFromChannelOp(
     assert(channel_get && "found channel op not in pairs");
     std::string memorySpaceDstStr =
         getMemorySpaceAsString(channel_get.getDstMemref());
-    std::string event_name =
-        "ChannelPutOp(" + memorySpaceSrcStr + "-->" + memorySpaceDstStr + ")";
+    std::string event_name = "ChannelPutOp@" + channel_put.getChanName().str() +
+                             "(" + memorySpaceSrcStr + "-->" +
+                             memorySpaceDstStr + ")";
     auto channel_op = getChannelDeclarationThroughSymbol(op);
     if (channel_op->hasAttr("broadcast_shape")) {
       auto size = extractFromI64ArrayAttr(channel_op.getSize());
@@ -557,8 +715,9 @@ Graph::vertex_descriptor dependencyCanonicalizer::addVertexFromChannelOp(
     assert(channel_put && "found channel op not in pairs");
     std::string memorySpaceSrcStr =
         getMemorySpaceAsString(channel_put.getSrcMemref());
-    std::string event_name =
-        "ChannelGetOp(" + memorySpaceDstStr + "<--" + memorySpaceSrcStr + ")";
+    std::string event_name = "ChannelGetOp@" + channel_get.getChanName().str() +
+                             "(" + memorySpaceDstStr + "<--" +
+                             memorySpaceSrcStr + ")";
     auto channel_op = getChannelDeclarationThroughSymbol(op);
     if (channel_op->hasAttr("broadcast_shape")) {
       auto size = extractFromI64ArrayAttr(channel_op.getSize());
@@ -773,6 +932,82 @@ dependencyCanonicalizer::getVertexFromOp(Operation *op,
     output.second = dep_ctx.op_to_g[entry_pair];
   }
   return output;
+}
+
+// Copy vertices and edges from dependencyGraph to FlatGraph
+void dependencyCanonicalizer::copyFromDependencyGraphToFlatGraph(
+    Graph g_src, FlatGraph &g_dst, vertex_to_flat_vertex_map &map,
+    bool copyEdges) {
+  // Copy vertices
+  auto vp = boost::vertices(g_src);
+  for (auto vit = vp.first; vit != vp.second; ++vit) {
+    auto new_v = add_vertex(g_dst);
+    // Copy vertex asyncEventName
+    put(get(boost::vertex_attribute, g_dst), new_v,
+        GraphvizAttributes{{"label", g_src[*vit].asyncEventName},
+                           {"color", g_src[*vit].color},
+                           {"shape", g_src[*vit].shape},
+                           {"style", "filled"}});
+    map.insert(std::make_pair(*vit, new_v));
+  }
+  if (copyEdges) {
+    // Copy edges
+    for (auto vit = vp.first; vit != vp.second; ++vit) {
+      for (auto it = out_edges(*vit, g_src).first;
+           it != out_edges(*vit, g_src).second; it++) {
+        auto target_it = target(*it, g_src);
+        add_edge(map[*vit], map[target_it], g_dst);
+      }
+    }
+  }
+}
+
+// Update subgraph in FlatGraph from dependencyGraph
+void dependencyCanonicalizer::updateSubgraphFromDependencyGraph(
+    Graph subg_src, FlatGraph &subg_dst, vertex_to_flat_vertex_map map,
+    bool copyEdges) {
+  // Update vertices
+  vertex_to_flat_vertex_map subg_map;
+  auto vp = boost::vertices(subg_src);
+  for (auto vit = vp.first; vit != vp.second; ++vit) {
+    auto new_v = add_vertex(map[*vit], subg_dst);
+    subg_map.insert(std::make_pair(*vit, new_v));
+  }
+  if (copyEdges) {
+    // Update edges
+    for (auto vit = vp.first; vit != vp.second; ++vit) {
+      for (auto it = out_edges(*vit, subg_src).first;
+           it != out_edges(*vit, subg_src).second; it++) {
+        auto target_it = target(*it, subg_src);
+        add_edge(subg_map[*vit], subg_map[target_it], subg_dst);
+      }
+    }
+  }
+}
+
+// Collect air.channel put and get pairs
+void dependencyCanonicalizer::collectAIRChannelPutAndGetInGraph(
+    Graph g, vertex_to_flat_vertex_map map, ChannelMap &channel_map) {
+  // Search for air.channep put/get
+  auto vp = boost::vertices(g);
+  for (auto vit = vp.first; vit != vp.second; ++vit) {
+    if (g[*vit].asyncEventType == "channel") {
+      auto channel_op = dyn_cast<air::ChannelInterface>(g[*vit].op);
+      auto chan_name = channel_op.getChanName().str();
+      if (channel_map.find(chan_name) == channel_map.end()) {
+        // If key not found, then create map entry with given key
+        channel_map.insert(std::make_pair(
+            chan_name, std::make_pair(std::numeric_limits<int>::max(),
+                                      std::numeric_limits<int>::max())));
+      }
+      if (dyn_cast<air::ChannelPutOp>(g[*vit].op)) {
+        channel_map[chan_name].first = map[*vit];
+      } else if (dyn_cast<air::ChannelGetOp>(g[*vit].op)) {
+        channel_map[chan_name].second = map[*vit];
+      } else
+        assert(false && "unknown air.channel op type");
+    }
+  }
 }
 
 // Trace dependency of every op in a boost graph
@@ -1299,6 +1534,58 @@ void dependencyCanonicalizer::removeRedundantWaitAllOps(func::FuncOp func) {
         wa_op.erase();
       } else {
         wa_op->removeAttr("id");
+      }
+    }
+  });
+}
+
+// air.hierarchy ops should only depend on scf loop ops
+void dependencyCanonicalizer::canonicalizeAIRHierarchyDependency(
+    func::FuncOp func) {
+  func.walk([&](air::HierarchyInterface hier) {
+    if (dyn_cast<air::LaunchOp>(hier.getOperation())) {
+      // air.launch is strictly synchronous
+      return;
+    }
+    auto async_hier = dyn_cast<air::AsyncOpInterface>(hier.getOperation());
+    SmallVector<Value, 1> erased_tokens;
+    // Add dependency to any control events involving this hierarchy op
+    SmallVector<Value, 1> control_token_history;
+    std::vector<Operation *> op_history;
+    traceDependentScfLoopToken(async_hier, control_token_history, op_history);
+    for (auto token : control_token_history) {
+      async_hier.addAsyncDependency(token);
+    }
+    // Erase non-control dependencies; air hierarchy ops should only depend on
+    // control events
+    for (auto dep : async_hier.getAsyncDependencies()) {
+      if ((!getForRegionIterArgsOwner(dep)) &&
+          (!getParallelRegionInitValsOwner(hier.getOperation(), dep))) {
+        if (dep.getDefiningOp() &&
+            (!dyn_cast<air::WaitAllOp>(dep.getDefiningOp()))) {
+          erased_tokens.push_back(dep);
+        }
+      }
+    }
+    for (auto dep : erased_tokens) {
+      eraseAsyncDependencyFromAsyncOp(async_hier, dep);
+    }
+  });
+}
+
+// Remove unused air.hierarchy arguments
+void dependencyCanonicalizer::removeRedundantAIRHierarchyArgs(
+    func::FuncOp func) {
+  auto module = func->getParentOfType<ModuleOp>();
+  OpBuilder builder(module);
+  SmallVector<air::HierarchyInterface, 1> erased_ops;
+  func.walk([&](air::HierarchyInterface hier) {
+    // for (unsigned hier_operand_id = 0; hier_operand_id <
+    // hier.getNumKernelOperands(); hier_operand_id++) {
+    for (int hier_operand_id = hier.getNumKernelOperands() - 1;
+         hier_operand_id >= 0; hier_operand_id--) {
+      if (hier.getKernelArguments()[hier_operand_id].use_empty()) {
+        eraseAIRHierarchyOperand(hier, hier_operand_id);
       }
     }
   });

--- a/mlir/test/Transform/AIRDependencyCanonicalization/canonicalize_herd_blockargs.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/canonicalize_herd_blockargs.mlir
@@ -1,0 +1,45 @@
+//===- canonicalize_herd_blockargs.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Xilinx Inc. All rights reserved.
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
+
+// Prune block arguments for air.herd and air.partition
+// CHECK: %[[EVENT0:.*]] = air.launch async{{.*}}args(%[[VALUE1:.*]]=%[[VALUE0:.*]])
+// CHECK: %[[EVENT1:.*]] = air.partition async{{.*}}args(%[[VALUE2:.*]]=%[[VALUE1]])
+// CHECK: %[[EVENT2:.*]] = air.herd async{{.*}}args(%[[VALUE3:.*]]=%[[VALUE2]])
+
+module {
+  func.func @foo(%arg0: memref<256xi32, 2>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<256xi32, 2> attributes {id = 13 : i32} {
+      %c0_0 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %asyncToken, %valOut = air.execute -> (memref<512xi32, 3>) {
+        %3 = memref.alloc() : memref<512xi32, 3>
+        air.execute_terminator %3 : memref<512xi32, 3>
+      } {id = 1 : i32}
+      %2 = air.partition async  unroll(%arg6, %arg7) in (%arg8=%c1_1, %arg9=%c1_1) args(%arg10=%arg5, %newarg1=%valOut) : memref<256xi32, 2>, memref<512xi32, 3> attributes {id = 82 : i32} {
+        %c0_3 = arith.constant 0 : index
+        %c1_4 = arith.constant 1 : index
+        %4 = air.herd async  tile (%arg11, %arg12) in (%arg13=%c1_4, %arg14=%c1_4) args(%arg15=%arg10, %newarg2=%newarg1) : memref<256xi32, 2>, memref<512xi32, 3> attributes {id = 15 : i32} {
+          %c0_8 = arith.constant 0 : index
+          %asyncToken_9, %valOut_10 = air.execute -> (memref<128xi32, 1>) {
+            %6 = memref.alloc() : memref<128xi32, 1>
+            air.execute_terminator %6 : memref<128xi32, 1>
+          } {id = 3 : i32}
+          %5 = air.dma_memcpy_nd async [%asyncToken_9] (%valOut_10[] [] [], %arg15[%c0_8] [%c0_8] [%c0_8]) {id = 43 : i32} : (memref<128xi32, 1>, memref<256xi32, 2>)
+          air.herd_terminator
+        }
+        air.partition_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}


### PR DESCRIPTION
- Visualizing with graphviz the dependency graph as a flattened directed graph
- Using boost subgraph and graphviz 'cluster' keyword to improve clarity
- Rotate the graph such that it goes horizontally
- Add canonicalization functions to clean up redundant edges and block args after channel hoisting
- Unit tests
- Clang format