### PR TITLE
AIRFuseChannel: Add fine-grained control over memory space

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1021,11 +1021,15 @@ def AIRFuseChannels: Pass<"air-fuse-channels", "ModuleOp"> {
   let description = [{
     This pass fuses multiple air.channel ops into one. The condition for fusing channels 
     is such that the puts and gets of all candidate channels mush share the same control 
-    loop hierarchy, where every parent loops must have matching loop bounds.
+    loop hierarchy, where every parent loops must have matching loop bounds. The 
+    'aggressive-mode' option, when enabled, will attempt to use as few air.channels as 
+    possible by time-multiplexing air.channel.puts and air.channel.gets to share the same
+    air.channel symbol.
   }];
   let options = [
-    Option<"clAggressiveMode", "aggressive-mode", "bool", /*default=*/"false",
-            "When enabled, will attempt to use as few air.channels as possible">
+    ListOption<"clAggressiveMode", "aggressive-mode", "std::string",
+            "List of memory spaces to enable aggressive channel fusion with. Available options include ['L1', 'L2', 'L3'].",
+            "llvm::cl::ZeroOrMore">
   ];
 }
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3111,7 +3111,7 @@ private:
   }
 
   // Check whether puts and gets hit the aggressive mode target memory spaces
-  bool hitsValidMSBasedOnOption(std::vector<air::ChannelPutOp> &puts,
+  bool hitsMemorySpaceForAggMode(std::vector<air::ChannelPutOp> &puts,
                                 std::vector<air::ChannelGetOp> &gets) {
     for (auto put : puts) {
       MemRefType ty = put.getMemref().getType().cast<MemRefType>();
@@ -3149,9 +3149,9 @@ private:
     if (a_gets.size() != b_gets.size())
       return false;
     // Filter out put/get memory space based on aggressive mode option
-    if (!hitsValidMSBasedOnOption(a_puts, a_gets))
+    if (!hitsMemorySpaceForAggMode(a_puts, a_gets))
       return false;
-    if (!hitsValidMSBasedOnOption(b_puts, b_gets))
+    if (!hitsMemorySpaceForAggMode(b_puts, b_gets))
       return false;
     for (unsigned i = 0; i < a_puts.size(); i++) {
       auto a_put_loop_nest = getParentLoopNest(a_puts[i].getOperation());

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3063,17 +3063,17 @@ public:
       return;
     for (unsigned i = 0; i < clAggressiveMode.size(); ++i) {
       if (clAggressiveMode[i] == "L1")
-        targetMemorySpaces.push_back((int)air::MemorySpace::L1);
+        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L1);
       else if (clAggressiveMode[i] == "L2")
-        targetMemorySpaces.push_back((int)air::MemorySpace::L2);
+        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L2);
       else if (clAggressiveMode[i] == "L3")
-        targetMemorySpaces.push_back((int)air::MemorySpace::L3);
+        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L3);
       LLVM_DEBUG(llvm::outs() << "clAggressiveMode[" << i
                               << "] = " << clAggressiveMode[i] << "\n");
     }
   }
 
