### PR TITLE
Update mlir-aie

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git clone https://github.com/Xilinx/cmakeModules.git
           pushd cmakeModules
-          git checkout -b air b0d8828f71bf61db5860843cb16cf8d068c862e4
+          git checkout -b air 7915d8fa4d2869bdbc078b9d266a555b72c2ebb2
           popd
         shell: bash
 

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git clone https://github.com/Xilinx/cmakeModules.git
           pushd cmakeModules
-          git checkout -b air 7915d8fa4d2869bdbc078b9d266a555b72c2ebb2
+          git checkout -b air 2c3885644ea115d1d61bbf102abbd41be8ba8427
           popd
         shell: bash
 

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -69,11 +69,11 @@ jobs:
         run: utils/clone-mlir-aie.sh
         shell: bash
 
-      - name: Rebuild and Install mlir-aie
-        run: utils/github-build-mlir-aie.sh
-
       - name: Rebuild and Install libxaie
         run: utils/github-clone-build-libxaie.sh
+
+      - name: Rebuild and Install mlir-aie
+        run: utils/github-build-mlir-aie.sh
 
       # Build the repo test target in debug mode to build and test.
       - name: Build and test (Assert)

--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -149,6 +149,9 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
     Option<"clTestPatterns", "test-patterns", "std::string",
           /*default=*/"\"\"",
            "Test the given patterns.">,
+    Option<"clDevice", "device", "std::string",
+          /*default=*/"\"xcvc1902\"",
+           "AIE device to target.">,
   ];
   let description = [{
     This pass converts AIR dialect `herd` and `segment` operations into AIE

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -964,7 +964,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
 
   LogicalResult matchAndRewrite(air::ChannelOp channel,
                                 PatternRewriter &rewriter) const override {
-    auto aie_module = channel->getParentOfType<AIE::DeviceOp>();
+    auto device = channel->getParentOfType<AIE::DeviceOp>();
     if (channel.getBundleSize() > 1)
       return failure();
 
@@ -999,7 +999,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
       }
     } else {
       // put from L3
-      producerTile = shimTileAlloc.getShimTile(aie_module, src_space,
+      producerTile = shimTileAlloc.getShimTile(device, src_space,
                                                (int)air::MemorySpace::L1);
     }
 
@@ -1031,14 +1031,14 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
     } else {
       // get from L3
       consumerTile = shimTileAlloc.getShimTile(
-          aie_module, (int)air::MemorySpace::L1, dst_space);
+          device, (int)air::MemorySpace::L1, dst_space);
     }
     consumers.push_back(consumerTile);
 
     // create objFifo
     // For now, number of memory elements in OF is hardcoded to 1
     // (single buffer). FIXME
-    rewriter.setInsertionPoint(*(aie_module.getOps<AIE::CoreOp>().begin()));
+    rewriter.setInsertionPoint(*(device.getOps<AIE::CoreOp>().begin()));
     AIE::AIEObjectFifoType datatype;
     if (channelPuts.size() > 0)
       datatype = AIE::AIEObjectFifoType::get(srcMemref);

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -7,25 +7,25 @@
 
 // RUN: air-opt %s --air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
 
