### PR TITLE
driver: Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ platforms/scripts/env_config
 platforms/scripts/br_config
 
 # build artifacts
+*.cmd
 *.jou
 *.log
 *.xsa

--- a/driver/.clang-format
+++ b/driver/.clang-format
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# clang-format configuration file. Intended for clang-format >= 4.
+#
+# For more information, see:
+#
+#   Documentation/process/clang-format.rst
+#   https://clang.llvm.org/docs/ClangFormat.html
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+#AlignEscapedNewlines: Left # Unknown to clang-format-4.0
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  #AfterExternBlock: false # Unknown to clang-format-5.0
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  #SplitEmptyFunction: true # Unknown to clang-format-4.0
+  #SplitEmptyRecord: true # Unknown to clang-format-4.0
+  #SplitEmptyNamespace: true # Unknown to clang-format-4.0
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+#BreakBeforeInheritanceComma: false # Unknown to clang-format-4.0
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+#BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+#CompactNamespaces: false # Unknown to clang-format-4.0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+#FixNamespaceComments: false # Unknown to clang-format-4.0
+
+# Taken from:
+#   git grep -h '^#define [^[:space:]]*for_each[^[:space:]]*(' include/ \
+#   | sed "s,^#define \([^[:space:]]*for_each[^[:space:]]*\)(.*$,  - '\1'," \
+#   | sort | uniq
+ForEachMacros:
+  - 'apei_estatus_for_each_section'
+  - 'ata_for_each_dev'
+  - 'ata_for_each_link'
+  - '__ata_qc_for_each'
+  - 'ata_qc_for_each'
+  - 'ata_qc_for_each_raw'
+  - 'ata_qc_for_each_with_internal'
+  - 'ax25_for_each'
+  - 'ax25_uid_for_each'
+  - '__bio_for_each_bvec'
+  - 'bio_for_each_bvec'
+  - 'bio_for_each_bvec_all'
+  - 'bio_for_each_integrity_vec'
+  - '__bio_for_each_segment'
+  - 'bio_for_each_segment'
+  - 'bio_for_each_segment_all'
+  - 'bio_list_for_each'
+  - 'bip_for_each_vec'
+  - 'bitmap_for_each_clear_region'
+  - 'bitmap_for_each_set_region'
+  - 'blkg_for_each_descendant_post'
+  - 'blkg_for_each_descendant_pre'
+  - 'blk_queue_for_each_rl'
+  - 'bond_for_each_slave'
+  - 'bond_for_each_slave_rcu'
+  - 'bpf_for_each_spilled_reg'
+  - 'btree_for_each_safe128'
+  - 'btree_for_each_safe32'
+  - 'btree_for_each_safe64'
+  - 'btree_for_each_safel'
+  - 'card_for_each_dev'
+  - 'cgroup_taskset_for_each'
+  - 'cgroup_taskset_for_each_leader'
+  - 'cpufreq_for_each_entry'
+  - 'cpufreq_for_each_entry_idx'
+  - 'cpufreq_for_each_valid_entry'
+  - 'cpufreq_for_each_valid_entry_idx'
+  - 'css_for_each_child'
+  - 'css_for_each_descendant_post'
+  - 'css_for_each_descendant_pre'
+  - 'device_for_each_child_node'
+  - 'displayid_iter_for_each'
+  - 'dma_fence_chain_for_each'
+  - 'do_for_each_ftrace_op'
+  - 'drm_atomic_crtc_for_each_plane'
+  - 'drm_atomic_crtc_state_for_each_plane'
+  - 'drm_atomic_crtc_state_for_each_plane_state'
+  - 'drm_atomic_for_each_plane_damage'
+  - 'drm_client_for_each_connector_iter'
+  - 'drm_client_for_each_modeset'
+  - 'drm_connector_for_each_possible_encoder'
+  - 'drm_for_each_bridge_in_chain'
+  - 'drm_for_each_connector_iter'
+  - 'drm_for_each_crtc'
+  - 'drm_for_each_crtc_reverse'
+  - 'drm_for_each_encoder'
+  - 'drm_for_each_encoder_mask'
+  - 'drm_for_each_fb'
+  - 'drm_for_each_legacy_plane'
+  - 'drm_for_each_plane'
+  - 'drm_for_each_plane_mask'
+  - 'drm_for_each_privobj'
+  - 'drm_mm_for_each_hole'
+  - 'drm_mm_for_each_node'
+  - 'drm_mm_for_each_node_in_range'
+  - 'drm_mm_for_each_node_safe'
+  - 'flow_action_for_each'
+  - 'for_each_acpi_dev_match'
+  - 'for_each_active_dev_scope'
+  - 'for_each_active_drhd_unit'
+  - 'for_each_active_iommu'
+  - 'for_each_aggr_pgid'
+  - 'for_each_available_child_of_node'
+  - 'for_each_bio'
+  - 'for_each_board_func_rsrc'
+  - 'for_each_bvec'
+  - 'for_each_card_auxs'
+  - 'for_each_card_auxs_safe'
+  - 'for_each_card_components'
+  - 'for_each_card_dapms'
+  - 'for_each_card_pre_auxs'
+  - 'for_each_card_prelinks'
+  - 'for_each_card_rtds'
+  - 'for_each_card_rtds_safe'
+  - 'for_each_card_widgets'
+  - 'for_each_card_widgets_safe'
+  - 'for_each_cgroup_storage_type'
+  - 'for_each_child_of_node'
+  - 'for_each_clear_bit'
+  - 'for_each_clear_bit_from'
+  - 'for_each_cmsghdr'
+  - 'for_each_compatible_node'
+  - 'for_each_component_dais'
+  - 'for_each_component_dais_safe'
+  - 'for_each_comp_order'
+  - 'for_each_console'
+  - 'for_each_cpu'
+  - 'for_each_cpu_and'
+  - 'for_each_cpu_not'
+  - 'for_each_cpu_wrap'
+  - 'for_each_dapm_widgets'
+  - 'for_each_dev_addr'
+  - 'for_each_dev_scope'
+  - 'for_each_dma_cap_mask'
+  - 'for_each_dpcm_be'
+  - 'for_each_dpcm_be_rollback'
+  - 'for_each_dpcm_be_safe'
+  - 'for_each_dpcm_fe'
+  - 'for_each_drhd_unit'
+  - 'for_each_dss_dev'
+  - 'for_each_dtpm_table'
+  - 'for_each_efi_memory_desc'
+  - 'for_each_efi_memory_desc_in_map'
+  - 'for_each_element'
+  - 'for_each_element_extid'
+  - 'for_each_element_id'
+  - 'for_each_endpoint_of_node'
+  - 'for_each_evictable_lru'
+  - 'for_each_fib6_node_rt_rcu'
+  - 'for_each_fib6_walker_rt'
+  - 'for_each_free_mem_pfn_range_in_zone'
+  - 'for_each_free_mem_pfn_range_in_zone_from'
+  - 'for_each_free_mem_range'
+  - 'for_each_free_mem_range_reverse'
+  - 'for_each_func_rsrc'
+  - 'for_each_hstate'
+  - 'for_each_if'
+  - 'for_each_iommu'
+  - 'for_each_ip_tunnel_rcu'
+  - 'for_each_irq_nr'
+  - 'for_each_link_codecs'
+  - 'for_each_link_cpus'
+  - 'for_each_link_platforms'
+  - 'for_each_lru'
+  - 'for_each_matching_node'
+  - 'for_each_matching_node_and_match'
+  - 'for_each_member'
+  - 'for_each_memcg_cache_index'
+  - 'for_each_mem_pfn_range'
+  - '__for_each_mem_range'
+  - 'for_each_mem_range'
+  - '__for_each_mem_range_rev'
+  - 'for_each_mem_range_rev'
+  - 'for_each_mem_region'
+  - 'for_each_migratetype_order'
+  - 'for_each_msi_entry'
+  - 'for_each_msi_entry_safe'
+  - 'for_each_msi_vector'
+  - 'for_each_net'
+  - 'for_each_net_continue_reverse'
+  - 'for_each_netdev'
+  - 'for_each_netdev_continue'
+  - 'for_each_netdev_continue_rcu'
+  - 'for_each_netdev_continue_reverse'
+  - 'for_each_netdev_feature'
+  - 'for_each_netdev_in_bond_rcu'
+  - 'for_each_netdev_rcu'
+  - 'for_each_netdev_reverse'
+  - 'for_each_netdev_safe'
+  - 'for_each_net_rcu'
+  - 'for_each_new_connector_in_state'
+  - 'for_each_new_crtc_in_state'
+  - 'for_each_new_mst_mgr_in_state'
+  - 'for_each_new_plane_in_state'
+  - 'for_each_new_private_obj_in_state'
+  - 'for_each_node'
+  - 'for_each_node_by_name'
+  - 'for_each_node_by_type'
+  - 'for_each_node_mask'
+  - 'for_each_node_state'
+  - 'for_each_node_with_cpus'
+  - 'for_each_node_with_property'
+  - 'for_each_nonreserved_multicast_dest_pgid'
+  - 'for_each_of_allnodes'
+  - 'for_each_of_allnodes_from'
+  - 'for_each_of_cpu_node'
+  - 'for_each_of_pci_range'
+  - 'for_each_old_connector_in_state'
+  - 'for_each_old_crtc_in_state'
+  - 'for_each_old_mst_mgr_in_state'
+  - 'for_each_oldnew_connector_in_state'
+  - 'for_each_oldnew_crtc_in_state'
+  - 'for_each_oldnew_mst_mgr_in_state'
+  - 'for_each_oldnew_plane_in_state'
+  - 'for_each_oldnew_plane_in_state_reverse'
+  - 'for_each_oldnew_private_obj_in_state'
+  - 'for_each_old_plane_in_state'
+  - 'for_each_old_private_obj_in_state'
+  - 'for_each_online_cpu'
+  - 'for_each_online_node'
+  - 'for_each_online_pgdat'
+  - 'for_each_pci_bridge'
+  - 'for_each_pci_dev'
+  - 'for_each_pci_msi_entry'
+  - 'for_each_pcm_streams'
+  - 'for_each_physmem_range'
+  - 'for_each_populated_zone'
+  - 'for_each_possible_cpu'
+  - 'for_each_present_cpu'
+  - 'for_each_prime_number'
+  - 'for_each_prime_number_from'
+  - 'for_each_process'
+  - 'for_each_process_thread'
+  - 'for_each_prop_codec_conf'
+  - 'for_each_prop_dai_codec'
+  - 'for_each_prop_dai_cpu'
+  - 'for_each_prop_dlc_codecs'
+  - 'for_each_prop_dlc_cpus'
+  - 'for_each_prop_dlc_platforms'
+  - 'for_each_property_of_node'
+  - 'for_each_registered_fb'
+  - 'for_each_requested_gpio'
+  - 'for_each_requested_gpio_in_range'
+  - 'for_each_reserved_mem_range'
+  - 'for_each_reserved_mem_region'
+  - 'for_each_rtd_codec_dais'
+  - 'for_each_rtd_components'
+  - 'for_each_rtd_cpu_dais'
+  - 'for_each_rtd_dais'
+  - 'for_each_set_bit'
+  - 'for_each_set_bit_from'
+  - 'for_each_set_clump8'
+  - 'for_each_sg'
+  - 'for_each_sg_dma_page'
+  - 'for_each_sg_page'
+  - 'for_each_sgtable_dma_page'
+  - 'for_each_sgtable_dma_sg'
+  - 'for_each_sgtable_page'
+  - 'for_each_sgtable_sg'
+  - 'for_each_sibling_event'
+  - 'for_each_subelement'
+  - 'for_each_subelement_extid'
+  - 'for_each_subelement_id'
+  - '__for_each_thread'
+  - 'for_each_thread'
+  - 'for_each_unicast_dest_pgid'
+  - 'for_each_vsi'
+  - 'for_each_wakeup_source'
+  - 'for_each_zone'
+  - 'for_each_zone_zonelist'
+  - 'for_each_zone_zonelist_nodemask'
+  - 'fwnode_for_each_available_child_node'
+  - 'fwnode_for_each_child_node'
+  - 'fwnode_graph_for_each_endpoint'
+  - 'gadget_for_each_ep'
+  - 'genradix_for_each'
+  - 'genradix_for_each_from'
+  - 'hash_for_each'
+  - 'hash_for_each_possible'
+  - 'hash_for_each_possible_rcu'
+  - 'hash_for_each_possible_rcu_notrace'
+  - 'hash_for_each_possible_safe'
+  - 'hash_for_each_rcu'
+  - 'hash_for_each_safe'
+  - 'hctx_for_each_ctx'
+  - 'hlist_bl_for_each_entry'
+  - 'hlist_bl_for_each_entry_rcu'
+  - 'hlist_bl_for_each_entry_safe'
+  - 'hlist_for_each'
+  - 'hlist_for_each_entry'
+  - 'hlist_for_each_entry_continue'
+  - 'hlist_for_each_entry_continue_rcu'
+  - 'hlist_for_each_entry_continue_rcu_bh'
+  - 'hlist_for_each_entry_from'
+  - 'hlist_for_each_entry_from_rcu'
+  - 'hlist_for_each_entry_rcu'
+  - 'hlist_for_each_entry_rcu_bh'
+  - 'hlist_for_each_entry_rcu_notrace'
+  - 'hlist_for_each_entry_safe'
+  - 'hlist_for_each_entry_srcu'
+  - '__hlist_for_each_rcu'
+  - 'hlist_for_each_safe'
+  - 'hlist_nulls_for_each_entry'
+  - 'hlist_nulls_for_each_entry_from'
+  - 'hlist_nulls_for_each_entry_rcu'
+  - 'hlist_nulls_for_each_entry_safe'
+  - 'i3c_bus_for_each_i2cdev'
+  - 'i3c_bus_for_each_i3cdev'
+  - 'ide_host_for_each_port'
+  - 'ide_port_for_each_dev'
+  - 'ide_port_for_each_present_dev'
+  - 'idr_for_each_entry'
+  - 'idr_for_each_entry_continue'
+  - 'idr_for_each_entry_continue_ul'
+  - 'idr_for_each_entry_ul'
+  - 'in_dev_for_each_ifa_rcu'
+  - 'in_dev_for_each_ifa_rtnl'
+  - 'inet_bind_bucket_for_each'
+  - 'inet_lhash2_for_each_icsk_rcu'
+  - 'key_for_each'
+  - 'key_for_each_safe'
+  - 'klp_for_each_func'
+  - 'klp_for_each_func_safe'
+  - 'klp_for_each_func_static'
+  - 'klp_for_each_object'
+  - 'klp_for_each_object_safe'
+  - 'klp_for_each_object_static'
+  - 'kunit_suite_for_each_test_case'
+  - 'kvm_for_each_memslot'
+  - 'kvm_for_each_vcpu'
+  - 'list_for_each'
+  - 'list_for_each_codec'
+  - 'list_for_each_codec_safe'
+  - 'list_for_each_continue'
+  - 'list_for_each_entry'
+  - 'list_for_each_entry_continue'
+  - 'list_for_each_entry_continue_rcu'
+  - 'list_for_each_entry_continue_reverse'
+  - 'list_for_each_entry_from'
+  - 'list_for_each_entry_from_rcu'
+  - 'list_for_each_entry_from_reverse'
+  - 'list_for_each_entry_lockless'
+  - 'list_for_each_entry_rcu'
+  - 'list_for_each_entry_reverse'
+  - 'list_for_each_entry_safe'
+  - 'list_for_each_entry_safe_continue'
+  - 'list_for_each_entry_safe_from'
+  - 'list_for_each_entry_safe_reverse'
+  - 'list_for_each_entry_srcu'
+  - 'list_for_each_prev'
+  - 'list_for_each_prev_safe'
+  - 'list_for_each_safe'
+  - 'llist_for_each'
+  - 'llist_for_each_entry'
+  - 'llist_for_each_entry_safe'
+  - 'llist_for_each_safe'
+  - 'mci_for_each_dimm'
+  - 'media_device_for_each_entity'
+  - 'media_device_for_each_intf'
+  - 'media_device_for_each_link'
+  - 'media_device_for_each_pad'
+  - 'nanddev_io_for_each_page'
+  - 'netdev_for_each_lower_dev'
+  - 'netdev_for_each_lower_private'
+  - 'netdev_for_each_lower_private_rcu'
+  - 'netdev_for_each_mc_addr'
+  - 'netdev_for_each_uc_addr'
+  - 'netdev_for_each_upper_dev_rcu'
+  - 'netdev_hw_addr_list_for_each'
+  - 'nft_rule_for_each_expr'
+  - 'nla_for_each_attr'
+  - 'nla_for_each_nested'
+  - 'nlmsg_for_each_attr'
+  - 'nlmsg_for_each_msg'
+  - 'nr_neigh_for_each'
+  - 'nr_neigh_for_each_safe'
+  - 'nr_node_for_each'
+  - 'nr_node_for_each_safe'
+  - 'of_for_each_phandle'
+  - 'of_property_for_each_string'
+  - 'of_property_for_each_u32'
+  - 'pci_bus_for_each_resource'
+  - 'pcl_for_each_chunk'
+  - 'pcl_for_each_segment'
+  - 'pcm_for_each_format'
+  - 'ping_portaddr_for_each_entry'
+  - 'plist_for_each'
+  - 'plist_for_each_continue'
+  - 'plist_for_each_entry'
+  - 'plist_for_each_entry_continue'
+  - 'plist_for_each_entry_safe'
+  - 'plist_for_each_safe'
+  - 'pnp_for_each_card'
+  - 'pnp_for_each_dev'
+  - 'protocol_for_each_card'
+  - 'protocol_for_each_dev'
+  - 'queue_for_each_hw_ctx'
+  - 'radix_tree_for_each_slot'
+  - 'radix_tree_for_each_tagged'
+  - 'rb_for_each'
+  - 'rbtree_postorder_for_each_entry_safe'
+  - 'rdma_for_each_block'
+  - 'rdma_for_each_port'
+  - 'rdma_umem_for_each_dma_block'
+  - 'resource_list_for_each_entry'
+  - 'resource_list_for_each_entry_safe'
+  - 'rhl_for_each_entry_rcu'
+  - 'rhl_for_each_rcu'
+  - 'rht_for_each'
+  - 'rht_for_each_entry'
+  - 'rht_for_each_entry_from'
+  - 'rht_for_each_entry_rcu'
+  - 'rht_for_each_entry_rcu_from'
+  - 'rht_for_each_entry_safe'
+  - 'rht_for_each_from'
+  - 'rht_for_each_rcu'
+  - 'rht_for_each_rcu_from'
+  - '__rq_for_each_bio'
+  - 'rq_for_each_bvec'
+  - 'rq_for_each_segment'
+  - 'scsi_for_each_prot_sg'
+  - 'scsi_for_each_sg'
+  - 'sctp_for_each_hentry'
+  - 'sctp_skb_for_each'
+  - 'shdma_for_each_chan'
+  - '__shost_for_each_device'
+  - 'shost_for_each_device'
+  - 'sk_for_each'
+  - 'sk_for_each_bound'
+  - 'sk_for_each_entry_offset_rcu'
+  - 'sk_for_each_from'
+  - 'sk_for_each_rcu'
+  - 'sk_for_each_safe'
+  - 'sk_nulls_for_each'
+  - 'sk_nulls_for_each_from'
+  - 'sk_nulls_for_each_rcu'
+  - 'snd_array_for_each'
+  - 'snd_pcm_group_for_each_entry'
+  - 'snd_soc_dapm_widget_for_each_path'
+  - 'snd_soc_dapm_widget_for_each_path_safe'
+  - 'snd_soc_dapm_widget_for_each_sink_path'
+  - 'snd_soc_dapm_widget_for_each_source_path'
+  - 'tb_property_for_each'
+  - 'tcf_exts_for_each_action'
+  - 'udp_portaddr_for_each_entry'
+  - 'udp_portaddr_for_each_entry_rcu'
+  - 'usb_hub_for_each_child'
+  - 'v4l2_device_for_each_subdev'
+  - 'v4l2_m2m_for_each_dst_buf'
+  - 'v4l2_m2m_for_each_dst_buf_safe'
+  - 'v4l2_m2m_for_each_src_buf'
+  - 'v4l2_m2m_for_each_src_buf_safe'
+  - 'virtio_device_for_each_vq'
+  - 'while_for_each_ftrace_op'
+  - 'xa_for_each'
+  - 'xa_for_each_marked'
+  - 'xa_for_each_range'
+  - 'xa_for_each_start'
+  - 'xas_for_each'
+  - 'xas_for_each_conflict'
+  - 'xas_for_each_marked'
+  - 'xbc_array_for_each_value'
+  - 'xbc_for_each_key_value'
+  - 'xbc_node_for_each_array_value'
+  - 'xbc_node_for_each_child'
+  - 'xbc_node_for_each_key_value'
+  - 'zorro_for_each_dev'
+
+#IncludeBlocks: Preserve # Unknown to clang-format-5.0
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+#IndentPPDirectives: None # Unknown to clang-format-5.0
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+#ObjCBinPackProtocolList: Auto # Unknown to clang-format-5.0
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+# Taken from git's rules
+#PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+#SortUsingDeclarations: false # Unknown to clang-format-4.0
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true # Unknown to clang-format-5.0
+#SpaceBeforeInheritanceColon: true # Unknown to clang-format-5.0
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-5.0
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth: 8
+UseTab: Always
+...

