### PR TITLE
Update setup_python_packages.sh

### DIFF
--- a/utils/setup_python_packages.sh
+++ b/utils/setup_python_packages.sh
@@ -13,7 +13,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-python3 -m virtualenv sandbox
+python3 -m venv sandbox
 source sandbox/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install -r utils/requirements.txt


### PR DESCRIPTION
We should use the Python3 built-in venv rather than required the optional virtualenv be installed.  Last machine I tried to use failed instantly due to the missing module