### PR TITLE
Use correct macros for C API

### DIFF
--- a/mlir/include/air-c/Dialects.h
+++ b/mlir/include/air-c/Dialects.h
@@ -28,4 +28,4 @@ MLIR_CAPI_EXPORTED MlirType mlirAIRAsyncTokenTypeGet(MlirContext ctx);
 }
 #endif
 
-#endif  // AIR_C_DIALECTS_H
+#endif // AIR_C_DIALECTS_H

--- a/mlir/include/air-c/Registration.h
+++ b/mlir/include/air-c/Registration.h
@@ -18,10 +18,10 @@ extern "C" {
 /** Registers all AIR dialects with a context.
  * This is needed before creating IR for these Dialects.
  */
-void airRegisterAllDialects(MlirContext context);
+MLIR_CAPI_EXPORTED void airRegisterAllDialects(MlirContext context);
 
 /** Registers all AIR passes for symbolic access with the global registry. */
-void airRegisterAllPasses();
+MLIR_CAPI_EXPORTED void airRegisterAllPasses();
 
 #ifdef __cplusplus
 }

--- a/mlir/include/air-c/Runner.h
+++ b/mlir/include/air-c/Runner.h
@@ -17,9 +17,11 @@
 extern "C" {
 #endif
 
-MLIR_CAPI_EXPORTED void airRunnerRun(MlirModule module, const char *json_file_name,
-                  const char *output_file_name, const char *function,
-                  const char *sim_granularity, bool verbose);
+MLIR_CAPI_EXPORTED void airRunnerRun(MlirModule module,
+                                     const char *json_file_name,
+                                     const char *output_file_name,
+                                     const char *function,
+                                     const char *sim_granularity, bool verbose);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/air-c/Runner.h
+++ b/mlir/include/air-c/Runner.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-void airRunnerRun(MlirModule module, const char *json_file_name,
+MLIR_CAPI_EXPORTED void airRunnerRun(MlirModule module, const char *json_file_name,
                   const char *output_file_name, const char *function,
                   const char *sim_granularity, bool verbose);
 

--- a/mlir/include/air-c/Transform.h
+++ b/mlir/include/air-c/Transform.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-void runTransform(MlirModule transform, MlirModule payload);
+MLIR_CAPI_EXPORTED void runTransform(MlirModule transform, MlirModule payload);
 
 #ifdef __cplusplus
 }

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -2,13 +2,13 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_public_c_api_library(AIRCAPI
-Dialects.cpp
-Registration.cpp
-Runner.cpp
-Transform.cpp
-
-LINK_LIBS PUBLIC
-AIRDialect
-AIRInitAll
-)
+add_mlir_public_c_api_library(
+  AIRCAPI
+  Dialects.cpp
+  Registration.cpp
+  Runner.cpp
+  Transform.cpp
+  LINK_LIBS
+  PUBLIC
+  AIRDialect
+  AIRInitAll)

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -2,21 +2,13 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_library(AIRCAPI
+add_mlir_public_c_api_library(AIRCAPI
 Dialects.cpp
 Registration.cpp
 Runner.cpp
 Transform.cpp
 
-DEPENDS
-
-ENABLE_AGGREGATION
-LINK_COMPONENTS
-Core
-
 LINK_LIBS PUBLIC
 AIRDialect
 AIRInitAll
-MLIRIR
-MLIRSupport
 )

--- a/mlir/lib/CAPI/Registration.cpp
+++ b/mlir/lib/CAPI/Registration.cpp
@@ -21,6 +21,4 @@ void airRegisterAllDialects(MlirContext context) {
   unwrap(context)->loadAllAvailableDialects();
 }
 
-void airRegisterAllPasses() {
-  xilinx::air::registerAllPasses();
-}
+void airRegisterAllPasses() { xilinx::air::registerAllPasses(); }


### PR DESCRIPTION
This PR uses the correct upstream CMake macros for building the C API (as well as the correct C export macros).

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
