### PR TITLE
AIR Runner: Refactor memory port modelling

### DIFF
--- a/mlir/include/air/Util/Runner.h
+++ b/mlir/include/air/Util/Runner.h
@@ -43,6 +43,7 @@ std::string to_string(dependencyNodeEntry &c);
 std::string to_string(mlir::Type t);
 std::string getElementTypeAsString(const mlir::Type ty);
 std::string lookUpMemorySpaceFromInt(unsigned memory_space);
+unsigned lookUpMemorySpaceIntFromString(std::string memory_space);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -188,9 +188,9 @@ public:
       // if there is a size mismatch, it's because we're moving a tile of the
       // larger tensor
       if (getTensorVolume(srcTy) <= getTensorVolume(dstTy))
-        execution_time = getTransferCost(d, srcSpace, dstSpace, srcTy);
+        execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, srcTy);
       else
-        execution_time = getTransferCost(d, srcSpace, dstSpace, dstTy);
+        execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, dstTy);
     } else if (type == "channel" &&
                (name.find("ChannelGetOp") != std::string::npos)) {
       auto getOp = mlir::dyn_cast<xilinx::air::ChannelGetOp>(c.op);
@@ -205,9 +205,9 @@ public:
       // if there is a size mismatch, it's because we're moving a tile of the
       // larger tensor
       if (getTensorVolume(srcTy) <= getTensorVolume(dstTy))
-        execution_time = getTransferCost(d, srcSpace, dstSpace, srcTy);
+        execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, srcTy);
       else
-        execution_time = getTransferCost(d, srcSpace, dstSpace, dstTy);
+        execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, dstTy);
     } else if (type == "execute" && name != "ExecuteTerminatorOp") {
       assert(dyn_cast<air::ExecuteOp>(c.op) &&
              "op type and node type do not match");
@@ -539,24 +539,25 @@ private:
   // Latency estimation helper functions
   //===----------------------------------------------------------------------===//
 
-  uint64_t getTransferCost(device &d, unsigned srcSpace, unsigned dstSpace,
-                           mlir::Type ty) {
-    return getTransferCost(d, srcSpace, dstSpace, getTensorVolume(ty), ty);
+  uint64_t getTransferCost(device &d, Operation *op, unsigned srcSpace,
+                           unsigned dstSpace, mlir::Type ty) {
+    return getTransferCost(d, op, srcSpace, dstSpace, getTensorVolume(ty), ty);
   }
 
-  uint64_t getTransferCost(device &d, unsigned srcSpace, unsigned dstSpace,
-                           int64_t volume, mlir::Type ty) {
-    double cps = 0.0f;
-    unsigned datawidth = 0;
-    if (d.interfaces.size()) {
-      cps = d.clock;
-      if (auto bytes = d.datatypes[getElementTypeAsString(ty)]) {
-        datawidth = bytes;
-      } else {
-        assert(false && "data type not found in JSON model");
-      }
+  uint64_t getTransferCost(device &d, Operation *op, unsigned srcSpace,
+                           unsigned dstSpace, int64_t volume, mlir::Type ty) {
+    double cps = d.clock;
+    if (cps == 0.0f) {
+      op->emitError("device clock frequency not found in JSON model");
     }
-    assert(cps != 0.0f && datawidth);
+    unsigned datawidth = 0;
+    if (auto bytes = d.datatypes[getElementTypeAsString(ty)]) {
+      datawidth = bytes;
+      if (!datawidth)
+        op->emitOpError("found data type with zero width in JSON model");
+    } else
+      op->emitOpError(
+          "involves data movement with data type not found in JSON model");
 
     double bytes = volume * datawidth;
     assert(d.interfaces[std::make_pair(srcSpace, dstSpace)].size());
@@ -720,6 +721,18 @@ std::string lookUpMemorySpaceFromInt(unsigned memory_space) {
     output += "L2";
   } else if (memory_space == 2) {
     output += "L1";
+  }
+  return output;
+}
+
+unsigned lookUpMemorySpaceIntFromString(std::string memory_space) {
+  unsigned output = 0;
+  if (memory_space == "L3") {
+    output = 0;
+  } else if (memory_space == "L2") {
+    output = 1;
+  } else if (memory_space == "L1") {
+    output = 2;
   }
   return output;
 }

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -557,11 +557,13 @@ private:
         op->emitOpError("found data type with zero width in JSON model");
     } else
       op->emitOpError(
-          "involves data movement with data type not found in JSON model");
+          "is data movement with data type not found in JSON model");
 
     double bytes = volume * datawidth;
-    assert(d.interfaces[std::make_pair(srcSpace, dstSpace)].size());
-    double bps = d.interfaces[{srcSpace, dstSpace}][0]->data_rate;
+    double bps = d.interfaces[{srcSpace, dstSpace}]->data_rate;
+    if (bps == 0.0f)
+      op->emitOpError(
+          "is data movement with data rate not found in JSON model");
     double seconds = bytes / bps;
     return (uint64_t)ceil(seconds * cps);
   }

--- a/mlir/lib/Util/Runner/Resource.cpp
+++ b/mlir/lib/Util/Runner/Resource.cpp
@@ -67,10 +67,9 @@ public:
     // need to copy while copying regions/tiles etc.
   }
 
