### PR TITLE
Fixup an issue with get1DOffset function 

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -44,7 +44,7 @@ std::vector<unsigned> convertToStdVec(SmallVector<int64_t, 6> vec);
 bool areIdenticalVectors(std::vector<unsigned> &a, std::vector<unsigned> &b);
 
 int64_t get1DOffset(SmallVector<Value> memcpy_offsets,
-                    SmallVector<Value> memcpy_sizes, int byte_count_per_elem);
+                    SmallVector<Value> memcpy_strides, int byte_count_per_elem);
 
 std::vector<AIE::BDDimLayoutAttr>
 getWrapsAndStrides(SmallVector<Value> memcpy_sizes,

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -43,7 +43,8 @@ std::vector<unsigned> convertToStdVec(SmallVector<int64_t, 6> vec);
 
 bool areIdenticalVectors(std::vector<unsigned> &a, std::vector<unsigned> &b);
 
-int64_t get1DOffset(SmallVector<Value> memcpy_offsets, Value memref);
+int64_t get1DOffset(SmallVector<Value> memcpy_offsets,
+                    SmallVector<Value> memcpy_sizes, int byte_count_per_elem);
 
 std::vector<AIE::BDDimLayoutAttr>
 getWrapsAndStrides(SmallVector<Value> memcpy_sizes,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2278,7 +2278,7 @@ public:
 
     int64_t len = getMemcpySizesAsInt(memref, sizes);
     int64_t offset =
-        get1DOffset(offsets, sizes, getElementSizeInBytes(memref.getType()));
+        get1DOffset(offsets, strides, getElementSizeInBytes(memref.getType()));
 
     Value length =
         b.create<arith::ConstantIndexOp>(memcpyOp.getLoc(), len)->getResult(0);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2277,7 +2277,8 @@ public:
                                      : ndcpy.getSrcStrides();
 
     int64_t len = getMemcpySizesAsInt(memref, sizes);
-    int64_t offset = get1DOffset(offsets, memref);
+    int64_t offset =
+        get1DOffset(offsets, sizes, getElementSizeInBytes(memref.getType()));
 
     Value length =
         b.create<arith::ConstantIndexOp>(memcpyOp.getLoc(), len)->getResult(0);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -154,10 +154,11 @@ bool air::areIdenticalVectors(std::vector<unsigned> &a,
   return a == b;
 }
 
-int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets, Value memref) {
+int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets,
+                         SmallVector<Value> memcpy_sizes,
+                         int byte_count_per_elem) {
   if (memcpy_offsets.empty())
     return 0;
-  SmallVector<int> memref_shape = getTensorShape(memref.getType());
 
   int64_t one_d_offset = 0;
   for (int i = memcpy_offsets.size() - 1; i >= 0; i--) {
@@ -166,10 +167,14 @@ int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets, Value memref) {
       assert(false && "non-static offset in memcpy op");
     if (i == memcpy_offsets.size() - 1)
       one_d_offset += *offset;
-    else
-      one_d_offset += *offset * memref_shape[i + 1];
+    else {
+      if (auto size_i_p_1 = mlir::getConstantIntValue(memcpy_sizes[i + 1])) {
+        one_d_offset += (*offset) * (*size_i_p_1);
+      } else
+        assert(false && "non-static size in memcpy op");
+    }
   }
-  return one_d_offset * getElementSizeInBytes(memref.getType());
+  return one_d_offset * byte_count_per_elem;
 }
 
 std::vector<AIE::BDDimLayoutAttr>

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -155,7 +155,7 @@ bool air::areIdenticalVectors(std::vector<unsigned> &a,
 }
 
 int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets,
-                         SmallVector<Value> memcpy_sizes,
+                         SmallVector<Value> memcpy_strides,
                          int byte_count_per_elem) {
   if (memcpy_offsets.empty())
     return 0;
@@ -168,8 +168,8 @@ int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets,
     if (i == memcpy_offsets.size() - 1)
       one_d_offset += *offset;
     else {
-      if (auto size_i_p_1 = mlir::getConstantIntValue(memcpy_sizes[i + 1])) {
-        one_d_offset += (*offset) * (*size_i_p_1);
+      if (auto stride_i = mlir::getConstantIntValue(memcpy_strides[i])) {
+        one_d_offset += (*offset) * (*stride_i);
       } else
         assert(false && "non-static size in memcpy op");
     }


### PR DESCRIPTION
- It was incorrectly getting data movement sizes from memref type instead of `strides` field.