### PR TITLE
Fix for more recent LLVM

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -34,6 +34,7 @@ class AsyncTokenType
 public:
   // Used for generic hooks in TypeBase.
   using Base::Base;
+  static constexpr StringLiteral name = "xilinx.air.async_token";
 };
 
 // Adds a `air.async.token` to the front of the argument list.

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -9,12 +9,12 @@
 #ifndef MLIR_AIR_DIALECT_H
 #define MLIR_AIR_DIALECT_H
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -42,12 +42,12 @@ void addAsyncDependency(Operation *op, Value token);
 // Erases a `air.async.token` at position index of the argument list.
 void eraseAsyncDependency(Operation *op, unsigned index);
 
-}
-}
+} // namespace air
+} // namespace xilinx
 
-#include "air/Dialect/AIR/AIROpInterfaces.h.inc"
 #include "air/Dialect/AIR/AIRDialect.h.inc"
 #include "air/Dialect/AIR/AIREnums.h.inc"
+#include "air/Dialect/AIR/AIROpInterfaces.h.inc"
 
 // include TableGen generated Op definitions
 #define GET_OP_CLASSES

--- a/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
+++ b/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
@@ -18,14 +18,15 @@ namespace airrt {
 class TensorType : public Type::TypeBase<TensorType, Type, TypeStorage> {
 public:
   using Base::Base;
-
   static TensorType get(MLIRContext *context) { return Base::get(context); }
+  static constexpr StringLiteral name = "xilinx.airrt.tensor";
 };
 
 class EventType
     : public Type::TypeBase<EventType, Type, TypeStorage> {
 public:
   using Base::Base;
+  static constexpr StringLiteral name = "xilinx.airrt.event";
 };
 
 } // namespace airrt

--- a/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
+++ b/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
@@ -22,8 +22,7 @@ public:
   static constexpr StringLiteral name = "xilinx.airrt.tensor";
 };
 
-class EventType
-    : public Type::TypeBase<EventType, Type, TypeStorage> {
+class EventType : public Type::TypeBase<EventType, Type, TypeStorage> {
 public:
   using Base::Base;
   static constexpr StringLiteral name = "xilinx.airrt.event";


### PR DESCRIPTION
This allows air to build with llvm commit on main branch:
hash: c45a66ecd4cb8f351298ca987d6086cf02b77bfb 
Date:  Fri Dec 1 17:22:12 2023 -0800

'const StringLiteral name' design copied from spriv dialect. 