### PR TITLE
Preserve attributes when rewriting HerdOp

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -41,7 +41,8 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
     OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernel_operands)>,
     OpBuilder<(ins "ValueRange":$async_dependencies,
       "ValueRange":$sizes,"ValueRange":$kernel_operands,
-      CArg<"bool", "false">:$is_async)>
+      CArg<"bool", "false">:$is_async,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
   ];
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
@@ -99,7 +100,8 @@ def air_PartitionOp : air_Op<"partition", [air_AsyncOpInterface,
     OpBuilder<(ins "ValueRange":$sizes,"ValueRange":$kernel_operands)>,
     OpBuilder<(ins "ValueRange":$async_dependencies,
       "ValueRange":$sizes,"ValueRange":$kernel_operands,
-      CArg<"bool", "false">:$is_async)>
+      CArg<"bool", "false">:$is_async,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
   ];
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
@@ -189,8 +191,8 @@ def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
     OpBuilder<(ins "ValueRange":$async_dependencies,
       "ValueRange":$sizes,
       "ValueRange":$kernel_operands,
-      CArg<"bool", "false">:$is_async
-    )>
+      CArg<"bool", "false">:$is_async,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
   ];
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -70,7 +70,8 @@ static LogicalResult removeUnusedArguments(HerdOp op,
   BlockAndValueMapping remap;
   auto newOp = rewriter.create<HerdOp>(op.getLoc(), op.getAsyncDependencies(),
                                        op.getSizeOperands(), newOperands,
-                                       op->getNumResults() > 0);
+                                       op->getNumResults() > 0, op->getAttrs());
+
   rewriter.setInsertionPointToStart(&newOp.getBody().front());
   remap.map(op.getSize()[0], newOp.getSize()[0]);
   remap.map(op.getSize()[1], newOp.getSize()[1]);
