### PR TITLE
Expand on broadcast detection conditions

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2322,7 +2322,7 @@ class AIRHoistDmaInAccumPattern
 
 public:
   AIRHoistDmaInAccumPattern() = default;
-  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass) {};
+  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2348,7 +2348,7 @@ class AIRBroadcastDetection
 
 public:
   AIRBroadcastDetection() = default;
-  AIRBroadcastDetection(const AIRBroadcastDetection &pass) {};
+  AIRBroadcastDetection(const AIRBroadcastDetection &pass){};
 
   void runOnOperation() override {
     BroadcastDetection proc;
@@ -2368,7 +2368,7 @@ class AIRPruneLinalgGenericInputDma
 
 public:
   AIRPruneLinalgGenericInputDma() = default;
-  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass) {};
+  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass){};
 
   void runOnOperation() override {
     PruneLinalgGenericInputDma proc;
@@ -2389,7 +2389,7 @@ class AIRAnnotateFrontAndBackOpsInForPattern
 public:
   AIRAnnotateFrontAndBackOpsInForPattern() = default;
   AIRAnnotateFrontAndBackOpsInForPattern(
-      const AIRAnnotateFrontAndBackOpsInForPattern &pass) {};
+      const AIRAnnotateFrontAndBackOpsInForPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2415,7 +2415,7 @@ class AIRHoistMemallocInForPattern
 
 public:
   AIRHoistMemallocInForPattern() = default;
-  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass) {};
+  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2442,7 +2442,7 @@ class AIRConstructPingPongDependencyPattern
 public:
   AIRConstructPingPongDependencyPattern() = default;
   AIRConstructPingPongDependencyPattern(
-      const AIRConstructPingPongDependencyPattern &pass) {};
+      const AIRConstructPingPongDependencyPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2469,7 +2469,7 @@ class AIRUnrollLoopForPipeliningPattern
 public:
   AIRUnrollLoopForPipeliningPattern() = default;
   AIRUnrollLoopForPipeliningPattern(
-      const AIRUnrollLoopForPipeliningPattern &pass) {};
+      const AIRUnrollLoopForPipeliningPattern &pass){};
 
   void runOnOperation() override {
     auto module = getOperation();
@@ -2496,7 +2496,7 @@ class AIRHoistOpsNotUsingPingPongPattern
 public:
   AIRHoistOpsNotUsingPingPongPattern() = default;
   AIRHoistOpsNotUsingPingPongPattern(
-      const AIRHoistOpsNotUsingPingPongPattern &pass) {};
+      const AIRHoistOpsNotUsingPingPongPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2523,7 +2523,7 @@ class AIRPingPongTransformationPattern
 public:
   AIRPingPongTransformationPattern() = default;
   AIRPingPongTransformationPattern(
-      const AIRPingPongTransformationPattern &pass) {};
+      const AIRPingPongTransformationPattern &pass){};
   AIRPingPongTransformationPattern(
       const AIRPingPongTransformationPatternOptions &options)
       : AIRPingPongTransformationPatternBase(options) {}
@@ -2613,7 +2613,7 @@ class AIRLabelScfForLoopForPingPongPattern
 public:
   AIRLabelScfForLoopForPingPongPattern() = default;
   AIRLabelScfForLoopForPingPongPattern(
-      const AIRLabelScfForLoopForPingPongPattern &pass) {};
+      const AIRLabelScfForLoopForPingPongPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2640,7 +2640,7 @@ class AIRLabelScfForLoopInAIRSegmentPattern
 public:
   AIRLabelScfForLoopInAIRSegmentPattern() = default;
   AIRLabelScfForLoopInAIRSegmentPattern(
-      const AIRLabelScfForLoopInAIRSegmentPattern &pass) {};
+      const AIRLabelScfForLoopInAIRSegmentPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2667,7 +2667,7 @@ class AIRSpecializeChannelWrapAndStridePattern
 public:
   AIRSpecializeChannelWrapAndStridePattern() = default;
   AIRSpecializeChannelWrapAndStridePattern(
-      const AIRSpecializeChannelWrapAndStridePattern &pass) {};
+      const AIRSpecializeChannelWrapAndStridePattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2702,7 +2702,7 @@ class AIRUnrollChannelByFactorPattern
 public:
   AIRUnrollChannelByFactorPattern() = default;
   AIRUnrollChannelByFactorPattern(
-      const AIRUnrollChannelByFactorPattern &pass) {};
+      const AIRUnrollChannelByFactorPattern &pass){};
 
   void runOnOperation() override {
     auto module = getOperation();

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2322,7 +2322,7 @@ class AIRHoistDmaInAccumPattern
 
 public:
   AIRHoistDmaInAccumPattern() = default;
-  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass){};
+  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2348,7 +2348,7 @@ class AIRBroadcastDetection
 
 public:
   AIRBroadcastDetection() = default;
