### PR TITLE
[AIR][AMD-AIE] Fix `link_with` relaying for nested func.call ops

### DIFF
--- a/mlir/test/Conversion/ConvertToAIR/affine_par_to_herd_launch.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/affine_par_to_herd_launch.mlir
@@ -75,3 +75,41 @@ module {
     return
   }
 }
+
+// -----
+
+// This test demonstrates the relaying of `link_with` construct to air.herd op even if the
+// func.call op is not an immediate child of scf.parallel.
+
+// CHECK-LABEL: module {
+//       CHECK:  func.func private @matmul_scalar_i32_i32
+//  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o", llvm.bareptr = true}
+//       CHECK:  func.func @matmul_small_nested_scf_dispatch_0_matmul_8x32x16_i32(
+//       CHECK:    air.herd @herd_0
+//  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o"} {
+//       CHECK:       scf.for
+//  CHECK-SAME:       {
+//       CHECK:           func.call @matmul_scalar_i32_i32
+//       CHECK:       }
+//       CHECK:       air.herd_terminator
+//       CHECK:    }
+//       CHECK:    return
+//       CHECK:  }
+//       CHECK: }
+module {
+  func.func private @matmul_scalar_i32_i32(memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) attributes {link_with = "/path/to/mm_microkernel.o", llvm.bareptr = true}
+  func.func @matmul_small_nested_scf_dispatch_0_matmul_8x32x16_i32(%base_buffer: memref<i32, 2 : i32>, %base_buffer_14: memref<i32, 2 : i32>, %base_buffer_18: memref<i32, 2 : i32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    scf.parallel (%x,%y) = (%c0,%c0) to (%c1,%c1) step (%c1, %c1) {
+      %2 = arith.addi %x, %y : index
+      scf.for %arg0 = %c0 to %c32 step %c4 {
+        func.call @matmul_scalar_i32_i32(%base_buffer, %c0, %base_buffer_14, %c0, %base_buffer_18, %c0) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
+      }
+      scf.reduce
+    }
+    return
+  }
+}


### PR DESCRIPTION
-- This commit adds a fix to relay `link_with` information from
   nested func.call ops within scf.parallel op while creating
   air.herd op.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>