### PR TITLE
Add air-par-to-launch first-dim option

### DIFF
--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -25,7 +25,13 @@ def ParallelToHerd : Pass<"air-par-to-herd", "ModuleOp"> {
   let options = [
     Option<"clAssignDepth", "depth", "int",
           /*default=*/"-1",
-          "Given a nest of parallel for loops, which depth to map to air.herd">
+          "Given a nest of parallel for loops, which depth to map to air.herd">,
+    Option<"clFirstDim", "first-dim", "int",
+          /*default=*/"0",
+          "Which herd dimension to map to first. Can be zero or one. If set to "
+          "zero, the 0th dimension of the scf.parallel will be mapped to the x "
+          "dimension of the herd. If set to one, the 0th dimension of the "
+          "scf.parallel will be mapped to the y dimension of the herd.">
   ];
 }
 

--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -66,7 +66,8 @@ def ParToHerdOp : Op<Transform_Dialect, "air.par_to_herd",
     herd. Returns the new `air.herd` operation.
   }];
   let arguments =
-    (ins PDL_Operation:$target);
+    (ins PDL_Operation:$target,
+     DefaultValuedAttr<I64Attr, "0">:$first_dim);
   let results = (outs PDL_Operation:$result);
   let assemblyFormat = "$target attr-dict";
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1325,9 +1325,10 @@ public:
 
   ScfParToHerdConversion(MLIRContext *ctx,
                          SmallPtrSet<Operation *, 8> &filteredOps,
-                         llvm::SmallSet<air::HerdOp, 2> &replacementOps)
+                         llvm::SmallSet<air::HerdOp, 2> &replacementOps,
+                         int firstDim)
       : OpRewritePattern(ctx), filteredOps(filteredOps),
-        replacementOps(replacementOps){};
+        replacementOps(replacementOps), firstDim(firstDim) {};
 
   LogicalResult matchAndRewrite(scf::ParallelOp parOp,
                                 PatternRewriter &rewriter) const override {
@@ -1397,16 +1398,19 @@ public:
       else
         args.push_back(v);
     }
+
+    int idx0 = firstDim;
+    int idx1 = (firstDim+1) % 2;
     SmallVector<Value, 2> dims{
-        rewriter.create<arith::ConstantIndexOp>(loc, bounds[0]),
-        rewriter.create<arith::ConstantIndexOp>(loc, bounds[1])};
+        rewriter.create<arith::ConstantIndexOp>(loc, bounds[idx0]),
+        rewriter.create<arith::ConstantIndexOp>(loc, bounds[idx1])};
     auto herdOp = rewriter.create<air::HerdOp>(op.getLoc(), dims, args);
     auto &bb = herdOp.getBody().front();
     auto ivs = op.getInductionVars();
 
-    ivs[0].replaceAllUsesWith(herdOp.getIds()[0]);
+    ivs[0].replaceAllUsesWith(herdOp.getIds()[idx0]);
     if (op.getNumLoops() == 2)
-      ivs[1].replaceAllUsesWith(herdOp.getIds()[1]);
+      ivs[1].replaceAllUsesWith(herdOp.getIds()[idx1]);
 
     auto &body = op.getBody()->getOperations();
     bb.getOperations().splice(bb.begin(), body, body.begin(), --body.end());
@@ -1432,6 +1436,7 @@ public:
 private:
   llvm::SmallPtrSet<Operation *, 8> filteredOps;
   llvm::SmallSet<air::HerdOp, 2> &replacementOps;
