### PR TITLE
Update petalinux Makefile with PHONY sysroot

### DIFF
--- a/platforms/xilinx_vck190_air/petalinux/Makefile
+++ b/platforms/xilinx_vck190_air/petalinux/Makefile
@@ -4,6 +4,8 @@
 
 SYSROOT=./sysroot
 
+.PHONY: sysroot
+
 all: refresh_hw xrt zocl kernel_config rootfs_config linux bootimage sysroot
 
 refresh_hw:


### PR DESCRIPTION
This is one way to fix issue #114 and re-enable builds of PYNQ for VCK190 .