### PR TITLE
[AIR][AMD-AIE] Remove unused variable

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2161,10 +2161,6 @@ public:
                              .getType()
                              .cast<MemRefType>()
                              .getMemorySpaceAsInt();
-      int dst_memspace = dma_op.getDstMemref()
-                             .getType()
-                             .cast<MemRefType>()
-                             .getMemorySpaceAsInt();
       auto externalOffsets = src_memspace == (int)air::MemorySpace::L1
                                  ? dma_op.getDstOffsets()
                                  : dma_op.getSrcOffsets();


### PR DESCRIPTION
-- This commit trivially removes an unused variable in
   AIRDependencyScheduleOpt.cpp.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>

The unused variable leads to build failure in IREE(iree-amd-aie) - hence raising this PR.