### PR TITLE
Keep output of air-to-aie in one module.

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIEPass.h
+++ b/mlir/include/air/Conversion/AIRToAIEPass.h
@@ -27,6 +27,8 @@ mlir::FailureOr<mlir::ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                                 air::SegmentOp segment);
 std::unique_ptr<mlir::Pass> createAIRToAIEPass();
 
+std::unique_ptr<mlir::Pass> createAIRSplitDevicesPass();
+
 } // namespace air
 } // namespace xilinx
 

--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -129,10 +129,6 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
   let summary = "Lower air.launch_herd to AIE dialect";
   let constructor = "xilinx::air::createAIRToAIEPass()";
   let options = [
-    Option<"clOutputPrefix", "output-prefix", "std::string",
-          /*default=*/"\"-\"",
-           "File name prefix for generated AIE modules. Set to /dev/null "
-           "for no output. Set to \'-\' for stdout (default).">,
     Option<"clRowOffset", "row-offset", "unsigned", /*default=*/"1",
            "The default start row for any herds without 'y_loc' attribute.">,
     Option<"clColOffset", "col-offset", "unsigned", /*default=*/"1",
@@ -269,6 +265,17 @@ def AIRRtToLLVM : Pass<"airrt-to-llvm", "ModuleOp"> {
     air_host.h.  Any changes to this pass must be reflected there.
   }];
   let options = [];
