### PR TITLE
update compiler only build and test

### DIFF
--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-repo:
-    name: Build and Test Compiler Only
+    name: Build and Test
     runs-on: ubuntu-20.04
     steps:
       - name: Configure Environment
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get install -y libboost-all-dev
 
       - name: Install pip packages
-        run: sudo pip install psutil pybind11 numpy
+        run: sudo pip install psutil pybind11 numpy launchpadlib
 
       - name: Install Ninja
         uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
@@ -70,7 +70,29 @@ jobs:
         shell: bash
 
       - name: Rebuild and Install mlir-aie
-        run: utils/github-build-mlir-aie.sh
+        run: |
+          mkdir -p mlir-aie/build
+          mkdir -p mlir-aie/install
+          pushd mlir-aie/build
+          cmake .. \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DAIE_COMPILER=NONE \
+              -DAIE_LINKER=NONE \
+              -DHOST_COMPILER=NONE \
+              -DLLVM_ENABLE_ASSERTIONS=ON \
+              -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
+              -DMLIR_DIR=`pwd`/../../llvm/install/lib/cmake/mlir/ \
+              -DLLVM_DIR=`pwd`/../../llvm/install/lib/cmake/llvm/ \
+              -DCMAKE_LINKER=lld \
+              -DCMAKE_C_COMPILER=clang-12 \
+              -DCMAKE_CXX_COMPILER=clang++-12 \
+              -DLLVM_EXTERNAL_LIT=`pwd`/../../llvm/build/bin/llvm-lit \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+              -DLibXAIE_x86_64_DIR=`pwd`/../runtime_lib/xaiengine/aie-rt \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/../install
+          ninja install
+          popd
 
       # Build the repo test target in debug mode to build and test.
       - name: Build and test (Assert)

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Rebuild and Install LLVM
         run: utils/github-build-llvm.sh
 
+      - name: Rebuild and Install libxaie
+        run: utils/github-clone-build-libxaie.sh
+
       - name: Get mlir-aie
         id: clone-mlir-aie
         run: utils/clone-mlir-aie.sh
@@ -89,7 +92,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-12 \
               -DLLVM_EXTERNAL_LIT=`pwd`/../../llvm/build/bin/llvm-lit \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-              -DLibXAIE_x86_64_DIR=`pwd`/../runtime_lib/xaiengine/aie-rt \
+              -DLibXAIE_x86_64_DIR=`pwd`/../../aienginev2/install/lib \
               -DCMAKE_INSTALL_PREFIX=`pwd`/../install
           ninja install
           popd
@@ -108,7 +111,7 @@ jobs:
             -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
             -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
             -DAIE_DIR=`pwd`/../mlir-aie/install/lib/cmake/aie/ \
-            -DLibXAIE_ROOT=`pwd`/../mlir-aie/install/runtime_lib/x86_64/xaiengine/ \
+            -DLibXAIE_ROOT=`pwd`/../aienginev2/install \
             -DAIR_RUNTIME_TARGETS:STRING="x86_64" \
             -Dx86_64_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
@@ -135,7 +138,7 @@ jobs:
             -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
             -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
             -DAIE_DIR=`pwd`/../mlir-aie/install/lib/cmake/aie/ \
