### PR TITLE
Compiling iree-amd-aie with g++13 

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -200,8 +200,9 @@ std::vector<AIE::BDDimLayoutAttr>
 air::getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
                         SmallVector<Value> memcpy_strides,
                         int byte_count_per_elem, MLIRContext *ctx) {
-  assert(byte_count_per_elem == 4 || byte_count_per_elem == 2 ||
-         byte_count_per_elem == 1 && "unsupported data format");
+  assert((byte_count_per_elem == 4 || byte_count_per_elem == 2 ||
+          byte_count_per_elem == 1) &&
+         "unsupported data format");
   int div_factor = mlir::ceilDiv(4, byte_count_per_elem);
   if (memcpy_sizes.empty() || memcpy_strides.empty())
     return std::vector<AIE::BDDimLayoutAttr>{};

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -2965,9 +2965,8 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
             memcpy_op.getOperation(), sink_op_memref_reads,
             sink_op_memref_writes, sink_op_scalar_ins, sink_op_scalar_outs);
 
-        assert(sink_op_memref_reads.size() ||
-               sink_op_memref_writes.size() &&
-                   "cannot read memref from channel op");
+        assert((sink_op_memref_reads.size() || sink_op_memref_writes.size()) &&
+               "cannot read memref from channel op");
 
         if (sink_wait_all_op) {
           // Detect RAW deps


### PR DESCRIPTION
error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]