### PR TITLE
Add a channel get/put hoisting pass

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -490,6 +490,9 @@ def air_ChannelPutOp : air_Op<"channel.put", [air_AsyncOpInterface,
       }
       return -1;
     }
+    OperandRange getOffsets() { return getSrcOffsets(); }
+    OperandRange getSizes() { return getSrcSizes(); }
+    OperandRange getStrides() { return getSrcStrides(); }
   }];
 }
 
@@ -522,6 +525,9 @@ def air_ChannelGetOp : air_Op<"channel.get", [air_AsyncOpInterface,
       }
       return -1;
     }
+    OperandRange getOffsets() { return getDstOffsets(); }
+    OperandRange getSizes() { return getDstSizes(); }
+    OperandRange getStrides() { return getDstStrides(); }
   }];
 }
 

--- a/mlir/include/air/Dialect/AIR/AIROpBase.td
+++ b/mlir/include/air/Dialect/AIR/AIROpBase.td
@@ -222,6 +222,21 @@ def air_ChannelInterface : OpInterface<"ChannelInterface"> {
     InterfaceMethod<"description",
     "StringRef", "getChanName"
     >,
+    InterfaceMethod<"",
+    "OperandRange", "getIndices"
+    >,
+    InterfaceMethod<"",
+    "OperandRange", "getOffsets"
+    >,
+    InterfaceMethod<"",
+    "OperandRange", "getSizes"
+    >,
+    InterfaceMethod<"",
+    "OperandRange", "getStrides"
+    >,
+    InterfaceMethod<"",
+    "Value", "getMemref"
+    >,
   ];
 }
 #endif

--- a/mlir/include/air/Transform/AIRMiscPasses.h
+++ b/mlir/include/air/Transform/AIRMiscPasses.h
@@ -25,6 +25,7 @@ std::unique_ptr<mlir::Pass> createAIRPipelineReducePass();
 std::unique_ptr<mlir::Pass> createAIRFuseParallelHerdPass();
 std::unique_ptr<mlir::Pass> createAIRRenumberDmaIdPass();
 std::unique_ptr<mlir::Pass> createAIRLowerHerdParallelPass();
+std::unique_ptr<mlir::Pass> createAIRHoistScfChannelGetPutPass();
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -961,4 +961,10 @@ def AIRLowerHerdParallelPass : Pass<"air-lower-herd-parallel", "func::FuncOp"> {
                 "scf.for.";
   let constructor = "xilinx::air::createAIRLowerHerdParallelPass()";
 }
+
+def AIRHoistScfChannelGetPutPass : Pass<"air-hoist-channels", "func::FuncOp"> {
+  let summary = "Hoist air.channel.get and air.channel.put out of scf.for.";
+  let constructor = "xilinx::air::createAIRHoistScfChannelGetPutPass()";
+}
+
 #endif // AIR_CONVERSION_PASSES

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -942,7 +942,8 @@ public:
     // compute a new stride equal to the stride of the repeated dimension
     // multiplied by the number of scf.loop iterations we're replacing
     SmallVector<Value> strides;