--- a/driver/.gitignore
+++ b/driver/.gitignore
@@ -1,0 +1,8 @@
+*.mod*
+*.ko
+*.o
+Module.symvers
+built-in.a
+modules.order
+tags
+

--- a/driver/Kconfig
+++ b/driver/Kconfig
@@ -1,0 +1,3 @@
+CFLAGS += -DDEBUG
+obj-$(CONFIG_XILINX_VCK5000) := vck5000.o
+vck5000-y := main.o

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,0 +1,14 @@
+# https://www.kernel.org/doc/html/latest/kbuild/modules.html
+
+obj-m := amdair.o
+amdair-y := main.o chardev.o
+
+ifeq ($(KERNELRELEASE),)
+KDIR ?= /usr/src/linux-headers-`uname -r`
+
+default:
+	make -C $(KDIR) M=$$PWD
+endif # KERNELRELEASE
+
+clean:
+	rm -f *.o *.ko *.a *.order *.mod.c *.symvers *.mod

--- a/driver/README.md
+++ b/driver/README.md
@@ -1,0 +1,78 @@
+# VCK5000 AIR Driver
+
+This is a Linux kernel driver to manage the VCK5000 PCIe card. It exposes a
+character device /dev/amdair for interfacing with user space applications.
+Applications can use the mmap() system call to access the DRAM and BRAM
+memory regions on the card. This is a very raw and low-level interface so it
+requires most of the logic concerning how to program the card to be in user
+space libraries. Part of the low-level interface is the AIE memory range, to
+address the AIE engines directly. This use is deprecated but still widely used
+by our test code. This memory range is disabled by default but can be enabled
+through a module parameter (see the section on Loading for more details).
+
+It is designed to use the same ioctl interface (function numbers and
+parameters) as the KFD driver, used by ROCm primarily for GPUs. Many of these
+functions are not yet implemented as this is an early stage of development.
+
+## Compiling
+
+The source code is kept out-of-tree at this time. That means it is not tied
+to any Linux upstream project and may not work with every version of the
+kernel. It has been designed and tested on the 5.11 kernel but will likely
+work without modifications on any 5.x kernel (and possibly more).
+There is a Makefile alongside the source code. It is designed to compile the
+driver for the kernel currently running in the host system. On success, it
+will produce a loadable kernel module called amdair.ko in the source directory.
+
+To compile the driver, you will need the standard build tools for the Linux
+kernel. You can install the 'build-essentials' package on your distro to get
+these tools if you don't have them already installed.
+
+## Loading and Unloading
+
+The driver will not load automatically since it is build out-of-tree and the
+module subsystem is not aware of its existence. To load it, use the 'insmod'
+tool with the path to the module. Of course you need the appropriate privilege
+level to load a kernel module ('sudo' will do):
+
+```
+insmod amdair.ko
+```
+
+If you want to pass a module parameter (e.g. to enable the AIE memory region),
+you can do it like this:
+
+```
+insmod amdair.ko enable_aie=1
+```
+
+To unload the module, use the 'rmmod' tool with the module name:
+```
+rmmod amdair
+```
+
+## Debugging
+
+When things go wrong in an application, people love to blame the driver. To
+see what the driver has done, you can review the kernel message log with the
+'dmesg' tool. The driver will not tell you everything that it is doing but
+might shed some light on what is happening in the system:
+```
+dmesg | grep amdair
+```
+
+## Known Issues & Limitations
+
+The driver will only bind to the first card it sees. If there are more cards,
+they cannot be used by this version of the driver.
+
+Only one queue can be used from the card. If you try to allocate more queues
+it will not work. This is also a limitation of the card's firmware.
+
+Most KFD ioctl functions are not yet implemented. The ones that are relevant
+to this card will be implemented eventually.
+
+
+-----
+
+<p align="center">Copyright&copy; 2019-2023 Advanced Micro Devices, Inc.</p>

