### PR TITLE
Use upstream `add_mlir_library` CMake functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,22 @@ foreach(target ${AIR_RUNTIME_TARGETS})
 	)
 endforeach()
 
+if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+	install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime_lib/airhost/include
+			DESTINATION include/..
+			COMPONENT runtime_lib-headers
+			FILES_MATCHING
+			PATTERN "*.h"
+			PATTERN "*.hpp"
+			)
+
+	if (NOT LLVM_ENABLE_IDE)
+		add_llvm_install_targets(install-runtime_lib-headers
+				DEPENDS runtime_lib-headers
+				COMPONENT runtime_lib-headers)
+	endif()
+endif()
+
 add_subdirectory(python)
 if (NOT AIR_RUNTIME_TEST_TARGET_VAL)
 	message("Skipping tests: No Runtime architecture found. Please configure AIR_RUNTIME_TARGETS.")
@@ -156,5 +172,5 @@ else()
 	add_subdirectory(test)
 endif()
 add_subdirectory(tools)
-add_subdirectory(cmake/modules)
 add_subdirectory(mlir)
+add_subdirectory(cmake/modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,9 @@ project(AIR LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-set(PEANO_INSTALL_DIR "<unset>" CACHE STRING "Location of Peano compiler")
+set(PEANO_INSTALL_DIR
+    "<unset>"
+    CACHE STRING "Location of Peano compiler")
 
 include(ExternalProject)
 
@@ -43,7 +45,8 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using AIEConfig.cmake in: ${AIE_DIR}")
 
 option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
+option(LLVM_BUILD_TOOLS
+       "Build the LLVM tools. If OFF, just generate build targets." ON)
 
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
@@ -52,10 +55,12 @@ set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 # Define the default arguments to use with 'lit', and an option for the user to
 # override.
 set(LIT_ARGS_DEFAULT "-sv --timeout=30")
-if (MSVC_IDE OR XCODE)
+if(MSVC_IDE OR XCODE)
   set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
 endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
+set(LLVM_LIT_ARGS
+    "${LIT_ARGS_DEFAULT}"
+    CACHE STRING "Default options for lit")
 set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" FORCE)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -73,7 +78,10 @@ include(AddMLIR)
 include(HandleLLVMOptions)
 
 # setup python
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(
+  Python3
+  COMPONENTS Interpreter Development
+  REQUIRED)
 include(MLIRDetectPythonEnv)
 mlir_detect_pybind11_install()
 find_package(pybind11 2.6 REQUIRED)
@@ -105,71 +113,80 @@ add_custom_target(check-all)
 add_custom_target(docs ALL)
 add_dependencies(docs mlir-doc)
 
-set(AIR_RUNTIME_TARGETS "" CACHE STRING "Architectures to compile the runtime libraries for.")
-set(AIR_RUNTIME_TEST_TARGET "" CACHE STRING "Runtime architecture to test with.")
+set(AIR_RUNTIME_TARGETS
+    ""
+    CACHE STRING "Architectures to compile the runtime libraries for.")
+set(AIR_RUNTIME_TEST_TARGET
+    ""
+    CACHE STRING "Runtime architecture to test with.")
 set(AIR_RUNTIME_TEST_TARGET_VAL ${AIR_RUNTIME_TEST_TARGET})
 
 foreach(target ${AIR_RUNTIME_TARGETS})
-	# By default, we test the first architecture in AIR_RUNTIME_TARGETS.
-	# Alternatively, this can be defined to force testing with a particular architecture.
-	if (NOT AIR_RUNTIME_TEST_TARGET_VAL)
-		set(AIR_RUNTIME_TEST_TARGET_VAL ${target})
-		message("Testing with AIR runtime target: ${AIR_RUNTIME_TEST_TARGET_VAL}")
-	endif()
+  # By default, we test the first architecture in AIR_RUNTIME_TARGETS.
+  # Alternatively, this can be defined to force testing with a particular
+  # architecture.
+  if(NOT AIR_RUNTIME_TEST_TARGET_VAL)
+    set(AIR_RUNTIME_TEST_TARGET_VAL ${target})
+    message("Testing with AIR runtime target: ${AIR_RUNTIME_TEST_TARGET_VAL}")
+  endif()
 
-	if (NOT EXISTS ${${target}_TOOLCHAIN_FILE})
-		message(FATAL_ERROR "Toolchain file ${${target}_TOOLCHAIN_FILE} not found! Cannot build target ${target}.")
-	endif()
-	message("Building AIR runtime for ${target} with TOOLCHAIN=${${target}_TOOLCHAIN_FILE}")
-	ExternalProject_Add(air_runtime_lib_${target}
-		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/runtime_libTmp/${target}
-		SOURCE_DIR ${PROJECT_SOURCE_DIR}/runtime_lib
-		BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib/${target}
-		CMAKE_CACHE_ARGS
-			-DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
-		CMAKE_ARGS
-			-DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
-			-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-			-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-			-DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
-			-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-			-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-			-DLibXAIE_ROOT=${LibXAIE_ROOT}
-			-DAIE_DIR=${AIE_DIR}
-		BUILD_ALWAYS true
-		STEP_TARGETS clean build install test
-		USES_TERMINAL_CONFIGURE true
-		USES_TERMINAL_BUILD true
-		USES_TERMINAL_TEST true
-		USES_TERMINAL_INSTALL true
-		TEST_BEFORE_INSTALL true
-		TEST_EXCLUDE_FROM_MAIN true
-	)
+  if(NOT EXISTS ${${target}_TOOLCHAIN_FILE})
+    message(
+      FATAL_ERROR
+        "Toolchain file ${${target}_TOOLCHAIN_FILE} not found! Cannot build target ${target}."
+    )
+  endif()
+  message(
+    "Building AIR runtime for ${target} with TOOLCHAIN=${${target}_TOOLCHAIN_FILE}"
+  )
+  ExternalProject_Add(
+    air_runtime_lib_${target}
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/runtime_libTmp/${target}
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/runtime_lib
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib/${target}
+    CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
+    CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DLibXAIE_ROOT=${LibXAIE_ROOT}
+               -DAIE_DIR=${AIE_DIR}
+    BUILD_ALWAYS true
+    STEP_TARGETS clean build install test
+    USES_TERMINAL_CONFIGURE true
+    USES_TERMINAL_BUILD true
+    USES_TERMINAL_TEST true
+    USES_TERMINAL_INSTALL true
+    TEST_BEFORE_INSTALL true
+    TEST_EXCLUDE_FROM_MAIN true)
 endforeach()
 
-if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-	install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime_lib/airhost/include
-			DESTINATION include/..
-			COMPONENT runtime_lib-headers
-			FILES_MATCHING
-			PATTERN "*.h"
-			PATTERN "*.hpp"
-			)
+if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/runtime_lib/airhost/include
+    DESTINATION include/..
+    COMPONENT runtime_lib-headers
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 
-	if (NOT LLVM_ENABLE_IDE)
-		add_llvm_install_targets(install-runtime_lib-headers
-				DEPENDS runtime_lib-headers
-				COMPONENT runtime_lib-headers)
-	endif()
+  if(NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-runtime_lib-headers DEPENDS
+                             runtime_lib-headers COMPONENT runtime_lib-headers)
+  endif()
 endif()
 
 add_subdirectory(python)
-if (NOT AIR_RUNTIME_TEST_TARGET_VAL)
-	message("Skipping tests: No Runtime architecture found. Please configure AIR_RUNTIME_TARGETS.")
-elseif (NOT LibXAIE_FOUND)
-	message("Skipping tests: LibXAIE not found.")
+if(NOT AIR_RUNTIME_TEST_TARGET_VAL)
+  message(
+    "Skipping tests: No Runtime architecture found. Please configure AIR_RUNTIME_TARGETS."
+  )
+elseif(NOT LibXAIE_FOUND)
+  message("Skipping tests: LibXAIE not found.")
 else()
-	add_subdirectory(test)
+  add_subdirectory(test)
 endif()
 add_subdirectory(tools)
 add_subdirectory(mlir)

--- a/cmake/modules/AIRConfig.cmake.in
+++ b/cmake/modules/AIRConfig.cmake.in
@@ -14,4 +14,4 @@ set(AIR_INCLUDE_DIRS "@AIR_CONFIG_INCLUDE_DIRS@")
 
 # Provide all our library targets to users.
 include("@AIR_CONFIG_EXPORTS_FILE@")
-
+include("@MLIR_CONFIG_INCLUDE_EXPORTS_FILE@")

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -2,9 +2,9 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# Generate a list of CMake library targets so that other CMake projects can
-# link against them. LLVM calls its version of this file LLVMExports.cmake, but
-# the usual CMake convention seems to be ${Project}Targets.cmake.
+# Generate a list of CMake library targets so that other CMake projects can link
+# against them. LLVM calls its version of this file LLVMExports.cmake, but the
+# usual CMake convention seems to be ${Project}Targets.cmake.
 set(AIR_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/air)
 set(air_cmake_builddir "${CMAKE_BINARY_DIR}/${AIR_INSTALL_PACKAGE_DIR}")
 
@@ -15,15 +15,11 @@ export(EXPORT AIRTargets FILE ${air_cmake_builddir}/AIRTargets.cmake)
 set(AIR_CONFIG_CMAKE_DIR "${air_cmake_builddir}")
 set(AIR_CONFIG_BINARY_DIR "${PROJECT_BINARY_DIR}")
 set(AIR_CONFIG_TOOLS_BINARY_DIR "${PROJECT_BINARY_DIR}/bin")
-set(AIR_CONFIG_INCLUDE_DIRS
-  "${PROJECT_SOURCE_DIR}/include"
-  "${PROJECT_BINARY_DIR}/include"
-  )
+set(AIR_CONFIG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include"
+                            "${PROJECT_BINARY_DIR}/include")
 set(AIR_CONFIG_EXPORTS_FILE "\${AIR_CMAKE_DIR}/AIRTargets.cmake")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/AIRConfig.cmake.in
-  ${air_cmake_builddir}/AIRConfig.cmake
-  @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AIRConfig.cmake.in
+               ${air_cmake_builddir}/AIRConfig.cmake @ONLY)
 set(AIR_CONFIG_CMAKE_DIR)
 set(AIR_CONFIG_BINARY_DIR)
 set(AIR_CONFIG_TOOLS_BINARY_DIR)
