### PR TITLE
Lower gemm to object fifo

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -459,6 +459,7 @@ def air_ChannelOp : air_Op<"channel", [Symbol]>,
       return size;
     }
   }];
+  let hasCanonicalizer = 1;
 }
 
 def air_ChannelPutOp : air_Op<"channel.put", [air_AsyncOpInterface, 

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -108,6 +108,19 @@ struct LinalgTransforms {
 char checkOpOperandReadOrWrite(mlir::OpOperand &op_operand);
 char checkOpOperandReadOrWrite(Value op_operand, Operation *owner);
 
+// Convert a vector of SSA returned from arith::ConstantIndexOp into a vector of
+// uints
+std::vector<unsigned>
+convertVecOfConstIndexToVecOfUInt(SmallVector<Value> svec);
+
+// Get iterator corresponding to a position in a multi-dimensional vector
+unsigned getIteratorFromMDVector(std::vector<unsigned> dims,
+                                 std::vector<unsigned> position);
+// Get coordinates corresponding to a position in a multi-dimensional vector
+// from an iterator
+std::vector<unsigned> getMDVectorFromIterator(std::vector<unsigned> dims,
+                                              unsigned iter);
+
 } // namespace air
 } // namespace xilinx
 

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -794,6 +794,51 @@ public:
   }
 };
 
+class ScfReduceOpConversion : public OpConversionPattern<scf::ReduceOp> {
+public:
+  using OpConversionPattern<scf::ReduceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::ReduceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto newOp =
+        rewriter.replaceOpWithNewOp<scf::ReduceOp>(op, adaptor.getOperand());
+    auto body = &op.getRegion().front();
+    auto newBody = &newOp.getRegion().front();
+
+    for (int i = 0, e = body->getNumArguments(); i < e; i++) {
+      body->getArgument(i).replaceAllUsesWith(newBody->getArgument(i));
+    }
+
+    auto &ops = body->getOperations();
+    auto &newOps = newBody->getOperations();
+    newOps.splice(newOps.begin(), ops, ops.begin(), ops.end());
+    return success();
+  }
+};
+
+class ScfReduceReturnOpConversion
+    : public OpConversionPattern<scf::ReduceReturnOp> {
+public:
+  using OpConversionPattern<scf::ReduceReturnOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::ReduceReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value, 8> operands{adaptor.getOperands()};
+    SmallVector<Type, 2> retTys;
+    for (auto t : op->getResultTypes()) {
+      if (t.isa<air::AsyncTokenType>()) {
+        retTys.push_back(airrt::EventType::get(op->getContext()));
+      } else {
+        retTys.push_back(t);
+      }
+    }
+    rewriter.replaceOpWithNewOp<scf::ReduceReturnOp>(op, retTys, operands);
+    return success();
+  }
+};
+
 class ScfIfOpConversion : public OpConversionPattern<scf::IfOp> {
 public:
   using OpConversionPattern<scf::IfOp>::OpConversionPattern;
@@ -852,6 +897,26 @@ public:
     auto &ops = body->getOperations();
     auto &newOps = newBody->getOperations();
     newOps.splice(newOps.begin(), ops, ops.begin(), ops.end());
+    return success();
+  }
+};
+
+class ScfParOpConversion : public OpConversionPattern<scf::ParallelOp> {
+public:
+  using OpConversionPattern<scf::ParallelOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::ParallelOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto newOp = rewriter.replaceOpWithNewOp<scf::ParallelOp>(
+        op, adaptor.getLowerBound(), adaptor.getUpperBound(), adaptor.getStep(),
+        adaptor.getInitVals());
+    auto body = op.getBody();
+    auto newBody = newOp.getBody();
+
+    auto &ops = body->getOperations();
+    auto &newOps = newBody->getOperations();
+    newOps.splice(newOps.begin(), ops, ops.begin(), --ops.end());
     return success();
   }
 };
@@ -948,6 +1013,14 @@ public:
       return true;
     });
 
+    target.addDynamicallyLegalOp<scf::ParallelOp>([&](scf::ParallelOp op) {
+      for (auto o : op.getInitVals()) {
+        if (o.getType().isa<air::AsyncTokenType>())
+          return false;
+      }
+      return true;
+    });
+
     target.addDynamicallyLegalOp<scf::YieldOp>([&](scf::YieldOp op) {
       for (auto v : op.getResults()) {
         if (v.getType().isa<air::AsyncTokenType>())
@@ -955,6 +1028,21 @@ public:
       }
       return true;
     });
