### PR TITLE
bump mlir-aie

### DIFF
--- a/test/03_mb_lock_rel/test.cpp
+++ b/test/03_mb_lock_rel/test.cpp
@@ -20,6 +20,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int main(int argc, char *argv[])
 {
   auto row = 2;

--- a/test/07_mb_beef_maker/test.cpp
+++ b/test/07_mb_beef_maker/test.cpp
@@ -25,6 +25,8 @@
 
 #define SCRATCH_AREA 8
 
+#define XAIE_NUM_COLS 10
+
 int
 main(int argc, char *argv[])
 {

--- a/test/09_mb_hsa_herd_lock/test.cpp
+++ b/test/09_mb_hsa_herd_lock/test.cpp
@@ -19,6 +19,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int main(int argc, char *argv[])
 {
   auto col = 7;

--- a/test/10_mb_shim_dma_to_tile_dma/test.cpp
+++ b/test/10_mb_shim_dma_to_tile_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int
 main(int argc, char *argv[])
 {

--- a/test/11_mb_shim_dma_from_tile_dma/test.cpp
+++ b/test/11_mb_shim_dma_from_tile_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int
 main(int argc, char *argv[])
 {

--- a/test/12_dual_channel_shim_dma/test.cpp
+++ b/test/12_dual_channel_shim_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int
 main(int argc, char *argv[])
 {

--- a/test/13_mb_add_one/test.cpp
+++ b/test/13_mb_add_one/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 int
 main(int argc, char *argv[])
 {

--- a/test/14_multi_shim_dma/test.cpp
+++ b/test/14_multi_shim_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 20
+
 int
 main(int argc, char *argv[])
 {

--- a/test/15_dual_mb_dual_herd_add_one/test.cpp
+++ b/test/15_dual_mb_dual_herd_add_one/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 36
+
 int
 main(int argc, char *argv[])
 {

--- a/test/16_multi_shim_dma_all_channels/test.cpp
+++ b/test/16_multi_shim_dma_all_channels/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 20
+
 int
 main(int argc, char *argv[])
 {

--- a/test/21_air_nd_memcpy_2d/test.cpp
+++ b/test/21_air_nd_memcpy_2d/test.cpp
@@ -22,6 +22,8 @@
 #include "air.hpp"
 #include "test_library.h"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 32
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE  (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/273_barrier_add_two/test.cpp
+++ b/test/273_barrier_add_two/test.cpp
@@ -22,6 +22,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 36
+
 int
 main(int argc, char *argv[])
 {

--- a/test/290_mb_matrix_add_ddr/test.cpp
+++ b/test/290_mb_matrix_add_ddr/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define DDR_ADDR  0x2000
 
 // test configuration

--- a/test/29_mb_matrix_add/test.cpp
+++ b/test/29_mb_matrix_add/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 // test configuration
 #define IMAGE_WIDTH 128
 #define IMAGE_HEIGHT 16

--- a/test/30_2d_mb_shim_dma/test.cpp
+++ b/test/30_2d_mb_shim_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 128
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE  (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/31_3d_mb_shim_dma/test.cpp
+++ b/test/31_3d_mb_shim_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 128
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE  (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/32_4d_mb_shim_dma/test.cpp
+++ b/test/32_4d_mb_shim_dma/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 128
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE  (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/36_4d_mb_multi_shim_dma_all_channels/test.cpp
+++ b/test/36_4d_mb_multi_shim_dma_all_channels/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 96
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/37_4d_mb_multi_shim_dma_broadcast/test.cpp
+++ b/test/37_4d_mb_multi_shim_dma_broadcast/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 10
+
 #define IMAGE_WIDTH 96
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/test/38_4d_mb_shim_dma_channel_stress/test.cpp
+++ b/test/38_4d_mb_shim_dma_channel_stress/test.cpp
@@ -23,6 +23,8 @@
 
 #include "aie_inc.cpp"
 
+#define XAIE_NUM_COLS 30
+
 #define IMAGE_WIDTH 64
 #define IMAGE_HEIGHT 16
 #define IMAGE_SIZE (IMAGE_WIDTH * IMAGE_HEIGHT)

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=da8a0b35868f8dffb59613de00a86049c11b5733
+export HASH=0c07d64c0d8ec4609b2472a2ace5c1b7835ce74e
 
 git clone --depth 1 https://github.com/Xilinx/mlir-aie.git mlir-aie
 pushd mlir-aie


### PR DESCRIPTION
Update mlir-aie to 0c07d64c

This exposed the fact that some of the tests were relying on `XAIE_NUM_COLS` from mlir-aie `test_library.h`. This macro was removed in mlir-aie. The tests were updated to define their own `XAIE_NUM_COLS` based on the the maximum column number used in their `aie.mlir` file.