### PR TITLE
New assemblyFormat for air.DmaMemcpyNdOp and air.ChannelPutOp/GetOp

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -347,8 +347,8 @@ def air_DmaMemcpyNdOp: air_Op<"dma_memcpy_nd",
   let results = (outs Optional<air_AsyncToken>:$async_token);
   let assemblyFormat = [{
     custom<AsyncDependencies>(type($async_token), $async_dependencies)
-    `(` $dst `[` ($dst_offsets^)? `]``[` ($dst_sizes^)? `]``[` ($dst_strides^)? `]` `,`
-        $src `[` ($src_offsets^)? `]``[` ($src_sizes^)? `]``[` ($src_strides^)? `]` `)`  attr-dict `:`
+    `(` $dst (`<` $dst_offsets^ `>`)? (`<` $dst_sizes^ `>`)? (`<` $dst_strides^ `>`)? `,`
+        $src (`<` $src_offsets^ `>`)? (`<` $src_sizes^ `>`)? (`<` $src_strides^ `>`)? `)`  attr-dict `:`
     `(` type($dst) `,` type($src) `)`
   }];
   let description = [{
@@ -463,7 +463,7 @@ def air_ChannelPutOp : air_Op<"channel.put", [air_AsyncOpInterface,
   let assemblyFormat = [{
     custom<AsyncDependencies>(type($async_token), $async_dependencies)
     $chan_name `[` ($indices^)? `]`
-    `(` $src `[` ($src_offsets^)? `]``[` ($src_sizes^)? `]``[` ($src_strides^)? `]` `)` attr-dict `:`
+    `(` $src (`<` $src_offsets^ `>`)? (`<` $src_sizes^ `>`)? (`<` $src_strides^ `>`)? `)` attr-dict `:`
     `(` type($src) `)`
   }];
   let extraClassDeclaration = [{
@@ -495,7 +495,7 @@ def air_ChannelGetOp : air_Op<"channel.get", [air_AsyncOpInterface,
   let assemblyFormat = [{
     custom<AsyncDependencies>(type($async_token), $async_dependencies)
     $chan_name `[` ($indices^)? `]`
-    `(` $dst `[` ($dst_offsets^)? `]``[` ($dst_sizes^)? `]``[` ($dst_strides^)? `]` `)` attr-dict `:`
+    `(` $dst (`<` $dst_offsets^ `>`)? (`<` $dst_sizes^ `>`)? (`<` $dst_strides^ `>`)? `)` attr-dict `:`
     `(` type($dst) `)`
   }];
   let extraClassDeclaration = [{


### PR DESCRIPTION
Summary of changes:
- Replaced square brackets with angle brackets
- Make brackets part of the optional group in assembly format

Examples:

`air.dma_memcpy_nd`
Before:
`air.dma_memcpy_nd (%alloc_3[] [] [], %arg13[%0, %arg16] [%c128, %c128] [%c1024, %c1]) : (memref<128x128xbf16, 1>, memref<256x1024xbf16>)`
After:
`air.dma_memcpy_nd (%alloc_3, %arg13<%0, %arg16> <%c128, %c128> <%c1024, %c1>) : (memref<128x128xbf16, 1>, memref<256x1024xbf16>)`

`air.channel_put`
Before:
Eg. 1 `air.channel.put @channel_11[] (%results_86[] [] []) : (memref<32x32xbf16, 2>)`
Eg. 2 `air.channel.put @channel_14[] (%results_51[%results_78, %results_80] [%c32_81, %c32_81] [%c128_82, %c1_83]) : (memref<128x128xbf16, 1>)`
After:
Eg. 1 `air.channel.put @channel_11[] (%results_86) : (memref<32x32xbf16, 2>)`
Eg. 2 `air.channel.put @channel_14[] (%results_51<%results_78, %results_80> <%c32_81, %c32_81> <%c128_82, %c1_83>) : (memref<128x128xbf16, 1>)`
