### PR TITLE
Tighten rules around warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,30 @@ include_directories(${PROJECT_BINARY_DIR}/mlir/include)
 
 add_definitions(${LLVM_DEFINITIONS})
 
+## flags duplicated from mlir-aie
+add_flag_if_supported("-Werror=sign-compare" WERROR_SIGN_COMPARE)
+add_flag_if_supported("-Werror=unused" WERROR_USED)
+# What happens when you have a non-void function with no return?
+# No `ret` instruction is generated and so execution of that function just
+# proceeds as if it doesn't have a care in the world (right into whatever comes next).
+# https://godbolt.org/z/Wr9nzv6ns
+add_flag_if_supported("-Werror=return-type" WERROR_RETURN_TYPE)
+## Stolen from MLIR
+# Forbid implicit function declaration: this may lead to subtle bugs and we
+# don't have a reason to support this.
+add_flag_if_supported("-Werror=implicit-function-declaration" WERROR_IMPLICIT_FUNCTION_DECLARATION)
+# Forbid mismatch between declaration and definition for class vs struct. This is
+# harmless on Unix systems, but it'll be a ticking bomb for MSVC/Windows systems
+# where it creeps into the ABI.
+add_flag_if_supported("-Werror=mismatched-tags" WERROR_MISMATCHED_TAGS)
+# Silence a false positive GCC -Wunused-but-set-parameter warning in constexpr
+# cases, by marking SelectedCase as used. See
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85827 for details. The issue is
+# fixed in GCC 10.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0")
+  add_flag_if_supported("-Wno-unused-but-set-parameter" WNO_UNUSED_BUT_SET_PARAMETER)
+endif()
+
 add_custom_target(check-all)
 
 # Make sure we build the docs

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -74,10 +74,10 @@ struct allocation_info_t {
   std::vector<int32_t> dma_id;
   std::vector<Operation *> memcpyOps;
   bool foundAlloc(air::ChannelOp channel_op);
-  bool foundAlloc(uint32_t col, uint32_t row, air::MemcpyInterface memcpyOp);
-  bool foundAlloc(uint32_t col, uint32_t row, int chan);
-  bool foundAlloc(uint32_t col, uint32_t row);
-  bool foundAlloc(uint32_t col, uint32_t row, air::ChannelOp channel_op);
+  bool foundAlloc(int32_t col, int32_t row, air::MemcpyInterface memcpyOp);
+  bool foundAlloc(int32_t col, int32_t row, int chan);
+  bool foundAlloc(int32_t col, int32_t row);
+  bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
   bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
 };
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -978,7 +978,7 @@ void L2MemrefToMemTileMap(
     auto memref_vol = getElementSizeInBytes(ty) * getTensorVolume(ty);
     while (memtileToSizeMap[memtiles[memtile_id]] < memref_vol) {
       memtile_id++;
-      assert(memtile_id < memtiles.size());
+      assert((unsigned)memtile_id < memtiles.size());
     }
     memtileToSizeMap[memtiles[memtile_id]] -= memref_vol;
     memrefToMemTileMap[alloc] = memtiles[memtile_id];

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -165,7 +165,7 @@ int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets,
     auto offset = mlir::getConstantIntValue(memcpy_offsets[i]);
     if (!offset)
       assert(false && "non-static offset in memcpy op");
-    if (i == memcpy_offsets.size() - 1)
+    if ((unsigned)i == memcpy_offsets.size() - 1)
       one_d_offset += *offset;
     else {
       if (auto stride_i = mlir::getConstantIntValue(memcpy_strides[i])) {
@@ -347,7 +347,7 @@ bool allocation_info_t::foundAlloc(air::ChannelOp channel_op) {
   }
   return false;
 }
-bool allocation_info_t::foundAlloc(uint32_t col, uint32_t row,
+bool allocation_info_t::foundAlloc(int32_t col, int32_t row,
                                    air::MemcpyInterface memcpyOp) {
   if (col == dma_tile.getCol() && row == dma_tile.getRow())
     for (auto o : memcpyOps)
@@ -355,13 +355,13 @@ bool allocation_info_t::foundAlloc(uint32_t col, uint32_t row,
         return true;
   return false;
 }
-bool allocation_info_t::foundAlloc(uint32_t col, uint32_t row, int chan) {
+bool allocation_info_t::foundAlloc(int32_t col, int32_t row, int chan) {
   if (col == dma_tile.getCol() && row == dma_tile.getRow() &&
       chan == dma_channel.channel)
     return true;
   return false;
 }
-bool allocation_info_t::foundAlloc(uint32_t col, uint32_t row) {
+bool allocation_info_t::foundAlloc(int32_t col, int32_t row) {
   if (col == dma_tile.getCol() && row == dma_tile.getRow())
     return true;
   return false;
@@ -373,7 +373,7 @@ bool allocation_info_t::foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel) {
   else
     return false;
 }
-bool allocation_info_t::foundAlloc(uint32_t col, uint32_t row,
+bool allocation_info_t::foundAlloc(int32_t col, int32_t row,
                                    air::ChannelOp channel_op) {
   if (col == dma_tile.getCol() && row == dma_tile.getRow() && channel_op) {
     for (auto o : memcpyOps) {

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -2441,9 +2441,9 @@ static LogicalResult canonicalizeAIRDmaOperands(OpBuilder builder,
   // Increase vector sizes up to memref size. When offsets, sizes and strides
   // are all empty, then it implies that the whole memref is accessed in the
   // default order.
-  int max_dim_size =
+  auto max_dim_size =
       std::max(std::max(offsets.size(), sizes.size()), strides.size());
-  int target_dim_size = std::max(max_dim_size, (int)memref.getRank());
+  auto target_dim_size = std::max(max_dim_size, (size_t)memref.getRank());
   if (max_dim_size && offsets.size() < target_dim_size) {
     for (unsigned i = offsets.size(); i < target_dim_size; i++) {
       offsets.insert(offsets.begin(), builder.create<arith::ConstantIndexOp>(

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3811,11 +3811,11 @@ private:
         induction_var_dim = i;
     }
     if (induction_var_dim == -1 ||
-        induction_var_dim < offsets.size() - memref_shape.size())
+        (unsigned)induction_var_dim < offsets.size() - memref_shape.size())
       return scf::ForOp(); // NYI.
     if (offsets.size() > memref_shape.size())
       induction_var_dim -= offsets.size() - memref_shape.size();
-    int access_volumn = 1;
+    unsigned access_volumn = 1;
     for (auto v : sizes)
       access_volumn *= *getConstantIntValue(v);
     if (offsets.empty() ||

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -661,16 +661,11 @@ struct LinalgTransformationFilter {
       ArrayRef<StringAttr> matchDisjunction = {},
       std::optional<StringAttr> replacement = std::nullopt);
 
-  explicit LinalgTransformationFilter(
-      const FilterFunction &f, ArrayRef<StringAttr> matchDisjunction = {},
-      std::optional<StringAttr> replacement = std::nullopt);
-
   LinalgTransformationFilter(LinalgTransformationFilter &&) = default;
   LinalgTransformationFilter(const LinalgTransformationFilter &) = default;
   LogicalResult checkAndNotify(PatternRewriter &rewriter, Operation *op) const;
   void replaceLinalgTransformationFilter(PatternRewriter &rewriter,
                                          Operation *op) const;
-  bool hasReplacementFilter(Operation *op) const;
 
   LinalgTransformationFilter &addFilter(const FilterFunction &f) {
     if (f)
@@ -708,16 +703,6 @@ LinalgTransformationFilter::LinalgTransformationFilter(
     std::optional<StringAttr> replacement)
     : matchDisjunction(matchDisjunction.begin(), matchDisjunction.end()),
       replacement(replacement), matchByDefault(false) {}
-
-LinalgTransformationFilter::LinalgTransformationFilter(
-    const FilterFunction &f, ArrayRef<StringAttr> matchDisjunction,
-    std::optional<StringAttr> replacement)
-    : filters(),
-      matchDisjunction(matchDisjunction.begin(), matchDisjunction.end()),
-      replacement(replacement), matchByDefault(false) {
-  if (f)
-    filters.push_back(f);
-}
 
 LogicalResult
 LinalgTransformationFilter::checkAndNotify(PatternRewriter &rewriter,
@@ -760,14 +745,6 @@ void LinalgTransformationFilter::replaceLinalgTransformationFilter(
   else
     op->removeAttr(
         rewriter.getStringAttr(air::LinalgTransforms::kLinalgTransformMarker));
-}
-
-bool LinalgTransformationFilter::hasReplacementFilter(Operation *op) const {
-  if (!replacement)
-    return false;
-  auto attr = op->getAttr(air::LinalgTransforms::kLinalgTransformMarker)
-                  .dyn_cast<StringAttr>();
-  return attr && attr == *replacement;
 }
 
 RemoveSubViewOpsPattern::RemoveSubViewOpsPattern(MLIRContext *ctx,

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -963,7 +963,7 @@ void AIRCollapseHerdPass::runOnOperation() {
     maximumColumnSize = INT_MAX; // max-col-size disabled.
   func.walk([&](air::HerdOp op) {
     if (op.getNumCols() != 1 && op.getNumDims() == 2 &&
-        op.getNumRows() * op.getNumCols() <= maximumColumnSize)
+        op.getNumRows() * op.getNumCols() <= (unsigned)maximumColumnSize)
       herds.push_back(op);
   });
 

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -637,7 +637,8 @@ bool air::positionHitsAffineIfCondition(Operation *op, Operation *spatial_loop,
     if (affine_if.getThenBlock()->findAncestorOpInBlock(*op)) {
       bool hit = true;
       for (unsigned i = 0; i < lbs_int.size(); i++) {
-        if ((position[i] < lbs_int[i]) || (position[i] > ubs_int[i])) {
+        if ((position[i] < (unsigned)lbs_int[i]) ||
+            (position[i] > (unsigned)ubs_int[i])) {
           hit = false;
         }
       }
@@ -651,7 +652,8 @@ bool air::positionHitsAffineIfCondition(Operation *op, Operation *spatial_loop,
   // If op isn't in any then blocks in affine.if nest
   bool hit = true;
   for (unsigned i = 0; i < lbs_spatial.size(); i++) {
-    if ((position[i] < lbs_spatial[i]) || (position[i] > ubs_spatial[i])) {
+    if ((position[i] < (unsigned)lbs_spatial[i]) ||
+        (position[i] > (unsigned)ubs_spatial[i])) {
       hit = false;
     }
   }
@@ -811,10 +813,10 @@ LogicalResult air::canonicalizeWrapAndStrideList(OpBuilder builder,
 
   bool listsHaveChanged = false;
   // Match offsets size with sizes and strides
-  int max_dim_size =
+  auto max_dim_size =
       std::max(std::max(offsets.size(), sizes.size()), strides.size());
   if (max_dim_size && offsets.size() < max_dim_size) {
-    for (unsigned i = offsets.size(); i < max_dim_size; i++) {
+    for (auto i = offsets.size(); i < max_dim_size; i++) {
       offsets.insert(offsets.begin(), builder.create<arith::ConstantIndexOp>(
                                           builder.getUnknownLoc(), 0));
     }
@@ -926,9 +928,9 @@ void air::foldForLoopNestAsExtendedSizesAndStrides(
       }
       // Index offset taking into account mismatch between memref rank and
       // offset list size difference.
-      int memref_rank = getTensorShape(memref.getType()).size();
+      auto memref_rank = getTensorShape(memref.getType()).size();
       if (memref_rank < offsets.size()) {
-        if (i < offsets.size() - memref_rank)
+        if ((unsigned)i < offsets.size() - memref_rank)
           ind_var_factor *= getTensorVolume(memref.getType());
         else
           ind_var_factor *= getTensorShape(


### PR DESCRIPTION
This copies some `-Werror` rules from mlir-aie to avoid issues like #490