### PR TITLE
Cleanup AIR_RUNTIME_TARGET support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ foreach(target ${AIR_RUNTIME_TARGETS})
     air_runtime_lib_${target}
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/runtime_libTmp/${target}
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/runtime_lib
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib/${target}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime_lib
     CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
     CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${${target}_TOOLCHAIN_FILE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
@@ -178,6 +178,7 @@ foreach(target ${AIR_RUNTIME_TARGETS})
                -DLibXAIE_ROOT=${LibXAIE_ROOT}
                -Dhsa-runtime64_DIR=${hsa-runtime64_DIR}
                -Dhsakmt_DIR=${hsakmt_DIR}
+               -DAIR_RUNTIME_TARGET=${target}
                -DAIE_DIR=${AIE_DIR}
     BUILD_ALWAYS true
     STEP_TARGETS clean build install test

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -30,7 +30,7 @@ config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.air_obj_root, 'test')
-air_runtime_lib = os.path.join(config.air_obj_root, "runtime_lib", config.test_arch)
+air_runtime_lib = os.path.join(config.air_obj_root, "runtime_lib", config.runtime_test_target)
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
@@ -38,9 +38,9 @@ config.substitutions.append(('%CLANG', "clang"))
 config.substitutions.append(('%LLC', config.llvm_tools_dir + "/llc"))
 config.substitutions.append(('%OPT', config.llvm_tools_dir + "/opt"))
 config.substitutions.append(("%airhost_inc", "-I" + air_runtime_lib + "/airhost/include"))
-config.substitutions.append(("%aircpu_lib", "-L" + air_runtime_lib + "/runtime_lib -laircpu"))
+config.substitutions.append(("%aircpu_lib", "-L" + air_runtime_lib + "/aircpu -laircpu"))
 config.substitutions.append(("%mlir_async_lib", "-L" + config.llvm_obj_root + "/lib -lmlir_async_runtime"))
-config.substitutions.append(("%ld_lib_path", "LD_LIBRARY_PATH=" + air_runtime_lib + "/runtime_lib:" + config.llvm_obj_root + "/lib"))
+config.substitutions.append(("%ld_lib_path", "LD_LIBRARY_PATH=" + air_runtime_lib + "/aircpu:" + config.llvm_obj_root + "/lib"))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -35,7 +35,7 @@ config.host_arch = "@HOST_ARCH@"
 config.aie_tools_dir = "@AIE_TOOLS_BINARY_DIR@"
 config.air_src_root = "@CMAKE_SOURCE_DIR@"
 config.air_obj_root = "@CMAKE_BINARY_DIR@"
-config.test_arch = "@AIR_RUNTIME_TEST_TARGET_VAL@"
+config.runtime_test_target = "@AIR_RUNTIME_TEST_TARGET_VAL@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/runtime_lib/aircpu/CMakeLists.txt
+++ b/runtime_lib/aircpu/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(aircpu SHARED
 set_property(TARGET aircpu PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_target_properties(aircpu PROPERTIES
-         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
-install(TARGETS aircpu DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/aircpu)
+         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${AIR_RUNTIME_TARGET}/aircpu)
+install(TARGETS aircpu DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIR_RUNTIME_TARGET}/aircpu)

--- a/runtime_lib/airhost/CMakeLists.txt
+++ b/runtime_lib/airhost/CMakeLists.txt
@@ -55,12 +55,12 @@ if (hsa-runtime64_FOUND)
   )
 
   set_target_properties(airhost PROPERTIES
-          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
-  install(TARGETS airhost DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
+          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${AIR_RUNTIME_TARGET}/airhost)
+  install(TARGETS airhost DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIR_RUNTIME_TARGET}/airhost)
 
   set_target_properties(airhost_shared PROPERTIES
-          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/runtime_lib)
-  install(TARGETS airhost_shared DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
+          LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${AIR_RUNTIME_TARGET}/airhost)
+  install(TARGETS airhost_shared DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIR_RUNTIME_TARGET}/airhost)
 
 
   # Stuff into the build area:
@@ -69,14 +69,11 @@ if (hsa-runtime64_FOUND)
   add_custom_target(copy-runtime-libs-${file} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file})
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
                       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-                      ${CMAKE_CURRENT_BINARY_DIR}/${file}
+                      ${PROJECT_BINARY_DIR}/${AIR_RUNTIME_TARGET}/airhost/${file}
                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
                       add_dependencies(copy-runtime-libs copy-runtime-libs-${file} )
                       endforeach()
 
-  # Install files
-  set(INSTALLS memory.cpp queue.cpp host.cpp pcie-ernic.cpp pcie-ernic-dev-mem-allocator.cpp network.cpp)
-  install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost)
 endif()
 
 add_subdirectory(include)

--- a/runtime_lib/airhost/include/CMakeLists.txt
+++ b/runtime_lib/airhost/include/CMakeLists.txt
@@ -17,11 +17,11 @@ foreach(file ${INSTALLS})
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file}
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-            ${CMAKE_CURRENT_BINARY_DIR}/${file}
+           ${PROJECT_BINARY_DIR}/${AIR_RUNTIME_TARGET}/airhost/include/${file}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file})
   add_dependencies(copy-runtime-includes copy-runtime-includes-${file})
 endforeach()
 
 # Install too
 install(FILES ${INSTALLS}
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/airhost/include)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIR_RUNTIME_TARGET}/airhost/include)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -46,12 +46,12 @@ config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.air_obj_root, 'test')
-air_runtime_lib = os.path.join(config.air_obj_root, "runtime_lib", config.test_arch)
+air_runtime_lib = os.path.join(config.air_obj_root, "runtime_lib", config.runtime_test_target)
 
 config.substitutions.append(('%PYTHON', config.python_executable))
 config.substitutions.append(('%CLANG', "clang++ -fuse-ld=lld -DLIBXAIENGINEV2"))
 config.substitutions.append(('%LIBXAIE_DIR%', config.libxaie_dir))
-config.substitutions.append(('%AIE_RUNTIME_DIR%', os.path.join(config.aie_obj_root, "runtime_lib", config.test_arch)))
+config.substitutions.append(('%AIE_RUNTIME_DIR%', os.path.join(config.aie_obj_root, "runtime_lib", config.runtime_test_target)))
 config.substitutions.append(("%aietools", config.vitis_aietools_dir))
 
 if config.hsa_found:

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -58,7 +58,7 @@ config.enable_run_xrt_tests = lit.util.pythonize_bool("@ENABLE_RUN_XRT_TESTS@")
 # pass on vitis settings
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.libxaie_dir = "@XILINX_XAIE_DIR@"
-config.test_arch = "@AIR_RUNTIME_TEST_TARGET_VAL@"
+config.runtime_test_target = "@AIR_RUNTIME_TEST_TARGET_VAL@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
Cleanup and finish support for compiling different runtime targets to different directories. I'm not sure if we need this at all anymore, but for now I made the decision to fix what's there instead of removing it.

Supersedes https://github.com/Xilinx/mlir-air/pull/217