-// CHECK: module @aie.segment_0 {
-// CHECK:   %0 = AIE.tile(1, 1)
-// CHECK:   %1 = AIE.tile(1, 2)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %3 = AIE.core(%1) {
-// CHECK:     %5 = AIE.objectFifo.acquire<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     AIE.objectFifo.release<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
-// CHECK:     AIE.end
-// CHECK:   } {elf_file = "segment_0_core_1_2.elf"}
-// CHECK:   %4 = AIE.core(%0) {
-// CHECK:     %5 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
-// CHECK:     AIE.end
-// CHECK:   } {elf_file = "segment_0_core_1_1.elf"}
-// CHECK: }
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:    %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:    %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK:    %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:    %[[VAL_3:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:      %[[VAL_4:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:      %[[VAL_5:.*]] = AIE.objectFifo.subview.access %[[VAL_4]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:      AIE.objectFifo.release<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:      AIE.end
+// CHECK:    } {elf_file = "segment_0_core_1_2.elf"}
+// CHECK:    %[[VAL_6:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:      %[[VAL_7:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:      %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_7]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:      AIE.objectFifo.release<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:      AIE.end
+// CHECK:    } {elf_file = "segment_0_core_1_1.elf"}
+// CHECK:  }
 
-module @aie.segment_0 {
+AIE.device(xcvc1902) {
   %0 = AIE.tile(1, 1)
   %1 = AIE.tile(1, 2)
   air.channel @channel_0 [1, 1]

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -10,7 +10,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:    %[[VAL_0:.*]] = AIE.tile(1, 1)
 // CHECK:    %[[VAL_1:.*]] = AIE.tile(1, 2)
-// CHECK:    %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:    %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:    %[[VAL_3:.*]] = AIE.core(%[[VAL_1]]) {
 // CHECK:      %[[VAL_4:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
 // CHECK:      %[[VAL_5:.*]] = AIE.objectFifo.subview.access %[[VAL_4]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
@@ -7,29 +7,29 @@
 
 // RUN: air-opt %s --air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
 
-// CHECK: module @aie.segment_0 {
-// CHECK:   %0 = AIE.tile(1, 1)
-// CHECK:   %1 = AIE.tile(2, 0)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%1, {%0}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %4 = AIE.core(%0) {
-// CHECK:     affine.for %arg0 = 0 to 4096 step 32 {
-// CHECK:       %5 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:       %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:       %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:       affine.for %arg1 = 0 to 32 {
-// CHECK:         %9 = affine.load %6[%arg1] : memref<32xi32, 2>
-// CHECK:         affine.store %9, %8[%arg1] : memref<32xi32, 2>
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(2, 0)
+// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_1]], {%[[VAL_0]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:     affine.for %[[VAL_5:.*]] = 0 to 4096 step 32 {
+// CHECK:       %[[VAL_6:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:       %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:       %[[VAL_8:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:       %[[VAL_9:.*]] = AIE.objectFifo.subview.access %[[VAL_8]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:       affine.for %[[VAL_10:.*]] = 0 to 32 {
+// CHECK:         %[[VAL_11:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<32xi32, 2>
+// CHECK:         affine.store %[[VAL_11]], %[[VAL_9]]{{\[}}%[[VAL_10]]] : memref<32xi32, 2>
 // CHECK:       }
-// CHECK:       AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
-// CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:       AIE.objectFifo.release<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:       AIE.objectFifo.release<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   } {elf_file = "segment_0_core_1_1.elf"}
 // CHECK: }
 
-module @aie.segment_0 {
+AIE.device(xcvc1902) {
   %0 = AIE.tile(1, 1)
   %1 = AIE.core(%0) {
     %c32 = arith.constant 32 : index

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
@@ -10,8 +10,8 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
 // CHECK:   %[[VAL_1:.*]] = AIE.tile(2, 0)
-// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_1]], {%[[VAL_0]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_1]], {%[[VAL_0]]}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_0]]) {
 // CHECK:     affine.for %[[VAL_5:.*]] = 0 to 4096 step 32 {
 // CHECK:       %[[VAL_6:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
@@ -7,31 +7,30 @@
 
 // RUN: air-opt %s --air-to-aie='test-patterns=lower-air-channels' | FileCheck %s
 
-// CHECK: module @aie.partition_0 {
-// CHECK:   %0 = AIE.tile(1, 1)
-// CHECK:   %1 = AIE.tile(1, 2)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 2) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %4 = AIE.core(%1) {
-// CHECK:     %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     %8 = AIE.objectFifo.acquire<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 2) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:     %[[VAL_5:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_6:.*]] = AIE.objectFifo.subview.access %[[VAL_5]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     %[[VAL_7:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_7]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
 // CHECK:     AIE.end
 // CHECK:   } {elf_file = "partition_0_core_1_2.elf"}
-// CHECK:   %5 = AIE.core(%0) {
-// CHECK:     %6 = AIE.objectFifo.acquire<Produce> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     %8 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
-// CHECK:     %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
-// CHECK:     AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:   %[[VAL_9:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:     %[[VAL_10:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     %[[VAL_12:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
 // CHECK:     AIE.end
 // CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
 // CHECK: }
 
-
-module @aie.partition_0 {
+AIE.device(xcvc1902) {
   %0 = AIE.tile(1, 1)
   %1 = AIE.tile(1, 2)
   air.channel @channel_0 [1, 1]

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
@@ -10,8 +10,8 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
 // CHECK:   %[[VAL_1:.*]] = AIE.tile(1, 2)
-// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 2) : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 2) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_1]]) {
 // CHECK:     %[[VAL_5:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
 // CHECK:     %[[VAL_6:.*]] = AIE.objectFifo.subview.access %[[VAL_5]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=2" | FileCheck %s
-
-module {
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=2 device=xcvc1902" -o out.mlir --split-input-file | FileCheck %s
 
 // CHECK: module @aie.segment_0
 // CHECK:         %[[VAL_12:.*]] = AIE.tile(2, 2)
@@ -49,4 +47,59 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
   return
 }
 
+// -----
+
+// CHECK: module @aie.segment_0
+// CHECK:         %[[VAL_12:.*]] = AIE.tile(2, 2)
+// CHECK:         %[[VAL_10:.*]] = AIE.tile(2, 0)
+// CHECK:         %[[VAL_15:.*]] = AIE.lock(%[[VAL_12]], 1)
+// CHECK:         %[[VAL_14:.*]] = AIE.lock(%[[VAL_12]], 0)
+// CHECK:         %[[VAL_13:.*]] = AIE.buffer(%[[VAL_12]]) {sym_name = {{.*}}} : memref<1024xi32, 2>
+// CHECK:         %[[VAL_16:.*]] = AIE.buffer(%[[VAL_12]]) {sym_name = {{.*}}} : memref<512xi32, 2>
+
+// CHECK:    AIE.mem(%[[VAL_12]])  {
+// CHECK:           AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:         ^bb1:
+// CHECK:           AIE.useLock(%[[VAL_14]], Acquire, 0)
+// CHECK:           AIE.dmaBd(<%[[VAL_13]] : memref<1024xi32, 2>, 0, 0>, 0)
+// CHECK:           AIE.useLock(%[[VAL_14]], Release, 1)
+// CHECK:           AIE.nextBd ^bb1
+// CHECK:         ^bb2:
+// CHECK:           AIE.end
+// CHECK:         ^bb3:
+// CHECK:           AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
+// CHECK:         ^bb4:
+// CHECK:           AIE.useLock(%[[VAL_15]], Acquire, 0)
+// CHECK:           AIE.dmaBd(<%[[VAL_16]] : memref<512xi32, 2>, 0, 0>, 0)
+// CHECK:           AIE.useLock(%[[VAL_15]], Release, 1)
+// CHECK:           AIE.nextBd ^bb4
+// CHECK:         }
+
+// CHECK:    AIE.core(%[[VAL_12]])  {
+// CHECK:           AIE.useLock(%[[VAL_15]], Acquire, 1)
+// CHECK:           AIE.useLock(%[[VAL_14]], Acquire, 1)
+// CHECK:           AIE.useLock(%[[VAL_14]], Release, 0)
+// CHECK:           AIE.useLock(%[[VAL_15]], Release, 0)
+// CHECK:           AIE.end
+// CHECK:         }
+
+// CHECK:         AIE.flow(%[[VAL_10]], DMA : 0, %[[VAL_12]], DMA : 0)
+// CHECK:         AIE.flow(%[[VAL_10]], DMA : 1, %[[VAL_12]], DMA : 1)
+func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
+  %herd_cols = arith.constant 1 : index
+  %herd_rows = arith.constant 1 : index
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<1024xi32>, memref<1024xi32> attributes { sym_name="func1"} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 0 : index
+    %c1024 = arith.constant 0 : index
+    %c512 = arith.constant 0 : index
+    %buf0 = memref.alloc() : memref<1024xi32, 2>
+    %buf1 = memref.alloc() : memref<512xi32, 2>
+    air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) {id = 1 : i32} : (memref<1024xi32, 2>, memref<1024xi32>)
+    air.dma_memcpy_nd (%buf1[] [] [], %ext0[%c0] [%c512] [%c1]) {id = 2 : i32} : (memref<512xi32, 2>, memref<1024xi32>)
+    memref.dealloc %buf0 : memref<1024xi32, 2>
+    memref.dealloc %buf1 : memref<512xi32, 2>
+    air.herd_terminator
+  }
+  return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -1,4 +1,4 @@
-//===- air_shimcpy_to_aie.mlir ---------------------------------*- MLIR -*-===//
+//===- air_shimcpy_to_aie2.mlir --------------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2021-2022, Xilinx Inc. All rights reserved.
 // Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
@@ -6,46 +6,88 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=2" | FileCheck %s
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" -o out.mlir --split-input-file | FileCheck %s
 
-module {
+// CHECK-LABEL:   AIE.device(xcve2802) {
+// CHECK:  %[[VAL_0:.*]] = AIE.tile(2, 3)
+// CHECK:  %[[VAL_1:.*]] = AIE.tile(2, 0)
+// CHECK:  %[[VAL_2:.*]] = AIE.lock(%[[VAL_0]], 1) {init = 1 : i32}
+// CHECK:  %[[VAL_3:.*]] = AIE.lock(%[[VAL_0]], 0) {init = 0 : i32}
+// CHECK:  %[[VAL_4:.*]] = AIE.buffer(%[[VAL_0]]) {{.*}} : memref<1024xi32, 2>
+// CHECK:  %[[VAL_5:.*]] = AIE.mem(%[[VAL_0]]) {
+// CHECK:    %[[VAL_6:.*]] = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
+// CHECK:  ^bb1:
+// CHECK:    AIE.useLock(%[[VAL_2]], AcquireGreaterEqual, 1)
+// CHECK:    AIE.dmaBd(<%[[VAL_4]] : memref<1024xi32, 2>, 0, 0>, 0)
+// CHECK:    AIE.useLock(%[[VAL_3]], Release, 1)
+// CHECK:    AIE.nextBd ^bb1
+// CHECK:  ^bb2:
+// CHECK:    AIE.end
+// CHECK:  }
+// CHECK:  %[[VAL_7:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:    cf.br ^bb1
+// CHECK:  ^bb1:
+// CHECK:    cf.br ^bb2
+// CHECK:  ^bb2:
+// CHECK:    AIE.useLock(%[[VAL_3]], AcquireGreaterEqual, 1)
+// CHECK:    AIE.useLock(%[[VAL_2]], Release, 1)
+// CHECK:    AIE.end
+// CHECK:  AIE.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
+func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
+  %herd_cols = arith.constant 1 : index
+  %herd_rows = arith.constant 1 : index
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<1024xi32>, memref<1024xi32> attributes { sym_name="func1"} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 0 : index
+    %c1024 = arith.constant 0 : index
+    %buf0 = memref.alloc() : memref<1024xi32, 2>
+    air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) : (memref<1024xi32, 2>, memref<1024xi32>)
+    memref.dealloc %buf0 : memref<1024xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
 
-// CHECK: module @aie.segment_0
-// CHECK:         %[[VAL_12:.*]] = AIE.tile(2, 2)
-// CHECK:         %[[VAL_10:.*]] = AIE.tile(2, 0)
-// CHECK:         %[[VAL_15:.*]] = AIE.lock(%[[VAL_12]], 1)
-// CHECK:         %[[VAL_14:.*]] = AIE.lock(%[[VAL_12]], 0)
-// CHECK:         %[[VAL_13:.*]] = AIE.buffer(%[[VAL_12]]) {sym_name = {{.*}}} : memref<1024xi32, 2>
-// CHECK:         %[[VAL_16:.*]] = AIE.buffer(%[[VAL_12]]) {sym_name = {{.*}}} : memref<512xi32, 2>
+// -----
 
-// CHECK:    AIE.mem(%[[VAL_12]])  {
-// CHECK:           AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
-// CHECK:         ^bb1:
-// CHECK:           AIE.useLock(%[[VAL_14]], Acquire, 0)
-// CHECK:           AIE.dmaBd(<%[[VAL_13]] : memref<1024xi32, 2>, 0, 0>, 0)
-// CHECK:           AIE.useLock(%[[VAL_14]], Release, 1)
-// CHECK:           AIE.nextBd ^bb1
-// CHECK:         ^bb2:
-// CHECK:           AIE.end
-// CHECK:         ^bb3:
-// CHECK:           AIE.dmaStart(S2MM, 1, ^bb4, ^bb2)
-// CHECK:         ^bb4:
-// CHECK:           AIE.useLock(%[[VAL_15]], Acquire, 0)
-// CHECK:           AIE.dmaBd(<%[[VAL_16]] : memref<512xi32, 2>, 0, 0>, 0)
-// CHECK:           AIE.useLock(%[[VAL_15]], Release, 1)
-// CHECK:           AIE.nextBd ^bb4
-// CHECK:         }
-
-// CHECK:    AIE.core(%[[VAL_12]])  {
-// CHECK:           AIE.useLock(%[[VAL_15]], Acquire, 1)
-// CHECK:           AIE.useLock(%[[VAL_14]], Acquire, 1)
-// CHECK:           AIE.useLock(%[[VAL_14]], Release, 0)
-// CHECK:           AIE.useLock(%[[VAL_15]], Release, 0)
-// CHECK:           AIE.end
-// CHECK:         }
-
-// CHECK:         AIE.flow(%[[VAL_10]], DMA : 0, %[[VAL_12]], DMA : 0)
-// CHECK:         AIE.flow(%[[VAL_10]], DMA : 1, %[[VAL_12]], DMA : 1)
+// CHECK-LABEL:   AIE.device(xcve2802) {
+// CHECK: %[[VAL_0:.*]] = AIE.tile(2, 3)
+// CHECK: %[[VAL_1:.*]] = AIE.tile(2, 0)
+// CHECK: %[[VAL_2:.*]] = AIE.lock(%[[VAL_0]], 3) {init = 1 : i32}
+// CHECK: %[[VAL_3:.*]] = AIE.lock(%[[VAL_0]], 2) {init = 0 : i32}
+// CHECK: %[[VAL_4:.*]] = AIE.lock(%[[VAL_0]], 1) {init = 1 : i32}
+// CHECK: %[[VAL_5:.*]] = AIE.lock(%[[VAL_0]], 0) {init = 0 : i32}
+// CHECK: %[[VAL_6:.*]] = AIE.buffer(%[[VAL_0]]) {{.*}} : memref<1024xi32, 2>
+// CHECK: %[[VAL_7:.*]] = AIE.buffer(%[[VAL_0]]) {{.*}} : memref<512xi32, 2>
+// CHECK: %[[VAL_8:.*]] = AIE.mem(%[[VAL_0]]) {
+// CHECK:   %[[VAL_9:.*]] = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK: ^bb1:
+// CHECK:   AIE.useLock(%[[VAL_4]], AcquireGreaterEqual, 1)
+// CHECK:   AIE.dmaBd(<%[[VAL_6]] : memref<1024xi32, 2>, 0, 0>, 0)
+// CHECK:   AIE.useLock(%[[VAL_5]], Release, 1)
+// CHECK:   AIE.nextBd ^bb1
+// CHECK: ^bb2:
+// CHECK:   AIE.end
+// CHECK: ^bb3:
+// CHECK:   %[[VAL_10:.*]] = AIE.dmaStart(MM2S, 0, ^bb4, ^bb2)
+// CHECK: ^bb4:
+// CHECK:   AIE.useLock(%[[VAL_3]], AcquireGreaterEqual, 1)
+// CHECK:   AIE.dmaBd(<%[[VAL_7]] : memref<512xi32, 2>, 0, 0>, 0)
+// CHECK:   AIE.useLock(%[[VAL_2]], Release, 1)
+// CHECK:   AIE.nextBd ^bb4
+// CHECK: }
+// CHECK: %[[VAL_11:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:   cf.br ^bb1
+// CHECK: ^bb1:
+// CHECK:   cf.br ^bb2
+// CHECK: ^bb2:
+// CHECK:   AIE.useLock(%[[VAL_2]], AcquireGreaterEqual, 1)
+// CHECK:   AIE.useLock(%[[VAL_5]], AcquireGreaterEqual, 1)
+// CHECK:   AIE.useLock(%[[VAL_4]], Release, 1)
+// CHECK:   AIE.useLock(%[[VAL_3]], Release, 1)
+// CHECK:   AIE.end
+// CHECK: AIE.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
+// CHECK: AIE.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
@@ -57,12 +99,10 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %buf0 = memref.alloc() : memref<1024xi32, 2>
     %buf1 = memref.alloc() : memref<512xi32, 2>
     air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) {id = 1 : i32} : (memref<1024xi32, 2>, memref<1024xi32>)
-    air.dma_memcpy_nd (%buf1[] [] [], %ext0[%c0] [%c512] [%c1]) {id = 2 : i32} : (memref<512xi32, 2>, memref<1024xi32>)
+    air.dma_memcpy_nd (%ext0[%c0] [%c512] [%c1], %buf1[] [] []) {id = 2 : i32} : (memref<1024xi32>, memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
     air.herd_terminator
   }
   return
-}
-
 }

--- a/runtime_lib/airhost/CMakeLists.txt
+++ b/runtime_lib/airhost/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${AIE_INCLUDE_DIRS}/../runtime_lib
+    ${AIE_INCLUDE_DIRS}/../runtime_lib/x86_64/test_lib/include
 )
 
 add_definitions(-DLIBXAIENGINEV2)

--- a/test/02_mb_dispatch/run.lit
+++ b/test/02_mb_dispatch/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -ltest_lib -I%aie_runtime_lib%/test_lib/include -L%aie_runtime_lib%/test_lib/lib %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/03_mb_lock_rel/run.lit
+++ b/test/03_mb_lock_rel/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/06_air_link_shared/run.lit
+++ b/test/06_air_link_shared/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py --shared -row-offset=2 -col-offset=7 %S/air.mlir -o aie_ctrl.so
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I./ -I./air_project/partition_0 -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I./ -I./air_project/segment_0 -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/07_mb_beef_maker/run.lit
+++ b/test/07_mb_beef_maker/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/09_mb_hsa_herd_lock/run.lit
+++ b/test/09_mb_hsa_herd_lock/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/10_mb_shim_dma_to_tile_dma/run.lit
+++ b/test/10_mb_shim_dma_to_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/11_mb_shim_dma_from_tile_dma/run.lit
+++ b/test/11_mb_shim_dma_from_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/12_dual_channel_shim_dma/run.lit
+++ b/test/12_dual_channel_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/13_mb_add_one/Makefile
+++ b/test/13_mb_add_one/Makefile
@@ -8,9 +8,9 @@ ACDC_AIR = $(dir $(shell which air-opt))/..
 all: test.elf
 
 test.elf: aie.mlir test.cpp
-	aiecc.py -v --aie-generate-xaiev2 --host-target=x86_64-amd-linux-gnu --sysroot= $< -I/opt/xaiengine/include -L/opt/xaiengine/lib -Wl,-R/opt/xaiengine/lib \
+	aiecc.py -v --host-target=x86_64-amd-linux-gnu --sysroot= $< -I/opt/xaiengine/include -L/opt/xaiengine/lib -Wl,-R/opt/xaiengine/lib \
 						-I$(ACDC_AIR)/runtime_lib/airhost/include -I$(ACDC_AIE)/runtime_lib $(ACDC_AIE)/runtime_lib/test_library.cpp \
-						-L$(ACDC_AIR)/runtime_lib/airhost test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o $@ 
+						-L$(ACDC_AIR)/runtime_lib/airhost test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o $@ 
 
 clean::
 	rm -rf acdc_project *.elf

--- a/test/13_mb_add_one/run.lit
+++ b/test/13_mb_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/14_multi_shim_dma/run.lit
+++ b/test/14_multi_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/15_dual_mb_dual_herd_add_one/run.lit
+++ b/test/15_dual_mb_dual_herd_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/16_multi_shim_dma_all_channels/run.lit
+++ b/test/16_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/18_2d_tile_dma_transpose/run.lit
+++ b/test/18_2d_tile_dma_transpose/run.lit
@@ -8,5 +8,5 @@
 
 // Expected to fail unless mlir-aie pull #55 is merged
 // XFAIL: *
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/19_air_nd_memcpy_to_tile_dma/run.lit
+++ b/test/19_air_nd_memcpy_to_tile_dma/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=5 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/20_air_nd_memcpy_from_tile_dma/run.lit
+++ b/test/20_air_nd_memcpy_from_tile_dma/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=5 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/21_air_nd_memcpy_2d/run.lit
+++ b/test/21_air_nd_memcpy_2d/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=5 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/23_air_shim_dma_to_tile_dma/run.lit
+++ b/test/23_air_shim_dma_to_tile_dma/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=2 -col-offset=7 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/24_air_shim_dma_from_tile_dma/run.lit
+++ b/test/24_air_shim_dma_from_tile_dma/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=2 -col-offset=7 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/25_2d_shim_dma/run.lit
+++ b/test/25_2d_shim_dma/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=2 -col-offset=7 %S/air.mlir -o %T/air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/26_air_beefmaker_extfn/run.lit
+++ b/test/26_air_beefmaker_extfn/run.lit
@@ -10,5 +10,5 @@
 // XFAIL: *
 // RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-to-aie="output-prefix=./ row-offset=2 col-offset=7" -o /dev/null
-// RUN: aiecc.py --aie-generate-xaiev2 aie.segment_0.mlir --no-xbridge  %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py --no-xbridge aie.segment_0.mlir %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/270_air_discover_mbs/run.lit
+++ b/test/270_air_discover_mbs/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/271_air_get_info/run.lit
+++ b/test/271_air_get_info/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/272_barrier_and_hello/run.lit
+++ b/test/272_barrier_and_hello/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/273_barrier_add_two/Makefile
+++ b/test/273_barrier_add_two/Makefile
@@ -8,9 +8,9 @@ ACDC_AIR = $(dir $(shell which air-opt))/..
 all: test.elf
 
 test.elf: aie.mlir test.cpp
-	aiecc.py -v --aie-generate-xaiev2 --host-target=x86_64-amd-linux-gnu --sysroot= $< -I/opt/xaiengine/include -L/opt/xaiengine/lib -Wl,-R/opt/xaiengine/lib \
+	aiecc.py -v --host-target=x86_64-amd-linux-gnu --sysroot= $< -I/opt/xaiengine/include -L/opt/xaiengine/lib -Wl,-R/opt/xaiengine/lib \
 						-I$(ACDC_AIR)/runtime_lib/airhost/include -I$(ACDC_AIE)/runtime_lib $(ACDC_AIE)/runtime_lib/test_library.cpp \
-						-L$(ACDC_AIR)/runtime_lib/airhost test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o $@ 
+						-L$(ACDC_AIR)/runtime_lib/airhost test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o $@ 
 
 clean::
 	rm -rf acdc_project *.elf

--- a/test/273_barrier_add_two/run.lit
+++ b/test/273_barrier_add_two/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/290_mb_matrix_add_ddr/run.lit
+++ b/test/290_mb_matrix_add_ddr/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/29_mb_matrix_add/run.lit
+++ b/test/29_mb_matrix_add/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/30_2d_mb_shim_dma/run.lit
+++ b/test/30_2d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/31_3d_mb_shim_dma/run.lit
+++ b/test/31_3d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/32_4d_mb_shim_dma/run.lit
+++ b/test/32_4d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/33_air_pipeline/run.lit
+++ b/test/33_air_pipeline/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=3 -col-offset=3 %S/air.mlir -o %T/air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I./ -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I./ -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/34_air_3d_nd_memcpy/run.lit
+++ b/test/34_air_3d_nd_memcpy/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=9 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/35_air_4d_nd_memcpy/run.lit
+++ b/test/35_air_4d_nd_memcpy/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=9 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/36_4d_mb_multi_shim_dma_all_channels/run.lit
+++ b/test/36_4d_mb_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/37_4d_mb_multi_shim_dma_broadcast/run.lit
+++ b/test/37_4d_mb_multi_shim_dma_broadcast/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/38_4d_mb_shim_dma_channel_stress/run.lit
+++ b/test/38_4d_mb_shim_dma_channel_stress/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py --aie-generate-xaiev2 %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/40_air_8x4_2d_square/run.lit
+++ b/test/40_air_8x4_2d_square/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=4 -col-offset=16 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/air_test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/air_test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf

--- a/test/42_air_add_one_place_random/run.lit
+++ b/test/42_air_add_one_place_random/run.lit
@@ -8,25 +8,25 @@
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
 // RUN: cat air_project/aiecc.segment_0.mlir | grep %1 | grep tile 
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
 // RUN: cat air_project/aiecc.segment_0.mlir | grep %1 | grep tile 
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
 // RUN: cat air_project/aiecc.segment_0.mlir | grep %1 | grep tile 
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
 // RUN: cat air_project/aiecc.segment_0.mlir | grep %1 | grep tile 
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
 // RUN: cat air_project/aiecc.segment_0.mlir | grep %1 | grep tile 
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf

--- a/test/44_air_mmult_2x2/run.lit
+++ b/test/44_air_mmult_2x2/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=3 -col-offset=13 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/45_air_segment_two_herd/run.lit
+++ b/test/45_air_segment_two_herd/run.lit
@@ -7,5 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/46_air_mmult_2x2_tokens/run.lit
+++ b/test/46_air_mmult_2x2_tokens/run.lit
@@ -6,5 +6,5 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=3 -col-offset=5 %S/air.mlir -o air.mlir.a
-// RUN: %CLANG %S/test.cpp %aie_runtime_lib%/test_library.cpp -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%aie_runtime_lib%/test_lib/lib -Wl,--whole-archive air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/47_read32_write32/run.lit
+++ b/test/47_read32_write32/run.lit
@@ -5,5 +5,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -45,7 +45,7 @@ config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 config.substitutions.append(('%PYTHON', config.python_executable))
 config.substitutions.append(('%CLANG', "clang++ -fuse-ld=lld -DLIBXAIENGINEV2"))
 config.substitutions.append(('%LIBXAIE_DIR%', config.libxaie_dir))
-config.substitutions.append(('%aie_runtime_lib%', os.path.join(config.aie_obj_root, "runtime_lib")))
+config.substitutions.append(('%aie_runtime_lib%', os.path.join(config.aie_obj_root, "runtime_lib", config.test_arch)))
 config.substitutions.append(('%air_runtime_lib%', air_runtime_lib))
 config.substitutions.append(('%airhost_libs%', "-I" + air_runtime_lib + "/airhost/include -L" + air_runtime_lib + "/airhost -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lpthread -lstdc++ -lsysfs -ldl -lrt"))
 

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -23,4 +23,5 @@ git clone --depth 1 https://github.com/Xilinx/mlir-aie.git mlir-aie
 pushd mlir-aie
 git fetch --depth=1 origin $HASH
 git checkout $HASH
+git submodule update --init
 popd

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=734cd0442f22b15da51f538ff4ec6304bee333a5
+export HASH=bbd8ce98c5db2e9d3bbb51eacd71e67a0fbeb68a
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=bbd8ce98c5db2e9d3bbb51eacd71e67a0fbeb68a
+export HASH=97bb9cc6fc4a1d5c2854a5704433341a6ee3ceb4
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,14 +14,14 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=97bb9cc6fc4a1d5c2854a5704433341a6ee3ceb4
+export HASH=cmake
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx
 
-git clone --depth 1 https://github.com/Xilinx/mlir-aie.git mlir-aie
+git clone https://github.com/Xilinx/mlir-aie.git mlir-aie
 pushd mlir-aie
-git fetch --depth=1 origin $HASH
-git checkout $HASH
+#git fetch --depth=1 origin $HASH
+git checkout -b cmake origin/cmake
 git submodule update --init
 popd

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,14 +14,11 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=cmake
+export HASH=da8a0b35868f8dffb59613de00a86049c11b5733
 
-git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
-export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx
-
-git clone https://github.com/Xilinx/mlir-aie.git mlir-aie
+git clone --depth 1 https://github.com/Xilinx/mlir-aie.git mlir-aie
 pushd mlir-aie
-#git fetch --depth=1 origin $HASH
-git checkout -b cmake origin/cmake
+git fetch --depth=1 origin $HASH
+git checkout $HASH
 git submodule update --init
 popd

--- a/utils/github-build-mlir-aie.sh
+++ b/utils/github-build-mlir-aie.sh
@@ -36,6 +36,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER=clang++-12 \
     -DLLVM_EXTERNAL_LIT=`pwd`/../../llvm/build/bin/llvm-lit \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DLibXAIE_ROOT=`pwd`/../aienginev2/install \
     -DCMAKE_INSTALL_PREFIX=`pwd`/../$INSTALL_DIR
 
 cmake --build . --target install -- -j$(nproc)

--- a/utils/github-build-mlir-aie.sh
+++ b/utils/github-build-mlir-aie.sh
@@ -36,7 +36,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER=clang++-12 \
     -DLLVM_EXTERNAL_LIT=`pwd`/../../llvm/build/bin/llvm-lit \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLibXAIE_x86_64_DIR=`pwd`/../aienginev2/install \
+    -DLibXAIE_x86_64_DIR=`pwd`/../../aienginev2/install/lib \
     -DCMAKE_INSTALL_PREFIX=`pwd`/../$INSTALL_DIR
 
 cmake --build . --target install -- -j$(nproc)

--- a/utils/github-build-mlir-aie.sh
+++ b/utils/github-build-mlir-aie.sh
@@ -36,7 +36,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER=clang++-12 \
     -DLLVM_EXTERNAL_LIT=`pwd`/../../llvm/build/bin/llvm-lit \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLibXAIE_ROOT=`pwd`/../aienginev2/install \
+    -DLibXAIE_x86_64_DIR=`pwd`/../aienginev2/install \
     -DCMAKE_INSTALL_PREFIX=`pwd`/../$INSTALL_DIR
 
 cmake --build . --target install -- -j$(nproc)

--- a/utils/github-build-mlir-aie.sh
+++ b/utils/github-build-mlir-aie.sh
@@ -28,7 +28,7 @@ cmake .. \
     -DAIE_LINKER=NONE \
     -DHOST_COMPILER=NONE \
     -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DCMAKE_MODULE_PATH=`pwd`/../cmakeModules \
+    -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
     -DMLIR_DIR=`pwd`/../../llvm/install/lib/cmake/mlir/ \
     -DLLVM_DIR=`pwd`/../../llvm/install/lib/cmake/llvm/ \
     -DCMAKE_LINKER=lld \


### PR DESCRIPTION
The start of updates for `AIE.device`, `AIETargetModel` and AIE2.

* update mlir-aie to da8a0b3
* Generate `AIE.device` op during `air-to-aie`
* Add device option to `air-to-aie`
* Generate AIE2 locks in `air-to-aie` dma lowering