### PR TITLE
Update vck5000 tests after #589

### DIFF
--- a/test/airhost/19_air_nd_memcpy_to_tile_dma/test.cpp
+++ b/test/airhost/19_air_nd_memcpy_to_tile_dma/test.cpp
@@ -25,10 +25,10 @@
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 int32_t mlir_aie_read_buffer_buf0(aie_libxaie_ctx_t *, int);
 };
-using namespace air::segments::segment_0;
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
 

--- a/test/airhost/21_air_nd_memcpy_2d/test.cpp
+++ b/test/airhost/21_air_nd_memcpy_2d/test.cpp
@@ -35,10 +35,10 @@
 #define TILE_HEIGHT 8
 #define TILE_SIZE (TILE_WIDTH * TILE_HEIGHT)
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
 };
-using namespace air::segments::segment_0;
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
   uint64_t row = 3;

--- a/test/airhost/23_air_shim_dma_to_tile_dma/test.cpp
+++ b/test/airhost/23_air_shim_dma_to_tile_dma/test.cpp
@@ -25,11 +25,11 @@
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 void mlir_aie_write_buffer_buf0(aie_libxaie_ctx_t *, int, int32_t);
 uint32_t mlir_aie_read_buffer_buf0(aie_libxaie_ctx_t *, int);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
   uint64_t row = 2;

--- a/test/airhost/24_air_shim_dma_from_tile_dma/test.cpp
+++ b/test/airhost/24_air_shim_dma_from_tile_dma/test.cpp
@@ -27,10 +27,10 @@
 
 #define DMA_COUNT 256
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 void mlir_aie_write_buffer_buf0(aie_libxaie_ctx_t *, int, int32_t);
 };
-using namespace air::segments::segment_0;
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
   uint64_t row = 6;

--- a/test/airhost/25_2d_shim_dma/test.cpp
+++ b/test/airhost/25_2d_shim_dma/test.cpp
@@ -35,11 +35,11 @@
 #define TILE_HEIGHT 8
 #define TILE_SIZE (TILE_WIDTH * TILE_HEIGHT)
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 int32_t mlir_aie_read_buffer_scratch_0_0(aie_libxaie_ctx_t *, int);
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
   auto shim_col = 2;

--- a/test/airhost/34_air_3d_nd_memcpy/test.cpp
+++ b/test/airhost/34_air_3d_nd_memcpy/test.cpp
@@ -34,11 +34,11 @@
 #define TILE_3D 2
 #define TILE_SIZE (TILE_1D * TILE_2D * TILE_3D)
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 int32_t mlir_aie_read_buffer_buf0(aie_libxaie_ctx_t *, int);
 void mlir_aie_write_buffer_buf0(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
 

--- a/test/airhost/35_air_4d_nd_memcpy/test.cpp
+++ b/test/airhost/35_air_4d_nd_memcpy/test.cpp
@@ -39,11 +39,11 @@
 #define TILE_4D 2
 #define TILE_SIZE (TILE_1D * TILE_2D * TILE_3D * TILE_4D)
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 int32_t mlir_aie_read_buffer_buf0(aie_libxaie_ctx_t *, int);
 void mlir_aie_write_buffer_buf0(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
 

--- a/test/airhost/40_air_8x4_2d_square/air_test.cpp
+++ b/test/airhost/40_air_8x4_2d_square/air_test.cpp
@@ -31,7 +31,7 @@
 #define NUM_3D (IMAGE_WIDTH / TILE_WIDTH)
 #define NUM_4D (IMAGE_HEIGHT / TILE_HEIGHT)
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_0_2(aie_libxaie_ctx_t *, int, int32_t);
@@ -64,8 +64,8 @@ void mlir_aie_write_buffer_scratch_7_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_1(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_2(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_7_3(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 int main(int argc, char *argv[]) {
 

--- a/test/airhost/42_air_add_one_place_random/run.lit
+++ b/test/airhost/42_air_add_one_place_random/run.lit
@@ -7,26 +7,26 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
-// RUN: cat air_project/aiecc.segment_0.mlir | grep tile | head -n 1
+// RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
-// RUN: cat air_project/aiecc.segment_0.mlir | grep tile | head -n 1
+// RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
-// RUN: cat air_project/aiecc.segment_0.mlir | grep tile | head -n 1
+// RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
-// RUN: cat air_project/aiecc.segment_0.mlir | grep tile | head -n 1
+// RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf
 
 // RUN: aircc.py -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
-// RUN: cat air_project/aiecc.segment_0.mlir | grep tile | head -n 1
+// RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/42_air_add_one_place_random/test.cpp
+++ b/test/airhost/42_air_add_one_place_random/test.cpp
@@ -25,13 +25,13 @@
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
-namespace air::segments::segment_0 {
+namespace air::segments::graph_0 {
 int32_t mlir_aie_read_buffer_scratch_0_0(aie_libxaie_ctx_t *, int);
 int32_t mlir_aie_read_buffer_scratch_copy_0_0(aie_libxaie_ctx_t *, int);
 void mlir_aie_write_buffer_scratch_0_0(aie_libxaie_ctx_t *, int, int32_t);
 void mlir_aie_write_buffer_scratch_copy_0_0(aie_libxaie_ctx_t *, int, int32_t);
-}; // namespace air::segments::segment_0
-using namespace air::segments::segment_0;
+}; // namespace air::segments::graph_0
+using namespace air::segments::graph_0;
 
 #define DMA_COUNT 16
 


### PR DESCRIPTION
Update vck5000 tests with un-named segments, which now derive their default name from the enclosing `func.func` instead of being called `segment_N`