### PR TITLE
Update AIR dialect canonicalizers

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -56,9 +56,6 @@ Value getLoopCarriedTokenFromScfOp(scf::ParallelOp op);
 Value getLoopCarriedTokenFromScfOp(scf::ForOp op,
                                    std::string operand_or_argument = "operand");
 void addAsyncDependencyIfNew(air::AsyncOpInterface op, Value token);
-std::string getMemorySpaceAsString(Value memref);
-air::ChannelGetOp getTheOtherChannelOpThroughSymbol(air::ChannelPutOp put);
-air::ChannelPutOp getTheOtherChannelOpThroughSymbol(air::ChannelGetOp get);
 
 //===----------------------------------------------------------------------===//
 // Dependency graph parsed as a Boost graph object
@@ -234,7 +231,7 @@ public:
                           vertex_to_vertex_map_tree &g_to_tr,
                           bool dump_graph = false, std::string dump_dir = "");
   void updateDepList(func::FuncOp func, dependencyGraph &global_graph);
-  void removeDepListRepitition(func::FuncOp func);
+  void removeDepListRepetition(func::FuncOp func);
   void removeUnusedExecuteOp(func::FuncOp func);
   void removeRedundantWaitAllOps(func::FuncOp func);
   void dumpDotGraphFiles(dependencyGraph global_graph,
@@ -244,7 +241,6 @@ public:
                                                   dependencyContext &dep_ctx,
                                                   bool dump_dot = false,
                                                   std::string dump_dir = "");
-  void removeRedundantAIRHierarchyArgs(func::FuncOp func);
   void canonicalizeAIRHierarchyDependency(func::FuncOp func);
   std::pair<Graph::vertex_descriptor, dependencyGraph *>
   getVertexFromOp(Operation *op, dependencyContext dep_ctx,

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -53,7 +53,7 @@ public:
       canonicalizer.removeUnusedExecuteOp(func);
       canonicalizer.removeRedundantWaitAllOps(func);
       canonicalizer.canonicalizeAIRHierarchyDependency(func);
-      canonicalizer.removeDepListRepitition(func);
+      canonicalizer.removeDepListRepetition(func);
 
       if (clDumpGraph) {
         // Dump graphs

--- a/mlir/test/Dialect/AIR/canonicalize_hierarchy_args.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_hierarchy_args.mlir
@@ -1,4 +1,4 @@
-//===- canonicalize_herd_blockargs.mlir ------------------------*- MLIR -*-===//
+//===- canonicalize_hierarchy_args.mlir ------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2022, Xilinx Inc. All rights reserved.
 // Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
-// XFAIL: *
+// RUN: air-opt %s -canonicalize | FileCheck %s
 
 // Prune block arguments for air.herd and air.partition
 // CHECK: %[[EVENT0:.*]] = air.launch async{{.*}}args(%[[VALUE1:.*]]=%[[VALUE0:.*]])


### PR DESCRIPTION
A small bit of refactoring after noticing overlap between the dialect canonicalization and `dependencyCanonicalizer`

@erwei-xilinx please have a look at the changes to `dependencyCanonicalizer::removeRedundantWaitAllOps`. We should favor putting "cleanup" canonicalizations in the dialect whenever possible so that they also run with ordinary `-canonicalize`. I made these changes before removal of `dependencyCanonicalizer::removeRedundantAIRHierarchyArgs` but that optimization is also covered by the dialect canonicalization. I did not move `dependencyCanonicalizer::removeUnusedExecuteOp` into the dialect because it doesn't seem safe in general (what if the execute block included an op with side effects?).  `dependencyCanonicalizer::removeDepListRepetition` is covered by the dialect canonicalization for hierarchy ops, but not yet for all other ops (TODO).

