### PR TITLE
non-const static variable -> class member for a thread safe pass

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -92,7 +92,7 @@ static uint64_t WaitAllOpID;
 static uint64_t ChannelOpID;
 
 namespace {
-  std::mutex mtx;
+std::mutex mtx;
 }
 
 class AIRDependency

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -108,17 +108,16 @@ public:
 
   void runOnOperation() override {
 
-    // RAII for the mutex mtx.
+    // This pass operates on builtin module ops, but it is not safe
+    // to assume that there is only one module being operated on at a time
+    // (example: IREE with multiple dispatches, creates nested modules).
     //
-    // While this pass operates at the builtin module scope, it is not correct
-    // to assume that there is only onle builtin module being operated at a time
-    // (example: IREE IR structure with multiple dispatches).
+    // This class contains state and so it is not designed to operate on ops
+    // in parallel (read/write race conditions on class state).
     //
-    // This class contains alot of state and is therefore not designed to
-    // operate on many ops at once (see
-    // https://mlir.llvm.org/docs/PassManagement)
+    // See also ... https://mlir.llvm.org/docs/PassManagement
     //
-    // As a temporary workaround, we use a mutex to ensure that only one
+    // As a temporary workaround, use a mutex to ensure that only one
     // operation is processed at a time.
     std::lock_guard<std::mutex> lock(mtx);
 


### PR DESCRIPTION
This PR ensures (for my build setup) that compile pipeline 2 with multithreading does not segfault (I ran ~10 times) 