### PR TITLE
A minimal graph class to replace boost equivalent

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -96,6 +96,7 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_INSTALL_PREFIX=install
           ninja
+          ninja check-air-cpp
           ninja check-air-mlir
           ninja check-air-python
           popd
@@ -122,7 +123,7 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_INSTALL_PREFIX=install
           make -j$(nproc)
-          make check-air-mlir check-air-python
+          make check-air-cpp check-air-mlir check-air-python
           popd
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/aienginev2/install/lib

--- a/mlir/include/air/Util/DirectedAdjacencyMap.h
+++ b/mlir/include/air/Util/DirectedAdjacencyMap.h
@@ -13,7 +13,7 @@ namespace xilinx {
 namespace air {
 
 /**
- * This class is funnctioanlly similar to the boost::adjacency_list class. It
+ * This class is functionally similar to the boost::adjacency_list class. It
  * provides minimal functionality to support the removal of boost in this
  * project. Additional functionality should be added as required.
  *

--- a/mlir/include/air/Util/DirectedAdjacencyMap.h
+++ b/mlir/include/air/Util/DirectedAdjacencyMap.h
@@ -1,0 +1,135 @@
+// Copyright (C) 2023, Xilinx Inc. All rights reserved.
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <set>
+#include <vector>
+
+namespace xilinx {
+namespace air {
+
+/**
+ * This class is based on the boost::adjacency_list class. It provides minimal
+ * functionality to support its use case. Additional functionality should be
+ * added as required.
+ *
+ * It implements a directed acyclic graph, where the each node can be queried
+ * for out going edges and in coming edges.
+ * */
+class DirectedAdjacencyMap {
+
+public:
+  using VertexId = uint64_t;
+
+  /**
+   * Add an edge from \p src to \p dst to the graph, so that \p dst is adjacent
+   * to \p src.
+   * */
+  void addEdge(VertexId src, VertexId dst);
+
+  /**
+   * \return The number of vertices which have an edge from \p v.
+   * */
+  uint64_t outDegree(VertexId v) const { return fwdEdges[v].size(); }
+
+  /**
+   * \return The number of vertices which have an edge to \p v.
+   * */
+  uint64_t inDegree(VertexId v) const { return bwdEdges[v].size(); }
+
+  /**
+   * \return The number of vertices in the graph.
+   * */
+  uint64_t numVertices() const { return fwdEdges.size(); }
+
+  /**
+   * Remove the edge from \p src to \p dst from the graph. If the graph is not
+   * in the graph, or if a VertexId is out of range, this function does nothing.
+   * */
+  void removeEdge(VertexId src, VertexId dst);
+
+  /**
+   * \return A vector of all vertices in the graph.
+   * */
+  std::vector<VertexId> getVertices() const;
+
+  /**
+   * \return true of the graph has an edge from \p src to \p dst, and false
+   *         otherwise.
+   * */
+  bool hasEdge(VertexId src, VertexId dst) const {
+    return src < numVertices() && (fwdEdges[src].count(dst) > 0);
+  }
+
+  /**
+   * \return A vector of all vertices which have an edge to \p v.
+   * */
+  std::vector<VertexId> inverseAdjacentVertices(VertexId v) const {
+    return {bwdEdges[v].begin(), bwdEdges[v].end()};
+  }
+
+  /**
+   * \return A vector of all vertices which have an edge from \p v.
+   * */
+  std::vector<VertexId> adjacentVertices(VertexId i) const {
+    return {fwdEdges[i].begin(), fwdEdges[i].end()};
+  }
+
+  /**
+   * \return The vertices in topological order. If the graph contains a cycle,
+   *         the subset of vertices which can be scheduled is returned, so that
+   *         the returned vector is smaller than the number of vertices in the
+   *         graph.
+   * */
+  std::vector<VertexId> getSchedule() const;
+
+  /**
+   * \return The topological closure of the graph. See
+   *         https://en.wikipedia.org/wiki/Transitive_closure
+   *
+   *         If out[i][j] is true, then there is a path from i to j (or i == i).
+   *
+   * */
+  std::vector<std::vector<bool>> getClosure() const;
+
+  /**
+   * Apply a transitive reduction to this graph. This reduces the number of
+   * edges to the minimal set possible which does not change the transitive
+   * closure of this graph. See
+   * https://en.wikipedia.org/wiki/Transitive_reduction
+   *
+   * O(n^2) memory, O(n^3) operations (same as boost).
+   * */
+  void applyTransitiveReduction();
+
+protected:
+  // These methods are protected, as they are intended to be called by their
+  // derived classes.
+
+  void addVertex() {
+    fwdEdges.push_back({});
+    bwdEdges.push_back({});
+  }
+
+  void clear() {
+    fwdEdges = {};
+    bwdEdges = {};
+  }
+
+  // Given that fwdEdges is up-to-date, update bwdEdges to correspond.
+  void updateBwdEdgesFromFwdEdges();
+
+private:
+  // The edges.
+  std::vector<std::set<VertexId>> fwdEdges;
+
+  // The inverse edges.
+  std::vector<std::set<VertexId>> bwdEdges;
+};
+
+} // namespace air
+} // namespace xilinx

