### PR TITLE
utils: use a parameter name for git clone

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -15,12 +15,16 @@
 ##===----------------------------------------------------------------------===##
 
 export commithash=0f80f5e362fb43a9335bd154c5f7976a96e32cfc
-branch=air
+target_dir=llvm
 
-git clone --depth 1 https://github.com/llvm/llvm-project.git llvm
-pushd llvm
+# clone llvm if it is not there already
+if [[ ! -d $target_dir ]]; then
+  git clone --depth 1 https://github.com/llvm/llvm-project.git $target_dir
+fi
+
+pushd $target_dir
 git fetch --depth=1 origin $commithash
-git checkout $commithash -b $branch
+git checkout $commithash
 # Make mlir_async_runtime library's symbol visible
 # so that we can link to this library in channel sim tests
 sed -i '/set_property(TARGET mlir_async_runtime PROPERTY CXX_VISIBILITY_PRESET hidden)/d' ./mlir/lib/ExecutionEngine/CMakeLists.txt

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -15,9 +15,13 @@
 ##===----------------------------------------------------------------------===##
 
 export HASH=48329cab738a35d6fd8e8b9f86ddcf68b459a176
+target_dir=mlir-aie
 
-git clone --depth 1 https://github.com/Xilinx/mlir-aie.git mlir-aie
-pushd mlir-aie
+if [[ ! -d $target_dir ]]; then
+  git clone --depth 1 https://github.com/Xilinx/mlir-aie.git $target_dir
+fi
+
+pushd $target_dir
 git fetch --depth=1 origin $HASH
 git checkout $HASH
 git submodule update --init

--- a/utils/clone-rocm-air-platforms.sh
+++ b/utils/clone-rocm-air-platforms.sh
@@ -12,4 +12,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-git clone https://github.com/Xilinx/ROCm-air-platforms
+target_dir=ROCm-air-platforms
+
+if [[ ! -d $target_dir ]]; then
+  git clone https://github.com/Xilinx/ROCm-air-platforms $target_dir
+fi


### PR DESCRIPTION
When cloning sub-projects, use a parameter name for the target directory. This makes the script a bit easier to read, and easier to check for existing directories before cloning. This does not change the behaviour at all, but it does suppress a non-fatal error when trying to clone to an existing directory.