### PR TITLE
Load PDI and ELF separately to VCK5000

### DIFF
--- a/platforms/scripts/load.tcl
+++ b/platforms/scripts/load.tcl
@@ -1,0 +1,108 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Load either a PDI file or ELF file (or both) to a VCK5000
+# Intended to be used with xsct, with JTAG over USB
+#
+# If you are loading an FPGA image (PDI file) it is recommended to use the
+# shell script wrapper (e.g. program_vck5000.sh) instead, since it performs
+# additional actions such as removing the PCIe device from Linux beforehand.
+#
+# If you only want to load firmware, it can be done like this:
+#    ELF_FILE=acdc_agent.elf xsct load.tcl
+#
+# A specific card can be targeted when more than one is installed:
+#    CARD_IDX=1 ELF_FILE=acdc_agent.elf xsct load.tcl
+
+# if the card index is not set, default to 0
+if {[info exists ::env(CARD_IDX)]} {
+	puts "ENV $::env(CARD_IDX)"
+	set card_idx $::env(CARD_IDX)
+} else {
+	set card_idx 0
+}
+puts "Using card index $card_idx"
+
+if {[info exists ::env(PDI_FILE)]} {
+	set pdi_file $::env(PDI_FILE)
+	puts "Using PDI $pdi_file"
+}
+
+if {[info exists ::env(ELF_FILE)]} {
+	set elf_file $::env(ELF_FILE)
+	puts "Using ELF $elf_file"
+}
+
+# Initiate hardware manager's server
+connect
+
+# get a list of all VCK5000 cards
+set cards [ targets -target-properties -filter { name =~ "Versal xcvc1902*" }]
+
+# validate the selected card index
+set num_cards [ llength $cards ]
+if { $card_idx >= $num_cards } {
+	puts "Invalid card index $card_idx; only $num_cards detected"
+	exit
+}
+
+# get the JTAG index and context of the board
+# The index is used for resetting, the context is used to distinguish child
+# nodes with the same name belonging to different cards
+set ta_board [ dict get [ lindex $cards $card_idx ] target_id ]
+set card_jtag_ctx [ dict get [ lindex $cards $card_idx ] jtag_device_ctx ]
+
+# get the PMC target ID
+# compare with the parent JTAG context to be sure we found the right one
+set pmcs [ targets -target-properties -filter { name =~ "PMC*" }]
+foreach pmc $pmcs {
+	if { [ dict get $pmc parent_ctx ] == "JTAG-$card_jtag_ctx" } {
+		set ta_pmc [ dict get $pmc target_id ]
+	}
+}
+if { ! [info exists ta_pmc]} {
+	puts "Couldn't find a valid PMC target!"
+	exit
+}
+
+# get the ARM target ID
+# The ARM core #0 is a child of the APU, which is a child of the board
+set apus [ targets -target-properties -filter { name =~ "APU*" }]
+foreach apu $apus {
+	if { [ dict get $apu parent_ctx ] == "JTAG-$card_jtag_ctx" } {
+		set apu_jtag_ctx [ dict get $apu jtag_device_ctx ]
+	}
+}
+if { ! [info exists apu_jtag_ctx]} {
+	puts "Couldn't find a valid APU target!"
+	exit
+}
+foreach arm [ targets -target-properties -filter { name =~ "Cortex-A72 #0" }] {
+	if  {[ dict get $arm jtag_device_ctx ] == $apu_jtag_ctx } {
+		set ta_arm0 [ dict get $arm target_id ]
+	}
+}
+if { ! [info exists ta_arm0]} {
+	puts "Couldn't find a valid ARM target!"
+	exit
+}
+
+if {[info exists pdi_file]} {
+	# reset the board
+	ta $ta_board
+	rst
+
+	# target the PMC and program it with the PDI file
+	ta $ta_pmc
+	device program $pdi_file
+}
+
+# select ARM processor 0 and load ELF
+# If the processor gets into suspended state, this will fail:
+# 6  Cortex-A72 #0 (Suspended, EL3(S)/A64)
+if {[info exists elf_file]} {
+	ta $ta_arm0
+	rst -processor -clear-registers -skip-activate-subsystem
+	dow $elf_file
+	con
+}

--- a/platforms/scripts/program_vck5000.sh
+++ b/platforms/scripts/program_vck5000.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+
+# load a new FPGA image + firmware
+# Usually, they are both contained in a single .PDI file. If not, set the ELF_FILE variable in addition to PDI_FILE.
+#
+# Parameters (as environment variables)
+# ELF_FILE		path to the ELF file with the controller firmware
+# PDI_FILE		path to the PDI file with the FPGA image
+# CARD_IDX		index of the card to be programmed, in JTAG scan-chain order (as seen by 'xsct')
+
+VIVADO_INSTALL_DIR=/proj/xbuilds/2022.1_released/installs/lin64/Vivado/2022.1
+DEVICE_ID=0000:21:00.0
+
+# these variables are used by load.tcl so they must be exported
+export CARD_IDX=${CARD_IDX:=0}
+export PDI_FILE=${PDI_FILE:?"You must set PDI_FILE to the path of the image to be programmed"}
+
+# ELF file is optional; export if if we have it
+if [ -v $ELF_FILE ]; then
+	export ELF_FILE=$ELF_FILE
+fi
+
+# get the path of this script - it is the script path
+this_script=$(realpath $0)
+script_path=${this_script%/*}
+
+# load environment for hw_server and xsct
+. $VIVADO_INSTALL_DIR/settings64.sh
+
+# start the hardware server in daemon mode (if it is not already running)
+hw_server -d
+
+# remove the PCI device in case it is already loaded
+echo "Removing device"
+sudo sh -c "echo 1 > /sys/bus/pci/devices/$DEVICE_ID/remove"
+
+# load the FPGA image and firmware
+echo "Loading FPGA and firmware"
+xsct $script_path/load.tcl
+
+# rescan PCIe bus
+echo "Scanning for new devices"
+sudo sh -c "echo '1' > /sys/bus/pci/rescan"


### PR DESCRIPTION
It is useful to be able to load the firmware separately from the PDI. In some cases, the PDI file does not contain the firmware for the command processor (often ARM). The firmware may be provided in a separate ELF file. The bash script loads both the PDI and then the ELF (if it is provided). In other cases such as firmware or driver development, the firmware can be reloaded without resetting the board or disturbing the rest of the system.

The firmware can be reloaded like this:
ELF_FILE=acdc_agent.elf xsct load.tcl

A specific card can be targeted when more than one is installed: CARD_IDX=1 ELF_FILE=acdc_agent.elf xsct load.tcl

All options are passed as environment variables. The shell script sets the environment which is then shared with the TCL script, or environment variables can be passed to the TCL script directly (without using the bash script) as shown in the examples above.

Signed-off-by: Joel Nider <joel.nider@xilinx.com>