### PR TITLE
AIRToAIE Lowering for Channels to ObjectFifos (L1 to L1)

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -847,9 +847,9 @@ void allocL1Buffers(ModuleOp m,
 }
 
 AIE::ObjectFifoCreateOp createObjectFifo(OpBuilder &builder,
-                                      AIE::AIEObjectFifoType datatype,
-                                      Value prodTile, Value consTile,
-                                      int depth) {
+                                         AIE::AIEObjectFifoType datatype,
+                                         Value prodTile, Value consTile,
+                                         int depth) {
   AIE::ObjectFifoCreateOp fifo = builder.create<AIE::ObjectFifoCreateOp>(
       builder.getUnknownLoc(), datatype, prodTile, consTile, depth);
   return fifo;
@@ -864,10 +864,11 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelPutOp> {
                                 PatternRewriter &rewriter) const override {
     // retrieve put/get of channel
     ChannelGetOp get = getTheOtherChannelOpThroughSymbol(put);
-    ChannelOp channel = getChannelDeclarationThroughSymbol(dyn_cast<air::ChannelInterface>(put.getOperation()));
-    if (!channel) 
+    ChannelOp channel = getChannelDeclarationThroughSymbol(
+        dyn_cast<air::ChannelInterface>(put.getOperation()));
+    if (!channel)
       return failure();
-    if (!get) 
+    if (!get)
       return failure();
 
     // get memrefs of put/get, find memory hierarchy levels
@@ -882,58 +883,74 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelPutOp> {
     if (src_space == (int)air::MemorySpace::L1 &&
         dst_space == (int)air::MemorySpace::L1) {
 
-        AIE::CoreOp producerCore = put->getParentOfType<AIE::CoreOp>();
-        if (!producerCore)
-          return failure();
-        producerTile = producerCore.getTileOp();
-        if (!producerTile)
-          return failure();
+      AIE::CoreOp producerCore = put->getParentOfType<AIE::CoreOp>();
+      if (!producerCore)
+        return failure();
+      producerTile = producerCore.getTileOp();
+      if (!producerTile)
+        return failure();
 
-        AIE::CoreOp consumerCore = get->getParentOfType<AIE::CoreOp>();
-        if (!consumerCore)
-          return failure();
-        consumerTile = consumerCore.getTileOp();
-        if (!consumerTile)
-          return failure();
+      AIE::CoreOp consumerCore = get->getParentOfType<AIE::CoreOp>();
+      if (!consumerCore)
+        return failure();
+      consumerTile = consumerCore.getTileOp();
+      if (!consumerTile)
+        return failure();
 
     } else {
       assert(false && "Unsupported data movement");
     }
 
     // create objFifo
-    // For now, number of memory elements in OF is hardcoded to 1 
+    // For now, number of memory elements in OF is hardcoded to 1
     // (single buffer). FIXME
     rewriter.setInsertionPoint(channel);
     auto datatype = AIE::AIEObjectFifoType::get(dstMemref);
-    AIE::ObjectFifoCreateOp objFifo = createObjectFifo(rewriter, datatype, producerTile, consumerTile, 1);
-    auto elementType = objFifo.getType().dyn_cast<AIE::AIEObjectFifoType>().getElementType();
+    AIE::ObjectFifoCreateOp objFifo =
+        createObjectFifo(rewriter, datatype, producerTile, consumerTile, 1);
+    auto elementType =
+        objFifo.getType().dyn_cast<AIE::AIEObjectFifoType>().getElementType();
     auto acqType = AIE::AIEObjectFifoSubviewType::get(elementType);
-    
+
     // replace put and the associated memref alloc
-    if (auto bco = dyn_cast<bufferization::ToMemrefOp>(put.getSrc().getDefiningOp()))
+    if (auto bco =
+            dyn_cast<bufferization::ToMemrefOp>(put.getSrc().getDefiningOp()))
       rewriter.setInsertionPoint(bco.getOperand().getDefiningOp());
     else if (auto a = dyn_cast<memref::AllocaOp>(put.getSrc().getDefiningOp()))
       rewriter.setInsertionPoint(put.getSrc().getDefiningOp());
     else
       rewriter.setInsertionPoint(&put->getBlock()->front());
-    AIE::ObjectFifoAcquireOp producerAcq = rewriter.create<AIE::ObjectFifoAcquireOp>(rewriter.getUnknownLoc(), acqType, AIE::ObjectFifoPort::Produce, objFifo, 1);
+    AIE::ObjectFifoAcquireOp producerAcq =
+        rewriter.create<AIE::ObjectFifoAcquireOp>(
+            rewriter.getUnknownLoc(), acqType, AIE::ObjectFifoPort::Produce,
+            objFifo, 1);
     rewriter.setInsertionPointAfter(producerAcq);
-    AIE::ObjectFifoSubviewAccessOp producerAccess = rewriter.create<AIE::ObjectFifoSubviewAccessOp>(rewriter.getUnknownLoc(), elementType, producerAcq.getSubview(), rewriter.getIntegerAttr(rewriter.getI32Type(), 0));
-    
+    AIE::ObjectFifoSubviewAccessOp producerAccess =
+        rewriter.create<AIE::ObjectFifoSubviewAccessOp>(
+            rewriter.getUnknownLoc(), elementType, producerAcq.getSubview(),
+            rewriter.getIntegerAttr(rewriter.getI32Type(), 0));
+
     // replace uses of alloc with result of acquire
     if (auto a = dyn_cast<memref::AllocOp>(put.getSrc().getDefiningOp()))
       a.getMemref().replaceAllUsesWith(producerAccess.getOutput());
-    
+
     // replace get and the associated memref alloc
-    if (auto bco = dyn_cast<bufferization::ToMemrefOp>(get.getDst().getDefiningOp()))
+    if (auto bco =
+            dyn_cast<bufferization::ToMemrefOp>(get.getDst().getDefiningOp()))
       rewriter.setInsertionPoint(bco.getOperand().getDefiningOp());
     else if (auto a = dyn_cast<memref::AllocaOp>(get.getDst().getDefiningOp()))
       rewriter.setInsertionPoint(get.getDst().getDefiningOp());
     else
       rewriter.setInsertionPoint(&get->getBlock()->front());
-    AIE::ObjectFifoAcquireOp consumerAcq = rewriter.create<AIE::ObjectFifoAcquireOp>(rewriter.getUnknownLoc(), acqType, AIE::ObjectFifoPort::Consume, objFifo, 1);
+    AIE::ObjectFifoAcquireOp consumerAcq =
+        rewriter.create<AIE::ObjectFifoAcquireOp>(
+            rewriter.getUnknownLoc(), acqType, AIE::ObjectFifoPort::Consume,
+            objFifo, 1);
     rewriter.setInsertionPointAfter(consumerAcq);
-    AIE::ObjectFifoSubviewAccessOp consumerAccess = rewriter.create<AIE::ObjectFifoSubviewAccessOp>(rewriter.getUnknownLoc(), elementType, consumerAcq.getSubview(), rewriter.getIntegerAttr(rewriter.getI32Type(), 0));
+    AIE::ObjectFifoSubviewAccessOp consumerAccess =
+        rewriter.create<AIE::ObjectFifoSubviewAccessOp>(
+            rewriter.getUnknownLoc(), elementType, consumerAcq.getSubview(),
+            rewriter.getIntegerAttr(rewriter.getI32Type(), 0));
 
     // replace uses of alloc with result of acquire
     if (auto a = dyn_cast<memref::AllocOp>(get.getDst().getDefiningOp()))
@@ -942,34 +959,34 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelPutOp> {
     // replace associated deallocs for put and get
     for (auto u : put.getSrc().getDefiningOp()->getUsers()) {
       if (auto dealloc = dyn_cast<memref::DeallocOp>(u)) {
-          rewriter.setInsertionPoint(dealloc);
-          rewriter.create<AIE::ObjectFifoReleaseOp>(dealloc->getLoc(), 
-                                                  AIE::ObjectFifoPort::Produce, objFifo, 1);
-          dealloc.erase();
+        rewriter.setInsertionPoint(dealloc);
+        rewriter.create<AIE::ObjectFifoReleaseOp>(
+            dealloc->getLoc(), AIE::ObjectFifoPort::Produce, objFifo, 1);
+        dealloc.erase();
       }
     }
     for (auto u : get.getDst().getDefiningOp()->getUsers()) {
       if (auto dealloc = dyn_cast<memref::DeallocOp>(u)) {
-          rewriter.setInsertionPoint(dealloc);
-          rewriter.create<AIE::ObjectFifoReleaseOp>(dealloc->getLoc(), 
-                                                  AIE::ObjectFifoPort::Consume, objFifo, 1);
-          dealloc.erase();
+        rewriter.setInsertionPoint(dealloc);
+        rewriter.create<AIE::ObjectFifoReleaseOp>(
+            dealloc->getLoc(), AIE::ObjectFifoPort::Consume, objFifo, 1);
+        dealloc.erase();
       }
     }
 
     // erase the channel and its put/get
     channel.erase();
-    put.erase();  
-    get.erase(); 
-    return success();               
+    put.erase();
+    get.erase();
+    return success();
   }
 };
 
-// This function replaces ChannelPutOp/ChannelGetOp with AIE_CreateObjectFifoOps and
-// with ObjectFifoAcquireOp<Producer/Consumer>. It also erases memref allocs as 
-// the objFifo lowering allocates its own memory. It replaces the associated memref 
-// deallocs with ObjectFifoReleaseOps.
-// void lowerAIRChannels(ModuleOp &m) {
+// This function replaces ChannelPutOp/ChannelGetOp with AIE_CreateObjectFifoOps
+// and with ObjectFifoAcquireOp<Producer/Consumer>. It also erases memref allocs
+// as the objFifo lowering allocates its own memory. It replaces the associated
+// memref deallocs with ObjectFifoReleaseOps. void lowerAIRChannels(ModuleOp &m)
+// {
 //   auto ctx = m->getContext();
 //   RewritePatternSet patterns(ctx);
 //   patterns.insert<LowerAIRChannelsPattern>(ctx);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -942,7 +942,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelPutOp> {
 
     // replace uses of alloc with result of acquire
     if (auto a = dyn_cast<memref::AllocOp>(put.getSrc().getDefiningOp()))
-      rewriter.replaceOp (a.getOperation(), producerAccess.getOutput());
+      rewriter.replaceOp(a.getOperation(), producerAccess.getOutput());
 
     // replace get and the associated memref alloc
     if (auto bco =
@@ -964,7 +964,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelPutOp> {
 
     // replace uses of alloc with result of acquire
     if (auto a = dyn_cast<memref::AllocOp>(get.getDst().getDefiningOp()))
-      rewriter.replaceOp (a.getOperation(), consumerAccess.getOutput());
+      rewriter.replaceOp(a.getOperation(), consumerAccess.getOutput());
 
     // replace associated deallocs for put and get
     for (auto u : put.getSrc().getDefiningOp()->getUsers()) {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie='test-patterns=specialize-affine-if,lower-air-channels' | air-opt --canonicalize | FileCheck %s
+// RUN: air-opt %s -air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
 // CHECK: module @aie.partition_0 {
 // CHECK:   %0 = AIE.tile(1, 1)
 // CHECK:   %1 = AIE.tile(1, 2)
@@ -24,56 +24,24 @@
 // CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
 // CHECK: }
 
-#set = affine_set<()[s0, s1] : (s0 >= 0, s1 == 0)>
-#set1 = affine_set<()[s0, s1] : (s0 >= 0, s1 - 1 == 0)>
 module @aie.partition_0 {
   %0 = AIE.tile(1, 1)
   %1 = AIE.tile(1, 2)
-  air.channel @channel_0 [1, 1] // Has to be added back in after 'test-patterns=to-aie-mlir'.
+  air.channel @channel_0 [1, 1]
   %2 = AIE.core(%1) {
-    cf.br ^bb1
-  ^bb1:  // pred: ^bb0
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c1_0 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    cf.br ^bb2
-  ^bb2:  // pred: ^bb1
-    %c0_1 = arith.constant 0 : index
     %c32 = arith.constant 32 : index
-    affine.if #set()[%c0, %c1] {
-      %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
-      air.channel.put  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
-      memref.dealloc %alloc : memref<32xi32, 2>
-    }
-    affine.if #set1()[%c0, %c1] {
-      %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
-      air.channel.get  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
-      memref.dealloc %alloc : memref<32xi32, 2>
-    }
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    air.channel.get  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
     AIE.end
   } {elf_file = "partition_0_core_1_2.elf"}
   %3 = AIE.core(%0) {
-    cf.br ^bb1
-  ^bb1:  // pred: ^bb0
-    %c0 = arith.constant 0 : index
-    %c0_0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    cf.br ^bb2
-  ^bb2:  // pred: ^bb1
-    %c0_1 = arith.constant 0 : index
     %c32 = arith.constant 32 : index
-    affine.if #set()[%c0, %c0_0] {
-      %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
-      air.channel.put  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
-      memref.dealloc %alloc : memref<32xi32, 2>
-    }
-    affine.if #set1()[%c0, %c0_0] {
-      %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
-      air.channel.get  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
-      memref.dealloc %alloc : memref<32xi32, 2>
-    }
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    air.channel.put  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
     AIE.end
   } {elf_file = "partition_0_core_1_1.elf"}
 }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -1,0 +1,79 @@
+//===- air_channel_to_objectFifo_L1toL1.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie='test-patterns=specialize-affine-if,lower-air-channels' | air-opt --canonicalize | FileCheck %s
+// CHECK: module @aie.partition_0 {
+// CHECK:   %0 = AIE.tile(1, 1)
+// CHECK:   %1 = AIE.tile(1, 2)
+// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %3 = AIE.core(%1) {
+// CHECK:     %5 = AIE.objectFifo.acquire<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_2.elf"}
+// CHECK:   %4 = AIE.core(%0) {
+// CHECK:     %5 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
+// CHECK: }
+
+#set = affine_set<()[s0, s1] : (s0 >= 0, s1 == 0)>
+#set1 = affine_set<()[s0, s1] : (s0 >= 0, s1 - 1 == 0)>
+module @aie.partition_0 {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.tile(1, 2)
+  air.channel @channel_0 [1, 1] // Has to be added back in after 'test-patterns=to-aie-mlir'.
+  %2 = AIE.core(%1) {
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    %c0_1 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    affine.if #set()[%c0, %c1] {
+      %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+      air.channel.put  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
+      memref.dealloc %alloc : memref<32xi32, 2>
+    }
+    affine.if #set1()[%c0, %c1] {
+      %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+      air.channel.get  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
+      memref.dealloc %alloc : memref<32xi32, 2>
+    }
+    AIE.end
+  } {elf_file = "partition_0_core_1_2.elf"}
+  %3 = AIE.core(%0) {
+    cf.br ^bb1
+  ^bb1:  // pred: ^bb0
+    %c0 = arith.constant 0 : index
+    %c0_0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    cf.br ^bb2
+  ^bb2:  // pred: ^bb1
+    %c0_1 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    affine.if #set()[%c0, %c0_0] {
+      %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+      air.channel.put  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
+      memref.dealloc %alloc : memref<32xi32, 2>
+    }
+    affine.if #set1()[%c0, %c0_0] {
+      %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+      air.channel.get  @channel_0[] (%alloc[%c0_1] [%c32] [%c0_1]) : (memref<32xi32, 2>)
+      memref.dealloc %alloc : memref<32xi32, 2>
+    }
+    AIE.end
+  } {elf_file = "partition_0_core_1_1.elf"}
+}


### PR DESCRIPTION
This PR adds a new test-pattern to AIRToAIE.cpp called "lower-air-channels".  For now, the lowering is done for data movement from L1 to L1. The pattern should be called after applying air-to-aie test patterns "to-aie-mlir" and "specialize-affine-if", then "canonicalize".