### PR TITLE
Use upstream CMake macros to find python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,8 @@ include(AddMLIR)
 include(HandleLLVMOptions)
 
 # setup python
-find_package(
-  Python3
-  COMPONENTS Interpreter Development
-  REQUIRED)
 include(MLIRDetectPythonEnv)
-mlir_detect_pybind11_install()
-find_package(pybind11 2.6 REQUIRED)
+mlir_configure_python_dev_packages()
 
 # python build directory
 if(NOT AIR_PYTHON_PACKAGES_DIR)


### PR DESCRIPTION
This PR uses the upstream CMake macros (which are more robust in various CI environment) to find python and pybind.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