@@ -31,11 +27,13 @@ set(AIR_CONFIG_INCLUDE_DIRS)
 set(AIR_CONFIG_EXPORTS_FILE)
 
 # Generate AIRConfig.cmake for the install tree.
-set(AIR_CONFIG_CODE "
+set(AIR_CONFIG_CODE
+    "
 # Compute the installation prefix from this file location.
-get_filename_component(AIR_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
-# Construct the proper number of get_filename_component(... PATH)
-# calls to compute the installation prefix.
+get_filename_component(AIR_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)"
+)
+# Construct the proper number of get_filename_component(... PATH) calls to
+# compute the installation prefix.
 string(REGEX REPLACE "/" ";" _count "${AIR_INSTALL_PACKAGE_DIR}")
 foreach(p ${_count})
   set(AIR_CONFIG_CODE "${AIR_CONFIG_CODE}
@@ -45,15 +43,11 @@ endforeach(p)
 set(AIR_CONFIG_CMAKE_DIR "\${AIR_INSTALL_PREFIX}/${AIR_INSTALL_PACKAGE_DIR}")
 set(AIR_CONFIG_BINARY_DIR "\${AIR_INSTALL_PREFIX}")
 set(AIR_CONFIG_TOOLS_BINARY_DIR "\${AIR_INSTALL_PREFIX}/bin")
-set(AIR_CONFIG_INCLUDE_DIRS
-  "\${AIR_INSTALL_PREFIX}/include"
-  )
+set(AIR_CONFIG_INCLUDE_DIRS "\${AIR_INSTALL_PREFIX}/include")
 set(AIR_CONFIG_EXPORTS_FILE "\${AIR_CMAKE_DIR}/AIRTargets.cmake")
 set(MLIR_CONFIG_INCLUDE_EXPORTS_FILE "\${AIR_CMAKE_DIR}/MLIRTargets.cmake")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/AIRConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake
-  @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AIRConfig.cmake.in
+               ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake @ONLY)
 set(AIR_CONFIG_CODE)
 set(AIR_CONFIG_CMAKE_DIR)
 set(AIR_CONFIG_BINARY_DIR)
@@ -62,11 +56,15 @@ set(AIR_CONFIG_INCLUDE_DIRS)
 set(AIR_CONFIG_EXPORTS_FILE)
 
 # export targets for the install directory
-install(EXPORT AIRTargets DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
-        COMPONENT air-cmake-exports)
-install(EXPORT MLIRTargets DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
-        COMPONENT air-cmake-exports)
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake
+install(
+  EXPORT AIRTargets
+  DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
+  COMPONENT air-cmake-exports)
+install(
+  EXPORT MLIRTargets
+  DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
+  COMPONENT air-cmake-exports)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake
   DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
   COMPONENT air-cmake-exports)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -49,6 +49,7 @@ set(AIR_CONFIG_INCLUDE_DIRS
   "\${AIR_INSTALL_PREFIX}/include"
   )
 set(AIR_CONFIG_EXPORTS_FILE "\${AIR_CMAKE_DIR}/AIRTargets.cmake")
+set(MLIR_CONFIG_INCLUDE_EXPORTS_FILE "\${AIR_CMAKE_DIR}/MLIRTargets.cmake")
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/AIRConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake
@@ -62,6 +63,8 @@ set(AIR_CONFIG_EXPORTS_FILE)
 
 # export targets for the install directory
 install(EXPORT AIRTargets DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
+        COMPONENT air-cmake-exports)
+install(EXPORT MLIRTargets DESTINATION ${AIR_INSTALL_PACKAGE_DIR}
         COMPONENT air-cmake-exports)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIRConfig.cmake

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -5,3 +5,36 @@
 add_subdirectory(lib)
 add_subdirectory(include)
 add_subdirectory(test)
+
+if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+    install(DIRECTORY include/air include/air-c
+            DESTINATION include
+            COMPONENT air-headers
+            FILES_MATCHING
+            PATTERN "*.def"
+            PATTERN "*.h"
+            PATTERN "*.inc"
+            PATTERN "*.td"
+            PATTERN "LICENSE.TXT"
+            )
+
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/include/air
+            DESTINATION include
+            COMPONENT air-headers
+            FILES_MATCHING
+            PATTERN "*.def"
+            PATTERN "*.h"
+            PATTERN "*.gen"
+            PATTERN "*.inc"
+            PATTERN "*.td"
+            PATTERN "CMakeFiles" EXCLUDE
+            PATTERN "config.h" EXCLUDE
+            )
+
+    if (NOT LLVM_ENABLE_IDE)
+        add_llvm_install_targets(install-air-headers
+                DEPENDS air-headers
+                COMPONENT air-headers)
+    endif()
+endif()
+

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -6,35 +6,33 @@ add_subdirectory(lib)
 add_subdirectory(include)
 add_subdirectory(test)
 
