### PR TITLE
Fixup a bug at AIRToAIEPass AIE.Core lock allocation

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -195,6 +195,7 @@ void simpleDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
                                 MemTileDMAAllocator &memtile_dma_alloc,
                                 TileDMAAllocator &tile_dma_alloc);
 template <typename T> int foundInVector(T item, std::vector<T> vec);
+template <typename T> void push_back_if_unique(SmallVector<T> &vec, T entry);
 int getSCFForLoopDepth(Operation *o);
 bool groupingMemcpysByLoop(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 


### PR DESCRIPTION
Enforce core dma ping-pong to only happen where different L1 buffers were accessed by the same channel.