### PR TITLE
controller: add command shell to UART

### DIFF
--- a/runtime_lib/controller/main.cpp
+++ b/runtime_lib/controller/main.cpp
@@ -30,6 +30,7 @@ extern "C" {
 }
 
 #include "platform.h"
+#include "shell.h"
 
 #define XAIE_NUM_ROWS 8
 #define XAIE_NUM_COLS 50
@@ -874,13 +875,13 @@ void xaie_herd_init(int start_col, int num_cols, int start_row, int num_rows) {
 
 } // namespace
 
-namespace {
-
 uint64_t shmem_base = 0x020100000000UL;
 uint64_t uart_lock_offset = 0x200;
 uint64_t base_address;
 
 bool setup;
+
+uint64_t get_base_address(void) { return shmem_base; }
 
 void lock_uart(uint32_t id) {
   bool is_locked = false;
@@ -1436,8 +1437,6 @@ int stage_packet_nd_memcpy(dispatch_packet_t *pkt, uint32_t slot,
   }
 }
 
-} // namespace
-
 void handle_agent_dispatch_packet(queue_t *q, uint32_t mb_id) {
   uint64_t rd_idx = queue_load_read_index(q);
   dispatch_packet_t *pkt =
@@ -1789,6 +1788,7 @@ int main() {
         }
       }
     }
+    shell();
   }
 
   cleanup_platform();

--- a/runtime_lib/controller/platform.h
+++ b/runtime_lib/controller/platform.h
@@ -1,34 +1,9 @@
-/******************************************************************************
-*
-* Copyright (C) 2008 - 2014 Xilinx, Inc.  All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* Use of the Software is limited solely to applications:
-* (a) running on a Xilinx device, or
-* (b) that interact with a Xilinx device through a bus or interconnect.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-* XILINX  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
-* OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*
-* Except as contained in this notice, the name of the Xilinx shall not be used
-* in advertising or otherwise to promote the sale, use or other dealings in
-* this Software without prior written authorization from Xilinx.
-*
-******************************************************************************/
+//===- platform.h -----------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef __PLATFORM_H_
 #define __PLATFORM_H_
@@ -37,5 +12,10 @@
 
 void init_platform();
 void cleanup_platform();
+
+/*
+        Return the base address of the interface data structures
+*/
+uint64_t get_base_address(void);
 
 #endif

