### PR TITLE
Only run buildAndTestAieTools on push to main

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [assigned, opened, synchronize, reopened, ready_for_review]
+  # pull_request:
+  #   types: [assigned, opened, synchronize, reopened, ready_for_review]
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Forks cannot access the secrets needed to run the workflow. The easy fix is to run on push to main only with the downside that PRs from fork may introduce regressions which are not caught right away.