### PR TITLE
Optimize 04_gemm_w_pack test.exe

### DIFF
--- a/test/xrt/04_gemm_w_pack/run.lit
+++ b/test/xrt/04_gemm_w_pack/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai
 // RUN: %python %S/aie.py
 // RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-ipu --no-compile-host --xclbin-name=aie.xclbin --ipu-insts-name=insts.txt aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: clang %S/test.cpp -O3 -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_ipu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/xrt/04_gemm_w_pack/test.cpp
+++ b/test/xrt/04_gemm_w_pack/test.cpp
@@ -163,19 +163,17 @@ int main(int argc, const char *argv[]) {
   if (verbosity >= 1)
     std::cout << "Writing data into buffer objects.\n";
   A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
-  std::vector<A_DATATYPE> AVec;
+  std::vector<A_DATATYPE> AVec(A_VOLUME);
   for (int i = 0; i < A_VOLUME; i++)
-    AVec.push_back(rand() % UINT16_MAX);
+    AVec[i] = rand() % UINT16_MAX;
   memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
   B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
-  std::vector<B_DATATYPE> BVec;
+  std::vector<B_DATATYPE> BVec(B_VOLUME);
   for (int i = 0; i < B_VOLUME; i++)
-    BVec.push_back(rand() % UINT16_MAX);
+    BVec[i] = rand() % UINT16_MAX;
   memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
   C_DATATYPE *bufC = bo_c.map<C_DATATYPE *>();
-  std::vector<C_DATATYPE> CVec;
-  for (int i = 0; i < C_VOLUME; i++)
-    CVec.push_back(0);
+  std::vector<C_DATATYPE> CVec(C_VOLUME, 0);
   memcpy(bufC, CVec.data(), (CVec.size() * sizeof(C_DATATYPE)));
 
   void *bufInstr = bo_instr.map<void *>();
@@ -198,9 +196,7 @@ int main(int argc, const char *argv[]) {
   int errors = 0;
   int max_errors = 100;
 
-  std::vector<C_DATATYPE> output_ref0;
-  for (uint32_t i = 0; i < C_VOLUME; i++)
-    output_ref0.push_back(0);
+  std::vector<C_DATATYPE> output_ref0(C_VOLUME, 0);
   mm_out(AVec, BVec, output_ref0);
 
   for (uint32_t i = 0; i < C_VOLUME; i++) {


### PR DESCRIPTION
This test spends a lot of time in test.exe. Compiling with -O3 reduced the overall build+run time for this test from roughly 120sec to 90sec.