-            -DLibXAIE_ROOT=`pwd`/../mlir-aie/install/runtime_lib/x86_64/xaiengine/ \
+            -DLibXAIE_ROOT=`pwd`/../aienginev2/install \
             -DAIR_RUNTIME_TARGETS:STRING="x86_64" \
             -Dx86_64_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -1,0 +1,126 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+name: Build and Test Compiler Only
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  build-repo:
+    name: Build and Test Compiler Only
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure Environment
+        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
+
+      # Clone the repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      - name: Install libboost
+        run: sudo apt-get install -y libboost-all-dev
+
+      - name: Install pip packages
+        run: sudo pip install psutil pybind11 numpy
+
+      - name: Install Ninja
+        uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
+
+      - name: Get Submodule Hash
+        id: get-submodule-hash
+        run: echo "::set-output name=hash::$(md5sum $(echo utils/clone-llvm.sh))"
+        shell: bash
+
+      - name: Ccache for C++ compilation
+        uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+        with:
+          key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
+          max-size: 1G
+
+      - name: Get cmakeModules
+        id: clone-cmakeModules
+        run: |
+          git clone https://github.com/Xilinx/cmakeModules.git
+          pushd cmakeModules
+          git checkout -b air 2c3885644ea115d1d61bbf102abbd41be8ba8427
+          popd
+        shell: bash
+
+      - name: Get LLVM
+        id: clone-llvm
+        run: utils/clone-llvm.sh
+        shell: bash
+        
+      - name: Rebuild and Install LLVM
+        run: utils/github-build-llvm.sh
+
+      - name: Get mlir-aie
+        id: clone-mlir-aie
+        run: utils/clone-mlir-aie.sh
+        shell: bash
+
+      - name: Rebuild and Install mlir-aie
+        run: utils/github-build-mlir-aie.sh
+
+      # Build the repo test target in debug mode to build and test.
+      - name: Build and test (Assert)
+        run: |
+          mkdir build_assert
+          pushd build_assert
+          cmake .. \
+            -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_MODULE_PATH=`pwd`/../cmakeModules \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DAIE_DIR=`pwd`/../mlir-aie/install/lib/cmake/aie/ \
+            -DLibXAIE_ROOT=`pwd`/../mlir-aie/install/runtime_lib/x86_64/xaiengine/ \
+            -DAIR_RUNTIME_TARGETS:STRING="x86_64" \
+            -Dx86_64_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_INSTALL_PREFIX=install
+          ninja
+          ninja check-air-cpp
+          ninja check-air-mlir
+          ninja check-air-python
+          popd
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/aienginev2/install/lib
+
+      # Build the repo test target in release mode to build and test.
+      - name: Build and test (Release)
+        run: |
+          mkdir build_release
+          pushd build_release
+          cmake .. \
+            -DCMAKE_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DCMAKE_MODULE_PATH=`pwd`/../cmakeModules \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DAIE_DIR=`pwd`/../mlir-aie/install/lib/cmake/aie/ \
+            -DLibXAIE_ROOT=`pwd`/../mlir-aie/install/runtime_lib/x86_64/xaiengine/ \
+            -DAIR_RUNTIME_TARGETS:STRING="x86_64" \
+            -Dx86_64_TOOLCHAIN_FILE=`pwd`/../cmake/modules/toolchain_x86_64.cmake \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_INSTALL_PREFIX=install
+          make -j$(nproc)
+          make check-air-cpp check-air-mlir check-air-python
+          popd
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/aienginev2/install/lib

--- a/cmake/modules/toolchain_x86_64.cmake
+++ b/cmake/modules/toolchain_x86_64.cmake
@@ -13,6 +13,3 @@ set(CLANG_LLD lld-${CLANG_VER} CACHE STRING "" FORCE)
 # Make it a debug runtime build
 #set(CMAKE_BUILD_TYPE Debug CACHE STRING "build type" FORCE)
 #set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "" FORCE)
-
-# the default for x86 is to build a PCIe runtime
-set(BUILD_AIR_PCIE ON CACHE BOOL "" FORCE)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,9 +63,8 @@ declare_mlir_python_extension(AirPythonExtensions.MLIR
     LLVMSupport
 )
 
-# Only building this if we are building the runtime, as it requires
-# the headers from the runtime
-if(AIR_RUNTIME_TARGETS)
+# Only building this if we are building the hsa runtime, as it requires hsa.h
+if(hsa-runtime64_FOUND)
   message(STATUS "Building python bindings because we are building the runtime")
   declare_mlir_python_extension(AirPythonExtensions.AIRRt
     MODULE_NAME _airRt
@@ -122,13 +121,13 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../runtime_lib/airhost/include
 )
 
-# Only include this if we are building the runtime
-if(AIR_RUNTIME_TARGETS)
+# Only include this if we are building the hsa runtime
+if(hsa-runtime64_FOUND)
   include_directories(
     ${hsa-runtime64_DIR}/../../../include
   )
 endif()
-  
+
 add_dependencies(AirPythonModules AirBackendPythonModules)
 add_subdirectory(air/backend)
 

--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_package(LibXAIE REQUIRED)
 find_package(AIE REQUIRED CONFIG)
-find_package(hsa-runtime64 REQUIRED)
+find_package(hsa-runtime64)
 
 add_subdirectory(airhost)
 add_subdirectory(aircpu)

