### PR TITLE
driver: revert license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,8 +21,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-The code in the 'driver' subdirectory (the "driver") is licensed separately
-under the terms and conditions of the GNU General Public License v2 ("GPLv2").
-The complete description of the license can be found at:
-https://spdx.org/licenses/GPL-2.0.html

--- a/driver/chardev.c
+++ b/driver/chardev.c
@@ -1,5 +1,5 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <linux/device.h>

--- a/driver/chardev.h
+++ b/driver/chardev.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: MIT
 
 #ifndef VCK5000_CHARDEV_H_
 #define VCK5000_CHARDEV_H_

--- a/driver/main.c
+++ b/driver/main.c
@@ -1,5 +1,5 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: MIT
 
 #include <linux/init.h>
 #include <linux/module.h>
@@ -171,7 +171,7 @@ module_exit(vck5000_exit);
 module_param(enable_aie, bool, 0644);
 MODULE_PARM_DESC(enable_aie, "Enable debug access to AIE BAR");
 
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("Dual MIT/GPL");
 MODULE_AUTHOR("Joel Nider <joel.nider@amd.com>");
 MODULE_DESCRIPTION("VCK5000 AIR driver");
 MODULE_VERSION("1.0");


### PR DESCRIPTION
This partially reverts commit dc50c477.

It is easier to develop with the wider team if the driver uses the MIT license.

The module declares a dual license so we can continue to use GPL-only functions such as 'device_destroy'. This follows the same procedure as the AMDKFD driver.