### PR TITLE
[AIR][AMD-AIE] Add changes to enable IREE microkernel based lowering

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -142,6 +142,10 @@ public:
           createAsyncExecute(module_builder, op, "linalg::unknown",
                              ExecuteOpID);
 
+        // Create async interface for func.call ops.
+        else if (isa<func::CallOp>(op))
+          createAsyncExecute(module_builder, op, "func::call", ExecuteOpID);
+
         // Create async execute region for memref.alloc
         else if (auto memalloc_op = dyn_cast<memref::AllocOp>(op))
           createAsyncExecute(module_builder, op, "memref::alloc", ExecuteOpID,
@@ -649,7 +653,8 @@ private:
     SmallVector<Value, 1> deps;
     air::ExecuteOp async_region;
     async_region = builder.create<xilinx::air::ExecuteOp>(
-        loc, air::AsyncTokenType::get(op->getContext()), valueType, deps);
+        loc, air::AsyncTokenType::get(op->getContext()),
+        op->getResults().getType(), deps);
     async_region->setAttr(
         "id", mlir::IntegerAttr::get(
                   mlir::IntegerType::get(op->getContext(), 32), ++ExecuteOpID));
@@ -658,10 +663,12 @@ private:
     Block *async_region_bb = builder.createBlock(&async_region.getBody());
     builder.setInsertionPointToStart(async_region_bb);
     auto op_cloned = builder.clone(*op);
-    builder.create<xilinx::air::ExecuteTerminatorOp>(
-        builder.getUnknownLoc(), op_cloned->getResults().front());
+    builder.create<xilinx::air::ExecuteTerminatorOp>(builder.getUnknownLoc(),
+                                                     op_cloned->getResults());
     SmallVector<Value, 1> returnVals;
-    returnVals.push_back(async_region.getResult(1));
+    for (auto val : async_region.getResults()) {
+      returnVals.push_back(val);
+    }
     op->replaceAllUsesWith(returnVals);
 
     // Create a vertex out of the current async execute region

--- a/mlir/test/Conversion/ConvertToAIR/affine_par_to_herd_launch.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/affine_par_to_herd_launch.mlir
@@ -43,3 +43,35 @@ func.func @par2()  {
   }
   return
 }
+
+// -----
+
+// This test demonstrates that while forming air.herd we look through func.call ops, fetch
+// the corresponding function declaration's 'link_with' attribute and attach it to the newly
+// formed air.herd op.
+
+// CHECK-LABEL: module {
+//       CHECK:  func.func private @matmul_i32_i32
+//  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o", llvm.bareptr = true}
+//       CHECK:  func.func @matmul_small_dispatch_0_matmul_8x32x16_i32(
+//       CHECK:    air.herd @herd_0
+//  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o"} {
+//       CHECK:       func.call @matmul_i32_i32
+//       CHECK:       air.herd_terminator
+//       CHECK:    }
+//       CHECK:    return
+//       CHECK:  }
+//       CHECK: }
+module {
+  func.func private @matmul_i32_i32(memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) attributes {link_with = "/path/to/mm_microkernel.o", llvm.bareptr = true}
+  func.func @matmul_small_dispatch_0_matmul_8x32x16_i32(%base_buffer: memref<i32, 2 : i32>, %base_buffer_14: memref<i32, 2 : i32>, %base_buffer_18: memref<i32, 2 : i32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.parallel (%x,%y) = (%c0,%c0) to (%c1,%c1) step (%c1, %c1) {
+      %2 = arith.addi %x, %y : index
+      func.call @matmul_i32_i32(%base_buffer, %c0, %base_buffer_14, %c0, %base_buffer_18, %c0) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
+      scf.reduce
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependency/func_call.mlir
+++ b/mlir/test/Transform/AIRDependency/func_call.mlir
@@ -1,0 +1,32 @@
+//===- func_call.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+// A single async air.execute op should be created around func.call op.
+//      CHECK: %[[EVENT0:.*]] = air.execute [
+// CHECK-NEXT:        func.call @matmul_scalar_i32_i32
+// CHECK-NEXT: } {id = 
+module {
+  func.func private @matmul_scalar_i32_i32(memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) attributes {link_with = "/path/to/mm_microkernel.o", llvm.bareptr = true}
+  func.func @generic() {
+    %c2_8 = arith.constant 2 : index
+    %c2_9 = arith.constant 2 : index
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c2_8, %arg5=%c2_9) args(%arg6=%alloc_3, %arg7=%alloc, %arg8=%alloc_2) : memref<8x8xi32, 1 : i32>, memref<8x16xi32, 1 : i32>, memref<16x8xi32, 1 : i32> attributes {link_with = "/path/to/mm_microkernel.o"} {
+      %base_buffer_lhs = memref.alloc() : memref<i32, 2 : i32>
+      %base_buffer_rhs = memref.alloc() : memref<i32, 2 : i32>
+      %base_buffer = memref.alloc() : memref<i32, 2 : i32>
+      %c0_11 = arith.constant 0 : index
+      func.call @matmul_scalar_i32_i32(%base_buffer_lhs, %c0_11, %base_buffer_rhs, %c0_11, %base_buffer, %c0_11) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
+      air.herd_terminator
+    }
+    return
+  }
+}


### PR DESCRIPTION
-- This commit adds changes to enable IREE microkernel based lowering.
-- iree-amd-aie gives us func.call targeting the microkernel and this
   commit updates air.herd's generation to incorporate adding the
   `link_with` parameter for the .o file containing microkernel.
-- This commit also adds update to wrap the func.call with air.execute
   ops.
   
Signed-off-by: Abhishek Varma <abhvarma@amd.com>