### PR TITLE
Add boost requirement to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,9 @@ project(AIR LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-set(PEANO_INSTALL_DIR "<unset>" CACHE STRING "Location of Peano compiler")
+set(PEANO_INSTALL_DIR
+    "<unset>"
+    CACHE STRING "Location of Peano compiler")
 
 include(ExternalProject)
 
@@ -44,7 +46,8 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using AIEConfig.cmake in: ${AIE_DIR}")
 
 option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
+option(LLVM_BUILD_TOOLS
+       "Build the LLVM tools. If OFF, just generate build targets." ON)
 
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
@@ -53,10 +56,12 @@ set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 # Define the default arguments to use with 'lit', and an option for the user to
 # override.
 set(LIT_ARGS_DEFAULT "-sv --timeout=30")
-if (MSVC_IDE OR XCODE)
+if(MSVC_IDE OR XCODE)
   set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
 endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
+set(LLVM_LIT_ARGS
+    "${LIT_ARGS_DEFAULT}"
+    CACHE STRING "Default options for lit")
 set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" FORCE)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -74,7 +79,10 @@ include(AddMLIR)
 include(HandleLLVMOptions)
 
 # setup python
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(
+  Python3
+  COMPONENTS Interpreter Development
+  REQUIRED)
 include(MLIRDetectPythonEnv)
 mlir_detect_pybind11_install()
 find_package(pybind11 2.6 REQUIRED)
@@ -107,55 +115,65 @@ add_custom_target(check-all)
 add_custom_target(docs ALL)
 add_dependencies(docs mlir-doc)
 
-set(AIR_RUNTIME_TARGETS "" CACHE STRING "Architectures to compile the runtime libraries for.")
-set(AIR_RUNTIME_TEST_TARGET "" CACHE STRING "Runtime architecture to test with.")
+set(AIR_RUNTIME_TARGETS
+    ""
+    CACHE STRING "Architectures to compile the runtime libraries for.")
+set(AIR_RUNTIME_TEST_TARGET
+    ""
+    CACHE STRING "Runtime architecture to test with.")
 set(AIR_RUNTIME_TEST_TARGET_VAL ${AIR_RUNTIME_TEST_TARGET})
 
 foreach(target ${AIR_RUNTIME_TARGETS})
-	# By default, we test the first architecture in AIR_RUNTIME_TARGETS.
-	# Alternatively, this can be defined to force testing with a particular architecture.
-	if (NOT AIR_RUNTIME_TEST_TARGET_VAL)
-		set(AIR_RUNTIME_TEST_TARGET_VAL ${target})
-		message("Testing with AIR runtime target: ${AIR_RUNTIME_TEST_TARGET_VAL}")
-	endif()
+  # By default, we test the first architecture in AIR_RUNTIME_TARGETS.
+  # Alternatively, this can be defined to force testing with a particular
+  # architecture.
+  if(NOT AIR_RUNTIME_TEST_TARGET_VAL)
+    set(AIR_RUNTIME_TEST_TARGET_VAL ${target})
+    message("Testing with AIR runtime target: ${AIR_RUNTIME_TEST_TARGET_VAL}")
+  endif()
 
-	if (NOT EXISTS ${${target}_TOOLCHAIN_FILE})
-		message(FATAL_ERROR "Toolchain file ${${target}_TOOLCHAIN_FILE} not found! Cannot build target ${target}.")
-	endif()
-	message("Building AIR runtime for ${target} with TOOLCHAIN=${${target}_TOOLCHAIN_FILE}")
-	ExternalProject_Add(air_runtime_lib_${target}
-		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/runtime_libTmp/${target}
-		SOURCE_DIR ${PROJECT_SOURCE_DIR}/runtime_lib
-		BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib/${target}
-		CMAKE_CACHE_ARGS
-			-DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
-		CMAKE_ARGS
-			-DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
-			-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-			-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-			-DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
-			-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-			-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-			-DLibXAIE_ROOT=${LibXAIE_ROOT}
-			-DAIE_DIR=${AIE_DIR}
-		BUILD_ALWAYS true
-		STEP_TARGETS clean build install test
-		USES_TERMINAL_CONFIGURE true
-		USES_TERMINAL_BUILD true
-		USES_TERMINAL_TEST true
-		USES_TERMINAL_INSTALL true
-		TEST_BEFORE_INSTALL true
-		TEST_EXCLUDE_FROM_MAIN true
-	)
+  if(NOT EXISTS ${${target}_TOOLCHAIN_FILE})
+    message(
+      FATAL_ERROR
+        "Toolchain file ${${target}_TOOLCHAIN_FILE} not found! Cannot build target ${target}."
+    )
+  endif()
+  message(
+    "Building AIR runtime for ${target} with TOOLCHAIN=${${target}_TOOLCHAIN_FILE}"
+  )
+  ExternalProject_Add(
+    air_runtime_lib_${target}
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/runtime_libTmp/${target}
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/runtime_lib
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib/${target}
+    CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
+    CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DLibXAIE_ROOT=${LibXAIE_ROOT}
+               -DAIE_DIR=${AIE_DIR}
+    BUILD_ALWAYS true
+    STEP_TARGETS clean build install test
+    USES_TERMINAL_CONFIGURE true
+    USES_TERMINAL_BUILD true
+    USES_TERMINAL_TEST true
+    USES_TERMINAL_INSTALL true
+    TEST_BEFORE_INSTALL true
+    TEST_EXCLUDE_FROM_MAIN true)
 endforeach()
 
 add_subdirectory(python)
-if (NOT AIR_RUNTIME_TEST_TARGET_VAL)
-	message("Skipping tests: No Runtime architecture found. Please configure AIR_RUNTIME_TARGETS.")
-elseif (NOT LibXAIE_FOUND)
-	message("Skipping tests: LibXAIE not found.")
+if(NOT AIR_RUNTIME_TEST_TARGET_VAL)
+  message(
+    "Skipping tests: No Runtime architecture found. Please configure AIR_RUNTIME_TARGETS."
+  )
+elseif(NOT LibXAIE_FOUND)
+  message("Skipping tests: LibXAIE not found.")
 else()
-	add_subdirectory(test)
+  add_subdirectory(test)
 endif()
 add_subdirectory(tools)
 add_subdirectory(cmake/modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(PEANO_INSTALL_DIR "<unset>" CACHE STRING "Location of Peano compiler")
 include(ExternalProject)
 
 find_package(MLIR REQUIRED CONFIG)
+find_package(Boost REQUIRED)
 find_package(AIE REQUIRED)
 find_package(LibXAIE)
 
@@ -96,6 +97,7 @@ include_directories(${AIE_INCLUDE_DIRS})
 
 include_directories(${PROJECT_SOURCE_DIR}/mlir/include)
 include_directories(${PROJECT_BINARY_DIR}/mlir/include)
+include_directories(${Boost_INCLUDE_DIRS})
 
 add_definitions(${LLVM_DEFINITIONS})
 


### PR DESCRIPTION
This PR adds boost as a build requirement to the root CMake.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
