### PR TITLE
Fixing the compiler only flow

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -65,7 +65,7 @@ declare_mlir_python_extension(AirPythonExtensions.MLIR
 
 # Only building this if we are building the runtime, as it requires
 # the headers from the runtime
-if(AIR_RUNTIME_TEST_TARGET_VAL)
+if(AIR_RUNTIME_TARGETS)
   message("Building AirHostModule.cpp because we are building the runtime")
   declare_mlir_python_extension(AirPythonExtensions.AIRRt
     MODULE_NAME _airRt
@@ -123,7 +123,7 @@ include_directories(
 )
 
 # Only include this if we are building the runtime
-if(AIR_RUNTIME_TEST_TARGET_VAL)
+if(AIR_RUNTIME_TARGETS)
   include_directories(
     ${hsa-runtime64_DIR}/../../../include
   )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -66,7 +66,7 @@ declare_mlir_python_extension(AirPythonExtensions.MLIR
 # Only building this if we are building the runtime, as it requires
 # the headers from the runtime
 if(AIR_RUNTIME_TARGETS)
-  message("Building AirHostModule.cpp because we are building the runtime")
+  message(STATUS "Building python bindings because we are building the runtime")
   declare_mlir_python_extension(AirPythonExtensions.AIRRt
     MODULE_NAME _airRt
     ADD_TO_PARENT AirPythonExtensions

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,17 +63,22 @@ declare_mlir_python_extension(AirPythonExtensions.MLIR
     LLVMSupport
 )
 
-declare_mlir_python_extension(AirPythonExtensions.AIRRt
-  MODULE_NAME _airRt
-  ADD_TO_PARENT AirPythonExtensions
-  ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-  SOURCES
-    AirHostModule.cpp
-  EMBED_CAPI_LINK_LIBS
-    AIRCAPI
-  PRIVATE_LINK_LIBS
-    LLVMSupport
-)
+# Only building this if we are building the runtime, as it requires
+# the headers from the runtime
+if(AIR_RUNTIME_TEST_TARGET_VAL)
+  message("Building AirHostModule.cpp because we are building the runtime")
+  declare_mlir_python_extension(AirPythonExtensions.AIRRt
+    MODULE_NAME _airRt
+    ADD_TO_PARENT AirPythonExtensions
+    ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+    SOURCES
+      AirHostModule.cpp
+    EMBED_CAPI_LINK_LIBS
+      AIRCAPI
+    PRIVATE_LINK_LIBS
+      LLVMSupport
+  )
+endif()
 
 add_mlir_python_common_capi_library(AirAggregateCAPI
   INSTALL_COMPONENT AirPythonModules
@@ -112,11 +117,17 @@ add_mlir_python_modules(AirPythonModules
     AirAggregateCAPI
 )
 
+include_directories(
+  ${AIE_INCLUDE_DIRS}/../runtime_lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../runtime_lib/airhost/include
+)
+
+# Only include this if we are building the runtime
+if(AIR_RUNTIME_TEST_TARGET_VAL)
   include_directories(
-    ${AIE_INCLUDE_DIRS}/../runtime_lib
-    ${CMAKE_CURRENT_SOURCE_DIR}/../runtime_lib/airhost/include
     ${hsa-runtime64_DIR}/../../../include
   )
+endif()
   
 add_dependencies(AirPythonModules AirBackendPythonModules)
 add_subdirectory(air/backend)

--- a/utils/build-mlir-air.sh
+++ b/utils/build-mlir-air.sh
@@ -23,8 +23,6 @@
 # <llvm dir>         - llvm
 # <cmakeModules dir> - cmakeModules
 # <mlir-aie dir>     - mlir-aie
-# <HSA dir>          - HSA to build runtime
-# <HSA kmt dir>      - HSA to build runtime
 #
 # <build dir>    - optional, build dir name, default is 'build'
 # <install dir>  - optional, install dir name, default is 'install'
@@ -40,11 +38,9 @@ SYSROOT_DIR=`realpath $1`
 LLVM_DIR=`realpath $2`
 CMAKEMODULES_DIR=`realpath $3`
 MLIR_AIE_DIR=`realpath $4`
-HSA_DIR=`realpath $5`
-HSAKMT_DIR=`realpath $6`
 
-BUILD_DIR=${7:-"build"}
-INSTALL_DIR=$86:-"install"}
+BUILD_DIR=${5:-"build"}
+INSTALL_DIR=${6:-"install"}
 
 mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
@@ -64,8 +60,6 @@ cmake .. \
     -DLLVM_DIR=${LLVM_DIR}/build/lib/cmake/llvm \
     -DMLIR_DIR=${LLVM_DIR}/build/lib/cmake/mlir \
     -DAIE_DIR=${MLIR_AIE_DIR}/build/lib/cmake/aie \
-    -Dhsa-runtime64_DIR=${HSA_DIR} \
-    -Dhsakmt_DIR=${HSAKMT_DIR} \
     -Dpybind11_DIR=${PYTHON_ROOT}/pybind11/share/cmake/pybind11 \
     -DBUILD_SHARED_LIBS=OFF \
     -DLLVM_USE_LINKER=lld \


### PR DESCRIPTION
This PR includes CMake changes to allow building just the AIR compiler without any runtime dependencies. Before this, the compiler only flow (`build-mlir-air.sh`) required the runtime headers, which became more cumbersome when our compiler runtime required the ROCm runtime (ROCr) as a dependency. 