### PR TITLE
Jnider sysfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ air_project
 
 # build results
 libadf.a
+*.elf
+*.elf.*

--- a/LICENSE
+++ b/LICENSE
@@ -22,3 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+The code in the 'driver' subdirectory (the "driver") is licensed separately
+under the terms and conditions of the GNU General Public License v2 ("GPLv2").
+The complete description of the license can be found at:
+https://spdx.org/licenses/GPL-2.0.html

--- a/driver/chardev.c
+++ b/driver/chardev.c
@@ -41,6 +41,8 @@
 #include <uapi/linux/kfd_ioctl.h>
 #include "chardev.h"
 
+#define DEVICE_INDEX_STR_MAX 15
+
 #define VCK5000_IOCTL_DEF(ioctl, _func, _flags)                                \
 	[_IOC_NR(ioctl)] = { .cmd = ioctl,                                     \
 			     .func = _func,                                    \
@@ -49,6 +51,12 @@
 			     .name = #ioctl }
 
 #define HERD_CONTROLLER_BRAM_SIZE 0x1000
+
+enum aie_address_validation {
+	AIE_ADDR_OK,
+	AIE_ADDR_ALIGNMENT,
+	AIE_ADDR_RANGE,
+};
 
 typedef int vck5000_ioctl_t(struct file *filep, void *data);
 
@@ -60,6 +68,28 @@ struct vck5000_ioctl_desc {
 	const char *name;
 };
 
+struct amdair_attribute {
+	struct attribute attr;
+	ssize_t (*show)(struct kobject *kobj, struct attribute *attr,
+			char *buf);
+	ssize_t (*store)(struct kobject *kobj, struct attribute *attr,
+			 const char *buf, size_t count);
+};
+
+/* Some forward declarations */
+static ssize_t aie_show(struct kobject *kobj, struct attribute *attr,
+			char *buf);
+static ssize_t aie_store(struct kobject *kobj, struct attribute *attr,
+			 const char *buf, size_t count);
+static ssize_t address_show(struct kobject *kobj, struct attribute *attr,
+			    char *buf);
+static ssize_t address_store(struct kobject *kobj, struct attribute *attr,
+			     const char *buf, size_t count);
+static ssize_t value_show(struct kobject *kobj, struct attribute *attr,
+			  char *buf);
+static ssize_t value_store(struct kobject *kobj, struct attribute *attr,
+			   const char *buf, size_t count);
+
 static long vck_ioctl(struct file *, unsigned int, unsigned long);
 static int vck_open(struct inode *, struct file *);
 static int vck_release(struct inode *, struct file *);
@@ -68,6 +98,24 @@ static int vck_mmap(struct file *, struct vm_area_struct *);
 static int vck5000_ioctl_get_version(struct file *filep, void *data);
 static int vck5000_ioctl_create_queue(struct file *filep, void *data);
 static int vck5000_ioctl_destroy_queue(struct file *filp, void *data);
+
+/* define sysfs attributes */
+struct amdair_attribute aie_attr_address = __ATTR_RW(address);
+struct amdair_attribute aie_attr_value = __ATTR_RW(value);
+
+static const struct sysfs_ops aie_sysfs_ops = {
+	.show = aie_show,
+	.store = aie_store,
+};
+
+static struct kobj_type aie_sysfs_type = {
+	.sysfs_ops = &aie_sysfs_ops,
+};
+
+struct attribute *aie_sysfs_attrs[] = { &aie_attr_address.attr,
+					&aie_attr_value.attr, NULL };
+
+ATTRIBUTE_GROUPS(aie_sysfs);
 
 static const struct file_operations vck_fops = {
 	.owner = THIS_MODULE,
@@ -81,7 +129,7 @@ static const struct file_operations vck_fops = {
 extern bool enable_aie;
 static int chardev_major = -1;
 static struct class *vck5000_class;
-static struct device *vck5000_device;
+static struct device *vck5000_chardev;
 
 /** Ioctl table */
 static const struct vck5000_ioctl_desc vck5000_ioctls[] = {
@@ -109,15 +157,13 @@ int vck5000_chardev_init(struct pci_dev *pdev)
 	if (IS_ERR(vck5000_class))
 		goto err_class;
 
-	vck5000_device =
-		device_create(vck5000_class, NULL, MKDEV(chardev_major, 0),
-			      NULL, amdair_dev_name());
+	vck5000_chardev =
+		device_create(vck5000_class, &pdev->dev,
+			      MKDEV(chardev_major, 0), pdev, "amdair");
 
-	ret = PTR_ERR(vck5000_device);
-	if (IS_ERR(vck5000_device))
+	ret = PTR_ERR(vck5000_chardev);
+	if (IS_ERR(vck5000_chardev))
 		goto err_device;
-
-	dev_set_drvdata(vck5000_device, pdev);
 
 	return 0;
 
@@ -128,7 +174,7 @@ err_class:
 	unregister_chrdev(chardev_major, amdair_dev_name());
 
 err_register:
-	return ret;
+	return -ENODEV;
 }
 
 void vck5000_chardev_exit(void)
@@ -137,7 +183,7 @@ void vck5000_chardev_exit(void)
 	class_destroy(vck5000_class);
 	unregister_chrdev(chardev_major, amdair_dev_name());
 
-	vck5000_device = NULL;
+	vck5000_chardev = NULL;
 }
 
 static long vck_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
@@ -151,10 +197,8 @@ static long vck_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
 	unsigned int nr = _IOC_NR(cmd);
 	int ret;
 
-	dev_warn(vck5000_device, "%s", __func__);
-
 	if ((nr < AMDKFD_COMMAND_START) || (nr >= AMDKFD_COMMAND_END)) {
-		dev_warn(vck5000_device, "%s invalid %u", __func__, nr);
+		dev_warn(vck5000_chardev, "%s invalid %u", __func__, nr);
 		return 0;
 	}
 
@@ -203,13 +247,13 @@ static long vck_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
 
 static int vck_open(struct inode *node, struct file *f)
 {
-	dev_warn(vck5000_device, "%s", __func__);
+	dev_warn(vck5000_chardev, "%s", __func__);
 	return 0;
 }
 
 static int vck_release(struct inode *node, struct file *f)
 {
-	dev_warn(vck5000_device, "%s", __func__);
+	dev_warn(vck5000_chardev, "%s", __func__);
 	return 0;
 }
 
@@ -221,12 +265,12 @@ static int vck_mmap(struct file *f, struct vm_area_struct *vma)
 	size_t size = vma->vm_end - vma->vm_start;
 	loff_t offset = (loff_t)vma->vm_pgoff << PAGE_SHIFT;
 
-	pdev = dev_get_drvdata(vck5000_device);
+	pdev = dev_get_drvdata(vck5000_chardev);
 
-	dev_warn(vck5000_device, "%s start %lx end %lx offset %llx", __func__,
+	dev_warn(vck5000_chardev, "%s start %lx end %lx offset %llx", __func__,
 		 vma->vm_start, vma->vm_end, offset);
 
-	if (offset >= 0x8000000ULL) {
+	if (offset >= MMAP_OFFSET_BRAM) {
 		unsigned int herd_idx = 0;
 		/* the herd private memory starts at 0x1000, and is 0x1000 long for each herd controller */
 		unsigned long herd_ctlr_offset =
@@ -234,20 +278,20 @@ static int vck_mmap(struct file *f, struct vm_area_struct *vma)
 		bar = pci_resource_start(pdev, BRAM_BAR_INDEX) +
 		      herd_ctlr_offset;
 		size = HERD_CONTROLLER_BRAM_SIZE;
-		dev_warn(vck5000_device, "mapping %lx BRAM at 0x%lx to 0x%lx",
+		dev_warn(vck5000_chardev, "mapping %lx BRAM at 0x%lx to 0x%lx",
 			 size, bar, vma->vm_start);
-	} else if (offset == 0x100000ULL) {
+	} else if (offset == MMAP_OFFSET_AIE) {
 		if (!enable_aie) {
-			dev_warn(vck5000_device,
+			dev_warn(vck5000_chardev,
 				 "mapping AIE BAR is not enabled");
 			return -EOPNOTSUPP;
 		}
 		bar = pci_resource_start(pdev, AIE_BAR_INDEX);
-		dev_warn(vck5000_device, "mapping %lx AIE at 0x%lx to 0x%lx",
+		dev_warn(vck5000_chardev, "mapping %lx AIE at 0x%lx to 0x%lx",
 			 size, bar, vma->vm_start);
 	} else {
 		bar = pci_resource_start(pdev, DRAM_BAR_INDEX) + offset;
-		dev_warn(vck5000_device, "mapping %lx DRAM at 0x%lx to 0x%lx",
+		dev_warn(vck5000_chardev, "mapping %lx DRAM at 0x%lx to 0x%lx",
 			 size, bar, vma->vm_start);
 	}
 	pgoff = (bar >> PAGE_SHIFT);
@@ -267,7 +311,7 @@ static int vck5000_ioctl_get_version(struct file *filep, void *data)
 {
 	struct kfd_ioctl_get_version_args *args = data;
 
-	dev_warn(vck5000_device, "%s %u.%u", __func__, KFD_IOCTL_MAJOR_VERSION,
+	dev_warn(vck5000_chardev, "%s %u.%u", __func__, KFD_IOCTL_MAJOR_VERSION,
 		 KFD_IOCTL_MINOR_VERSION);
 	args->major_version = KFD_IOCTL_MAJOR_VERSION;
 	args->minor_version = KFD_IOCTL_MINOR_VERSION;
@@ -280,7 +324,7 @@ static int vck5000_ioctl_get_version(struct file *filep, void *data)
 */
 static int vck5000_ioctl_create_queue(struct file *filep, void *data)
 {
-	dev_warn(vck5000_device, "%s", __func__);
+	dev_warn(vck5000_chardev, "%s", __func__);
 
 	return 0;
 }
@@ -291,7 +335,126 @@ static int vck5000_ioctl_create_queue(struct file *filep, void *data)
 static int vck5000_ioctl_destroy_queue(struct file *filp, void *data)
 {
 	int retval = 0;
-	dev_warn(vck5000_device, "%s", __func__);
+	dev_warn(vck5000_chardev, "%s", __func__);
 
 	return retval;
+}
+
+static int validate_aie_address(uint64_t offset, struct vck5000_device *dev)
+{
+	/* alignment */
+	if (offset & 0x3) {
+		printk("%s: 0x%llx not aligned to 4 bytes\n", __func__, offset);
+		return AIE_ADDR_ALIGNMENT;
+	}
+
+	/* range within the specified BAR */
+	if (offset >= dev->aie_bar_len) {
+		printk("%s: invalid offset 0x%llx (max 0x%llx)\n", __func__,
+		       offset, dev->aie_bar_len);
+		return AIE_ADDR_RANGE;
+	}
+
+	return AIE_ADDR_OK;
+}
+
+static ssize_t address_show(struct kobject *kobj, struct attribute *attr,
+			    char *buf)
+{
+	struct vck5000_device *drv_priv =
+		container_of(kobj, struct vck5000_device, kobj_aie);
+
+	snprintf(buf, PAGE_SIZE, "0x%llx\n", drv_priv->mem_addr);
+	return strlen(buf) + 1;
+}
+
+static ssize_t address_store(struct kobject *kobj, struct attribute *attr,
+			     const char *buf, size_t count)
+{
+	unsigned long address;
+	struct vck5000_device *drv_priv =
+		container_of(kobj, struct vck5000_device, kobj_aie);
+
+	kstrtoul(buf, 0, &address);
+	drv_priv->mem_addr = address;
+	return count;
+}
+
+static ssize_t value_show(struct kobject *kobj, struct attribute *attr,
+			  char *buf)
+{
+	uint32_t value;
+	struct vck5000_device *drv_priv =
+		container_of(kobj, struct vck5000_device, kobj_aie);
+	uint64_t offset = drv_priv->mem_addr;
+
+	if (validate_aie_address(offset, drv_priv)) {
+		snprintf(buf, PAGE_SIZE, "0xffffffff\n");
+		return strlen(buf) + 1;
+	}
+
+	value = ioread32(drv_priv->aie_bar + offset);
+
+	snprintf(buf, PAGE_SIZE, "0x%x\n", value);
+	return strlen(buf) + 1;
+}
+
+static ssize_t value_store(struct kobject *kobj, struct attribute *attr,
+			   const char *buf, size_t count)
+{
+	uint32_t value;
+	struct vck5000_device *drv_priv =
+		container_of(kobj, struct vck5000_device, kobj_aie);
+	uint64_t offset = drv_priv->mem_addr;
+
+	if (validate_aie_address(offset, drv_priv) == AIE_ADDR_OK) {
+		kstrtouint(buf, 0, &value);
+		iowrite32(value, drv_priv->aie_bar + offset);
+	}
+
+	return count;
+}
+
+static ssize_t aie_show(struct kobject *kobj, struct attribute *attr, char *buf)
+{
+	struct amdair_attribute *air_attr =
+		container_of(attr, struct amdair_attribute, attr);
+
+	if (!air_attr->show) {
+		printk("Missing show method for %s\r\n", attr->name);
+		return 0;
+	}
+
+	return air_attr->show(kobj, attr, buf);
+}
+
+static ssize_t aie_store(struct kobject *kobj, struct attribute *attr,
+			 const char *buf, size_t count)
+{
+	struct amdair_attribute *air_attr =
+		container_of(attr, struct amdair_attribute, attr);
+
+	if (!air_attr->store) {
+		printk("Missing store method for %s\r\n", attr->name);
+		return 0;
+	}
+
+	return air_attr->store(kobj, attr, buf, count);
+}
+
+int create_aie_mem_sysfs(struct vck5000_device *priv, uint32_t index)
+{
+	int err;
+
+	err = kobject_init_and_add(&priv->kobj_aie, &aie_sysfs_type,
+				   &vck5000_chardev->kobj, "%02u", index);
+	if (err) {
+		dev_err(vck5000_chardev, "Error creating sysfs device");
+		kobject_put(&priv->kobj_aie);
+		return -1;
+	}
+
+	sysfs_create_groups(&priv->kobj_aie, aie_sysfs_groups);
+
+	return 0;
 }

--- a/driver/chardev.c
+++ b/driver/chardev.c
@@ -1,24 +1,5 @@
-/*
- * Copyright 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: GPL-2.0
 
 #include <stddef.h>
 #include <linux/device.h>

--- a/driver/chardev.h
+++ b/driver/chardev.h
@@ -28,15 +28,44 @@
 #define AIE_BAR_INDEX 2
 #define BRAM_BAR_INDEX 4
 
-struct vck5000_priv {
+#define MMAP_OFFSET_AIE 0x100000ULL
+#define MMAP_OFFSET_BRAM 0x8000000ULL
+
+/*
+	This represents a single VCK5000 card.
+
+	This does not use the Linux kernel 'device' infrastructure because we want
+	to have only a single character device interface (/dev/amdair) regardless of
+	how many physical devices are attached. This follows the AMDKFD driver
+	design.
+*/
+struct vck5000_device {
+	struct kobject kobj_aie;
+
 	void __iomem *dram_bar;
+	uint64_t dram_bar_len;
+
 	void __iomem *aie_bar;
+	uint64_t aie_bar_len;
+
 	void __iomem *bram_bar;
+	uint64_t bram_bar_len;
+
 	uint64_t total_controllers;
+
+	/* device memory can be accessed indirectly through sysfs.
+		It is a two-step protocol:
+		(1) write the memory address to:
+		/sys/class/amdair/<id>/aie/address
+		(2) Read (or write) the value from:
+		/sys/class/amdair/<id>/aie/value
+	*/
+	uint64_t mem_addr; /* address for indirect memory access */
 };
 
 int vck5000_chardev_init(struct pci_dev *pdev);
 void vck5000_chardev_exit(void);
+int create_aie_mem_sysfs(struct vck5000_device *priv, uint32_t index);
 
 const char *amdair_dev_name(void);
 

--- a/driver/chardev.h
+++ b/driver/chardev.h
@@ -1,24 +1,5 @@
-/*
- * Copyright 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: GPL-2.0
 
 #ifndef VCK5000_CHARDEV_H_
 #define VCK5000_CHARDEV_H_
@@ -53,12 +34,12 @@ struct vck5000_device {
 
 	uint64_t total_controllers;
 
-	/* device memory can be accessed indirectly through sysfs.
+	/* AIE memory can be accessed indirectly through sysfs.
 		It is a two-step protocol:
 		(1) write the memory address to:
-		/sys/class/amdair/<id>/aie/address
+		/sys/class/amdair/amdair/<id>/address
 		(2) Read (or write) the value from:
-		/sys/class/amdair/<id>/aie/value
+		/sys/class/amdair/amdair/<id>/value
 	*/
 	uint64_t mem_addr; /* address for indirect memory access */
 };

--- a/driver/main.c
+++ b/driver/main.c
@@ -1,24 +1,5 @@
-/*
- * Copyright 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: GPL-2.0
 
 #include <linux/init.h>
 #include <linux/module.h>

--- a/driver/main.c
+++ b/driver/main.c
@@ -25,8 +25,20 @@
 #include <linux/pci.h>
 #include "chardev.h"
 
+#define MAX_HERD_CONTROLLERS 64
+
+/* Offsets into BRAM BAR */
+#define HERD_CONTROLLER_BASE_ADDR(_base, _x)                                   \
+	((((uint64_t)ioread32(_base + (_x * sizeof(uint64_t) + 4))) << 32) |   \
+	 ioread32(_base + (_x * sizeof(uint64_t) + 0)))
+#define REG_HERD_CONTROLLER_COUNT 0x208
+
 static const char air_dev_name[] = "amdair";
+static int dev_idx; /* linear index of managed devices */
 bool enable_aie;
+
+static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent);
+static void vck5000_remove(struct pci_dev *pdev);
 
 static struct pci_device_id vck5000_id_table[] = { { PCI_DEVICE(0x10EE,
 								0xB034) },
@@ -36,22 +48,11 @@ static struct pci_device_id vck5000_id_table[] = { { PCI_DEVICE(0x10EE,
 
 MODULE_DEVICE_TABLE(pci, vck5000_id_table);
 
-static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent);
-static void vck5000_remove(struct pci_dev *pdev);
-
 /* Driver registration structure */
 static struct pci_driver vck5000 = { .name = air_dev_name,
 				     .id_table = vck5000_id_table,
 				     .probe = vck5000_probe,
 				     .remove = vck5000_remove };
-
-#define MAX_HERD_CONTROLLERS 64
-
-/* Offsets into BRAM BAR */
-#define HERD_CONTROLLER_BASE_ADDR(_base, _x)                                   \
-	((((uint64_t)ioread32(_base + (_x * sizeof(uint64_t) + 4))) << 32) |   \
-	 ioread32(_base + (_x * sizeof(uint64_t) + 0)))
-#define REG_HERD_CONTROLLER_COUNT 0x208
 
 /*
 	Register the driver with the PCI subsystem
@@ -74,14 +75,10 @@ static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 {
 	int bar_mask;
 	int err;
-	struct vck5000_priv *drv_priv;
+	struct vck5000_device *dev_priv;
 	uint32_t controller_count;
 	uint64_t controller_base;
 	uint32_t idx;
-	//uint8_t *ptr;
-
-	dev_warn(&pdev->dev, "vendor: 0x%X device: 0x%X\n", pdev->vendor,
-		 pdev->device);
 
 	/* Enable device memory */
 	err = pcim_enable_device(pdev);
@@ -90,17 +87,17 @@ static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 		return err;
 	}
 
-	/* Allocate memory for the driver private data */
-	drv_priv = kzalloc(sizeof(struct vck5000_priv), GFP_KERNEL);
-	if (!drv_priv) {
+	/* Allocate memory for the device private data */
+	dev_priv = kzalloc(sizeof(struct vck5000_device), GFP_KERNEL);
+	if (!dev_priv) {
 		dev_err(&pdev->dev, "Error allocating private data");
 		pci_disable_device(pdev);
 		return -ENOMEM;
 	}
+	dev_priv->mem_addr = 0xbadbeef;
 
 	/* Find all memory BARs. We are expecting 3 64-bit BARs */
 	bar_mask = pci_select_bars(pdev, IORESOURCE_MEM);
-	dev_warn(&pdev->dev, "bar mask: 0x%X", bar_mask);
 	if (bar_mask != 0x15) {
 		dev_err(&pdev->dev,
 			"These are not the bars we're looking for: 0x%x",
@@ -115,34 +112,54 @@ static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 		// pci_disable_device(pdev);
 		return err;
 	}
-	drv_priv->dram_bar = pcim_iomap_table(pdev)[DRAM_BAR_INDEX];
-	drv_priv->aie_bar = pcim_iomap_table(pdev)[AIE_BAR_INDEX];
-	drv_priv->bram_bar = pcim_iomap_table(pdev)[BRAM_BAR_INDEX];
-	dev_warn(&pdev->dev, "bar 0: 0x%lx", (unsigned long)drv_priv->dram_bar);
-	dev_warn(&pdev->dev, "bar 2: 0x%lx", (unsigned long)drv_priv->aie_bar);
-	dev_warn(&pdev->dev, "bar 4: 0x%lx", (unsigned long)drv_priv->bram_bar);
+	dev_priv->dram_bar = pcim_iomap_table(pdev)[DRAM_BAR_INDEX];
+	dev_priv->aie_bar = pcim_iomap_table(pdev)[AIE_BAR_INDEX];
+	dev_priv->bram_bar = pcim_iomap_table(pdev)[BRAM_BAR_INDEX];
+	dev_priv->dram_bar_len = pci_resource_len(pdev, DRAM_BAR_INDEX);
+	dev_priv->aie_bar_len = pci_resource_len(pdev, AIE_BAR_INDEX);
+	dev_priv->bram_bar_len = pci_resource_len(pdev, BRAM_BAR_INDEX);
+	dev_warn(&pdev->dev, "bar 0: 0x%lx (0x%llx)",
+		 (unsigned long)dev_priv->dram_bar, dev_priv->dram_bar_len);
+	dev_warn(&pdev->dev, "bar 2: 0x%lx (0x%llx)",
+		 (unsigned long)dev_priv->aie_bar, dev_priv->aie_bar_len);
+	dev_warn(&pdev->dev, "bar 4: 0x%lx (0x%llx)",
+		 (unsigned long)dev_priv->bram_bar, dev_priv->bram_bar_len);
 
 	/* Set driver private data */
-	pci_set_drvdata(pdev, drv_priv);
+	pci_set_drvdata(pdev, dev_priv);
 
 	/* Request interrupt and set up handler */
 
 	/* set up chardev interface */
-	vck5000_chardev_init(pdev);
+	err = vck5000_chardev_init(pdev);
+	if (err) {
+		dev_err(&pdev->dev, "Error creating char device");
+		return -EINVAL;
+	}
 
 	/* Query number of herd controllers */
 	controller_count =
-		ioread32(drv_priv->bram_bar + REG_HERD_CONTROLLER_COUNT);
-	dev_warn(&pdev->dev, "Total controllers: 0x%x", controller_count);
-	drv_priv->total_controllers = controller_count;
+		ioread32(dev_priv->bram_bar + REG_HERD_CONTROLLER_COUNT);
+	if (controller_count > MAX_HERD_CONTROLLERS) {
+		dev_err(&pdev->dev,
+			"Number of controllers: %u exceeds maximum expected %u",
+			controller_count, MAX_HERD_CONTROLLERS);
+		return -EINVAL;
+	}
+
+	dev_priv->total_controllers = controller_count;
 
 	/* Each herd controller has a private memory region */
 	for (idx = 0; idx < controller_count; idx++) {
 		controller_base =
-			HERD_CONTROLLER_BASE_ADDR(drv_priv->bram_bar, idx);
+			HERD_CONTROLLER_BASE_ADDR(dev_priv->bram_bar, idx);
 		dev_warn(&pdev->dev, "Controller %u base address: 0x%llx", idx,
 			 controller_base);
 	}
+
+	/* Create sysfs files for accessing AIE memory region */
+	create_aie_mem_sysfs(dev_priv, dev_idx);
+	dev_idx++;
 
 	return 0;
 }
@@ -150,12 +167,13 @@ static int vck5000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 /* Clean up */
 static void vck5000_remove(struct pci_dev *pdev)
 {
-	struct vck5000_priv *drv_priv = pci_get_drvdata(pdev);
+	struct vck5000_device *dev_priv = pci_get_drvdata(pdev);
 
 	vck5000_chardev_exit();
 
-	if (drv_priv) {
-		kfree(drv_priv);
+	if (dev_priv) {
+		kobject_put(&dev_priv->kobj_aie);
+		kfree(dev_priv);
 	}
 
 	dev_warn(&pdev->dev, "removed");

--- a/utils/github-clone-build-libxaie.sh
+++ b/utils/github-clone-build-libxaie.sh
@@ -23,7 +23,7 @@ git clone --branch $HASH --depth 1 https://github.com/jnider/embeddedsw.git $LIB
 mkdir -p $LIBXAIE_DIR/$INSTALL_DIR/lib
 
 pushd $LIBXAIE_DIR/XilinxProcessorIPLib/drivers/aienginev2/src/
-make -f Makefile.Linux CFLAGS="-D__AIELINUX__"
+make -f Makefile.Linux CFLAGS="-D__AIELINUX__ -D__AIESYSFS__"
 popd
 
 cp -v $LIBXAIE_DIR/XilinxProcessorIPLib/drivers/aienginev2/src/*.so* $LIBXAIE_DIR/$INSTALL_DIR/lib

--- a/utils/github-clone-build-libxaie.sh
+++ b/utils/github-clone-build-libxaie.sh
@@ -16,9 +16,9 @@
 LIBXAIE_DIR="aienginev2"
 INSTALL_DIR="install"
 
-HASH="xlnx_rel_v2021.2"
+HASH="vck5000"
 
-git clone --branch $HASH --depth 1 https://github.com/Xilinx/embeddedsw.git $LIBXAIE_DIR
+git clone --branch $HASH --depth 1 https://github.com/jnider/embeddedsw.git $LIBXAIE_DIR
 
 mkdir -p $LIBXAIE_DIR/$INSTALL_DIR/lib
 


### PR DESCRIPTION
Add sysfs interface to replace direct access to AIE BAR.
Depends on changes to libxaie (https://github.com/jnider/embeddedsw/tree/vck5000)

Updated the license to GPLv2 and made a note in the top-level license, as requested.