### PR TITLE
Propagate function symbol name as base for air.segment symbol name

### DIFF
--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -3249,7 +3249,13 @@ static void getSegmentNames(ModuleOp module) {
         std::string name;
         do {
           std::stringstream ss;
-          ss << "segment_" << id++;
+          assert(
+              f->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()) &&
+              "enclosing function of air.sgement op expected to have a symbol "
+              "name");
+          ss << f->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+                    .str()
+             << "_" << id++;
           name = ss.str();
         } while (std::find(seg_syms.begin(), seg_syms.end(), name) !=
                  seg_syms.end());

--- a/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_launch_and_segment.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_launch_and_segment.mlir
@@ -38,7 +38,7 @@ func.func @f1()  {
 // CHECK-LABEL: func.func @f2
 // CHECK: %[[VAL_0:.*]] = arith.constant 2 : index
 // CHECK: air.launch (%[[VAL_1:.*]], %[[VAL_2:.*]]) in (%[[VAL_3:.*]]=%[[VAL_0]], %[[VAL_4:.*]]=%[[VAL_0]]) {
-// CHECK:   air.segment @segment_2  args(%[[VAL_5:.*]]=%[[VAL_1]], %[[VAL_6:.*]]=%[[VAL_2]], %[[VAL_7:.*]]=%[[VAL_3]], %[[VAL_8:.*]]=%[[VAL_4]]) : index, index, index, index
+// CHECK:   air.segment @f2_0  args(%[[VAL_5:.*]]=%[[VAL_1]], %[[VAL_6:.*]]=%[[VAL_2]], %[[VAL_7:.*]]=%[[VAL_3]], %[[VAL_8:.*]]=%[[VAL_4]]) : index, index, index, index
 func.func @f2()  {
   %c0 = arith.constant 0 : index
   %c32 = arith.constant 32 : index
@@ -51,7 +51,7 @@ func.func @f2()  {
 
 // CHECK-LABEL: func.func @f3
 // CHECK: air.launch
-// CHECK:   air.segment @segment_3
+// CHECK:   air.segment @f3_0
 // CHECK:     memref.alloc() : memref<1x1x64x128xbf16, 1 : i32>
 // CHECK:     memref.alloc() : memref<1x1x16x8x8x4xbf16, 2 : i32>
 // CHECK:     air.dma_memcpy_nd


### PR DESCRIPTION
The current air.segment symbol naming logic makes sure that we don't end up with the same symbol name for air.segments in a given module. But the symbols can still be same across different modules. This can be a problem if we want to merge functions from multiple modules into one. In this PR we use the symbol name of the function enclosing the air.segment op as the base name. This way such conflicts wont happen assuming the function names are unique.