### PR TITLE
Thread sanitizer (tsan) fixes

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -10,8 +10,8 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/MathExtras.h"
-#include <set>
 #include <mutex>
+#include <set>
 
 #define DEBUG_TYPE "air-to-aie-scheduling-utils"
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -45,8 +45,8 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
-#include <sstream>
 #include <atomic>
+#include <sstream>
 
 using namespace mlir;
 using namespace xilinx;

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -46,13 +46,14 @@
 
 #include <algorithm>
 #include <sstream>
+#include <atomic>
 
 using namespace mlir;
 using namespace xilinx;
 
 #define DEBUG_TYPE "convert-to-air"
 
-static uint64_t DmaMemcpyOpID;
+static std::atomic<uint64_t> DmaMemcpyOpID;
 
 static FailureOr<air::DmaMemcpyNdOp>
 matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
@@ -1137,7 +1138,8 @@ class AIRDmaToAIRChannelConversion
         insertionPointAtHierOp = rewriter.saveInsertionPoint();
       }
 
-      for (auto b : backwardSlice) {
+      auto backwardSliceCopy = backwardSlice;
+      for (auto b : backwardSliceCopy) {
         if (dyn_cast<air::ExecuteOp>(b)) {
           for (auto &exec_child_op : b->getRegions().front().getOps()) {
             getBackwardSlice(&exec_child_op, &backwardSlice, bsOptions);


### PR DESCRIPTION
See issue https://github.com/nod-ai/iree-amd-aie/issues/130 for reproducer

Note that this PR does NOT fix https://github.com/nod-ai/iree-amd-aie/issues/130 just the issues detected with tsan

Steps taken:

1) build iree-amd-aie with tsan (thread sanitizer) enabled. This requires setting IREE_ENABLE_TSAN:BOOL=ON,  IREE_BYTECODE_MODULE_ENABLE_TSAN:BOOL=ON, and IREE_BYTECODE_MODULE_FORCE_LLVM_SYSTEM_LINKER:BOOL=ON . At least that worked for me. 

2) run the reproducer (see "compile pipeline 2" in https://github.com/nod-ai/iree-amd-aie/issues/130 )

3) observe the warnings that tsan throws up and fix them. In total there were 3 warnings, which this PR fixes. With this done, tsan produces no more warnings with "compile pipeline 2". Good, but the UB remains. 

Warnings were:


```
SUMMARY: ThreadSanitizer: data race /proj/gdba/jamesn/workspace/iree-amd-aie/third_party/mlir-air/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp:124:29 in xilinx::air::generateBufferNameInStringStream(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long&, mlir::StringAttr, int, int)
```

```
SUMMARY: ThreadSanitizer: heap-use-after-free /proj/gdba/jamesn/workspace/iree-amd-aie/third_party/mlir-air/mlir/lib/Conversion/ConvertToAIRPass.cpp:1140:19 in (anonymous namespace)::AIRDmaToAIRChannelConversion::matchAndRewrite(xilinx::air::DmaMemcpyNdOp, mlir::PatternRewriter&) const
```

and another data race warning. 
