### PR TITLE
AIR Runner: Hotfixes

### DIFF
--- a/examples/runner/mmult/arch.json
+++ b/examples/runner/mmult/arch.json
@@ -53,11 +53,6 @@
           "name": "linalg.matmul"
       }
   },
-  "ops_per_core_per_cycle": 512,
-  "num_herd_slots": 4,
-  "num_dispatch_queues": 8,
-  "num_dispatch_dma_queues" : 2,
-  "num_core_dma_queues" : 2,
   "dus": {
       "count": [4, 4],
       "memory": {

--- a/examples/runner/mmult/arch.json
+++ b/examples/runner/mmult/arch.json
@@ -1,83 +1,105 @@
 {
   "clock": 1000000000,
-  "datatype": {
-    "bytes": 4,
-    "name": "fp32"
-  },
-  "devicename": "testdevice",
-  "interfaces": [
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 1,
-      "src": 0
-    },
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 0,
-      "src": 1
-    },
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 2,
-      "src": 0
-    },
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 0,
-      "src": 2
-    },
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 2,
-      "src": 1
-    },
-    {
-      "bytes_per_second": 100000000000,
-      "dst": 1,
-      "src": 2
-    }
+  "cores": 1,
+  "datatypes": [
+      {
+      "bytes": 2,
+      "name": "bf16"
+      },
+      {
+      "bytes": 4,
+      "name": "f32"
+      }
   ],
+  "devicename": "testdevice",
   "kernels": {
-    "linalg.copy": {
-      "efficiency": 1,
-      "name": "linalg.copy"
-    },
-    "linalg.fill": {
-      "efficiency": 1,
-      "name": "linalg.fill"
-    },
-    "linalg.matmul": {
-      "efficiency": 1,
-      "name": "linalg.matmul"
-    }
-  },
-  "memories": {
-    "0": {
-      "bytes": 34359738368,
-      "name": "offchip",
-      "read_bytes_per_second": 0,
-      "space": 0,
-      "type": "simplex",
-      "write_bytes_per_second": 0
-    },
-    "1": {
-      "bytes": 33554432,
-      "name": "onchip",
-      "read_bytes_per_second": 0,
-      "space": 1,
-      "type": "duplex",
-      "write_bytes_per_second": 0
-    },
-    "2": {
-      "bytes": 32768,
-      "name": "tile",
-      "read_bytes_per_second": 0,
-      "space": 2,
-      "type": "duplex",
-      "write_bytes_per_second": 0
-    }
+      "linalg.copy": {
+          "datatypes": {
+              "bf16": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              },
+              "f32": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              }
+          },
+          "name": "linalg.copy"
+      },
+      "linalg.fill": {
+          "datatypes": {
+              "bf16": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              },
+              "f32": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              }
+          },
+          "name": "linalg.fill"
+      },
+      "linalg.matmul": {
+          "datatypes": {
+              "bf16": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              },
+              "f32": {
+                  "ops_per_core_per_cycle": 8,
+                  "efficiency": 1
+              }
+          },
+          "name": "linalg.matmul"
+      }
   },
   "ops_per_core_per_cycle": 512,
   "num_herd_slots": 4,
-  "num_dispatch_queues": 4
+  "num_dispatch_queues": 8,
+  "num_dispatch_dma_queues" : 2,
+  "num_core_dma_queues" : 2,
+  "dus": {
+      "count": [4, 4],
+      "memory": {
+          "memory_space": "L2",
+          "bytes": 524288
+      },
+      "ports": {
+          "outbound": {
+              "count": 6,
+              "bytes_per_second": 100000000000
+          },
+          "inbound": {
+              "count": 6,
+              "bytes_per_second": 100000000000
+          }
+      },
+      "tiles": {
+          "count": [1, 4],
+          "memory": {
+              "memory_space": "L1",
+              "bytes": 65536
+          },
+          "ports": {
+              "outbound": {
+                  "count": 2,
+                  "bytes_per_second": 100000000000
+              },
+              "inbound": {
+                  "count": 2,
+                  "bytes_per_second": 100000000000
+              }
+          }
+      }
+  },
+  "noc": {
+      "outbound": {
+          "count": 4,
+          "bytes_per_second": 100000000000
+      },
+      "inbound": {
+          "count": 4,
+          "bytes_per_second": 100000000000
+      }
+  }
 }