-  AIRBroadcastDetection(const AIRBroadcastDetection &pass){};
+  AIRBroadcastDetection(const AIRBroadcastDetection &pass) {};
 
   void runOnOperation() override {
     BroadcastDetection proc;
@@ -2368,7 +2368,7 @@ class AIRPruneLinalgGenericInputDma
 
 public:
   AIRPruneLinalgGenericInputDma() = default;
-  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass){};
+  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass) {};
 
   void runOnOperation() override {
     PruneLinalgGenericInputDma proc;
@@ -2389,7 +2389,7 @@ class AIRAnnotateFrontAndBackOpsInForPattern
 public:
   AIRAnnotateFrontAndBackOpsInForPattern() = default;
   AIRAnnotateFrontAndBackOpsInForPattern(
-      const AIRAnnotateFrontAndBackOpsInForPattern &pass){};
+      const AIRAnnotateFrontAndBackOpsInForPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2415,7 +2415,7 @@ class AIRHoistMemallocInForPattern
 
 public:
   AIRHoistMemallocInForPattern() = default;
-  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass){};
+  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2442,7 +2442,7 @@ class AIRConstructPingPongDependencyPattern
 public:
   AIRConstructPingPongDependencyPattern() = default;
   AIRConstructPingPongDependencyPattern(
-      const AIRConstructPingPongDependencyPattern &pass){};
+      const AIRConstructPingPongDependencyPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2469,7 +2469,7 @@ class AIRUnrollLoopForPipeliningPattern
 public:
   AIRUnrollLoopForPipeliningPattern() = default;
   AIRUnrollLoopForPipeliningPattern(
-      const AIRUnrollLoopForPipeliningPattern &pass){};
+      const AIRUnrollLoopForPipeliningPattern &pass) {};
 
   void runOnOperation() override {
     auto module = getOperation();
@@ -2496,7 +2496,7 @@ class AIRHoistOpsNotUsingPingPongPattern
 public:
   AIRHoistOpsNotUsingPingPongPattern() = default;
   AIRHoistOpsNotUsingPingPongPattern(
-      const AIRHoistOpsNotUsingPingPongPattern &pass){};
+      const AIRHoistOpsNotUsingPingPongPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2523,7 +2523,7 @@ class AIRPingPongTransformationPattern
 public:
   AIRPingPongTransformationPattern() = default;
   AIRPingPongTransformationPattern(
-      const AIRPingPongTransformationPattern &pass){};
+      const AIRPingPongTransformationPattern &pass) {};
   AIRPingPongTransformationPattern(
       const AIRPingPongTransformationPatternOptions &options)
       : AIRPingPongTransformationPatternBase(options) {}
