### PR TITLE
Pin numpy version to 1.x

### DIFF
--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -7,6 +7,6 @@ ipykernel
 psutil
 rich
 pybind11
-numpy
+numpy<2
 cmake
 bfloat16


### PR DESCRIPTION
When I was trying to run test/xrt examples, I started to get an error:
```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "/scratch/ehunhoff/mlir-air/test/xrt/03_mul_L1L2_1x1/run.py", line 17, in <module>
    from bfloat16 import bfloat16
AttributeError: _ARRAY_API not found
ImportError: numpy.core.multiarray failed to import
```

Following the advice in the error message, I pinned the numpy version to 1.x