### PR TITLE
bump the LLVM used by mlir-air

### DIFF
--- a/mlir/include/air/Conversion/PassDetail.h
+++ b/mlir/include/air/Conversion/PassDetail.h
@@ -10,6 +10,8 @@
 #define AIR_CONVERSION_PASSDETAIL_H
 
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "mlir/Pass/PassOptions.h"
+#include "mlir/Pass/Pass.h"
 
 namespace xilinx {
 namespace air {

--- a/mlir/include/air/Conversion/PassDetail.h
+++ b/mlir/include/air/Conversion/PassDetail.h
@@ -10,8 +10,8 @@
 #define AIR_CONVERSION_PASSDETAIL_H
 
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
-#include "mlir/Pass/PassOptions.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassOptions.h"
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -751,9 +751,9 @@ public:
   matchAndRewrite(scf::ReduceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto newOp =
-        rewriter.replaceOpWithNewOp<scf::ReduceOp>(op, adaptor.getOperand());
-    auto body = &op.getRegion().front();
-    auto newBody = &newOp.getRegion().front();
+        rewriter.replaceOpWithNewOp<scf::ReduceOp>(op, adaptor.getOperands()[0]);
+    auto body = &op.getRegion(0).front();
+    auto newBody = &newOp.getRegion(0).front();
 
     for (int i = 0, e = body->getNumArguments(); i < e; i++) {
       body->getArgument(i).replaceAllUsesWith(newBody->getArgument(i));
@@ -1042,7 +1042,7 @@ public:
     });
 
     target.addDynamicallyLegalOp<scf::ReduceOp>([&](scf::ReduceOp op) {
-      if (op.getOperand().getType().isa<air::AsyncTokenType>())
+      if (op.getOperands()[0].getType().isa<air::AsyncTokenType>())
         return false;
       else
         return true;

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -750,8 +750,8 @@ public:
   LogicalResult
   matchAndRewrite(scf::ReduceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto newOp =
-        rewriter.replaceOpWithNewOp<scf::ReduceOp>(op, adaptor.getOperands()[0]);
+    auto newOp = rewriter.replaceOpWithNewOp<scf::ReduceOp>(
+        op, adaptor.getOperands()[0]);
     auto body = &op.getRegion(0).front();
     auto newBody = &newOp.getRegion(0).front();
 

--- a/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
@@ -979,10 +979,12 @@ public:
   LogicalResult
   matchAndRewrite(scf::ReduceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto newOp =
-        rewriter.replaceOpWithNewOp<scf::ReduceOp>(op, adaptor.getOperand());
-    auto body = &op.getRegion().front();
-    auto newBody = &newOp.getRegion().front();
+    auto newOp = rewriter.replaceOpWithNewOp<scf::ReduceOp>(
+        op, adaptor.getOperands()[0]);
+    // TODO(JamesNewling / ErweiWang) : op has been erased above, and should not
+    // be referenced below. Logic needs updating.
+    auto body = &op.getRegion(0).front();
+    auto newBody = &newOp.getRegion(0).front();
 
     for (int i = 0, e = body->getNumArguments(); i < e; i++) {
       body->getArgument(i).replaceAllUsesWith(newBody->getArgument(i));
@@ -1271,7 +1273,7 @@ public:
     });
 
     target.addDynamicallyLegalOp<scf::ReduceOp>([&](scf::ReduceOp op) {
-      if (op.getOperand().getType().isa<xilinx::airrt::EventType>())
+      if (op.getOperand(0).getType().isa<xilinx::airrt::EventType>())
         return false;
       else
         return true;

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -344,10 +344,10 @@ scf::ReduceOp createSCFReduceForAsyncSCFParallel(OpBuilder builder,
                                                  Location loc, Value token,
                                                  MLIRContext *ctx) {
   auto reduce_op = builder.create<scf::ReduceOp>(loc, token);
-  builder.setInsertionPointToStart(&reduce_op.getRegion().front());
+  builder.setInsertionPointToStart(&reduce_op.getRegion(0).front());
   SmallVector<Value, 4> reduce_tokens;
-  reduce_tokens.push_back(reduce_op.getRegion().front().getArgument(0));
-  reduce_tokens.push_back(reduce_op.getRegion().front().getArgument(1));
+  reduce_tokens.push_back(reduce_op.getRegion(0).front().getArgument(0));
+  reduce_tokens.push_back(reduce_op.getRegion(0).front().getArgument(1));
   auto reduce_res = builder.create<xilinx::air::WaitAllOp>(
       builder.getUnknownLoc(), air::AsyncTokenType::get(ctx), reduce_tokens);
   builder.create<scf::ReduceReturnOp>(builder.getUnknownLoc(),
@@ -2119,7 +2119,7 @@ void dependencyTracer::reconnectLoopCarriedDependencyFromOp(Operation *op) {
     if (reduce_ops.size() != 1)
       scf_par->emitOpError("number of reduce ops is not one");
     auto reduce_wait_all =
-        dyn_cast<air::WaitAllOp>(reduce_ops[0].getOperand().getDefiningOp());
+        dyn_cast<air::WaitAllOp>(reduce_ops[0].getOperand(0).getDefiningOp());
     if (!reduce_wait_all)
       scf_par->emitOpError("reduce op is not dependent on any air::WaitAllOp");
 

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -15,9 +15,8 @@
 ##===----------------------------------------------------------------------===##
 
 # export commithash=d36b483f4f1109f53399ef82fda32f2c04d4ef44
-# branch=air
-export commithash=cb7fe9ad4c3103d90c20d55819a9e69ab66ab3d0
-branch=main
+export commithash=cd101ab76bdee8d2583ae7b0dfbae9a745373731
+branch=air
 
 git clone --depth 1 https://github.com/llvm/llvm-project.git llvm
 pushd llvm

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -14,8 +14,10 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=d36b483f4f1109f53399ef82fda32f2c04d4ef44
-branch=air
+# export commithash=d36b483f4f1109f53399ef82fda32f2c04d4ef44
+# branch=air
+export commithash=cb7fe9ad4c3103d90c20d55819a9e69ab66ab3d0
+branch=main
 
 git clone --depth 1 https://github.com/llvm/llvm-project.git llvm
 pushd llvm


### PR DESCRIPTION
This focuses on the LLVM bump. Mostly related to the SCF ReduceOp changes in https://github.com/llvm/llvm-project/pull/75314

As a follow-up we can bump the mlir-aie used. I just first want to see if this PR actually works (I haven't built and tested succesfully locally). 
