### PR TITLE
[UNTESTED] Do not use deprecated dyn_cast 

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -454,21 +454,21 @@ def air_ChannelOp : air_Op<"channel", [Symbol]>,
       int broadcastNum = 1;
       if (isBroadcast())
         for (auto bShape : getOperation()->getAttrOfType<ArrayAttr>("broadcast_shape")) {
-          auto attr = bShape.dyn_cast<IntegerAttr>().getInt();
+          auto attr = dyn_cast<IntegerAttr>(bShape).getInt();
           broadcastNum *= attr;
         }
       return broadcastNum;
     }
     int getBufferResources() {
       if(auto attr = getOperation()->getAttrOfType<IntegerAttr>("buffer_resources"))
-        return attr.dyn_cast<IntegerAttr>().getInt();
+        return dyn_cast<IntegerAttr>(attr).getInt();
       else
         return 1;
     }
     int getBundleSize() {
       int size = 1;
       for (auto i : getSize())
-        size *= i.dyn_cast<IntegerAttr>().getInt();
+        size *= dyn_cast<IntegerAttr>(i).getInt();
       return size;
     }
   }];

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -291,7 +291,7 @@ public:
     auto getOp = cast<air::PipelineGetOp>(op);
     SmallVector<Value, 2> gets;
     for (auto r : getOp.getResults()) {
-      if (auto ty = r.getType().dyn_cast<RankedTensorType>())
+      if (auto ty = dyn_cast<RankedTensorType>(r.getType()))
         gets.push_back(rewriter.create<bufferization::AllocTensorOp>(
             op->getLoc(), ty, ValueRange{}));
       else
@@ -963,7 +963,7 @@ public:
     TypeConverter converter;
     converter.addConversion([&](Type type) -> std::optional<Type> {
       // convert !air.async.token to !airrt.event
-      if (auto t = type.dyn_cast<air::AsyncTokenType>())
+      if (auto t = dyn_cast<air::AsyncTokenType>(type))
         return airrt::EventType::get(context);
       else
         return type;

--- a/mlir/lib/Conversion/AIRPipeline.cpp
+++ b/mlir/lib/Conversion/AIRPipeline.cpp
@@ -64,7 +64,7 @@ LogicalResult AIRPipeStageConversion::matchAndRewrite(
     // For each output of the pipeline stage, create a buffer + store
     SmallVector<Value, 4> bufs;
     for (auto o : yield.getOperands()) {
-      if (RankedTensorType tt = o.getType().dyn_cast<RankedTensorType>()) {
+      if (RankedTensorType tt = dyn_cast<RankedTensorType>(o.getType())) {
         auto memrefTy = MemRefType::get(tt.getShape(), tt.getElementType());
         rewriter.setInsertionPoint(aif);
         auto buf = rewriter.create<memref::AllocOp>(op->getLoc(), memrefTy);
@@ -83,7 +83,7 @@ LogicalResult AIRPipeStageConversion::matchAndRewrite(
     SmallVector<Value, 4> bufs;
     rewriter.setInsertionPoint(aif);
     for (auto o : yield.getOperands()) {
-      if (RankedTensorType tt = o.getType().dyn_cast<RankedTensorType>()) {
+      if (RankedTensorType tt = dyn_cast<RankedTensorType>(o.getType())) {
         rewriter.setInsertionPoint(&yield);
         auto idValPlus =
             rewriter.create<arith::ConstantIndexOp>(op->getLoc(), id + 1);

--- a/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
@@ -1208,12 +1208,12 @@ public:
 
     converter.addConversion([&](Type type) -> std::optional<Type> {
       // convert L1 memrefs to L3
-      if (auto memref = type.dyn_cast<MemRefType>())
+      if (auto memref = dyn_cast<MemRefType>(type))
         if (memref.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
           return mlir::MemRefType::get(memref.getShape(),
                                        memref.getElementType(),
                                        memref.getLayout(), 0);
-      if (auto t = type.dyn_cast<xilinx::airrt::EventType>())
+      if (auto t = dyn_cast<xilinx::airrt::EventType>(type))
         return LLVM::LLVMPointerType::get(context);
       return std::optional<Type>(type);
     });
@@ -1291,12 +1291,12 @@ public:
 
     target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {
       for (auto t : op.getOperandTypes()) {
-        if (auto mty = t.dyn_cast<MemRefType>())
+        if (auto mty = dyn_cast<MemRefType>(t))
           if (mty.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
             return false;
       }
       for (auto t : op.getResultTypes()) {
-        if (auto mty = t.dyn_cast<MemRefType>())
+        if (auto mty = dyn_cast<MemRefType>(t))
           if (mty.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
             return false;
       }

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -289,7 +289,7 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
                 core_builder.create<arith::ConstantIndexOp>(hloc, herd_size_y));
 
       for (auto a : h.getKernelArguments()) {
-        auto memrefTy = a.getType().dyn_cast<MemRefType>();
+        auto memrefTy = dyn_cast<MemRefType>(a.getType());
         if (!memrefTy)
           continue;
 
@@ -444,7 +444,7 @@ bool isInSet(IntegerSet is) {
 
   int i = 0;
   for (auto c : constraints) {
-    auto expr = simplifyAffineExpr(c, 0, 1).dyn_cast<AffineConstantExpr>();
+    auto expr = simplifyAffineExpr(c, 0, dyn_cast<AffineConstantExpr>(1));
     if (!expr)
       return false;
     if (eqFlags[i++]) {
@@ -716,7 +716,7 @@ void lowerScfAirTokens(AIE::DeviceOp m) {
 //       auto o = std::get<0>(p); // operand of put
 //       auto r = std::get<1>(p); // result of get
 //       // for each ranked tensor put (yielded) by the tile
-//       if (RankedTensorType tt = o.getType().dyn_cast<RankedTensorType>()) {
+//       if (RankedTensorType tt = dyn_cast<RankedTensorType>(o.getType())) {
 //         auto memrefTy = MemRefType::get(tt.getShape(), tt.getElementType(),
 //         {},
 //                                         (int)air::MemorySpace::L1);
@@ -1241,7 +1241,7 @@ void lowerAIRChannels(AIE::DeviceOp &d, ShimTileAllocator &a) {
 
 // Get owner (scf.parallelop) of channel indices
 scf::ParallelOp getChannelIndicesOwner(Value val) {
-  auto ivArg = val.dyn_cast<BlockArgument>();
+  auto ivArg = dyn_cast<BlockArgument>(val);
   if (!ivArg)
     return scf::ParallelOp();
   if (!ivArg.getOwner()) {

--- a/mlir/lib/Conversion/AIRToAsyncPass.cpp
+++ b/mlir/lib/Conversion/AIRToAsyncPass.cpp
@@ -153,7 +153,7 @@ static func::CallOp convertOpToFunction(Operation *op, ArrayRef<Value> operands,
   SmallVector<Value, 4> dependencies;
   for (auto o : operands) {
     // erase the size to reduce the number of manglings
-    if (auto memrefTy = o.getType().dyn_cast<MemRefType>()) {
+    if (auto memrefTy = dyn_cast<MemRefType>(o.getType())) {
       auto t = MemRefType::get(
           std::vector<int64_t>(memrefTy.getRank(), ShapedType::kDynamic),
           memrefTy.getElementType(), memrefTy.getLayout(),
@@ -170,7 +170,7 @@ static func::CallOp convertOpToFunction(Operation *op, ArrayRef<Value> operands,
   SmallVector<MemRefType, 16> real_result_tys;
   SmallVector<Type, 1> token_result_tys;
   for (auto t : op->getResultTypes()) {
-    if (auto memrefTy = t.dyn_cast<MemRefType>()) {
+    if (auto memrefTy = dyn_cast<MemRefType>(t)) {
       auto mrt = MemRefType::get(
           std::vector<int64_t>(memrefTy.getRank(), ShapedType::kDynamic),
           memrefTy.getElementType(), memrefTy.getLayout(),
@@ -206,7 +206,7 @@ static func::CallOp convertOpToFunction(Operation *op, ArrayRef<Value> operands,
     results = call.getResults();
     for (unsigned i = 0, real_result_idx = 0; i < results.size(); ++i) {
       auto r = results[i];
-      if (auto memrefTy = r.getType().dyn_cast<MemRefType>()) {
+      if (auto memrefTy = dyn_cast<MemRefType>(r.getType())) {
         auto t = real_result_tys[real_result_idx++];
         auto c =
             rewriter.create<UnrealizedConversionCastOp>(op->getLoc(), t, r);
@@ -598,7 +598,7 @@ struct ChannelOpConversion : public OpConversionPattern<air::ChannelOp> {
 
     SmallVector<int64_t, 2> shape;
     for (auto i : op.getSize()) {
-      shape.push_back(i.dyn_cast<IntegerAttr>().getInt());
+      dyn_cast<IntegerAttr>(shape.push_back(i).getInt());
     }
     // if channel dim < 2, add until dim = 2
     while (shape.size() < 2) {
@@ -719,9 +719,9 @@ public:
     TypeConverter converter;
     converter.addConversion([&](Type type) -> std::optional<Type> {
       // convert air::AsyncTokenType to async::TokenType
-      if (auto t = type.dyn_cast<air::AsyncTokenType>())
+      if (auto t = dyn_cast<air::AsyncTokenType>(type))
         return async::TokenType::get(context);
-      if (auto t = type.dyn_cast<MemRefType>())
+      if (auto t = dyn_cast<MemRefType>(type))
         if (t.getMemorySpaceAsInt() != 0)
           return MemRefType::get(t.getShape(), t.getElementType(),
                                  t.getLayout(), 0);
@@ -772,7 +772,7 @@ public:
       auto isIllegal = [](Type t) {
         if (t.isa<air::AsyncTokenType>())
           return true;
-        if (auto mt = t.dyn_cast<MemRefType>())
+        if (auto mt = dyn_cast<MemRefType>(t))
           return mt.getMemorySpaceAsInt() != 0;
         return false;
       };

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -63,8 +63,8 @@ matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
   rewriter.setInsertionPoint(op);
 
   // It must already be a memref
-  auto src_type = src.getType().dyn_cast<MemRefType>();
-  auto dst_type = dst.getType().dyn_cast<MemRefType>();
+  auto src_type = dyn_cast<MemRefType>(src.getType());
+  auto dst_type = dyn_cast<MemRefType>(dst.getType());
   if (!src_type)
     return failure();
 
@@ -553,8 +553,8 @@ class LinalgCopyToAIRDmaConversion : public OpRewritePattern<linalg::CopyOp> {
     auto dst = op.getOutputs()[0];
 
     // It must already be a memref
-    auto src_type = src.getType().dyn_cast<MemRefType>();
-    auto dst_type = dst.getType().dyn_cast<MemRefType>();
+    auto src_type = dyn_cast<MemRefType>(src.getType());
+    auto dst_type = dyn_cast<MemRefType>(dst.getType());
     if (!src_type)
       return failure();
 
@@ -680,8 +680,8 @@ void replaceAIRDmaWithAIRChannelPairs(
   auto dst = op.getDstMemref();
   auto ctx = op->getContext();
 
-  auto src_type = src.getType().dyn_cast<MemRefType>();
-  auto dst_type = dst.getType().dyn_cast<MemRefType>();
+  auto src_type = dyn_cast<MemRefType>(src.getType());
+  auto dst_type = dyn_cast<MemRefType>(dst.getType());
   SmallVector<Value, 4> src_offsets = op.getSrcOffsets();
   SmallVector<Value, 4> dst_offsets = op.getDstOffsets();
   SmallVector<Value, 4> src_sizes = op.getSrcSizes();
@@ -1000,8 +1000,8 @@ class AIRDmaToAIRChannelConversion
     auto ctx = op->getContext();
 
     // It must already be a memref
-    auto src_type = src.getType().dyn_cast<MemRefType>();
-    auto dst_type = dst.getType().dyn_cast<MemRefType>();
+    auto src_type = dyn_cast<MemRefType>(src.getType());
+    auto dst_type = dyn_cast<MemRefType>(dst.getType());
     if (!src_type)
       return failure();
 
@@ -1259,9 +1259,9 @@ public:
 
     auto loc = op.getLoc();
     auto ub0 =
-        op.getUpperBoundsMap().getResult(0).dyn_cast<AffineConstantExpr>();
+        dyn_cast<AffineConstantExpr>(op.getUpperBoundsMap().getResult(0));
     auto ub1 =
-        op.getUpperBoundsMap().getResult(1).dyn_cast<AffineConstantExpr>();
+        dyn_cast<AffineConstantExpr>(op.getUpperBoundsMap().getResult(1));
 
     if (!ub0 || !ub1) {
       return op->emitOpError("failed conversion to 'air.herd': only constant "
@@ -1967,8 +1967,8 @@ struct CopyToDmaPass : public air::CopyToDmaBase<CopyToDmaPass> {
                       affine::AffineYieldOp>();
 
     target.addDynamicallyLegalOp<memref::CopyOp>([](memref::CopyOp co) {
-      auto src_type = co.getSource().getType().dyn_cast<MemRefType>();
-      auto dst_type = co.getTarget().getType().dyn_cast<MemRefType>();
+      auto src_type = dyn_cast<MemRefType>(co.getSource().getType());
+      auto dst_type = dyn_cast<MemRefType>(co.getTarget().getType());
       return src_type.getMemorySpaceAsInt() == dst_type.getMemorySpaceAsInt();
     });
 

--- a/mlir/lib/Targets/AIRTargets.cpp
+++ b/mlir/lib/Targets/AIRTargets.cpp
@@ -55,14 +55,14 @@ static llvm::cl::opt<int>
                 llvm::cl::init(0));
 
 llvm::json::Value attrToJSON(Attribute &attr) {
-  if (auto a = attr.dyn_cast<StringAttr>()) {
+  if (auto a = dyn_cast<StringAttr>(attr)) {
     return llvm::json::Value(a.getValue().str());
-  } else if (auto array_attr = attr.dyn_cast<ArrayAttr>()) {
+  } else if (auto array_attr = dyn_cast<ArrayAttr>(attr)) {
     llvm::json::Array arrayJSON;
     for (auto a : array_attr)
       arrayJSON.push_back(attrToJSON(a));
     return llvm::json::Value(std::move(arrayJSON));
-  } else if (auto dict_attr = attr.dyn_cast<DictionaryAttr>()) {
+  } else if (auto dict_attr = dyn_cast<DictionaryAttr>(attr)) {
     llvm::json::Object dictJSON;
     for (auto a : dict_attr) {
       auto ident = a.getName();
@@ -70,7 +70,7 @@ llvm::json::Value attrToJSON(Attribute &attr) {
       dictJSON[ident.str()] = attrToJSON(attr);
     }
     return llvm::json::Value(std::move(dictJSON));
-  } else if (auto int_attr = attr.dyn_cast<IntegerAttr>()) {
+  } else if (auto int_attr = dyn_cast<IntegerAttr>(attr)) {
     return llvm::json::Value(int_attr.getInt());
   } else
     return llvm::json::Value(std::string(""));

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -169,7 +169,7 @@ struct MemrefsPattern : public OpRewritePattern<memref::AllocOp> {
 
 //   LogicalResult matchAndRewrite(memref::DimOp op,
 //                                 PatternRewriter &rewriter) const override {
-//     auto operTy = op.memrefOrTensor().getType().dyn_cast<ShapedType>();
+//     auto operTy = dyn_cast<ShapedType>(op.memrefOrTensor().getType());
 //     if (!operTy.hasStaticShape())
 //       return failure();
 
@@ -1386,7 +1386,7 @@ public:
         affine::makeComposedFoldedMultiResultAffineApply(
             b, loc, shapeSizesToLoopsMap, allShapeSizes);
     for (auto size : shapeSizes) {
-      if (auto v = size.dyn_cast<Value>()) {
+      if (auto v = dyn_cast<Value>(size)) {
         auto c = dyn_cast<arith::ConstantIndexOp>(v.getDefiningOp());
         if (!c) {
           LLVM_DEBUG(llvm::outs() << "Found non-constant dim!\n");
@@ -1394,8 +1394,8 @@ public:
         }
         tripCounts.push_back(c.value());
       } else {
-        auto a = size.dyn_cast<Attribute>();
-        auto c = a.dyn_cast<IntegerAttr>();
+        auto a = dyn_cast<Attribute>(size);
+        auto c = dyn_cast<IntegerAttr>(a);
         if (!c) {
           LLVM_DEBUG(llvm::outs() << "unhandled addr!\n");
           return {};
@@ -2076,7 +2076,7 @@ transform::LinalgTileOp::apply(TransformRewriter &rewriter,
             sizes.reserve(tileSizes.size());
             unsigned dynamicIdx = 0;
             for (OpFoldResult ofr : getMixedSizes()) {
-              if (auto attr = ofr.dyn_cast<Attribute>()) {
+              if (auto attr = dyn_cast<Attribute>(ofr)) {
                 sizes.push_back(b.create<arith::ConstantIndexOp>(
                     getLoc(), attr.cast<IntegerAttr>().getInt()));
               } else {

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -366,7 +366,7 @@ private:
             if (c.isSymbolicOrConstant()) {
               auto newC = c.replaceSymbols(zero_syms);
               auto expr =
-                  simplifyAffineExpr(newC, 0, 1).dyn_cast<AffineConstantExpr>();
+                  simplifyAffineExpr(newC, 0, dyn_cast<AffineConstantExpr>(1));
               if (!expr) {
                 continue;
               }
@@ -569,7 +569,7 @@ private:
         getAffineConstantExpr(0, ctx),
     };
     auto newC = c.replaceSymbols(zero_syms);
-    auto expr = simplifyAffineExpr(newC, 0, 1).dyn_cast<AffineConstantExpr>();
+    auto expr = simplifyAffineExpr(newC, 0, dyn_cast<AffineConstantExpr>(1));
     assert(expr);
     int result = expr.getValue();
     // Both + and - constant eval are legal for AffineExpr
@@ -605,9 +605,9 @@ private:
       return;
     }
     auto acc = add_operand.value();
-    assert(c.dyn_cast<AffineConstantExpr>() &&
+    dyn_cast<AffineConstantExpr>(assert(c) &&
            "non-constant affine expression");
-    acc += c.dyn_cast<AffineConstantExpr>().getValue();
+    acc += dyn_cast<AffineConstantExpr>(c).getValue();
     c = getAffineConstantExpr(acc, ctx);
   }
 
@@ -631,9 +631,9 @@ private:
       return;
     }
     auto mul = mul_operand.value();
-    assert(c.dyn_cast<AffineConstantExpr>() &&
+    dyn_cast<AffineConstantExpr>(assert(c) &&
            "non-constant affine expression");
-    mul *= c.dyn_cast<AffineConstantExpr>().getValue();
+    mul *= dyn_cast<AffineConstantExpr>(c).getValue();
     c = getAffineConstantExpr(mul, ctx);
   }
 

--- a/mlir/lib/Util/CostModel.cpp
+++ b/mlir/lib/Util/CostModel.cpp
@@ -43,7 +43,7 @@ static uint64_t getTensorVolume(const ShapedType ty) {
 }
 
 static uint64_t getTensorVolume(const Type ty) {
-  if (auto t = ty.dyn_cast<ShapedType>()) {
+  if (auto t = dyn_cast<ShapedType>(ty)) {
     return getTensorVolume(t);
   }
   else {
@@ -70,7 +70,7 @@ CostModel::getLinalgOpCounts(OpCountMap &map, linalg::LinalgOp op) {
   int64_t writes = 0;
   uint64_t footprint = 0;
   for (auto size : shapeSizes) {
-    if (auto v = size.dyn_cast<Value>()) {
+    if (auto v = dyn_cast<Value>(size)) {
       auto c = dyn_cast<arith::ConstantIndexOp>(v.getDefiningOp());
       if (!c) {
         LLVM_DEBUG(llvm::outs() << "Found non-constant dim!\n");
@@ -78,8 +78,8 @@ CostModel::getLinalgOpCounts(OpCountMap &map, linalg::LinalgOp op) {
       }
       iters *= c.value();
     } else {
-      auto a = size.dyn_cast<Attribute>();
-      auto c = a.dyn_cast<IntegerAttr>();
+      auto a = dyn_cast<Attribute>(size);
+      auto c = dyn_cast<IntegerAttr>(a);
       if (!c) {
         LLVM_DEBUG(llvm::outs() << "unhandled addr!\n");
         return;

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -34,7 +34,7 @@ const StringLiteral air::LinalgTransforms::kLinalgTransformMarker =
 static std::string getMangledType(const Type ty) {
   std::stringstream ret;
 
-  if (const MemRefType mrt = ty.dyn_cast<const MemRefType>()) {
+  if (const MemRefType mrt = dyn_cast<const MemRefType>(ty)) {
     ret << "M";
     ret << mrt.getMemorySpaceAsInt();
     if (mrt.hasStaticShape()) {
@@ -46,13 +46,13 @@ static std::string getMangledType(const Type ty) {
     }
     const Type elem = mrt.getElementType();
     ret << getMangledType(elem);
-  } else if (FloatType ft = ty.dyn_cast<FloatType>()) {
+  } else if (FloatType ft = dyn_cast<FloatType>(ty)) {
     ret << "F" << ft.getWidth();
-  } else if (const IntegerType it = ty.dyn_cast<const IntegerType>()) {
+  } else if (const IntegerType it = dyn_cast<const IntegerType>(ty)) {
     ret << "I" << it.getWidth();
-  } else if (const IndexType it = ty.dyn_cast<const IndexType>()) {
+  } else if (const IndexType it = dyn_cast<const IndexType>(ty)) {
     ret << "I64";
-  } else if (ty.dyn_cast<air::AsyncTokenType>()) {
+  } else if dyn_cast<air::AsyncTokenType>((ty)) {
     ret << "E";
   } else {
     Type t = ty;
@@ -142,7 +142,7 @@ uint64_t air::getTensorVolume(const ShapedType ty) {
 }
 
 uint64_t air::getTensorVolume(const Type ty) {
-  if (auto t = ty.dyn_cast<ShapedType>()) {
+  if (auto t = dyn_cast<ShapedType>(ty)) {
     return getTensorVolume(t);
   } else {
     return 1;
@@ -159,7 +159,7 @@ SmallVector<int> air::getTensorShape(const ShapedType ty) {
 }
 
 SmallVector<int> air::getTensorShape(const Type ty) {
-  if (auto t = ty.dyn_cast<ShapedType>()) {
+  if (auto t = dyn_cast<ShapedType>(ty)) {
     return getTensorShape(t);
   } else {
     return SmallVector<int>(1);
@@ -167,7 +167,7 @@ SmallVector<int> air::getTensorShape(const Type ty) {
 }
 
 std::string air::getElementTypeAsString(const mlir::Type ty) {
-  if (auto st = ty.dyn_cast<mlir::ShapedType>()) {
+  if (auto st = dyn_cast<mlir::ShapedType>(ty)) {
     return to_string(st.getElementType());
   } else {
     return to_string(ty);
@@ -195,7 +195,7 @@ uint64_t air::getElementSizeInBytes(const mlir::Type ty) {
 
 // Get the parent scf.for op of an iter_arg
 scf::ForOp air::getForRegionIterArgsOwner(Value val) {
-  auto ivArg = val.dyn_cast<BlockArgument>();
+  auto ivArg = dyn_cast<BlockArgument>(val);
   if (!ivArg)
     return scf::ForOp();
   if (!ivArg.getOwner()) {
@@ -219,7 +219,7 @@ scf::ParallelOp air::getParallelRegionInitValsOwner(Operation *op, Value val) {
 
 // Get the parent air.launch_herd op of a tile id
 air::HerdOp air::getHerdArgOwner(Value val) {
-  auto ivArg = val.dyn_cast<BlockArgument>();
+  auto ivArg = dyn_cast<BlockArgument>(val);
   if (!ivArg)
     return air::HerdOp();
   if (!ivArg.getOwner()) {
@@ -232,7 +232,7 @@ air::HerdOp air::getHerdArgOwner(Value val) {
 
 // Get the parent air.hierarchy op of a tile id
 air::HierarchyInterface air::getHierarchyArgOwner(Value val) {
-  auto ivArg = val.dyn_cast<BlockArgument>();
+  auto ivArg = dyn_cast<BlockArgument>(val);
   if (!ivArg)
     return air::HierarchyInterface();
   if (!ivArg.getOwner()) {
@@ -323,7 +323,7 @@ std::string air::getMemorySpaceAsString(Value memref) {
     return "";
   }
   auto memory_space_as_int =
-      memref.getType().dyn_cast<MemRefType>().getMemorySpaceAsInt();
+      dyn_cast<MemRefType>(memref.getType()).getMemorySpaceAsInt();
   std::string memorySpaceStr = "";
   if (memory_space_as_int == (int)air::MemorySpace::L1) {
     memorySpaceStr = "L1";
@@ -506,7 +506,7 @@ void air::getSizesFromIntegerSet(MLIRContext *ctx, IntegerSet int_set,
       if (c.isSymbolicOrConstant()) {
         auto newC = c.replaceSymbols(zero_syms);
         auto expr =
-            simplifyAffineExpr(newC, 0, 1).dyn_cast<AffineConstantExpr>();
+            simplifyAffineExpr(newC, 0, dyn_cast<AffineConstantExpr>(1));
         int v = expr.getValue();
         if (c.isFunctionOfSymbol(i)) {
           if (eqFlags[c_iter]) {

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -52,7 +52,7 @@ static std::string getMangledType(const Type ty) {
     ret << "I" << it.getWidth();
   } else if (const IndexType it = dyn_cast<const IndexType>(ty)) {
     ret << "I64";
-  } else if dyn_cast<air::AsyncTokenType>((ty)) {
+  } else if (dyn_cast<air::AsyncTokenType>(ty)) {
     ret << "E";
   } else {
     Type t = ty;


### PR DESCRIPTION
Run this in root directory mlir-air repo:

```
 find . -type f -exec sed -i 's/\([^[:space:]]\+\)\.dyn_cast<\(.*\)>()/dyn_cast<\2>(\1)/g' {} +
 ```