### PR TITLE
Use correct upstream CMake functions for tools

### DIFF
--- a/tools/air-runner/CMakeLists.txt
+++ b/tools/air-runner/CMakeLists.txt
@@ -2,24 +2,20 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set(LLVM_LINK_COMPONENTS
-        Core
-        Support
-)
+set(LLVM_LINK_COMPONENTS Core Support)
 
 # Now build our tools
 add_mlir_tool(air-runner air-runner.cpp)
 llvm_update_compile_flags(air-runner)
 
 set(LIBS
-AIRDialect
-AIRRtDialect
-AIRUtil
-AIRConversionPasses
-AIRTransformPasses
-AIRInitAll
-MLIRSupport
-)
+    AIRDialect
+    AIRRtDialect
+    AIRUtil
+    AIRConversionPasses
+    AIRTransformPasses
+    AIRInitAll
+    MLIRSupport)
 
 target_link_libraries(air-runner PRIVATE ${LIBS})
 

--- a/tools/air-runner/CMakeLists.txt
+++ b/tools/air-runner/CMakeLists.txt
@@ -2,14 +2,14 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-llvm_map_components_to_libnames(llvm_libs support core irreader)
+set(LLVM_LINK_COMPONENTS
+        Core
+        Support
+)
 
 # Now build our tools
-add_llvm_tool(air-runner air-runner.cpp)
+add_mlir_tool(air-runner air-runner.cpp)
 llvm_update_compile_flags(air-runner)
-
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 set(LIBS
 AIRDialect
@@ -18,6 +18,9 @@ AIRUtil
 AIRConversionPasses
 AIRTransformPasses
 AIRInitAll
+MLIRSupport
 )
 
 target_link_libraries(air-runner PRIVATE ${LIBS})
+
+export_executable_symbols(mlir-cpu-runner)


### PR DESCRIPTION
This PR uses the upstream CMake functions for buildings `air-runner`.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
