### PR TITLE
Fixup wrap-and-stride canonicalization

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -236,6 +236,11 @@ bool air::isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
   SmallVector<int> memref_shape = getTensorShape(memref.getType());
   if (memcpy_sizes.size() != memref_shape.size())
     return false;
+  if (memcpy_sizes.size() == 1 && memcpy_strides.size() == 1) {
+    auto stepsize = mlir::getConstantIntValue(memcpy_strides[0]);
+    if (stepsize && *stepsize == 1)
+      return true;
+  }
   unsigned stride_factor = 1;
   for (int i = memcpy_sizes.size() - 1; i >= 0; i--) {
     auto stepsize = mlir::getConstantIntValue(memcpy_strides[i]);

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -846,6 +846,8 @@ LogicalResult air::canonicalizeWrapAndStrideList(OpBuilder builder,
           getConstantIntValue(sizes[i]) && getConstantIntValue(sizes[i - 1]) &&
           getConstantIntValue(strides[i]) &&
           getConstantIntValue(strides[i - 1])) {
+        auto const_offset = *getConstantIntValue(offsets[i]);
+        auto const_offset_next = *getConstantIntValue(offsets[i - 1]);
         auto const_size = *getConstantIntValue(sizes[i]);
         auto const_size_next = *getConstantIntValue(sizes[i - 1]);
         auto const_stride = *getConstantIntValue(strides[i]);
@@ -853,6 +855,9 @@ LogicalResult air::canonicalizeWrapAndStrideList(OpBuilder builder,
         if (const_stride_next == const_size * const_stride) {
           sizes[i] = builder.create<arith::ConstantIndexOp>(
               builder.getUnknownLoc(), const_size * const_size_next);
+          offsets[i] = builder.create<arith::ConstantIndexOp>(
+              builder.getUnknownLoc(),
+              const_stride_next * const_offset_next + const_offset);
           offsets.erase(offsets.begin() + i - 1);
           sizes.erase(sizes.begin() + i - 1);
           strides.erase(strides.begin() + i - 1);

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -584,9 +584,9 @@ func.func @func8(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
-// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 0, 32, [<size = 32, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 0, 32)
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 128, 32, [<size = 32, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 128, 32)
 // CHECK: @func9
 #map = affine_map<()[s0] -> (s0 * 32)>
 air.channel @channel_1 [2, 1]

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -183,7 +183,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512, [<size = 512, stride = 1>])
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -224,4 +224,26 @@ module {
     %1 = air.channel.put async @channel_18[] (%arg0[%c0, %c0, %c0, %c0] [%c4, %c2, %c8, %c4] [%c64, %c32, %c4, %c1]) : (memref<1x1x4x2x8x4xi32>)
     return
   }
+
+  // CHECK-LABEL: test7
+  // CHECK: put async  @channel_19[%c0, %c0] (%arg0[%c0] [%c16384] [%c1]) : (memref<256x256xbf16>)
+  // CHECK: put async  @channel_19[%c1, %c0] (%arg0[%c16384] [%c16384] [%c1]) : (memref<256x256xbf16>)
+  // CHECK: put async  @channel_19[%c2, %c0] (%arg0[%c32768] [%c16384] [%c1]) : (memref<256x256xbf16>)
+  // CHECK: put async  @channel_19[%c3, %c0] (%arg0[%c49152] [%c16384] [%c1]) : (memref<256x256xbf16>)
+
+  func.func @test7(%arg0: memref<256x256xbf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c128 = arith.constant 128 : index
+    %c192 = arith.constant 192 : index
+    %c256 = arith.constant 256 : index
+    %c64 = arith.constant 64 : index
+    %1 = air.channel.put async @channel_19[%c0, %c0] (%arg0[%c0, %c0] [%c64, %c256] [%c256, %c1]) : (memref<256x256xbf16>)
+    %2 = air.channel.put async @channel_19[%c1, %c0] (%arg0[%c64, %c0] [%c64, %c256] [%c256, %c1]) : (memref<256x256xbf16>)
+    %3 = air.channel.put async @channel_19[%c2, %c0] (%arg0[%c128, %c0] [%c64, %c256] [%c256, %c1]) : (memref<256x256xbf16>)
+    %4 = air.channel.put async @channel_19[%c3, %c0] (%arg0[%c192, %c0] [%c64, %c256] [%c256, %c1]) : (memref<256x256xbf16>)
+    return
+  }
 }


### PR DESCRIPTION
- Fixup an issue where non-zero offsets get deleted.
- Relax condition to detect a default data access pattern in `-air-to-aie` pass.