### PR TITLE
A tsan warning fix

### DIFF
--- a/mlir/lib/Transform/AffineLoopOptPass.cpp
+++ b/mlir/lib/Transform/AffineLoopOptPass.cpp
@@ -146,6 +146,10 @@ void AffineLoopOptPass::tileLoops(
   // Tile each band.
   for (auto &band : *bands) {
 
+    assert(!band.empty());
+    auto stringAttr = band[0]->getAttrOfType<StringAttr>(
+        AffineLoopOptPass::affineOptAttrName);
+
     SmallVector<affine::AffineForOp, 6> tiledNest;
     SmallVector<unsigned, 6> actualTileSizes = optTileSizes;
 
@@ -163,8 +167,6 @@ void AffineLoopOptPass::tileLoops(
       (void)separateFullTiles(intraTileLoops);
     }
 
-    auto stringAttr = band[0]->getAttrOfType<StringAttr>(
-        AffineLoopOptPass::affineOptAttrName);
     if (stringAttr)
       tiledNest[0]->setAttr(
           AffineLoopOptPass::affineOptAttrName,


### PR DESCRIPTION
band[0] was modified or removed before used maybe? Not 100% sure but this fixes the warning. 