### PR TITLE
Remove unused lit config option vitis_root

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -155,6 +155,8 @@ jobs:
               export LIT_FILTER="${{ inputs.LIT_FILTER }}"
             fi
 
+            export LIT_OPTS="-sv --timeout 300 -j1 --time-tests --order=random"
+
             utils/clone-rocm-air-platforms.sh
             utils/github-clone-build-libxaie.sh
 

--- a/test/airhost/40_air_8x4_2d_square/air_test.cpp
+++ b/test/airhost/40_air_8x4_2d_square/air_test.cpp
@@ -31,7 +31,7 @@
 #define NUM_3D (IMAGE_WIDTH / TILE_WIDTH)
 #define NUM_4D (IMAGE_HEIGHT / TILE_HEIGHT)
 
-namespace air::segments::copyherd {
+namespace air::segments::segment_0 {
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_2(aie_libxaie_ctx_t *, int, int32_t);
@@ -64,8 +64,8 @@ void mlir_aie_write_buffer_scratch_7_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_2(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_3(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::copyherd
-using namespace air::segments::copyherd;
+}; // namespace air::segments::segment_0
+using namespace air::segments::segment_0;
 
 int main(int argc, char *argv[]) {
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -135,15 +135,14 @@ llvm_config.with_environment('PATH', config.air_tools_dir, append_path=True)
 # test if LM_LICENSE_FILE valid
 if config.enable_chess_tests:
     import shutil
-    result = None
-    if config.vitis_root:
-        result = shutil.which("xchesscc")
+    result = shutil.which("xchesscc")
 
     import subprocess
     if result != None:
         result = subprocess.run(['xchesscc','+v'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
         validLMLicense = (len(result.stderr.decode('utf-8')) == 0)
     else:
+        printf("WARNING: xchesscc not found")
         validLMLicense = False
 
     if validLMLicense:
@@ -158,9 +157,8 @@ if config.enable_chess_tests:
         print("WARNING: no valid xchess license that is required by some of the lit tests")
 
 
-if config.vitis_root:
+if config.vitis_aietools_dir:
   llvm_config.with_environment('CARDANO', config.vitis_aietools_dir)
-  llvm_config.with_environment('VITIS', config.vitis_root)
 
 tool_dirs = [config.peano_tools_dir, config.aie_tools_dir, config.air_tools_dir, config.llvm_tools_dir]
 tools = [

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -140,9 +140,12 @@ if config.enable_chess_tests:
     import subprocess
     if result != None:
         result = subprocess.run(['xchesscc','+v'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-        validLMLicense = (len(result.stderr.decode('utf-8')) == 0)
+        errs = result.stderr.decode('utf-8')
+        validLMLicense = (len(errs) == 0)
+        if not validLMLicense:
+            print ("WARNING: xchesscc did not work,", errs)
     else:
-        printf("WARNING: xchesscc not found")
+        print ("WARNING: xchesscc not found")
         validLMLicense = False
 
     if validLMLicense:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -140,12 +140,8 @@ if config.enable_chess_tests:
     import subprocess
     if result != None:
         result = subprocess.run(['xchesscc','+v'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-        errs = result.stderr.decode('utf-8')
-        validLMLicense = (len(errs) == 0)
-        if not validLMLicense:
-            print ("WARNING: xchesscc did not work,", errs)
+        validLMLicense = (len(result.stderr.decode('utf-8')) == 0)
     else:
-        print ("WARNING: xchesscc not found")
         validLMLicense = False
 
     if validLMLicense:

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -56,7 +56,6 @@ config.enable_run_airhost_tests = lit.util.pythonize_bool("@ENABLE_RUN_AIRHOST_T
 config.enable_run_xrt_tests = lit.util.pythonize_bool("@ENABLE_RUN_XRT_TESTS@")
 
 # pass on vitis settings
-config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.libxaie_dir = "@XILINX_XAIE_DIR@"
 config.test_arch = "@AIR_RUNTIME_TEST_TARGET_VAL@"


### PR DESCRIPTION
The check for `config.vitis_root` was preventing lit tests tagged with `REQUIRES: valid_xchess_license` from running in the "Build and Test with AIE tools" action. The check is not used anywhere else, and is pointless, so the fix it to remove it.