### PR TITLE
Extend -air-specialize-channel-wrap-and-stride for tile/memtile DMA repeat count

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -47,6 +47,8 @@ bool areIdenticalVectors(std::vector<unsigned> &a, std::vector<unsigned> &b);
 int64_t get1DOffset(SmallVector<Value> memcpy_offsets,
                     SmallVector<Value> memcpy_strides, int byte_count_per_elem);
 
+int getRepeatCount(Operation *memcpy_op);
+
 std::vector<AIE::BDDimLayoutAttr>
 getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
                    SmallVector<Value> memcpy_strides, MLIRContext *ctx);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -408,8 +408,9 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk(
-        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
+    seg.walk([&](xilinx::air::HerdOp h) {
+      aie_modules.push_back({aie_dev, h});
+    });
 
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1708,9 +1708,9 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
         offsets.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 0));
         wraps.push_back(
             rewriter.create<arith::ConstantIndexOp>(loc, memref_shape[i]));
+        current_stride /= memref_shape[i];
         strides.push_back(
             rewriter.create<arith::ConstantIndexOp>(loc, current_stride));
-        current_stride /= memref_shape[i];
       }
     }
     for (auto o : for_loops) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1698,6 +1698,21 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
     SmallVector<Value> offsets = channel_ops[0].getOffsets();
     SmallVector<Value> wraps = channel_ops[0].getSizes();
     SmallVector<Value> strides = channel_ops[0].getStrides();
+    // If empty offsets/sizes/strides, then populate the lists with default
+    // values.
+    if (offsets.empty() && wraps.empty() && strides.empty()) {
+      auto memref_shape = getTensorShape(channel_ops[0].getMemref().getType());
+      int current_stride =
+          getTensorVolume(channel_ops[0].getMemref().getType());
+      for (unsigned i = 0; i < memref_shape.size(); i++) {
+        offsets.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 0));
+        wraps.push_back(
+            rewriter.create<arith::ConstantIndexOp>(loc, memref_shape[i]));
+        strides.push_back(
+            rewriter.create<arith::ConstantIndexOp>(loc, current_stride));
+        current_stride /= memref_shape[i];
+      }
+    }
     for (auto o : for_loops) {
       // Check for perfect loop nest containing only air.channel ops
       if (!hasNElements(o.getBody(), 1))

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -194,4 +194,19 @@ module {
     %2 = air.wait_all async [%0, %1]
     return %alloc : memref<128xf32>
   }
+
+  // CHECK-LABEL: test5
+  // CHECK: put async  @channel_17[] (%arg0[%c0, %c0, %c0] [%c8, %c32, %c32] [%c0, %c32, %c1]) : (memref<32x32xf32>)
+
+  func.func @test5(%arg0: memref<32x32xf32>) -> memref<32x32xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %alloc = memref.alloc() : memref<32x32xf32>
+    scf.for %arg2 = %c0 to %c8 step %c1 {
+      %0 = affine.apply #map()[%arg2]
+      %1 = air.channel.put async @channel_17[] (%arg0[] [] []) : (memref<32x32xf32>)
+    }
+    return %alloc : memref<32x32xf32>
+  }
 }


### PR DESCRIPTION
.. when folding for loop into an `air.channel` op with empty offsets and strides list, i.e. the default DMA access pattern.