### PR TITLE
Fix to enable lowering of 16-bit types 

### DIFF
--- a/mlir/lib/Conversion/AIRRtToIpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToIpuPass.cpp
@@ -61,6 +61,7 @@ struct RelocateAssumeAlignmentOp
   matchAndRewrite(memref::AssumeAlignmentOp assumeOp,
                   mlir::PatternRewriter &rewriter) const override {
 
+
     auto producerOp = assumeOp.getOperand().getDefiningOp();
     if (!producerOp)
       return rewriter.notifyMatchFailure(assumeOp,

--- a/mlir/lib/Conversion/AIRRtToIpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToIpuPass.cpp
@@ -61,7 +61,6 @@ struct RelocateAssumeAlignmentOp
   matchAndRewrite(memref::AssumeAlignmentOp assumeOp,
                   mlir::PatternRewriter &rewriter) const override {
 
-
     auto producerOp = assumeOp.getOperand().getDefiningOp();
     if (!producerOp)
       return rewriter.notifyMatchFailure(assumeOp,

--- a/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
+++ b/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
@@ -558,11 +558,9 @@ module {
 
 // -----
 
-
-
 // Before PR https://github.com/Xilinx/mlir-air/pull/447 running
 // `air-opt --cse  --canonicalize -airrt-to-ipu`
-// on function in the test produces:
+// on the function in the test produced:
 //
 //  func.func @func12(%arg0: memref<16xi32>) {
 //    %alloc = memref.alloc() : memref<32xbf16>
@@ -571,14 +569,16 @@ module {
 //    return
 //  }
 //
-// PR 447 fixes relocates the memref.assume_alignment op.
-// `air-opt -airrt-to-ipu` on function in the test now produces:
+// PR 447 relocates the memref.assume_alignment op so that calling
+// `air-opt -airrt-to-ipu` on the function in the test now produces:
 //
 //  func.func @func12(%arg0: memref<16xi32>) {
 //    memref.assume_alignment %arg0, 64 : memref<16xi32>
 //    aiex.ipu.dma_memcpy_nd(0, 0, %arg0 ...
 //    return
 //  }
+//
+// The key difference is that memref.alloc is removed.
 
 // CHECK-LABEL: func12
 // CHECK-NOT: memref.alloc


### PR DESCRIPTION
Before this PR, the IR created in airrt-to-ipu was like

```
           func.func @matmul_8x32_16xi32__dispatch_0_matmul_8x32x16_i16xi16xi32(%arg0: memref<64xi32>, %arg1: memref<256xi32>, %arg2: memref<8x32xi32>) {
             %c0 = arith.constant 0 : index
             %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<8x16xi16>
             memref.assume_alignment %0, 64 : memref<8x16xi16>
             %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<16x32xi16>
             memref.assume_alignment %1, 64 : memref<16x32xi16>
             %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<8x32xi32>
             memref.assume_alignment %arg2, 64 : memref<8x32xi32>
             %3 = builtin.unrealized_conversion_cast %0 : memref<8x16xi16> to memref<64xi32>
             aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][4, 1, 8, 8][0, 0, 8]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<64xi32>
```

The `hal.interface.binding.subspan` ops are then never dead-code-eliminated, I assume because the `memref.assume_alignment` cannot be removed (it might throw?)

The IR we want the pass to generate should have %arg1 and %arg2 being the operands to `hal.interface.binding.subspan` ops. i.e. we want: 

```
           func.func @matmul_8x32_16xi32__dispatch_0_matmul_8x32x16_i16xi16xi32(%arg0: memref<64xi32>, %arg1: memref<256xi32>, %arg2: memref<8x32xi32>) {
             %c0 = arith.constant 0 : index
             %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<8x16xi16>
             memref.assume_alignment %arg0, 64 : memref<64xi32>
             %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<16x32xi16>
             memref.assume_alignment %arg1, 64 : memref<256xi32>
             %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<8x32xi32>
             memref.assume_alignment %arg2, 64 : memref<8x32xi32>
             %3 = builtin.unrealized_conversion_cast %0 : memref<8x16xi16> to memref<64xi32>
             aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][4, 1, 8, 8][0, 0, 8]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<64xi32>
```


In this case the `hal.interface.binding.subspan` ops can be removed in a subsequent canonicalization pass. 

@fifield this is my goal, and the "peep-hole" pattern I've added achieves this, although you might have a neater way of doing this. 