+  int firstDim;
 };
 
 class ScfParToLaunchConversion : public OpRewritePattern<scf::ParallelOp> {
@@ -1945,7 +1950,7 @@ struct ParallelToHerdPass : public air::ParallelToHerdBase<ParallelToHerdPass> {
 
     RewritePatternSet patterns(context);
     patterns.add<AffineParToHerdConversion>(context);
-    patterns.add<ScfParToHerdConversion>(context, filteredOps, replacementOps);
+    patterns.add<ScfParToHerdConversion>(context, filteredOps, replacementOps, clFirstDim);
 
     ConversionTarget target(*context);
 
@@ -2059,7 +2064,8 @@ transform::ParToHerdOp::applyToOne(scf::ParallelOp target,
   llvm::SmallSet<air::HerdOp, 2> herdOps;
   llvm::SmallSet<Operation *, 8> filteredOps;
   filteredOps.insert(target);
-  patterns.add<ScfParToHerdConversion>(ctx, filteredOps, herdOps);
+  patterns.add<ScfParToHerdConversion>(ctx, filteredOps, herdOps,
+                                       getFirstDim());
   (void)applyPatternsAndFoldGreedily(
       target->getParentWithTrait<OpTrait::IsIsolatedFromAbove>(),
       std::move(patterns));

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1328,7 +1328,7 @@ public:
                          llvm::SmallSet<air::HerdOp, 2> &replacementOps,
                          int firstDim)
       : OpRewritePattern(ctx), filteredOps(filteredOps),
-        replacementOps(replacementOps), firstDim(firstDim) {};
+        replacementOps(replacementOps), firstDim(firstDim){};
 
   LogicalResult matchAndRewrite(scf::ParallelOp parOp,
                                 PatternRewriter &rewriter) const override {
@@ -1400,7 +1400,7 @@ public:
     }
 
     int idx0 = firstDim;
-    int idx1 = (firstDim+1) % 2;
+    int idx1 = (firstDim + 1) % 2;
     SmallVector<Value, 2> dims{
         rewriter.create<arith::ConstantIndexOp>(loc, bounds[idx0]),
         rewriter.create<arith::ConstantIndexOp>(loc, bounds[idx1])};
@@ -1950,7 +1950,8 @@ struct ParallelToHerdPass : public air::ParallelToHerdBase<ParallelToHerdPass> {
 
     RewritePatternSet patterns(context);
     patterns.add<AffineParToHerdConversion>(context);
-    patterns.add<ScfParToHerdConversion>(context, filteredOps, replacementOps, clFirstDim);
+    patterns.add<ScfParToHerdConversion>(context, filteredOps, replacementOps,
+                                         clFirstDim);
 
     ConversionTarget target(*context);
 

--- a/mlir/test/Conversion/ConvertToAIR/transform-ops.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/transform-ops.mlir
@@ -41,7 +41,9 @@ transform.with_pdl_patterns {
 // -----
 
 // CHECK-LABEL @air_par_to_herd
-// CHECK: air.herd
+// CHECK: %[[C4:.*]] = arith.constant 4 : index
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: air.herd @herd_0  tile ({{.*}}) in (%{{.*}}=%[[C4]], %{{.*}}=%[[C1]])
 func.func @air_par_to_herd() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -68,5 +70,40 @@ transform.with_pdl_patterns {
   ^bb1(%arg1 : !pdl.operation):
       %0 = pdl_match @match_par in %arg1 : (!pdl.operation) -> !pdl.operation
       %1 = transform.air.par_to_herd %0
+  }
+}
+
+// -----
+
+// CHECK-LABEL @air_par_to_herd_vert
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C4:.*]] = arith.constant 4 : index
+// CHECK: air.herd @herd_0  tile ({{.*}}) in (%{{.*}}=%[[C1]], %{{.*}}=%[[C4]])
+func.func @air_par_to_herd_vert() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  scf.parallel (%a) = (%c0) to (%c4) step (%c1) {
+    %alloc = memref.alloc() : memref<1xi32>
+    %c = arith.constant 0 : i32
+    linalg.fill ins(%c : i32) outs(%alloc : memref<1xi32>)
+    scf.yield
+  }
+  return
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  pdl.pattern @match_par : benefit(1) {
+    %args = pdl.operands
+    %results = pdl.types
+    %op = pdl.operation "scf.parallel"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+    pdl.rewrite %op with "transform.dialect"
+  }
+
+  sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1 : !pdl.operation):
+      %0 = pdl_match @match_par in %arg1 : (!pdl.operation) -> !pdl.operation
+      %1 = transform.air.par_to_herd %0 {"first_dim"=1}
   }
 }


### PR DESCRIPTION
The primary motivation is to select between Nx1 or 1xN herd when mapping a 1d scf.parallel