### PR TITLE
Extend base graph class with ability to store vertices of different types 

### DIFF
--- a/mlir/include/air/Util/DirectedAdjacencyMap.h
+++ b/mlir/include/air/Util/DirectedAdjacencyMap.h
@@ -131,5 +131,42 @@ private:
   std::vector<std::set<VertexId>> bwdEdges;
 };
 
+/**
+ * An extension to DirectedAdjacencyMap where vertices have types.
+ *
+ * \tparam T The type of the vertex.
+ * */
+template <typename T>
+class TypedDirectedAdjacencyMap : public DirectedAdjacencyMap {
+public:
+  using DirectedAdjacencyMap::VertexId;
+
+  VertexId addVertex() {
+    auto id = nodes.size();
+    nodes.push_back({});
+    DirectedAdjacencyMap::addVertex();
+    return id;
+  }
+
+  const T &operator[](VertexId v) const {
+    assert(v < numVertices());
+    return nodes[v];
+  }
+
+  T &operator[](VertexId v) {
+    // const_cast, really? See Scott Meyers: Effective C++ for this use case.
+    return const_cast<T &>(
+        static_cast<const TypedDirectedAdjacencyMap<T> &>(*this)[v]);
+  }
+
+  void clear() {
+    nodes = {};
+    DirectedAdjacencyMap::clear();
+  }
+
+private:
+  std::vector<T> nodes;
+};
+
 } // namespace air
 } // namespace xilinx

--- a/mlir/test/CppUnitTests/directed_adjacency_map.cpp
+++ b/mlir/test/CppUnitTests/directed_adjacency_map.cpp
@@ -45,7 +45,24 @@ void basicTest() {
   }
 }
 
+void templateClassTest() {
+
+  class TGraph : public xilinx::air::TypedDirectedAdjacencyMap<std::string> {};
+
+  TGraph a;
+  a.addVertex();
+  a.addVertex();
+
+  a[0] = "foo";
+  a[1] = "bar";
+
+  if (a[0] != "foo" || a[1] != "bar") {
+    throw std::runtime_error("string vertex type setter/getter failure");
+  }
+}
+
 int main() {
   basicTest();
+  templateClassTest();
   return 0;
 }


### PR DESCRIPTION
This class will be used in 2 cases in the boost removal task:

In include/air/Util/Dependency.h with template parameter dependencyNodeEntry
In lib/Transform/AIRDependency.cpp with template parameter executeNode