### PR TITLE
Tweak airrt segment lowering

### DIFF
--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -637,7 +637,6 @@ public:
 
     rewriter.eraseOp(op);
     return success();
-    return success();
   }
 };
 

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -122,11 +122,11 @@ public:
     air::SegmentOp segment = cast<air::SegmentOp>(op);
     if (auto attr =
             op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
+      OpBuilder::InsertionGuard guard(rewriter);
       auto segment_name = attr.getValue().str();
       rewriter.setInsertionPointToStart(op->getBlock());
       rewriter.create<airrt::SegmentLoadOp>(op->getLoc(), rewriter.getI64Type(),
                                             segment_name);
-      rewriter.setInsertionPoint(op);
     }
 
     SmallVector<Value> lbs, ubs, steps;
@@ -222,8 +222,12 @@ public:
       return failure();
     }
 
-    rewriter.create<airrt::HerdLoadOp>(op->getLoc(), rewriter.getI64Type(),
-                                       herd_name_attr.getValue().str());
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(op->getBlock());
+      rewriter.create<airrt::HerdLoadOp>(op->getLoc(), rewriter.getI64Type(),
+                                        herd_name_attr.getValue().str());
+    }
 
     SmallVector<Value, 4> deps;
     for (auto &o : operands)

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -226,7 +226,7 @@ public:
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(op->getBlock());
       rewriter.create<airrt::HerdLoadOp>(op->getLoc(), rewriter.getI64Type(),
-                                        herd_name_attr.getValue().str());
+                                         herd_name_attr.getValue().str());
     }
 
     SmallVector<Value, 4> deps;
@@ -566,8 +566,8 @@ AIRChannelInterfaceToAIRRtConversionImpl(OpBuilder builder,
     for (auto o : op_strides.drop_back())
       strides[idx++] =
           builder.create<arith::IndexCastOp>(loc, IntegerType::get(ctx, 64), o);
-  idx = 4 - std::max(thisOp.getSizes().size(),
-                     (size_t)thisMemrefType.getRank());
+  idx =
+      4 - std::max(thisOp.getSizes().size(), (size_t)thisMemrefType.getRank());
   // If sizes field is empty, then infer sizes from memref shape
   if (thisOp.getSizes().empty())
     for (auto d : air::getTensorShape(thisMemrefType))

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -169,6 +169,12 @@ public:
               o)) {
         rewriter.clone(o, remap);
       } else if (auto chanOp = dyn_cast<air::ChannelInterface>(o)) {
+        // clone L3 get/put
+        MemRefType memrefTy = chanOp.getMemref().getType().cast<MemRefType>();
+        if (memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) {
+          rewriter.clone(o, remap);
+          continue;
+        }
         auto async = cast<air::AsyncOpInterface>(o);
         if (o.getNumResults()) {
           auto tok = o.getResult(0);

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -603,7 +603,6 @@ public:
   LogicalResult
   matchAndRewrite(xilinx::air::ChannelPutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto loc = op->getLoc();
     auto ctx = op->getContext();
 
     if (op->getParentOfType<air::HerdOp>())
@@ -650,7 +649,6 @@ public:
   LogicalResult
   matchAndRewrite(xilinx::air::ChannelGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto loc = op->getLoc();
     auto ctx = op->getContext();
 
     if (op->getParentOfType<air::HerdOp>())
@@ -930,7 +928,7 @@ public:
             opers.push_back(oper);
           }
         }
-        auto y = rewriter.create<scf::YieldOp>(o.getLoc(), opers);
+        rewriter.create<scf::YieldOp>(o.getLoc(), opers);
       } else {
         rewriter.clone(o, remap);
       }
@@ -981,7 +979,7 @@ public:
             opers.push_back(oper);
           }
         }
