### PR TITLE
Update run.lit

### DIFF
--- a/test/xrt/08_gemm_extern_vec/run.lit
+++ b/test/xrt/08_gemm_extern_vec/run.lit
@@ -5,6 +5,6 @@
 
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/mm.cc -o mm.o
 // RUN: %python %S/aie.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-ipu --no-compile-host --xclbin-name=aie.xclbin --ipu-insts-name=insts.txt aie.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-ipu --no-compile-host --xclbin-name=aie.xclbin --ipu-insts-name=insts.txt aie.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_ipu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt


### PR DESCRIPTION
Add  `--xchesscc --xbridge` to aiecc command line. Otherwise test will fail to build if chess is not default compiler