@@ -161,7 +162,8 @@ static void printAsyncDependencies(OpAsmPrinter &printer, Operation *op,
 
 void LaunchOp::build(OpBuilder &builder, OperationState &result,
                      ValueRange asyncDependencies, ValueRange sizes,
-                     ValueRange launchOperands, bool isAsync) {
+                     ValueRange launchOperands, bool isAsync,
+                     ArrayRef<NamedAttribute> attrs) {
 
   result.addOperands(asyncDependencies);
   if (isAsync)
@@ -175,6 +177,12 @@ void LaunchOp::build(OpBuilder &builder, OperationState &result,
   segmentSizes.back() = static_cast<int32_t>(launchOperands.size());
   result.addAttribute(getOperandSegmentSizeAttr(),
                       builder.getDenseI32ArrayAttr(segmentSizes));
+
+  for (auto attr : attrs)
+    if (attr.getName() == getOperandSegmentSizeAttr())
+      continue;
+    else
+      result.addAttribute(attr.getName(), attr.getValue());
 
   Region *r = result.addRegion();
   Block *body = new Block();
@@ -240,8 +248,7 @@ void LaunchOp::print(OpAsmPrinter &p) {
 
   SmallVector<NamedAttribute, 8> filteredAttrs(
       llvm::make_filter_range((*this)->getAttrs(), [&](NamedAttribute attr) {
-        if (attr.getName() == OpTrait::AttrSizedOperandSegments<
-                                  void>::getOperandSegmentSizeAttr())
+        if (attr.getName() == getOperandSegmentSizeAttr())
           return false;
         if (attr.getName() == mlir::SymbolTable::getSymbolAttrName())
           return false;
@@ -353,9 +360,8 @@ ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
   segmentSizes.front() = asyncDependencies.size();
   segmentSizes[1] = tileSize.size();
   segmentSizes.back() = kernelOperands.size();
-  result.addAttribute(
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr(),
-      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
+  result.addAttribute(getOperandSegmentSizeAttr(),
+                      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
   return success();
 }
 
@@ -399,8 +405,7 @@ BlockArgument LaunchOp::getKernelArgument(unsigned i) {
 }
 
 unsigned LaunchOp::getNumDims() {
-  auto size_attr_name =
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr();
+  auto size_attr_name = getOperandSegmentSizeAttr();
   auto size_attr = (*this)->getAttrOfType<DenseI32ArrayAttr>(size_attr_name);
   auto segment_sizes = size_attr.asArrayRef();
   return segment_sizes[1];
@@ -412,7 +417,8 @@ unsigned LaunchOp::getNumDims() {
 
 void PartitionOp::build(OpBuilder &builder, OperationState &result,
                         ValueRange asyncDependencies, ValueRange sizes,
-                        ValueRange partitionOperands, bool isAsync) {
+                        ValueRange partitionOperands, bool isAsync,
+                        ArrayRef<NamedAttribute> attrs) {
 
   result.addOperands(asyncDependencies);
   if (isAsync)
@@ -426,6 +432,12 @@ void PartitionOp::build(OpBuilder &builder, OperationState &result,
   segmentSizes.back() = static_cast<int32_t>(partitionOperands.size());
   result.addAttribute(getOperandSegmentSizeAttr(),
                       builder.getDenseI32ArrayAttr(segmentSizes));
+
+  for (auto attr : attrs)
+    if (attr.getName() == getOperandSegmentSizeAttr())
+      continue;
+    else
+      result.addAttribute(attr.getName(), attr.getValue());
 
   Region *r = result.addRegion();
   Block *body = new Block();
@@ -493,8 +505,7 @@ void PartitionOp::print(OpAsmPrinter &p) {
 
   SmallVector<NamedAttribute, 8> filteredAttrs(
       llvm::make_filter_range((*this)->getAttrs(), [&](NamedAttribute attr) {
-        if (attr.getName() == OpTrait::AttrSizedOperandSegments<
-                                  void>::getOperandSegmentSizeAttr())
+        if (attr.getName() == getOperandSegmentSizeAttr())
           return false;
         if (attr.getName() == mlir::SymbolTable::getSymbolAttrName())
           return false;
@@ -608,9 +619,8 @@ ParseResult PartitionOp::parse(OpAsmParser &parser, OperationState &result) {
   segmentSizes.front() = asyncDependencies.size();
   segmentSizes[1] = tileSize.size();
   segmentSizes.back() = kernelOperands.size();
-  result.addAttribute(
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr(),
-      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
+  result.addAttribute(getOperandSegmentSizeAttr(),
+                      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
   return success();
 }
 
@@ -654,8 +664,7 @@ BlockArgument PartitionOp::getKernelArgument(unsigned i) {
 }
 
 unsigned PartitionOp::getNumDims() {
-  auto size_attr_name =
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr();
+  auto size_attr_name = getOperandSegmentSizeAttr();
   auto size_attr = (*this)->getAttrOfType<DenseI32ArrayAttr>(size_attr_name);
   auto segment_sizes = size_attr.asArrayRef();
   return segment_sizes[1];
@@ -667,7 +676,8 @@ unsigned PartitionOp::getNumDims() {
 
 void HerdOp::build(OpBuilder &builder, OperationState &result,
                    ValueRange asyncDependencies, ValueRange sizes,
-                   ValueRange launchOperands, bool isAsync) {
+                   ValueRange launchOperands, bool isAsync,
+                   ArrayRef<NamedAttribute> attrs) {
 
   result.addOperands(asyncDependencies);
   if (isAsync)
@@ -681,6 +691,12 @@ void HerdOp::build(OpBuilder &builder, OperationState &result,
   segmentSizes.back() = static_cast<int32_t>(launchOperands.size());
   result.addAttribute(getOperandSegmentSizeAttr(),
                       builder.getDenseI32ArrayAttr(segmentSizes));
+
+  for (auto attr : attrs)
+    if (attr.getName() == getOperandSegmentSizeAttr())
+      continue;
+    else
+      result.addAttribute(attr.getName(), attr.getValue());
 
   Region *r = result.addRegion();
   Block *body = new Block();
@@ -746,8 +762,7 @@ void HerdOp::print(OpAsmPrinter &p) {
 
   SmallVector<NamedAttribute, 8> filteredAttrs(
       llvm::make_filter_range((*this)->getAttrs(), [&](NamedAttribute attr) {
-        if (attr.getName() == OpTrait::AttrSizedOperandSegments<
-                                  void>::getOperandSegmentSizeAttr())
+        if (attr.getName() == getOperandSegmentSizeAttr())
           return false;
         if (attr.getName() == mlir::SymbolTable::getSymbolAttrName())
           return false;
@@ -862,9 +877,8 @@ ParseResult HerdOp::parse(OpAsmParser &parser, OperationState &result) {
   segmentSizes.front() = asyncDependencies.size();
   segmentSizes[1] = tileSize.size();
   segmentSizes.back() = kernelOperands.size();
-  result.addAttribute(
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr(),
-      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
+  result.addAttribute(getOperandSegmentSizeAttr(),
+                      parser.getBuilder().getDenseI32ArrayAttr(segmentSizes));
   return success();
 }
 
@@ -908,8 +922,7 @@ BlockArgument HerdOp::getKernelArgument(unsigned i) {
 }
 
 unsigned HerdOp::getNumDims() {
-  auto size_attr_name =
-      OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr();
+  auto size_attr_name = getOperandSegmentSizeAttr();
   auto size_attr = (*this)->getAttrOfType<DenseI32ArrayAttr>(size_attr_name);
   auto segment_sizes = size_attr.asArrayRef();
   return segment_sizes[1];

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -936,14 +936,11 @@ private:
                          SmallVector<Value, 1> deps, SmallVector<Value, 4> args,
                          SmallVector<Value, 4> constants) {
     auto loc = op->getLoc();
-    T new_op = builder.create<T>(loc, deps, op.getSizeOperands(), args, true);
+    T new_op = builder.create<T>(loc, deps, op.getSizeOperands(), args, true,
+                                 op->getAttrs());
     new_op->setAttr("id",
                     mlir::IntegerAttr::get(
                         mlir::IntegerType::get(op->getContext(), 32), ++OpID));
-
-    if (auto attr = op->template getAttrOfType<StringAttr>(
-            SymbolTable::getSymbolAttrName()))
-      new_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
 
     auto &bb = new_op.getBody().front();
     for (unsigned i = 0; i < op.getIds().size(); i++) {

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -752,7 +752,9 @@ void AIRFuseParallelHerdPass::runOnOperation() {
       args.push_back(v);
   }
 
-  auto newLaunchOp = b.create<air::HerdOp>(parOp.getLoc(), dims, args);
+  auto newLaunchOp = b.create<air::HerdOp>(
+      parOp.getLoc(), launchOp.getAsyncDependencies(), dims, args,
+      launchOp->getNumResults() > 0, launchOp->getAttrs());
 
   BlockAndValueMapping remap;
   remap.map(parOp.getInductionVars()[0], (herd_size_x == 1)

--- a/mlir/test/Dialect/AIR/air_canonicalize.mlir
+++ b/mlir/test/Dialect/AIR/air_canonicalize.mlir
@@ -24,13 +24,13 @@ func.func @herd(%arg0: i32) {
 }
 
 // CHECK-LABEL: func.func @herd_async
-// CHECK: air.herd async [{{.*}}] tile ({{.*}}, {{.*}}) in ({{.*}}={{.*}}, {{.*}}={{.*}}) {
+// CHECK: air.herd async [{{.*}}] tile ({{.*}}, {{.*}}) in ({{.*}}={{.*}}, {{.*}}={{.*}}) attributes {attr_name = "attrValue"} {
 // CHECK:   air.herd_terminator
 // CHECK: }
 func.func @herd_async(%arg0: i32) {
   %cst2 = arith.constant 2 : index
   %e0 = air.wait_all async
-  %e1 = air.herd async [%e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%arg0, %op1=%arg0, %op2=%arg0, %op3=%arg0) : i32, i32, i32, i32 attributes { } {
+  %e1 = air.herd async [%e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%arg0, %op1=%arg0, %op2=%arg0, %op3=%arg0) : i32, i32, i32, i32 attributes { attr_name="attrValue" } {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32


### PR DESCRIPTION
This allows a pre-placed herd, for example.