+
+    target.addDynamicallyLegalOp<scf::ReduceOp>([&](scf::ReduceOp op) {
+      if (op.getOperand().getType().isa<air::AsyncTokenType>())
+        return false;
+      else
+        return true;
+    });
+
+    target.addDynamicallyLegalOp<scf::ReduceReturnOp>(
+        [&](scf::ReduceReturnOp op) {
+          if (op.getResult().getType().isa<air::AsyncTokenType>())
+            return false;
+          else
+            return true;
+        });
 
     target.addDynamicallyLegalOp<scf::IfOp>([&](scf::IfOp op) {
       for (auto v : op.getResults()) {
@@ -964,11 +1052,11 @@ public:
       return true;
     });
 
-    air_patterns
-        .add<ScfYieldOpConversion, ScfIfOpConversion, ScfForOpConversion,
-             L2AllocToAIRRtConversion, L2DeallocToAIRRtConversion,
-             AIRLaunchConversion, AIRSegmentConversion, AIRHerdConversion>(
-            context);
+    air_patterns.add<
+        ScfYieldOpConversion, ScfIfOpConversion, ScfParOpConversion,
+        ScfReduceReturnOpConversion, ScfReduceOpConversion, ScfForOpConversion,
+        L2AllocToAIRRtConversion, L2DeallocToAIRRtConversion,
+        AIRLaunchConversion, AIRSegmentConversion, AIRHerdConversion>(context);
 
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(air_patterns,
                                                                    converter);

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -914,6 +914,10 @@ public:
     auto body = op.getBody();
     auto newBody = newOp.getBody();
 
+    for (int i = 0, e = body->getNumArguments(); i < e; i++) {
+      body->getArgument(i).replaceAllUsesWith(newBody->getArgument(i));
+    }
+
     auto &ops = body->getOperations();
     auto &newOps = newBody->getOperations();
     newOps.splice(newOps.begin(), ops, ops.begin(), --ops.end());

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1243,8 +1243,11 @@ struct SpecializeChannelBundlePattern
           rewriter.setInsertionPoint(put);
           auto new_put =
               createChannelPutGetWithoutBundle(rewriter, new_chan, put);
-          replaceAllUsesInRegionWith(
-              put.getAsyncToken(), new_put.getAsyncToken(), device.getRegion());
+          if (put.getAsyncToken()) {
+            replaceAllUsesInRegionWith(put.getAsyncToken(),
+                                       new_put.getAsyncToken(),
+                                       device.getRegion());
+          }
         }
       }
       for (auto get : channelGets) {
@@ -1254,8 +1257,11 @@ struct SpecializeChannelBundlePattern
           rewriter.setInsertionPoint(get);
           auto new_get =
               createChannelPutGetWithoutBundle(rewriter, new_chan, get);
-          replaceAllUsesInRegionWith(
-              get.getAsyncToken(), new_get.getAsyncToken(), device.getRegion());
+          if (get.getAsyncToken()) {
+            replaceAllUsesInRegionWith(get.getAsyncToken(),
+                                       new_get.getAsyncToken(),
+                                       device.getRegion());
+          }
         }
       }
     }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1066,8 +1066,11 @@ struct HoistOpsNotUsingPingPongPattern : public OpRewritePattern<scf::ForOp> {
         target_ops.push_back(child_par.getOperation());
       }
     }
-    if (target_ops.empty())
+    if (target_ops.empty()) {
+      // Loop is already in isolation
+      for_op->setAttr("isolated", rewriter.getBoolAttr(true));
       return failure();
+    }
 
     // Hoist ops out to a new scf.for loop
     rewriter.setInsertionPoint(for_op);

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -627,3 +627,52 @@ char air::checkOpOperandReadOrWrite(mlir::OpOperand &op_operand) {
   else
     return 'u';
 }
+
+// Convert a vector of SSA returned from arith::ConstantIndexOp into a vector of
+// uints
+std::vector<unsigned>
+air::convertVecOfConstIndexToVecOfUInt(SmallVector<Value> svec) {
+  std::vector<unsigned> output;
+  for (auto v : svec) {
+    auto op = v.getDefiningOp<arith::ConstantIndexOp>();
+    if (!op)
+      return std::vector<unsigned>();
+    output.push_back(op.value());
+  }
+  return output;
+}
+
+// Get iterator corresponding to a position in a multi-dimensional vector
+unsigned air::getIteratorFromMDVector(std::vector<unsigned> dims,
+                                      std::vector<unsigned> position) {
+  if (dims.size() != position.size())
+    return 0;
+
+  std::reverse(position.begin(), position.end());
+  unsigned output = 0;
+  for (int i = dims.size() - 1; i >= 0; i--) { // In reversed order
+    unsigned scale_factor = 1;
+    for (unsigned j = i + 1; j < dims.size(); j++) {
+      scale_factor *= dims[j];
+    }
+    output += scale_factor * position[i];
+  }
+  return output;
+}
+
+// Get coordinates corresponding to a position in a multi-dimensional vector
+// from an iterator
+std::vector<unsigned> air::getMDVectorFromIterator(std::vector<unsigned> dims,
+                                                   unsigned iter) {
+  std::vector<unsigned> output;
+  for (int i = dims.size() - 1; i >= 0; i--) { // reversed order
+    unsigned denominator = 1;
+    for (int j = 0; j < i; j++) {
+      denominator *= dims[j];
+    }
+    output.push_back((iter / (denominator)) % dims[i]);
+  }
+  // Reverse to original order
+  std::reverse(output.begin(), output.end());
+  return output;
+}

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -7,11 +7,12 @@
 
 // RUN: air-opt %s -air-to-std | FileCheck %s
 
