### PR TITLE
[FAILS] Store edges as a set instead of a vector 

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -78,7 +78,7 @@ struct executeNode {
   unsigned operationId;
 };
 
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS,
+typedef boost::adjacency_list<boost::setS, boost::vecS, boost::bidirectionalS,
                               executeNode>
     Graph;
 typedef boost::graph_traits<Graph>::in_edge_iterator in_edge_iterator;


### PR DESCRIPTION
The equivalent change worked fine for the graph class in Dependency.h (see https://github.com/Xilinx/mlir-air/pull/342) 

but with this one (AIRDependency.cpp) the change makes 5 tests fail. 

This PR changes the storage of graph edges from vector (where the same edge can be stored multiple times) to set (where each edge is unique). 

Previous discussion (see https://github.com/Xilinx/mlir-air/pull/340) suggests that it should be valid to assume edges are unique. 

So I'm not sure what to do here, I think the first thing is to understand what is failing. I don't really understand what the test (see CI lit test failure) is doing -- is the change in IR invalid or just noise? 
/
@erwei-xilinx  -- if you have any insights, please let me know! 