### PR TITLE
Repair herd to ipu lowering and add e2e test

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -417,7 +417,7 @@ void createAIEModulesAndOutlineCores(
 
   for (auto h : herds) {
     std::string segment_name;
-    segment_name = "segment_" + std::to_string(aie_modules.size());
+    segment_name = "herd_" + std::to_string(aie_modules.size());
     std::string aie_module_name = "aie." + segment_name;
     auto builder = OpBuilder::atBlockBegin(module.getBody());
     auto aie_dev = builder.create<AIE::DeviceOp>(

--- a/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
+++ b/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
@@ -357,3 +357,28 @@ module {
     return
   }
 }
+
+// -----
+
+// check that lowering works for the herd_load case
+
+// CHECK: aie.device
+// CHECK: func.func @func0
+// CHECK: aiex.ipu.dma_memcpy_nd
+// CHECK: aiex.ipu.sync
+module {
+  aie.device(ipu) {
+    aie.shim_dma_allocation @airMemcpyId7(S2MM, 0, 0)
+    memref.global "public" @airMemcpyId7 : memref<64xi32, 1>
+  } {sym_name = "herd"}
+  func.func @func0(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c7_i32 = arith.constant 7 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %p = airrt.herd_load "herd" : i64
+    airrt.dma_memcpy_nd(%c7_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
@@ -31,7 +31,7 @@ func.func @foo(%arg0: i32) {
     memref.store %2, %dst0[%zero] : memref<1xi32, 2>
     air.herd_terminator
   }
-  // CHECK: sym_name = "segment_0"
+  // CHECK: sym_name = "herd_0"
   return
 }
 

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
@@ -17,7 +17,7 @@ func.func @foo(%arg0: i32) {
   // CHECK: aie.core(%[[VAL_0]])  {
   // CHECK:   call @beefmaker_kernel(%[[VAL_1]]) : (memref<1024xi32, 2>) -> ()
   // CHECK:   aie.end
-  // CHECK: } {elf_file = "segment_0_core_1_1.elf", link_with = "beefmaker.o"}
+  // CHECK: } {elf_file = "herd_0_core_1_1.elf", link_with = "beefmaker.o"}
   air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with="beefmaker.o"} {
     %src0 = memref.alloc() : memref<1024xi32, 2>
     func.call @beefmaker_kernel(%src0) : (memref<1024xi32, 2>) -> ()

--- a/test/xrt/02_mul_shim/gen.py
+++ b/test/xrt/02_mul_shim/gen.py
@@ -1,0 +1,100 @@
+# gen.py -*- Python -*-
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import air
+from air.ir import *
+from air.passmanager import *
+from air.dialects import air as airdialect
+from air.dialects import arith, func, linalg, memref
+from air.dialects.linalg.opdsl.lang import *
+from air._mlir_libs._airMlir import _run_air_transform as run_air_transform
+
+import numpy as np
+import pyxrt as xrt
+
+def generate_add_module(shape, dtype):
+    module = Module.create()
+    with InsertionPoint(module.body):
+        @func.FuncOp.from_py_func(
+            MemRefType.get(shape, dtype), MemRefType.get(shape, dtype), MemRefType.get(shape, dtype))
+        def mul(lhs, rhs, out):
+            linalg.elemwise_binary(
+                lhs,
+                rhs,
+                outs=[out],
+                fun=BinaryFn.mul,
+                cast=TypeFn.cast_unsigned)
+            return
+
+    #print ("\nlinalg Module:\n\n", module)
+
+    transform_ir_string = """
+    transform.with_pdl_patterns {
+    ^bb0(%arg0: !pdl.operation):
+      pdl.pattern @match_copy : benefit(1) {
+        %args = pdl.operands
+        %results = pdl.types
+        %op = pdl.operation "memref.copy"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+        pdl.rewrite %op with "transform.dialect"
+      }
+      transform.sequence %arg0 : !pdl.operation failures(propagate) {
+      ^bb1(%arg1: !pdl.operation):
+        %l0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %l1, %outer_tile_loops:1 = transform.air.linalg_tile %l0 [1024]
+        %l2, %inner_tile_loops:1 = transform.air.linalg_tile %l1 [32]
+        transform.air.linalg_promote %l2 {"operands_to_promote"=[0,1,2], "memory_space"="L1"}
+        %herds = transform.air.par_to_herd %outer_tile_loops#0
+        %copies = transform.pdl_match @match_copy in %arg0 : (!pdl.operation) -> !pdl.operation
+        %h = transform.air.copy_to_dma %copies
+      }
+    }
+    """
+
+    pm = PassManager.parse('builtin.module(func.func(linalg-generalize-named-ops))')
+    pm.run(module.operation)
+    transform_ir = Module.parse(transform_ir_string)
+    run_air_transform(transform_ir, module)
+
+    pm = PassManager.parse('builtin.module(func.func(canonicalize,cse))')
+    pm.run(module.operation)
+    return module
+
+with Context() as ctx, Location.unknown():
+    airdialect.register_dialect(ctx)
+    mlir_module = generate_add_module([32*32], IntegerType.get_signless(32))
+
+    # print("\nTiled AIR Module:\n\n", mlir_module)
+    # with open("mul.air.mlir", "w") as f:
+    #     f.write(str(mlir_module))
+
+    pipeline = "builtin.module(" + ",".join([
+        "func.func(air-lower-herd-parallel)",
+        "air-dma-to-channel",
+        "canonicalize", "cse",
+        "air-specialize-channel-wrap-and-stride",
+        "func.func(convert-linalg-to-loops)",
+        'func.func(air-renumber-dma)',
+        "air-to-aie{emit-while-loop=true device=ipu row-offset=2 col-offset=0}",
+        "air-to-std",
+        "airrt-to-ipu",
+        "canonicalize", "cse",
+    ]) + ")"
+    pm = PassManager.parse(pipeline)
+    pm.run(mlir_module.operation)
+
+    # print("\nAIE Module:\n\n", mlir_module)
+    # with open("mul.air_ipu.mlir", "w") as f:
+    #     f.write(str(mlir_module))
+
+    import aie.compiler.aiecc.main as aiecc
+
+    aiecc_options = ['--no-aiesim',
+                     '--aie-generate-cdo',
+                     '--aie-generate-ipu',
+                     '--no-compile-host',
+                     '--ipu-insts-name=insts.txt',
+                     '--xclbin-name=mul.xclbin',
+                     'aie.mlir']
+    aiecc.run(mlir_module, aiecc_options)

--- a/test/xrt/02_mul_shim/gen.py
+++ b/test/xrt/02_mul_shim/gen.py
@@ -11,9 +11,6 @@ from air.dialects import arith, func, linalg, memref
 from air.dialects.linalg.opdsl.lang import *
 from air._mlir_libs._airMlir import _run_air_transform as run_air_transform
 
-import numpy as np
-import pyxrt as xrt
-
 def generate_add_module(shape, dtype):
     module = Module.create()
     with InsertionPoint(module.body):

--- a/test/xrt/02_mul_shim/run.lit
+++ b/test/xrt/02_mul_shim/run.lit
@@ -1,0 +1,6 @@
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+// RUN: %python %S/gen.py
+// RUN: %run_on_ipu %python %S/run.py mul.xclbin

--- a/test/xrt/02_mul_shim/run.py
+++ b/test/xrt/02_mul_shim/run.py
@@ -1,0 +1,67 @@
+# run.py -*- Python -*-
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import pyxrt as xrt
+
+in_size = 32*32
+out_size = 32*32
+
+in_size_bytes = in_size * 4
+out_size_bytes = out_size * 4
+
+with open('insts.txt', 'r') as f:
+    instr_text = f.read().split('\n')
+    instr_text = [l for l in instr_text if l != '']
+    instr_v = np.array([int(i,16) for i in instr_text], dtype=np.uint32)
+
+opts_xclbin = 'mul.xclbin'
+opts_kernel = 'MLIR_AIE'
+
+device = xrt.device(0)
+xclbin = xrt.xclbin(opts_xclbin)
+kernels = xclbin.get_kernels()
+try:
+    xkernel = [k for k in kernels if opts_kernel in k.get_name()][0]
+except:
+    print(f"Kernel '{opts_kernel}' not found in '{opts_xclbin}'")
+    exit(-1)
+
+device.register_xclbin(xclbin)
+context = xrt.hw_context(device, xclbin.get_uuid())
+kernel = xrt.kernel(context, xkernel.get_name())
+
+bo_instr = xrt.bo(device, len(instr_v)*4, xrt.bo.cacheable, kernel.group_id(0))
+bo_a = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(2))
+bo_b = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(3))
+bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(4))
+
+bo_instr.write(instr_v, 0)
+bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+input_a = np.arange(in_size, dtype=np.uint32)
+bo_a.write(input_a, 0)
+bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+input_b = np.arange(in_size, dtype=np.uint32)
+bo_b.write(input_b, 0)
+bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+h = kernel(bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+h.wait()
+
+bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+output_buffer = bo_c.read(out_size_bytes, 0).view(np.uint32)
+print("input:", input_a)
+print("input:", input_b)
+print("output:", output_buffer)
+
+ref = input_a * input_b
+if np.equal(ref, output_buffer).all():
+    print("PASS!")
+    exit(0)
+else:
+    print("failed.")
+    exit(-1)


### PR DESCRIPTION
* restore ability to lower `air.herd` to ipu without `air.launch` or `air.segment`
* add eltwise mul e2e test: one core; simple tiling from L3 to L1; no `air.launch` or `air.segment`
 