--- a/runtime_lib/airhost/CMakeLists.txt
+++ b/runtime_lib/airhost/CMakeLists.txt
@@ -11,74 +11,72 @@ include_directories(
 
 add_definitions(-DLIBXAIENGINEV2)
 
-if(BUILD_AIR_PCIE)
-  message("Building PCIe runtime (BUILD_AIR_PCIE=${BUILD_AIR_PCIE})")
-  add_definitions(-DAIR_PCIE)
+# Only build the runtime if hsa was found
+if (hsa-runtime64_FOUND)
+  include_directories(${XILINX_XAIE_INCLUDE_DIR})
+  link_libraries(${XILINX_XAIE_LIBS})
+
+  add_library(airhost STATIC
+      memory.cpp
+      queue.cpp
+      runtime.cpp
+      host.cpp
+      pcie-ernic.cpp
+      pcie-ernic-dev-mem-allocator.cpp
+      network.cpp
+  )
+  set_property(TARGET airhost PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+  add_library(airhost_shared SHARED
+      memory.cpp
+      queue.cpp
+      runtime.cpp
+      host.cpp
+      pcie-ernic.cpp
+      pcie-ernic-dev-mem-allocator.cpp
+      network.cpp
+    )
+  set_property(TARGET airhost_shared PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+  add_library(libelf_pic STATIC IMPORTED)
+  set_target_properties(libelf_pic PROPERTIES
+    IMPORTED_LOCATION "/lib/x86_64-linux-gnu/libelf.so"
+  )
+
+  target_link_libraries(airhost
+    ${AIR_LIBXAIE_LIBS}
+    dl
+    hsa-runtime64::hsa-runtime64
+  )
+
+  target_link_libraries(airhost_shared
+    hsa-runtime64::hsa-runtime64
+    libelf_pic
+  )
+
+  set_target_properties(airhost PROPERTIES
+          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
+  install(TARGETS airhost DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
+
+  set_target_properties(airhost_shared PROPERTIES
+          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
+  install(TARGETS airhost_shared DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
+
+
+  # Stuff into the build area:
+  add_custom_target(copy-runtime-libs ALL)
+  foreach(file ${INSTALLS})
+  add_custom_target(copy-runtime-libs-${file} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file})
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
+                      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+                      ${CMAKE_CURRENT_BINARY_DIR}/${file}
+                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+                      add_dependencies(copy-runtime-libs copy-runtime-libs-${file} )
+                      endforeach()
+
+  # Install files
+  set(INSTALLS memory.cpp queue.cpp host.cpp pcie-ernic.cpp pcie-ernic-dev-mem-allocator.cpp network.cpp)
+  install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
 endif()
 
-include_directories(${XILINX_XAIE_INCLUDE_DIR})
-link_libraries(${XILINX_XAIE_LIBS})
-
-add_library(airhost STATIC
-    memory.cpp
-    queue.cpp
-    runtime.cpp
-    host.cpp
-    pcie-ernic.cpp
-    pcie-ernic-dev-mem-allocator.cpp
-    network.cpp
-)
-set_property(TARGET airhost PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-add_library(airhost_shared SHARED
-    memory.cpp
-    queue.cpp
-    runtime.cpp
-    host.cpp
-    pcie-ernic.cpp
-    pcie-ernic-dev-mem-allocator.cpp
-    network.cpp
-   )
-set_property(TARGET airhost_shared PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-add_library(libelf_pic STATIC IMPORTED)
-set_target_properties(libelf_pic PROPERTIES
-  IMPORTED_LOCATION "/lib/x86_64-linux-gnu/libelf.so"
-)
-
-target_link_libraries(airhost
-  ${AIR_LIBXAIE_LIBS}
-  dl
-  hsa-runtime64::hsa-runtime64
-)
-
-target_link_libraries(airhost_shared
-  hsa-runtime64::hsa-runtime64
-  libelf_pic
-)
-
-set_target_properties(airhost PROPERTIES
-         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
-install(TARGETS airhost DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
-
-set_target_properties(airhost_shared PROPERTIES
-         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
-install(TARGETS airhost_shared DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
-
-
 add_subdirectory(include)
-
-# Stuff into the build area:
-add_custom_target(copy-runtime-libs ALL)
-foreach(file ${INSTALLS})
-    add_custom_target(copy-runtime-libs-${file} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file})
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
-                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-                    ${CMAKE_CURRENT_BINARY_DIR}/${file}
-                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
-    add_dependencies(copy-runtime-libs copy-runtime-libs-${file} )
-endforeach()
-
-# Install files
-set(INSTALLS memory.cpp queue.cpp host.cpp pcie-ernic.cpp pcie-ernic-dev-mem-allocator.cpp network.cpp)
-install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)

--- a/runtime_lib/airhost/include/CMakeLists.txt
+++ b/runtime_lib/airhost/include/CMakeLists.txt
@@ -2,7 +2,12 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set(INSTALLS air_tensor.h air_host.h air_channel.h air_host_impl.h air_queue.h pcie-ernic.h pcie-ernic-dev-mem-allocator.h air_network.h air.hpp hsa_ext_air.h)
+# aircpu library and tests require air_tensor.h
+# install it even if hsa is missing and we aren't building the runtime
+set(INSTALLS air_tensor.h)
+if (hsa-runtime64_FOUND)
+  list(APPEND INSTALLS air_host.h air_channel.h air_host_impl.h air_queue.h pcie-ernic.h pcie-ernic-dev-mem-allocator.h air_network.h air.hpp hsa_ext_air.h)
+endif()
 
 # Stuff into the build area:
 add_custom_target(copy-runtime-includes ALL)


### PR DESCRIPTION
Some of the MLIR tests require that runtime_lib/aircpu is built, which in turn depends on runtime_lib/airhost/include/air_tensor.h. This PR ensures that both are built and installed when the runtime itself is not built and adds a workflow to test it all.