--- a/mlir/include/air/Util/DirectedAdjacencyMap.h
+++ b/mlir/include/air/Util/DirectedAdjacencyMap.h
@@ -13,12 +13,12 @@ namespace xilinx {
 namespace air {
 
 /**
- * This class is based on the boost::adjacency_list class. It provides minimal
- * functionality to support its use case. Additional functionality should be
- * added as required.
+ * This class is funnctioanlly similar to the boost::adjacency_list class. It
+ * provides minimal functionality to support the removal of boost in this
+ * project. Additional functionality should be added as required.
  *
- * It implements a directed acyclic graph, where the each node can be queried
- * for out going edges and in coming edges.
+ * The class implements a directed acyclic graph, where each node can be queried
+ * for outgoing edges and incoming edges.
  * */
 class DirectedAdjacencyMap {
 
@@ -26,18 +26,18 @@ public:
   using VertexId = uint64_t;
 
   /**
-   * Add an edge from \p src to \p dst to the graph, so that \p dst is adjacent
-   * to \p src.
+   * Insert an edge from \p src to \p dst to the graph, so that \p dst is
+   * adjacent to \p src.
    * */
   void addEdge(VertexId src, VertexId dst);
 
   /**
-   * \return The number of vertices which have an edge from \p v.
+   * \return The number of vertices which have an edge \b from \p v.
    * */
   uint64_t outDegree(VertexId v) const { return fwdEdges[v].size(); }
 
   /**
-   * \return The number of vertices which have an edge to \p v.
+   * \return The number of vertices which have an edge \b to \p v.
    * */
   uint64_t inDegree(VertexId v) const { return bwdEdges[v].size(); }
 

--- a/mlir/lib/Util/CMakeLists.txt
+++ b/mlir/lib/Util/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_library(AIRUtil
   CostModel.cpp
   Runner.cpp
   Dependency.cpp
+  DirectedAdjacencyMap.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Util/DirectedAdjacencyMap.cpp
+++ b/mlir/lib/Util/DirectedAdjacencyMap.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) 2023, Xilinx Inc. All rights reserved.
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "air/Util/DirectedAdjacencyMap.h"
+
+namespace xilinx {
+namespace air {
+
+using VertexId = DirectedAdjacencyMap::VertexId;
+
+// Kahn's algorithm. See https://en.wikipedia.org/wiki/Topological_sorting
+std::vector<VertexId> DirectedAdjacencyMap::getSchedule() const {
+
+  std::vector<VertexId> toProcess;
+
+  std::vector<uint64_t> nRemaining(numVertices());
+  for (uint64_t i = 0; i < numVertices(); ++i) {
+    nRemaining[i] = bwdEdges[i].size();
+    if (nRemaining[i] == 0) {
+      toProcess.push_back(i);
+    }
+  }
+
+  std::vector<VertexId> schedule;
+  schedule.reserve(numVertices());
+  while (!toProcess.empty()) {
+    auto nxt = toProcess.back();
+    toProcess.pop_back();
+    schedule.push_back(nxt);
+    for (auto n : fwdEdges[nxt]) {
+      --nRemaining[n];
+      if (nRemaining[n] == 0) {
+        toProcess.push_back(n);
+      }
+    }
+  }
+
+  return schedule;
+}
+
+void DirectedAdjacencyMap::addEdge(VertexId src, VertexId dst) {
+  assert(src < numVertices());
+  assert(dst < numVertices());
+  fwdEdges[src].insert(dst);
+  bwdEdges[dst].insert(src);
+}
+
+void DirectedAdjacencyMap::removeEdge(VertexId src, VertexId dst) {
+  if (src >= numVertices() || dst >= numVertices()) {
+    return;
+  }
+  if (fwdEdges[src].count(dst) > 0) {
+    fwdEdges[src].erase(dst);
+    bwdEdges[dst].erase(src);
+  }
+}
+
+std::vector<VertexId> DirectedAdjacencyMap::getVertices() const {
+  std::vector<VertexId> vs;
+  vs.reserve(numVertices());
+  for (uint64_t i = 0; i < numVertices(); ++i) {
+    vs.push_back(i);
+  }
+  return vs;
+}
+
+std::vector<std::vector<bool>> DirectedAdjacencyMap::getClosure() const {
+
+  std::vector<std::vector<bool>> closure(
+      numVertices(), std::vector<bool>(numVertices(), false));
+
+  auto schedule = getSchedule();
+  for (uint64_t i = 0; i < numVertices(); ++i) {
+    auto vertexId = schedule[numVertices() - i - 1];
+    closure[vertexId][vertexId] = true;
+    for (auto nxt : adjacentVertices(vertexId)) {
+      for (uint64_t j = 0; j < numVertices(); ++j) {
+        closure[vertexId][j] = closure[vertexId][j] || closure[nxt][j];
+      }
+    }
+  }
+  return closure;
+}
+
+void DirectedAdjacencyMap::applyTransitiveReduction() {
+  auto closure = getClosure();
+  for (uint64_t i = 0; i < numVertices(); ++i) {
+    std::set<VertexId> reducedEdges;
+    for (auto nxt : adjacentVertices(i)) {
+      bool retain = true;
+      for (auto other : adjacentVertices(i)) {
+        if (nxt == other) {
+          continue;
+        }
+        // if nxt is in the transitive closure of other, don't keep it.
+        if (closure[other][nxt]) {
+          retain = false;
+        }
+      }
+      if (retain) {
+        reducedEdges.insert(nxt);
+      }
+    }
+    fwdEdges[i] = reducedEdges;
+  }
+  updateBwdEdgesFromFwdEdges();
+}
+
+void DirectedAdjacencyMap::updateBwdEdgesFromFwdEdges() {
+  bwdEdges.clear();
+  bwdEdges.resize(numVertices());
+  for (uint64_t i = 0; i < numVertices(); ++i) {
+    for (auto nxt : fwdEdges[i]) {
+      bwdEdges[nxt].insert(i);
+    }
+  }
+}
+
+} // namespace air
+} // namespace xilinx

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -19,3 +19,5 @@ set_target_properties(check-air-mlir PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(AIRMLIR ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TEST_DEPENDS})
 add_dependencies(check-all check-air-mlir)
+
+add_subdirectory(CppUnitTests)

--- a/mlir/test/CppUnitTests/CMakeLists.txt
+++ b/mlir/test/CppUnitTests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (C) 2023, Xilinx Inc. All rights reserved.
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+include(CTest)
+
+add_executable(directed_adjacency_map  directed_adjacency_map.cpp)
+add_test(NAME DirectedAdjacencyMap COMMAND directed_adjacency_map)
+add_custom_target(check-air-cpp COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS directed_adjacency_map)
+target_link_libraries(directed_adjacency_map PRIVATE AIRUtil)
+
+add_dependencies(check-all check-air-cpp)

--- a/mlir/test/CppUnitTests/directed_adjacency_map.cpp
+++ b/mlir/test/CppUnitTests/directed_adjacency_map.cpp
@@ -1,3 +1,7 @@
+// Copyright (C) 2023, Xilinx Inc. All rights reserved.
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
 #include "air/Util/DirectedAdjacencyMap.h"
 #include <stdexcept>
 

--- a/mlir/test/CppUnitTests/directed_adjacency_map.cpp
+++ b/mlir/test/CppUnitTests/directed_adjacency_map.cpp
@@ -1,0 +1,47 @@
+#include "air/Util/DirectedAdjacencyMap.h"
+#include <stdexcept>
+
+class TestGraph : public xilinx::air::DirectedAdjacencyMap {
+public:
+  using xilinx::air::DirectedAdjacencyMap::addVertex;
+};
+
+using VertexId = TestGraph::VertexId;
+
+void basicTest() {
+
+  TestGraph g;
+
+  g.addVertex();
+  g.addVertex();
+  g.addVertex();
+
+  g.addEdge(2, 0);
+  g.addEdge(1, 0);
+  g.addEdge(2, 1);
+
+  if (g.getSchedule() != std::vector<VertexId>{2, 1, 0}) {
+    throw std::runtime_error("Incorrect schedule");
+  }
+
+  auto closure = g.getClosure();
+  decltype(closure) expected = {{1, 0, 0}, {1, 1, 0}, {1, 1, 1}};
+  if (closure != expected) {
+    throw std::runtime_error("Incorrect closure");
+  }
+
+  if (!g.hasEdge(2, 0)) {
+    throw std::runtime_error("Edge 2->0 was inserted into graph");
+  }
+
+  g.applyTransitiveReduction();
+
+  if (g.hasEdge(2, 0)) {
+    throw std::runtime_error("Edge 2->0 not removed in reduction");
+  }
+}
+
+int main() {
+  basicTest();
+  return 0;
+}


### PR DESCRIPTION
A user of mlir-air (i.e. IREE) has prioritized removing the boost dependency from mlir-air. 

A (WIP) PR which completely removes boost from mlir-air is at https://github.com/Xilinx/mlir-air/pull/340 

The PR 340 is probably too large, I'd like to break it up. This PR introduces the first part of the decomposition: a graph class which replaces boost's graph class.  

Subsequent PR(s) will use this new class to replace boost. 

This PR also introduces C++ unit tests, I couldn't find any pre-existing equivalent in mlir-air. I can add more tests, if requested.  