### PR TITLE
remove 'using namespace boost'

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -29,10 +29,7 @@
 
 // boost graph
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/copy.hpp>
-#include <boost/graph/graph_traits.hpp>
 #include <boost/graph/subgraph.hpp>
-#include <boost/graph/transitive_reduction.hpp>
 
 using namespace mlir;
 

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -5,8 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Transform/AIRDependency.h"
+#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Dependency.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -61,7 +61,6 @@ void boost::throw_exception(std::exception const &e,
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
-using namespace boost;
 
 #define DEBUG_TYPE "air-dependency"
 
@@ -486,7 +485,8 @@ public:
     std::iota(id_map.begin(), id_map.end(), 0u);
 
     transitive_reduction(asyncExecuteGraph, asyncExecuteGraphTR,
-                         make_assoc_property_map(g_to_tr), id_map.data());
+                         boost::make_assoc_property_map(g_to_tr),
+                         id_map.data());
 
     for (vertex_map::iterator i = g_to_tr.begin(); i != g_to_tr.end(); ++i) {
       // Copy over graph properties

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -13,7 +13,6 @@
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
-using namespace boost;
 
 #define DEBUG_TYPE "air-dependency-canonicalize"
 

--- a/mlir/lib/Transform/AIRDependencyParseGraph.cpp
+++ b/mlir/lib/Transform/AIRDependencyParseGraph.cpp
@@ -5,14 +5,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Transform/AIRDependencyParseGraph.h"
+#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Dependency.h"
 
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
-using namespace boost;
 
 #define DEBUG_TYPE "air-dependency-parse-graph"
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Transform/AIRDependencyScheduleOpt.h"
+#include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Dependency.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -47,7 +47,6 @@
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
-using namespace boost;
 
 #define DEBUG_TYPE "air-dependency-schedule-opt"
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -13,6 +13,10 @@
 
 #include <sys/stat.h>
 
+#include <boost/graph/copy.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/transitive_reduction.hpp>
+
 #define DEBUG_TYPE "air-dependency-util"
 
 using namespace mlir;

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -54,7 +54,6 @@
 #define INDEX_WIDTH 32
 
 using namespace mlir;
-using namespace boost;
 
 namespace xilinx {
 namespace air {


### PR DESCRIPTION
Makes it slightly easier to see where boost is used. 