### PR TITLE
A number of fixups on AIRSegmentLoopFusion pass

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -12,6 +12,7 @@
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -172,9 +173,23 @@ getEffectiveMemrefSizeFromAccessPattern(SmallVector<int> memref_shape,
 
 // Get the overall data access pattern from air.channel ops which access the
 // memref.
+std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+writeAccessPattern(air::ChannelInterface chanOp);
+std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+writeAccessPattern(memref::SubViewOp subview);
+SmallVector<int64_t>
+getDataAccessShapeFromMemcpyOp(Value memref,
+                               SmallVector<air::ChannelInterface> chanUsers);
 SmallVector<int64_t>
 getDataAccessShapeFromMemcpyOp(Value memref,
                                SmallVector<air::ChannelInterface> chanOps);
+SmallVector<int64_t> getDataAccessShapeFromMemcpyOp(
+    Value memref,
+    SmallVector<
+        std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>>
+        patterns);
+SmallVector<int64_t>
+getDataAccessShapeFromMemcpyOp(Value memref, SmallVector<Operation *> users);
 
 // Update strides after memref shrinkage. Assuming there is only one dimension
 // being shrunk.
@@ -182,6 +197,11 @@ SmallVector<int>
 getUpdatedStridesAfterShrinkage(SmallVector<int> old_memref_shape,
                                 SmallVector<int64_t> new_memref_shape,
                                 SmallVector<Value> strides);
+// Update offsets after memref shrinkage.
+SmallVector<int>
+getUpdatedOffsetsAfterShrinkage(SmallVector<int> old_memref_shape,
+                                SmallVector<int64_t> new_memref_shape,
+                                SmallVector<Value> offsets);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4010,7 +4010,7 @@ public:
                   .create<air::WaitAllOp>(
                       loc,
                       air::AsyncTokenType::get(waitAllBuilder.getContext()),
-                      exec.getAsyncDependencies())
+                      SmallVector<Value>{})
                   .getAsyncToken());
         }
       }
@@ -4062,18 +4062,17 @@ public:
     });
     for (auto put_parent : put_parents) {
       auto get_parent = put_get_mapping[put_parent];
-      if (put_parent->isBeforeInBlock(get_parent)) {
+      if (put_parent->isBeforeInBlock(get_parent))
         put_parent->moveAfter(get_parent);
-        Value get_parent_token = nullptr;
-        for (auto res : get_parent->getResults())
-          if (isa<AsyncTokenType>(res.getType()))
-            get_parent_token = res;
-        for (unsigned i = 0; i < put_parent->getNumOperands(); i++)
-          if (get_parent_token &&
-              isa<AsyncTokenType>(put_parent->getOperand(i).getType())) {
-            put_parent->getOpOperand(i).assign(get_parent_token);
-          }
-      }
+      Value get_parent_token = nullptr;
+      for (auto res : get_parent->getResults())
+        if (isa<AsyncTokenType>(res.getType()))
+          get_parent_token = res;
+      for (unsigned i = 0; i < put_parent->getNumOperands(); i++)
+        if (get_parent_token &&
+            isa<AsyncTokenType>(put_parent->getOperand(i).getType())) {
+          put_parent->getOpOperand(i).assign(get_parent_token);
+        }
     }
   }
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2702,8 +2702,8 @@ class AIRUnrollChannelByFactorPattern
 
 public:
   AIRUnrollChannelByFactorPattern() = default;
