### PR TITLE
Add openssl-dev to buildAndTestAieTools workflow

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -86,7 +86,7 @@ jobs:
             apt update
             apt install -y rocm-hip-runtime-dev5.6.0 python3.10-venv \
                            libboost-all-dev pkg-config libelf-dev elfutils \
-                           libdwarf-dev libsysfs-dev clang
+                           libdwarf-dev libsysfs-dev clang libssl-dev
             apt-get clean
 
             cd /


### PR DESCRIPTION
Fix workflow failure after mlir-aie update