--- a/runtime_lib/controller/shell.cpp
+++ b/runtime_lib/controller/shell.cpp
@@ -1,0 +1,167 @@
+//===- shell.cpp ------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "shell.h"
+#include "platform.h"
+#include "xuartpsv_hw.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#define MAX_LINE_LENGTH 256
+#define MAX_CMD_LENGTH 15
+#define NUM_CMDS (sizeof(command_tbl) / sizeof(command_entry))
+
+/*
+        Each command handler has this format
+*/
+typedef struct command_entry {
+  char cmd[MAX_CMD_LENGTH + 1]; // the command string
+  void (*fn)(char *cmd);        // the handler function
+} command_entry;
+
+// forward declarations of handlers
+static void command_cp(char *line);
+static void command_help(char *line);
+static void command_x(char *line);
+
+static int new_cmd = 1;
+static int cmd_len;
+static char line[MAX_LINE_LENGTH];
+static command_entry command_tbl[] = {
+    {"cp", command_cp},
+    {"help", command_help},
+    {"x", command_x},
+};
+
+static char to_ascii(uint8_t byte) {
+  if ((byte >= 'A' && byte <= 'Z') || (byte >= 'a' && byte <= 'z') ||
+      (byte >= '0' && byte <= '9'))
+    return byte;
+
+  return '.';
+}
+
+/*
+        Print information about the command processors
+*/
+static void command_cp(char *line) {
+  uint32_t cp_count;
+  uint64_t base = get_base_address();
+
+  cp_count = *(uint32_t *)(base + 0x208);
+  xil_printf("Number of command processors: %u\r\n", cp_count);
+
+  uint64_t *queue_base = (uint64_t *)base;
+  for (uint32_t idx = 0; idx < cp_count; idx++) {
+    xil_printf("[%02u]\t0x%llx\r\n", idx, queue_base[idx]);
+  }
+}
+
+/*
+        List all supported shell commands
+*/
+static void command_help(char *line) {
+  uint32_t ll = 0; // line length
+  uint32_t len;    // string length
+
+  xil_printf("Supported commands:\r\n");
+
+  for (uint32_t idx = 0; idx < NUM_CMDS; idx++) {
+    len = strlen(command_tbl[idx].cmd) + 1;
+    if (ll + len > 80) {
+      ll = len;
+      xil_printf("\r\n");
+    }
+    xil_printf("%s ", command_tbl[idx].cmd);
+  }
+  xil_printf("\r\n");
+}
+
+/*
+        Print out a memory range
+
+        parameter 1: ARM virtual address (in hex or decimal)
+        parameter 2: number of bytes to read (should be aligned to 8)
+*/
+static void command_x(char *line) {
+  char *cmd;
+  char *address_str;
+  char *range_str;
+  uint64_t address = 0x400000;
+  uint32_t range = 8;
+
+  cmd = strtok(line, " ");
+  address_str = strtok(NULL, " ");
+  range_str = strtok(NULL, " ");
+
+  if (address_str)
+    address = strtoul(address_str, NULL, 16);
+  if (range_str)
+    range = strtoul(range_str, NULL, 16);
+
+  xil_printf("%s: addr=0x%llx range=0x%llx\r\n", cmd, address, range);
+
+  uint8_t *w = (uint8_t *)address;
+
+  for (uint32_t i = 0; i < range; i += 8)
+    xil_printf("[%16llx]: %02x %02x %02x %02x %02x %02x %02x %02x | "
+               "%c%c%c%c%c%c%c%c\r\n",
+               address + i * sizeof(*w), w[i], w[i + 1], w[i + 2], w[i + 3],
+               w[i + 4], w[i + 5], w[i + 6], w[i + 7], to_ascii(w[i]),
+               to_ascii(w[i + 1]), to_ascii(w[i + 2]), to_ascii(w[i + 3]),
+               to_ascii(w[i + 4]), to_ascii(w[i + 5]), to_ascii(w[i + 6]),
+               to_ascii(w[i + 7]));
+}
+
+static void handle_command(void) {
+  // look up the command and call the handler
+  for (uint32_t idx = 0; idx < NUM_CMDS; idx++) {
+    if (strncmp(line, command_tbl[idx].cmd, strlen(command_tbl[idx].cmd)) ==
+        0) {
+      command_tbl[idx].fn(line);
+      break;
+    }
+  }
+}
+
+void shell(void) {
+  uint8_t in;
+
+  if (new_cmd) {
+    new_cmd = 0;
+    cmd_len = 0;
+
+    // good old DOS prompt
+    xil_printf("C:\\> ");
+  }
+
+  // handle all characters from the UART (which is a slow interface) so the UI
+  // is responsive. If no character is waiting, go back to processing queues.
+  while ((in = XUartPsv_RecvByte(STDOUT_BASEADDRESS))) {
+    // make sure character will fit in the command buffer
+    if (cmd_len >= MAX_LINE_LENGTH) {
+      xil_printf("Line too long\r\n");
+      new_cmd = 1;
+      break;
+    }
+
+    // if it's a return character, handle the command
+    if (in == '\r' || in == '\n') {
+      XUartPsv_SendByte(STDOUT_BASEADDRESS, '\r');
+      XUartPsv_SendByte(STDOUT_BASEADDRESS, '\n');
+      handle_command();
+      new_cmd = 1;
+      break;
+    }
+
+    line[cmd_len++] = in;
+    line[cmd_len] = 0;
+
+    // reflect the typed character back for confirmation
+    XUartPsv_SendByte(STDOUT_BASEADDRESS, in);
+  }
+}

--- a/runtime_lib/controller/shell.h
+++ b/runtime_lib/controller/shell.h
@@ -1,0 +1,21 @@
+//===- shell.h --------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __SHELL_H_
+#define __SHELL_H_
+
+/*
+        Poll for incoming commands on the UART
+
+        If there are no waiting characters, return
+        If there are waiting characters, add them to the command buffer
+        A command is terminated by the \r or \n character
+        When a full command is received, parse it and try to do what it says
+*/
+void shell(void);
+
+#endif // __SHELL_H_


### PR DESCRIPTION
Use the UART to enter commands in an interactive shell. This is a very powerful debug tool as it enables interacting with the device directly during operation.

This is first being used while debugging AIRBIN but has general applicability.