-    auto lastStrideOffset = chanOp.getStrides().size() - memrefTy.getRank() + ivOffsetIdx;
+    auto lastStrideOffset =
+        chanOp.getStrides().size() - memrefTy.getRank() + ivOffsetIdx;
     auto lastStride = dyn_cast<arith::ConstantIndexOp>(
         chanOp.getStrides()[lastStrideOffset].getDefiningOp());
     auto foldedStride = step.value() * lastStride.value();

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -879,6 +879,110 @@ void AIRLowerHerdParallelPass::runOnOperation() {
   (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
 }
 
+class HoistScfChannelGetPutPass
+    : public RewritePattern {
+public:
+  HoistScfChannelGetPutPass(MLIRContext *context, PatternBenefit benefit = 1)
+    : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto chanOp = dyn_cast<air::ChannelInterface>(op);
+    if (!chanOp)
+      return failure();
+    MemRefType memrefTy = chanOp.getMemref().getType().cast<MemRefType>();
+
+    // channel op must be in an scf.for loop
+    auto forOp = op->getParentOfType<scf::ForOp>();
+    if (!forOp)
+      return failure();
+
+    // channel op must be the only op in the loop
+    if (forOp.getBody()->getOperations().size() != 2)
+      return failure();
+
+    // scf.for must have constant bounds and step
+    auto lb = forOp.getLowerBound().getDefiningOp<arith::ConstantIndexOp>();
+    auto ub = forOp.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
+    auto step = forOp.getStep().getDefiningOp<arith::ConstantIndexOp>();
+    if (!lb || !ub || !step)
+      return failure();
+
+    auto trip_count = (ub.value() - lb.value()) / step.value();
+
+    rewriter.setInsertionPoint(forOp);
+    auto loc = op->getLoc();
+
+    SmallVector<Value> offsets;
+    Value iv = nullptr;
+    int ivOffsetIdx = 0;
+    for (auto v : chanOp.getOffsets()) {
+      auto c = dyn_cast_if_present<arith::ConstantIndexOp>(v.getDefiningOp());
+      if (!c) {
+        if (v == forOp.getInductionVar()) {
+          if (iv) // there can be only one
+            return failure();
+          iv = v;
+          v = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+        }
+      }
+      offsets.push_back(v);
+      if (!iv)
+        ivOffsetIdx++;
+    }
+
+    SmallVector<Value> sizes;
+    sizes.push_back(rewriter.create<arith::ConstantIndexOp>(loc, trip_count));
+    for (auto v : chanOp.getSizes()) {
+      auto c = dyn_cast<arith::ConstantIndexOp>(v.getDefiningOp());
+      if (!c)
+        return failure();
+      sizes.push_back(c);
+    }
+
+    SmallVector<Value> strides;
+    auto foldedStride = step.value();
+    if (ivOffsetIdx < 1)
+      foldedStride *= memrefTy.getDimSize(0);
+    strides.push_back(rewriter.create<arith::ConstantIndexOp>(loc, foldedStride));
+    for (auto v : chanOp.getStrides()) {
+      auto c = dyn_cast<arith::ConstantIndexOp>(v.getDefiningOp());
+      if (!c)
+        return failure();
+      strides.push_back(c);
+    }
+
+    SmallVector<Value> deps;
+    SmallVector<Type> tys;
+    auto ctx = op->getContext();
+    auto channel = FlatSymbolRefAttr::get(ctx, chanOp.getChanName());
+    rewriter.create<air::ChannelPutOp>(loc, tys, deps, channel, chanOp.getIndices(), chanOp.getMemref(),
+                                       offsets, sizes, strides);
+    rewriter.eraseOp(op);
+    rewriter.eraseOp(forOp);
+    return success();
+  }
+};
+
+class AIRHoistScfChannelGetPutPass : public air::AIRHoistScfChannelGetPutPassBase<AIRHoistScfChannelGetPutPass> {
+
+public:
+  AIRHoistScfChannelGetPutPass() = default;
+  AIRHoistScfChannelGetPutPass(const AIRHoistScfChannelGetPutPass &pass){};
+
+  void runOnOperation() override;
+
+private:
+};
+
+void AIRHoistScfChannelGetPutPass::runOnOperation() {
+  auto op = getOperation();
+  auto context = op->getContext();
+  RewritePatternSet patterns(context);
+  patterns.add<HoistScfChannelGetPutPass>(context);
+  (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+}
+
 } // anonymous namespace
 
 namespace xilinx {
@@ -918,6 +1022,10 @@ std::unique_ptr<Pass> createAIRRenumberDmaIdPass() {
 
 std::unique_ptr<Pass> createAIRLowerHerdParallelPass() {
   return std::make_unique<AIRLowerHerdParallelPass>();
+}
+
+std::unique_ptr<Pass> createAIRHoistScfChannelGetPutPass() {
+  return std::make_unique<AIRHoistScfChannelGetPutPass>();
 }
 
 } // namespace air

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -881,11 +881,10 @@ void AIRLowerHerdParallelPass::runOnOperation() {
   (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
 }
 
-class HoistScfChannelGetPutPass
-    : public RewritePattern {
+class HoistScfChannelGetPutPass : public RewritePattern {
 public:
   HoistScfChannelGetPutPass(MLIRContext *context, PatternBenefit benefit = 1)
-    : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
@@ -947,7 +946,8 @@ public:
         chanOp.getStrides()[ivOffsetIdx].getDefiningOp());
     auto foldedStride = step.value() * lastStride.value();
 
-    strides.push_back(rewriter.create<arith::ConstantIndexOp>(loc, foldedStride));
+    strides.push_back(
+        rewriter.create<arith::ConstantIndexOp>(loc, foldedStride));
     for (auto v : chanOp.getStrides()) {
       auto c = dyn_cast<arith::ConstantIndexOp>(v.getDefiningOp());
       if (!c)
@@ -973,7 +973,9 @@ public:
   }
 };
 
-class AIRHoistScfChannelGetPutPass : public air::AIRHoistScfChannelGetPutPassBase<AIRHoistScfChannelGetPutPass> {
+class AIRHoistScfChannelGetPutPass
+    : public air::AIRHoistScfChannelGetPutPassBase<
+          AIRHoistScfChannelGetPutPass> {
 
 public:
   AIRHoistScfChannelGetPutPass() = default;

--- a/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
@@ -9,7 +9,7 @@
 
 // CHECK: put @channel_0[%c0, %c0] (%arg0[%c0] [%c4, %c32] [%c32, %c1]) : (memref<128xf32>)
 // CHECK: get @channel_1[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c4096, %c128, %c1]) : (memref<128x128xf32>)
-// CHECK: put @channel_2[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c32, %c32, %c1]) : (memref<128x128xf32>)
+// CHECK: put @channel_2[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c32, %c128, %c1]) : (memref<128x128xf32>)
 #map = affine_map<(d0) -> (d0)>
 module {
   air.channel @channel_2 [1, 1]
@@ -28,7 +28,7 @@ module {
       air.channel.get  @channel_1[%c0, %c0] (%arg1[%arg2, %c0] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
     }
     scf.for %arg2 = %c0 to %c128 step %c32 {
-      air.channel.put  @channel_2[%c0, %c0] (%arg1[%c0, %arg2] [%c32, %c32] [%c32, %c1]) : (memref<128x128xf32>)
+      air.channel.put  @channel_2[%c0, %c0] (%arg1[%c0, %arg2] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
     }
     return %alloc : memref<128xf32>
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
@@ -1,0 +1,35 @@
+//===- air_hoist_channels.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-hoist-channels %s | FileCheck %s
+
+// CHECK: put @channel_0[%c0, %c0] (%arg0[%c0] [%c4, %c32] [%c32, %c1]) : (memref<128xf32>)
+// CHECK: get @channel_1[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c4096, %c128, %c1]) : (memref<128x128xf32>)
+// CHECK: put @channel_2[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c32, %c32, %c1]) : (memref<128x128xf32>)
+#map = affine_map<(d0) -> (d0)>
+module {
+  air.channel @channel_2 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  func.func @t0(%arg0: memref<128xf32>, %arg1: memref<128x128xf32>) -> memref<128xf32> {
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() : memref<128xf32>
+    scf.for %arg2 = %c0 to %c128 step %c32 {
+      air.channel.put  @channel_0[%c0, %c0] (%arg0[%arg2] [%c32] [%c1]) : (memref<128xf32>)
+    }
+    scf.for %arg2 = %c0 to %c128 step %c32 {
+      air.channel.get  @channel_1[%c0, %c0] (%arg1[%arg2, %c0] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
+    }
+    scf.for %arg2 = %c0 to %c128 step %c32 {
+      air.channel.put  @channel_2[%c0, %c0] (%arg1[%c0, %arg2] [%c32, %c32] [%c32, %c1]) : (memref<128x128xf32>)
+    }
+    return %alloc : memref<128xf32>
+  }
+}

--- a/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_hoist_channels.mlir
@@ -10,8 +10,12 @@
 // CHECK: put @channel_0[%c0, %c0] (%arg0[%c0] [%c4, %c32] [%c32, %c1]) : (memref<128xf32>)
 // CHECK: get @channel_1[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c4096, %c128, %c1]) : (memref<128x128xf32>)
 // CHECK: put @channel_2[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c32, %c32] [%c32, %c128, %c1]) : (memref<128x128xf32>)
+// CHECK: put @channel_3[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c4, %c32, %c32] [%c32, %c4096, %c128, %c1]) : (memref<128x128xf32>)
+// CHECK: get @channel_4[%c0, %c0] (%arg1[%c0, %c0] [%c4, %c4, %c32, %c32] [%c4096, %c32, %c128, %c1]) : (memref<128x128xf32>)
 #map = affine_map<(d0) -> (d0)>
 module {
+  air.channel @channel_4 [1, 1]
+  air.channel @channel_3 [1, 1]
   air.channel @channel_2 [1, 1]
   air.channel @channel_1 [1, 1]
   air.channel @channel_0 [1, 1]
@@ -29,6 +33,16 @@ module {
     }
     scf.for %arg2 = %c0 to %c128 step %c32 {
       air.channel.put  @channel_2[%c0, %c0] (%arg1[%c0, %arg2] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
+    }
+    scf.for %arg2 = %c0 to %c128 step %c32 {
+      scf.for %arg3 = %c0 to %c128 step %c32 {
+        air.channel.put  @channel_3[%c0, %c0] (%arg1[%arg3, %arg2] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
+      }
+    }
+    scf.for %arg2 = %c0 to %c128 step %c32 {
+      scf.for %arg3 = %c0 to %c128 step %c32 {
+        air.channel.get  @channel_4[%c0, %c0] (%arg1[%arg2, %arg3] [%c32, %c32] [%c128, %c1]) : (memref<128x128xf32>)
+      }
     }
     return %alloc : memref<128xf32>
   }


### PR DESCRIPTION
Some experiments hoisting `air.channel.get/put` out of loops by adding an extra dimension to the op.

In addition this adds some methods to the `air::ChannelInterface` interface