### PR TITLE
utils: add branch name for LLVM

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -15,10 +15,10 @@
 ##===----------------------------------------------------------------------===##
 
 export commithash=7ccbb4dff10efe6c26219204e361ddb0264938b8
+branch=air-2022.12
 
 git clone --depth 1 https://github.com/llvm/llvm-project.git llvm
 pushd llvm
 git fetch --depth=1 origin $commithash
-git checkout $commithash
+git checkout $commithash -b $branch
 popd
-


### PR DESCRIPTION
When checking out a specific commit for LLVM, give the branch a name instead of leaving it in 'detached head' state. This makes it a little easier to restore the state when changing branches.