### PR TITLE
Small fixes for sysfs libxaie backend

### DIFF
--- a/runtime_lib/airhost/host.cpp
+++ b/runtime_lib/airhost/host.cpp
@@ -153,18 +153,11 @@ For a non-PCIe device, memory map the base address directly.
                          0x100000);              // offset
 
   XAie_BackendType backend;
-  if (mapped_aie_base == MAP_FAILED) {
-    printf("Failed mapping AIE BAR - using sysfs backend\n");
-    xaie->AieConfigPtr.Backend = XAIE_IO_BACKEND_SYSFS;
-    backend = XAIE_IO_BACKEND_SYSFS;
-    xaie->AieConfigPtr.BaseAddr = 0;
-    xaie->DevInst.IOInst = (void *)sysfs_path;
-  } else {
-    printf("Using Linux backend\n");
-    xaie->AieConfigPtr.Backend = XAIE_IO_BACKEND_LINUX;
-    backend = XAIE_IO_BACKEND_METAL;
-    xaie->AieConfigPtr.BaseAddr = (uint64_t)mapped_aie_base;
-  }
+  xaie->AieConfigPtr.Backend = XAIE_IO_BACKEND_AMDAIR;
+  backend = XAIE_IO_BACKEND_AMDAIR;
+  xaie->AieConfigPtr.BaseAddr = 0;
+  xaie->DevInst.IOInst = (void *)sysfs_path;
+
 #else
   xaie->AieConfigPtr.BaseAddr = XAIE_BASE_ADDR;
 #endif
@@ -325,6 +318,12 @@ uint64_t air_segment_load(const char *name) {
 
 #ifdef AIR_PCIE
   XAie_Finish(&(_air_host_active_libxaie->DevInst));
+
+  // Setting the driver libxaie backend back up
+  // Currently only targetting device 0
+  _air_host_active_libxaie->AieConfigPtr.Backend = XAIE_IO_BACKEND_AMDAIR;
+  _air_host_active_libxaie->DevInst.IOInst = (void *)"/sys/class/amdair/amdair/00";
+
   XAie_CfgInitialize(&(_air_host_active_libxaie->DevInst),
                      &(_air_host_active_libxaie->AieConfigPtr));
   XAie_PmRequestTiles(&(_air_host_active_libxaie->DevInst), NULL, 0);

--- a/runtime_lib/airhost/host.cpp
+++ b/runtime_lib/airhost/host.cpp
@@ -322,7 +322,8 @@ uint64_t air_segment_load(const char *name) {
   // Setting the driver libxaie backend back up
   // Currently only targetting device 0
   _air_host_active_libxaie->AieConfigPtr.Backend = XAIE_IO_BACKEND_AMDAIR;
-  _air_host_active_libxaie->DevInst.IOInst = (void *)"/sys/class/amdair/amdair/00";
+  _air_host_active_libxaie->DevInst.IOInst =
+      (void *)"/sys/class/amdair/amdair/00";
 
   XAie_CfgInitialize(&(_air_host_active_libxaie->DevInst),
                      &(_air_host_active_libxaie->AieConfigPtr));


### PR DESCRIPTION
Two changes:

1. Removing the ability to fall back to Linux backend as the Linux backend won't work on x86. Could fall back to the hacked debug backend, but unclear how useful that is if we are planning on not supporting it in the near future.
2. Initializing state of libxaie context created in segment_load to access driver's sysfs.