### PR TITLE
[wip] herd runtime parameter support for npu

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -27,10 +27,10 @@ AIE::TileOp getPhysTileOpOrNull(AIE::DeviceOp aie_device, int col, int row);
 AIE::TileOp getPhysTileOp(AIE::DeviceOp aie_device, int col, int row);
 
 AIE::LockOp allocateLockOp(AIE::DeviceOp aie_device, AIE::TileOp tile,
-                           int init = 0, int id = -1);
+                           int init = 0, int id = -1, StringAttr name = nullptr);
 
 std::stringstream
-generateBufferNameInStringStream(std::string prefix, uint64_t &BufferId,
+generateBufferNameInStringStream(StringRef prefix, uint64_t &BufferId,
                                  mlir::StringAttr attr = nullptr, int x = -1,
                                  int y = -1);
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3503,10 +3503,6 @@ public:
                                   AIE::DMAChannelDir::MM2S,
                                   chan_renumber_reverse_map, dma_allocations);
 
-        getSegmentDmaAllocations(builder, ctx, seg, shimDmaAlloc.mm2s_allocs,
-                                 true, chan_renumber_reverse_map,
-                                 dma_allocations);
-
         auto segment_name =
             device->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
                 .getValue();

--- a/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-to-std | FileCheck %s
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: %{{.*}} = airrt.herd_load "herd_0" () : () -> i64
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32, 1>, memref<64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.memcpy_nd({{.*}}) : (memref<64x64xi32>, memref<64x64xi32, 1>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 module attributes {torch.debug_module_name = "mmult"}  {
   func.func @forward(%arg0: memref<64x64xi32>, %arg1: memref<64x64xi32>, %arg2: memref<?x?xi32>) {

--- a/mlir/test/Conversion/AIRLowering/air_herd_rtp.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_herd_rtp.mlir
@@ -1,0 +1,29 @@
+//===- air_herd_rtp.mlir ---------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-std | FileCheck %s
+// CHECK-LABEL: func.func @herd1
+// CHECK: %{{.*}} = airrt.herd_load "herd" (%{{.*}}, %{{.*}}) : (i32, i32) -> i64
+func.func @herd1(%arg0: i32, %arg1: i32) {
+  %cst1 = arith.constant 1 : index
+  %cst2 = arith.constant 2 : index
+  air.herd @herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst2) args(%a = %arg0, %b = %arg1) : i32, i32 {
+    %src0 = memref.alloc() : memref<1xi32, 2>
+    %src1 = memref.alloc() : memref<1xi32, 2>
+    %zero = arith.constant 0 : index
+    %0 = memref.load %src0[%zero] : memref<1xi32, 2>
+    %1 = memref.load %src1[%zero] : memref<1xi32, 2>
+    %2 = arith.addi %0, %a : i32
+    %3 = arith.addi %1, %b : i32
+    %4 = arith.addi %2, %3 : i32
+    %dst0 = memref.alloc() : memref<1xi32, 2>
+    memref.store %4, %dst0[%zero] : memref<1xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -380,6 +380,9 @@ module {
     memref.global "public" @airMemcpyId21 : memref<64x64xi32, 1>
   } {sym_name = "segment_0"}
   airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "segment_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
   }
   func.func @func7(%arg0: memref<2048x512xi32>, %arg1: memref<512x2048xi32>) {
     %c2048_i64 = arith.constant 2048 : i64
@@ -430,6 +433,11 @@ module {
     aie.shim_dma_allocation @airMemcpyId7(S2MM, 0, 0)
     memref.global "public" @airMemcpyId7 : memref<64xi32, 1>
   } {sym_name = "herd"}
+  airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = ""} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd"}
+    }
+  }
   func.func @func8(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
@@ -474,6 +482,9 @@ module {
     memref.global "public" @airMemcpyId21 : memref<256x64xi32, 1>
   } {sym_name = "segment_0"}
   airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "segment_0"} {
+      airrt.herd_metadata {size_x = 4 : i64, size_y = 4 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
   }
   func.func @func9(%arg0: memref<2048x2048xi32>, %arg1: memref<2048x2048xi32>) {
     %c64_i64 = arith.constant 64 : i64
@@ -530,6 +541,9 @@ module {
     memref.global "public" @airMemcpyId21 : memref<256x64xbf16, 1>
   } {sym_name = "segment_0"}
   airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "segment_0"} {
+      airrt.herd_metadata {size_x = 3 : i64, size_y = 3 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
   }
   func.func @func10(%arg2: memref<2304x2304xbf16>) {
     %c64_i64 = arith.constant 64 : i64
@@ -982,6 +996,11 @@ module {
     aie.shim_dma_allocation @airMemcpyId31(S2MM, 0, 0)
     memref.global "public" @airMemcpyId31 : memref<1x2x2x32x32xi32, 1 : i32>
   } {sym_name = "batch_matmul_dispatch_0_batch_matmul_2x64x64x64_i32_0"}
+  airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "segment_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
   func.func @func22(%arg0: memref<2x64x64xi32>) {
     %c32_i64 = arith.constant 32 : i64
     %c2_i64 = arith.constant 2 : i64

--- a/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
@@ -10,123 +10,123 @@
 
 
 // CHECK-LABEL: aie.device(npu1_4col)
-// CHECK: aie.shim_dma_allocation @airMemcpyId29(S2MM, 0, 0)
-// CHECK: memref.global "public" @airMemcpyId29 : memref<128x128xf32, 1>
-// CHECK: aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
-// CHECK: memref.global "public" @airMemcpyId4 : memref<128x256xbf16, 1>
-// CHECK: aie.shim_dma_allocation @airMemcpyId10(MM2S, 1, 0)
-// CHECK: memref.global "public" @airMemcpyId10 : memref<32x8x8x16xbf16, 1>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aie.shim_dma_allocation @[[ID0:airMemcpyId29]](S2MM, 0, 0)
+// CHECK: memref.global "public" @[[ID0]] : memref<128x128xf32, 1>
+// CHECK: aie.shim_dma_allocation @[[ID1:airMemcpyId4]](MM2S, 0, 0)
+// CHECK: memref.global "public" @[[ID1]] : memref<128x256xbf16, 1>
+// CHECK: aie.shim_dma_allocation @[[ID2:airMemcpyId10]](MM2S, 1, 0)
+// CHECK: memref.global "public" @[[ID2]] : memref<32x8x8x16xbf16, 1>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @[[ID1]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @[[ID2]]} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @[[ID0]]} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 
 module {
@@ -139,6 +139,9 @@ module {
     memref.global "public" @airMemcpyId10 : memref<32x8x8x16xbf16, 1>
   } {sym_name = "forward_0"}
   airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
   }
   func.func @forward(%arg0: memref<512x1024xbf16>, %arg1: memref<128x8x8x64xbf16>, %arg2: memref<512x512xf32>) -> memref<512x512xf32> {
     %c384_i64 = arith.constant 384 : i64

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
@@ -96,6 +96,9 @@ module {
     memref.global "public" @airMemcpyId5 : memref<16x8x8x16xbf16, 1>
   } {sym_name = "forward_0"}
   airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
   }
   func.func @forward(%arg0: memref<512x128xbf16>, %arg1: memref<16x8x8x64xbf16>, %arg2: memref<512x512xf32>) -> memref<512x512xf32> {
     %c384_i64 = arith.constant 384 : i64

--- a/mlir/test/Conversion/AIRRtToNpu/herd_load_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/herd_load_to_npu.mlir
@@ -1,0 +1,24 @@
+//===- herd_load_to_npu.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_10_20, 0, 11)
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_10_20, 1, 22)
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_10_21, 0, 11)
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_10_21, 1, 22)
+airrt.module_metadata{
+    airrt.segment_metadata attributes {sym_name = "segment"} {
+        airrt.herd_metadata {size_x = 1 : i64, size_y = 2 : i64, loc_x = 10 : i64, loc_y = 20 : i64, sym_name = "herd"}
+    }
+}
+func.func @func1(%arg0: i32, %arg1: i32) {
+    %c11_i32 = arith.constant 11 : i32
+    %c22_i32 = arith.constant 22 : i32
+    %h = airrt.herd_load "herd" (%c11_i32, %c22_i32) : (i32, i32) -> i64
+    %c1 = arith.constant 1 : index
+    return
+}

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_rtp.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_rtp.mlir
@@ -1,0 +1,48 @@
+//===- air_herd_to_aie.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2021-2022, Xilinx Inc. All rights reserved.
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie | FileCheck %s
+
+func.func @herd1(%arg0: i32, %arg1: i32, %arg2: i32) {
+  // CHECK-LABEL: aie.device
+  // CHECK: %[[VAR1:.*]] = aie.tile(1, 1)
+  // CHECK: %[[VAR2:.*]] = aie.tile(1, 2)
+
+  // CHECK: %[[RTP2:.*]] = aie.buffer(%[[VAR2]]) {{{.*}}sym_name = "__air_herd_rtp_1_2"{{.*}}} : memref<3xi32>  
+  // CHECK: aie.core(%[[VAR2]])
+  // CHECK: load %[[RTP2]][%c0] : memref<3xi32>
+  // CHECK: load %[[RTP2]][%c1] : memref<3xi32>
+  // CHECK: load %[[RTP2]][%c2] : memref<3xi32>
+
+  // CHECK: %[[RTP1:.*]] = aie.buffer(%[[VAR1]]) {{{.*}}sym_name = "__air_herd_rtp_1_1"{{.*}}} : memref<3xi32>
+  // CHECK: aie.core(%[[VAR1]])
+  // CHECK: load %[[RTP1]][%c0] : memref<3xi32>
+  // CHECK: load %[[RTP1]][%c1] : memref<3xi32>
+  // CHECK: load %[[RTP1]][%c2] : memref<3xi32>
+  %cst1 = arith.constant 1 : index
+  %cst2 = arith.constant 2 : index
+  %cst12 = arith.constant 12 : i32
+  %cst23 = arith.constant 23 : i32
+  %cst34 = arith.constant 34 : i32
+  air.herd @herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst2) args(%a = %cst12, %b = %cst23, %c = %cst34) : i32, i32, i32 {
+    %src0 = memref.alloc() : memref<1xi32, 2>
+    %src1 = memref.alloc() : memref<1xi32, 2>
+    %zero = arith.constant 0 : index
+    %0 = memref.load %src0[%zero] : memref<1xi32, 2>
+    %1 = memref.load %src1[%zero] : memref<1xi32, 2>
+    %2 = arith.addi %0, %a : i32
+    %3 = arith.addi %1, %b : i32
+    %4 = arith.addi %2, %3 : i32
+    %5 = arith.addi %4, %c : i32
+    %dst0 = memref.alloc() : memref<1xi32, 2>
+    memref.store %5, %dst0[%zero] : memref<1xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+

--- a/test/xrt/xx_mul_rtp_1x1/run.py
+++ b/test/xrt/xx_mul_rtp_1x1/run.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import air.backend.xrt as xrt_backend
+import air.compiler.aircc.main as aircc
+from air.dialects.air import *
+from air.dialects.func import FuncOp, ReturnOp
+from air.dialects.linalg import elemwise_binary
+from air.dialects.linalg.opdsl.lang import BinaryFn, TypeFn
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.scf import for_, yield_
+from air.ir import *
+
+import numpy as np
+import filelock
+from ml_dtypes import bfloat16
+
+verbose = True
+
+sizes = [
+    [1024],
+]
+
+dtypes = [
+    (np.int32, np.int32),
+    # (np.int16, np.int32),
+    # (np.int16, np.int16),
+    # (np.float32, np.float32),
+    # (bfloat16, np.float32),
+    # (bfloat16, bfloat16),
+]
+
+
+def to_type(dtype):
+    if dtype == np.int32:
+        return T.i32()
+    if dtype == np.int16:
+        return T.i16()
+    if dtype == np.float32:
+        return F32Type.get()
+    if dtype == bfloat16:
+        return BF16Type.get()
+    return None
+
+
+@module_builder
+def build_module(shape, idtype, odtype, tile_size):
+    memrefTyIn = MemRefType.get(shape, to_type(idtype))
+    memrefTyOut = MemRefType.get(shape, to_type(odtype))
+    ChannelOp("ChanA")
+    ChannelOp("ChanB")
+    ChannelOp("ChanC")
+
+    @FuncOp.from_py_func(memrefTyIn, memrefTyIn, memrefTyOut)
+    def mul(arg0, arg1, arg2):
+        @launch(operands=[arg0, arg1, arg2])
+        def launch_body(a, b, c):
+            ChannelPut("ChanA", a)
+            ChannelPut("ChanB", b)
+            ChannelGet("ChanC", c)
+
+            @segment(name="segment_0")
+            def segment_body():
+                c = arith.ConstantOp.create_index(tile_size)
+                @herd(name="herd_0", sizes=[1, 1], operands=[c])
+                def herd_body(x, y, sx, sy, count):
+                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+                    itile_type = MemRefType.get(
+                        shape=[tile_size],
+                        element_type=to_type(idtype),
+                        memory_space=mem_space,
+                    )
+                    otile_type = MemRefType.get(
+                        shape=[tile_size],
+                        element_type=to_type(odtype),
+                        memory_space=mem_space,
+                    )
+                    for _ in for_(count):
+                        tile_a = AllocOp(itile_type, [], [])
+                        tile_b = AllocOp(itile_type, [], [])
+                        tile_c = AllocOp(otile_type, [], [])
+                        ChannelGet("ChanA", tile_a)
+                        ChannelGet("ChanB", tile_b)
+                        elemwise_binary(
+                            tile_a,
+                            tile_b,
+                            outs=[tile_c],
+                            fun=BinaryFn.mul,
+                            cast=TypeFn.cast_unsigned,
+                        )
+                        ChannelPut("ChanC", tile_c)
+                        DeallocOp(tile_a)
+                        DeallocOp(tile_b)
+                        DeallocOp(tile_c)
+                        yield_([])
+
+
+def run_test(size, idtype, odtype):
+
+    mlir_module = build_module(size, idtype, odtype, 32)
+    print(mlir_module)
+
+    input_a = (np.random.rand(*size) * 127).astype(idtype).reshape(size)
+    input_b = (np.random.rand(*size) * 127).astype(idtype).reshape(size)
+    ref = (input_a * input_b).astype(odtype)
+    input_c = np.ones_like(ref)
+
+    backend = xrt_backend.XRTBackend(verbose=verbose)
+
+    # run the module
+    with filelock.FileLock("/tmp/npu.lock"):
+        mul = backend.compile_and_load(mlir_module)
+        print("running")
+        (_, _, output_c) = mul(input_a, input_b, input_c)
+
+    backend.unload()
+
+    print("inputA:", input_a)
+    print("inputB:", input_b)
+    print("output:", output_c)
+
+    if np.allclose(ref, output_c, 0.01):
+        print("PASS!")
+        return 1
+    else:
+        print("failed.")
+        return 0
+
+
+passed = 0
+for idtype, odtype in dtypes:
+    for size in sizes:
+        try:
+            print("Testing size:", size, "dtype:", idtype, odtype)
+            passed = passed + run_test(size, idtype, odtype)
+        except Exception as e:
+            print(e)
+
+num_tests = len(sizes) * len(dtypes)
+if passed != num_tests:
+    print(f"failed. {passed}/{num_tests}")
+    exit(-1)
+else:
+    print(f"PASSED! {passed}/{num_tests}")
+    exit(0)


### PR DESCRIPTION
work in progress to lower `air.herd` integer operands to mlir-aie runtime parameters. i.e `aie.buffer` + `npu.rtp_write` + `memref.load`