-  SmallVector<int> targetMemorySpaces;
+  SmallVector<unsigned> targetMemorySpaces;
 
 private:
   void sortChannelsByLoopNests(air::ChannelOp &chan_a, air::ChannelOp &chan_b) {
@@ -3115,7 +3115,7 @@ private:
                                  std::vector<air::ChannelGetOp> &gets) {
     for (auto put : puts) {
       MemRefType ty = put.getMemref().getType().cast<MemRefType>();
-      if (llvm::any_of(targetMemorySpaces, [&](int memSpace) {
+      if (llvm::any_of(targetMemorySpaces, [&](unsigned memSpace) {
             return memSpace == ty.getMemorySpaceAsInt();
           })) {
         return true;
@@ -3123,7 +3123,7 @@ private:
     }
     for (auto get : gets) {
       MemRefType ty = get.getMemref().getType().cast<MemRefType>();
-      if (llvm::any_of(targetMemorySpaces, [&](int memSpace) {
+      if (llvm::any_of(targetMemorySpaces, [&](unsigned memSpace) {
             return memSpace == ty.getMemorySpaceAsInt();
           })) {
         return true;

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3112,7 +3112,7 @@ private:
 
   // Check whether puts and gets hit the aggressive mode target memory spaces
   bool hitsMemorySpaceForAggMode(std::vector<air::ChannelPutOp> &puts,
-                                std::vector<air::ChannelGetOp> &gets) {
+                                 std::vector<air::ChannelGetOp> &gets) {
     for (auto put : puts) {
       MemRefType ty = put.getMemref().getType().cast<MemRefType>();
       if (llvm::any_of(targetMemorySpaces, [&](int memSpace) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2998,6 +2998,7 @@ public:
   }
 
   void runOnFunction(func::FuncOp f, std::vector<air::ChannelOp> channelOps) {
+    init_options();
     if (channelOps.empty())
       return;
     std::map<air::ChannelOp, air::ChannelOp> chan_merge_map;
@@ -3017,7 +3018,7 @@ public:
         chan_merge_map[chanB] = chanA;
       }
     }
-    if (clAggressiveMode) {
+    if (!targetMemorySpaces.empty()) {
       for (unsigned i = 0; i < channelOps.size() - 1; i++) {
         for (unsigned j = i + 1; j < channelOps.size(); j++) {
           if (!checkIfMergeable(channelOps[i], channelOps[j]))
@@ -3056,6 +3057,24 @@ public:
     }
   }
 
+  void init_options() {
+    targetMemorySpaces.clear();
+    if (clAggressiveMode.empty())
+      return;
+    for (unsigned i = 0; i < clAggressiveMode.size(); ++i) {
+      if (clAggressiveMode[i] == "L1")
+        targetMemorySpaces.push_back((int)air::MemorySpace::L1);
+      else if (clAggressiveMode[i] == "L2")
+        targetMemorySpaces.push_back((int)air::MemorySpace::L2);
+      else if (clAggressiveMode[i] == "L3")
+        targetMemorySpaces.push_back((int)air::MemorySpace::L3);
+      LLVM_DEBUG(llvm::outs() << "clAggressiveMode[" << i
+                              << "] = " << clAggressiveMode[i] << "\n");
+    }
+  }
+
+  SmallVector<int> targetMemorySpaces;
+
 private:
   void sortChannelsByLoopNests(air::ChannelOp &chan_a, air::ChannelOp &chan_b) {
     std::vector<air::ChannelPutOp> a_puts =
@@ -3090,7 +3109,33 @@ private:
     } else
       assert(false && "NYI");
   }
+
+  // Check whether puts and gets hit the aggressive mode target memory spaces
+  bool hitsValidMSBasedOnOption(std::vector<air::ChannelPutOp> &puts,
+                                std::vector<air::ChannelGetOp> &gets) {
+    for (auto put : puts) {
+      MemRefType ty = put.getMemref().getType().cast<MemRefType>();
+      if (llvm::any_of(targetMemorySpaces, [&](int memSpace) {
+            return memSpace == ty.getMemorySpaceAsInt();
+          })) {
+        return true;
+      }
+    }
+    for (auto get : gets) {
+      MemRefType ty = get.getMemref().getType().cast<MemRefType>();
+      if (llvm::any_of(targetMemorySpaces, [&](int memSpace) {
+            return memSpace == ty.getMemorySpaceAsInt();
+          })) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool checkIfMergeable(air::ChannelOp chan_a, air::ChannelOp chan_b) {
+    // Check which memory space to time-multiplex channels onto.
+    if (targetMemorySpaces.empty())
+      return false;
     std::vector<air::ChannelPutOp> a_puts =
         getChannelPutOpThroughSymbol(chan_a);
     std::vector<air::ChannelPutOp> b_puts =
@@ -3102,6 +3147,11 @@ private:
     if (a_puts.size() != b_puts.size())
       return false;
     if (a_gets.size() != b_gets.size())
+      return false;
+    // Filter out put/get memory space based on aggressive mode option
+    if (!hitsValidMSBasedOnOption(a_puts, a_gets))
+      return false;
+    if (!hitsValidMSBasedOnOption(b_puts, b_gets))
       return false;
     for (unsigned i = 0; i < a_puts.size(); i++) {
       auto a_put_loop_nest = getParentLoopNest(a_puts[i].getOperation());

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -air-fuse-channels="aggressive-mode=true" -air-place-herds='num-rows=2 num-cols=2 row-anchor=3 col-anchor=5' -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcve2802" %s | FileCheck %s
+// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-place-herds='num-rows=2 num-cols=2 row-anchor=3 col-anchor=5' -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcve2802" %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(xcve2802) {
 // CHECK:   %[[VAL_0:.*]] = aie.tile(2, 0)

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -air-fuse-channels="aggressive-mode=true" -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcve2802" %s | FileCheck %s
+// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcve2802" %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(xcve2802) {
 // CHECK:   %[[VAL_0:.*]] = aie.tile(2, 0)

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -air-fuse-channels="aggressive-mode=true" -air-to-aie="row-offset=2 col-offset=0 device=npu" -canonicalize -cse %s | FileCheck %s
+// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-to-aie="row-offset=2 col-offset=0 device=npu" -canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(npu) {
 // CHECK:   %[[tile_0_0:.*]] = aie.tile(0, 0)

--- a/mlir/test/Conversion/AIRToAIE/async_one_core_gemm_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_one_core_gemm_to_npu.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -air-fuse-channels="aggressive-mode=true" -air-to-aie="row-offset=2 col-offset=0 device=npu" -canonicalize -cse %s | FileCheck %s
+// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-to-aie="row-offset=2 col-offset=0 device=npu" -canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(npu) {
 // CHECK:  %[[VAL_0:.*]] = aie.tile(0, 0)

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
@@ -5,28 +5,38 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-fuse-channels="aggressive-mode=true" --split-input-file | FileCheck %s
-// RUN: air-opt %s -air-fuse-channels="aggressive-mode=false" --split-input-file | FileCheck %s --check-prefix=FUSELOOP
+// RUN: air-opt %s -air-fuse-channels="aggressive-mode=false" --split-input-file | FileCheck %s
+// RUN: air-opt %s -air-fuse-channels="aggressive-mode=L1,L2,L3" --split-input-file | FileCheck %s --check-prefix=AGGRESSIVE
+// RUN: air-opt %s -air-fuse-channels="aggressive-mode=L1" --split-input-file | FileCheck %s --check-prefix=AGGL1
 
 // Have multiple channel put-get pairs share the same symbolic channels.
 // CHECK-LABEL: func0
 // CHECK: air.launch
 // CHECK: air.channel.put @channel_0
-// CHECK: air.channel.put @channel_0
+// CHECK: air.channel.put @channel_1
 // CHECK: air.segment
 // CHECK: air.channel.get @channel_0
-// CHECK: air.channel.get @channel_0
+// CHECK: air.channel.get @channel_1
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func0
-// FUSELOOP: air.launch
-// FUSELOOP: air.channel.put @channel_0
-// FUSELOOP: air.channel.put @channel_1
-// FUSELOOP: air.segment
-// FUSELOOP: air.channel.get @channel_0
-// FUSELOOP: air.channel.get @channel_1
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func0
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.channel.put @channel_0
+// AGGRESSIVE: air.channel.put @channel_0
+// AGGRESSIVE: air.segment
+// AGGRESSIVE: air.channel.get @channel_0
+// AGGRESSIVE: air.channel.get @channel_0
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func0
+// AGGL1: air.launch
+// AGGL1: air.channel.put @channel_0
+// AGGL1: air.channel.put @channel_1
+// AGGL1: air.segment
+// AGGL1: air.channel.get @channel_0
+// AGGL1: air.channel.get @channel_1
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -67,30 +77,45 @@ module {
 // CHECK: air.channel.put @channel_2
 // CHECK: scf.for
 // CHECK: air.channel.put @channel_0
-// CHECK: air.channel.put @channel_0
+// CHECK: air.channel.put @channel_1
 // CHECK: air.herd
 // CHECK: air.channel.get @channel_2
 // CHECK: scf.for
 // CHECK: air.channel.get @channel_0
-// CHECK: air.channel.get @channel_0
+// CHECK: air.channel.get @channel_1
 // CHECK: air.herd_terminator
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func1
-// FUSELOOP: air.launch
-// FUSELOOP: air.segment
-// FUSELOOP: air.channel.put @channel_2
-// FUSELOOP: scf.for
-// FUSELOOP: air.channel.put @channel_0
-// FUSELOOP: air.channel.put @channel_1
-// FUSELOOP: air.herd
-// FUSELOOP: air.channel.get @channel_2
-// FUSELOOP: scf.for
-// FUSELOOP: air.channel.get @channel_0
-// FUSELOOP: air.channel.get @channel_1
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func1
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.segment
+// AGGRESSIVE: air.channel.put @channel_2
+// AGGRESSIVE: scf.for
+// AGGRESSIVE: air.channel.put @channel_0
+// AGGRESSIVE: air.channel.put @channel_0
+// AGGRESSIVE: air.herd
+// AGGRESSIVE: air.channel.get @channel_2
+// AGGRESSIVE: scf.for
+// AGGRESSIVE: air.channel.get @channel_0
+// AGGRESSIVE: air.channel.get @channel_0
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func1
+// AGGL1: air.launch
+// AGGL1: air.segment
+// AGGL1: air.channel.put @channel_2
+// AGGL1: scf.for
+// AGGL1: air.channel.put @channel_0
+// AGGL1: air.channel.put @channel_0
+// AGGL1: air.herd
+// AGGL1: air.channel.get @channel_2
+// AGGL1: scf.for
+// AGGL1: air.channel.get @channel_0
+// AGGL1: air.channel.get @channel_0
+// AGGL1: air.herd_terminator
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -146,21 +171,30 @@ module {
 // CHECK-LABEL: func2
 // CHECK: air.launch
 // CHECK: air.channel.put{{.*}}@channel_0
-// CHECK: air.channel.put{{.*}}@channel_0
+// CHECK: air.channel.put{{.*}}@channel_1
 // CHECK: air.segment
 // CHECK: air.channel.get{{.*}}@channel_0
-// CHECK: air.channel.get{{.*}}@channel_0
+// CHECK: air.channel.get{{.*}}@channel_1
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func2
-// FUSELOOP: air.launch
-// FUSELOOP: air.channel.put{{.*}}@channel_0
-// FUSELOOP: air.channel.put{{.*}}@channel_1
-// FUSELOOP: air.segment
-// FUSELOOP: air.channel.get{{.*}}@channel_0
-// FUSELOOP: air.channel.get{{.*}}@channel_1
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func2
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.channel.put{{.*}}@channel_0
+// AGGRESSIVE: air.channel.put{{.*}}@channel_0
+// AGGRESSIVE: air.segment
+// AGGRESSIVE: air.channel.get{{.*}}@channel_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_0
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func2
+// AGGL1: air.launch
+// AGGL1: air.channel.put{{.*}}@channel_0
+// AGGL1: air.channel.put{{.*}}@channel_1
+// AGGL1: air.segment
+// AGGL1: air.channel.get{{.*}}@channel_0
+// AGGL1: air.channel.get{{.*}}@channel_1
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -215,26 +249,37 @@ module {
 
 // CHECK-LABEL: func3
 // CHECK: air.launch
-// CHECK: air.channel.put{{.*}}@channel_1
+// CHECK: air.channel.put{{.*}}@channel_0
 // CHECK: air.channel.put{{.*}}@channel_1
 // CHECK: air.segment @segment_0
 // CHECK: air.herd @herd_0
-// CHECK: air.channel.get{{.*}}@channel_1
+// CHECK: air.channel.get{{.*}}@channel_0
 // CHECK: air.channel.get{{.*}}@channel_1
 // CHECK: air.herd_terminator
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func3
-// FUSELOOP: air.launch
-// FUSELOOP: air.channel.put{{.*}}@channel_0
-// FUSELOOP: air.channel.put{{.*}}@channel_1
-// FUSELOOP: air.segment @segment_0
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: air.channel.get{{.*}}@channel_0
-// FUSELOOP: air.channel.get{{.*}}@channel_1
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func3
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.channel.put{{.*}}@channel_1
+// AGGRESSIVE: air.channel.put{{.*}}@channel_1
+// AGGRESSIVE: air.segment @segment_0
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_1
+// AGGRESSIVE: air.channel.get{{.*}}@channel_1
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func3
+// AGGL1: air.launch
+// AGGL1: air.channel.put{{.*}}@channel_1
+// AGGL1: air.channel.put{{.*}}@channel_1
+// AGGL1: air.segment @segment_0
+// AGGL1: air.herd @herd_0
+// AGGL1: air.channel.get{{.*}}@channel_1
+// AGGL1: air.channel.get{{.*}}@channel_1
+// AGGL1: air.herd_terminator
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {
@@ -321,25 +366,44 @@ module {
 // CHECK: air.herd_terminator
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func4
-// FUSELOOP: air.launch
-// FUSELOOP: air.segment @segment_0
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: air.channel.get{{.*}}@channel_2
-// FUSELOOP: air.channel.get{{.*}}@channel_3
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: scf.for
-// FUSELOOP-NEXT: scf.for
-// FUSELOOP: air.channel.put{{.*}}@channel_2
-// FUSELOOP: scf.for
-// FUSELOOP-NEXT: scf.for
-// FUSELOOP: air.channel.put{{.*}}@channel_3
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: air.channel.get{{.*}}@channel_2
-// FUSELOOP: air.channel.get{{.*}}@channel_3
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func4
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.segment @segment_0
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_2
+// AGGRESSIVE: air.channel.get{{.*}}@channel_3
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: scf.for
+// AGGRESSIVE-NEXT: scf.for
+// AGGRESSIVE: air.channel.put{{.*}}@channel_2
+// AGGRESSIVE: scf.for
+// AGGRESSIVE-NEXT: scf.for
+// AGGRESSIVE: air.channel.put{{.*}}@channel_3
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_2
+// AGGRESSIVE: air.channel.get{{.*}}@channel_3
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func4
+// AGGL1: air.launch
+// AGGL1: air.segment @segment_0
+// AGGL1: air.herd @herd_0
+// AGGL1: air.channel.get{{.*}}@channel_2
+// AGGL1: air.channel.get{{.*}}@channel_3
+// AGGL1: air.herd_terminator
+// AGGL1: scf.for
+// AGGL1-NEXT: scf.for
+// AGGL1: air.channel.put{{.*}}@channel_2
+// AGGL1: scf.for
+// AGGL1-NEXT: scf.for
+// AGGL1: air.channel.put{{.*}}@channel_3
+// AGGL1: air.herd @herd_0
+// AGGL1: air.channel.get{{.*}}@channel_2
+// AGGL1: air.channel.get{{.*}}@channel_3
+// AGGL1: air.herd_terminator
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 #map = affine_map<(d0) -> (d0 * 8)>
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
@@ -479,17 +543,28 @@ module {
 // CHECK: scf.yield
 // CHECK: air.segment_terminator
 // CHECK: air.launch_terminator
-// FUSELOOP-LABEL: func5
-// FUSELOOP: air.launch
-// FUSELOOP: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
-// FUSELOOP: air.channel.put{{.*}}@channel_4
-// FUSELOOP: scf.yield
-// FUSELOOP: air.segment @segment_0
-// FUSELOOP: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
-// FUSELOOP: air.channel.get{{.*}}@channel_4
-// FUSELOOP: scf.yield
-// FUSELOOP: air.segment_terminator
-// FUSELOOP: air.launch_terminator
+// AGGRESSIVE-LABEL: func5
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGRESSIVE: air.channel.put{{.*}}@channel_4
+// AGGRESSIVE: scf.yield
+// AGGRESSIVE: air.segment @segment_0
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGRESSIVE: air.channel.get{{.*}}@channel_4
+// AGGRESSIVE: scf.yield
+// AGGRESSIVE: air.segment_terminator
+// AGGRESSIVE: air.launch_terminator
+// AGGL1-LABEL: func5
+// AGGL1: air.launch
+// AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGL1: air.channel.put{{.*}}@channel_4
+// AGGL1: scf.yield
+// AGGL1: air.segment @segment_0
+// AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGL1: air.channel.get{{.*}}@channel_4
+// AGGL1: scf.yield
+// AGGL1: air.segment_terminator
+// AGGL1: air.launch_terminator
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 32)>
@@ -578,24 +653,42 @@ module {
 // CHECK: air.channel.get{{.*}}@channel_6
 // CHECK: air.herd_terminator
 // CHECK: air.segment_terminator
-// FUSELOOP-LABEL: func6
-// FUSELOOP: air.segment @segment_0
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: air.channel.get{{.*}}@channel_6
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
-// FUSELOOP-NEXT: scf.parallel
-// FUSELOOP: air.channel.put{{.*}}@channel_6
-// FUSELOOP: scf.reduce
-// FUSELOOP: scf.yield
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
-// FUSELOOP: air.channel.get{{.*}}@channel_6
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: air.herd @herd_0
-// FUSELOOP: air.channel.get{{.*}}@channel_6
-// FUSELOOP: air.herd_terminator
-// FUSELOOP: air.segment_terminator
+// AGGRESSIVE-LABEL: func6
+// AGGRESSIVE: air.segment @segment_0
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_6
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGRESSIVE-NEXT: scf.parallel
+// AGGRESSIVE: air.channel.put{{.*}}@channel_6
+// AGGRESSIVE: scf.reduce
+// AGGRESSIVE: scf.yield
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
+// AGGRESSIVE: air.channel.get{{.*}}@channel_6
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: air.herd @herd_0
+// AGGRESSIVE: air.channel.get{{.*}}@channel_6
+// AGGRESSIVE: air.herd_terminator
+// AGGRESSIVE: air.segment_terminator
+// AGGL1-LABEL: func6
+// AGGL1: air.segment @segment_0
+// AGGL1: air.herd @herd_0
+// AGGL1: air.channel.get{{.*}}@channel_6
+// AGGL1: air.herd_terminator
+// AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
+// AGGL1-NEXT: scf.parallel
+// AGGL1: air.channel.put{{.*}}@channel_6
+// AGGL1: scf.reduce
+// AGGL1: scf.yield
+// AGGL1: air.herd @herd_0
+// AGGL1: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
+// AGGL1: air.channel.get{{.*}}@channel_6
+// AGGL1: air.herd_terminator
+// AGGL1: air.herd @herd_0
+// AGGL1: air.channel.get{{.*}}@channel_6
+// AGGL1: air.herd_terminator
+// AGGL1: air.segment_terminator
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {


### PR DESCRIPTION
The `-aggressive-mode` option now takes as input a list of memory spaces to allow user to control the channel fusion behaviour.