### PR TITLE
Cleanup temporary L2 allocations

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -420,12 +420,14 @@ void outlineAIEMemtiles(OpBuilder &builder, AIE::DeviceOp aie_device,
 
     // make the aie.tile
     AIE::TileOp tile = getPhysTileOp(aie_device, phys_x, phys_y);
+
+    // Create a temporary buffer allocated to the memtile. This prevents
+    // an unused memtile from being folded away before the L2 allocation pass.
     auto memrefTy =
         MemRefType::get(SmallVector<int64_t>{1}, builder.getI8Type());
-    builder.create<AIE::BufferOp>(
-        tile->getLoc(), memrefTy, tile, /*sym_name*/ nullptr,
-        /*address*/ nullptr, /*initial_value*/ nullptr,
-        builder.getI32IntegerAttr(0));
+    static uint64_t BufferId = 0;
+    allocateBufferOp(BufferId, memrefTy, tile,
+                     builder.getStringAttr("__L2_tmp"));
   }
 }
 
@@ -1131,6 +1133,19 @@ void allocL2Buffers(AIE::DeviceOp m,
                                            bufferToMemtileMap, BufferId);
     (void)applyPatternsAndFoldGreedily(m, std::move(patterns));
   }
+
+  // Remove L2 temporary buffer allocs now that
+  // allocation is complete.
+  SmallVector<AIE::BufferOp> buffers;
+  m.walk([&](AIE::BufferOp buffer) {
+    auto name = buffer.getSymName();
+    if (!name)
+      return;
+    if (name->starts_with("__L2_tmp"))
+      buffers.push_back(buffer);
+  });
+  for (auto b : buffers)
+    b.erase();
 }
 
 struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -100,7 +100,6 @@ func.func @multi_memcpys_over_time() {
 
 // core-to-core ping pong
 // CHECK: aie.device
-// CHECK:         %[[VAL_0:.*]] = aie.tile(2, 1)
 // CHECK:         %[[VAL_1:.*]] = aie.tile(2, 3)
 // CHECK:         %[[VAL_2:.*]] = aie.tile(2, 4)
 // CHECK:         %[[VAL_3:.*]] = aie.lock(%[[VAL_1]], 1) {init = 2 : i32}
@@ -208,7 +207,6 @@ func.func @core_to_core_ping_pong() {
 
 // core-to-core ping pong, with multi-token scf.for loop
 // CHECK: aie.device
-// CHECK:         %[[VAL_0:.*]] = aie.tile(2, 1)
 // CHECK:         %[[VAL_1:.*]] = aie.tile(2, 3)
 // CHECK:         %[[VAL_2:.*]] = aie.tile(2, 4)
 // CHECK:         %[[VAL_3:.*]] = aie.lock(%[[VAL_1]], 1) {init = 2 : i32}

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -406,8 +406,6 @@ func.func @func5(%arg0 : memref<1024xi32>) -> () {
 // CHECK: aie.device(xcve2802)
 // CHECK: %[[tile_2_0:.*]] = aie.tile(2, 0)
 // CHECK: %[[tile_3_0:.*]] = aie.tile(3, 0)
-// CHECK: %[[tile_2_1:.*]] = aie.tile(2, 1)
-// CHECK: %[[tile_3_1:.*]] = aie.tile(3, 1)
 // CHECK: %[[tile_0_3:.*]] = aie.tile(0, 3)
 // CHECK: %[[tile_1_3:.*]] = aie.tile(1, 3)
 // CHECK: %[[tile_0_4:.*]] = aie.tile(0, 4)

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
@@ -10,7 +10,6 @@
 // CHECK-LABEL:   aie.device(xcve2802) {
 // CHECK:   %[[VAL_0:.*]] = aie.tile(2, 0)
 // CHECK:   %[[VAL_1:.*]] = aie.tile(5, 1)
-// CHECK:   %[[VAL_2:.*]] = aie.tile(6, 1)
 // CHECK:   %[[VAL_3:.*]] = aie.tile(5, 3)
 // CHECK:   %[[VAL_4:.*]] = aie.tile(6, 3)
 // CHECK:   %[[VAL_5:.*]] = aie.tile(5, 4)


### PR DESCRIPTION
cleanup of a [previous fix](https://github.com/Xilinx/mlir-air/pull/540/commits/3e4188325f7bb7d29ad398819cf842cf4c152f45)