### PR TITLE
AIR Runner: Improvements and bugfixes on resource backend

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -52,11 +52,18 @@ void traceDependentInductionVar(air::AsyncOpInterface async_op,
                                 std::vector<Operation *> &op_history);
 void eraseAsyncDependencyFromAsyncOp(xilinx::air::AsyncOpInterface op,
                                      Value token);
-void clearAsyncDependenciesOfAsyncOp(xilinx::air::AsyncOpInterface op);
+void clearAsyncDependenciesOfAsyncOp(Operation *op);
+void clearAsyncDependenciesOfAsyncOpImpl(xilinx::air::AsyncOpInterface op);
+void clearAsyncDependenciesOfAsyncOpImpl(scf::ForOp op);
+void clearAsyncDependenciesOfAsyncOpImpl(scf::ParallelOp op);
 Value getLoopCarriedTokenFromScfOp(scf::ParallelOp op);
 Value getLoopCarriedTokenFromScfOp(scf::ForOp op,
                                    std::string operand_or_argument = "operand");
-void addAsyncDependencyIfNew(air::AsyncOpInterface op, Value token);
+void addAsyncDependencyIfNew(Operation *op, Value token);
+void addAsyncDependencyIfNewImpl(air::AsyncOpInterface op, Value token);
+void addAsyncDependencyIfNewImpl(scf::ForOp op, Value token);
+void addAsyncDependencyIfNewImpl(scf::ParallelOp op, Value token);
+bool isAsyncOp(Operation *op);
 
 //===----------------------------------------------------------------------===//
 // Dependency graph parsed as a Boost graph object

--- a/mlir/include/air/Util/Runner.h
+++ b/mlir/include/air/Util/Runner.h
@@ -44,6 +44,7 @@ std::string to_string(mlir::Type t);
 std::string getElementTypeAsString(const mlir::Type ty);
 std::string lookUpMemorySpaceFromInt(unsigned memory_space);
 unsigned lookUpMemorySpaceIntFromString(std::string memory_space);
+template <typename T> void push_back_if_unique(std::vector<T> &vec, T entry);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -604,8 +604,8 @@ private:
     std::string cpuops = "math.rsqrt;";
     cpuops += "arith.mulf;arith.divf;arith.addf;arith.subf;arith.truncf;"
               "arith.cmpf;arith.maxf;";
-    cpuops += "arith.muli;arith.divi;arith.addi;arith.subi;arith.trunci;"
-              "arith.cmpi;arith.maxi";
+    cpuops += "arith.muli;arith.divsi;arith.divsi;arith.addi;arith.subi;"
+              "arith.trunci;arith.cmpi;arith.maxi";
     cpuops += "std.select";
     uint64_t memory_op_count = 0;
     uint64_t compute_op_count = 0;

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -584,14 +584,12 @@ private:
       if (!datawidth)
         op->emitOpError("found data type with zero width in JSON model");
     } else
-      op->emitOpError(
-          "is data movement with data type not found in JSON model");
+      op->emitOpError("data type not found in JSON model");
 
     double bytes = volume * datawidth;
     double bps = d.interfaces[{srcSpace, dstSpace}]->data_rate;
     if (bps == 0.0f)
-      op->emitOpError(
-          "is data movement with data rate not found in JSON model");
+      op->emitOpError("data rate not found in JSON model");
     double seconds = bytes / bps;
     return (uint64_t)ceil(seconds * cps);
   }

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -414,6 +414,7 @@ public:
 
     // Simulation performance report
     std::string end_ts = convertToTimeStampInStr(time, device_resource_node);
