### PR TITLE
build: update toolchain cmake variable

### DIFF
--- a/utils/build-mlir-air-pcie.sh
+++ b/utils/build-mlir-air-pcie.sh
@@ -53,7 +53,7 @@ cmake .. \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
     -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/ \
-    -DCMAKE_TOOLCHAIN_FILE=../cmake/modules/toolchain_x86.cmake \
+    -Dx86_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86.cmake \
     -DLLVM_DIR=${LLVM_DIR}/build/lib/cmake/llvm \
     -DMLIR_DIR=${LLVM_DIR}/build/lib/cmake/mlir \
     -DAIE_DIR=${MLIR_AIE_DIR}/build/lib/cmake/aie \


### PR DESCRIPTION
When building mlir-air, the build fails with this message:

CMake Error at CMakeLists.txt:121 (message):
  Toolchain file not found! Cannot build target x86.

Referring to commit 6fc6d6b0b it is clear that the variable name for the toolchain file in the script used in the CI flow is x86_TOOLCHAIN_FILE .

Update the standalone script to match the variable name used in the CI script.