--- a/examples/runner/mmult/mmult.py
+++ b/examples/runner/mmult/mmult.py
@@ -62,6 +62,7 @@ with air.mlir.ir.Context(), Location.unknown():
         "air-dependency-canonicalize",
         "air-dependency-parse-graph{output-dir=dot_graphs/}",
         "canonicalize", "cse",
+        "air-place-herds{num-rows=2 num-cols=2 row-anchor=0 col-anchor=0}"
     ])+')'
     pm = air.mlir.passmanager.PassManager.parse(pipeline)
     pm.run(air_module)
@@ -71,63 +72,109 @@ with air.mlir.ir.Context(), Location.unknown():
 
     arch = {
     "clock": 1000000000,
-    "datatype": {
+    "cores": 1,
+    "datatypes": [
+        {
         "bytes": 2,
-        "name": "fp16"
-    },
-    "devicename": "testdevice",
-    "interfaces": [
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 0
+        "name": "bf16"
         },
         {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 0
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 0,
-        "src": 2
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 2,
-        "src": 1
-        },
-        {
-        "bytes_per_second": 100000000000,
-        "dst": 1,
-        "src": 2
+        "bytes": 4,
+        "name": "f32"
         }
     ],
+    "devicename": "testdevice",
     "kernels": {
         "linalg.copy": {
-        "efficiency": 1,
-        "name": "linalg.copy"
+            "datatypes": {
+                "bf16": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                },
+                "f32": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.copy"
         },
         "linalg.fill": {
-        "efficiency": 1,
-        "name": "linalg.fill"
+            "datatypes": {
+                "bf16": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                },
+                "f32": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.fill"
         },
         "linalg.matmul": {
-        "efficiency": 1,
-        "name": "linalg.matmul"
+            "datatypes": {
+                "bf16": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                },
+                "f32": {
+                    "ops_per_core_per_cycle": 8,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.matmul"
         }
     },
     "ops_per_core_per_cycle": 512,
     "num_herd_slots": 4,
     "num_dispatch_queues": 8,
     "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2
+    "num_core_dma_queues" : 2,
+    "dus": {
+        "count": [4, 1],
+        "memory": {
+            "memory_space": "L2",
+            "bytes": 524288
+        },
+        "ports": {
+            "outbound": {
+                "count": 6,
+                "bytes_per_second": 100000000000
+            },
+            "inbound": {
+                "count": 6,
+                "bytes_per_second": 100000000000
+            }
+        },
+        "tiles": {
+            "count": [1, 4],
+            "memory": {
+                "memory_space": "L1",
+                "bytes": 65536
+            },
+            "ports": {
+                "outbound": {
+                    "count": 2,
+                    "bytes_per_second": 100000000000
+                },
+                "inbound": {
+                    "count": 2,
+                    "bytes_per_second": 100000000000
+                }
+            }
+        }
+    },
+    "noc": {
+        "outbound": {
+            "count": 4,
+            "bytes_per_second": 100000000000
+        },
+        "inbound": {
+            "count": 4,
+            "bytes_per_second": 100000000000
+        }
     }
+  }
 
 runner = air.compiler.util.Runner(arch)
 trace = runner.run(air_module, "matmul")

--- a/examples/runner/mmult/mmult.py
+++ b/examples/runner/mmult/mmult.py
@@ -125,11 +125,6 @@ with air.mlir.ir.Context(), Location.unknown():
             "name": "linalg.matmul"
         }
     },