+}
+
+def AIRSplitDevices : Pass<"air-split-devices", "ModuleOp"> {
+  let summary = "Split the input into one output per AIE.device op";
+  let constructor = "xilinx::air::createAIRSplitDevicesPass()";
+  let options = [
+    Option<"clOutputPrefix", "output-prefix", "std::string",
+          /*default=*/"\"-\"",
+           "File name prefix for split AIE modules. "
+           "Set to \'-\' for stdout (default).">,
+  ];
 }
 
 def AIRPipelineToAffine : Pass<"air-pipeline-to-affine", "ModuleOp"> {

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -65,9 +65,11 @@ DmaMemcpyNdOp getAIRDmaInBlock(mlir::Block *block);
 // Get channel declaration through channel symbol
 ChannelOp getChannelDeclarationThroughSymbol(ChannelInterface op);
 // Get ChannelPutOps from ChannelOp
-std::vector<ChannelPutOp> getChannelPutOpThroughSymbol(ChannelOp channel);
+std::vector<ChannelPutOp>
+getChannelPutOpThroughSymbol(ChannelOp channel, Operation *scope = nullptr);
 // Get ChannelGetOps from ChannelOp
-std::vector<ChannelGetOp> getChannelGetOpThroughSymbol(ChannelOp channel);
+std::vector<ChannelGetOp>
+getChannelGetOpThroughSymbol(ChannelOp channel, Operation *scope = nullptr);
 // Get the other channel op through channel symbol
 std::vector<ChannelGetOp> getTheOtherChannelOpThroughSymbol(ChannelPutOp put);
 std::vector<ChannelPutOp> getTheOtherChannelOpThroughSymbol(ChannelGetOp get);

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -15,6 +15,8 @@
 #include "air/Dialect/AIRRt/AIRRtOps.h"
 #include "air/Util/Util.h"
 
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -456,6 +458,9 @@ public:
     if (op->getParentOfType<air::HerdOp>())
       return failure();
 
+    if (op->getParentOfType<AIE::CoreOp>())
+      return failure();
+
     SmallVector<Value, 4> deps;
     for (auto o : adaptor.getOperands())
       if (o.getType().isa<xilinx::airrt::EventType>())
@@ -577,6 +582,9 @@ public:
     auto ctx = op->getContext();
 
     if (op->getParentOfType<air::HerdOp>())
+      return failure();
+
+    if (op->getParentOfType<AIE::CoreOp>())
       return failure();
 
     SmallVector<Value, 4> deps;

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -326,13 +326,16 @@ air::getChannelDeclarationThroughSymbol(air::ChannelInterface op) {
 
 // Get ChannelPutOp through ChannelOp
 std::vector<air::ChannelPutOp>
-air::getChannelPutOpThroughSymbol(air::ChannelOp channel) {
-  auto module = channel->getParentOfType<ModuleOp>();
+air::getChannelPutOpThroughSymbol(air::ChannelOp channel, Operation *scope) {
+
+  if (!scope)
+    scope = channel->getParentOfType<ModuleOp>();
+
   auto attr =
       channel->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
 
   std::vector<ChannelPutOp> channelPuts;
-  module.walk([&](Operation *op) {
+  scope->walk([&](Operation *op) {
     if (auto put = dyn_cast<air::ChannelPutOp>(op)) {
       if (put.getChanName() == attr) {
         channelPuts.push_back(put);
@@ -345,13 +348,16 @@ air::getChannelPutOpThroughSymbol(air::ChannelOp channel) {
 
 // Get ChannelGetOps through ChannelOp
 std::vector<air::ChannelGetOp>
-air::getChannelGetOpThroughSymbol(air::ChannelOp channel) {
-  auto module = channel->getParentOfType<ModuleOp>();
+air::getChannelGetOpThroughSymbol(air::ChannelOp channel, Operation *scope) {
+
+  if (!scope)
+    scope = channel->getParentOfType<ModuleOp>();
+
   auto attr =
       channel->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
 
   std::vector<ChannelGetOp> channelGets;
-  module.walk([&](Operation *op) {
+  scope->walk([&](Operation *op) {
     if (auto get = dyn_cast<air::ChannelGetOp>(op)) {
       if (get.getChanName() == attr) {
         channelGets.push_back(get);

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -2,6 +2,10 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+if(NOT AIE_BINARY_DIR)
+  find_package(AIE REQUIRED CONFIG)
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
@@ -11,7 +11,7 @@ module {
 
 func.func @foo(%arg0: i32) {
   %cst1 = arith.constant 1 : index
-  // CHECK-LABEL: module @aie.segment_0
+  // CHECK-LABEL: AIE.device
   // CHECK: %[[VAR1:.*]] = AIE.tile(1, 1)
   // CHECK: %[[BUF1:.*]] = AIE.buffer(%[[VAR1]]) {sym_name = {{.*}}} : memref<1xi32, 2>
   // CHECK: %[[BUF2:.*]] = AIE.buffer(%[[VAR1]]) {sym_name = {{.*}}} : memref<1xi32, 2>
@@ -31,6 +31,7 @@ func.func @foo(%arg0: i32) {
     memref.store %2, %dst0[%zero] : memref<1xi32, 2>
     air.herd_terminator
   }
+  // CHECK: sym_name = "segment_0"
   return
 }
 

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_buf_names.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_buf_names.mlir
@@ -8,7 +8,7 @@
 
 // RUN: air-opt -air-to-aie %s | FileCheck %s
 
-// CHECK-LABEL: module @aie.segment_0
+// CHECK: AIE.device
 // CHECK: scratch_2_2
 // CHECK: buf8
 // ...

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
@@ -11,7 +11,7 @@ module {
 
 func.func @foo(%arg0: i32) {
   %cst1 = arith.constant 1 : index
-  // CHECK-LABEL: module @aie.segment_0
+  // CHECK: AIE.device
   // CHECK: AIE.core(%0)  {
   // CHECK:   call @beefmaker_kernel(%1) : (memref<1024xi32, 2>) -> ()
   // CHECK:   AIE.end

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=2 device=xcvc1902" -o out.mlir --split-input-file | FileCheck %s
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=2 device=xcvc1902" --split-input-file | FileCheck %s
 
-// CHECK: module @aie.segment_0
+// CHECK: AIE.device
 // CHECK:         %[[VAL_12:.*]] = AIE.tile(2, 2)
 // CHECK:         %[[VAL_10:.*]] = AIE.tile(2, 0)
 // CHECK:         %[[VAL_14:.*]] = AIE.lock(%[[VAL_12]], 0)
@@ -49,7 +49,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 
 // -----
 
-// CHECK: module @aie.segment_0
+// CHECK: AIE.device
 // CHECK:         %[[VAL_12:.*]] = AIE.tile(2, 2)
 // CHECK:         %[[VAL_10:.*]] = AIE.tile(2, 0)
 // CHECK:         %[[VAL_15:.*]] = AIE.lock(%[[VAL_12]], 1)

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" -o out.mlir --split-input-file | FileCheck %s
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" --split-input-file | FileCheck %s
 
 // CHECK-LABEL:   AIE.device(xcve2802) {
 // CHECK:  %[[VAL_0:.*]] = AIE.tile(2, 3)

--- a/mlir/test/Conversion/AIRToAIE/create_and_outline.mlir
+++ b/mlir/test/Conversion/AIRToAIE/create_and_outline.mlir
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie='test-patterns=to-aie-mlir' -o /dev/null | FileCheck %s
+// RUN: air-opt %s -air-to-aie='test-patterns=to-aie-mlir' --split-input-file | FileCheck %s
 
-// CHECK-LABEL: @aie.segment0
+// CHECK: AIE.device
 // CHECK: [[T00:%.*]] = AIE.tile(1, 1)
 // CHECK: [[T10:%.*]] = AIE.tile(2, 1)
 // CHECK: [[T01:%.*]] = AIE.tile(1, 2)
@@ -56,7 +56,9 @@ module attributes {torch.debug_module_name = "mmult"} {
   }
 }
 
-// CHECK-LABEL: @aie.segment_1
+// -----
+
+// CHECK: AIE.device
 // CHECK: air.channel @channel_0 [1, 1] {broadcast_shape = [1, 4]}
 air.channel @channel_0 [1, 1] {broadcast_shape = [1, 4]}
 func.func @f1() -> () {

--- a/mlir/test/Conversion/AIRToAIE/lower_affine_if.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_affine_if.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie -o /dev/null | air-opt | FileCheck %s
+// RUN: air-opt %s -air-to-aie | FileCheck %s
 // CHECK: [[T_0_0:%.*]] = AIE.tile(1, 1)
 // CHECK: [[T_1_0:%.*]] = AIE.tile(2, 1)
 // CHECK: [[T_0_1:%.*]] = AIE.tile(1, 2)

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie -o /dev/null | air-opt | FileCheck %s
+// RUN: air-opt %s -air-to-aie | FileCheck %s
 // CHECK: AIE.core({{.*}}) {
 // CHECK: AIE.useLock({{.*}}, Acquire, 0)
 // CHECK: AIE.useLock({{.*}}, Acquire, 1)

--- a/mlir/test/Conversion/AIRToAIE/split_devices.mlir
+++ b/mlir/test/Conversion/AIRToAIE/split_devices.mlir
@@ -1,0 +1,24 @@
+//===- split_devices.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-split-devices='output-prefix=%T/' | FileCheck %s
+// RUN: aie-opt %T/aie.TestSegment0.mlir | FileCheck -check-prefix=AIE %s
+
+// CHECK-NOT: AIE.device
+// CHECK: func.func @main
+
+// AIE: module @aie.TestSegment0
+// AIE-NEXT: AIE.device
+// AIE-NOT: func.func @main
+
+AIE.device(xcvc1902) {
+  %tile11 = AIE.tile(1, 1)
+} { sym_name = "TestSegment0" }
+
+func.func @main(%a0: memref<1024xbf16>, %a1: memref<1024xbf16>, %a2: memref<1024xbf16>) {
+  return
+}

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -53,10 +53,11 @@ config.air_tools_dir = os.path.join(config.air_obj_root, 'bin')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+llvm_config.with_environment('PATH', config.aie_tools_dir, append_path=True)
 
-tool_dirs = [config.air_tools_dir, config.llvm_tools_dir]
+tool_dirs = [config.air_tools_dir, config.aie_tools_dir, config.llvm_tools_dir]
 tools = [
-    'air-opt', 'air-translate', 'air-runner'
+    'air-opt', 'air-translate', 'air-runner', 'aie-opt'
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -32,6 +32,7 @@ config.host_ldflags = '@HOST_LDFLAGS@'
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
+config.aie_tools_dir = "@AIE_TOOLS_BINARY_DIR@"
 config.air_src_root = "@CMAKE_SOURCE_DIR@"
 config.air_obj_root = "@CMAKE_BINARY_DIR@"
 


### PR DESCRIPTION
The goal is to keep more of the lowering unified in one module (file) for longer. A new pass -air-split-devices can split out just the device code for input to aiecc.