### PR TITLE
Run CastFunctionArgs after BufferMemrefToFuncArgs

### DIFF
--- a/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
+++ b/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
@@ -536,3 +536,22 @@ module {
     }
   }
 }
+
+// -----
+
+// 16-bit conversion with dma operands that aren't function arguments
+
+// CHECK-LABEL: func.func @func11
+// CHECK-SAME: %arg0: memref<16xi32>
+// CHECK-NEXT: aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 16][0, 0, 0]) {{.*}} : memref<16xi32>
+module {
+ func.func @func11() {
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %alloc = memref.alloc() : memref<32xbf16>
+    airrt.dma_memcpy_nd(%c1_i32, %c0_i64, %c0_i64, %alloc[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c32_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @md0} : (i32, i64, i64, memref<32xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+    return
+  }
+}

--- a/test/xrt/06_add_shim_bf16/run.lit
+++ b/test/xrt/06_add_shim_bf16/run.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, valid_xchess_license
+// REQUIRES: ryzen_ai
 // RUN: %python %S/gen.py
 // RUN: %run_on_ipu %python %S/run.py add.xclbin


### PR DESCRIPTION
Run `CastFunctionArgs` after `BufferMemrefToFuncArgs` because `CastFunctionArgs` assumes the IR is in the form produced by the legalization in `BufferMemrefToFuncArgs`.