-    "ops_per_core_per_cycle": 512,
-    "num_herd_slots": 4,
-    "num_dispatch_queues": 8,
-    "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2,
     "dus": {
         "count": [4, 1],
         "memory": {

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -372,7 +372,7 @@ public:
 
     // Simulation performance report
     std::string end_ts = convertToTimeStampInStr(time, device_resource_node);
-    std::cout << "Latency: " << end_ts << "ms\n";
+    std::cout << "Latency: " << end_ts << "us\n";
   }
 
   void scheduleLaunch(runnerNode &launch, device &device_resource_node,

--- a/mlir/lib/Util/Runner/ResourceHierarchy.cpp
+++ b/mlir/lib/Util/Runner/ResourceHierarchy.cpp
@@ -108,6 +108,7 @@ class du : public resourceHierarchy {
 public:
   memory *du_mem;
   std::vector<tile *> tiles;
+  std::vector<unsigned> shape;
   // Keys: port direction (inbound/outbound); mapped: vector of ports.
   std::map<std::string, std::vector<port *>> ports;
   unsigned idx;
@@ -119,6 +120,7 @@ public:
     this->set_memory(duObject->getObject("memory"));
     this->set_tiles(duObject->getObject("tiles"));
     this->set_ports(duObject->getObject("ports"));
+    this->set_shape(duObject->getObject("tiles")->getArray("count"));
     this->reset_reservation();
   }
 
@@ -193,6 +195,16 @@ public:
       }
     } else {
       assert(false);
+    }
+  }
+
+  // Get the shape of each DU (in tiles)
+  void set_shape(llvm::json::Array *sizesObject) {
+    for (auto it = sizesObject->begin(), ie = sizesObject->end(); it != ie;
+         ++it) {
+      llvm::json::Value jv = *it;
+      auto val = jv.getAsInteger();
+      this->shape.push_back(*val);
     }
   }
 

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -1631,7 +1631,9 @@ private:
                                             stepCstOp.value());
           output *= tripCount;
         }
-      } else if (auto hier = dyn_cast<air::HierarchyInterface>(parent)) {
+      } else if (isa<air::HierarchyInterface>(parent) &&
+                 !isa<air::LaunchOp>(parent)) {
+        auto hier = dyn_cast<air::HierarchyInterface>(parent);
         output *= this->canonicalizer.getTripCountInHierarchyOp(hier);
       } else if (auto affine_if = dyn_cast<mlir::AffineIfOp>(parent)) {
         // Fast forward through affine.if nest

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -503,21 +503,37 @@ private:
   }
 
   // Get resource cost