@@ -2613,7 +2613,7 @@ class AIRLabelScfForLoopForPingPongPattern
 public:
   AIRLabelScfForLoopForPingPongPattern() = default;
   AIRLabelScfForLoopForPingPongPattern(
-      const AIRLabelScfForLoopForPingPongPattern &pass){};
+      const AIRLabelScfForLoopForPingPongPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2640,7 +2640,7 @@ class AIRLabelScfForLoopInAIRSegmentPattern
 public:
   AIRLabelScfForLoopInAIRSegmentPattern() = default;
   AIRLabelScfForLoopInAIRSegmentPattern(
-      const AIRLabelScfForLoopInAIRSegmentPattern &pass){};
+      const AIRLabelScfForLoopInAIRSegmentPattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2667,7 +2667,7 @@ class AIRSpecializeChannelWrapAndStridePattern
 public:
   AIRSpecializeChannelWrapAndStridePattern() = default;
   AIRSpecializeChannelWrapAndStridePattern(
-      const AIRSpecializeChannelWrapAndStridePattern &pass){};
+      const AIRSpecializeChannelWrapAndStridePattern &pass) {};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2702,7 +2702,7 @@ class AIRUnrollChannelByFactorPattern
 public:
   AIRUnrollChannelByFactorPattern() = default;
   AIRUnrollChannelByFactorPattern(
-      const AIRUnrollChannelByFactorPattern &pass){};
+      const AIRUnrollChannelByFactorPattern &pass) {};
 
   void runOnOperation() override {
     auto module = getOperation();
@@ -2735,7 +2735,7 @@ class AIRDependencyScheduleOpt
 
 public:
   AIRDependencyScheduleOpt() = default;
-  AIRDependencyScheduleOpt(const AIRDependencyScheduleOpt &pass){}
+  AIRDependencyScheduleOpt(const AIRDependencyScheduleOpt &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2780,7 +2780,7 @@ class AIREnforceLoopCarriedMemrefDeallocPattern
 public:
   AIREnforceLoopCarriedMemrefDeallocPattern() = default;
   AIREnforceLoopCarriedMemrefDeallocPattern(
-      const AIREnforceLoopCarriedMemrefDeallocPattern &pass){}
+      const AIREnforceLoopCarriedMemrefDeallocPattern &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2815,7 +2815,7 @@ class AIRDeAliasMemref
 
 public:
   AIRDeAliasMemref() = default;
-  AIRDeAliasMemref(const AIRDeAliasMemref &pass){}
+  AIRDeAliasMemref(const AIRDeAliasMemref &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2984,7 +2984,7 @@ class AIRFuseChannels
 
 public:
   AIRFuseChannels() = default;
-  AIRFuseChannels(const AIRFuseChannels &pass){}
+  AIRFuseChannels(const AIRFuseChannels &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -3265,7 +3265,7 @@ class AIRIsolateAsyncDmaLoopNests
 
 public:
   AIRIsolateAsyncDmaLoopNests() = default;
-  AIRIsolateAsyncDmaLoopNests(const AIRIsolateAsyncDmaLoopNests &pass){}
+  AIRIsolateAsyncDmaLoopNests(const AIRIsolateAsyncDmaLoopNests &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -3566,7 +3566,7 @@ class AIRSegmentLoopFusion
 
 public:
   AIRSegmentLoopFusion() = default;
-  AIRSegmentLoopFusion(const AIRSegmentLoopFusion &pass){}
+  AIRSegmentLoopFusion(const AIRSegmentLoopFusion &pass) {}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2322,7 +2322,7 @@ class AIRHoistDmaInAccumPattern
 
 public:
   AIRHoistDmaInAccumPattern() = default;
-  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass) {};
+  AIRHoistDmaInAccumPattern(const AIRHoistDmaInAccumPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2348,7 +2348,7 @@ class AIRBroadcastDetection
 
 public:
   AIRBroadcastDetection() = default;
-  AIRBroadcastDetection(const AIRBroadcastDetection &pass) {};
+  AIRBroadcastDetection(const AIRBroadcastDetection &pass){};
 
   void runOnOperation() override {
     BroadcastDetection proc;
@@ -2368,7 +2368,7 @@ class AIRPruneLinalgGenericInputDma
 
 public:
   AIRPruneLinalgGenericInputDma() = default;
-  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass) {};
+  AIRPruneLinalgGenericInputDma(const AIRPruneLinalgGenericInputDma &pass){};
 
   void runOnOperation() override {
     PruneLinalgGenericInputDma proc;
@@ -2389,7 +2389,7 @@ class AIRAnnotateFrontAndBackOpsInForPattern
 public:
   AIRAnnotateFrontAndBackOpsInForPattern() = default;
   AIRAnnotateFrontAndBackOpsInForPattern(
-      const AIRAnnotateFrontAndBackOpsInForPattern &pass) {};
+      const AIRAnnotateFrontAndBackOpsInForPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2415,7 +2415,7 @@ class AIRHoistMemallocInForPattern
 
 public:
   AIRHoistMemallocInForPattern() = default;
-  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass) {};
+  AIRHoistMemallocInForPattern(const AIRHoistMemallocInForPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2442,7 +2442,7 @@ class AIRConstructPingPongDependencyPattern
 public:
   AIRConstructPingPongDependencyPattern() = default;
   AIRConstructPingPongDependencyPattern(
-      const AIRConstructPingPongDependencyPattern &pass) {};
+      const AIRConstructPingPongDependencyPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2469,7 +2469,7 @@ class AIRUnrollLoopForPipeliningPattern
 public:
   AIRUnrollLoopForPipeliningPattern() = default;
   AIRUnrollLoopForPipeliningPattern(
-      const AIRUnrollLoopForPipeliningPattern &pass) {};
+      const AIRUnrollLoopForPipeliningPattern &pass){};
 
   void runOnOperation() override {
     auto module = getOperation();
@@ -2496,7 +2496,7 @@ class AIRHoistOpsNotUsingPingPongPattern
 public:
   AIRHoistOpsNotUsingPingPongPattern() = default;
   AIRHoistOpsNotUsingPingPongPattern(
-      const AIRHoistOpsNotUsingPingPongPattern &pass) {};
+      const AIRHoistOpsNotUsingPingPongPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2523,7 +2523,7 @@ class AIRPingPongTransformationPattern
 public:
   AIRPingPongTransformationPattern() = default;
   AIRPingPongTransformationPattern(
-      const AIRPingPongTransformationPattern &pass) {};
+      const AIRPingPongTransformationPattern &pass){};
   AIRPingPongTransformationPattern(
       const AIRPingPongTransformationPatternOptions &options)
       : AIRPingPongTransformationPatternBase(options) {}
@@ -2613,7 +2613,7 @@ class AIRLabelScfForLoopForPingPongPattern
 public:
   AIRLabelScfForLoopForPingPongPattern() = default;
   AIRLabelScfForLoopForPingPongPattern(
-      const AIRLabelScfForLoopForPingPongPattern &pass) {};
+      const AIRLabelScfForLoopForPingPongPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2640,7 +2640,7 @@ class AIRLabelScfForLoopInAIRSegmentPattern
 public:
   AIRLabelScfForLoopInAIRSegmentPattern() = default;
   AIRLabelScfForLoopInAIRSegmentPattern(
-      const AIRLabelScfForLoopInAIRSegmentPattern &pass) {};
+      const AIRLabelScfForLoopInAIRSegmentPattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2667,7 +2667,7 @@ class AIRSpecializeChannelWrapAndStridePattern
 public:
   AIRSpecializeChannelWrapAndStridePattern() = default;
   AIRSpecializeChannelWrapAndStridePattern(
-      const AIRSpecializeChannelWrapAndStridePattern &pass) {};
+      const AIRSpecializeChannelWrapAndStridePattern &pass){};
 
   void runOptPatterns(func::FuncOp funcOp) {
     MLIRContext *ctx = funcOp.getContext();
@@ -2701,8 +2701,8 @@ class AIRUnrollChannelByFactorPattern
 
 public:
   AIRUnrollChannelByFactorPattern() = default;
-  AIRUnrollChannelByFactorPattern(const AIRUnrollChannelByFactorPattern &pass) {
-  };
+  AIRUnrollChannelByFactorPattern(
+      const AIRUnrollChannelByFactorPattern &pass){};
 
   void runOnOperation() override {
     auto module = getOperation();
@@ -2735,7 +2735,7 @@ class AIRDependencyScheduleOpt
 
 public:
   AIRDependencyScheduleOpt() = default;
-  AIRDependencyScheduleOpt(const AIRDependencyScheduleOpt &pass) {}
+  AIRDependencyScheduleOpt(const AIRDependencyScheduleOpt &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2780,7 +2780,7 @@ class AIREnforceLoopCarriedMemrefDeallocPattern
 public:
   AIREnforceLoopCarriedMemrefDeallocPattern() = default;
   AIREnforceLoopCarriedMemrefDeallocPattern(
-      const AIREnforceLoopCarriedMemrefDeallocPattern &pass) {}
+      const AIREnforceLoopCarriedMemrefDeallocPattern &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2815,7 +2815,7 @@ class AIRDeAliasMemref
 
 public:
   AIRDeAliasMemref() = default;
-  AIRDeAliasMemref(const AIRDeAliasMemref &pass) {}
+  AIRDeAliasMemref(const AIRDeAliasMemref &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -2984,7 +2984,7 @@ class AIRFuseChannels
 
 public:
   AIRFuseChannels() = default;
-  AIRFuseChannels(const AIRFuseChannels &pass) {}
+  AIRFuseChannels(const AIRFuseChannels &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -3265,7 +3265,7 @@ class AIRIsolateAsyncDmaLoopNests
 
 public:
   AIRIsolateAsyncDmaLoopNests() = default;
-  AIRIsolateAsyncDmaLoopNests(const AIRIsolateAsyncDmaLoopNests &pass) {}
+  AIRIsolateAsyncDmaLoopNests(const AIRIsolateAsyncDmaLoopNests &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();
@@ -3566,7 +3566,7 @@ class AIRSegmentLoopFusion
 
 public:
   AIRSegmentLoopFusion() = default;
-  AIRSegmentLoopFusion(const AIRSegmentLoopFusion &pass) {}
+  AIRSegmentLoopFusion(const AIRSegmentLoopFusion &pass){}
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, air::airDialect>();

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/broadcast_detection.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/broadcast_detection.mlir
@@ -6,59 +6,102 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-dependency -air-broadcast-detection | FileCheck %s
+// RUN: air-opt %s -air-dependency -air-broadcast-detection --split-input-file | FileCheck %s
 
 // Detects broadcast pattern for DMAs
 // CHECK: [[$SET0:#set[0-9]*]] = affine_set<(d0, d1)[s0] : (d0 - s0 == 0, d1 >= 0, -d1 + 1 >= 0, s0 >= 0, -s0 + 1 >= 0)>
 // CHECK: [[$SET1:#set[0-9]*]] = affine_set<(d0, d1)[s0] : (d0 >= 0, -d0 + 1 >= 0, d1 - s0 == 0, s0 >= 0, -s0 + 1 >= 0)>
+// CHECK-LABEL: func.func @matmul
 // CHECK: %[[EVENT0:.*]] = air.dma_memcpy_nd {{.*}}broadcast_pattern = [[$SET0]]{{.*}}
 // CHECK: %[[EVENT1:.*]] = air.dma_memcpy_nd {{.*}}broadcast_pattern = [[$SET1]]{{.*}}
 
 #map = affine_map<()[s0] -> (s0 * 32)>
+func.func @matmul(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg2: memref<512x512xbf16>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c0 = arith.constant 0 : index
+  %c512 = arith.constant 512 : index
+  %c64 = arith.constant 64 : index
+  %0 = memref.alloc() {alignment = 128 : i64} : memref<512x512xbf16>
+  memref.copy %arg2, %0 : memref<512x512xbf16> to memref<512x512xbf16>
+  scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c512, %c512) step (%c64, %c64) {
+    scf.for %arg5 = %c0 to %c512 step %c64 {
+      %1 = memref.alloc() : memref<64x64xbf16, 1>
+      %2 = memref.alloc() : memref<64x64xbf16, 1>
+      %3 = memref.alloc() : memref<64x64xbf16, 1>
+      air.dma_memcpy_nd (%1[] [] [], %arg0[%arg3, %arg5] [%c64, %c64] [%c512, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+      air.dma_memcpy_nd (%2[] [] [], %arg1[%arg5, %arg4] [%c64, %c64] [%c512, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+      air.dma_memcpy_nd (%3[] [] [], %0[%arg3, %arg4] [%c64, %c64] [%c512, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
+      air.herd  tile (%arg6, %arg7) in (%arg8=%c2, %arg9=%c2) args(%arg10=%1, %arg11=%2, %arg12=%3) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {sym_name = "herd_0"} {
+        %c1_0 = arith.constant 1 : index
+        %c0_1 = arith.constant 0 : index
+        %c64_2 = arith.constant 64 : index
+        %c32 = arith.constant 32 : index
+        %4 = affine.apply #map()[%arg6]
+        %5 = affine.apply #map()[%arg7]
+        scf.for %arg13 = %c0_1 to %c64_2 step %c32 {
+          %6 = memref.alloc() : memref<32x32xbf16, 2>
+          %7 = memref.alloc() : memref<32x32xbf16, 2>
+          %8 = memref.alloc() : memref<32x32xbf16, 2>
+          air.dma_memcpy_nd (%6[] [] [], %arg10[%4, %arg13] [%c32, %c32] [%c64_2, %c1_0]) {id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+          air.dma_memcpy_nd (%7[] [] [], %arg11[%arg13, %5] [%c32, %c32] [%c64_2, %c1_0]) {id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+          air.dma_memcpy_nd (%8[] [] [], %arg12[%4, %5] [%c32, %c32] [%c64_2, %c1_0]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
+          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%6, %7 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%8 : memref<32x32xbf16, 2>)
+          air.dma_memcpy_nd (%arg12[%4, %5] [%c32, %c32] [%c64_2, %c1_0], %8[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
+          memref.dealloc %6 : memref<32x32xbf16, 2>
+          memref.dealloc %7 : memref<32x32xbf16, 2>
+          memref.dealloc %8 : memref<32x32xbf16, 2>
+        }
+        air.herd_terminator
+      }
+      air.dma_memcpy_nd (%0[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %3[] [] []) {id = 8 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
+      memref.dealloc %1 : memref<64x64xbf16, 1>
+      memref.dealloc %2 : memref<64x64xbf16, 1>
+      memref.dealloc %3 : memref<64x64xbf16, 1>
+    }
+  }
+  return
+}
+
+// -----
+
+// CHECK: [[$SET0:#set[0-9]*]] = affine_set<(d0, d1)[s0] : (d0 >= 0, -d0 + 3 >= 0, d1 - s0 == 0, s0 >= 0, -s0 + 3 >= 0)>
+// CHECK-LABEL: func.func @func0
+// CHECK: %[[EVENT0:.*]] = air.dma_memcpy_nd {{.*}} {id = 1 : i32} : (memref<256x64xbf16, 1>, memref<1024x256xbf16>)
+// CHECK: %[[EVENT1:.*]] = air.dma_memcpy_nd {{.*}}broadcast_pattern = [[$SET0]]{{.*}}
+
+#map = affine_map<()[s0] -> (s0 * 256)>
+#map1 = affine_map<()[s0] -> (s0 * 64)>
 module {
-  func.func @matmul(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg2: memref<512x512xbf16>) {
+  func.func @func0(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x256xbf16>, %arg2: memref<256x256xbf16>) {
     %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %c0 = arith.constant 0 : index
-    %c512 = arith.constant 512 : index
-    %c64 = arith.constant 64 : index
-    %0 = memref.alloc() {alignment = 128 : i64} : memref<512x512xbf16>
-    memref.copy %arg2, %0 : memref<512x512xbf16> to memref<512x512xbf16>
-    scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c512, %c512) step (%c64, %c64) {
-      scf.for %arg5 = %c0 to %c512 step %c64 {
-        %1 = memref.alloc() : memref<64x64xbf16, 1>
-        %2 = memref.alloc() : memref<64x64xbf16, 1>
-        %3 = memref.alloc() : memref<64x64xbf16, 1>
-        air.dma_memcpy_nd (%1[] [] [], %arg0[%arg3, %arg5] [%c64, %c64] [%c512, %c1]) {id = 1 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
-        air.dma_memcpy_nd (%2[] [] [], %arg1[%arg5, %arg4] [%c64, %c64] [%c512, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
-        air.dma_memcpy_nd (%3[] [] [], %0[%arg3, %arg4] [%c64, %c64] [%c512, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<512x512xbf16>)
-        air.herd  tile (%arg6, %arg7) in (%arg8=%c2, %arg9=%c2) args(%arg10=%1, %arg11=%2, %arg12=%3) : memref<64x64xbf16, 1>, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> attributes {sym_name = "herd_0"} {
+    air.launch (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) args(%arg7=%arg1) : memref<1024x256xbf16> attributes {id = 3 : i32} {
+      air.segment @segment_0  args(%arg8=%arg4, %arg9=%arg7) : index, memref<1024x256xbf16> attributes {id = 2 : i32} {
+        %c4 = arith.constant 4 : index
+        %0 = affine.apply #map()[%arg8]
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c4, %arg13=%c4) args(%arg14=%0, %arg15=%arg9) : index, memref<1024x256xbf16> attributes {id = 1 : i32} {
           %c1_0 = arith.constant 1 : index
-          %c0_1 = arith.constant 0 : index
-          %c64_2 = arith.constant 64 : index
-          %c32 = arith.constant 32 : index
-          %4 = affine.apply #map()[%arg6]
-          %5 = affine.apply #map()[%arg7]
-          scf.for %arg13 = %c0_1 to %c64_2 step %c32 {
-            %6 = memref.alloc() : memref<32x32xbf16, 2>
-            %7 = memref.alloc() : memref<32x32xbf16, 2>
-            %8 = memref.alloc() : memref<32x32xbf16, 2>
-            air.dma_memcpy_nd (%6[] [] [], %arg10[%4, %arg13] [%c32, %c32] [%c64_2, %c1_0]) {id = 4 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-            air.dma_memcpy_nd (%7[] [] [], %arg11[%arg13, %5] [%c32, %c32] [%c64_2, %c1_0]) {id = 5 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-            air.dma_memcpy_nd (%8[] [] [], %arg12[%4, %5] [%c32, %c32] [%c64_2, %c1_0]) {id = 6 : i32} : (memref<32x32xbf16, 2>, memref<64x64xbf16, 1>)
-            linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%6, %7 : memref<32x32xbf16, 2>, memref<32x32xbf16, 2>) outs(%8 : memref<32x32xbf16, 2>)
-            air.dma_memcpy_nd (%arg12[%4, %5] [%c32, %c32] [%c64_2, %c1_0], %8[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
-            memref.dealloc %6 : memref<32x32xbf16, 2>
-            memref.dealloc %7 : memref<32x32xbf16, 2>
-            memref.dealloc %8 : memref<32x32xbf16, 2>
+          %c0 = arith.constant 0 : index
+          %c256 = arith.constant 256 : index
+          %c64 = arith.constant 64 : index
+          %c1024 = arith.constant 1024 : index
+          %1 = affine.apply #map1()[%arg11]
+          %2 = arith.addi %arg14, %1 : index
+          scf.for %arg16 = %c0 to %c1024 step %c256 {
+            %alloc = memref.alloc() : memref<256x64xbf16, 1>
+            air.dma_memcpy_nd (%alloc[] [] [], %arg15[%arg16, %2] [%c256, %c64] [%c256, %c1_0]) {id = 2 : i32} : (memref<256x64xbf16, 1>, memref<1024x256xbf16>)
+            scf.for %arg17 = %c0 to %c256 step %c64 {
+              %alloc_1 = memref.alloc() : memref<64x64xbf16, 2>
+              air.dma_memcpy_nd (%alloc_1[] [] [], %alloc[%arg17, %c0] [%c64, %c64] [%c64, %c1_0]) {id = 4 : i32} : (memref<64x64xbf16, 2>, memref<256x64xbf16, 1>)
+              memref.dealloc %alloc_1 : memref<64x64xbf16, 2>
+            }
+            memref.dealloc %alloc : memref<256x64xbf16, 1>
           }
           air.herd_terminator
         }
-        air.dma_memcpy_nd (%0[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %3[] [] []) {id = 8 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
-        memref.dealloc %1 : memref<64x64xbf16, 1>
-        memref.dealloc %2 : memref<64x64xbf16, 1>
-        memref.dealloc %3 : memref<64x64xbf16, 1>
+        air.segment_terminator
       }
+      air.launch_terminator
     }
     return
   }


### PR DESCRIPTION
- Add detection for a new form of broadcastable `air.dma_memcpy_nd` op.
- Enables broadcast detection for straight-forward AIR tiling strategy.