-  port(resource *parent, unsigned src, unsigned dst, double data_rate,
-       unsigned idx) {
+  port(resource *parent, unsigned src, unsigned dst, double data_rate) {
     this->set_name("L" + std::to_string(src) + "_to_" + "L" +
-                   std::to_string(dst) + "_" + std::to_string(idx));
+                   std::to_string(dst));
     this->set_data_rate(data_rate);
     this->set_parent(parent);
     this->reset_reservation();

--- a/mlir/lib/Util/Runner/Resource.cpp
+++ b/mlir/lib/Util/Runner/Resource.cpp
@@ -76,10 +76,10 @@ public:
     this->reset_reservation();
   }
 
-  port(resource *parent, std::string memory_space,
+  port(resource *parent, std::string ms_n_dir,
        std::optional<double> bytes_per_second, unsigned idx) {
     if (bytes_per_second) {
-      this->set_name(memory_space + "_" + std::to_string(idx));
+      this->set_name(ms_n_dir + "_" + std::to_string(idx));
       this->set_data_rate(*bytes_per_second);
       this->set_parent(parent);
       this->reset_reservation();
@@ -173,6 +173,13 @@ public:
 
   memory(unsigned ms, double b) {
     this->set_memory_space(ms);
+    this->set_bytes(b);
+    this->reset_reservation();
+    this->reset_usage();
+  }
+
+  memory(std::string ms, double b) {
+    this->set_memory_space(lookUpMemorySpaceIntFromString(ms));
     this->set_bytes(b);
     this->reset_reservation();
     this->reset_usage();

--- a/mlir/lib/Util/Runner/ResourceHierarchy.cpp
+++ b/mlir/lib/Util/Runner/ResourceHierarchy.cpp
@@ -148,8 +148,7 @@ public:
       for (auto it = tileArray->begin(), ie = tileArray->end(); it != ie;
            ++it) {
         llvm::json::Value jv = *it;
-        llvm::json::Object *tileObject = jv.getAsObject();
-        auto val = tileObject->getInteger("num");
+        auto val = jv.getAsInteger();
         total_count *= *val;
       }
       for (unsigned i = 0; i < total_count; i++) {
@@ -281,8 +280,7 @@ public:
       for (auto it = countArray->begin(), ie = countArray->end(); it != ie;
            ++it) {
         llvm::json::Value jv = *it;
-        llvm::json::Object *countObject = jv.getAsObject();
-        auto val = countObject->getInteger("num");
+        auto val = jv.getAsInteger();
         total_count *= *val;
       }
       for (unsigned i = 0; i < total_count; i++) {
@@ -378,7 +376,8 @@ public:
           return 0;
       } else
         return 0;
-    }
+    } else
+      return 0;
   }
 
   device(std::string name = "", resource *parent = nullptr,

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -673,10 +673,6 @@ private:
   // Return how many events can be dispatched at this point in time.
   unsigned checkResourceFulfillmentForOp(air::ChannelPutOp putOp) {
 
-    // Get src memory spaces
-    MemRefType srcTy = putOp.getSrc().getType().cast<MemRefType>();
-    auto srcSpace = srcTy.getMemorySpaceAsInt();
-
     // Get a pool of available ports from src
     std::vector<resource *> src_resource_pool;
     this->getPortsPool(src_resource_pool, "outbound");
@@ -695,10 +691,6 @@ private:
     return std::min(remaining, (unsigned)src_resource_pool.size());
   }
   unsigned checkResourceFulfillmentForOp(air::ChannelGetOp getOp) {
-
-    // Get dst memory spaces
-    MemRefType dstTy = getOp.getDst().getType().cast<MemRefType>();
-    auto dstSpace = dstTy.getMemorySpaceAsInt();
 
     // Get a pool of available ports from dst
     std::vector<resource *> dst_resource_pool;

--- a/mlir/test/Util/Runner/arch.json
+++ b/mlir/test/Util/Runner/arch.json
@@ -58,7 +58,7 @@
     "num_dispatch_queues": 8,
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
-    "columns": {
+    "dus": {
         "count": [4, 4],
         "memory": {
             "memory_space": "L2",

--- a/mlir/test/Util/Runner/arch.json
+++ b/mlir/test/Util/Runner/arch.json
@@ -59,16 +59,7 @@
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
     "columns": {
-        "count": [
-            {
-                "dim": 0,
-                "num": 4
-            },
-            {
-                "dim": 1,
-                "num": 4
-            }
-        ],
+        "count": [4, 4],
         "memory": {
             "memory_space": "L2",
             "bytes": 262144
@@ -84,16 +75,7 @@
             }
         },
         "tiles": {
-            "count": [
-                {
-                    "dim": 0,
-                    "num": 1
-                },
-                {
-                    "dim": 1,
-                    "num": 4
-                }
-            ],
+            "count": [1, 4],
             "memory": {
                 "memory_space": "L1",
                 "bytes": 32768

--- a/mlir/test/Util/Runner/arch.json
+++ b/mlir/test/Util/Runner/arch.json
@@ -12,48 +12,6 @@
         }
     ],
     "devicename": "testdevice",
-    "interfaces": [
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 2
-        }
-    ],
     "kernels": {
         "linalg.copy": {
             "datatypes": {

--- a/mlir/test/Util/Runner/arch.json
+++ b/mlir/test/Util/Runner/arch.json
@@ -112,15 +112,15 @@
             }
         ],
         "memory": {
-            "memory_space": 1,
+            "memory_space": "L2",
             "bytes": 262144
         },
         "ports": {
-            "L1": {
+            "outbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             },
-            "L2": {
+            "inbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             }
@@ -137,11 +137,15 @@
                 }
             ],
             "memory": {
-                "memory_space": 2,
+                "memory_space": "L1",
                 "bytes": 32768
             },
             "ports": {
-                "L1": {
+                "outbound": {
+                    "count": 4,
+                    "bytes_per_second": 100000000000
+                },
+                "inbound": {
                     "count": 4,
                     "bytes_per_second": 100000000000
                 }
@@ -149,11 +153,11 @@
         }
     },
     "noc": {
-        "L2": {
+        "outbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         },
-        "L3": {
+        "inbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         }

--- a/mlir/test/Util/Runner/bad_launch/arch.json
+++ b/mlir/test/Util/Runner/bad_launch/arch.json
@@ -12,48 +12,6 @@
         }
     ],
     "devicename": "testdevice",
-    "interfaces": [
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 2
-        }
-    ],
     "kernels": {
         "linalg.copy": {
             "datatypes": {
@@ -116,11 +74,11 @@
             "bytes": 262144
         },
         "ports": {
-            "L1": {
+            "outbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             },
-            "L2": {
+            "inbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             }
@@ -141,7 +99,11 @@
                 "bytes": 2048
             },
             "ports": {
-                "L1": {
+                "outbound": {
+                    "count": 4,
+                    "bytes_per_second": 100000000000
+                },
+                "inbound": {
                     "count": 4,
                     "bytes_per_second": 100000000000
                 }
@@ -149,11 +111,11 @@
         }
     },
     "noc": {
-        "L2": {
+        "outbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         },
-        "L3": {
+        "inbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         }

--- a/mlir/test/Util/Runner/bad_launch/arch.json
+++ b/mlir/test/Util/Runner/bad_launch/arch.json
@@ -112,7 +112,7 @@
             }
         ],
         "memory": {
-            "memory_space": 1,
+            "memory_space": "L2",
             "bytes": 262144
         },
         "ports": {
@@ -137,7 +137,7 @@
                 }
             ],
             "memory": {
-                "memory_space": 2,
+                "memory_space": "L1",
                 "bytes": 2048
             },
             "ports": {

--- a/mlir/test/Util/Runner/bad_launch/arch.json
+++ b/mlir/test/Util/Runner/bad_launch/arch.json
@@ -59,16 +59,7 @@
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
     "columns": {
-        "count": [
-            {
-                "dim": 0,
-                "num": 3
-            },
-            {
-                "dim": 1,
-                "num": 1
-            }
-        ],
+        "count": [3, 1],
         "memory": {
             "memory_space": "L2",
             "bytes": 262144
@@ -84,16 +75,7 @@
             }
         },
         "tiles": {
-            "count": [
-                {
-                    "dim": 0,
-                    "num": 1
-                },
-                {
-                    "dim": 1,
-                    "num": 4
-                }
-            ],
+            "count": [1, 4],
             "memory": {
                 "memory_space": "L1",
                 "bytes": 2048

--- a/mlir/test/Util/Runner/bad_launch/arch.json
+++ b/mlir/test/Util/Runner/bad_launch/arch.json
@@ -58,7 +58,7 @@
     "num_dispatch_queues": 8,
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
-    "columns": {
+    "dus": {
         "count": [3, 1],
         "memory": {
             "memory_space": "L2",

--- a/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
@@ -20,7 +20,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [3, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [3, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
@@ -21,7 +21,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [3, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [3, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
@@ -20,7 +20,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
@@ -21,7 +21,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bandwidth_contention/arch.json
+++ b/mlir/test/Util/Runner/bandwidth_contention/arch.json
@@ -59,16 +59,7 @@
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
     "columns": {
-        "count": [
-            {
-                "dim": 0,
-                "num": 4
-            },
-            {
-                "dim": 1,
-                "num": 4
-            }
-        ],
+        "count": [4, 4],
         "memory": {
             "memory_space": "L2",
             "bytes": 262144
@@ -84,16 +75,7 @@
             }
         },
         "tiles": {
-            "count": [
-                {
-                    "dim": 0,
-                    "num": 1
-                },
-                {
-                    "dim": 1,
-                    "num": 4
-                }
-            ],
+            "count": [1, 4],
             "memory": {
                 "memory_space": "L1",
                 "bytes": 2048

--- a/mlir/test/Util/Runner/bandwidth_contention/arch.json
+++ b/mlir/test/Util/Runner/bandwidth_contention/arch.json
@@ -58,7 +58,7 @@
     "num_dispatch_queues": 8,
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
-    "columns": {
+    "dus": {
         "count": [4, 4],
         "memory": {
             "memory_space": "L2",

--- a/mlir/test/Util/Runner/bandwidth_contention/arch.json
+++ b/mlir/test/Util/Runner/bandwidth_contention/arch.json
@@ -12,48 +12,6 @@
         }
     ],
     "devicename": "testdevice",
-    "interfaces": [
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 2
-        }
-    ],
     "kernels": {
         "linalg.copy": {
             "datatypes": {

--- a/mlir/test/Util/Runner/bandwidth_contention/arch.json
+++ b/mlir/test/Util/Runner/bandwidth_contention/arch.json
@@ -112,15 +112,15 @@
             }
         ],
         "memory": {
-            "memory_space": 1,
+            "memory_space": "L2",
             "bytes": 262144
         },
         "ports": {
-            "L1": {
-                "count": 4,
+            "outbound": {
+                "count": 1,
                 "bytes_per_second": 100000000000
             },
-            "L2": {
+            "inbound": {
                 "count": 1,
                 "bytes_per_second": 100000000000
             }
@@ -137,11 +137,15 @@
                 }
             ],
             "memory": {
-                "memory_space": 2,
+                "memory_space": "L1",
                 "bytes": 2048
             },
             "ports": {
-                "L1": {
+                "outbound": {
+                    "count": 1,
+                    "bytes_per_second": 100000000000
+                },
+                "inbound": {
                     "count": 1,
                     "bytes_per_second": 100000000000
                 }
@@ -149,11 +153,11 @@
         }
     },
     "noc": {
-        "L2": {
+        "outbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         },
-        "L3": {
+        "inbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         }

--- a/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
@@ -81,7 +81,7 @@ module {
       %c128 = arith.constant 128 : index
       %c256 = arith.constant 256 : index
       %1 = air.channel.put async  @channel_0[] (%arg8[] [] []) : (memref<128x128xbf16>)
-      %3 = air.segment async attributes {column_usage = [4, 1]} {
+      %3 = air.segment async attributes {du_usage = [4, 1]} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
@@ -126,7 +126,7 @@ module {
       %c128 = arith.constant 128 : index
       %c256 = arith.constant 256 : index
       %1 = air.channel.put async  @channel_0[] (%arg8[] [] []) : (memref<128x128xbf16>)
-      %3 = air.segment async attributes {column_usage = [4, 1]} {
+      %3 = air.segment async attributes {du_usage = [4, 1]} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/channel.mlir
+++ b/mlir/test/Util/Runner/channel.mlir
@@ -53,7 +53,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {column_usage = [4, 1]} {
+      %3 = air.segment async attributes {du_usage = [4, 1]} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/channel_broadcast.mlir
@@ -58,7 +58,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {column_usage = [4, 1]} {
+      %3 = air.segment async attributes {du_usage = [4, 1]} {
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0_6 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/channel.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel.mlir
@@ -53,7 +53,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {column_usage = [4, 1]} {
+      %3 = air.segment async attributes {du_usage = [4, 1]} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
@@ -58,7 +58,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {column_usage = [4, 1]}  {
+      %3 = air.segment async attributes {du_usage = [4, 1]}  {
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0_6 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
+++ b/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
@@ -27,7 +27,7 @@ module {
   func.func @test() {
     %c1 = arith.constant 1 : index
     %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) {
-      %1 = air.segment async attributes {column_usage = [1, 1]} {
+      %1 = air.segment async attributes {du_usage = [1, 1]} {
         %c1_0 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async  tile (%arg4, %arg5) in (%arg6=%c1_0, %arg7=%c4) {

--- a/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
@@ -143,7 +143,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) {
-      %1 = air.segment async attributes {column_usage = [1, 1]} {
+      %1 = air.segment async attributes {du_usage = [1, 1]} {
         %c1_4 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
@@ -77,7 +77,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) {
-      %1 = air.segment async attributes {column_usage = [2, 1]} {
+      %1 = air.segment async attributes {du_usage = [2, 1]} {
         %c2 = arith.constant 2 : index
         %async_token_4, %results_5 = air.execute -> (memref<128x128xbf16, 1>) {
           %alloc = memref.alloc() : memref<128x128xbf16, 1>

--- a/mlir/test/Util/Runner/dma.mlir
+++ b/mlir/test/Util/Runner/dma.mlir
@@ -37,7 +37,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%results_2) : memref<256x1024xbf16> {
-      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {column_usage = [1, 1]} {
+      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {du_usage = [1, 1]} {
         %c1_4 = arith.constant 1 : index
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index

--- a/mlir/test/Util/Runner/dma_broadcast.mlir
+++ b/mlir/test/Util/Runner/dma_broadcast.mlir
@@ -41,7 +41,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%results_2) : memref<256x1024xbf16> {
-      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {du_usage = [4, 1]} {
         %c1_4 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/hierarchy.mlir
+++ b/mlir/test/Util/Runner/hierarchy.mlir
@@ -70,7 +70,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/multi_token_loop.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop.mlir
@@ -49,7 +49,7 @@ module {
         %4 = air.channel.put async [%arg10]  @channel_0[%arg4, %arg5] (%arg8[%c0, %arg9] [%c128, %c128] [%c1024, %c1_4]) : (memref<256x1024xbf16>)
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async  args(%arg9=%arg4, %arg10=%arg5) : index, index attributes {column_usage = [1, 1]} {
+      %3 = air.segment async  args(%arg9=%arg4, %arg10=%arg5) : index, index attributes {du_usage = [1, 1]} {
         %c0_5 = arith.constant 0 : index
         %c1024_6 = arith.constant 1024 : index
         %c128_7 = arith.constant 128 : index

--- a/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
@@ -38,7 +38,7 @@ module {
         %2 = affine.apply #map()[%arg4]
         air.execute_terminator %2 : index
       }
-      %1 = air.segment async attributes {column_usage = [4, 1]} {
+      %1 = air.segment async attributes {du_usage = [4, 1]} {
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index
         %c512 = arith.constant 512 : index

--- a/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
@@ -56,7 +56,7 @@ module attributes {torch.debug_module_name = "mmult"} {
       memref.copy %results, %results_8 : memref<512x512xf32> to memref<512x512xf32>
     } {id = 8 : i32}
     %0 = air.launch async [%async_token_9] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) attributes {id = 7 : i32} {
-      %1 = air.segment async  attributes {column_usage = [4, 1], id = 2 : i32} {
+      %1 = air.segment async  attributes {du_usage = [4, 1], id = 2 : i32} {
         %c64 = arith.constant 64 : index
         %c32 = arith.constant 32 : index
         %c1_10 = arith.constant 1 : index

--- a/mlir/test/Util/Runner/multi_token_loop_race.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_race.mlir
@@ -31,7 +31,7 @@ module {
       memref.copy %arg2, %results : memref<512x512xbf16> to memref<512x512xbf16>
     }
     %0 = air.launch async [%async_token_0] (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%results) : memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 1 : i32} {
-      %1 = air.segment async  args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg13=%arg8, %arg14=%arg9) : index, index, memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 2 : i32, column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg13=%arg8, %arg14=%arg9) : index, index, memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 2 : i32, du_usage = [4, 1]} {
         %c1_1 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/tile_memory_contention/arch.json
+++ b/mlir/test/Util/Runner/tile_memory_contention/arch.json
@@ -59,16 +59,7 @@
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
     "columns": {
-        "count": [
-            {
-                "dim": 0,
-                "num": 4
-            },
-            {
-                "dim": 1,
-                "num": 4
-            }
-        ],
+        "count": [4, 4],
         "memory": {
             "memory_space": "L2",
             "bytes": 262144
@@ -84,16 +75,7 @@
             }
         },
         "tiles": {
-            "count": [
-                {
-                    "dim": 0,
-                    "num": 1
-                },
-                {
-                    "dim": 1,
-                    "num": 4
-                }
-            ],
+            "count": [1, 4],
             "memory": {
                 "memory_space": "L1",
                 "bytes": 2048

--- a/mlir/test/Util/Runner/tile_memory_contention/arch.json
+++ b/mlir/test/Util/Runner/tile_memory_contention/arch.json
@@ -58,7 +58,7 @@
     "num_dispatch_queues": 8,
     "num_dispatch_dma_queues" : 2,
     "num_core_dma_queues" : 2,
-    "columns": {
+    "dus": {
         "count": [4, 4],
         "memory": {
             "memory_space": "L2",

--- a/mlir/test/Util/Runner/tile_memory_contention/arch.json
+++ b/mlir/test/Util/Runner/tile_memory_contention/arch.json
@@ -12,48 +12,6 @@
         }
     ],
     "devicename": "testdevice",
-    "interfaces": [
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 2
-        }
-    ],
     "kernels": {
         "linalg.copy": {
             "datatypes": {

--- a/mlir/test/Util/Runner/tile_memory_contention/arch.json
+++ b/mlir/test/Util/Runner/tile_memory_contention/arch.json
@@ -112,15 +112,15 @@
             }
         ],
         "memory": {
-            "memory_space": 1,
+            "memory_space": "L2",
             "bytes": 262144
         },
         "ports": {
-            "L1": {
+            "outbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             },
-            "L2": {
+            "inbound": {
                 "count": 4,
                 "bytes_per_second": 100000000000
             }
@@ -137,11 +137,15 @@
                 }
             ],
             "memory": {
-                "memory_space": 2,
+                "memory_space": "L1",
                 "bytes": 2048
             },
             "ports": {
-                "L1": {
+                "outbound": {
+                    "count": 4,
+                    "bytes_per_second": 100000000000
+                },
+                "inbound": {
                     "count": 4,
                     "bytes_per_second": 100000000000
                 }
@@ -149,11 +153,11 @@
         }
     },
     "noc": {
-        "L2": {
+        "outbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         },
-        "L3": {
+        "inbound": {
             "count": 4,
             "bytes_per_second": 100000000000
         }

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
@@ -38,7 +38,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
@@ -81,7 +81,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {column_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
         %c1_1 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c1_1) {


### PR DESCRIPTION
- Implement separate pools of port resources for inbound and outbound communication per resource hierarchy.
- Remove "interfaces" object from resource model. The object shall now be inferred by a member function of class device instead.
- Declare tile and CU arrays as arrays of ints.
- Rename columns to DUs.