### PR TITLE
platform: fix loading scripts

### DIFF
--- a/platforms/scripts/load.tcl
+++ b/platforms/scripts/load.tcl
@@ -16,7 +16,6 @@
 
 # if the card index is not set, default to 0
 if {[info exists ::env(CARD_IDX)]} {
-	puts "ENV $::env(CARD_IDX)"
 	set card_idx $::env(CARD_IDX)
 } else {
 	set card_idx 0
@@ -41,7 +40,7 @@ set cards [ targets -target-properties -filter { name =~ "Versal xcvc1902*" }]
 
 # validate the selected card index
 set num_cards [ llength $cards ]
-if { $card_idx >= $num_cards } {
+if { $card_idx > $num_cards } {
 	puts "Invalid card index $card_idx; only $num_cards detected"
 	exit
 }

--- a/platforms/scripts/program_vck5000.sh
+++ b/platforms/scripts/program_vck5000.sh
@@ -8,20 +8,32 @@
 # Usually, they are both contained in a single .PDI file. If not, set the ELF_FILE variable in addition to PDI_FILE.
 #
 # Parameters (as environment variables)
-# ELF_FILE		path to the ELF file with the controller firmware
-# PDI_FILE		path to the PDI file with the FPGA image
-# CARD_IDX		index of the card to be programmed, in JTAG scan-chain order (as seen by 'xsct')
+# ELF_FILE				path to the ELF file with the controller firmware
+# PDI_FILE				path to the PDI file with the FPGA image
+# CARD_IDX				index of the card to be programmed, in JTAG scan-chain order (as seen by 'xsct')
+# DEVICE_ID				PCI BDI address of the card to be programmed
+# VIVADO_INSTALL_DIR	install directory of Vivado
 
-VIVADO_INSTALL_DIR=/proj/xbuilds/2022.1_released/installs/lin64/Vivado/2022.1
-DEVICE_ID=0000:21:00.0
+VIVADO_INSTALL_DIR=${VIVADO_INSTALL_DIR:=/proj/xbuilds/2022.1_released/installs/lin64/Vivado/2022.1}
+DEVICE_ID=${DEVICE_ID:=0000:21:00.0}
 
 # these variables are used by load.tcl so they must be exported
 export CARD_IDX=${CARD_IDX:=0}
-export PDI_FILE=${PDI_FILE:?"You must set PDI_FILE to the path of the image to be programmed"}
 
-# ELF file is optional; export if if we have it
-if [ -v $ELF_FILE ]; then
+# PDI file is optional
+if [ -v PDI_FILE ]; then
+	export PDI_FILE=$PDI_FILE
+fi
+
+# ELF file is optional
+if [ -v ELF_FILE ]; then
 	export ELF_FILE=$ELF_FILE
+fi
+
+# make sure at least one file is being programmed
+if [[ ! -v ELF_FILE && ! -v PDI_FILE ]]; then
+	echo "You must set at least one of ELF_FILE or PDI_FILE to be programmed"
+	exit
 fi
 
 # get the path of this script - it is the script path


### PR DESCRIPTION
In load.tcl, the 0-based card index is compared to the 1-based card count and must be strictly less than.

When checking for the existence of optional variables, use the variable name and not its value.