### PR TITLE
Collapse multi-dimensional offsets to 1d for bf16 func arguments

### DIFF
--- a/mlir/lib/Conversion/AIRRtToIpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToIpuPass.cpp
@@ -358,9 +358,9 @@ static LogicalResult CastFunctionArgs(func::FuncOp funcOp,
     for (Operation *user : users) {
       if (auto dmaUser = dyn_cast<AIEX::IpuDmaMemcpyNdOp>(user)) {
         int oneDOffset = *getConstantIntValue(dmaUser.getMixedOffsets().back());
-        for (int i = dmaUser.getMixedOffsets().size() - 2; i >= 0; i--)
-          oneDOffset += *getConstantIntValue(dmaUser.getMixedOffsets()[i]) *
-                        *getConstantIntValue(dmaUser.getMixedStrides()[i]);
+        for (int j = dmaUser.getMixedOffsets().size() - 2; j >= 0; j--)
+          oneDOffset += *getConstantIntValue(dmaUser.getMixedOffsets()[j]) *
+                        *getConstantIntValue(dmaUser.getMixedStrides()[j]);
         rewriter.setInsertionPoint(dmaUser);
         const std::vector<int64_t> newStaticOffsets = {0, 0, 0, oneDOffset};
         rewriter.create<AIEX::IpuDmaMemcpyNdOp>(

--- a/mlir/lib/Conversion/AIRRtToIpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToIpuPass.cpp
@@ -348,10 +348,10 @@ static LogicalResult CastFunctionArgs(func::FuncOp funcOp,
     // needs to be collapsed.
     SmallVector<Operation *> users;
     for (auto user : entry.getArgument(i + 1).getUsers()) {
-      if (auto cast = dyn_cast<UnrealizedConversionCastOp>(user)) {
-        assert(cast.getNumResults() == 1);
-        for (auto cast_user : cast.getResult(0).getUsers())
-          users.push_back(cast_user);
+      if (auto cast_user = dyn_cast<UnrealizedConversionCastOp>(user)) {
+        assert(cast_user.getNumResults() == 1);
+        for (auto cast_r_user : cast_user.getResult(0).getUsers())
+          users.push_back(cast_r_user);
       } else
         users.push_back(user);
     }
@@ -369,7 +369,7 @@ static LogicalResult CastFunctionArgs(func::FuncOp funcOp,
             dmaUser.getStrides(), ArrayRef(newStaticOffsets),
             dmaUser.getStaticSizes(), dmaUser.getStaticStrides(),
             dmaUser.getMetadata(), dmaUser.getId());
-        dmaUser->erase();
+        rewriter.eraseOp(dmaUser);
       }
     }
     entry.getArgument(i + 1).replaceAllUsesWith(cast.getResult(0));

--- a/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
+++ b/mlir/test/Conversion/AIRRtToIpu/airrt_to_ipu.mlir
@@ -604,6 +604,25 @@ module {
 
 // -----
 
+// Multi-dimensional offset collapsing
+
+// CHECK-LABEL: func.func @func13
+// CHECK-SAME: %arg0: memref<512xi32>
+// CHECK-NEXT: aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 264][1, 1, 16, 8][0, 0, 16]) {id = 0 : i64, metadata = @md0} : memref<512xi32>
+module {
+ func.func @func13(%arg0 : memref<32x32xbf16>) {
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i64 = arith.constant 32 : i64
+    airrt.dma_memcpy_nd(%c1_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c16_i64, %c16_i64], [%c1_i64, %c1_i64, %c16_i64, %c16_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @md0} : (i32, i64, i64, memref<32x32xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+    return
+  }
+}
+
+// -----
+
 // Loop carried event
 
 // CHECK-LABEL: func.func @func14


### PR DESCRIPTION
... when func argument memref type gets collapsed.

This PR inteprets offset(i), 0 <= i < 3, as "offset after this many dim i-1 strides". Offset(3), i.e. lowest-dimension offset, is still counted as "number of 32-bit offsets".

Without this PR, IPU instructions on multi-dimensional, bf16 memrefs are failing at MLIR-AIE due to higher-dimension offsets (higher than memref rank, i.e. 1) being ignored.