-if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-    install(DIRECTORY include/air include/air-c
-            DESTINATION include
-            COMPONENT air-headers
-            FILES_MATCHING
-            PATTERN "*.def"
-            PATTERN "*.h"
-            PATTERN "*.inc"
-            PATTERN "*.td"
-            PATTERN "LICENSE.TXT"
-            )
+if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  install(
+    DIRECTORY include/air include/air-c
+    DESTINATION include
+    COMPONENT air-headers
+    FILES_MATCHING
+    PATTERN "*.def"
+    PATTERN "*.h"
+    PATTERN "*.inc"
+    PATTERN "*.td"
+    PATTERN "LICENSE.TXT")
 
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/include/air
-            DESTINATION include
-            COMPONENT air-headers
-            FILES_MATCHING
-            PATTERN "*.def"
-            PATTERN "*.h"
-            PATTERN "*.gen"
-            PATTERN "*.inc"
-            PATTERN "*.td"
-            PATTERN "CMakeFiles" EXCLUDE
-            PATTERN "config.h" EXCLUDE
-            )
+  install(
+    DIRECTORY ${PROJECT_BINARY_DIR}/include/air
+    DESTINATION include
+    COMPONENT air-headers
+    FILES_MATCHING
+    PATTERN "*.def"
+    PATTERN "*.h"
+    PATTERN "*.gen"
+    PATTERN "*.inc"
+    PATTERN "*.td"
+    PATTERN "CMakeFiles" EXCLUDE
+    PATTERN "config.h" EXCLUDE)
 
