### PR TITLE
Use new policy CMP0091 for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 if(POLICY CMP0116)
   cmake_policy(SET CMP0116 OLD)
 endif()


### PR DESCRIPTION
This PR sets `CMP0091` to be the [new policy](https://cmake.org/cmake/help/latest/policy/CMP0091.html); [LLVM_USE_CRT_](https://github.com/llvm/llvm-project/blob/d03a7f15f019beb1896872ba9321cfed5f16a05f/llvm/docs/CMake.rst?plain=1#L782) is deprecated.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
