### PR TITLE
Bump the mlir-aie version that is used 

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -178,8 +178,9 @@ AIE::BufferOp allocateBufferOp(uint64_t &BufferId, MemRefType memrefTy,
   while (dyn_cast_or_null<AIE::TileOp>(t->getNextNode()))
     t = t->getNextNode();
   builder.setInsertionPointAfter(t);
-  AIE::BufferOp bufferOp = builder.create<AIE::BufferOp>(
-      tile->getLoc(), memrefTy, tile, nullptr, nullptr);
+  AIE::BufferOp bufferOp =
+      builder.create<AIE::BufferOp>(tile->getLoc(), memrefTy, tile, nullptr,
+                                    nullptr, /* initial value = */ nullptr);
 
   std::stringstream ss =
       generateBufferNameInStringStream("buf", BufferId, attr, x, y);

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=d07ee8ee44b5f0fa9b48ceb0f38878cb71c6533f
+export HASH=64eac091fb2f4756790aece6664bf5fd94ce3ebb
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then


### PR DESCRIPTION
aie's buffer op now has an optional initial value. 