-  unsigned getResourceCost(Operation *op, std::string attrName) {
+  unsigned getResourceCost(air::SegmentOp op) {
     unsigned usage_count = 1;
-    if (op->hasAttr(attrName)) {
-      auto size =
-          extractFromI64ArrayAttr(op->getAttrOfType<mlir::ArrayAttr>(attrName));
-      for (auto &s : size) {
-        usage_count *= s;
+
+    // Get the size of each DU
+    unsigned du_size_x = 0;
+    unsigned du_size_y = 0;
+    if (this->resource_hiers.size()) {
+      auto dev = static_cast<device *>(this->resource_hiers[0]);
+      if (dev->dus.size()) {
+        auto du = dev->dus[0];
+        du_size_x = du->shape[0];
+        du_size_y = du->shape[1];
       }
-      return usage_count;
     }
-    // If no resource cost attr passed, then disable resource contention
-    // modelling
-    // TODO: this state will become an error once resource modelling is complete
-    else
+
+    // Get the size of segment in tiles
+    auto num_rows = op.getNumRows();
+    auto num_cols = op.getNumCols();
+    if (num_rows) {
+      if (num_cols) {
+        usage_count *= mlir::ceilDiv(*num_rows, du_size_x);
+        usage_count *= mlir::ceilDiv(*num_cols, du_size_y);
+        return usage_count;
+      } else {
+        op->emitOpError("Segment has no placed AIE cores");
+        return 0;
+      }
+    } else {
+      op->emitOpError("Segment has no placed AIE cores");
       return 0;
+    }
   }
   double getMemoryCostInBytes(MemRefType ty, Operation *op) {
     // Get number of bytes per element in tensor
@@ -626,7 +642,7 @@ private:
     std::vector<resource *> resource_hier_pool;
     this->getDUsPool(resource_hier_pool);
     // Get resource cost
-    unsigned du_count = this->getResourceCost(Op.getOperation(), "du_usage");
+    unsigned du_count = this->getResourceCost(Op);
     if (du_count <= resource_hier_pool.size()) {
       return true;
     } else
@@ -753,7 +769,7 @@ private:
     // Get resource pool
     this->getDUsPoolFromParent(resource_hier_pool);
     // Get resource cost
-    unsigned du_count = this->getResourceCost(Op, "du_usage");
+    unsigned du_count = this->parent->getResourceCost(Op);
     // Reserve resource
     this->allocateRunnerNodeToResourceHiers(resource_hier_pool,
                                             reserved_resources, du_count);

--- a/mlir/test/Util/Runner/arch.json
+++ b/mlir/test/Util/Runner/arch.json
@@ -53,11 +53,6 @@
             "name": "linalg.matmul"
         }
     },
-    "ops_per_core_per_cycle": 512,
-    "num_herd_slots": 4,
-    "num_dispatch_queues": 8,
-    "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2,
     "dus": {
         "count": [4, 4],
         "memory": {

--- a/mlir/test/Util/Runner/bad_launch/arch.json
+++ b/mlir/test/Util/Runner/bad_launch/arch.json
@@ -53,11 +53,6 @@
             "name": "linalg.matmul"
         }
     },
-    "ops_per_core_per_cycle": 512,
-    "num_herd_slots": 4,
-    "num_dispatch_queues": 8,
-    "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2,
     "dus": {
         "count": [3, 1],
         "memory": {

--- a/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
@@ -20,7 +20,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [3, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 3 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
@@ -21,7 +21,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [3, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 3 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
@@ -20,7 +20,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
@@ -21,7 +21,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/bandwidth_contention/arch.json
+++ b/mlir/test/Util/Runner/bandwidth_contention/arch.json
@@ -53,11 +53,6 @@
             "name": "linalg.matmul"
         }
     },
-    "ops_per_core_per_cycle": 512,
-    "num_herd_slots": 4,
-    "num_dispatch_queues": 8,
-    "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2,
     "dus": {
         "count": [4, 4],
         "memory": {

--- a/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
@@ -81,7 +81,7 @@ module {
       %c128 = arith.constant 128 : index
       %c256 = arith.constant 256 : index
       %1 = air.channel.put async  @channel_0[] (%arg8[] [] []) : (memref<128x128xbf16>)
-      %3 = air.segment async attributes {du_usage = [4, 1]} {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
@@ -126,7 +126,7 @@ module {
       %c128 = arith.constant 128 : index
       %c256 = arith.constant 256 : index
       %1 = air.channel.put async  @channel_0[] (%arg8[] [] []) : (memref<128x128xbf16>)
-      %3 = air.segment async attributes {du_usage = [4, 1]} {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/channel.mlir
+++ b/mlir/test/Util/Runner/channel.mlir
@@ -53,7 +53,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {du_usage = [4, 1]} {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/channel_broadcast.mlir
@@ -58,7 +58,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {du_usage = [4, 1]} {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0_6 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/channel.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel.mlir
@@ -53,7 +53,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {du_usage = [4, 1]} {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c32 = arith.constant 32 : index
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index

--- a/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
@@ -58,7 +58,7 @@ module {
         }
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async attributes {du_usage = [4, 1]}  {
+      %3 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64}  {
         %c1_5 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0_6 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
+++ b/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
@@ -27,7 +27,7 @@ module {
   func.func @test() {
     %c1 = arith.constant 1 : index
     %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) {
-      %1 = air.segment async attributes {du_usage = [1, 1]} {
+      %1 = air.segment async attributes {x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_0 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async  tile (%arg4, %arg5) in (%arg6=%c1_0, %arg7=%c4) {

--- a/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
@@ -143,7 +143,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) {
-      %1 = air.segment async attributes {du_usage = [1, 1]} {
+      %1 = air.segment async attributes {x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_4 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
@@ -77,7 +77,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) {
-      %1 = air.segment async attributes {du_usage = [2, 1]} {
+      %1 = air.segment async attributes {x_loc = 0 : i64, x_size = 2 : i64, y_loc = 0 : i64, y_size = 2 : i64} {
         %c2 = arith.constant 2 : index
         %async_token_4, %results_5 = air.execute -> (memref<128x128xbf16, 1>) {
           %alloc = memref.alloc() : memref<128x128xbf16, 1>

--- a/mlir/test/Util/Runner/dma.mlir
+++ b/mlir/test/Util/Runner/dma.mlir
@@ -37,7 +37,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%results_2) : memref<256x1024xbf16> {
-      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {du_usage = [1, 1]} {
+      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_4 = arith.constant 1 : index
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index

--- a/mlir/test/Util/Runner/dma_broadcast.mlir
+++ b/mlir/test/Util/Runner/dma_broadcast.mlir
@@ -41,7 +41,7 @@ module {
       memref.copy %results, %results_2 : memref<256x1024xbf16> to memref<256x1024xbf16>
     } {id = 4 : i32}
     %0 = air.launch async [%async_token_3] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%results_2) : memref<256x1024xbf16> {
-      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg9=%arg8) : memref<256x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_4 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/hierarchy.mlir
+++ b/mlir/test/Util/Runner/hierarchy.mlir
@@ -70,7 +70,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/hierarchy.mlir
+++ b/mlir/test/Util/Runner/hierarchy.mlir
@@ -11,55 +11,55 @@
 
 // CHECK: "name": "SegmentOp",
 // CHECK: "ph": "B",
-// CHECK: "ts": 1,
+// CHECK: "ts": 0.001,
 // CHECK: "name": "SegmentOp",
 // CHECK: "ph": "E",
-// CHECK: "ts": 2,
+// CHECK: "ts": 0.002,
 
 // CHECK: "name": "HerdOp(herd_0)",
 // CHECK: "ph": "B",
-// CHECK: "ts": 2,
+// CHECK: "ts": 0.002,
 // CHECK: "name": "HerdOp(herd_0)",
 // CHECK: "ph": "E",
-// CHECK: "ts": 3,
+// CHECK: "ts": 0.003,
 
 // CHECK: "name": "AllocOp(L1)",
 // CHECK: "ph": "B",
-// CHECK: "ts": 3,
+// CHECK: "ts": 0.003,
 // CHECK: "name": "AllocOp(L1)",
 // CHECK: "ph": "E",
-// CHECK: "ts": 4,
+// CHECK: "ts": 0.004,
 
 // CHECK: "name": "DeallocOp(L1)",
 // CHECK: "ph": "B",
-// CHECK: "ts": 5,
+// CHECK: "ts": 0.005,
 // CHECK: "name": "DeallocOp(L1)",
 // CHECK: "ph": "E",
-// CHECK: "ts": 6,
+// CHECK: "ts": 0.006,
 
 // CHECK: "name": "HerdTerminator",
 // CHECK: "ph": "B",
-// CHECK: "ts": 7,
+// CHECK: "ts": 0.007,
 
 // CHECK: "name": "SegmentTerminator",
 // CHECK: "ph": "B",
-// CHECK: "ts": 8,
+// CHECK: "ts": 0.008,
 
 // CHECK: "name": "HerdTerminator",
 // CHECK: "ph": "E",
-// CHECK: "ts": 8,
+// CHECK: "ts": 0.008,
 
 // CHECK: "name": "LaunchTerminator",
 // CHECK: "ph": "B",
-// CHECK: "ts": 9,
+// CHECK: "ts": 0.009,
 
 // CHECK: "name": "SegmentTerminator",
 // CHECK: "ph": "E",
-// CHECK: "ts": 9,
+// CHECK: "ts": 0.009,
 
 // CHECK: "name": "LaunchTerminator",
 // CHECK: "ph": "E",
-// CHECK: "ts": 10,
+// CHECK: "ts": 0.010,
 
 module {
   ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>

--- a/mlir/test/Util/Runner/multi_token_loop.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop.mlir
@@ -49,7 +49,7 @@ module {
         %4 = air.channel.put async [%arg10]  @channel_0[%arg4, %arg5] (%arg8[%c0, %arg9] [%c128, %c128] [%c1024, %c1_4]) : (memref<256x1024xbf16>)
         scf.yield %4 : !air.async.token
       }
-      %3 = air.segment async  args(%arg9=%arg4, %arg10=%arg5) : index, index attributes {du_usage = [1, 1]} {
+      %3 = air.segment async  args(%arg9=%arg4, %arg10=%arg5) : index, index attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c0_5 = arith.constant 0 : index
         %c1024_6 = arith.constant 1024 : index
         %c128_7 = arith.constant 128 : index

--- a/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
@@ -38,7 +38,7 @@ module {
         %2 = affine.apply #map()[%arg4]
         air.execute_terminator %2 : index
       }
-      %1 = air.segment async attributes {du_usage = [4, 1]} {
+      %1 = air.segment async attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index
         %c512 = arith.constant 512 : index

--- a/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
@@ -56,7 +56,7 @@ module attributes {torch.debug_module_name = "mmult"} {
       memref.copy %results, %results_8 : memref<512x512xf32> to memref<512x512xf32>
     } {id = 8 : i32}
     %0 = air.launch async [%async_token_9] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) attributes {id = 7 : i32} {
-      %1 = air.segment async  attributes {du_usage = [4, 1], id = 2 : i32} {
+      %1 = air.segment async  attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64, id = 2 : i32} {
         %c64 = arith.constant 64 : index
         %c32 = arith.constant 32 : index
         %c1_10 = arith.constant 1 : index

--- a/mlir/test/Util/Runner/multi_token_loop_race.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_race.mlir
@@ -31,7 +31,7 @@ module {
       memref.copy %arg2, %results : memref<512x512xbf16> to memref<512x512xbf16>
     }
     %0 = air.launch async [%async_token_0] (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%results) : memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 1 : i32} {
-      %1 = air.segment async  args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg13=%arg8, %arg14=%arg9) : index, index, memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 2 : i32, du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg13=%arg8, %arg14=%arg9) : index, index, memref<512x512xbf16>, memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c1_1 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %c0 = arith.constant 0 : index

--- a/mlir/test/Util/Runner/multiple_launches.mlir
+++ b/mlir/test/Util/Runner/multiple_launches.mlir
@@ -1,0 +1,59 @@
+//===- multiple_launches.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Multiple air.launch operations; multiple iterations per air.launch operation.
+
+// CHECK-COUNT-16: "name": "LaunchTerminator",
+
+module {
+  func.func @test(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>, %arg2: memref<1024x1024xbf16>, %arg3: memref<1024x1024xbf16>) -> memref<256x1024xbf16> {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %async_token_1, %results_2 = air.execute -> (memref<256x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<256x1024xbf16>
+      air.execute_terminator %alloc : memref<256x1024xbf16>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_5 = air.execute [%async_token_3] {
+            memref.dealloc %results_4 : memref<32x32xbf16, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    %3 = air.launch async [%0] (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
+      %4 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+        %c4 = arith.constant 4 : index
+        %5 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_5 = air.execute [%async_token_3] {
+            memref.dealloc %results_4 : memref<32x32xbf16, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<256x1024xbf16>
+  }
+}
+

--- a/mlir/test/Util/Runner/multiple_launches.mlir
+++ b/mlir/test/Util/Runner/multiple_launches.mlir
@@ -20,7 +20,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {
@@ -37,7 +37,7 @@ module {
       air.launch_terminator
     }
     %3 = air.launch async [%0] (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %4 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %4 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %5 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/tile_memory_contention/arch.json
+++ b/mlir/test/Util/Runner/tile_memory_contention/arch.json
@@ -53,11 +53,6 @@
             "name": "linalg.matmul"
         }
     },
-    "ops_per_core_per_cycle": 512,
-    "num_herd_slots": 4,
-    "num_dispatch_queues": 8,
-    "num_dispatch_dma_queues" : 2,
-    "num_core_dma_queues" : 2,
     "dus": {
         "count": [4, 4],
         "memory": {

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
@@ -38,7 +38,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
           %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
@@ -81,7 +81,7 @@ module {
       air.execute_terminator %alloc : memref<256x1024xbf16>
     }
     %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
-      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {du_usage = [4, 1]} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
         %c1_1 = arith.constant 1 : index
         %c4 = arith.constant 4 : index
         %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c1_1) {


### PR DESCRIPTION
- Fixup an issue with having multiple air.launch operations in a program.
- Fixup an issue with mismatch in timestamp between runner and chrome tracing viewer.
- Fixup E2E runner example by making -air-place-herds pass assign size attributes to air.segment.