--- a/driver/chardev.c
+++ b/driver/chardev.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stddef.h>
+#include <linux/device.h>
+#include <linux/export.h>
+#include <linux/err.h>
+#include <linux/fs.h>
+#include <linux/file.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/compat.h>
+#include <linux/time.h>
+#include <linux/mm.h>
+#include <linux/mman.h>
+#include <linux/ptrace.h>
+#include <linux/dma-buf.h>
+#include <linux/fdtable.h>
+#include <linux/processor.h>
+#include <linux/pci.h>
+#include <uapi/linux/kfd_ioctl.h>
+#include "chardev.h"
+
+#define VCK5000_IOCTL_DEF(ioctl, _func, _flags)                                \
+	[_IOC_NR(ioctl)] = { .cmd = ioctl,                                     \
+			     .func = _func,                                    \
+			     .flags = _flags,                                  \
+			     .cmd_drv = 0,                                     \
+			     .name = #ioctl }
+
+#define HERD_CONTROLLER_BRAM_SIZE 0x1000
+
+typedef int vck5000_ioctl_t(struct file *filep, void *data);
+
+struct vck5000_ioctl_desc {
+	unsigned int cmd;
+	int flags;
+	vck5000_ioctl_t *func;
+	unsigned int cmd_drv;
+	const char *name;
+};
+
+static long vck_ioctl(struct file *, unsigned int, unsigned long);
+static int vck_open(struct inode *, struct file *);
+static int vck_release(struct inode *, struct file *);
+static int vck_mmap(struct file *, struct vm_area_struct *);
+
+static int vck5000_ioctl_get_version(struct file *filep, void *data);
+static int vck5000_ioctl_create_queue(struct file *filep, void *data);
+static int vck5000_ioctl_destroy_queue(struct file *filp, void *data);
+
+static const struct file_operations vck_fops = {
+	.owner = THIS_MODULE,
+	.unlocked_ioctl = vck_ioctl,
+	.compat_ioctl = compat_ptr_ioctl,
+	.open = vck_open,
+	.release = vck_release,
+	.mmap = vck_mmap,
+};
+
+static int chardev_major = -1;
+static struct class *vck5000_class;
+static struct device *vck5000_device;
+
+/** Ioctl table */
+static const struct vck5000_ioctl_desc vck5000_ioctls[] = {
+	VCK5000_IOCTL_DEF(AMDKFD_IOC_GET_VERSION, vck5000_ioctl_get_version, 0),
+
+	VCK5000_IOCTL_DEF(AMDKFD_IOC_CREATE_QUEUE, vck5000_ioctl_create_queue,
+			  0),
+
+	VCK5000_IOCTL_DEF(AMDKFD_IOC_DESTROY_QUEUE, vck5000_ioctl_destroy_queue,
+			  0),
+};
+
+int vck5000_chardev_init(struct pci_dev *pdev)
+{
+	int ret = 0;
+
+	ret = register_chrdev(0, amdair_dev_name(), &vck_fops);
+	if (ret < 0)
+		goto err_register;
+
+	chardev_major = ret;
+
+	vck5000_class = class_create(THIS_MODULE, amdair_dev_name());
+	ret = PTR_ERR(vck5000_class);
+	if (IS_ERR(vck5000_class))
+		goto err_class;
+
+	vck5000_device =
+		device_create(vck5000_class, NULL, MKDEV(chardev_major, 0),
+			      NULL, amdair_dev_name());
+
+	ret = PTR_ERR(vck5000_device);
+	if (IS_ERR(vck5000_device))
+		goto err_device;
+
+	dev_set_drvdata(vck5000_device, pdev);
+
+	return 0;
+
+err_device:
+	class_destroy(vck5000_class);
+
+err_class:
+	unregister_chrdev(chardev_major, amdair_dev_name());
+
+err_register:
+	return ret;
+}
+
+void vck5000_chardev_exit(void)
+{
+	device_destroy(vck5000_class, MKDEV(chardev_major, 0));
+	class_destroy(vck5000_class);
+	unregister_chrdev(chardev_major, amdair_dev_name());
+
+	vck5000_device = NULL;
+}
+
+static long vck_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
+{
+	uint32_t amdkfd_size;
+	uint32_t usize, asize;
+	char stack_kdata[128];
+	char *kdata = NULL;
+	vck5000_ioctl_t *func;
+	const struct vck5000_ioctl_desc *ioctl = NULL;
+	unsigned int nr = _IOC_NR(cmd);
+	int ret;
+
+	dev_warn(vck5000_device, "%s", __func__);
+
+	if ((nr < AMDKFD_COMMAND_START) || (nr >= AMDKFD_COMMAND_END)) {
+		dev_warn(vck5000_device, "%s invalid %u", __func__, nr);
+		return 0;
+	}
+
+	ioctl = &vck5000_ioctls[nr];
+
+	amdkfd_size = _IOC_SIZE(ioctl->cmd);
+	usize = asize = _IOC_SIZE(cmd);
+	if (amdkfd_size > asize)
+		asize = amdkfd_size;
+
+	cmd = ioctl->cmd;
+	func = ioctl->func;
+	if (cmd & (IOC_IN | IOC_OUT)) {
+		if (asize <= sizeof(stack_kdata)) {
+			kdata = stack_kdata;
+		} else {
+			kdata = kmalloc(asize, GFP_KERNEL);
+			if (!kdata) {
+				return -ENOMEM;
+			}
+		}
+		if (asize > usize)
+			memset(kdata + usize, 0, asize - usize);
+	}
+
+	if (cmd & IOC_IN) {
+		if (copy_from_user(kdata, (void __user *)arg, usize) != 0) {
+			if (kdata != stack_kdata)
+				kfree(kdata);
+			return -EFAULT;
+		}
+	} else if (cmd & IOC_OUT) {
+		memset(kdata, 0, usize);
+	}
+	ret = func(filep, kdata);
+
+	/* copy any results back to userspace */
+	if (cmd & IOC_OUT)
+		if (copy_to_user((void __user *)arg, kdata, usize) != 0)
+			ret = -EFAULT;
+
+	if (kdata != stack_kdata)
+		kfree(kdata);
+	return ret;
+}
+
+static int vck_open(struct inode *node, struct file *f)
+{
+	dev_warn(vck5000_device, "%s", __func__);
+	return 0;
+}
+
+static int vck_release(struct inode *node, struct file *f)
+{
+	dev_warn(vck5000_device, "%s", __func__);
+	return 0;
+}
+
+static int vck_mmap(struct file *f, struct vm_area_struct *vma)
+{
+	struct pci_dev *pdev;
+	unsigned long pgoff = 0;
+	size_t size = vma->vm_end - vma->vm_start;
+	loff_t offset = (loff_t)vma->vm_pgoff << PAGE_SHIFT;
+
+	pdev = dev_get_drvdata(vck5000_device);
+
+	dev_warn(vck5000_device, "%s start %lx end %lx offset %llx", __func__,
+		 vma->vm_start, vma->vm_end, offset);
+
+	if (offset >= 0x8000000ULL) {
+		unsigned int herd_idx = 0;
+		/* the herd private memory starts at 0x1000, and is 0x1000 long for each herd controller */
+		unsigned long herd_ctlr_offset =
+			HERD_CONTROLLER_BRAM_SIZE * (1 + herd_idx);
+		unsigned long bram = pci_resource_start(pdev, BRAM_BAR_INDEX) +
+				     herd_ctlr_offset;
+		size = HERD_CONTROLLER_BRAM_SIZE;
+		dev_warn(vck5000_device, "mapping %lx BRAM at 0x%lx to 0x%lx",
+			 size, bram, vma->vm_start);
+		pgoff = (bram >> PAGE_SHIFT);
+	} else if (offset == 0x100000ULL) {
+		unsigned long aie = pci_resource_start(pdev, AIE_BAR_INDEX);
+		dev_warn(vck5000_device, "mapping %lx AIE at 0x%lx to 0x%lx",
+			 size, aie, vma->vm_start);
+		pgoff = (aie >> PAGE_SHIFT);
+	} else {
+		unsigned long dram =
+			pci_resource_start(pdev, DRAM_BAR_INDEX) + offset;
+		dev_warn(vck5000_device, "mapping %lx DRAM at 0x%lx to 0x%lx",
+			 size, dram, vma->vm_start);
+		pgoff = (dram >> PAGE_SHIFT);
+	}
+
+	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+
+	/* Remap-pfn-range will mark the range VM_IO */
+	if (remap_pfn_range(vma, vma->vm_start, pgoff, size,
+			    vma->vm_page_prot)) {
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+static int vck5000_ioctl_get_version(struct file *filep, void *data)
+{
+	struct kfd_ioctl_get_version_args *args = data;
+
+	dev_warn(vck5000_device, "%s %u.%u", __func__, KFD_IOCTL_MAJOR_VERSION,
+		 KFD_IOCTL_MINOR_VERSION);
+	args->major_version = KFD_IOCTL_MAJOR_VERSION;
+	args->minor_version = KFD_IOCTL_MINOR_VERSION;
+
+	return 0;
+}
+
+/*
+	This shouldn't be used (yet) - use mmap instead
+*/
+static int vck5000_ioctl_create_queue(struct file *filep, void *data)
+{
+	dev_warn(vck5000_device, "%s", __func__);
+
+	return 0;
+}
+
+/*
+	This shouldn't be used either
+*/
+static int vck5000_ioctl_destroy_queue(struct file *filp, void *data)
+{
+	int retval = 0;
+	dev_warn(vck5000_device, "%s", __func__);
+
+	return retval;
+}

--- a/driver/chardev.h
+++ b/driver/chardev.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VCK5000_CHARDEV_H_
+#define VCK5000_CHARDEV_H_
+
+/* The indices in config space (64-bit BARs) */
+#define DRAM_BAR_INDEX 0
+#define AIE_BAR_INDEX 2
+#define BRAM_BAR_INDEX 4
+
+struct vck5000_priv {
+	void __iomem *dram_bar;
+	void __iomem *aie_bar;
+	void __iomem *bram_bar;
+	uint64_t total_controllers;
+};
+
+int vck5000_chardev_init(struct pci_dev *pdev);
+void vck5000_chardev_exit(void);
+
+const char *amdair_dev_name(void);
+
+#endif /* VCK5000_CHARDEV_H_ */

--- a/driver/main.c
+++ b/driver/main.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/pci.h>
+#include "chardev.h"
+
+static const char air_dev_name[] = "amdair";
+static bool enable_aie;
+
+static struct pci_device_id vck5000_id_table[] = { { PCI_DEVICE(0x10EE,
+								0xB034) },
+						   {
+							   0,
+						   } };
+
+MODULE_DEVICE_TABLE(pci, vck5000_id_table);
+
+static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent);
+static void vck5000_remove(struct pci_dev *pdev);
+
+/* Driver registration structure */
+static struct pci_driver vck5000 = { .name = air_dev_name,
+				     .id_table = vck5000_id_table,
+				     .probe = vck5000_probe,
+				     .remove = vck5000_remove };
+
+#define MAX_HERD_CONTROLLERS 64
+
+/* Offsets into BRAM BAR */
+#define HERD_CONTROLLER_BASE_ADDR(_base, _x)                                   \
+	((((uint64_t)ioread32(_base + (_x * sizeof(uint64_t) + 4))) << 32) |   \
+	 ioread32(_base + (_x * sizeof(uint64_t) + 0)))
+#define REG_HERD_CONTROLLER_COUNT 0x208
+
+/*
+	Register the driver with the PCI subsystem
+*/
+static int __init vck5000_init(void)
+{
+	if (enable_aie)
+		printk("%s: AIE bar access enabled\n", air_dev_name);
+
+	return pci_register_driver(&vck5000);
+}
+
+static void __exit vck5000_exit(void)
+{
+	/* Unregister */
+	pci_unregister_driver(&vck5000);
+}
+
+static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+{
+	int bar_mask;
+	int err;
+	struct vck5000_priv *drv_priv;
+	uint32_t controller_count;
+	uint64_t controller_base;
+	uint32_t idx;
+	//uint8_t *ptr;
+
+	dev_warn(&pdev->dev, "vendor: 0x%X device: 0x%X\n", pdev->vendor,
+		 pdev->device);
+
+	/* Enable device memory */
+	err = pcim_enable_device(pdev);
+	if (err) {
+		dev_err(&pdev->dev, "Can't enable device memory");
+		return err;
+	}
+
+	/* Allocate memory for the driver private data */
+	drv_priv = kzalloc(sizeof(struct vck5000_priv), GFP_KERNEL);
+	if (!drv_priv) {
+		dev_err(&pdev->dev, "Error allocating private data");
+		pci_disable_device(pdev);
+		return -ENOMEM;
+	}
+
+	/* Find all memory BARs. We are expecting 3 64-bit BARs */
+	bar_mask = pci_select_bars(pdev, IORESOURCE_MEM);
+	dev_warn(&pdev->dev, "bar mask: 0x%X", bar_mask);
+	if (bar_mask != 0x15) {
+		dev_err(&pdev->dev,
+			"These are not the bars we're looking for: 0x%x",
+			bar_mask);
+		pci_disable_device(pdev);
+		return -ENOMEM;
+	}
+
+	err = pcim_iomap_regions_request_all(pdev, bar_mask, air_dev_name);
+	if (err) {
+		dev_err(&pdev->dev, "Can't get memory region for bars");
+		// pci_disable_device(pdev);
+		return err;
+	}
+	drv_priv->dram_bar = pcim_iomap_table(pdev)[DRAM_BAR_INDEX];
+	if (enable_aie)
+		drv_priv->aie_bar = pcim_iomap_table(pdev)[AIE_BAR_INDEX];
+	drv_priv->bram_bar = pcim_iomap_table(pdev)[BRAM_BAR_INDEX];
+	dev_warn(&pdev->dev, "bar 0: 0x%lx", (unsigned long)drv_priv->dram_bar);
+	dev_warn(&pdev->dev, "bar 2: 0x%lx", (unsigned long)drv_priv->aie_bar);
+	dev_warn(&pdev->dev, "bar 4: 0x%lx", (unsigned long)drv_priv->bram_bar);
+
+	/* Set driver private data */
+	pci_set_drvdata(pdev, drv_priv);
+
+	/* Request interrupt and set up handler */
+
+	/* set up chardev interface */
+	vck5000_chardev_init(pdev);
+
+	/* Query number of herd controllers */
+	controller_count =
+		ioread32(drv_priv->bram_bar + REG_HERD_CONTROLLER_COUNT);
+	dev_warn(&pdev->dev, "Total controllers: 0x%x", controller_count);
+	drv_priv->total_controllers = controller_count;
+
+	/* Each herd controller has a private memory region */
+	for (idx = 0; idx < controller_count; idx++) {
+		controller_base =
+			HERD_CONTROLLER_BASE_ADDR(drv_priv->bram_bar, idx);
+		dev_warn(&pdev->dev, "Controller %u base address: 0x%llx", idx,
+			 controller_base);
+	}
+
+	return 0;
+}
+
+/* Clean up */
+static void vck5000_remove(struct pci_dev *pdev)
+{
+	struct vck5000_priv *drv_priv = pci_get_drvdata(pdev);
+
+	vck5000_chardev_exit();
+
+	if (drv_priv) {
+		kfree(drv_priv);
+	}
+
+	dev_warn(&pdev->dev, "removed");
+}
+
+const char *amdair_dev_name(void)
+{
+	return air_dev_name;
+}
+
+module_init(vck5000_init);
+module_exit(vck5000_exit);
+
+module_param(enable_aie, bool, 0644);
+MODULE_PARM_DESC(enable_aie, "Enable debug access to AIE BAR");
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Joel Nider <joel.nider@amd.com>");
+MODULE_DESCRIPTION("VCK5000 AIR driver");
+MODULE_VERSION("1.0");


### PR DESCRIPTION
Add a kernel-mode driver for VCK5000. It provides memory-mapped access to the PCIe BARs. This initial implementation is very simple but forms the basis for future features. The device and module are called 'amdair'. Runtimes and low-level apps should use the /dev/amdair character device for communication.

Only a single device is supported at this time. This is planned to be extended in the future.

The VCK5000 currently exposes 3 PCIe BARs (memory ranges). The BARs can be mapped by using the mmap system call from user space. The different BARs can be selected by using an offset, similar to the io_uring driver. Bar 2 (AIE) is deprecated but still in use. To discourage future use, a module parameter enable_aie must be used to gain access to the BAR.

Use GPL license so the string passes some Linux makefile magic that only accepts certain values.