-    if (NOT LLVM_ENABLE_IDE)
-        add_llvm_install_targets(install-air-headers
-                DEPENDS air-headers
-                COMPONENT air-headers)
-    endif()
+  if(NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-air-headers DEPENDS air-headers COMPONENT
+                             air-headers)
+  endif()
 endif()
-

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ add_subdirectory(Util)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
-add_air_library(AIRInitAll
+add_mlir_library(AIRInitAll
   InitAll.cpp
 
   DEPENDS

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -12,7 +12,8 @@ add_subdirectory(Util)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
-add_mlir_library(AIRInitAll
+add_mlir_library(
+  AIRInitAll
   InitAll.cpp
 
   DEPENDS
@@ -29,5 +30,4 @@ add_mlir_library(AIRInitAll
   AIRUtil
   MLIRSupport
   ${conversion_libs}
-  ${dialect_libs}
-  )
+  ${dialect_libs})

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_air_library(AIRConversionPasses
+add_mlir_library(AIRConversionPasses
 ConvertToAIRPass.cpp
 AIRLoweringPass.cpp
 AIRRtToLLVMPass.cpp

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -2,31 +2,31 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_library(AIRConversionPasses
-ConvertToAIRPass.cpp
-AIRLoweringPass.cpp
-AIRRtToLLVMPass.cpp
-AIRToAIEPass.cpp
-AIRToAsyncPass.cpp
-AIRPipeline.cpp
-Passes.cpp
+add_mlir_library(
+  AIRConversionPasses
+  ConvertToAIRPass.cpp
+  AIRLoweringPass.cpp
+  AIRRtToLLVMPass.cpp
+  AIRToAIEPass.cpp
+  AIRToAsyncPass.cpp
+  AIRPipeline.cpp
+  Passes.cpp
 
-DEPENDS
-AIRConversionPassIncGen
-AIRDialect
-AIRRtDialect
+  DEPENDS
+  AIRConversionPassIncGen
+  AIRDialect
+  AIRRtDialect
 
-LINK_COMPONENTS
-Core
+  LINK_COMPONENTS
+  Core
 
-LINK_LIBS
-AIRDialect
-AIRRtDialect
-AIRUtil
-AIE
-MLIRIR
-MLIRLinalgUtils
-MLIRLinalgTransforms
-MLIRSupport
-MLIRTransforms
-)
+  LINK_LIBS
+  AIRDialect
+  AIRRtDialect
+  AIRUtil
+  AIE
+  MLIRIR
+  MLIRLinalgUtils
+  MLIRLinalgTransforms
+  MLIRSupport
+  MLIRTransforms)

--- a/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_air_dialect_library(AIRDialect
+add_mlir_dialect_library(AIRDialect
   AIRDialect.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_dialect_library(AIRDialect
+add_mlir_dialect_library(
+  AIRDialect
   AIRDialect.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -13,5 +14,4 @@ add_mlir_dialect_library(AIRDialect
   MLIRAIROpInterfacesIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
-)
+  MLIRIR)

--- a/mlir/lib/Dialect/AIRRt/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/AIRRt/IR/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_air_dialect_library(AIRRtDialect
+add_mlir_dialect_library(AIRRtDialect
   AIRRtDialect.cpp
   AIRRtOps.cpp
 

--- a/mlir/lib/Dialect/AIRRt/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/AIRRt/IR/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_dialect_library(AIRRtDialect
+add_mlir_dialect_library(
+  AIRRtDialect
   AIRRtDialect.cpp
   AIRRtOps.cpp
 
@@ -13,5 +14,4 @@ add_mlir_dialect_library(AIRRtDialect
   MLIRAIRRtOpsIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
-)
+  MLIRIR)

--- a/mlir/lib/Targets/CMakeLists.txt
+++ b/mlir/lib/Targets/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_air_library(AIRTargets
+add_mlir_library(AIRTargets
   AIRTargets.cpp
   AIRHerdToJSON.cpp
 

--- a/mlir/lib/Targets/CMakeLists.txt
+++ b/mlir/lib/Targets/CMakeLists.txt
@@ -2,16 +2,14 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_library(AIRTargets
+add_mlir_library(
+  AIRTargets
   AIRTargets.cpp
   AIRHerdToJSON.cpp
 
-  LINK_LIBS
-
-  PUBLIC
+  LINK_LIBS PUBLIC
   AIRRtDialect
   AIRDialect
   MLIRIR
   MLIRSupport
-  MLIRTransforms
-  )
+  MLIRTransforms)

--- a/mlir/lib/Transform/CMakeLists.txt
+++ b/mlir/lib/Transform/CMakeLists.txt
@@ -2,42 +2,42 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_mlir_library(AIRTransformPasses
-AffineLoopOptPass.cpp
-AIRAutomaticTilingPass.cpp
-AIRHerdAssignPass.cpp
-AIRHerdPlacementPass.cpp
-AIRLinalgCodegen.cpp
-AIRLinalgOpStats.cpp
-AIRLoopMergingPass.cpp
-AIRLoopPermutationPass.cpp
-AIRLowerLinalgTensors.cpp
-AIRMiscPasses.cpp
-AIRRegularizeLoopPass.cpp
-AIRTilingUtils.cpp
-AIRTransformInterpreter.cpp
-AIRDependency.cpp
-AIRDependencyScheduleOpt.cpp
-AIRDependencyCanonicalize.cpp
-AIRDependencyParseGraph.cpp
-Passes.cpp
-ReturnEliminationPass.cpp
+add_mlir_library(
+  AIRTransformPasses
+  AffineLoopOptPass.cpp
+  AIRAutomaticTilingPass.cpp
+  AIRHerdAssignPass.cpp
+  AIRHerdPlacementPass.cpp
+  AIRLinalgCodegen.cpp
+  AIRLinalgOpStats.cpp
+  AIRLoopMergingPass.cpp
+  AIRLoopPermutationPass.cpp
+  AIRLowerLinalgTensors.cpp
+  AIRMiscPasses.cpp
+  AIRRegularizeLoopPass.cpp
+  AIRTilingUtils.cpp
+  AIRTransformInterpreter.cpp
+  AIRDependency.cpp
+  AIRDependencyScheduleOpt.cpp
+  AIRDependencyCanonicalize.cpp
+  AIRDependencyParseGraph.cpp
+  Passes.cpp
+  ReturnEliminationPass.cpp
 
-DEPENDS
-AIRTransformOpsIncGen
-AIRTransformPassIncGen
-AIRDialect
-AIRRtDialect
+  DEPENDS
+  AIRTransformOpsIncGen
+  AIRTransformPassIncGen
+  AIRDialect
+  AIRRtDialect
 
-LINK_COMPONENTS
-Core
+  LINK_COMPONENTS
+  Core
 
-LINK_LIBS PUBLIC
-AIRDialect
-AIRRtDialect
-AIRUtil
-MLIRIR
-MLIRLinalgTransforms
-MLIRLinalgUtils
-MLIRSupport
-)
+  LINK_LIBS PUBLIC
+  AIRDialect
+  AIRRtDialect
+  AIRUtil
+  MLIRIR
+  MLIRLinalgTransforms
+  MLIRLinalgUtils
+  MLIRSupport)

--- a/mlir/lib/Transform/CMakeLists.txt
+++ b/mlir/lib/Transform/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-add_air_library(AIRTransformPasses
+add_mlir_library(AIRTransformPasses
 AffineLoopOptPass.cpp
 AIRAutomaticTilingPass.cpp
 AIRHerdAssignPass.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -60,6 +60,7 @@ declare_mlir_python_extension(AirPythonExtensions.MLIR
   SOURCES
     AIRMLIRModule.cpp
     AIRRunnerModule.cpp
+    AIRRunnerModule.h
   EMBED_CAPI_LINK_LIBS
     AIRCAPI
   PRIVATE_LINK_LIBS
@@ -73,6 +74,7 @@ declare_mlir_python_extension(AirPythonExtensions.AIRRt
   SOURCES
     Module.cpp
     LibAirHostModule.cpp
+    LibAirHostModule.h
   EMBED_CAPI_LINK_LIBS
     AIRCAPI
   PRIVATE_LINK_LIBS

--- a/runtime_lib/airhost/include/CMakeLists.txt
+++ b/runtime_lib/airhost/include/CMakeLists.txt
@@ -3,30 +3,32 @@
 # SPDX-License-Identifier: MIT
 
 set(INSTALLS
-        air.hpp
-        air_channel.h
-        air_host.h
-        air_host_impl.h
-        air_network.h
-        air_queue.h
-        air_tensor.h
-        hsa_defs.h
-        pcie-ernic.h
-        pcie-ernic-defines.h
-        pcie-ernic-dev-mem-allocator.h
-        utility.hpp
-        )
+    air.hpp
+    air_channel.h
+    air_host.h
+    air_host_impl.h
+    air_network.h
+    air_queue.h
+    air_tensor.h
+    hsa_defs.h
+    pcie-ernic.h
+    pcie-ernic-defines.h
+    pcie-ernic-dev-mem-allocator.h
+    utility.hpp)
 
 # Stuff into the build area:
 add_custom_target(copy-runtime-includes ALL)
 foreach(file ${INSTALLS})
-    add_custom_target(copy-runtime-includes-${file} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file})
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
-                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-                    ${CMAKE_CURRENT_BINARY_DIR}/${file}
-                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
-    add_dependencies(copy-runtime-includes copy-runtime-includes-${file} )
+  add_custom_target(copy-runtime-includes-${file} ALL
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file})
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+            ${CMAKE_CURRENT_BINARY_DIR}/${file}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+  add_dependencies(copy-runtime-includes copy-runtime-includes-${file})
 endforeach()
 
 # Install too
-install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost/include)
+install(FILES ${INSTALLS}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost/include)

--- a/runtime_lib/airhost/include/CMakeLists.txt
+++ b/runtime_lib/airhost/include/CMakeLists.txt
@@ -2,7 +2,20 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set(INSTALLS air_tensor.h air_host.h air_channel.h air_host_impl.h air_queue.h hsa_defs.h pcie-ernic.h pcie-ernic-dev-mem-allocator.h air_network.h air.hpp utility.hpp)
+set(INSTALLS
+        air.hpp
+        air_channel.h
+        air_host.h
+        air_host_impl.h
+        air_network.h
+        air_queue.h
+        air_tensor.h
+        hsa_defs.h
+        pcie-ernic.h
+        pcie-ernic-defines.h
+        pcie-ernic-dev-mem-allocator.h
+        utility.hpp
+        )
 
 # Stuff into the build area:
 add_custom_target(copy-runtime-includes ALL)


### PR DESCRIPTION
This PR uses the upstream CMake functions for `add_mlir_library`.

I'm not sure what the intent was of having the local `add_air_library` but it does not probably add to any export sets and thus the generated `AirConfig.cmake` is not usable for downstream builds (such as python bindings built independently of core). A first pass/attempt/solution added the correct CMake to `add_air_library` for that export set but it didn't work. Thus, in addition this patch adds a "re-export" of the MLIR export target set.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
