### PR TITLE
[WIP] remove erasures (should rely on DCE)

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -608,8 +608,6 @@ private:
     // Update op-to-graph map
     region_to_g[async_region.getId()] = v;
 
-    // Erase op
-    op->erase();
     return async_region;
   }
 
@@ -650,8 +648,6 @@ private:
     // Update op-to-graph map
     region_to_g[async_region.getId()] = v;
 
-    // Erase op
-    op->erase();
     return async_region;
   }
 
@@ -682,8 +678,6 @@ private:
     // Update op-to-graph map
     dma_to_g[id] = v;
 
-    // Erase op
-    op->erase();
   }
 
   // Re-instantiate the channel op with async interface; update graph
@@ -729,8 +723,6 @@ private:
     // Update op-to-graph map
     channel_to_g[ChannelOpID] = v;
 
-    // Erase op
-    op->erase();
   }
 
   // Re-instantiate the hierarchy op with async interface; update graph
@@ -804,8 +796,6 @@ private:
     }
     auto new_hier = dyn_cast<air::HierarchyInterface>(new_op);
 
-    // Erase op
-    op->erase();
     return new_hier;
   }
 
@@ -1530,8 +1520,6 @@ private:
     elevateAsyncTokens<scf::ForOp, scf::ParallelOp>(new_loop_op,
                                                     wait_all_op_yielded_v);
 
-    loop_op.erase();
-
     loop_op = new_loop_op;
   }
 
@@ -1582,8 +1570,6 @@ private:
 
     // Remove the old scf::YieldOp
     SmallVector<scf::YieldOp, 2> y_ops(new_loop_op.getOps<scf::YieldOp>());
-    for (auto y_op : y_ops)
-      y_op.erase();
 
     // Create scf::ReduceOp
     builder.setInsertionPointToEnd(new_loop_op.getBody());
@@ -1602,7 +1588,6 @@ private:
     elevateAsyncTokens<scf::ParallelOp, scf::ParallelOp>(new_loop_op,
                                                          wait_all_op_yielded_v);
 
-    loop_op.erase();
 
     loop_op = new_loop_op;
   }


### PR DESCRIPTION
This compilation fails ungracefully:

jamesn@wsl:~/iree/samples/models $ ~/iree-build/tools/iree-compile --iree-hal-target-backends=amd-aie simple_abs.mlir --mlir-print-ir-before-all --print-module-scope > dump.mlir

With report:

```
// -----// IR Dump Before AIRDependency (air-dependency) //----- //
module {
  func.func @abs_dispatch_0_generic() {
    %c0 = arith.constant 0 : index
    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<f32>>
    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<f32>>
    %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:tensor<f32>> -> tensor<f32>
    %3 = tensor.empty() : tensor<f32>
    %4 = linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%2 : tensor<f32>) outs(%3 : tensor<f32>) {
    ^bb0(%in: f32, %out: f32):
      %5 = math.absf %in : f32
      linalg.yield %5 : f32
    } -> tensor<f32>
    flow.dispatch.tensor.store %4, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !flow.dispatch.tensor<writeonly:tensor<f32>>
    return
  }
}

LLVM ERROR: operation destroyed but still has uses
Please report issues to https://github.com/openxla/iree/issues and include the crash backtrace.
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libIREECompiler.so 0x00007ff6f0bd5f57 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 39
1  libIREECompiler.so 0x00007ff6f0bd4180 llvm::sys::RunSignalHandlers() + 80
2  libIREECompiler.so 0x00007ff6f0bd661a
3  libc.so.6          0x00007ff6ea7eb520
```

I'm trying to fix this. 