### PR TITLE
Add libxaie paths to aiecc command lines

### DIFF
--- a/test/03_mb_lock_rel/run.lit
+++ b/test/03_mb_lock_rel/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/07_mb_beef_maker/run.lit
+++ b/test/07_mb_beef_maker/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/09_mb_hsa_herd_lock/run.lit
+++ b/test/09_mb_hsa_herd_lock/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/10_mb_shim_dma_to_tile_dma/run.lit
+++ b/test/10_mb_shim_dma_to_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/11_mb_shim_dma_from_tile_dma/run.lit
+++ b/test/11_mb_shim_dma_from_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/12_dual_channel_shim_dma/run.lit
+++ b/test/12_dual_channel_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/13_mb_add_one/run.lit
+++ b/test/13_mb_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/14_multi_shim_dma/run.lit
+++ b/test/14_multi_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/15_dual_mb_dual_herd_add_one/run.lit
+++ b/test/15_dual_mb_dual_herd_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/16_multi_shim_dma_all_channels/run.lit
+++ b/test/16_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/18_2d_tile_dma_transpose/run.lit
+++ b/test/18_2d_tile_dma_transpose/run.lit
@@ -8,5 +8,5 @@
 
 // Expected to fail unless mlir-aie pull #55 is merged
 // XFAIL: *
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/273_barrier_add_two/run.lit
+++ b/test/273_barrier_add_two/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/290_mb_matrix_add_ddr/run.lit
+++ b/test/290_mb_matrix_add_ddr/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/29_mb_matrix_add/run.lit
+++ b/test/29_mb_matrix_add/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/30_2d_mb_shim_dma/run.lit
+++ b/test/30_2d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/31_3d_mb_shim_dma/run.lit
+++ b/test/31_3d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/32_4d_mb_shim_dma/run.lit
+++ b/test/32_4d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/36_4d_mb_multi_shim_dma_all_channels/run.lit
+++ b/test/36_4d_mb_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/37_4d_mb_multi_shim_dma_broadcast/run.lit
+++ b/test/37_4d_mb_multi_shim_dma_broadcast/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/38_4d_mb_shim_dma_channel_stress/run.lit
+++ b/test/38_4d_mb_shim_dma_channel_stress/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -I%air_runtime_lib%/airhost/include -I%aie_runtime_lib%/test_lib/include -ltest_lib -L%aie_runtime_lib%/test_lib/lib -L%air_runtime_lib%/airhost %S/test.cpp -Wl,--whole-archive -lairhost -Wl,--no-whole-archive -lstdc++ -ldl -o %T/test.elf
 // RUN: %run_on_board %T/test.elf


### PR DESCRIPTION
The defaults assumed by aiecc.py do not work for these tests. The issue is that aiecc sets the libxaie paths assuming libxaie was built as a subproject of mlir-aie, which is not always true.