### PR TITLE
add `#include <cstddef>` to memory.cpp

### DIFF
--- a/runtime_lib/airhost/memory.cpp
+++ b/runtime_lib/airhost/memory.cpp
@@ -10,6 +10,7 @@
 #include "air_host_impl.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>    /* for open() */


### PR DESCRIPTION
Compiling for tip gives me this

```
/home/mlevental/dev_projects/mlir-air/runtime_lib/airhost/memory.cpp:275:77: note: ‘offsetof’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
/home/mlevental/dev_projects/mlir-air/runtime_lib/airhost/memory.cpp:337:77: error: ‘offsetof’ was not declared in this scope
  337 |       uint64_t signal_offset = offsetof(dispatch_packet_t, completion_signal);
```

including `<cstddef>` in memory.cpp fixes

cc @stephenneuendorffer 