### PR TITLE
Add `AIRTransformOpsIncGen` as a dep of  `AIRConversionPasses`

### DIFF
--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_library(
 
   DEPENDS
   AIRConversionPassIncGen
+  AIRTransformOpsIncGen
   AIRDialect
   AIRRtDialect
 

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -30,4 +30,5 @@ add_mlir_library(
   MLIRLinalgUtils
   MLIRLinalgTransforms
   MLIRSupport
-  MLIRTransforms)
+  MLIRTransforms
+  MLIRPass)


### PR DESCRIPTION
This PR adds `AIRTransformOpsIncGen` as a dependency of `AIRConversionPasses` and uses the upstream CMake functions for `add_mlir_library`.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-air/releases) and [here](https://github.com/makslevental/mlir-air/actions/runs/6060015760).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