-  AIRUnrollChannelByFactorPattern(const AIRUnrollChannelByFactorPattern &pass) {
-  };
+  AIRUnrollChannelByFactorPattern(
+      const AIRUnrollChannelByFactorPattern &pass){};
 
   void runOnOperation() override {
     auto module = getOperation();

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3950,7 +3950,9 @@ public:
       }
       if (canMove) {
         builder.setInsertionPointToEnd(new_loop_op.getBody());
-        auto new_alloc_exec = builder.clone(*alloc_exec);
+        auto new_alloc_exec = builder.clone(*alloc_exec, remap);
+        clearAsyncDependenciesOfAsyncOp(
+            dyn_cast<air::AsyncOpInterface>(new_alloc_exec));
         for (unsigned i = 0; i < new_alloc_exec->getNumResults(); i++)
           remap.map(alloc_exec->getResult(i), new_alloc_exec->getResult(i));
       } else

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3969,7 +3969,9 @@ public:
     for (auto forOp : fusableForOps) {
       remap.map(forOp.getInductionVar(), new_loop_op.getInductionVar());
       for (unsigned i = 0; i < forOp.getRegionIterArgs().size(); i++)
-        remap.map(forOp.getRegionIterArgs(), new_loop_op.getRegionIterArgs());
+        remap.map(forOp.getRegionIterArgs()[i],
+                  remap.lookupOrDefault(
+                      forOp.getOperand(i + forOp.getNumControlOperands())));
       builder.setInsertionPointToEnd(new_loop_op.getBody());
       for (auto &child_op : forOp.getBody()->getOperations())
         if (!child_op.mightHaveTrait<OpTrait::IsTerminator>())

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3645,13 +3645,15 @@ struct ShrinkMemrefSizesByAccessPattern
     auto memref_shape = getTensorShape(memref.getType());
 
     bool shrinkMemref = false;
+    bool boundsAreAllOnes = true;
     for (unsigned i = 0; i < memref_shape.size(); i++) {
-      if (overall_access_bounds[i] <= 0)
-        return failure();
-      if (overall_access_bounds[i] < memref_shape[i]) {
+      if (overall_access_bounds[i] != 1)
+        boundsAreAllOnes = false;
+      if (overall_access_bounds[i] < memref_shape[i])
         shrinkMemref = true;
-      }
     }
+    if (boundsAreAllOnes)
+      return failure(); // Memref access pattern analysis failed
     if (shrinkMemref) {
       // Start shrinking memref.
       for (auto user : users) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3705,27 +3705,23 @@ struct ShrinkMemrefSizesByAccessPattern
           if (static_sizes[i] < 0) {
             if (*getConstantIntValue(*subview_sizes++) !=
                 overall_access_bounds[i])
-              assert(
-                  false &&
-                  "Memref shrinkage attempting to mutate memref.subview, NYI.");
+              return failure(); // Memref shrinkage attempting to mutate
+                                // memref.subview, NYI.
           } else {
             if (static_sizes[i] != overall_access_bounds[i])
-              assert(
-                  false &&
-                  "Memref shrinkage attempting to mutate memref.subview, NYI.");
+              return failure(); // Memref shrinkage attempting to mutate
+                                // memref.subview, NYI.
           }
         }
         for (unsigned i = 0; i < static_strides.size(); i++) {
           if (static_strides[i] < 0) {
             if (*getConstantIntValue(*subview_strides++) != 1)
-              assert(
-                  false &&
-                  "Memref shrinkage attempting to mutate memref.subview, NYI.");
+              return failure(); // Memref shrinkage attempting to mutate
+                                // memref.subview, NYI.
           } else {
             if (static_strides[i] != 1)
-              assert(
-                  false &&
-                  "Memref shrinkage attempting to mutate memref.subview, NYI.");
+              return failure(); // Memref shrinkage attempting to mutate
+                                // memref.subview, NYI.
           }
         }
         subViewOp.getResult().replaceAllUsesWith(subViewOp.getSource());

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1070,11 +1070,14 @@ SmallVector<int64_t> air::getDataAccessShapeFromMemcpyOp(
   SmallVector<int64_t> overall_access_bounds(memref_shape.size(), 1);
   for (auto pattern : patterns) {
     SmallVector<int64_t> access_bounds(memref_shape.size(), 1);
+    // Empty offsets list means default data access pattern spaning the entire
+    // memref
     if (std::get<0>(pattern).empty())
       for (unsigned i = 0; i < memref_shape.size(); i++)
         access_bounds[i] = memref_shape[i];
-    access_bounds = getEffectiveMemrefSizeFromAccessPattern(
-        memref_shape, std::get<1>(pattern), std::get<2>(pattern));
+    else
+      access_bounds = getEffectiveMemrefSizeFromAccessPattern(
+          memref_shape, std::get<1>(pattern), std::get<2>(pattern));
     // Update overall access bounds.
     for (unsigned i = 0; i < memref_shape.size(); i++)
       overall_access_bounds[i] =

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
@@ -164,113 +164,101 @@ func.func @func1() {
 
 // Multiple herds.
 
+// CHECK: func.func private @linalg_fill_bf16(bf16, memref<1x1x16x16x4x4xbf16, 2 : i32>)
 // CHECK-LABEL: func.func @func2
 // CHECK: air.launch
 // CHECK: air.segment
-// CHECK: scf.for
-// CHECK: memref.alloc() : memref<1x1x64x64xbf16, 1 : i32>
-// CHECK: %[[EVENT0:.*]] = air.channel.get {{.*}} : (memref<1x1x64x64xbf16, 1 : i32>)
-// CHECK-NEXT: %[[EVENT1:.*]] = air.channel.put {{.*}} : (memref<1x1x64x64xbf16, 1 : i32>)
-// CHECK-NEXT: %[[EVENT2:.*]] = air.channel.put {{.*}} : (memref<1x1x64x64xbf16, 1 : i32>)
-// CHECK: memref.dealloc %{{.*}} : memref<1x1x64x64xbf16, 1 : i32>
+// CHECK: %[[EVENT1:.*]], %[[RESULT1:.*]] = air.execute -> (memref<1x1x16x16x4x4xbf16, 2 : i32>) {
+// CHECK-NEXT: memref.alloc() : memref<1x1x16x16x4x4xbf16, 2 : i32>
+// CHECK: %[[EVENT2:.*]] = air.herd @herd_0 async [%[[EVENT1]]]  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
+// CHECK: func.call @linalg_fill_bf16(%{{.*}}, %{{.*}}) : (bf16, memref<1x1x16x16x4x4xbf16, 2 : i32>) -> ()
+// CHECK: air.herd_terminator
+// CHECK: %[[EVENT3:.*]] = air.herd @herd_0 async [%[[EVENT2]]]  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
+// CHECK: func.call @linalg_fill_bf16(%{{.*}}, %{{.*}}) : (bf16, memref<1x1x16x16x4x4xbf16, 2 : i32>) -> ()
+// CHECK: air.herd_terminator
+// CHECK: %[[EVENT4:.*]] = air.herd @herd_0 async  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
+// CHECK-DAG: %[[CST256:.*]] = arith.constant 256 : index
+// CHECK-DAG: %[[CST8192:.*]] = arith.constant 8192 : index
+// CHECK-DAG: %[[CST1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[CST4:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[CST16:.*]] = arith.constant 16 : index
+// CHECK-DAG: %[[CST0:.*]] = arith.constant 0 : index
+// CHECK: air.channel.put async [{{.*}}]  @channel_12[%{{.*}}, %{{.*}}] (%{{.*}}[%[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]]] [%[[CST1]], %[[CST1]], %[[CST16]], %[[CST4]], %[[CST16]], %[[CST4]]] [%[[CST8192]], %[[CST8192]], %[[CST16]], %[[CST4]], %[[CST256]], %[[CST1]]]) {{.*}} : (memref<1x1x16x16x4x4xbf16, 2 : i32>)
+// CHECK: air.herd_terminator
+// CHECK: memref.dealloc %{{.*}} : memref<1x1x16x16x4x4xbf16, 2 : i32>
 
 #map = affine_map<()[s0] -> (s0 * 128)>
-#map1 = affine_map<()[s0] -> (s0 * 16)>
-#map2 = affine_map<()[s0] -> (s0 * 64)>
-#set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
-#set1 = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 1 >= 0, s1 == 0)>
-func.func @func2(%arg0: memref<512x1024xbf16>) {
+air.channel @channel_12 [2, 2]
+air.channel @channel_5 [1, 1] {broadcast_shape = [1, 2]}
+air.channel @channel_4 [1, 1] {broadcast_shape = [1, 2]}
+func.func private @linalg_fill_bf16(bf16, memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>) attributes {link_with = "mm.o", llvm.emit_c_interface}
+func.func @func2() {
   %c4 = arith.constant 4 : index
-  %0 = air.launch async (%arg3, %arg4) in (%arg5=%c4, %arg6=%c4) args(%arg7=%arg0) : memref<512x1024xbf16> {
-    %c16 = arith.constant 16 : index
-    %c64 = arith.constant 64 : index
-    %c128 = arith.constant 128 : index
-    %c1024 = arith.constant 1024 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %async_token_2, %results_3 = air.execute -> (index) {
-      %7 = affine.apply #map()[%arg3]
-      air.execute_terminator %7 : index
-    }
-    %1 = air.wait_all async 
-    %2 = scf.for %arg10 = %c0 to %c16 step %c1 iter_args(%arg11 = %1) -> (!air.async.token) {
-      %async_token_10, %results_11 = air.execute [%arg11] -> (index) {
-        %8 = affine.apply #map1()[%arg10]
-        air.execute_terminator %8 : index
-      }
-      %7 = air.channel.put async [%async_token_10, %async_token_2]  @channel_10[] (%arg7[%results_3, %results_11] [%c128, %c64] [%c1024, %c1]) {id = 3 : i32} : (memref<512x1024xbf16>)
-      scf.yield %7 : !air.async.token
-    }
-    %6 = air.segment @segment_0 async  attributes {id = 2 : i32} {
-      %c8192 = arith.constant 8192 : index
-      %c8 = arith.constant 8 : index
-      %c256 = arith.constant 256 : index
-      %c4_10 = arith.constant 4 : index
-      %c16384 = arith.constant 16384 : index
-      %c64_11 = arith.constant 64 : index
-      %c0_14 = arith.constant 0 : index
+  %0 = air.launch async (%arg3, %arg4) in (%arg5=%c4, %arg6=%c4) attributes {id = 1 : i32} {
+    %1 = air.segment @segment_0 async  attributes {id = 2 : i32} {
       %c2 = arith.constant 2 : index
-      %c1_15 = arith.constant 1 : index
-      %c16_16 = arith.constant 16 : index
-      %async_token_19, %results_20 = air.execute -> (memref<1x1x8x16x4x8xbf16, 2 : i32>) {
-        %alloc = memref.alloc() : memref<1x1x8x16x4x8xbf16, 2 : i32>
-        air.execute_terminator %alloc : memref<1x1x8x16x4x8xbf16, 2 : i32>
+      %async_token, %results = air.execute -> (memref<1x1x32x32x4x4xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<1x1x32x32x4x4xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<1x1x32x32x4x4xbf16, 2 : i32>
       }
-      %async_token_23, %results_24 = air.execute -> (memref<1x1x128x64xbf16, 1 : i32>) {
-        %alloc = memref.alloc() : memref<1x1x128x64xbf16, 1 : i32>
-        air.execute_terminator %alloc : memref<1x1x128x64xbf16, 1 : i32>
-      }
-      %7 = air.herd @herd_0 async [%async_token_19, %async_token_23]  tile (%arg10, %arg11) in (%arg12=%c2, %arg13=%c2) args(%arg14=%results_20) : memref<1x1x8x16x4x8xbf16, 2 : i32> {
+      %2 = air.herd @herd_0 async [%async_token]  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results) : memref<1x1x32x32x4x4xbf16, 2 : i32> attributes {id = 3 : i32, link_with = "mm.o"} {
         %cst = arith.constant 0.000000e+00 : bf16
-        %async_token_35, %results_36 = air.execute -> (index) {
-          %21 = affine.apply #map2()[%arg10]
-          air.execute_terminator %21 : index
+        %async_token_1, %results_2 = air.execute -> (index) {
+          %5 = affine.apply #map()[%arg7]
+          air.execute_terminator %5 : index
         }
-        %async_token_37, %results_38 = air.execute -> (index) {
-          %21 = affine.apply #map2()[%arg11]
-          air.execute_terminator %21 : index
+        %async_token_3, %results_4 = air.execute -> (index) {
+          %5 = affine.apply #map()[%arg8]
+          air.execute_terminator %5 : index
         }
-        %19 = affine.if #set()[%arg10, %arg11] -> !air.async.token {
-          %21 = air.channel.get async  @channel_4[%arg10, %arg11] (%arg14[] [] []) {id = 12 : i32} : (memref<1x1x8x16x4x8xbf16, 2 : i32>)
-          affine.yield %21 : !air.async.token
-        } else {
-          %21 = air.channel.get async  @channel_5[%arg10, %arg11] (%arg14[] [] []) {id = 13 : i32} : (memref<1x1x8x16x4x8xbf16, 2 : i32>)
-          affine.yield %21 : !air.async.token
+        %subview = memref.subview %arg11[0, 0, %results_4, %results_2, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x32x32x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>
+        %async_token_5 = air.execute {
+          func.call @linalg_fill_bf16(%cst, %subview) : (bf16, memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>) -> ()
         }
         air.herd_terminator
       }
-      %8 = air.wait_all async [%async_token_23, %7] 
-      %9 = scf.for %arg10 = %c0_14 to %c16_16 step %c1_15 iter_args(%arg11 = %async_token_23) -> (!air.async.token) {
-        %19 = air.channel.get async [%arg11]  @channel_10[] (%results_24[] [] []) {id = 16 : i32} : (memref<1x1x128x64xbf16, 1 : i32>)
-        scf.yield %19 : !air.async.token
-      }
-      %11 = scf.for %arg10 = %c0_14 to %c16_16 step %c1_15 iter_args(%arg11 = %async_token_23) -> (!air.async.token) {
-        %19 = air.channel.put async [%async_token_23]  @channel_4[] (%results_24[%c0_14, %c0_14, %c0_14, %c0_14, %c0_14, %c0_14] [%c1_15, %c1_15, %c8, %c16_16, %c4_10, %c8] [%c8192, %c8192, %c8, %c256, %c64_11, %c1_15]) {id = 18 : i32} : (memref<1x1x128x64xbf16, 1 : i32>)
-        scf.yield %19 : !air.async.token
-      }
-      %12 = scf.for %arg10 = %c0_14 to %c16_16 step %c1_15 iter_args(%arg11 = %async_token_23) -> (!air.async.token) {
-        %19 = air.channel.put async [%async_token_23]  @channel_5[] (%results_24[%c0_14, %c0_14, %c0_14, %c0_14, %c64_11, %c0_14] [%c1_15, %c1_15, %c8, %c16_16, %c4_10, %c8] [%c8192, %c8192, %c8, %c256, %c64_11, %c1_15]) {id = 19 : i32} : (memref<1x1x128x64xbf16, 1 : i32>)
-        scf.yield %19 : !air.async.token
-      }
-      %15 = air.herd @herd_0 async [%8]  tile (%arg10, %arg11) in (%arg12=%c2, %arg13=%c2) args(%arg14=%results_20) : memref<1x1x8x16x4x8xbf16, 2 : i32> {
-        %c1_35 = arith.constant 1 : index
-        %c16_36 = arith.constant 16 : index
-        scf.for %arg17 = %c1_35 to %c16_36 step %c1_35 {
-          %19 = affine.if #set()[%arg10, %arg11] -> !air.async.token {
-            %21 = air.channel.get async  @channel_4[%arg10, %arg11] (%arg14[] [] []) {id = 22 : i32} : (memref<1x1x8x16x4x8xbf16, 2 : i32>)
-            affine.yield %21 : !air.async.token
-          } else {
-            %21 = air.channel.get async  @channel_5[%arg10, %arg11] (%arg14[] [] []) {id = 23 : i32} : (memref<1x1x8x16x4x8xbf16, 2 : i32>)
-            affine.yield %21 : !air.async.token
+      %3 = air.herd @herd_0 async [%2]  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results) : memref<1x1x32x32x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
+        %cst = arith.constant 0.000000e+00 : bf16
+        %c1 = arith.constant 1 : index
+        %c16 = arith.constant 16 : index
+        scf.for %arg12 = %c1 to %c16 step %c1 {
+          %async_token_1, %results_2 = air.execute -> (index) {
+            %5 = affine.apply #map()[%arg7]
+            air.execute_terminator %5 : index
+          }
+          %async_token_3, %results_4 = air.execute -> (index) {
+            %5 = affine.apply #map()[%arg8]
+            air.execute_terminator %5 : index
+          }
+          %subview = memref.subview %arg11[0, 0, %results_4, %results_2, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x32x32x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>
+          %async_token_5 = air.execute [%async_token_1, %async_token_3] {
+            func.call @linalg_fill_bf16(%cst, %subview) : (bf16, memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>) -> ()
           }
         }
         air.herd_terminator
       }
-      %async_token_31 = air.execute [%15] {
-        memref.dealloc %results_24 : memref<1x1x128x64xbf16, 1 : i32>
+      %4 = air.herd @herd_0 async  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results) : memref<1x1x32x32x4x4xbf16, 2 : i32> attributes {id = 5 : i32} {
+        %c1 = arith.constant 1 : index
+        %c512 = arith.constant 512 : index
+        %c4_1 = arith.constant 4 : index
+        %c16 = arith.constant 16 : index
+        %c16384 = arith.constant 16384 : index
+        %c0 = arith.constant 0 : index
+        %async_token_2, %results_3 = air.execute -> (index) {
+          %8 = affine.apply #map()[%arg7]
+          air.execute_terminator %8 : index
+        }
+        %async_token_4, %results_5 = air.execute -> (index) {
+          %8 = affine.apply #map()[%arg8]
+          air.execute_terminator %8 : index
+        }
+        %5 = air.wait_all async 
+        %6 = air.wait_all async 
+        %7 = air.channel.put async [%async_token_2, %async_token_4, %5, %6]  @channel_12[%arg7, %arg8] (%arg11[%c0, %c0, %results_5, %results_3, %c0, %c0] [%c1, %c1, %c16, %c4_1, %c16, %c4_1] [%c16384, %c16384, %c16, %c4_1, %c512, %c1]) {id = 27 : i32} : (memref<1x1x32x32x4x4xbf16, 2 : i32>)
+        air.herd_terminator
       }
-      %async_token_33 = air.execute [%15] {
-        memref.dealloc %results_20 : memref<1x1x8x16x4x8xbf16, 2 : i32>
+      %async_token_0 = air.execute [%4] {
+        memref.dealloc %results : memref<1x1x32x32x4x4xbf16, 2 : i32>
       }
       air.segment_terminator
     }


### PR DESCRIPTION
- Rewrite async token tracing for air-loop-fusion
- Rewrite memref shrinkage to account for more complex multi-dimensional cases
- Rewrite memref shrinkage to take into account peeled herd