### PR TITLE
AIRSplitL2Memref pass: improve coverage to corner cases

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -71,7 +71,7 @@ scf::ForOp hoistTargetOpsToNewSCFFor(OpBuilder builder, scf::ForOp for_op,
 LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
                                                   scf::ParallelOp par,
                                                   Operation *originalChanOp,
-                                                  IRMapping &remap);
+                                                  IRMapping remap);
 
 //===----------------------------------------------------------------------===//
 // Dependency graph


### PR DESCRIPTION
- Support 1d `scf.parallel`.
- Support `parallel`-`for`-`air.channel` nest.