### PR TITLE
Unify aircc.py flows

### DIFF
--- a/python/air/compiler/aircc/cl_arguments.py
+++ b/python/air/compiler/aircc/cl_arguments.py
@@ -13,6 +13,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(prog='aircc')
     parser.add_argument('air_mlir_file',
             metavar="air_mlir_file",
+            default="air.mlir",
             help='AIR Dialect mlir file')
     parser.add_argument('-o',
             dest="output_file",


### PR DESCRIPTION
The command line tool used the `aircc.run_flow` api while the library interface used the `aircc.run` api. Now both use `aircc.run`

This fixes a lot of code duplication.