### PR TITLE
Pass in toolchain as cmake_toolchain_file to make air build with docker

### DIFF
--- a/utils/build-mlir-air-pcie.sh
+++ b/utils/build-mlir-air-pcie.sh
@@ -55,6 +55,7 @@ cmake .. \
     -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
     -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/ \
+    -DCMAKE_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
     -Dx86_64_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
     -DLLVM_DIR=${LLVM_DIR}/build/lib/cmake/llvm \
     -DMLIR_DIR=${LLVM_DIR}/build/lib/cmake/mlir \


### PR DESCRIPTION
Related to issue https://github.com/Xilinx/mlir-air/issues/273