### PR TITLE
Canonicalize printing of async dependencies

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -576,9 +576,9 @@ def air_ExecuteOp : air_Op<"execute", [SingleBlockImplicitTerminator<"ExecuteTer
     the region must be executed sequentially.
   }];
 
-  // TODO(jn) async_dependencies are printed in sorted order for ops which have
-  // custom assembly formats. ExecuteOp should be made to have a custom print
-  // and parse too, so that it follows this pattern.
+  // Note: async_dependencies are printed in sorted order for ops which have
+  // custom assembly formats. We can consider giving ExecuteOp custom
+  // printer/parser too.
   let assemblyFormat = [{
     (` ``[` $async_dependencies^ `]`)?
     (`->` `(` type($results)^ `)`)? regions attr-dict

--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -576,10 +576,14 @@ def air_ExecuteOp : air_Op<"execute", [SingleBlockImplicitTerminator<"ExecuteTer
     the region must be executed sequentially.
   }];
 
+  // TODO(jn) async_dependencies are printed in sorted order for ops which have
+  // custom assembly formats. ExecuteOp should be made to have a custom print
+  // and parse too, so that it follows this pattern.
   let assemblyFormat = [{
     (` ``[` $async_dependencies^ `]`)?
     (`->` `(` type($results)^ `)`)? regions attr-dict
   }];
+
   let extraClassDeclaration = [{
     int32_t getId() {
       if (auto id_attr = (*this)->getAttrOfType<IntegerAttr>("id")) {

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -34,6 +34,7 @@ class AsyncTokenType
 public:
   // Used for generic hooks in TypeBase.
   using Base::Base;
+  static constexpr StringLiteral name = "xilinx.air.async_token";
 };
 
 // Adds a `air.async.token` to the front of the argument list.

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -9,12 +9,12 @@
 #ifndef MLIR_AIR_DIALECT_H
 #define MLIR_AIR_DIALECT_H
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -42,12 +42,12 @@ void addAsyncDependency(Operation *op, Value token);
 // Erases a `air.async.token` at position index of the argument list.
 void eraseAsyncDependency(Operation *op, unsigned index);
 
-}
-}
+} // namespace air
+} // namespace xilinx
 
-#include "air/Dialect/AIR/AIROpInterfaces.h.inc"
 #include "air/Dialect/AIR/AIRDialect.h.inc"
 #include "air/Dialect/AIR/AIREnums.h.inc"
+#include "air/Dialect/AIR/AIROpInterfaces.h.inc"
 
 // include TableGen generated Op definitions
 #define GET_OP_CLASSES

--- a/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
+++ b/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
@@ -18,14 +18,15 @@ namespace airrt {
 class TensorType : public Type::TypeBase<TensorType, Type, TypeStorage> {
 public:
   using Base::Base;
-
   static TensorType get(MLIRContext *context) { return Base::get(context); }
+  static constexpr StringLiteral name = "xilinx.airrt.tensor";
 };
 
 class EventType
     : public Type::TypeBase<EventType, Type, TypeStorage> {
 public:
   using Base::Base;
+  static constexpr StringLiteral name = "xilinx.airrt.event";
 };
 
 } // namespace airrt

--- a/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
+++ b/mlir/include/air/Dialect/AIRRt/AIRRtDialect.h
@@ -22,8 +22,7 @@ public:
   static constexpr StringLiteral name = "xilinx.airrt.tensor";
 };
 
-class EventType
-    : public Type::TypeBase<EventType, Type, TypeStorage> {
+class EventType : public Type::TypeBase<EventType, Type, TypeStorage> {
 public:
   using Base::Base;
   static constexpr StringLiteral name = "xilinx.airrt.event";

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -466,7 +466,6 @@ void SegmentOp::build(OpBuilder &builder, OperationState &result,
                       ValueRange segmentOperands, bool isAsync,
                       ArrayRef<NamedAttribute> attrs) {
 
-
   result.addOperands(asyncDependencies);
   if (isAsync)
     result.addTypes(AsyncTokenType::get(builder.getContext()));

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -170,19 +170,20 @@ static void printAsyncDependencies(OpAsmPrinter &printer, Operation *op,
   if (asyncDependenciesUnsorted.empty())
     return;
 
-  // The values can be sorted by their order in a basic block, if they all have
-  // defining ops in the same basic block.
+  // The values can be sorted by their order in a basic block, but only if they
+  // all have defining ops in the same basic block. We go through all the
+  // values, and check that they have defining ops in the same block.
   bool canSort = [&]() {
     auto v0 = asyncDependenciesUnsorted[0];
     if (!v0.getDefiningOp())
       return false;
-    auto b0 = v0.getDefiningOp()->getBlock();
+    auto block = v0.getDefiningOp()->getBlock();
     for (auto v : asyncDependenciesUnsorted) {
       auto op = v.getDefiningOp();
       if (!op)
         return false;
       auto b = op->getBlock();
-      if (b != b0)
+      if (b != block)
         return false;
     }
     return true;
@@ -190,7 +191,6 @@ static void printAsyncDependencies(OpAsmPrinter &printer, Operation *op,
 
   printer << "[";
 
-  // canSort = false;
   if (!canSort) {
     llvm::interleaveComma(asyncDependenciesUnsorted, printer);
   } else {

--- a/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
@@ -26,7 +26,7 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
@@ -26,7 +26,7 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
@@ -26,7 +26,7 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg5[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT1]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg5[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>


### PR DESCRIPTION
With the change, the order in which the async dependencies (mlir::Values) are stored does not effect the order in which they are printed.

This makes it easier to change the implementation of the underlying dependency analysis (currently using boost) without effecting the printed IR used for testing. 

Alternatives considered:

1) just update the tests whenever the underlying algorithm changes
2) make the storage of async dependencies natively sorted 

1 seems fine, and I can still take this approach, but brittle tests might slow future development down
2 seems good, although I can't figure out how to do this (might take me more time to check this option out).  