-        auto y = rewriter.create<scf::YieldOp>(o.getLoc(), opers);
+        rewriter.create<scf::YieldOp>(o.getLoc(), opers);
       } else {
         rewriter.clone(o, remap);
       }

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1102,8 +1102,6 @@ class AIRDmaToAIRChannelConversion
           insertionPointAtHierOp; // To keep a record of the insertion point as
                                   // destination for hoisting
       rewriter.setInsertionPoint(hier_op);
-      MemRefType externalMemrefTy =
-          externalGetPut[0].getMemref().getType().cast<MemRefType>();
       if (herd) {
         // Scf parallel shape is either herd shape, or channel set shape if
         // broadcasting

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1105,11 +1105,6 @@ class AIRDmaToAIRChannelConversion
       MemRefType externalMemrefTy =
           externalGetPut[0].getMemref().getType().cast<MemRefType>();
       if (herd) {
-        if (externalMemrefTy.getMemorySpaceAsInt() ==
-                (int)air::MemorySpace::L3 &&
-            segment) {
-          rewriter.setInsertionPoint(segment);
-        }
         // Scf parallel shape is either herd shape, or channel set shape if
         // broadcasting
         SmallVector<int, 2> lbs;
@@ -1154,16 +1149,8 @@ class AIRDmaToAIRChannelConversion
         remap.map(herd.getIds()[0], scf_par.getInductionVars()[0]);
         remap.map(herd.getIds()[1], scf_par.getInductionVars()[1]);
         int arg_idx = 0;
-        if (externalMemrefTy.getMemorySpaceAsInt() ==
-                (int)air::MemorySpace::L3 &&
-            segment) {
-          // If hoisting directly to launch region
-          for (auto arg : herd.getKernelArguments())
-            remap.map(arg, segment.getKernelOperand(arg_idx++));
-        } else {
-          for (auto arg : herd.getKernelArguments())
-            remap.map(arg, herd.getKernelOperand(arg_idx++));
-        }
+        for (auto arg : herd.getKernelArguments())
+          remap.map(arg, herd.getKernelOperand(arg_idx++));
 
         // Clone ops into hoisted scf.parallel
         rewriter.setInsertionPointToStart(scf_par.getBody());

--- a/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-to-std | FileCheck %s
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: %{{.*}} = airrt.herd_load "herd_0" : i64
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32>, memref<64x64xi32, 1>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 module attributes {torch.debug_module_name = "mmult"}  {
   func.func @forward(%arg0: memref<64x64xi32>, %arg1: memref<64x64xi32>, %arg2: memref<?x?xi32>) {

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -5,207 +5,249 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-std | FileCheck %s
+// RUN: air-opt %s --split-input-file -air-to-std | FileCheck %s
 
 // CHECK-LABEL:   func.func @single_put_get
+// CHECK: affine.for %{{.*}} 0 to 2
+// CHECK: affine.for %{{.*}} 0 to 2
+// CHECK: airrt.segment_load
 // CHECK: airrt.dma_memcpy_nd(%c3_i32, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%c4_i32, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-air.channel @channel_1 [1, 1]
-air.channel @channel_0 [1, 1]
-func.func @single_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
-  %c8 = arith.constant 8 : index
-  %c16 = arith.constant 16 : index
-  %c32 = arith.constant 32 : index
-  %c1 = arith.constant 1 : index
-  %c0 = arith.constant 0 : index
-  %async_token = air.channel.put async  @channel_0[%c0, %c0] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
-  %async_token_0 = air.channel.get async @channel_1[%c0, %c0] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
-  air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c1, %arg5=%c1) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
-    %c0_1 = arith.constant 0 : index
-    %c32_2 = arith.constant 32 : index
-    %c16_3 = arith.constant 16 : index
-    %c8_4 = arith.constant 8 : index
-    %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
-    %alloc_5 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
-    air.channel.get  @channel_0[%arg2, %arg3] (%alloc[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 3 : i32} : (memref<16x8xi32, 2>)
-    affine.for %arg6 = 0 to 8 {
-      affine.for %arg7 = 0 to 16 {
-        %0 = affine.load %alloc[%arg7, %arg6] : memref<16x8xi32, 2>
-        affine.store %0, %alloc_5[%arg7, %arg6] : memref<16x8xi32, 2>
+module {
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  func.func @single_put_get(%a0: memref<32x16xi32>, %a1: memref<32x16xi32>) {
+    %c2_0 = arith.constant 2 : index
+    air.launch (%arg2, %arg3) in (%arg4=%c2_0, %arg5=%c2_0) args(%arg0=%a0, %arg1=%a1) : memref<32x16xi32>, memref<32x16xi32> {
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %0 = air.channel.put async  @channel_0[%c0, %c0] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
+      %1 = air.channel.get async  @channel_1[%c0, %c0] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
+      air.segment @segment_0 {
+        %c1_0 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c1_0, %arg13=%c1_0) {
+          %c0_4 = arith.constant 0 : index
+          %c32_5 = arith.constant 32 : index
+          %c16_6 = arith.constant 16 : index
+          %c8_7 = arith.constant 8 : index
+          %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
+          %alloc_8 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
+          air.channel.get  @channel_0[%arg10, %arg11] (%alloc[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 3 : i32} : (memref<16x8xi32, 2>)
+          affine.for %arg18 = 0 to 8 {
+            affine.for %arg19 = 0 to 16 {
+              %2 = affine.load %alloc[%arg19, %arg18] : memref<16x8xi32, 2>
+              affine.store %2, %alloc_8[%arg19, %arg18] : memref<16x8xi32, 2>
+            }
+          }
+          air.channel.put  @channel_1[%arg10, %arg11] (%alloc_8[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 4 : i32} : (memref<16x8xi32, 2>)
+          memref.dealloc %alloc_8 : memref<16x8xi32, 2>
+          memref.dealloc %alloc : memref<16x8xi32, 2>
+          air.herd_terminator
+        }
+        air.segment_terminator
       }
+      air.launch_terminator
     }
-    air.channel.put  @channel_1[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 4 : i32} : (memref<16x8xi32, 2>)
-    memref.dealloc %alloc_5 : memref<16x8xi32, 2>
-    memref.dealloc %alloc : memref<16x8xi32, 2>
-    air.herd_terminator
+    return
   }
-  return
 }
+
+// -----
 
 // CHECK-LABEL:   func.func @par_put_get
+// CHECK: affine.for %{{.*}} 0 to 1
+// CHECK: affine.for %{{.*}} 0 to 1
+// CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: airrt.dma_memcpy_nd(%c3_i32, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.dma_memcpy_nd(%c4_i32, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.herd_load "herd_0" : i64
-// CHECK: affine.for
-// CHECK:   affine.for
-// CHECK:     airrt.dma_memcpy_nd(%c3_i32, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK:     airrt.dma_memcpy_nd(%c4_i32, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK:   } {air.herd = "inner"}
-// CHECK: } {affine_opt_label = "tiling", air.herd = "outer"}
 
-air.channel @channel_3 [2, 2]
-air.channel @channel_2 [2, 2]
-func.func @par_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
-  %c8 = arith.constant 8 : index
-  %c16 = arith.constant 16 : index
-  %c32 = arith.constant 32 : index
-  %c2 = arith.constant 2 : index
-  %c1 = arith.constant 1 : index
-  %c0 = arith.constant 0 : index
-  %async_token_2 = air.wait_all async
-  %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
-    %async_token = air.channel.put async  @channel_2[%arg8, %arg9] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
-    scf.reduce(%async_token : !air.async.token) {
-    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
-      %9 = air.wait_all async [%arg10, %arg11] 
-      scf.reduce.return %9 : !air.async.token
-    }
-  }
-  %6 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
-    %async_token_0 = air.channel.get async @channel_3[%arg8, %arg9] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
-    scf.reduce(%async_token_0 : !air.async.token) {
-    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
-      %9 = air.wait_all async [%arg10, %arg11] 
-      scf.reduce.return %9 : !air.async.token
-    }
-  }
-  air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c2, %arg5=%c2) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
-    %c0_1 = arith.constant 0 : index
-    %c32_2 = arith.constant 32 : index
-    %c16_3 = arith.constant 16 : index
-    %c8_4 = arith.constant 8 : index
-    %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
-    %alloc_5 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
-    air.channel.get  @channel_2[%arg2, %arg3] (%alloc[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 3 : i32} : (memref<16x8xi32, 2>)
-    affine.for %arg6 = 0 to 8 {
-      affine.for %arg7 = 0 to 16 {
-        %0 = affine.load %alloc[%arg7, %arg6] : memref<16x8xi32, 2>
-        affine.store %0, %alloc_5[%arg7, %arg6] : memref<16x8xi32, 2>
+module {
+  air.channel @channel_3 [2, 2]
+  air.channel @channel_2 [2, 2]
+  func.func @par_put_get(%a0: memref<32x16xi32>, %a1: memref<32x16xi32>) {
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg2, %arg3) in (%arg4=%c1_0, %arg5=%c1_0) args(%arg0=%a0, %arg1=%a1) : memref<32x16xi32>, memref<32x16xi32> {
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %0 = air.wait_all async 
+      %1 = scf.parallel (%a2, %a3) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%0) -> !air.async.token {
+        %3 = air.channel.put async  @channel_2[%a2, %a3] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
+        scf.reduce(%3 : !air.async.token) {
+        ^bb0(%a4: !air.async.token, %a5: !air.async.token):
+          %4 = air.wait_all async [%a4, %a5] 
+          scf.reduce.return %4 : !air.async.token
+        }
       }
+      %2 = scf.parallel (%a2, %a3) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%0) -> !air.async.token {
+        %3 = air.channel.get async  @channel_3[%a2, %a3] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
+        scf.reduce(%3 : !air.async.token) {
+        ^bb0(%a4: !air.async.token, %a5: !air.async.token):
+          %4 = air.wait_all async [%a4, %a5] 
+          scf.reduce.return %4 : !air.async.token
+        }
+      }
+      air.segment @segment_0  args(%arg6=%arg2, %arg7=%arg3, %arg8=%arg4, %arg9=%arg5) : index, index, index, index {
+        %c2_2 = arith.constant 2 : index
+        %c2_3 = arith.constant 2 : index
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c2_2, %arg13=%c2_3) args(%arg14=%arg6, %arg15=%arg7, %arg16=%arg8, %arg17=%arg9) : index, index, index, index {
+          %c0_4 = arith.constant 0 : index
+          %c32_5 = arith.constant 32 : index
+          %c16_6 = arith.constant 16 : index
+          %c8_7 = arith.constant 8 : index
+          %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
+          %alloc_8 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
+          air.channel.get  @channel_2[%arg10, %arg11] (%alloc[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 3 : i32} : (memref<16x8xi32, 2>)
+          affine.for %arg18 = 0 to 8 {
+            affine.for %arg19 = 0 to 16 {
+              %3 = affine.load %alloc[%arg19, %arg18] : memref<16x8xi32, 2>
+              affine.store %3, %alloc_8[%arg19, %arg18] : memref<16x8xi32, 2>
+            }
+          }
+          air.channel.put  @channel_3[%arg10, %arg11] (%alloc_8[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 4 : i32} : (memref<16x8xi32, 2>)
+          memref.dealloc %alloc_8 : memref<16x8xi32, 2>
+          memref.dealloc %alloc : memref<16x8xi32, 2>
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
     }
-    air.channel.put  @channel_3[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 4 : i32} : (memref<16x8xi32, 2>)
-    memref.dealloc %alloc_5 : memref<16x8xi32, 2>
-    memref.dealloc %alloc : memref<16x8xi32, 2>
-    air.herd_terminator
+    return
   }
-  return
 }
 
+// -----
+
 // CHECK-LABEL:   func.func @par_with_for_put_get
-// CHECK: airrt.herd_load "herd_0" : i64
-// CHECK: affine.for
-// CHECK:   affine.for
+// CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: affine.for %{{.*}} 0 to 2
+// CHECK:   affine.for %{{.*}} 0 to 2
 // CHECK:     airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:     scf.for
 // CHECK:       airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:       scf.yield
-// CHECK:   } {air.herd = "inner"}
-// CHECK: } {affine_opt_label = "tiling", air.herd = "outer"}
-air.channel @channel_5 [2, 2]
-air.channel @channel_4 [2, 2]
-func.func @par_with_for_put_get(%arg0: memref<32x16xi32>, %arg1: memref<32x16xi32>) {
-  %c8 = arith.constant 8 : index
-  %c16 = arith.constant 16 : index
-  %c32 = arith.constant 32 : index
-  %c2 = arith.constant 2 : index
-  %c1 = arith.constant 1 : index
-  %c0 = arith.constant 0 : index
-  %async_token_2 = air.wait_all async
-  %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
-    %async_token = air.channel.put async  @channel_4[%arg8, %arg9] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
-    scf.reduce(%async_token : !air.async.token) {
-    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
-      %9 = air.wait_all async [%arg10, %arg11] 
-      scf.reduce.return %9 : !air.async.token
-    }
-  }
-  %6 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%async_token_2) -> !air.async.token {
-    %7 = scf.for %arg12 = %c0 to %c2 step %c1 iter_args(%arg13 = %async_token_2) -> (!air.async.token) {
-      %async_token_0 = air.channel.get async [%arg13] @channel_5[%arg8, %arg9] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
-      scf.yield %async_token_0 : !air.async.token
-    }
-    scf.reduce(%7 : !air.async.token) {
-    ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
-      %9 = air.wait_all async [%arg10, %arg11] 
-      scf.reduce.return %9 : !air.async.token
-    }
-  }
-  air.herd @herd_0  tile (%arg2, %arg3) in (%arg4=%c2, %arg5=%c2) attributes {x_loc = 7 : i64, y_loc = 2 : i64} {
-    %c0_1 = arith.constant 0 : index
-    %c2_1 = arith.constant 2 : index
+// CHECK: airrt.herd_load "herd_0" : i64
+module {
+  air.channel @channel_5 [2, 2]
+  air.channel @channel_4 [2, 2]
+  func.func @par_with_for_put_get(%a0: memref<32x16xi32>, %a1: memref<32x16xi32>) {
+    %c1_0 = arith.constant 1 : index
     %c1_1 = arith.constant 1 : index
-    %c32_2 = arith.constant 32 : index
-    %c16_3 = arith.constant 16 : index
-    %c8_4 = arith.constant 8 : index
-    %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
-    %alloc_5 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
-    air.channel.get  @channel_4[%arg2, %arg3] (%alloc[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 3 : i32} : (memref<16x8xi32, 2>)
-    affine.for %arg6 = 0 to 8 {
-      affine.for %arg7 = 0 to 16 {
-        %0 = affine.load %alloc[%arg7, %arg6] : memref<16x8xi32, 2>
-        affine.store %0, %alloc_5[%arg7, %arg6] : memref<16x8xi32, 2>
+    air.launch (%arg2, %arg3) in (%arg4=%c1_0, %arg5=%c1_1) args (%arg0=%a0, %arg1=%a1) : memref<32x16xi32>, memref<32x16xi32> {
+      %c8 = arith.constant 8 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %0 = air.wait_all async 
+      %1 = scf.parallel (%a2, %a3) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%0) -> !air.async.token {
+        %3 = air.channel.put async  @channel_4[%a2, %a3] (%arg0[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 1 : i32} : (memref<32x16xi32>)
+        scf.reduce(%3 : !air.async.token) {
+        ^bb0(%a4: !air.async.token, %a5: !air.async.token):
+          %4 = air.wait_all async [%a4, %a5] 
+          scf.reduce.return %4 : !air.async.token
+        }
       }
+      %2 = scf.parallel (%a2, %a3) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%0) -> !air.async.token {
+        %3 = scf.for %a4 = %c0 to %c2 step %c1 iter_args(%a5 = %0) -> (!air.async.token) {
+          %4 = air.channel.get async [%a5]  @channel_5[%a2, %a3] (%arg1[%c8, %c0] [%c8, %c16] [%c32, %c0]) {id = 2 : i32} : (memref<32x16xi32>)
+          scf.yield %4 : !air.async.token
+        }
+        scf.reduce(%3 : !air.async.token) {
+        ^bb0(%a4: !air.async.token, %a5: !air.async.token):
+          %4 = air.wait_all async [%a4, %a5] 
+          scf.reduce.return %4 : !air.async.token
+        }
+      }
+      air.segment @segment_0  args(%arg6=%arg2, %arg7=%arg3, %arg8=%arg4, %arg9=%arg5) : index, index, index, index {
+        %c2_2 = arith.constant 2 : index
+        %c2_3 = arith.constant 2 : index
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c2_2, %arg13=%c2_3) args(%arg14=%arg6, %arg15=%arg7, %arg16=%arg8, %arg17=%arg9) : index, index, index, index {
+          %c0_4 = arith.constant 0 : index
+          %c2_5 = arith.constant 2 : index
+          %c1_6 = arith.constant 1 : index
+          %c32_7 = arith.constant 32 : index
+          %c16_8 = arith.constant 16 : index
+          %c8_9 = arith.constant 8 : index
+          %alloc = memref.alloc() {sym_name = "scratch"} : memref<16x8xi32, 2>
+          %alloc_10 = memref.alloc() {sym_name = "scratch_copy"} : memref<16x8xi32, 2>
+          air.channel.get  @channel_4[%arg10, %arg11] (%alloc[%c0_4, %c0_4] [%c8_9, %c16_8] [%c32_7, %c0_4]) {id = 3 : i32} : (memref<16x8xi32, 2>)
+          affine.for %arg18 = 0 to 8 {
+            affine.for %arg19 = 0 to 16 {
+              %3 = affine.load %alloc[%arg19, %arg18] : memref<16x8xi32, 2>
+              affine.store %3, %alloc_10[%arg19, %arg18] : memref<16x8xi32, 2>
+            }
+          }
+          scf.for %arg18 = %c0_4 to %c2_5 step %c1_6 {
+            air.channel.put  @channel_5[%arg10, %arg11] (%alloc_10[%c0_4, %c0_4] [%c8_9, %c16_8] [%c32_7, %c0_4]) {id = 4 : i32} : (memref<16x8xi32, 2>)
+          }
+          memref.dealloc %alloc_10 : memref<16x8xi32, 2>
+          memref.dealloc %alloc : memref<16x8xi32, 2>
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
     }
-    scf.for %arg12 = %c0_1 to %c2_1 step %c1_1 {
-      air.channel.put  @channel_5[%arg2, %arg3] (%alloc_5[%c0_1, %c0_1] [%c8_4, %c16_3] [%c32_2, %c0_1]) {id = 4 : i32} : (memref<16x8xi32, 2>)
-    }
-    memref.dealloc %alloc_5 : memref<16x8xi32, 2>
-    memref.dealloc %alloc : memref<16x8xi32, 2>
-    air.herd_terminator
+    return
   }
-  return
 }
+// -----
 
 // CHECK-LABEL:   func.func @one_d_scf_parallel
 // CHECK: affine.for
-// CHECK:   airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<128xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-// CHECK: } {affine_opt_label = "tiling"}
+// CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<128xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+// CHECK: airrt.herd_load "herd_0" : i64
 
 #map = affine_map<()[s0] -> (s0 * 64)>
-air.channel @channel_6 [1, 1]
-func.func @one_d_scf_parallel(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
-  %c2 = arith.constant 2 : index
-  %0 = air.launch async (%arg2) in (%arg3=%c2) args(%arg4=%arg0) : memref<128xf32> attributes {id = 1 : i32} {
-    %c64 = arith.constant 64 : index
-    %c1 = arith.constant 1 : index
-    %async_token, %results = air.execute -> (index) {
-      %3 = affine.apply #map()[%arg2]
-      air.execute_terminator %3 : index
-    }
-    %1 = air.channel.put async [%async_token]  @channel_6[] (%arg4[%results] [%c64] [%c1]) {id = 1 : i32} : (memref<128xf32>)
-    %2 = air.segment @segment_0 async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 2 : i64, y_size = 4 : i64} {
-      %c1_0 = arith.constant 1 : index
-      %c2_1 = arith.constant 2 : index
-      %3 = air.wait_all async 
-      %async_token_2, %results_3 = air.execute -> (memref<64xf32, 1>) {
-        %alloc = memref.alloc() : memref<64xf32, 1>
-        air.execute_terminator %alloc : memref<64xf32, 1>
+module {
+  air.channel @channel_6 [1, 1]
+  func.func @one_d_scf_parallel(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
+    %c2 = arith.constant 2 : index
+    %0 = air.launch async (%arg2) in (%arg3=%c2) args(%arg4=%arg0) : memref<128xf32> attributes {id = 1 : i32} {
+      %c64 = arith.constant 64 : index
+      %c1 = arith.constant 1 : index
+      %async_token, %results = air.execute -> (index) {
+        %3 = affine.apply #map()[%arg2]
+        air.execute_terminator %3 : index
       }
-      %4 = air.channel.get async [%3, %async_token_2]  @channel_6[] (%results_3[] [] []) {id = 3 : i32} : (memref<64xf32, 1>)
-      %5 = air.herd @herd_0 async [%4]  tile (%arg5, %arg6) in (%arg7=%c1_0, %arg8=%c2_1) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
-        %async_token_5, %results_6 = air.execute -> (memref<32xf32, 2>) {
-          %alloc = memref.alloc() : memref<32xf32, 2>
-          air.execute_terminator %alloc : memref<32xf32, 2>
+      %1 = air.channel.put async [%async_token]  @channel_6[] (%arg4[%results] [%c64] [%c1]) {id = 1 : i32} : (memref<128xf32>)
+      %2 = air.segment @segment_0 async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 2 : i64, y_size = 4 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %c2_1 = arith.constant 2 : index
+        %3 = air.wait_all async 
+        %async_token_2, %results_3 = air.execute -> (memref<64xf32, 1>) {
+          %alloc = memref.alloc() : memref<64xf32, 1>
+          air.execute_terminator %alloc : memref<64xf32, 1>
         }
-        %async_token_7 = air.execute [%async_token_5] {
-          memref.dealloc %results_6 : memref<32xf32, 2>
+        %4 = air.channel.get async [%3, %async_token_2]  @channel_6[] (%results_3[] [] []) {id = 3 : i32} : (memref<64xf32, 1>)
+        %5 = air.herd @herd_0 async [%4]  tile (%arg5, %arg6) in (%arg7=%c1_0, %arg8=%c2_1) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+          %async_token_5, %results_6 = air.execute -> (memref<32xf32, 2>) {
+            %alloc = memref.alloc() : memref<32xf32, 2>
+            air.execute_terminator %alloc : memref<32xf32, 2>
+          }
+          %async_token_7 = air.execute [%async_token_5] {
+            memref.dealloc %results_6 : memref<32xf32, 2>
+          }
+          air.herd_terminator
         }
-        air.herd_terminator
+        %async_token_4 = air.execute [%4] {
+          memref.dealloc %results_3 : memref<64xf32, 1>
+        }
+        air.segment_terminator
       }
-      %async_token_4 = air.execute [%4] {
-        memref.dealloc %results_3 : memref<64xf32, 1>
-      }
-      air.segment_terminator
+      air.launch_terminator
     }
-    air.launch_terminator
+    return
   }
-  return
 }

--- a/mlir/test/Conversion/AIRLowering/air_to_ipu.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_to_ipu.mlir
@@ -15,8 +15,8 @@
 // CHECK-DAG: %[[CST_2:.*]] = arith.constant 2 : i32
 // CHECK-DAG: %[[CST_7:.*]] = arith.constant 7 : i32
 // CHECK-DAG: %[[CST_64:.*]] = arith.constant 64 : i64
-// CHECK: airrt.dma_memcpy_nd(%[[CST_2]], %[[CST_0]], %[[CST_0]], %[[VAL_0]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: %[[VAL_2:.*]] = airrt.segment_load "segment0" : i64
+// CHECK: airrt.dma_memcpy_nd(%[[CST_2]], %[[CST_0]], %[[CST_0]], %[[VAL_0]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%[[CST_7]], %[[CST_0]], %[[CST_0]], %[[VAL_1]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 
 module {
@@ -76,8 +76,8 @@ module {
 // CHECK-DAG: %[[CST_2:.*]] = arith.constant 2 : i32
 // CHECK-DAG: %[[CST_7:.*]] = arith.constant 7 : i32
 // CHECK-DAG: %[[CST_64:.*]] = arith.constant 64 : i64
-// CHECK: airrt.dma_memcpy_nd(%[[CST_2]], %[[CST_0]], %[[CST_0]], %[[VAL_0]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: %[[VAL_2:.*]] = airrt.segment_load "segment0" : i64
+// CHECK: airrt.dma_memcpy_nd(%[[CST_2]], %[[CST_0]], %[[CST_0]], %[[VAL_0]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%[[CST_7]], %[[CST_0]], %[[CST_0]], %[[VAL_1]][%[[CST_0]], %[[CST_0]], %[[CST_0]], %[[CST_0]]], [%[[CST_1]], %[[CST_1]], %[[CST_1]], %[[CST_64]]], [%[[CST_0]], %[[CST_0]], %[[CST_0]]]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 
 module {

--- a/test/airhost/19_air_nd_memcpy_to_tile_dma/air.mlir
+++ b/test/airhost/19_air_nd_memcpy_to_tile_dma/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<256xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>attributes { sym_name="segment_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0) : memref<256xi32>attributes { sym_name="herd_0"} {
     %c0 = arith.constant 0 : index
     %c256 = arith.constant 256 : index
     %buf0 = memref.alloc() : memref<256xi32, 2>

--- a/test/airhost/21_air_nd_memcpy_2d/air.mlir
+++ b/test/airhost/21_air_nd_memcpy_2d/air.mlir
@@ -11,7 +11,7 @@ module {
 func.func @graph(%arg0 : memref<32x16xi32>, %arg1 : memref<32x16xi32>) -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
-  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<32x16xi32>, memref<32x16xi32> attributes { sym_name="segment_0"} {
+  air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args(%ext0 = %arg0, %ext1 = %arg1) : memref<32x16xi32>, memref<32x16xi32> attributes { sym_name="herd_0"} {
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c32 = arith.constant 32 : index


### PR DESCRIPTION
This is part of a rabbit hole trying to make `air-dma-to-channel` safe to run on a broader set of code, in particular the existing airhost tests, so that it can be included in standard pipelines like aircc.py

This updates the air.segment to airrt lowering by,

* Don't delete segments if they don't contain dma ops. The idea is to preserve control flow around herd load operations. e.g. a herd may occur in a loop inside a segment.
* Don't "Move herd load to before the first ctrl loop"  This was (I think) a workaround of the fact that channel get/put ops, after being hoisted out of herd, will happen before herd or segment load, which is an error.
* Instead of above, make sure segment load is emitted at the start of its region. This implies that air.segment is required.
* replace some `replaceAllUsesWith`/`erase` with rewriter `clone`/`eraseOp`