### PR TITLE
Bugfixes on AIRSegmentLoopFusion

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3713,10 +3713,15 @@ public:
     // Get roots to perfectly nested scf.for loops.
     SmallVector<scf::ForOp> perfectlyNestedForBands;
     auto hasNElements = [](Block *block, unsigned N) {
-      auto op_ptr = block->begin();
-      for (unsigned i = 0; i < N; i++)
-        op_ptr = std::next(op_ptr);
-      return op_ptr != block->end() && &*op_ptr == &block->back();
+      unsigned counter = 0;
+      for (auto &o : block->getOperations()) {
+        if (o.mightHaveTrait<OpTrait::IsTerminator>())
+          continue;
+        if (isa<air::WaitAllOp>(o))
+          continue;
+        counter++;
+      }
+      return counter == N;
     };
     for (auto forOp : op.getOps<scf::ForOp>()) {
       if (hasNElements(forOp.getBody(), 1) &&
@@ -3782,10 +3787,22 @@ public:
         }
       }
       if (canMove) {
-        for (auto user : alloc_exec.getAsyncToken().getUsers()) {
+        // Clear async dependencies to alloc op
+        for (auto user : alloc_exec.getAsyncToken().getUsers())
           if (auto async_user = dyn_cast<air::AsyncOpInterface>(user))
             eraseAsyncDependencyFromAsyncOp(async_user,
                                             alloc_exec.getAsyncToken());
+        for (auto &use : alloc_exec.getAsyncToken().getUses()) {
+          if (auto for_user = dyn_cast<scf::ForOp>(use.getOwner())) {
+            OpBuilder waitAllBuilder(for_user);
+            use.assign(
+                waitAllBuilder
+                    .create<air::WaitAllOp>(
+                        loc,
+                        air::AsyncTokenType::get(waitAllBuilder.getContext()),
+                        alloc_exec.getAsyncDependencies())
+                    .getAsyncToken());
+          }
         }
         alloc_exec->moveBefore(new_loop_op.getBody(),
                                new_loop_op.getBody()->getOperations().end());


### PR DESCRIPTION
- Fixup for perfect-loop-nest detection to ignore `air.wait_all` as only a synchronization point, i.e. a no-op in the context of BD optimization.
- Fixup missing condition re dependency tracing to an scf.for loop.