### PR TITLE
Add -air-fuse-channels pass to aircc.py

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -116,6 +116,7 @@ def run(mlir_module, args=None):
     air_placed = opts.tmpdir+'/placed.'+air_mlir_filename
     pass_pipeline = ','.join([
       'air-pipeline-to-affine{lowering-type=getput}',
+      'air-fuse-channels',
       'canonicalize', 'cse',
       'func.func(air-renumber-dma)',
       'func.func(convert-linalg-to-loops)',


### PR DESCRIPTION
- In a previous patch, the DMA channel sharing capability of -air-to-aie pass has been taken out and reimplemented with a new pass `-air-fuse-channels`.
- If aircc.py doesn't contain `-air-fuse-channels`, it will not properly handle cases where more than two memcpys go into one single tile.