### PR TITLE
Fixes for Windows build

### DIFF
--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -535,8 +535,8 @@ AIRChannelInterfaceToAIRRtConversionImpl(OpBuilder builder,
       for (auto o : op_strides.drop_back())
         strides[idx++] = builder.create<arith::IndexCastOp>(
             loc, IntegerType::get(ctx, 64), o);
-    idx = 4 - std::max(thisOp.getSizes().size(),
-                       (unsigned long)thisMemrefType.getRank());
+    idx = 4 -
+          std::max(thisOp.getSizes().size(), (size_t)thisMemrefType.getRank());
     // If sizes field is empty, then infer sizes from memref shape
     if (thisOp.getSizes().empty())
       for (auto d : air::getTensorShape(thisMemrefType))

--- a/mlir/lib/Conversion/AIRRtToIpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToIpuPass.cpp
@@ -168,7 +168,7 @@ struct DmaToIpuPattern : public OpConversionPattern<DmaMemcpyNdOp> {
     else
       sizes.push_back(adaptor.getLength1());
     if (auto const_int = getConstantIntValue(adaptor.getLength0()))
-      staticSizes.push_back(std::max(1L, *const_int / div));
+      staticSizes.push_back(std::max((int64_t)1, *const_int / div));
     else
       sizes.push_back(divOp(adaptor.getLength0()));
     SmallVector<Value> strides;


### PR DESCRIPTION
MSVC makes long 32 bits, which creates some confusion in these calls to std::max.