### PR TITLE
Update CMakeLists.txt include order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,11 +99,11 @@ endif()
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 
-link_directories(${AIE_BINARY_DIR}/lib)
-include_directories(${AIE_INCLUDE_DIRS})
-
 include_directories(${PROJECT_SOURCE_DIR}/mlir/include)
 include_directories(${PROJECT_BINARY_DIR}/mlir/include)
+
+link_directories(${AIE_BINARY_DIR}/lib)
+include_directories(${AIE_INCLUDE_DIRS})
 
 add_definitions(${LLVM_DEFINITIONS})
 


### PR DESCRIPTION
Move the mlir-aie include path to be after the project build area include path. Otherwise, if one uses the same install area for both mlir-aie and mlir-air, then they will likely pick up a stale version of any header that had changed since their last build, leading to general chaos and confusion.