+// CHECK-LABEL:   func.func @single_put_get
 // CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 air.channel @channel_1 [1, 1]
 air.channel @channel_0 [1, 1]
-func.func @graph(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
+func.func @single_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
   %c8 = arith.constant 8 : index
   %c16 = arith.constant 16 : index
   %c32 = arith.constant 32 : index
@@ -34,6 +35,140 @@ func.func @graph(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
       }
     }
     air.channel.put  @channel_1[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) : (memref<16x8xi32, 2>)
+    memref.dealloc %alloc_5 : memref<16x8xi32, 2>
+    memref.dealloc %alloc : memref<16x8xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @par_put_get
+// CHECK: scf.parallel{{.*}} -> !airrt.event {
+// CHECK:   airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK:   scf.reduce({{.*}})  : !airrt.event {
+// CHECK:   ^bb0({{.*}}: !airrt.event, {{.*}}: !airrt.event):
+// CHECK:     airrt.wait_all {{.*}} : !airrt.event
+// CHECK:     scf.reduce.return {{.*}} : !airrt.event
+// CHECK:   }
+// CHECK:   scf.yield
+// CHECK: }
+// CHECK: scf.parallel{{.*}} -> !airrt.event {
+// CHECK:   airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK:   scf.reduce({{.*}})  : !airrt.event {
+// CHECK:   ^bb0({{.*}}: !airrt.event, {{.*}}: !airrt.event):
+// CHECK:     airrt.wait_all {{.*}} : !airrt.event
+// CHECK:     scf.reduce.return {{.*}} : !airrt.event
+// CHECK:   }
+// CHECK:   scf.yield
+// CHECK: }
+air.channel @channel_3 [2, 2]
+air.channel @channel_2 [2, 2]
+func.func @par_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %async_token_2 = air.wait_all async
+  %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
+    %async_token = air.channel.put async  @channel_2[%arg8, %arg9] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
+    scf.reduce(%async_token)  : !air.async.token {
+    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+      %9 = air.wait_all async [%arg10, %arg11] 
+      scf.reduce.return %9 : !air.async.token
+    }
+    scf.yield
+  }
+  %6 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
+    %async_token_0 = air.channel.get async @channel_3[%arg8, %arg9] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
+    scf.reduce(%async_token_0)  : !air.async.token {
+    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+      %9 = air.wait_all async [%arg10, %arg11] 
+      scf.reduce.return %9 : !air.async.token
+    }
+    scf.yield
+  }
+  air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c2, %arg5=%c2) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
+    %c0_1 = arith.constant 0 : index
+    %c32_2 = arith.constant 32 : index
+    %c16_3 = arith.constant 16 : index
+    %c8_4 = arith.constant 8 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
+    %alloc_5 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
+    air.channel.get  @channel_2[%arg2, %arg3] (%alloc[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) : (memref<16x8xi32, 2>)
+    affine.for %arg6 = 0 to 8 {
+      affine.for %arg7 = 0 to 16 {
+        %0 = affine.load %alloc[%arg7, %arg6] : memref<16x8xi32, 2>
+        affine.store %0, %alloc_5[%arg7, %arg6] : memref<16x8xi32, 2>
+      }
+    }
+    air.channel.put  @channel_3[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) : (memref<16x8xi32, 2>)
+    memref.dealloc %alloc_5 : memref<16x8xi32, 2>
+    memref.dealloc %alloc : memref<16x8xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @par_with_for_put_get
+// CHECK: scf.parallel{{.*}} -> !airrt.event {
+// CHECK:   airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: scf.parallel{{.*}} -> !airrt.event {
+// CHECK:   scf.for{{.*}} -> (!airrt.event) {  
+// CHECK:     airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK:     scf.yield {{.*}} : !airrt.event
+// CHECK:   }
+air.channel @channel_5 [2, 2]
+air.channel @channel_4 [2, 2]
+func.func @par_with_for_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %async_token_2 = air.wait_all async
+  %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
+    %async_token = air.channel.put async  @channel_4[%arg8, %arg9] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
+    scf.reduce(%async_token)  : !air.async.token {
+    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+      %9 = air.wait_all async [%arg10, %arg11] 
+      scf.reduce.return %9 : !air.async.token
+    }
+    scf.yield
+  }
+  %6 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
+    %7 = scf.for %arg12 = %c0 to %c2 step %c1 iter_args(%arg13 = %async_token_2) -> (!air.async.token) {
+      %async_token_0 = air.channel.get async [%arg13] @channel_5[%arg8, %arg9] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
+      scf.yield %async_token_0 : !air.async.token
+    }
+    scf.reduce(%7)  : !air.async.token {
+    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+      %9 = air.wait_all async [%arg10, %arg11] 
+      scf.reduce.return %9 : !air.async.token
+    }
+    scf.yield
+  }
+  air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c2, %arg5=%c2) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
+    %c0_1 = arith.constant 0 : index
+    %c2_1 = arith.constant 2 : index
+    %c1_1 = arith.constant 1 : index
+    %c32_2 = arith.constant 32 : index
+    %c16_3 = arith.constant 16 : index
+    %c8_4 = arith.constant 8 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
+    %alloc_5 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
+    air.channel.get  @channel_4[%arg2, %arg3] (%alloc[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) : (memref<16x8xi32, 2>)
+    affine.for %arg6 = 0 to 8 {
+      affine.for %arg7 = 0 to 16 {
+        %0 = affine.load %alloc[%arg7, %arg6] : memref<16x8xi32, 2>
+        affine.store %0, %alloc_5[%arg7, %arg6] : memref<16x8xi32, 2>
+      }
+    }
+    scf.for %arg12 = %c0_1 to %c2_1 step %c1_1 {
+      air.channel.put  @channel_5[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) : (memref<16x8xi32, 2>)
+    }
     memref.dealloc %alloc_5 : memref<16x8xi32, 2>
     memref.dealloc %alloc : memref<16x8xi32, 2>
     air.herd_terminator

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -17,12 +17,8 @@ func.func @graph(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
   %c32 = arith.constant 32 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  %async_token = air.execute {
-    air.channel.put  @channel_0[%c0, %c0] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
-  }
-  %async_token_0 = air.execute {
-    air.channel.get  @channel_1[%c0, %c0] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
-  }
+  %async_token = air.channel.put async  @channel_0[%c0, %c0] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
+  %async_token_0 = air.channel.get async @channel_1[%c0, %c0] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) : (memref<32x16xi32>)
   air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c1, %arg5=%c1) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
     %c0_1 = arith.constant 0 : index
     %c32_2 = arith.constant 32 : index

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL1.mlir
@@ -46,3 +46,43 @@ AIE.device(xcvc1902) {
     AIE.end
   } {elf_file = "segment_0_core_1_1.elf"}
 }
