### PR TITLE
driver: add multi-queue support

### DIFF
--- a/driver/amdair_ioctl.h
+++ b/driver/amdair_ioctl.h
@@ -1,0 +1,77 @@
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef AMDAIR_HEADER_H_
+#define AMDAIR_HEADER_H_
+
+#define AMDAIR_MMAP_RANGE_BRAM 0x0
+#define AMDAIR_MMAP_RANGE_DRAM 0x1
+#define AMDAIR_MMAP_RANGE_AIE 0x8
+
+#define AMDAIR_IOCTL_MAJOR_VERSION 1
+#define AMDAIR_IOCTL_MINOR_VERSION 0
+
+struct amdair_get_version_args {
+	uint32_t major_version; /* from driver */
+	uint32_t minor_version; /* from driver */
+};
+
+enum amdair_queue_type {
+	AMDAIR_QUEUE_HOST, /* queue is in host memory */
+	AMDAIR_QUEUE_DEVICE, /* queue is in device memory */
+	AMDAIR_QUEUE_3RD_PARTY, /* queue is not in device or host memory */
+};
+
+struct amdair_create_queue_args {
+	uint64_t ring_base_address; /* to driver */
+	uint64_t write_pointer_address; /* from driver */
+	uint64_t read_pointer_address; /* from driver */
+	uint64_t doorbell_offset; /* from driver */
+
+	uint32_t ring_size; /* to driver */
+	uint32_t device_id; /* to driver */
+	uint32_t queue_type; /* to driver */
+	uint32_t queue_id; /* from driver */
+};
+
+struct amdair_destroy_queue_args {
+	uint32_t queue_id; /* from driver */
+};
+
+#define AMDAIR_COMMAND_START 1
+#define AMDAIR_COMMAND_END 3
+
+#define AMDAIR_IOCTL_BASE 'K'
+#define AMDAIR_IO(nr) _IO(AMDAIR_IOCTL_BASE, nr)
+#define AMDAIR_IOR(nr, type) _IOR(AMDAIR_IOCTL_BASE, nr, type)
+#define AMDAIR_IOW(nr, type) _IOW(AMDAIR_IOCTL_BASE, nr, type)
+#define AMDAIR_IOWR(nr, type) _IOWR(AMDAIR_IOCTL_BASE, nr, type)
+
+#define AMDAIR_IOC_GET_VERSION AMDAIR_IOR(0x01, struct amdair_get_version_args)
+
+#define AMDAIR_IOC_CREATE_QUEUE                                                \
+	AMDAIR_IOWR(0x02, struct amdair_create_queue_args)
+
+#define AMDAIR_IOC_DESTROY_QUEUE                                               \
+	AMDAIR_IOWR(0x03, struct amdair_destroy_queue_args)
+
+/*
+The mmap interface is not designed to handle multiple devices or address
+ranges, so we must encode multiple fields into the offset.
+
+[39:36] device ID
+[35:32] range (BRAM, DRAM, etc.)
+[31:12] offset
+[11:0] empty
+*/
+#define AMDAIR_MMAP_OFFSET_MASK 0xFFFFF000UL
+#define AMDAIR_MMAP_ENCODE_OFFSET(_range, _offset, _devid)                     \
+	((_offset & AMDAIR_MMAP_OFFSET_MASK) |                                 \
+	 (((uint64_t)AMDAIR_MMAP_RANGE_##_range & 0xF) << 32) |                \
+	 (((uint64_t)_devid & 0xF) << 36))
+
+#define AMDAIR_MMAP_DECODE_OFFSET_DEVID(_offset) ((_offset >> 36) & 0xF)
+#define AMDAIR_MMAP_DECODE_OFFSET_RANGE(_offset) ((_offset >> 32) & 0xF)
+#define AMDAIR_MMAP_DECODE_OFFSET(_offset) ((_offset)&AMDAIR_MMAP_OFFSET_MASK)
+
+#endif /* AMDAIR_HEADER_H_ */

--- a/driver/chardev.h
+++ b/driver/chardev.h
@@ -4,45 +4,12 @@
 #ifndef VCK5000_CHARDEV_H_
 #define VCK5000_CHARDEV_H_
 
+#include "device.h"
+
 /* The indices in config space (64-bit BARs) */
 #define DRAM_BAR_INDEX 0
 #define AIE_BAR_INDEX 2
 #define BRAM_BAR_INDEX 4
-
-#define MMAP_OFFSET_AIE 0x100000ULL
-#define MMAP_OFFSET_BRAM 0x8000000ULL
-
-/*
-	This represents a single VCK5000 card.
-
-	This does not use the Linux kernel 'device' infrastructure because we want
-	to have only a single character device interface (/dev/amdair) regardless of
-	how many physical devices are attached. This follows the AMDKFD driver
-	design.
-*/
-struct vck5000_device {
-	struct kobject kobj_aie;
-
-	void __iomem *dram_bar;
-	uint64_t dram_bar_len;
-
-	void __iomem *aie_bar;
-	uint64_t aie_bar_len;
-
-	void __iomem *bram_bar;
-	uint64_t bram_bar_len;
-
-	uint64_t total_controllers;
-
-	/* AIE memory can be accessed indirectly through sysfs.
-		It is a two-step protocol:
-		(1) write the memory address to:
-		/sys/class/amdair/amdair/<id>/address
-		(2) Read (or write) the value from:
-		/sys/class/amdair/amdair/<id>/value
-	*/
-	uint64_t mem_addr; /* address for indirect memory access */
-};
 
 int vck5000_chardev_init(struct pci_dev *pdev);
 void vck5000_chardev_exit(void);

--- a/driver/device.h
+++ b/driver/device.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef DEVICE_H_
+#define DEVICE_H_
+
+#define MAX_HERD_CONTROLLERS 64
+
+/* For now, there is a 1:1 relationship between queues and controllers */
+#define MAX_QUEUES MAX_HERD_CONTROLLERS
+
+/*
+	This represents a single VCK5000 card.
+
+	This does not use the Linux kernel 'device' infrastructure because we want
+	to have only a single character device interface (/dev/amdair) regardless of
+	how many physical devices are attached. This follows the AMDKFD driver
+	design.
+*/
+struct vck5000_device {
+	struct list_head list;
+	uint32_t device_id;
+	struct kobject kobj_aie;
+
+	void __iomem *dram_bar;
+	uint64_t dram_bar_len;
+
+	void __iomem *aie_bar;
+	uint64_t aie_bar_len;
+
+	void __iomem *bram_bar;
+	uint64_t bram_bar_len;
+
+	uint32_t controller_count;
+	uint64_t queue_used; /* bitmap to remember which queues are free */
+	pid_t queue_owner[MAX_QUEUES]; /* which process owns this queue */
+
+	/* AIE memory can be accessed indirectly through sysfs.
+		It is a two-step protocol:
+		(1) write the memory address to:
+		/sys/class/amdair/amdair/<id>/address
+		(2) Read (or write) the value from:
+		/sys/class/amdair/amdair/<id>/value
+	*/
+	uint64_t mem_addr; /* address for indirect memory access */
+};
+
+struct vck5000_device *get_device_by_id(uint32_t device_id);
+uint32_t get_controller_count(struct vck5000_device *dev);
+uint64_t get_controller_base_address(struct vck5000_device *dev,
+				     uint32_t ctrlr_idx);
+uint32_t find_free_controller(struct vck5000_device *dev);
+void mark_controller_busy(struct vck5000_device *dev, uint32_t ctrlr_idx,
+			  pid_t pid);
+
+#endif /* DEVICE_H_ */

--- a/runtime_lib/airhost/CMakeLists.txt
+++ b/runtime_lib/airhost/CMakeLists.txt
@@ -5,6 +5,7 @@
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${AIE_INCLUDE_DIRS}/../runtime_lib
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../driver
 )
 
 add_definitions(-DLIBXAIENGINEV2)

--- a/runtime_lib/airhost/host.cpp
+++ b/runtime_lib/airhost/host.cpp
@@ -8,6 +8,7 @@
 
 #include "air_host.h"
 #include "air_host_impl.h"
+#include "amdair_ioctl.h"
 #include "test_library.h"
 
 #ifdef AIR_PCIE
@@ -150,7 +151,7 @@ For a non-PCIe device, memory map the base address directly.
                          PROT_READ | PROT_WRITE, // prot
                          MAP_SHARED,             // flags
                          fda,                    // device fd
-                         0x100000);              // offset
+                         AMDAIR_MMAP_ENCODE_OFFSET(AIE, 0, device_id));
 
   XAie_BackendType backend;
   if (mapped_aie_base == MAP_FAILED) {
@@ -218,8 +219,9 @@ air_module_handle_t air_module_load_from_file(const char *filename, queue_t *q,
   int fd = open(vck5000_driver_name, O_RDWR | O_SYNC);
   assert(fd != -1 && "Failed to open bram fd");
 
-  _air_host_bram_ptr = (uint32_t *)mmap(NULL, 0x8000, PROT_READ | PROT_WRITE,
-                                        MAP_SHARED, fd, 0x1C0000);
+  _air_host_bram_ptr =
+      (uint32_t *)mmap(NULL, 0x8000, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+                       AMDAIR_MMAP_ENCODE_OFFSET(BRAM, 0x1C0000, device_id));
   _air_host_bram_paddr = AIR_BBUFF_BASE;
 #else
 

--- a/runtime_lib/airhost/memory.cpp
+++ b/runtime_lib/airhost/memory.cpp
@@ -8,6 +8,7 @@
 
 #include "air_host.h"
 #include "air_host_impl.h"
+#include "amdair_ioctl.h"
 
 #include <cassert>
 #include <cstdio>
@@ -116,14 +117,14 @@ int air_init_dev_mem_allocator(uint64_t dev_mem_size, uint32_t device_id) {
 #ifdef AIR_PCIE
   int fd = open(air_get_driver_name(), O_RDWR | O_SYNC);
   if (fd < 0) {
-    printf("[ERROR] Could not open DDR BAR\n");
+    printf("[ERROR] Could not open DRAM BAR\n");
     return 1;
   }
-  dev_mem_allocator->dev_mem =
-      (uint32_t *)mmap(NULL, dev_mem_size /*0x8000*/, PROT_READ | PROT_WRITE,
-                       MAP_SHARED, fd, 0x1C0000);
+  dev_mem_allocator->dev_mem = (uint32_t *)mmap(
+      NULL, dev_mem_size /*0x8000*/, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+      AMDAIR_MMAP_ENCODE_OFFSET(DRAM, 0x1C0000, device_id));
   if (dev_mem_allocator->dev_mem == MAP_FAILED) {
-    printf("[ERROR] Could not map DDR BAR\n");
+    printf("[ERROR] Could not map DRAM BAR\n");
     return 1;
   }
 #else


### PR DESCRIPTION
Multiple contexts can share a single AIE device by using separate command queues. In this first implementation, each command processor exposes a single queue. On a BP-based platform, that means 7 queues. There must be a mechanism to allocate and free these queues for use by separate contexts.

In the first case, queue 0 (belonging to the ARM processor) is reserved for administration functions that can be performed only by the driver. This includes the read32/write32 commands and possibly global administration functions (such as card-level reset and initialize) in the future.

The mmap() interface has changed to support multiple devices. The offset field is now encoded using a macro found in amdair_ioctl.h. The macro encodes the target device, the memory range (BRAM, DRAM, etc.) the offset inside that range.

The IOCTLs have been renamed to move away from the KFD starting point.

In the future, we must also add a mechanism to prevent mapping memory for a queue that has not been created or not owned by the mapping process.