+    std::cout << "Latency: " << end_ts << "us\n";
   }
 
   void scheduleLaunch(runnerNode &launch, device &device_resource_node,

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -977,7 +977,7 @@ private:
   // Get the number of remaining dispatches in a dynamically dispatched event
   // (e.g., events in scf.parallel)
   unsigned getRemainingDispatchesForDynamicDispatch(air::ChannelPutOp putOp) {
-    // Only launch runner node holds channel_ops_in_progress cache
+    // Only launch runner node shall hold channel_ops_in_progress cache
     if (this->runner_node_type != "launch") {
       return 0;
     }
@@ -1190,7 +1190,6 @@ private:
     }
 
     // Get op progress
-    auto put = air::getTheOtherChannelOpThroughSymbol(op);
     auto put_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(
         op.getChanName().str(), "put");
     auto get_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -183,8 +183,6 @@ public:
         // If v is a hierarchy op, then recursively clear the entire subgraph
         if (G[v].asyncEventType == "hierarchy") {
           for (auto sub_c : G[v].nextDependencyGraphs) {
-            auto start = sub_c->start_vertex;
-            auto terminator_v = sub_c->terminator_vertex;
             auto sub_g = sub_c->g;
             auto sub_runner = sub_c->runner_node;
             sub_runner->resetGraph(time);
@@ -1005,7 +1003,6 @@ private:
                  runnerNode *sub_runner_node, Graph::vertex_descriptor it) {
     // Initialize sub runner and sub graph prior to execution
     auto sub_start_v = sub_runner_node->ctrl_g->start_vertex;
-    auto sub_terminator_v = sub_runner_node->ctrl_g->terminator_vertex;
     sub_runner_node->resetGraph(time);
     sub_runner_node->loop_trip_count.clear();
 

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
@@ -170,3 +170,186 @@ func.func @affine_if(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>
   }
   return
 }
+
+// Check with the presence of scf.for loop as consumer thread.
+// CHECK-LABEL: scf_for
+// CHECK: air.segment async
+// CHECK: air.segment async
+// CHECK: %[[EVENT0:.*]]:4 = scf.for {{.*}} iter_args(%[[EVENT1:.*]] = {{.*}} %[[EVENT2:.*]] = {{.*}} %[[EVENT3:.*]] = {{.*}} %[[EVENT4:.*]] = {{.*}})
+// CHECK: %[[EVENT5:.*]] = air.channel.get async [%[[EVENT4]], %[[EVENT1]]] @channel_5
+// CHECK: %[[EVENT6:.*]] = air.wait_all async [%[[EVENT3]], %[[EVENT5]]]
+// CHECK: %[[EVENT7:.*]] = scf.for
+// CHECK: %[[EVENT8:.*]] = air.wait_all async [%[[EVENT7]]]
+// CHECK: %[[EVENT9:.*]] = air.channel.get async [%[[EVENT5]], %[[EVENT2]]] @channel_5
+// CHECK-NEXT: %[[EVENT10:.*]] = air.wait_all async [%[[EVENT8]], %[[EVENT9]]]
+// CHECK-NEXT: %[[EVENT11:.*]] = scf.for
+// CHECK: %[[EVENT12:.*]] = air.wait_all async [%[[EVENT11]]]
+// CHECK: scf.yield %[[EVENT8]], %[[EVENT12]], %[[EVENT12]], %[[EVENT9]] : !air.async.token, !air.async.token, !air.async.token, !air.async.token
+// CHECK: air.segment async
+// CHECK: %[[EVENT0:.*]]:4 = scf.for {{.*}} iter_args(%[[EVENT1:.*]] = {{.*}} %[[EVENT2:.*]] = {{.*}} %[[EVENT3:.*]] = {{.*}} %[[EVENT4:.*]] = {{.*}})
+// CHECK: %[[EVENT5:.*]] = air.channel.get async [%[[EVENT4]], %[[EVENT1]]] @channel_7
+// CHECK: %[[EVENT6:.*]] = air.wait_all async [%[[EVENT3]], %[[EVENT5]]]
+// CHECK: %[[EVENT7:.*]] = scf.for
+// CHECK: %[[EVENT8:.*]] = air.wait_all async [%[[EVENT7]]]
+// CHECK: %[[EVENT9:.*]] = air.channel.get async [%[[EVENT5]], %[[EVENT2]]] @channel_7
+// CHECK-NEXT: %[[EVENT10:.*]] = air.wait_all async [%[[EVENT8]], %[[EVENT9]]]
+// CHECK-NEXT: %[[EVENT11:.*]] = scf.for
+// CHECK: %[[EVENT12:.*]] = air.wait_all async [%[[EVENT11]]]
+// CHECK: scf.yield %[[EVENT8]], %[[EVENT12]], %[[EVENT12]], %[[EVENT9]] : !air.async.token, !air.async.token, !air.async.token, !air.async.token
+
+air.channel @channel_8 [1, 1]
+air.channel @channel_7 [1, 1]
+air.channel @channel_6 [1, 1]
+air.channel @channel_5 [1, 1]
+func.func @scf_for() {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+    %1 = air.segment async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+      %c0 = arith.constant 0 : index
+      %c1024 = arith.constant 1024 : index
+      %c256 = arith.constant 256 : index
+      %4 = air.wait_all async 
+      %5 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %4) -> (!air.async.token) {
+        %async_token, %results = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x128xbf16, 1>
+          air.execute_terminator %alloc : memref<128x128xbf16, 1>
+        }
+        %6 = air.channel.put async [%async_token]  @channel_5[] (%results[] [] []) {id = 16 : i32} : (memref<128x128xbf16, 1>)
+        %async_token_0 = air.execute [%6] {
+          memref.dealloc %results : memref<128x128xbf16, 1>
+        }
+        scf.yield %async_token_0 : !air.async.token
+      }
+      air.segment_terminator
+    }
+    %2 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+      %c512 = arith.constant 512 : index
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c1024 = arith.constant 1024 : index
+      %c128 = arith.constant 128 : index
+      %c256 = arith.constant 256 : index
+      %4 = air.wait_all async 
+      %async_token, %results = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+        %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+        air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+      %async_token_1, %results_2 = air.execute [%async_token] -> (memref<128x1024xbf16, 1>) {
+        %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+        air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %5 = scf.for %arg4 = %c0 to %c1024 step %c512 iter_args(%arg5 = %async_token_1) -> (!air.async.token) {
+        %8 = air.channel.get async [%arg5]  @channel_5[] (%results_2[%arg4, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, unrolled_iteration = 0 : i32} : (memref<128x1024xbf16, 1>)
+        %9 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %8) -> (!air.async.token) {
+          %15 = air.channel.put async [%arg7]  @channel_6[] (%results_2[%c0, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+          scf.yield %15 : !air.async.token
+        } {unrolled_iteration = 0 : i32}
+        %10 = air.wait_all async [%9]  {async_back = true, unrolled_iteration = 0 : i32}
+        %11 = arith.addi %arg4, %c256 : index
+        %12 = air.channel.get async [%10]  @channel_5[] (%results[%11, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, unrolled_iteration = 1 : i32} : (memref<128x1024xbf16, 1>)
+        %13 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %12) -> (!air.async.token) {
+          %15 = air.channel.put async [%arg7]  @channel_6[] (%results[%c0, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+          scf.yield %15 : !air.async.token
+        } {unrolled_iteration = 1 : i32}
+        %14 = air.wait_all async [%13]  {async_back = true, unrolled_iteration = 1 : i32}
+        scf.yield %14 : !air.async.token
+      } {unroll = 2 : i64}
+      %async_token_3 = air.execute [%5] {
+        memref.dealloc %results_2 : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %async_token_4 = air.execute [%5] {
+        memref.dealloc %results : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+      %6 = air.wait_all async 
+      %7 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %6) -> (!air.async.token) {
+        %async_token_5, %results_6 = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x128xbf16, 1>
+          air.execute_terminator %alloc : memref<128x128xbf16, 1>
+        }
+        %8 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %async_token_5) -> (!air.async.token) {
+          %async_token_8, %results_9 = air.execute [%arg7] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %10 = air.channel.get async [%async_token_8]  @channel_6[] (%results_9[] [] []) {id = 22 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_10 = air.execute [%10] {
+            memref.dealloc %results_9 : memref<128x128xbf16, 1>
+          }
+          %11 = air.wait_all async [%async_token_10] 
+          scf.yield %11 : !air.async.token
+        }
+        %9 = air.channel.put async [%8]  @channel_7[] (%results_6[] [] []) {id = 32 : i32} : (memref<128x128xbf16, 1>)
+        %async_token_7 = air.execute [%9] {
+          memref.dealloc %results_6 : memref<128x128xbf16, 1>
+        }
+        scf.yield %async_token_7 : !air.async.token
+      }
+      air.segment_terminator
+    }
+    %3 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+      %c512 = arith.constant 512 : index
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c1024 = arith.constant 1024 : index
+      %c128 = arith.constant 128 : index
+      %c256 = arith.constant 256 : index
+      %4 = air.wait_all async 
+      %async_token, %results = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+        %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+        air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+      %async_token_1, %results_2 = air.execute [%async_token] -> (memref<128x1024xbf16, 1>) {
+        %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+        air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %5 = scf.for %arg4 = %c0 to %c1024 step %c512 iter_args(%arg5 = %async_token_1) -> (!air.async.token) {
+        %8 = air.channel.get async [%arg5]  @channel_7[] (%results_2[%arg4, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, unrolled_iteration = 0 : i32} : (memref<128x1024xbf16, 1>)
+        %9 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %8) -> (!air.async.token) {
+          %15 = air.channel.put async [%arg7]  @channel_8[] (%results_2[%arg4, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+          scf.yield %15 : !air.async.token
+        } {unrolled_iteration = 0 : i32}
+        %10 = air.wait_all async [%9]  {async_back = true, unrolled_iteration = 0 : i32}
+        %11 = arith.addi %arg4, %c256 : index
+        %12 = air.channel.get async [%10]  @channel_7[] (%results[%11, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, unrolled_iteration = 1 : i32} : (memref<128x1024xbf16, 1>)
+        %13 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %12) -> (!air.async.token) {
+          %15 = air.channel.put async [%arg7]  @channel_8[] (%results[%11, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+          scf.yield %15 : !air.async.token
+        } {unrolled_iteration = 1 : i32}
+        %14 = air.wait_all async [%13]  {async_back = true, unrolled_iteration = 1 : i32}
+        scf.yield %14 : !air.async.token
+      } {unroll = 2 : i64}
+      %async_token_3 = air.execute [%5] {
+        memref.dealloc %results_2 : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %async_token_4 = air.execute [%5] {
+        memref.dealloc %results : memref<128x1024xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+      %6 = air.wait_all async 
+      %7 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %6) -> (!air.async.token) {
+        %async_token_5, %results_6 = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x128xbf16, 1>
+          air.execute_terminator %alloc : memref<128x128xbf16, 1>
+        }
+        %8 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %async_token_5) -> (!air.async.token) {
+          %async_token_8, %results_9 = air.execute [%arg7] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %9 = air.channel.get async [%async_token_8]  @channel_8[] (%results_9[] [] []) {id = 38 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_10 = air.execute [%9] {
+            memref.dealloc %results_9 : memref<128x128xbf16, 1>
+          }
+          %10 = air.wait_all async [%async_token_10] 
+          scf.yield %10 : !air.async.token
+        }
+        %async_token_7 = air.execute [%8] {
+          memref.dealloc %results_6 : memref<128x128xbf16, 1>
+        }
+        scf.yield %async_token_7 : !air.async.token
+      }
+      air.segment_terminator
+    }
+    air.launch_terminator
+  }
+  return
+}

--- a/mlir/test/Util/Runner/cost_function/arch.json
+++ b/mlir/test/Util/Runner/cost_function/arch.json
@@ -1,0 +1,133 @@
+{
+    "clock": 1000000000,
+    "cores": 1,
+    "datatypes": [
+        {
+        "bytes": 1,
+        "name": "i8"
+        },
+        {
+        "bytes": 2,
+        "name": "bf16"
+        },
+        {
+        "bytes": 4,
+        "name": "i32"
+        }
+    ],
+    "devicename": "testdevice",
+    "kernels": {
+        "linalg.copy": {
+            "datatypes": {
+                "i8": {
+                    "ops_per_core_per_cycle": 32,
+                    "efficiency": 1
+                },
+                "bf16": {
+                    "ops_per_core_per_cycle": 32,
+                    "efficiency": 1
+                },
+                "i32": {
+                    "ops_per_core_per_cycle": 16,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.copy"
+        },
+        "linalg.fill": {
+            "datatypes": {
+                "i8": {
+                    "ops_per_core_per_cycle": 32,
+                    "efficiency": 1
+                },
+                "bf16": {
+                    "ops_per_core_per_cycle": 32,
+                    "efficiency": 1
+                },
+                "i32": {
+                    "ops_per_core_per_cycle": 16,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.fill"
+        },
+        "linalg.generic": {
+            "datatypes": {
+                "i8": {
+                    "ops_per_core_per_cycle": 1,
+                    "efficiency": 1
+                },
+                "bf16": {
+                    "ops_per_core_per_cycle": 1,
+                    "efficiency": 1
+                },
+                "i32": {
+                    "ops_per_core_per_cycle": 1,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.generic"
+        },
+        "linalg.matmul": {
+            "datatypes": {
+                "i8": {
+                    "macs_per_core_per_cycle": 256,
+                    "efficiency": 1
+                },
+                "bf16": {
+                    "macs_per_core_per_cycle": 128,
+                    "efficiency": 1
+                },
+                "i32": {
+                    "macs_per_core_per_cycle": 32,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.matmul"
+        }
+    },
+    "dus": {
+        "count": [4, 4],
+        "memory": {
+            "memory_space": "L2",
+            "bytes": 524288
+        },
+        "ports": {
+            "outbound": {
+                "count": 6,
+                "bytes_per_second": 4000000000
+            },
+            "inbound": {
+                "count": 6,
+                "bytes_per_second": 4000000000
+            }
+        },
+        "tiles": {
+            "count": [1, 4],
+            "memory": {
+                "memory_space": "L1",
+                "bytes": 65536
+            },
+            "ports": {
+                "outbound": {
+                    "count": 2,
+                    "bytes_per_second": 4000000000
+                },
+                "inbound": {
+                    "count": 2,
+                    "bytes_per_second": 4000000000
+                }
+            }
+        }
+    },
+    "noc": {
+        "outbound": {
+            "count": 4,
+            "bytes_per_second": 4000000000
+        },
+        "inbound": {
+            "count": 4,
+            "bytes_per_second": 4000000000
+        }
+    }
+  }

--- a/mlir/test/Util/Runner/cost_function/data_movement.mlir
+++ b/mlir/test/Util/Runner/cost_function/data_movement.mlir
@@ -1,0 +1,129 @@
+//===- data_movement.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Test trace latency modelling of data movement.
+
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME0:]],
+
+// CHECK: "name": "ChannelGetOp@channel_2(L1<--L2)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME1:]],
+
+// CHECK: "name": "ChannelGetOp@channel_2(L1<--L2)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#TIME1 + 512]],
+
+// CHECK: "name": "ChannelGetOp@channel_4(L1<--L2)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.[[#%d,TIME2:]],
+
+// CHECK: "name": "ChannelGetOp@channel_4(L1<--L2)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#TIME2 + 256]],
+
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 1.0[[#TIME0 + 1024 - 1000]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  air.channel @channel_0 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_2 [1, 1]
+  air.channel @channel_3 [1, 1]
+  air.channel @channel_4 [1, 1]
+  air.channel @channel_5 [1, 1]
+  func.func @test(%arg0: memref<32x32xi32>, %arg1: memref<1024x1024xi32>, %arg2: memref<1024x1024xi32>, %arg3: memref<1024x1024xi32>) -> memref<32x32xi32> {
+    %c1 = arith.constant 1 : index
+    %async_token_1, %results_2 = air.execute -> (memref<32x32xi32>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xi32>
+      air.execute_terminator %alloc : memref<32x32xi32>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<32x32xi32>, memref<1024x1024xi32> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<32x32xi32>, memref<1024x1024xi32> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c4 = arith.constant 4 : index
+        %c1_0 = arith.constant 1 : index
+        %async_token_3, %results_4 = air.execute -> (memref<32x32xi32, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xi32, 1>
+          air.execute_terminator %alloc : memref<32x32xi32, 1>
+        }
+        %3 = air.channel.put async [%async_token_3]  @channel_0[] (%results_4[] [] []) : (memref<32x32xi32, 1>)
+        %async_token_5, %results_6 = air.execute -> (memref<32x32xi32, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xi32, 1>
+          air.execute_terminator %alloc : memref<32x32xi32, 1>
+        }
+        %4 = air.channel.get async [%async_token_5]  @channel_1[] (%results_6[] [] []) : (memref<32x32xi32, 1>)
+        %async_token_7, %results_8 = air.execute -> (memref<32x32xbf16, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xbf16, 1>
+          air.execute_terminator %alloc : memref<32x32xbf16, 1>
+        }
+        %5 = air.channel.put async [%async_token_7]  @channel_2[] (%results_8[] [] []) : (memref<32x32xbf16, 1>)
+        %async_token_9, %results_10 = air.execute -> (memref<32x32xbf16, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xbf16, 1>
+          air.execute_terminator %alloc : memref<32x32xbf16, 1>
+        }
+        %6 = air.channel.get async [%async_token_9]  @channel_3[] (%results_10[] [] []) : (memref<32x32xbf16, 1>)
+        %async_token_11, %results_12 = air.execute -> (memref<32x32xi8, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xi8, 1>
+          air.execute_terminator %alloc : memref<32x32xi8, 1>
+        }
+        %7 = air.channel.put async [%async_token_11]  @channel_4[] (%results_12[] [] []) : (memref<32x32xi8, 1>)
+        %async_token_13, %results_14 = air.execute -> (memref<32x32xi8, 1>) {
+          %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x32xi8, 1>
+          air.execute_terminator %alloc : memref<32x32xi8, 1>
+        }
+        %8 = air.channel.get async [%async_token_13]  @channel_5[] (%results_14[] [] []) : (memref<32x32xi8, 1>)
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c1_0, %arg24=%c1_0) {
+          %cst_8 = arith.constant 2 : i32
+          %cst_9 = arith.constant 1 : i32
+          %cst_10 = arith.constant 1 : i32
+          %async_token_15, %results_16 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %9 = air.channel.get async [%async_token_15]  @channel_0[] (%results_16[] [] []) : (memref<32x32xi32, 2>)
+          %10 = air.channel.put async [%9]  @channel_1[] (%results_16[] [] []) : (memref<32x32xi32, 2>)
+          %async_token_17 = air.execute [%10] {
+            memref.dealloc %results_16 : memref<32x32xi32, 2>
+          }
+          %async_token_19, %results_20 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %11 = air.channel.get async [%async_token_19]  @channel_2[] (%results_20[] [] []) : (memref<32x32xbf16, 2>)
+          %12 = air.channel.put async [%11]  @channel_3[] (%results_20[] [] []) : (memref<32x32xbf16, 2>)
+          %async_token_21 = air.execute [%12] {
+            memref.dealloc %results_20 : memref<32x32xbf16, 2>
+          }
+          %async_token_23, %results_24 = air.execute -> (memref<32x32xi8, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi8, 2>
+            air.execute_terminator %alloc : memref<32x32xi8, 2>
+          }
+          %13 = air.channel.get async [%async_token_23]  @channel_4[] (%results_24[] [] []) : (memref<32x32xi8, 2>)
+          %14 = air.channel.put async [%13]  @channel_5[] (%results_24[] [] []) : (memref<32x32xi8, 2>)
+          %async_token_25 = air.execute [%14] {
+            memref.dealloc %results_24 : memref<32x32xi8, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<32x32xi32>
+  }
+}

--- a/mlir/test/Util/Runner/cost_function/generic_i32.mlir
+++ b/mlir/test/Util/Runner/cost_function/generic_i32.mlir
@@ -1,0 +1,72 @@
+//===- generic_i32.mlir ----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Test trace latency modelling of linalg.generic ops.
+
+// CHECK: "name": "LinalgOp(linalg.generic)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME0:]],
+// CHECK: "name": "LinalgOp(linalg.generic)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 4.[[#TIME0 + 4096 - 4000]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @test(%arg0: memref<256x1024xi32>, %arg1: memref<1024x1024xi32>, %arg2: memref<1024x1024xi32>, %arg3: memref<1024x1024xi32>) -> memref<256x1024xi32> {
+    %c1 = arith.constant 1 : index
+    %async_token_1, %results_2 = air.execute -> (memref<256x1024xi32>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<256x1024xi32>
+      air.execute_terminator %alloc : memref<256x1024xi32>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xi32>, memref<1024x1024xi32> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xi32>, memref<1024x1024xi32> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %cst_8 = arith.constant 2 : i32
+          %cst_9 = arith.constant 1 : i32
+          %cst_10 = arith.constant 1 : i32
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %async_token_5, %results_6 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %async_token_7 = air.execute [%async_token_3, %async_token_5] {
+            linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%results_4 : memref<32x32xi32, 2>) outs(%results_6 : memref<32x32xi32, 2>) {
+            ^bb0(%in: i32, %out: i32):
+              %9 = arith.divsi %in, %cst_8 : i32
+              %11 = arith.addi %9, %cst_9 : i32
+              %12 = arith.muli %11, %cst_10 : i32
+              %13 = arith.muli %in, %12 : i32
+              linalg.yield %13 : i32
+            }
+          }
+          %async_token_10 = air.execute [%async_token_7] {
+            memref.dealloc %results_4 : memref<32x32xi32, 2>
+          }
+          %async_token_11 = air.execute [%async_token_7] {
+            memref.dealloc %results_6 : memref<32x32xi32, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<256x1024xi32>
+  }
+}

--- a/mlir/test/Util/Runner/cost_function/mac_bf16.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_bf16.mlir
@@ -1,0 +1,68 @@
+//===- mac_bf16.mlir -------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Test trace latency modelling of MACs.
+
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME0:]],
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#TIME0 + 256]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  func.func @test(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>, %arg2: memref<1024x1024xbf16>, %arg3: memref<1024x1024xbf16>) -> memref<256x1024xbf16> {
+    %c1 = arith.constant 1 : index
+    %async_token_1, %results_2 = air.execute -> (memref<256x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<256x1024xbf16>
+      air.execute_terminator %alloc : memref<256x1024xbf16>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_5, %results_6 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_7, %results_8 = air.execute -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_9 = air.execute [%async_token_5, %async_token_7] {
+            linalg.matmul ins(%results_4, %results_6 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%results_8 : memref<32x32xbf16, 2>)
+          }
+          %async_token_10 = air.execute [%async_token_9] {
+            memref.dealloc %results_4 : memref<32x32xbf16, 2>
+          }
+          %async_token_11 = air.execute [%async_token_9] {
+            memref.dealloc %results_6 : memref<32x32xbf16, 2>
+          }
+          %async_token_12 = air.execute [%async_token_9] {
+            memref.dealloc %results_8 : memref<32x32xbf16, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<256x1024xbf16>
+  }
+}

--- a/mlir/test/Util/Runner/cost_function/mac_i32.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_i32.mlir
@@ -1,0 +1,68 @@
+//===- mac_i32.mlir --------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Test trace latency modelling of MACs.
+
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME0:]],
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 1.0[[#TIME0 + 1024 - 1000]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  func.func @test(%arg0: memref<256x1024xi32>, %arg1: memref<1024x1024xi32>, %arg2: memref<1024x1024xi32>, %arg3: memref<1024x1024xi32>) -> memref<256x1024xi32> {
+    %c1 = arith.constant 1 : index
+    %async_token_1, %results_2 = air.execute -> (memref<256x1024xi32>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<256x1024xi32>
+      air.execute_terminator %alloc : memref<256x1024xi32>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xi32>, memref<1024x1024xi32> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xi32>, memref<1024x1024xi32> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %async_token_5, %results_6 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %async_token_7, %results_8 = air.execute -> (memref<32x32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi32, 2>
+            air.execute_terminator %alloc : memref<32x32xi32, 2>
+          }
+          %async_token_9 = air.execute [%async_token_5, %async_token_7] {
+            linalg.matmul ins(%results_4, %results_6 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%results_8 : memref<32x32xi32, 2>)
+          }
+          %async_token_10 = air.execute [%async_token_9] {
+            memref.dealloc %results_4 : memref<32x32xi32, 2>
+          }
+          %async_token_11 = air.execute [%async_token_9] {
+            memref.dealloc %results_6 : memref<32x32xi32, 2>
+          }
+          %async_token_12 = air.execute [%async_token_9] {
+            memref.dealloc %results_8 : memref<32x32xi32, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<256x1024xi32>
+  }
+}

--- a/mlir/test/Util/Runner/cost_function/mac_i8.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_i8.mlir
@@ -1,0 +1,68 @@
+//===- mac_i8.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// Test trace latency modelling of MACs.
+
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,TIME0:]],
+// CHECK: "name": "LinalgOp(linalg.matmul)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#TIME0 + 128]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  func.func @test(%arg0: memref<256x1024xi8>, %arg1: memref<1024x1024xi8>, %arg2: memref<1024x1024xi8>, %arg3: memref<1024x1024xi8>) -> memref<256x1024xi8> {
+    %c1 = arith.constant 1 : index
+    %async_token_1, %results_2 = air.execute -> (memref<256x1024xi8>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<256x1024xi8>
+      air.execute_terminator %alloc : memref<256x1024xi8>
+    }
+    %0 = air.launch async [%async_token_1] (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xi8>, memref<1024x1024xi8> attributes {id = 7 : i32} {
+      %1 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xi8>, memref<1024x1024xi8> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %async_token_3, %results_4 = air.execute -> (memref<32x32xi8, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi8, 2>
+            air.execute_terminator %alloc : memref<32x32xi8, 2>
+          }
+          %async_token_5, %results_6 = air.execute -> (memref<32x32xi8, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi8, 2>
+            air.execute_terminator %alloc : memref<32x32xi8, 2>
+          }
+          %async_token_7, %results_8 = air.execute -> (memref<32x32xi8, 2>) {
+            %alloc = memref.alloc() : memref<32x32xi8, 2>
+            air.execute_terminator %alloc : memref<32x32xi8, 2>
+          }
+          %async_token_9 = air.execute [%async_token_5, %async_token_7] {
+            linalg.matmul ins(%results_4, %results_6 : memref<32x32xi8, 2>, memref<32x32xi8, 2>) outs(%results_8 : memref<32x32xi8, 2>)
+          }
+          %async_token_10 = air.execute [%async_token_9] {
+            memref.dealloc %results_4 : memref<32x32xi8, 2>
+          }
+          %async_token_11 = air.execute [%async_token_9] {
+            memref.dealloc %results_6 : memref<32x32xi8, 2>
+          }
+          %async_token_12 = air.execute [%async_token_9] {
+            memref.dealloc %results_8 : memref<32x32xi8, 2>
+          }
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_2 : memref<256x1024xi8>
+  }
+}

--- a/mlir/test/Util/Runner/segment_dataflow.mlir
+++ b/mlir/test/Util/Runner/segment_dataflow.mlir
@@ -1,0 +1,257 @@
+//===- segment_dataflow.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// A dataflow pipeline made of air.segments as pipeline stages.
+// Stages are connected with FIFOs to enable concurrent execution.
+
+// CHECK: "name": "ChannelGetOp@channel_5(L2<--L2)",
+// CHECK: "name": "ChannelGetOp@channel_1(L2<--L3)",
+// CHECK: "name": "ChannelGetOp@channel_9(L2<--L2)",
+// CHECK: "name": "ChannelGetOp@channel_5(L2<--L2)",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  air.channel @channel_11 [1, 1]
+  air.channel @channel_10 [1, 1]
+  air.channel @channel_9 [1, 1]
+  air.channel @channel_8 [1, 1]
+  air.channel @channel_7 [1, 1]
+  air.channel @channel_6 [1, 1]
+  air.channel @channel_5 [1, 1]
+  air.channel @channel_4 [1, 1]
+  air.channel @channel_3 [1, 1]
+  air.channel @channel_2 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  func.func @test(%arg0: memref<1024x1024xbf16>, %arg1: memref<1024x1024xbf16>, %arg2: memref<1024x1024xbf16>, %arg3: memref<1024x1024xbf16>) -> memref<1024x1024xbf16> {
+    %c1 = arith.constant 1 : index
+    %async_token, %results = air.execute -> (memref<1024x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<1024x1024xbf16>
+      air.execute_terminator %alloc : memref<1024x1024xbf16>
+    }
+    %async_token_0, %results_1 = air.execute -> (memref<1024x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<1024x1024xbf16>
+      air.execute_terminator %alloc : memref<1024x1024xbf16>
+    }
+    %async_token_2, %results_3 = air.execute -> (memref<1024x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<1024x1024xbf16>
+      air.execute_terminator %alloc : memref<1024x1024xbf16>
+    }
+    %async_token_4, %results_5 = air.execute -> (memref<1024x1024xbf16>) {
+      %alloc = memref.alloc() {alignment = 128 : i64} : memref<1024x1024xbf16>
+      air.execute_terminator %alloc : memref<1024x1024xbf16>
+    }
+    %0 = air.launch async (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1, %arg10=%results_1, %arg11=%arg2, %arg12=%arg3, %arg13=%results_3, %arg14=%results_5) : memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xbf16>, memref<1024x1024xbf16> attributes {id = 1 : i32} {
+      %c1_6 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c1024 = arith.constant 1024 : index
+      %c128 = arith.constant 128 : index
+      %c256 = arith.constant 256 : index
+      %1 = air.wait_all async 
+      %2 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %1) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_0[] (%arg10[%arg15, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 1 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %3 = air.wait_all async 
+      %4 = scf.for %arg15 = %c0 to %c1024 step %c128 iter_args(%arg16 = %3) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_1[] (%arg8[%arg15, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 2 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %5 = air.wait_all async 
+      %6 = scf.for %arg15 = %c0 to %c1024 step %c128 iter_args(%arg16 = %5) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_2[] (%arg9[%c0, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 3 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %7 = air.segment async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c0_7 = arith.constant 0 : index
+        %c1024_8 = arith.constant 1024 : index
+        %c128_9 = arith.constant 128 : index
+        %c256_10 = arith.constant 256 : index
+        %20 = air.wait_all async 
+        %21 = scf.for %arg15 = %c0_7 to %c1024_8 step %c256_10 iter_args(%arg16 = %20) -> (!air.async.token) {
+          %async_token_11, %results_12 = air.execute [%arg16] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %22 = air.channel.get async [%async_token_11]  @channel_0[] (%results_12[] [] []) {id = 5 : i32} : (memref<128x128xbf16, 1>)
+          %23 = scf.for %arg17 = %c0_7 to %c256_10 step %c128_9 iter_args(%arg18 = %22) -> (!air.async.token) {
+            %async_token_14, %results_15 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %async_token_16, %results_17 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %25 = air.channel.get async [%async_token_14]  @channel_1[] (%results_15[] [] []) {id = 6 : i32} : (memref<128x128xbf16, 1>)
+            %26 = air.channel.get async [%async_token_16]  @channel_2[] (%results_17[] [] []) {id = 7 : i32} : (memref<128x128xbf16, 1>)
+            %async_token_18 = air.execute [%25] {
+              memref.dealloc %results_15 : memref<128x128xbf16, 1>
+            }
+            %async_token_19 = air.execute [%26] {
+              memref.dealloc %results_17 : memref<128x128xbf16, 1>
+            }
+            %27 = air.wait_all async [%async_token_18, %async_token_19] 
+            scf.yield %27 : !air.async.token
+          }
+          %24 = air.channel.put async [%23]  @channel_3[] (%results_12[] [] []) {id = 16 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_13 = air.execute [%24] {
+            memref.dealloc %results_12 : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_13 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      %8 = air.wait_all async 
+      %9 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %8) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_4[] (%arg13[%arg15, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 17 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %10 = air.wait_all async 
+      %11 = scf.for %arg15 = %c0 to %c1024 step %c128 iter_args(%arg16 = %10) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_6[] (%arg11[%c0, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 19 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %12 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c1_7 = arith.constant 1 : index
+        %c0_8 = arith.constant 0 : index
+        %c1024_9 = arith.constant 1024 : index
+        %c128_10 = arith.constant 128 : index
+        %c256_11 = arith.constant 256 : index
+        %async_token_12, %results_13 = air.execute -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        }
+        %20 = scf.for %arg15 = %c0_8 to %c1024_9 step %c256_11 iter_args(%arg16 = %async_token_12) -> (!air.async.token) {
+          %23 = air.channel.get async [%arg16]  @channel_3[] (%results_13[%arg15, %c0_8] [%c128_10, %c128_10] [%c1024_9, %c1_7]) {id = 4 : i32} : (memref<128x1024xbf16, 1>)
+          %24 = scf.for %arg17 = %c0_8 to %c256_11 step %c128_10 iter_args(%arg18 = %23) -> (!air.async.token) {
+            %25 = air.channel.put async [%arg18]  @channel_5[] (%results_13[%c0_8, %c0_8] [%c128_10, %c128_10] [%c128_10, %c1_7]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %25 : !air.async.token
+          }
+          scf.yield %24 : !air.async.token
+        }
+        %async_token_14 = air.execute [%20] {
+          memref.dealloc %results_13 : memref<128x1024xbf16, 1>
+        }
+        %21 = air.wait_all async 
+        %22 = scf.for %arg15 = %c0_8 to %c1024_9 step %c256_11 iter_args(%arg16 = %21) -> (!air.async.token) {
+          %async_token_15, %results_16 = air.execute [%arg16] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %23 = air.channel.get async [%async_token_15]  @channel_4[] (%results_16[] [] []) {id = 21 : i32} : (memref<128x128xbf16, 1>)
+          %24 = scf.for %arg17 = %c0_8 to %c256_11 step %c128_10 iter_args(%arg18 = %23) -> (!air.async.token) {
+            %async_token_18, %results_19 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %async_token_20, %results_21 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %26 = air.channel.get async [%async_token_18]  @channel_5[] (%results_19[] [] []) {id = 22 : i32} : (memref<128x128xbf16, 1>)
+            %27 = air.channel.get async [%async_token_20]  @channel_6[] (%results_21[] [] []) {id = 23 : i32} : (memref<128x128xbf16, 1>)
+            %async_token_22 = air.execute [%26] {
+              memref.dealloc %results_19 : memref<128x128xbf16, 1>
+            }
+            %async_token_23 = air.execute [%27] {
+              memref.dealloc %results_21 : memref<128x128xbf16, 1>
+            }
+            %28 = air.wait_all async [%async_token_23, %async_token_22] 
+            scf.yield %28 : !air.async.token
+          }
+          %25 = air.channel.put async [%24]  @channel_7[] (%results_16[] [] []) {id = 32 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_17 = air.execute [%25] {
+            memref.dealloc %results_16 : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_17 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      %13 = air.wait_all async 
+      %14 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %13) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_8[] (%arg14[%arg15, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 33 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %15 = air.wait_all async 
+      %16 = scf.for %arg15 = %c0 to %c1024 step %c128 iter_args(%arg16 = %15) -> (!air.async.token) {
+        %20 = air.channel.put async [%arg16]  @channel_10[] (%arg12[%c0, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 35 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %17 = air.wait_all async 
+      %18 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %17) -> (!air.async.token) {
+        %20 = air.channel.get async [%arg16]  @channel_11[] (%arg14[%arg15, %c0] [%c128, %c128] [%c1024, %c1_6]) {id = 36 : i32} : (memref<1024x1024xbf16>)
+        scf.yield %20 : !air.async.token
+      }
+      %19 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c1_7 = arith.constant 1 : index
+        %c0_8 = arith.constant 0 : index
+        %c1024_9 = arith.constant 1024 : index
+        %c128_10 = arith.constant 128 : index
+        %c256_11 = arith.constant 256 : index
+        %async_token_12, %results_13 = air.execute -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        }
+        %20 = scf.for %arg15 = %c0_8 to %c1024_9 step %c256_11 iter_args(%arg16 = %async_token_12) -> (!air.async.token) {
+          %23 = air.channel.get async [%arg16]  @channel_7[] (%results_13[%arg15, %c0_8] [%c128_10, %c128_10] [%c1024_9, %c1_7]) {id = 4 : i32} : (memref<128x1024xbf16, 1>)
+          %24 = scf.for %arg17 = %c0_8 to %c256_11 step %c128_10 iter_args(%arg18 = %23) -> (!air.async.token) {
+            %25 = air.channel.put async [%arg18]  @channel_9[] (%results_13[%arg15, %c0_8] [%c128_10, %c128_10] [%c128_10, %c1_7]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %25 : !air.async.token
+          }
+          scf.yield %24 : !air.async.token
+        }
+        %async_token_14 = air.execute [%20] {
+          memref.dealloc %results_13 : memref<128x1024xbf16, 1>
+        }
+        %21 = air.wait_all async 
+        %22 = scf.for %arg15 = %c0_8 to %c1024_9 step %c256_11 iter_args(%arg16 = %21) -> (!air.async.token) {
+          %async_token_15, %results_16 = air.execute [%arg16] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %23 = air.channel.get async [%async_token_15]  @channel_8[] (%results_16[] [] []) {id = 37 : i32} : (memref<128x128xbf16, 1>)
+          %24 = scf.for %arg17 = %c0_8 to %c256_11 step %c128_10 iter_args(%arg18 = %23) -> (!air.async.token) {
+            %async_token_18, %results_19 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %async_token_20, %results_21 = air.execute [%arg18] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %26 = air.channel.get async [%async_token_18]  @channel_9[] (%results_19[] [] []) {id = 38 : i32} : (memref<128x128xbf16, 1>)
+            %27 = air.channel.get async [%async_token_20]  @channel_10[] (%results_21[] [] []) {id = 39 : i32} : (memref<128x128xbf16, 1>)
+            %async_token_22 = air.execute [%26] {
+              memref.dealloc %results_19 : memref<128x128xbf16, 1>
+            }
+            %async_token_23 = air.execute [%27] {
+              memref.dealloc %results_21 : memref<128x128xbf16, 1>
+            }
+            %28 = air.wait_all async [%async_token_23, %async_token_22] 
+            scf.yield %28 : !air.async.token
+          }
+          %25 = air.channel.put async [%24]  @channel_11[] (%results_16[] [] []) {id = 48 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_17 = air.execute [%25] {
+            memref.dealloc %results_16 : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_17 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return %results_5 : memref<1024x1024xbf16>
+  }
+}

--- a/mlir/test/Util/Runner/segment_dataflow_pipeline.mlir
+++ b/mlir/test/Util/Runner/segment_dataflow_pipeline.mlir
@@ -1,0 +1,176 @@
+//===- segment_dataflow_pipeline.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// A dataflow pipeline made of air.segments as pipeline stages.
+// Stages are connected with FIFOs to enable concurrent execution.
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "B",
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  air.channel @channel_3 [1, 1]
+  air.channel @channel_2 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c0 = arith.constant 0 : index
+        %c1024 = arith.constant 1024 : index
+        %c256 = arith.constant 256 : index
+        %4 = air.wait_all async 
+        %5 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %4) -> (!air.async.token) {
+          %async_token, %results = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %6 = air.channel.put async [%async_token]  @channel_0[] (%results[] [] []) {id = 16 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_0 = air.execute [%6] {
+            memref.dealloc %results : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_0 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      %2 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c512 = arith.constant 512 : index
+        %c1_0 = arith.constant 1 : index
+        %c0 = arith.constant 0 : index
+        %c1024 = arith.constant 1024 : index
+        %c128 = arith.constant 128 : index
+        %c256 = arith.constant 256 : index
+        %4 = air.wait_all async 
+        %async_token, %results = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        } {ping_pong = 0 : ui32}
+        %async_token_1, %results_2 = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        } {ping_pong = 1 : ui32}
+        %5:4 = scf.for %arg4 = %c0 to %c1024 step %c512 iter_args(%arg5 = %async_token, %arg6 = %async_token_1, %arg7 = %async_token_1, %arg8 = %async_token_1) -> (!air.async.token, !air.async.token, !air.async.token, !air.async.token) {
+          %8 = air.channel.get async [%arg8, %arg5]  @channel_0[] (%results[%arg4, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, ping_pong = 0 : ui32, producer = 0 : ui32} : (memref<128x1024xbf16, 1>)
+          %9 = air.wait_all async [%arg7, %8] 
+          %10 = scf.for %arg9 = %c0 to %c256 step %c128 iter_args(%arg10 = %9) -> (!air.async.token) {
+            %15 = air.channel.put async [%arg10]  @channel_1[] (%results[%c0, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %15 : !air.async.token
+          } {async_back = true, consumer = 0 : ui32, ping_pong = 0 : ui32}
+          %waitall_1 = air.wait_all async [%10]
+          %11 = arith.addi %arg4, %c256 : index
+          %12 = air.channel.get async [%8, %arg6]  @channel_0[] (%results_2[%11, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, ping_pong = 1 : ui32, producer = 1 : ui32} : (memref<128x1024xbf16, 1>)
+          %13 = air.wait_all async [%waitall_1, %12] 
+          %14 = scf.for %arg9 = %c0 to %c256 step %c128 iter_args(%arg10 = %13) -> (!air.async.token) {
+            %15 = air.channel.put async [%arg10]  @channel_1[] (%results_2[%c0, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %15 : !air.async.token
+          } {async_back = true, consumer = 1 : ui32, ping_pong = 1 : ui32}
+          scf.yield %waitall_1, %14, %14, %12 : !air.async.token, !air.async.token, !air.async.token, !air.async.token
+        }
+        %async_token_3 = air.execute [%5#1] {
+          memref.dealloc %results : memref<128x1024xbf16, 1>
+        } {ping_pong = 0 : ui32}
+        %async_token_4 = air.execute [%5#1] {
+          memref.dealloc %results_2 : memref<128x1024xbf16, 1>
+        } {ping_pong = 1 : ui32}
+        %6 = air.wait_all async 
+        %7 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %6) -> (!air.async.token) {
+          %async_token_5, %results_6 = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %8 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %async_token_5) -> (!air.async.token) {
+            %async_token_8, %results_9 = air.execute [%arg7] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %10 = air.channel.get async [%async_token_8]  @channel_1[] (%results_9[] [] []) {id = 22 : i32} : (memref<128x128xbf16, 1>)
+            %async_token_10 = air.execute [%10] {
+              memref.dealloc %results_9 : memref<128x128xbf16, 1>
+            }
+            scf.yield %async_token_10 : !air.async.token
+          }
+          %9 = air.channel.put async [%8]  @channel_2[] (%results_6[] [] []) {id = 32 : i32} : (memref<128x128xbf16, 1>)
+          %async_token_7 = air.execute [%9] {
+            memref.dealloc %results_6 : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_7 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      %3 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
+        %c512 = arith.constant 512 : index
+        %c1_0 = arith.constant 1 : index
+        %c0 = arith.constant 0 : index
+        %c1024 = arith.constant 1024 : index
+        %c128 = arith.constant 128 : index
+        %c256 = arith.constant 256 : index
+        %4 = air.wait_all async 
+        %async_token, %results = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        } {ping_pong = 0 : ui32}
+        %async_token_1, %results_2 = air.execute [%4] -> (memref<128x1024xbf16, 1>) {
+          %alloc = memref.alloc() : memref<128x1024xbf16, 1>
+          air.execute_terminator %alloc : memref<128x1024xbf16, 1>
+        } {ping_pong = 1 : ui32}
+        %5:4 = scf.for %arg4 = %c0 to %c1024 step %c512 iter_args(%arg5 = %async_token, %arg6 = %async_token_1, %arg7 = %async_token_1, %arg8 = %async_token_1) -> (!air.async.token, !air.async.token, !air.async.token, !air.async.token) {
+          %8 = air.channel.get async [%arg8, %arg5]  @channel_2[] (%results[%arg4, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, ping_pong = 0 : ui32, producer = 0 : ui32} : (memref<128x1024xbf16, 1>)
+          %9 = air.wait_all async [%arg7, %8] 
+          %10 = scf.for %arg9 = %c0 to %c256 step %c128 iter_args(%arg10 = %9) -> (!air.async.token) {
+            %15 = air.channel.put async [%arg10]  @channel_3[] (%results[%arg4, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %15 : !air.async.token
+          } {async_back = true, consumer = 0 : ui32, ping_pong = 0 : ui32}
+          %waitall_2 = air.wait_all async [%10]
+          %11 = arith.addi %arg4, %c256 : index
+          %12 = air.channel.get async [%8, %arg6]  @channel_2[] (%results_2[%11, %c0] [%c128, %c128] [%c1024, %c1_0]) {async_front = true, id = 4 : i32, ping_pong = 1 : ui32, producer = 1 : ui32} : (memref<128x1024xbf16, 1>)
+          %13 = air.wait_all async [%waitall_2, %12] 
+          %14 = scf.for %arg9 = %c0 to %c256 step %c128 iter_args(%arg10 = %13) -> (!air.async.token) {
+            %15 = air.channel.put async [%arg10]  @channel_3[] (%results_2[%11, %c0] [%c128, %c128] [%c128, %c1_0]) {id = 18 : i32} : (memref<128x1024xbf16, 1>)
+            scf.yield %15 : !air.async.token
+          } {async_back = true, consumer = 1 : ui32, ping_pong = 1 : ui32}
+          scf.yield %waitall_2, %14, %14, %12 : !air.async.token, !air.async.token, !air.async.token, !air.async.token
+        }
+        %async_token_3 = air.execute [%5#1] {
+          memref.dealloc %results : memref<128x1024xbf16, 1>
+        } {ping_pong = 0 : ui32}
+        %async_token_4 = air.execute [%5#1] {
+          memref.dealloc %results_2 : memref<128x1024xbf16, 1>
+        } {ping_pong = 1 : ui32}
+        %6 = air.wait_all async 
+        %7 = scf.for %arg4 = %c0 to %c1024 step %c256 iter_args(%arg5 = %6) -> (!air.async.token) {
+          %async_token_5, %results_6 = air.execute [%arg5] -> (memref<128x128xbf16, 1>) {
+            %alloc = memref.alloc() : memref<128x128xbf16, 1>
+            air.execute_terminator %alloc : memref<128x128xbf16, 1>
+          }
+          %8 = scf.for %arg6 = %c0 to %c256 step %c128 iter_args(%arg7 = %async_token_5) -> (!air.async.token) {
+            %async_token_8, %results_9 = air.execute [%arg7] -> (memref<128x128xbf16, 1>) {
+              %alloc = memref.alloc() : memref<128x128xbf16, 1>
+              air.execute_terminator %alloc : memref<128x128xbf16, 1>
+            }
+            %9 = air.channel.get async [%async_token_8]  @channel_3[] (%results_9[] [] []) {id = 38 : i32} : (memref<128x128xbf16, 1>)
+            %async_token_10 = air.execute [%9] {
+              memref.dealloc %results_9 : memref<128x128xbf16, 1>
+            }
+            scf.yield %async_token_10 : !air.async.token
+          }
+          %async_token_7 = air.execute [%8] {
+            memref.dealloc %results_6 : memref<128x128xbf16, 1>
+          }
+          scf.yield %async_token_7 : !air.async.token
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
@@ -13,10 +13,6 @@
 // CHECK: "name": "DeallocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
 // CHECK-NEXT: "ph": "B",
-
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "E",
 // CHECK-NEXT: "ts": [[TIME0:.*]],
 
 // CHECK: "name": "AllocOp(L1)",

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
@@ -14,32 +14,21 @@
 // CHECK: "name": "DeallocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
 // CHECK-NEXT: "ph": "B",
-
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "B",
-
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "B",
-
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "B",
-
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "E",
 // CHECK-NEXT: "ts": [[TIME0:.*]],
 
-// CHECK: "name": "AllocOp(L1)",
+// CHECK: "name": "DeallocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
 // CHECK-NEXT: "ph": "B",
 // CHECK-NEXT: "ts": [[TIME0]],
 
 // CHECK: "name": "DeallocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "E",
+// CHECK-NEXT: "ph": "B",
+// CHECK-NEXT: "ts": [[TIME0]],
+
+// CHECK: "name": "DeallocOp(L1)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "B",
 // CHECK-NEXT: "ts": [[TIME0]],
 
 // CHECK: "name": "AllocOp(L1)",
@@ -47,19 +36,14 @@
 // CHECK-NEXT: "ph": "B",
 // CHECK-NEXT: "ts": [[TIME0]],
 
-// CHECK: "name": "DeallocOp(L1)",
-// CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "E",
-// CHECK-NEXT: "ts": [[TIME0]],
-
 // CHECK: "name": "AllocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
 // CHECK-NEXT: "ph": "B",
 // CHECK-NEXT: "ts": [[TIME0]],
 
-// CHECK: "name": "DeallocOp(L1)",
+// CHECK: "name": "AllocOp(L1)",
 // CHECK-NEXT: "cat": "layer",
-// CHECK-NEXT: "ph": "E",
+// CHECK-NEXT: "ph": "B",
 // CHECK-NEXT: "ts": [[TIME0]],
 
 // CHECK: "name": "AllocOp(L1)",


### PR DESCRIPTION
- Differentiate the format for compute capacity per core between ops/cycle and macs/cycle.
- Resource allocation and deallocation will make some previously inexecutable ops on wavefront executable. Therefore, simulation needs to recurse to check for these knock-on effects.
- The ordering of ops on wavefront is important. For example, yield ops shall reset the execution status of other ops which are ready to execute at the same timestamp.
- Detected a corner case where the runner nodes fail to cover enough vertices as candidate events to be pushed to wavefront. Current solution is to keep a temporary buffer of neighbouring vertices to recently resetted vertices, which are sometimes victims of such corner cases.
- Given that in our async CDFG dependence to scf.for goes out from scf.yield, and that scf.yield is non-blocking, a air.wait_all barrier is inserted after for loops to protect the scheduling behaviour.