+
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:    %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:    %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK:    %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1 : i32) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:    %[[VAL_3:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:      %[[VAL_4:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:      %[[VAL_5:.*]] = AIE.objectFifo.subview.access %[[VAL_4]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:      AIE.objectFifo.release<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:      AIE.end
+// CHECK:    } {elf_file = "segment_0_core_1_2.elf"}
+// CHECK:    %[[VAL_6:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:      %[[VAL_7:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:      %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_7]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:      AIE.objectFifo.release<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:      AIE.end
+// CHECK:    } {elf_file = "segment_0_core_1_1.elf"}
+// CHECK:  }
+
+AIE.device(xcvc1902) {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.tile(1, 2)
+  air.channel @channel_0 [1, 1]
+  %2 = AIE.core(%1) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    %4 = air.channel.get async @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "segment_0_core_1_2.elf"}
+  %3 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    %5 = air.channel.put async @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "segment_0_core_1_1.elf"}
+}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_L1toL3.mlir
@@ -37,7 +37,7 @@ AIE.device(xcvc1902) {
     %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
     %alloc_0 = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
     affine.for %arg0 = 0 to 4096 step 32 {
-      air.channel.get  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+      %3 = air.channel.get async @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
       affine.for %arg1 = 0 to 32 {
         %2 = affine.load %alloc[%arg1] : memref<32xi32, 2>
         affine.store %2, %alloc_0[%arg1] : memref<32xi32, 2>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectFifo_buffer_resources.mlir
@@ -40,9 +40,10 @@ AIE.device(xcvc1902) {
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
     %alloc2 = memref.alloc() {sym_name = "scratch_copy2"} : memref<32xi32, 2>
-    air.channel.get  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
-    air.channel.get  @channel_1[] (%alloc2[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.get @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.get @channel_1[] (%alloc2[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
     memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
     AIE.end
   } {elf_file = "partition_0_core_1_2.elf"}
   %3 = AIE.core(%0) {
@@ -50,9 +51,62 @@ AIE.device(xcvc1902) {
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
     %alloc2 = memref.alloc() {sym_name = "scratch2"} : memref<32xi32, 2>
-    air.channel.put  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
-    air.channel.put  @channel_1[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.put @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.put @channel_1[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
     memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_1.elf"}
+}
+
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 1 : i32) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
+// CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:     %[[VAL_5:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_6:.*]] = AIE.objectFifo.subview.access %[[VAL_5]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     %[[VAL_7:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_7]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_2.elf"}
+// CHECK:   %[[VAL_9:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:     %[[VAL_10:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     %[[VAL_12:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
+// CHECK:     %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
+// CHECK:     AIE.objectFifo.release<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1)
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
+// CHECK: }
+
+AIE.device(xcvc1902) {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.tile(1, 2)
+  air.channel @channel_0 [1, 1]
+  air.channel @channel_1 [1, 1] {buffer_resources = 2}
+  %2 = AIE.core(%1) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch_copy2"} : memref<32xi32, 2>
+    %4 = air.channel.get async  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    %5 = air.channel.get async [%4] @channel_1[] (%alloc2[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_2.elf"}
+  %3 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch2"} : memref<32xi32, 2>
+    %4 = air.channel.put async @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    %5 = air.channel.put async @channel_1[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
     AIE.end
   } {elf_file = "partition_0_core_1_1.elf"}
 }

--- a/mlir/test/Conversion/AIRToAIE/air_ping_pong_to_objectFifo.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_ping_pong_to_objectFifo.mlir
@@ -13,7 +13,7 @@
 // CHECK:   %[[VAL_2:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) {sym_name = "air_channel_1"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %[[VAL_3:.*]] = AIE.objectFifo.createObjectFifo(%[[VAL_1]], {%[[VAL_0]]}, 2 : i32) {sym_name = "air_channel_0"} : !AIE.objectFifo<memref<32xi32, 2>>
 // CHECK:   %[[VAL_4:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:     affine.for %[[VAL_5:.*]] = 0 to 4096 step 32 {
+// CHECK:     scf.for
 // CHECK:       %[[VAL_6:.*]] = AIE.objectFifo.acquire<Consume> (%[[VAL_3]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
 // CHECK:       %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<32xi32, 2>> -> memref<32xi32, 2>
 // CHECK:       %[[VAL_8:.*]] = AIE.objectFifo.acquire<Produce> (%[[VAL_2]] : !AIE.objectFifo<memref<32xi32, 2>>, 1) : !AIE.objectFifoSubview<memref<32xi32, 2>>
@@ -33,10 +33,9 @@ AIE.device(xcvc1902) {
     %c4096 = arith.constant 4096 : index
     %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
     %async_token_0 = air.wait_all async
-    %2 = scf.for %arg0 = %c0 to %c4096 step %c32 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
-      %3 = air.channel.get async [%arg11]  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    scf.for %arg0 = %c0 to %c4096 step %c32 {
+      %3 = air.channel.get async  @channel_0[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
       %4 = air.channel.put async [%3]  @channel_1[] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
-      scf.yield %4 : !air.async.token
     } {isolated = true, unroll = 2 : i64}
     memref.dealloc %alloc : memref<32xi32, 2>
     AIE.end

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_objectFifo.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_objectFifo.mlir
@@ -1,0 +1,170 @@
+//===- async_gemm_to_objectFifo.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-to-aie="emit-while-loop=false row-offset=3 col-offset=5 device=xcvc1902" %s | FileCheck %s
+
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(5, 3)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(6, 3)
+// CHECK:   %[[VAL_2:.*]] = AIE.tile(5, 4)
+// CHECK:   %[[VAL_3:.*]] = AIE.tile(6, 4)
+// CHECK:   %[[VAL_4:.*]] = AIE.buffer(%[[VAL_3]]){{.*}}memref<64x96xbf16, 2>
+// CHECK:   %[[VAL_5:.*]] = AIE.buffer(%[[VAL_3]]){{.*}}memref<96x64xbf16, 2>
+// CHECK:   %[[VAL_6:.*]] = AIE.buffer(%[[VAL_3]]){{.*}}memref<64x64xbf16, 2>
+// CHECK:   %[[VAL_7:.*]] = AIE.buffer(%[[VAL_2]]){{.*}}memref<64x96xbf16, 2>
+// CHECK:   %[[VAL_8:.*]] = AIE.buffer(%[[VAL_2]]){{.*}}memref<96x64xbf16, 2>
+// CHECK:   %[[VAL_9:.*]] = AIE.buffer(%[[VAL_2]]){{.*}}memref<64x64xbf16, 2>
+// CHECK:   %[[VAL_10:.*]] = AIE.buffer(%[[VAL_1]]){{.*}}memref<64x96xbf16, 2>
+// CHECK:   %[[VAL_11:.*]] = AIE.buffer(%[[VAL_1]]){{.*}}memref<96x64xbf16, 2>
+// CHECK:   %[[VAL_12:.*]] = AIE.buffer(%[[VAL_1]]){{.*}}memref<64x64xbf16, 2>
+// CHECK:   %[[VAL_13:.*]] = AIE.buffer(%[[VAL_0]]){{.*}}memref<64x96xbf16, 2>
+// CHECK:   %[[VAL_14:.*]] = AIE.buffer(%[[VAL_0]]){{.*}}memref<96x64xbf16, 2>
+// CHECK:   %[[VAL_15:.*]] = AIE.buffer(%[[VAL_0]]){{.*}}memref<64x64xbf16, 2>
+// CHECK-COUNT-16:    AIE.objectFifo.createObjectFifo
+// CHECK:   %[[VAL_16:.*]] = AIE.core(%[[VAL_3]]) {
+// CHECK:   %[[VAL_17:.*]] = AIE.core(%[[VAL_2]]) {
+// CHECK:   %[[VAL_18:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:   %[[VAL_19:.*]] = AIE.core(%[[VAL_0]]) {
+
+#map = affine_map<()[s0] -> (s0 * 64)>
+module {
+  air.channel @channel_3 [2, 2]
+  air.channel @channel_2 [2, 2]
+  air.channel @channel_1 [2, 2]
+  air.channel @channel_0 [2, 2]
+  func.func @matmul(%arg0: memref<128x384xbf16>, %arg1: memref<384x128xbf16>, %arg2: memref<128x128xbf16>) {
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c96 = arith.constant 96 : index
+    %c384 = arith.constant 384 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %async_token, %results = air.execute -> (memref<128x128xbf16>) {
+      %alloc = memref.alloc() {alignment = 64 : i64} : memref<128x128xbf16>
+      air.execute_terminator %alloc : memref<128x128xbf16>
+    }
+    %async_token_0 = air.execute [%async_token] {
+      memref.copy %arg2, %results : memref<128x128xbf16> to memref<128x128xbf16>
+    }
+    %0 = air.wait_all async 
+    %1 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%0) -> !air.async.token {
+      %async_token_1, %results_2 = air.execute -> (index) {
+        %8 = affine.apply #map()[%arg3]
+        air.execute_terminator %8 : index
+      }
+      %7 = scf.for %arg5 = %c0 to %c384 step %c96 iter_args(%arg6 = %async_token_1) -> (!air.async.token) {
+        %8 = air.channel.put async [%arg6]  @channel_0[%arg3, %arg4] (%arg0[%results_2, %arg5] [%c64, %c96] [%c384, %c1]) {id = 1 : i32} : (memref<128x384xbf16>)
+        scf.yield %8 : !air.async.token
+      }
+      scf.reduce(%7)  : !air.async.token {
+      ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+        %8 = air.wait_all async [%arg5, %arg6] 
+        scf.reduce.return %8 : !air.async.token
+      }
+      scf.yield
+    }
+    %2 = air.wait_all async 
+    %3 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%2) -> !air.async.token {
+      %async_token_1, %results_2 = air.execute -> (index) {
+        %8 = affine.apply #map()[%arg4]
+        air.execute_terminator %8 : index
+      }
+      %7 = scf.for %arg5 = %c0 to %c384 step %c96 iter_args(%arg6 = %async_token_1) -> (!air.async.token) {
+        %8 = air.channel.put async [%arg6]  @channel_1[%arg3, %arg4] (%arg1[%arg5, %results_2] [%c96, %c64] [%c128, %c1]) {id = 2 : i32} : (memref<384x128xbf16>)
+        scf.yield %8 : !air.async.token
+      }
+      scf.reduce(%7)  : !air.async.token {
+      ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+        %8 = air.wait_all async [%arg5, %arg6] 
+        scf.reduce.return %8 : !air.async.token
+      }
+      scf.yield
+    }
+    %4 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_0) -> !air.async.token {
+      %async_token_1, %results_2 = air.execute -> (index) {
+        %9 = affine.apply #map()[%arg3]
+        air.execute_terminator %9 : index
+      }
+      %async_token_3, %results_4 = air.execute -> (index) {
+        %9 = affine.apply #map()[%arg4]
+        air.execute_terminator %9 : index
+      }
+      %7 = air.wait_all async [%async_token_3, %async_token_1, %async_token_0] 
+      %8 = scf.for %arg5 = %c0 to %c384 step %c96 iter_args(%arg6 = %7) -> (!air.async.token) {
+        %9 = air.channel.put async [%arg6]  @channel_2[%arg3, %arg4] (%results[%results_2, %results_4] [%c64, %c64] [%c128, %c1]) {id = 3 : i32} : (memref<128x128xbf16>)
+        scf.yield %9 : !air.async.token
+      }
+      scf.reduce(%8)  : !air.async.token {
+      ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+        %9 = air.wait_all async [%arg5, %arg6] 
+        scf.reduce.return %9 : !air.async.token
+      }
+      scf.yield
+    }
+    %5 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_0) -> !air.async.token {
+      %async_token_1, %results_2 = air.execute -> (index) {
+        %9 = affine.apply #map()[%arg3]
+        air.execute_terminator %9 : index
+      }
+      %async_token_3, %results_4 = air.execute -> (index) {
+        %9 = affine.apply #map()[%arg4]
+        air.execute_terminator %9 : index
+      }
+      %7 = air.wait_all async [%async_token_3, %async_token_1, %async_token_0] 
+      %8 = scf.for %arg5 = %c0 to %c384 step %c96 iter_args(%arg6 = %7) -> (!air.async.token) {
+        %9 = air.channel.get async [%arg6]  @channel_3[%arg3, %arg4] (%results[%results_2, %results_4] [%c64, %c64] [%c128, %c1]) {id = 4 : i32} : (memref<128x128xbf16>)
+        scf.yield %9 : !air.async.token
+      }
+      scf.reduce(%8)  : !air.async.token {
+      ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+        %9 = air.wait_all async [%arg5, %arg6] 
+        scf.reduce.return %9 : !air.async.token
+      }
+      scf.yield
+    }
+    %6 = air.herd @herd_0 async [%async_token_0]  tile (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) attributes {id = 1 : i32} {
+      %c0_1 = arith.constant 0 : index
+      %c384_2 = arith.constant 384 : index
+      %c96_3 = arith.constant 96 : index
+      %7 = air.wait_all async 
+      %8 = scf.for %arg7 = %c0_1 to %c384_2 step %c96_3 iter_args(%arg8 = %7) -> (!air.async.token) {
+        %async_token_4, %results_5 = air.execute -> (memref<64x96xbf16, 2>) {
+          %alloc = memref.alloc() {hoist_alloc = true} : memref<64x96xbf16, 2>
+          air.execute_terminator %alloc : memref<64x96xbf16, 2>
+        }
+        %async_token_6, %results_7 = air.execute -> (memref<96x64xbf16, 2>) {
+          %alloc = memref.alloc() {hoist_alloc = true} : memref<96x64xbf16, 2>
+          air.execute_terminator %alloc : memref<96x64xbf16, 2>
+        }
+        %async_token_8, %results_9 = air.execute -> (memref<64x64xbf16, 2>) {
+          %alloc = memref.alloc() {hoist_alloc = true} : memref<64x64xbf16, 2>
+          air.execute_terminator %alloc : memref<64x64xbf16, 2>
+        }
+        %9 = air.channel.get async [%async_token_4, %arg8]  @channel_0[%arg3, %arg4] (%results_5[] [] []) {id = 5 : i32} : (memref<64x96xbf16, 2>)
+        %10 = air.channel.get async [%async_token_6, %arg8]  @channel_1[%arg3, %arg4] (%results_7[] [] []) {id = 6 : i32} : (memref<96x64xbf16, 2>)
+        %11 = air.channel.get async [%async_token_8, %arg8]  @channel_2[%arg3, %arg4] (%results_9[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 2>)
+        %async_token_10 = air.execute [%11, %10, %9] {
+          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_5, %results_7 : memref<64x96xbf16, 2>, memref<96x64xbf16, 2>) outs(%results_9 : memref<64x64xbf16, 2>)
+        }
+        %12 = air.channel.put async [%async_token_10]  @channel_3[%arg3, %arg4] (%results_9[] [] []) {id = 8 : i32} : (memref<64x64xbf16, 2>)
+        %async_token_11 = air.execute [%async_token_10] {
+          memref.dealloc %results_5 : memref<64x96xbf16, 2>
+        }
+        %async_token_12 = air.execute [%async_token_10] {
+          memref.dealloc %results_7 : memref<96x64xbf16, 2>
+        }
+        %async_token_13 = air.execute [%12] {
+          memref.dealloc %results_9 : memref<64x64xbf16, 2>
+        }
+        scf.yield %12 : !air.async.token
+      } {unroll = 2 : i32}
+      air.herd_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/specialize_channel_bundle.mlir
+++ b/mlir/test/Conversion/AIRToAIE/specialize_channel_bundle.mlir
@@ -1,0 +1,102 @@
+//===- specialize_channel_bundle.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-to-aie='test-patterns=specialize-channel-bundle' | FileCheck %s
+
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK-COUNT-8:    air.channel @{{.*}}[1, 1]
+// CHECK:   %[[VAL_2:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:     air.channel.get @channel{{.*}}[]
+// CHECK:     air.channel.get @channel{{.*}}[]
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_2.elf"}
+// CHECK:   %[[VAL_3:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:     air.channel.put @channel{{.*}}[]
+// CHECK:     air.channel.put @channel{{.*}}[]
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
+// CHECK: }
+
+AIE.device(xcvc1902) {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.tile(1, 2)
+  air.channel @channel_0 [2, 2]
+  air.channel @channel_1 [2, 2]
+  %2 = AIE.core(%1) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch_copy2"} : memref<32xi32, 2>
+    air.channel.get @channel_0[%c0, %c0] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.get @channel_1[%c0, %c1] (%alloc2[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_2.elf"}
+  %3 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch2"} : memref<32xi32, 2>
+    air.channel.put @channel_0[%c0, %c0] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    air.channel.put @channel_1[%c0, %c1] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_1.elf"}
+}
+
+// CHECK-LABEL:   AIE.device(xcvc1902) {
+// CHECK:   %[[VAL_0:.*]] = AIE.tile(1, 1)
+// CHECK:   %[[VAL_1:.*]] = AIE.tile(1, 2)
+// CHECK-COUNT-8:    air.channel @{{.*}}[1, 1]
+// CHECK:   %[[VAL_2:.*]] = AIE.core(%[[VAL_1]]) {
+// CHECK:     %[[VAL_3:.*]] = air.channel.get async @channel{{.*}}[]
+// CHECK:     %[[VAL_4:.*]] = air.channel.get async @channel{{.*}}[]
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_2.elf"}
+// CHECK:   %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
+// CHECK:     %[[VAL_6:.*]] = air.channel.put async @channel{{.*}}[]
+// CHECK:     %[[VAL_7:.*]] = air.channel.put async @channel{{.*}}[]
+// CHECK:     AIE.end
+// CHECK:   } {elf_file = "partition_0_core_1_1.elf"}
+// CHECK: }
+
+AIE.device(xcvc1902) {
+  %0 = AIE.tile(1, 1)
+  %1 = AIE.tile(1, 2)
+  air.channel @channel_0 [2, 2]
+  air.channel @channel_1 [2, 2]
+  %2 = AIE.core(%1) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() {sym_name = "scratch_copy"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch_copy2"} : memref<32xi32, 2>
+    %4 = air.channel.get async @channel_0[%c0, %c0] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    %5 = air.channel.get async @channel_1[%c0, %c1] (%alloc2[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_2.elf"}
+  %3 = AIE.core(%0) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() {sym_name = "scratch"} : memref<32xi32, 2>
+    %alloc2 = memref.alloc() {sym_name = "scratch2"} : memref<32xi32, 2>
+    %4 = air.channel.put async @channel_0[%c0, %c0] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    %5 = air.channel.put async @channel_1[%c0, %c1] (%alloc[%c0] [%c32] [%c0]) : (memref<32xi32, 2>)
+    memref.dealloc %alloc : memref<32xi32, 2>
+    memref.dealloc %alloc2 : memref<32xi32, 2>
+    AIE.end
+  } {elf_file = "partition_0_core_1_1.elf"}
+}

--- a/mlir/test/Dialect/AIR/canonicalize_channel.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel.mlir
@@ -1,0 +1,27 @@
+//===- canonicalize_channel.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -canonicalize | FileCheck %s
+
+// Prune channels with empty uses.
+// CHECK-LABEL: module
+// CHECK-NEXT: %c2 = arith.constant 2 : index
+// CHECK-NEXT: %c1 = arith.constant 1 : index
+// CHECK-NEXT: air.channel @channel_0 [1, 1]
+// CHECK-NEXT: air.launch (%{{.*}}, %{{.*}}) in (%{{.*}}=%c1, %{{.*}}=%c2) attributes {foo = "bar"} {
+
+module {
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  air.launch (%tx, %ty) in (%size_x = %c1, %size_y = %c2) attributes {foo = "bar"} {
+    %alloc = memref.alloc() : memref<16x8xi32>
+    air.channel.get  @channel_0[] (%alloc[] [] []) : (memref<16x8xi32>)
+    air.launch_terminator
+  }
+}

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -228,7 +228,7 @@ def run(mlir_module, args=None):
       aiecc_dir = opts.tmpdir+'/'+segment
 
       do_call(['air-opt', segment_file, '-air-lower-linalg-tensors',
-               '-lower-affine', '-cse', '-o', aiecc_file])
+               '-lower-affine', '-canonicalize', '-cse', '-o', aiecc_file])
 
       # set host target for aiecc
       if 'x86_64' in platform.uname()[5]:


### PR DESCRIPTION
- Make `-channel-to-objfifo` pass support:
-- `air.channel` with size
-- async ops
- Make `-air-to-std` and `-airrt-to-llvm` support:
-- scf.parallel, scf.reduce, scf.reducereturn ops with async tokens as operands and results