### PR TITLE
Fix test 21 - undefined symbol

### DIFF
--- a/test/airhost/21_air_nd_memcpy_2d/Makefile
+++ b/test/airhost/21_air_nd_memcpy_2d/Makefile
@@ -20,6 +20,7 @@ CFLAGS += -g -I/opt/xaiengine/include
 CFLAGS += -I${ROCM_ROOT}/include
 CFLAGS += -std=c++17 -I$(ACDC_AIR)/runtime_lib/airhost/include -I$(ACDC_AIE)/runtime_lib/x86_64/test_lib/include \
           -DAIR_LIBXAIE_ENABLE
+CFLAGS += -I air_project/herd_0/
 LDFLAGS += -L/opt/xaiengine/lib -Wl,-R/opt/xaiengine/lib
 LDFLAGS += -L$(ACDC_AIR)/runtime_lib/airhost
 LDFLAGS += -L/lib/x86_64-linux-gnu/

--- a/test/airhost/21_air_nd_memcpy_2d/test.cpp
+++ b/test/airhost/21_air_nd_memcpy_2d/test.cpp
@@ -22,6 +22,8 @@
 #include "air.hpp"
 #include "test_library.h"
 
+#include "aie_inc.cpp"
+
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
@@ -34,11 +36,6 @@
 #define TILE_WIDTH 16
 #define TILE_HEIGHT 8
 #define TILE_SIZE (TILE_WIDTH * TILE_HEIGHT)
-
-namespace air::segments::segment_0 {
-void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
-};
-using namespace air::segments::segment_0;
 
 int main(int argc, char *argv[]) {
   uint64_t row = 3;


### PR DESCRIPTION
The host code depends on a symbol generated by `aiecc.py`. It was not added by the makefile to the compilation and the linker complained with `undefined symbol: air::segments::segment_0::mlir_aie_wr…ite_buffer_scratch_0_0(aie_libxaie_ctx_t*, int, int)`. 