### PR TITLE
Fixes for airhost tests

### DIFF
--- a/test/airhost/19_air_nd_memcpy_to_tile_dma/air.mlir
+++ b/test/airhost/19_air_nd_memcpy_to_tile_dma/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<256xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c256 = arith.constant 256 : index
     %buf0 = memref.alloc() : memref<256xi32, 2>

--- a/test/airhost/21_air_nd_memcpy_2d/air.mlir
+++ b/test/airhost/21_air_nd_memcpy_2d/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<32x16xi32>, %arg1 : memref<32x16xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<32x16xi32>, memref<32x16xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<32x16xi32>, memref<32x16xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c32 = arith.constant 32 : index

--- a/test/airhost/23_air_shim_dma_to_tile_dma/air.mlir
+++ b/test/airhost/23_air_shim_dma_to_tile_dma/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<256xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>, memref<256xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>, memref<256xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c256 = arith.constant 256 : index

--- a/test/airhost/24_air_shim_dma_from_tile_dma/air.mlir
+++ b/test/airhost/24_air_shim_dma_from_tile_dma/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg1 : memref<256xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext1 = %arg1) : memref<256xi32>, memref<256xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext1 = %arg1) : memref<256xi32>, memref<256xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c256 = arith.constant 256 : index

--- a/test/airhost/25_2d_shim_dma/test.cpp
+++ b/test/airhost/25_2d_shim_dma/test.cpp
@@ -35,11 +35,11 @@
 #define TILE_HEIGHT 8
 #define TILE_SIZE (TILE_WIDTH * TILE_HEIGHT)
 
-namespace air::segments::segment_0 {
+namespace air::segments::copyherd {
 int32_t mlir_aie_read_buffer_scratch_0_0(aie_libxaie_ctx_t *, int);
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::copyherd
+using namespace air::segments::copyherd;
 
 int main(int argc, char *argv[]) {
   auto shim_col = 2;

--- a/test/airhost/34_air_3d_nd_memcpy/air.mlir
+++ b/test/airhost/34_air_3d_nd_memcpy/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<16x4x2xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<16x4x2xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<16x4x2xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
     %c16 = arith.constant 16 : index

--- a/test/airhost/35_air_4d_nd_memcpy/air.mlir
+++ b/test/airhost/35_air_4d_nd_memcpy/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<16x4x2x3xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<16x4x2x3xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<16x4x2x3xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c256 = arith.constant 256 : index
     %c64 = arith.constant 64 : index

--- a/test/airhost/40_air_8x4_2d_square/air_test.cpp
+++ b/test/airhost/40_air_8x4_2d_square/air_test.cpp
@@ -31,7 +31,7 @@
 #define NUM_3D (IMAGE_WIDTH / TILE_WIDTH)
 #define NUM_4D (IMAGE_HEIGHT / TILE_HEIGHT)
 
-namespace air::segments::segment_0 {
+namespace air::segments::copyherd {
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_2(aie_libxaie_ctx_t *, int, int32_t);
@@ -64,8 +64,8 @@ void mlir_aie_write_buffer_scratch_7_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_2(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_3(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::copyherd
+using namespace air::segments::copyherd;
 
 int main(int argc, char *argv[]) {
 

--- a/test/airhost/40_air_8x4_2d_square/run.lit
+++ b/test/airhost/40_air_8x4_2d_square/run.lit
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc.py -row-offset=4 -col-offset=16 %S/air.mlir -o %T/air.a
+// REQUIRES: valid_xchess_license
+
+// RUN: aircc.py -xchesscc -xbridge -row-offset=4 -col-offset=16 %S/air.mlir -o %T/air.a
 // RUN: %CLANG %S/air_test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/air_test.elf
 // RUN: %run_on_board %T/air_test.elf

--- a/test/airhost/42_air_add_one_place_random/air.mlir
+++ b/test/airhost/42_air_add_one_place_random/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<16xi32>, %arg1 : memref<16xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<16xi32>, memref<16xi32> attributes { sym_name="herd_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<16xi32>, memref<16xi32> attributes { sym_name="segment_0"} {
     %c0 = arith.constant 0 : index
     %c16 = arith.constant 16 : index
     %c1_32 = arith.constant 1 : i32

--- a/test/airhost/44_air_mmult_2x2/run.lit
+++ b/test/airhost/44_air_mmult_2x2/run.lit
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc.py -row-offset=3 -col-offset=13 %S/air.mlir -o %T/air.a
+// REQUIRES: valid_xchess_license
+
+// RUN: aircc.py -xchesscc -xbridge -row-offset=3 -col-offset=13 %S/air.mlir -o %T/air.a
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/46_air_mmult_2x2_tokens/run.lit
+++ b/test/airhost/46_air_mmult_2x2_tokens/run.lit
@@ -5,6 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc.py -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
+// REQUIRES: valid_xchess_license
+
+// RUN: aircc.py -xchesscc -xbridge -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf


### PR DESCRIPTION
* Fix for wrong C++ namespaces in host code after #441
* Use xchesscc for airhost tests 40, 44, and 46, which are mis-compiled by peano