### PR TITLE
Make channel name the objfifo name

### DIFF
--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -10,7 +10,7 @@
 // CHECK: module @aie.segment_0 {
 // CHECK:   %0 = AIE.tile(1, 1)
 // CHECK:   %1 = AIE.tile(1, 2)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %3 = AIE.core(%1) {
 // CHECK:     %5 = AIE.objectFifo.acquire<Consume> (%2 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
 // CHECK:     %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
@@ -10,8 +10,8 @@
 // CHECK: module @aie.segment_0 {
 // CHECK:   %0 = AIE.tile(1, 1)
 // CHECK:   %1 = AIE.tile(2, 0)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%1, {%0}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%1, {%0}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %4 = AIE.core(%0) {
 // CHECK:     affine.for %arg0 = 0 to 4096 step 32 {
 // CHECK:       %5 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
@@ -10,8 +10,8 @@
 // CHECK: module @aie.partition_0 {
 // CHECK:   %0 = AIE.tile(1, 1)
 // CHECK:   %1 = AIE.tile(1, 2)
-// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 2) : !AIE.objectFifo<memref<32xi32, 2>>
-// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 2) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%0, {%1}, 1) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %4 = AIE.core(%1) {
 // CHECK:     %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
 // CHECK:     %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>


### PR DESCRIPTION
Set the symbol name of object fifos generated in air-to-aie to `"air_<channel_name>"`