### PR TITLE
Channel to ObjFifo Lowering L1toL3

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -467,7 +467,7 @@ def air_ChannelPutOp : air_Op<"channel.put", [air_AsyncOpInterface,
     `(` type($src) `)`
   }];
   let extraClassDeclaration = [{
-    Value getSrcMemref() { return getSrc(); }
+    Value getMemref() { return getSrc(); }
     int32_t getId() {
       if (auto id_attr = (*this)->getAttrOfType<IntegerAttr>("id")) {
         return id_attr.getInt();
@@ -499,7 +499,7 @@ def air_ChannelGetOp : air_Op<"channel.get", [air_AsyncOpInterface,
     `(` type($dst) `)`
   }];
   let extraClassDeclaration = [{
-    Value getDstMemref() { return getDst(); }
+    Value getMemref() { return getDst(); }
     int32_t getId() {
       if (auto id_attr = (*this)->getAttrOfType<IntegerAttr>("id")) {
         return id_attr.getInt();

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -60,6 +60,10 @@ DmaMemcpyNdOp getAIRDmaInBlock(mlir::Block *block);
 
 // Get channel declaration through channel symbol
 ChannelOp getChannelDeclarationThroughSymbol(ChannelInterface op);
+// Get ChannelPutOp from ChannelOp
+ChannelPutOp getChannelPutOpThroughSymbol(ChannelOp channel);
+// Get ChannelGetOp from ChannelOp
+ChannelGetOp getChannelGetOpThroughSymbol(ChannelOp channel);
 // Get the other channel op through channel symbol
 ChannelGetOp getTheOtherChannelOpThroughSymbol(ChannelPutOp put);
 ChannelPutOp getTheOtherChannelOpThroughSymbol(ChannelGetOp get);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -954,14 +954,14 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
 
       } else {
         // get from L3 to L1/L2
-        producerTile = shimDmaAlloc.getTile(aie_module, src_space, dst_space, 1, consumerTile.getCol(), consumerTile.getRow(), 0);
-
         consumerCore = get->getParentOfType<AIE::CoreOp>();
         if (!consumerCore)
           return failure();
         consumerTile = consumerCore.getTileOp();
         if (!consumerTile)
           return failure();
+
+        producerTile = shimDmaAlloc.getTile(aie_module, src_space, dst_space, 1, consumerTile.getCol(), consumerTile.getRow(), 0);
       }
 
       // create objFifo

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -155,17 +155,18 @@ struct DMAAllocator {
         dmaOp.getSrcMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
     auto dst_memory_space =
         dmaOp.getDstMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
-
+    assert(src_memory_space != dst_memory_space);
+    
     bool isMM2S = (src_memory_space < dst_memory_space);
     auto allocs = isMM2S ? &mm2s_allocs : &s2mm_allocs;
 
     for (auto &t : *allocs) {
       if (col == t.col && row == t.row) {
         for (auto id : t.dma_id)
-          if (dmaOp.getId(); == id)
+          if (dmaOp.getId() == id)
             return t.dma_tile;
         if (tile_channel == t.tile_channel) {
-          t.dma_id.push_back(dmaOp.getId(););
+          t.dma_id.push_back(dmaOp.getId());
           return t.dma_tile;
         }
       }
@@ -178,8 +179,8 @@ struct DMAAllocator {
                        row,
                        (int64_t)dma_channel,
                        tile_channel,
-                       {dmaOp.getId();}});
-    LLVM_DEBUG(llvm::outs() << "isMM2S = " << isMM2S << " " << dmaOp.getId();
+                       {dmaOp.getId()}});
+    LLVM_DEBUG(llvm::outs() << "isMM2S = " << isMM2S << " " << dmaOp.getId()
                             << ", col =" << col << ", row = " << row
                             << ", l2 col =" << dma_col
                             << ", l2 chan =" << dma_channel << "\n");

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -152,21 +152,20 @@ struct DMAAllocator {
   AIE::TileOp getTile(ModuleOp aie_module, air::DmaMemcpyInterface &dmaOp,
                       int64_t tile_channel, int64_t col, int64_t row) {
     auto src_memory_space =
-      dmaOp.getSrcMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
+        dmaOp.getSrcMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
     auto dst_memory_space =
-      dmaOp.getDstMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
-    auto dmaID = dmaOp.getId();
-    
+        dmaOp.getDstMemref().getType().cast<MemRefType>().getMemorySpaceAsInt();
+
     bool isMM2S = (src_memory_space < dst_memory_space);
     auto allocs = isMM2S ? &mm2s_allocs : &s2mm_allocs;
 
     for (auto &t : *allocs) {
       if (col == t.col && row == t.row) {
         for (auto id : t.dma_id)
-          if (dmaID == id)
+          if (dmaOp.getId(); == id)
             return t.dma_tile;
         if (tile_channel == t.tile_channel) {
-          t.dma_id.push_back(dmaID);
+          t.dma_id.push_back(dmaOp.getId(););
           return t.dma_tile;
         }
       }
@@ -179,8 +178,8 @@ struct DMAAllocator {
                        row,
                        (int64_t)dma_channel,
                        tile_channel,
-                       {dmaID}});
-    LLVM_DEBUG(llvm::outs() << "isMM2S = " << isMM2S << " " << dmaID
+                       {dmaOp.getId();}});
+    LLVM_DEBUG(llvm::outs() << "isMM2S = " << isMM2S << " " << dmaOp.getId();
                             << ", col =" << col << ", row = " << row
                             << ", l2 col =" << dma_col
                             << ", l2 chan =" << dma_channel << "\n");

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -396,10 +396,10 @@ public:
                (name.find("ChannelGetOp") != std::string::npos)) {
       auto getOp = mlir::dyn_cast<xilinx::air::ChannelGetOp>(c.op);
       assert(getOp);
-      MemRefType dstTy = getOp.getDstMemref().getType().cast<MemRefType>();
+      MemRefType dstTy = getOp.getDst().getType().cast<MemRefType>();
       air::ChannelPutOp putOp = air::getTheOtherChannelOpThroughSymbol(getOp);
       assert(putOp);
-      MemRefType srcTy = putOp.getSrcMemref().getType().cast<MemRefType>();
+      MemRefType srcTy = putOp.getSrc().getType().cast<MemRefType>();
       auto srcSpace = srcTy.getMemorySpaceAsInt();
       auto dstSpace = dstTy.getMemorySpaceAsInt();
       // if there is a size mismatch, it's because we're moving a tile of the

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -302,6 +302,50 @@ air::getChannelDeclarationThroughSymbol(air::ChannelInterface op) {
   return dyn_cast<air::ChannelOp>(module.lookupSymbol(op.getChanName()));
 }
 
+// Get ChannelPutOp through ChannelOp
+air::ChannelPutOp
+air::getChannelPutOpThroughSymbol(air::ChannelOp channel) {
+  auto module = channel->getParentOfType<ModuleOp>();
+  auto attr =
+      channel->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
+
+  air::ChannelPutOp output = nullptr;
+  module.walk([&](Operation *op) {
+    if (auto put = dyn_cast<air::ChannelPutOp>(op)) {
+      if (put.getChanName() == attr) {
+        output = put;
+      }
+    }
+  });
+
+  if (output)
+    return output;
+  else
+    return ChannelPutOp();
+}
+
+// Get ChannelGetOp through ChannelOp
+air::ChannelGetOp
+air::getChannelGetOpThroughSymbol(air::ChannelOp channel) {
+  auto module = channel->getParentOfType<ModuleOp>();
+  auto attr =
+      channel->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
+
+  air::ChannelGetOp output = nullptr;
+  module.walk([&](Operation *op) {
+    if (auto get = dyn_cast<air::ChannelGetOp>(op)) {
+      if (get.getChanName() == attr) {
+        output = get;
+      }
+    }
+  });
+
+  if (output)
+    return output;
+  else
+    return ChannelGetOp();
+}
+
 // Get the other channel op through channel symbol
 air::ChannelGetOp
 air::getTheOtherChannelOpThroughSymbol(air::ChannelPutOp put) {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -5,7 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
+// RUN: air-opt %s --air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
+
 // CHECK: module @aie.partition_0 {
 // CHECK:   %0 = AIE.tile(1, 1)
 // CHECK:   %1 = AIE.tile(1, 2)

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
@@ -1,0 +1,53 @@
+//===- air_channel_to_objectFifo_L1toL3.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
+
+// CHECK: module @aie.partition_0 {
+// CHECK:   %0 = AIE.tile(1, 1)
+// CHECK:   %1 = AIE.tile(2, 0)
+// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%1, {%0}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %4 = AIE.core(%0) {
+// CHECK:     affine.for %arg0 = 0 to 4096 step 32 {
+// CHECK:       %5 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:       %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:       %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:       affine.for %arg1 = 0 to 32 {
+// CHECK:         %9 = affine.load %6[%arg1] : memref<32xi32, 2>
+// CHECK:         affine.store %9, %8[%arg1] : memref<32xi32, 2>
+// CHECK:       }
+// CHECK:       AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:     }
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
+// CHECK: }
+
+module @aie.partition_0 {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    %alloc_0 = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    affine.for %arg0 = 0 to 4096 step 32 {
+      air.channel.get  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+      affine.for %arg1 = 0 to 32 {
+        %2 = affine.load %alloc[%arg1] : memref<32xi32, 2>
+        affine.store %2, %alloc_0[%arg1] : memref<32xi32, 2>
+      }
+      air.channel.put  @channel_1[] (%alloc_0[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    }
+    memref.dealloc %alloc_0 : memref<32xi32, 2>
+    memref.dealloc %alloc : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_1.elf"}
+  air.channel @channel_0 [1, 1]
+  air.channel @channel_1 [1, 1]
+}


### PR DESCRIPTION
This PR changes the channel-to-objectFifo rewrite pattern in AIRToAIE.cpp to target ChannelOps directly. With the addition of two new helper functions, the channel symbol is used to search for both the associated ChannelPut and ChannelGet. If either is missing, then the communication is done through L3. As objectFifos require physically placed tiles, for now, a simple ShimTileAllocator is used to instantiate new shim tiles when required. 

One small change to AIR.td ChannelPut and ChannelGet ops is made such that code for the rewrite pattern can be written more cleanly: the getSrcMemref() and getDstMemref() are both changed to getMemref(). This change was applied to any source files currently using those functions.