### PR TITLE
Fixup SingleBlockImplicitTerminator interfaces

### DIFF
--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -104,8 +104,9 @@ static LogicalResult canonicalizeHierarchyOpArgs(T op,
   for (int i : newOperandsIdx)
     remap.map(op.getKernelArgument(i), newOp.getKernelArgument(newIdx++));
 
-  for (Operation &o : op.getRegion().front().getOperations())
-    rewriter.clone(o, remap);
+  auto &ops = op.getBody().front().getOperations();
+  for (auto oi = ops.begin(), oe = --ops.end(); oi != oe; ++oi)
+    rewriter.clone(*oi, remap);
 
   rewriter.replaceOp(op, newOp->getResults());
   return success();
@@ -241,6 +242,7 @@ void LaunchOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
+  ensureTerminator(*r, builder, result.location);
 }
 
 void LaunchOp::build(OpBuilder &builder, OperationState &result,
@@ -309,7 +311,8 @@ void LaunchOp::print(OpAsmPrinter &p) {
   }
   if (nameAttr && getBody().front().getOperations().size() == 1)
     return;
-  p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/false);
 }
 
 ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -495,6 +498,7 @@ void SegmentOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
+  ensureTerminator(*r, builder, result.location);
 }
 
 void SegmentOp::build(OpBuilder &builder, OperationState &result,
@@ -565,7 +569,8 @@ void SegmentOp::print(OpAsmPrinter &p) {
   }
   if (nameAttr && getBody().front().getOperations().size() == 1)
     return;
-  p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/false);
 }
 
 ParseResult SegmentOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -753,6 +758,7 @@ void HerdOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
+  ensureTerminator(*r, builder, result.location);
 }
 
 void HerdOp::build(OpBuilder &builder, OperationState &result, ValueRange sizes,
@@ -821,7 +827,8 @@ void HerdOp::print(OpAsmPrinter &p) {
   }
   if (nameAttr && getBody().front().getOperations().size() == 1)
     return;
-  p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/false);
 }
 
 ParseResult HerdOp::parse(OpAsmParser &parser, OperationState &result) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -242,7 +242,7 @@ void LaunchOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
-  ensureTerminator(*r, builder, result.location);
+  LaunchOp::ensureTerminator(*r, builder, result.location);
 }
 
 void LaunchOp::build(OpBuilder &builder, OperationState &result,
@@ -396,7 +396,7 @@ ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
   Region *body = result.addRegion();
 
   auto regionResult = parser.parseOptionalRegion(*body, tileArgs);
-  ensureTerminator(*body, parser.getBuilder(), result.location);
+  LaunchOp::ensureTerminator(*body, parser.getBuilder(), result.location);
 
   if (!regionResult.has_value()) {
     if (!nameAttr)
@@ -498,7 +498,7 @@ void SegmentOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
-  ensureTerminator(*r, builder, result.location);
+  SegmentOp::ensureTerminator(*r, builder, result.location);
 }
 
 void SegmentOp::build(OpBuilder &builder, OperationState &result,
@@ -656,7 +656,7 @@ ParseResult SegmentOp::parse(OpAsmParser &parser, OperationState &result) {
 
   Region *body = result.addRegion();
   auto regionResult = parser.parseOptionalRegion(*body, tileArgs);
-  ensureTerminator(*body, parser.getBuilder(), result.location);
+  SegmentOp::ensureTerminator(*body, parser.getBuilder(), result.location);
 
   if (!regionResult.has_value()) {
     if (!nameAttr)
@@ -758,7 +758,7 @@ void HerdOp::build(OpBuilder &builder, OperationState &result,
     body->addArgument(v.getType(), builder.getUnknownLoc());
   }
   r->push_back(body);
-  ensureTerminator(*r, builder, result.location);
+  HerdOp::ensureTerminator(*r, builder, result.location);
 }
 
 void HerdOp::build(OpBuilder &builder, OperationState &result, ValueRange sizes,
@@ -915,7 +915,7 @@ ParseResult HerdOp::parse(OpAsmParser &parser, OperationState &result) {
   Region *body = result.addRegion();
 
   auto regionResult = parser.parseOptionalRegion(*body, tileArgs);
-  ensureTerminator(*body, parser.getBuilder(), result.location);
+  HerdOp::ensureTerminator(*body, parser.getBuilder(), result.location);
 
   if (!regionResult.has_value()) {
     if (!nameAttr)

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -776,7 +776,6 @@ private:
                                                     air::HierarchyInterface op,
                                                     uint64_t &HierarchyOpID) {
     builder.setInsertionPoint(op);
-    auto loc = op->getLoc();
     SmallVector<Value, 1> deps;
     SmallVector<Value, 4> args;
     SmallVector<Value, 4> constants;
@@ -793,9 +792,6 @@ private:
       auto new_launch = createAsyncHierarchy<air::LaunchOp>(
           builder, launch, HierarchyOpID, deps, args, constants);
       new_op = new_launch.getOperation();
-      auto &bb = new_launch.getBody().front();
-      builder.setInsertionPointToEnd(&bb);
-      builder.create<air::LaunchTerminatorOp>(loc);
       // Create a vertex out of the current hierarchy op
       auto v = asyncExecuteGraph.addVertex();
       asyncExecuteGraph[v].asyncEventName = "air::launch";
@@ -809,9 +805,6 @@ private:
       auto new_segment = createAsyncHierarchy<air::SegmentOp>(
           builder, segment, HierarchyOpID, deps, args, constants);
       new_op = new_segment.getOperation();
-      auto &bb = new_segment.getBody().front();
-      builder.setInsertionPointToEnd(&bb);
-      builder.create<air::SegmentTerminatorOp>(loc);
       // Create a vertex out of the current hierarchy op
       auto v = asyncExecuteGraph.addVertex();
       asyncExecuteGraph[v].asyncEventName = "air::segment";
@@ -825,9 +818,6 @@ private:
       auto new_herd = createAsyncHierarchy<air::HerdOp>(
           builder, herd, HierarchyOpID, deps, args, constants);
       new_op = new_herd.getOperation();
-      auto &bb = new_herd.getBody().front();
-      builder.setInsertionPointToEnd(&bb);
-      builder.create<air::HerdTerminatorOp>(loc);
       // Create a vertex out of the current hierarchy op
       auto v = asyncExecuteGraph.addVertex();
       asyncExecuteGraph[v].asyncEventName = "air::herd";

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -854,10 +854,8 @@ struct HoistAIRHerdInForPattern : public OpRewritePattern<air::HerdOp> {
     auto newHerdOp = rewriter.create<air::HerdOp>(
         loc, forRegionIterOperands, herdOp.getSizeOperands(), herdOperands,
         true, herdOp->getAttrs());
-    auto builder = OpBuilder::atBlockEnd(&newHerdOp.getBody().front());
-    auto newHerdTerm = builder.create<air::HerdTerminatorOp>(loc);
-    outerMostLoop->moveBefore(newHerdTerm);
-    builder.setInsertionPointToStart(&newHerdOp.getBody().front());
+    outerMostLoop->moveBefore(newHerdOp.getBody().front().getTerminator());
+    OpBuilder builder(outerMostLoop);
 
     // Replace uses of tokens and consts in for loop nest.
     for (auto val : forRegionIterOperands) {

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -1042,8 +1042,6 @@ FailureOr<linalg::TiledLinalgOp> static pipelineReduceLinalgOp(
     // if (erased) erased.erase();
   }
 
-  b.setInsertionPointToEnd(&herd.getBody().front());
-  b.create<air::HerdTerminatorOp>(loc);
   int i = 0;
   for (auto a : args) {
     replaceAllUsesInRegionWith(a, herd.getKernelArgument(i++), herd.getBody());

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -785,7 +785,6 @@ void AIRFuseParallelHerdPass::runOnOperation() {
       b.clone(o, remap);
     }
   }
-  b.create<air::HerdTerminatorOp>(parOp.getLoc());
 
   b.setInsertionPointToStart(&newLaunchOp.getBody().front());
   for (auto c : constants) {

--- a/mlir/test/Conversion/AIRLowering/air_L1L2_memcpy.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_L1L2_memcpy.mlir
@@ -21,7 +21,6 @@ module  {
       %1 = memref.alloc() : memref<16xi32, 2>
       air.dma_memcpy_nd (%1[][][], %arg6 [%c0] [%c16] [%c16]) {id = 1 : i32} : (memref<16xi32, 2>, memref<1024xi32, 1>)
       air.dma_memcpy_nd (%arg6[%c16] [%c0] [%c16], %1[][][]) {id = 2 : i32} : (memref<1024xi32, 1>, memref<16xi32, 2>)
-      air.herd_terminator
     }
     memref.dealloc %0 : memref<1024xi32, 1>
     return

--- a/mlir/test/Conversion/AIRLowering/air_L1L2_memcpy_async.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_L1L2_memcpy_async.mlir
@@ -24,7 +24,6 @@ module  {
       %e0 = air.dma_memcpy_nd async (%1[][][], %arg6[%c0][%c16][%c16]) {id = 1 : i32} : (memref<16xi32, 2>, memref<1024xi32, 1>)
       %e1 = air.dma_memcpy_nd async [%e0] (%arg6[%c16][%c0][%c16], %1[][][]) {id = 2 : i32} : (memref<1024xi32, 1>, memref<16xi32, 2>)
       air.wait_all [%e0, %e1]
-      air.herd_terminator
     }
     memref.dealloc %0 : memref<1024xi32, 1>
     return

--- a/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_L2L3_to_airrt.mlir
@@ -69,7 +69,6 @@ module attributes {torch.debug_module_name = "mmult"}  {
         memref.dealloc %8 : memref<32x32xi32, 2>
         memref.dealloc %9 : memref<32x32xi32, 2>
       }
-      air.herd_terminator
     }
     air.dma_memcpy_nd (%1[%c0, %c0] [%c64, %c64] [%c64, %c1], %4[] [] []) {id = 8 : i32} : (memref<64x64xi32>, memref<64x64xi32, 1>)
     memref.dealloc %2 : memref<64x64xi32, 1>

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -45,11 +45,8 @@ module {
           air.channel.put  @channel_1[%arg10, %arg11] (%alloc_8[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 4 : i32} : (memref<16x8xi32, 2>)
           memref.dealloc %alloc_8 : memref<16x8xi32, 2>
           memref.dealloc %alloc : memref<16x8xi32, 2>
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -114,11 +111,8 @@ module {
           air.channel.put  @channel_3[%arg10, %arg11] (%alloc_8[%c0_4, %c0_4] [%c8_7, %c16_6] [%c32_5, %c0_4]) {id = 4 : i32} : (memref<16x8xi32, 2>)
           memref.dealloc %alloc_8 : memref<16x8xi32, 2>
           memref.dealloc %alloc : memref<16x8xi32, 2>
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -192,11 +186,8 @@ module {
           }
           memref.dealloc %alloc_10 : memref<16x8xi32, 2>
           memref.dealloc %alloc : memref<16x8xi32, 2>
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -239,14 +230,11 @@ module {
           %async_token_7 = air.execute [%async_token_5] {
             memref.dealloc %results_6 : memref<32xf32, 2>
           }
-          air.herd_terminator
         }
         %async_token_4 = air.execute [%4] {
           memref.dealloc %results_3 : memref<64xf32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRLowering/air_deps.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_deps.mlir
@@ -131,9 +131,7 @@ func.func @scf_for_par(%arg0: memref<1024x512xi8>, %arg1: memref<512x1024xi8>, %
         }
         scf.yield %29 : !air.async.token
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRLowering/air_launch.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_launch.mlir
@@ -37,7 +37,6 @@ func.func @launch_1() {
   %e0 = air.wait_all async
   %e1 = air.wait_all async [%e0]
   %t = air.launch async [%e0, %e1] () in () {
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRLowering/air_pipeline.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_pipeline.mlir
@@ -80,7 +80,6 @@ module  {
         }
         air.pipeline.terminator
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRLowering/air_shimcpy_to_airrt.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_shimcpy_to_airrt.mlir
@@ -46,7 +46,6 @@ module  {
             memref.dealloc %4 : memref<32x32x128xi32, 2>
             memref.dealloc %5 : memref<32x32x128xi32, 2>
             memref.dealloc %6 : memref<32x32x128xi32, 2>
-            air.herd_terminator
           }
         }
       }

--- a/mlir/test/Conversion/AIRLowering/air_to_npu.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_to_npu.mlir
@@ -51,13 +51,11 @@ module {
         air.channel.put  @channel_2[%arg2, %arg3] (%alloc_2[] [] []) {id = 5 : i32} : (memref<64xi32, 2>)
         memref.dealloc %alloc_1 : memref<64xi32, 2>
         memref.dealloc %alloc_2 : memref<64xi32, 2>
-        air.herd_terminator
       }
       %alloc_0 = memref.alloc() : memref<64xi32, 1>
       air.channel.get  @channel_2[] (%alloc_0[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
       air.channel.put  @channel_3[] (%alloc_0[] [] []) {id = 7 : i32} : (memref<64xi32, 1>)
       memref.dealloc %alloc_0 : memref<64xi32, 1>
-      air.segment_terminator
     }
     air.channel.get  @channel_3[] (%arg1[] [] []) {id = 8 : i32, metadata = @airMemcpyId7} : (memref<64xi32>)
     return
@@ -131,7 +129,6 @@ module {
         %async_token_10 = air.execute [%9] {
           memref.dealloc %results_7 : memref<64xi32, 2>
         } {id = 7 : i32}
-        air.herd_terminator
       }
       %async_token_1, %results_2 = air.execute -> (memref<64xi32, 1>) {
         %alloc = memref.alloc() : memref<64xi32, 1>
@@ -142,7 +139,6 @@ module {
       %async_token_3 = air.execute [%7] {
         memref.dealloc %results_2 : memref<64xi32, 1>
       } {id = 9 : i32}
-      air.segment_terminator
     }
     %2 = air.channel.get async  @channel_3[] (%arg1[] [] []) {id = 8 : i32, metadata = @airMemcpyId7} : (memref<64xi32>)
     return
@@ -229,9 +225,7 @@ module {
         %async_token_19 = air.execute [%7] {
           memref.dealloc %results_16 : memref<1x1x8x16xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
@@ -78,11 +78,8 @@ func.func @one_to_one() {
         %async_token_8 = air.execute [%3] {
           memref.dealloc %results_7 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -126,11 +123,8 @@ func.func @two_to_two() {
         %async_token_8 = air.execute [%3] {
           memref.dealloc %results_7 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -185,11 +179,8 @@ func.func @one_to_two() {
         %async_token_8 = air.execute [%3] {
           memref.dealloc %results_7 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -87,11 +87,8 @@ func.func @multi_memcpys_over_time() {
         %async_token_7 = air.execute [%5] {
           memref.dealloc %results_5 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -194,11 +191,8 @@ func.func @core_to_core_ping_pong() {
         %async_token_9 = air.execute [%3] {
           memref.dealloc %results_7 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -315,11 +309,8 @@ func.func @core_to_core_ping_pong() {
           }
           affine.yield %4#2 : !air.async.token
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -393,7 +384,6 @@ func.func @not_really_ping_pong() {
       }
       %7 = air.herd @herd_0 async  tile (%arg7, %arg8) in (%arg9=%c1_24, %arg10=%c1_24) args(%arg11=%results_32) : memref<1x1x4x8x4x8xi32, 2 : i32> attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 3 : i64} {
         %23 = air.channel.get async  @channel_2[] (%arg11[] [] []) {id = 4 : i32} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-        air.herd_terminator
       }
       %async_token_39, %results_40 = air.execute -> (memref<1x1x64x32xi32, 1 : i32>) {
         %alloc = memref.alloc() : memref<1x1x64x32xi32, 1 : i32>
@@ -412,14 +402,11 @@ func.func @not_really_ping_pong() {
         scf.for %arg14 = %c1_52 to %c5_51 step %c1_52 {
           %23 = air.channel.get async  @channel_2[] (%arg11[] [] []) {id = 26 : i32} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
         }
-        air.herd_terminator
       }
       %async_token_47 = air.execute {
         memref.dealloc %results_32 : memref<1x1x4x8x4x8xi32, 2 : i32>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectfifo_L1toL2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectfifo_L1toL2.mlir
@@ -63,11 +63,8 @@ module {
             %async_token_3 = air.execute [%9] {
               memref.dealloc %results_2 : memref<32xi32, 2>
             }
-            air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_objectfifo_L2_broadcast.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_objectfifo_L2_broadcast.mlir
@@ -71,11 +71,8 @@ module {
             %async_token_3 = air.execute [%9] {
               memref.dealloc %results_2 : memref<32xi32, 2>
             }
-            air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie.mlir
@@ -29,7 +29,6 @@ func.func @foo(%arg0: i32) {
     %dst0 = memref.alloc() : memref<1xi32, 2>
     // CHECK: memref.store {{.*}}, %[[BUF3]]
     memref.store %2, %dst0[%zero] : memref<1xi32, 2>
-    air.herd_terminator
   }
   // CHECK: sym_name = "herd_0"
   return

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_buf_names.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_buf_names.mlir
@@ -21,7 +21,6 @@ func.func @launch(%arg0: i32) {
     %buf1 = memref.alloc() : memref<10xindex,2>
     memref.dealloc %buf0 : memref<10xindex,2>
     memref.dealloc %buf1 : memref<10xindex,2>
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
@@ -21,7 +21,6 @@ func.func @foo(%arg0: i32) {
   air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with="beefmaker.o"} {
     %src0 = memref.alloc() : memref<1024xi32, 2>
     func.call @beefmaker_kernel(%src0) : (memref<1024xi32, 2>) -> ()
-    air.herd_terminator
   }
   return
 } 

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_sizes.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_sizes.mlir
@@ -19,7 +19,6 @@ func.func @launch(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     memref.store %0, %buf[%1] : memref<1024xindex,2>
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -44,7 +44,6 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %buf0 = memref.alloc() : memref<1024xi32, 2>
     air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) {id = 1 : i32} : (memref<1024xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -102,7 +101,6 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.dma_memcpy_nd (%buf1[] [] [], %ext0[%c0] [%c512] [%c1]) {id = 2 : i32} : (memref<512xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -164,7 +162,6 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.channel.put @channel_1[%tx, %ty] (%buf1[] [] []) {id = 3 : i32} : (memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   air.channel.get @channel_1[] (%arg1[%c0] [%c512] [%c1]) {id = 4 : i32} : (memref<1024xi32>)
   return
@@ -227,7 +224,6 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.channel.get @channel_3[%tx, %ty] (%buf1[] [] []) {id = 4 : i32} : (memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -300,7 +296,6 @@ func.func @func5(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %token_8 = air.execute [%token_6] {
       memref.dealloc %buf1 : memref<512xi32, 2>
     }
-    air.herd_terminator
   }
   return
 }
@@ -378,7 +373,6 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %token_8 = air.execute [%aif1] {
       memref.dealloc %buf1 : memref<512xi32, 2>
     }
-    air.herd_terminator
   }
   return
 }
@@ -498,7 +492,6 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
     %token_13 = air.execute [%token_12] {
       memref.dealloc %buf0 : memref<1024xi32, 2>
     }
-    air.herd_terminator
   }
   return
 }
@@ -554,7 +547,6 @@ module {
       air.dma_memcpy_nd (%arg7[%c8, %c0] [%c8, %c16] [%c32, %c1_1], %alloc_0[%c0, %c0] [%c8, %c16] [%c32, %c1_1]) {id = 2 : i32} : (memref<32x16xi32>, memref<16x8xi32, 2>)
       memref.dealloc %alloc_0 : memref<16x8xi32, 2>
       memref.dealloc %alloc : memref<16x8xi32, 2>
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -45,7 +45,6 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %buf0 = memref.alloc() : memref<1024xi32, 2>
     air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) : (memref<1024xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -109,7 +108,6 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.dma_memcpy_nd (%ext0[%c0] [%c512] [%c1], %buf1[] [] []) {id = 2 : i32} : (memref<1024xi32>, memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -181,7 +179,6 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.channel.put @channel_1[%tx, %ty] (%buf1[] [] []) {id = 3 : i32} : (memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   air.channel.get @channel_1[] (%arg1[%c0] [%c512] [%c1]) {id = 4 : i32} : (memref<1024xi32>)
   return
@@ -295,13 +292,11 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
       air.channel.get @channel_3[%tx, %ty] (%buf0[] [] []) {id = 4 : i32} : (memref<1024xi32, 2>)
       air.channel.put @channel_4[%tx, %ty] (%buf0[] [] []) {id = 5 : i32} : (memref<1024xi32, 2>)
       memref.dealloc %buf0 : memref<1024xi32, 2>
-      air.herd_terminator
     }
     %memtile1 = memref.alloc() : memref<1024xi32, 1>
     air.channel.get @channel_4[] (%memtile1[] [] []) {id = 6 : i32} : (memref<1024xi32, 1>)
     air.channel.put @channel_5[] (%memtile1[] [] []) {id = 7 : i32} : (memref<1024xi32, 1>)
     memref.dealloc %memtile1 : memref<1024xi32, 1>
-    air.segment_terminator
   }
   air.channel.get @channel_5[] (%arg1[] [] []) {id = 8 : i32} : (memref<1024xi32>)
   return
@@ -393,9 +388,7 @@ func.func @func5(%arg0 : memref<1024xi32>) -> () {
       %token_9 = air.execute [%aif1] {
         memref.dealloc %buf1 : memref<512xi32, 2>
       }
-      air.herd_terminator
     }
-    air.segment_terminator
   }
   return
 }
@@ -464,11 +457,8 @@ func.func @func6(%arg5 : memref<8x8xi32>) {
         %async_token_45 = air.execute [%27] {
           memref.dealloc %results_35 : memref<4x4xi32, 2>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -516,7 +506,6 @@ func.func @func7(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
       %results_35 = memref.alloc() : memref<4x4xi32, 2>
       air.channel.put @channel_2[%arg6, %arg7] (%results_35[] [] []) {id = 14 : i32} : (memref<4x4xi32, 2>)
       memref.dealloc %results_35 : memref<4x4xi32, 2>
-      air.herd_terminator
     }
     %buf0 = memref.alloc() : memref<4x4xi32, 1>
     %buf1 = memref.alloc() : memref<8x16xi32, 1>
@@ -525,7 +514,6 @@ func.func @func7(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
     air.channel.get @channel_2[] (%buf1[%c0, %c0] [%c4, %c4] [%c16, %c1]) {id = 4 : i32} : (memref<8x16xi32, 1>)
     memref.dealloc %buf0 : memref<4x4xi32, 1>
     memref.dealloc %buf1 : memref<8x16xi32, 1>
-    air.segment_terminator
   }
   air.channel.get @channel_1[] (%arg1[] [] []) {id = 4 : i32} : (memref<16x8xi32>)
   return
@@ -561,12 +549,10 @@ func.func @func8(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
       %results_35 = memref.alloc() : memref<32x32xi32, 2>
       air.channel.get @channel_0[%arg6, %arg7] (%results_35[] [] []) {id = 14 : i32} : (memref<32x32xi32, 2>)
       memref.dealloc %results_35 : memref<32x32xi32, 2>
-      air.herd_terminator
     }
     %buf0 = memref.alloc() : memref<64x256xi32, 1>
     air.channel.put @channel_0[] (%buf0[%c0, %c32, %c0] [%c8, %c32, %c32] [%c32, %c256, %c1]) : (memref<64x256xi32, 1>)
     memref.dealloc %buf0 : memref<64x256xi32, 1>
-    air.segment_terminator
   }
   return
 }
@@ -623,14 +609,11 @@ func.func @func9(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
         %async_token_5 = air.execute [%5] {
           memref.dealloc %results_4 : memref<32xf32, 2>
         }
-        air.herd_terminator
       }
       %async_token_1 = air.execute [%3] {
         memref.dealloc %results : memref<64xf32, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -688,14 +671,11 @@ func.func @func10(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
         %async_token_5 = air.execute [%5] {
           memref.dealloc %results_4 : memref<32x256xi32, 2>
         }
-        air.herd_terminator
       }
       %async_token_1 = air.execute [%3] {
         memref.dealloc %results : memref<32x256xi32, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -755,14 +735,11 @@ func.func @func11(%arg0: memref<128xbf16>, %arg1: memref<128xbf16>) {
         %async_token_5 = air.execute [%5] {
           memref.dealloc %results_4 : memref<32x256xbf16, 2>
         }
-        air.herd_terminator
       }
       %async_token_1 = air.execute [%3] {
         memref.dealloc %results : memref<32x256xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -947,7 +924,6 @@ module {
           %async_token_17 = air.execute [%35] {
             memref.dealloc %results_16 : memref<16x16x4x4xbf16, 2>
           }
-          air.herd_terminator
         }
         %13 = air.channel.put async [%12]  @channel_0[] (%results_5[] [] []) {id = 45 : i32} : (memref<64x256xbf16, 1>)
         %14 = air.channel.put async [%12]  @channel_1[] (%results_6[] [] []) {id = 46 : i32} : (memref<64x256xbf16, 1>)
@@ -966,9 +942,7 @@ module {
         %async_token_12 = air.execute [%17] {
           memref.dealloc %results_8 : memref<64x256xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -1039,7 +1013,6 @@ module {
             air.execute_terminator %7 : index
           }
           %6 = air.channel.put async  @channel_8[%arg6, %arg7] (%arg10[%results_13, %c0_11, %results_15, %c0_11] [%c16, %c4, %c16, %c4] [%c16, %c4, %c256, %c1_10]) {id = 19 : i32} : (memref<1x1x16x16x4x4xf32, 2 : i32>)
-          air.herd_terminator
         }
         %5 = air.channel.put async [%4]  @channel_9[] (%results_5[] [] []) {id = 20 : i32} : (memref<1x1x64x64xf32, 1 : i32>)
         %async_token_8 = air.execute [%4] {
@@ -1048,9 +1021,7 @@ module {
         %async_token_9 = air.execute [%4] {
           memref.dealloc %results_5 : memref<1x1x64x64xf32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -51,7 +51,6 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %buf0 = memref.alloc() : memref<1024xi32, 2>
     air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) : (memref<1024xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -129,7 +128,6 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.dma_memcpy_nd (%ext0[%c0] [%c512] [%c1], %buf1[] [] []) {id = 2 : i32} : (memref<1024xi32>, memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -214,7 +212,6 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.channel.put @channel_1[%tx, %ty] (%buf1[] [] []) {id = 3 : i32} : (memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   air.channel.get @channel_1[] (%arg1[%c0] [%c512] [%c1]) {id = 4 : i32} : (memref<1024xi32>)
   return
@@ -347,13 +344,11 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
       air.channel.get @channel_3[%tx, %ty] (%buf0[] [] []) {id = 4 : i32} : (memref<1024xi32, 2>)
       air.channel.put @channel_4[%tx, %ty] (%buf0[] [] []) {id = 5 : i32} : (memref<1024xi32, 2>)
       memref.dealloc %buf0 : memref<1024xi32, 2>
-      air.herd_terminator
     }
     %memtile1 = memref.alloc() : memref<1024xi32, 1>
     air.channel.get @channel_4[] (%memtile1[] [] []) {id = 6 : i32} : (memref<1024xi32, 1>)
     air.channel.put @channel_5[] (%memtile1[] [] []) {id = 7 : i32} : (memref<1024xi32, 1>)
     memref.dealloc %memtile1 : memref<1024xi32, 1>
-    air.segment_terminator
   }
   air.channel.get @channel_5[] (%arg1[] [] []) {id = 8 : i32} : (memref<1024xi32>)
   return

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
@@ -52,7 +52,6 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     %buf0 = memref.alloc() : memref<1024xi32, 2>
     air.dma_memcpy_nd (%buf0[] [] [], %ext0[%c0] [%c1024] [%c1]) : (memref<1024xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -132,7 +131,6 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.dma_memcpy_nd (%buf1[] [] [], %ext0[%c0] [%c512] [%c1]) {id = 2 : i32} : (memref<512xi32, 2>, memref<1024xi32>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   return
 }
@@ -216,7 +214,6 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.channel.put @channel_1[%tx, %ty] (%buf1[] [] []) {id = 3 : i32} : (memref<512xi32, 2>)
     memref.dealloc %buf0 : memref<1024xi32, 2>
     memref.dealloc %buf1 : memref<512xi32, 2>
-    air.herd_terminator
   }
   air.channel.get @channel_1[] (%arg1[%c0] [%c512] [%c1]) {id = 4 : i32} : (memref<1024xi32>)
   return

--- a/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
@@ -124,13 +124,11 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
       air.channel.put @channel_2[%tx, %ty] (%buf1[] [] []) {id = 5 : i32} : (memref<64xi32, 2>)
       memref.dealloc %buf0 : memref<64xi32, 2>
       memref.dealloc %buf1 : memref<64xi32, 2>
-      air.herd_terminator
     }
     %memtile1 = memref.alloc() : memref<64xi32, 1>
     air.channel.get @channel_2[] (%memtile1[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
     air.channel.put @channel_3[] (%memtile1[] [] []) {id = 7 : i32} : (memref<64xi32, 1>)
     memref.dealloc %memtile1 : memref<64xi32, 1>
-    air.segment_terminator
   }
   air.channel.get @channel_3[] (%arg1[] [] []) {id = 8 : i32} : (memref<64xi32>)
   return
@@ -274,7 +272,6 @@ module {
         %async_token_12 = air.execute [%9] {
           memref.dealloc %results_9 : memref<64xi32, 2>
         } {id = 7 : i32}
-        air.herd_terminator
       }
       %async_token_3, %results_4 = air.execute -> (memref<64xi32, 1>) {
         %alloc = memref.alloc() : memref<64xi32, 1>
@@ -285,7 +282,6 @@ module {
       %async_token_5 = air.execute [%7] {
         memref.dealloc %results_4 : memref<64xi32, 1>
       } {id = 9 : i32}
-      air.segment_terminator
     }
     %2 = air.channel.get async  @channel_3[] (%arg1[] [] []) {id = 8 : i32} : (memref<64xi32>)
     return

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks.mlir
@@ -174,7 +174,6 @@ module {
         }
         scf.yield %12 : !air.async.token
       } {unroll = 2 : i32}
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_locks_aie2.mlir
@@ -239,7 +239,6 @@ module {
               }
               scf.yield %25 : !air.async.token
             }
-            air.herd_terminator
           }
           %18 = air.channel.put async [%17]  @channel_7[] (%results_23[] [] []) {id = 16 : i32} : (memref<64x64xi32, 1>)
           %async_token_24 = air.execute [%10] {
@@ -254,9 +253,7 @@ module {
           %19 = air.wait_all async [%16, %15, %14, %18, %13] 
           scf.yield %19 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_to_objectfifo.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_to_objectfifo.mlir
@@ -143,7 +143,6 @@ module {
         }
         scf.yield %12 : !air.async.token
       } {unroll = 2 : i32}
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
@@ -255,7 +255,6 @@ module {
       %async_token_14 = air.execute [%14] {
         memref.dealloc %results_5 : memref<32x32xi32, 2>
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
@@ -266,7 +266,6 @@ module {
             %async_token_43 = air.execute [%20] {
               memref.dealloc %results_34 : memref<32x32xi32, 2>
             }
-            air.herd_terminator
           }
           %14 = scf.parallel (%arg12, %arg13) = (%c0_16, %c0_16) to (%c2_15, %c2_15) step (%c1_13, %c1_13) init (%arg11) -> !air.async.token {
             %async_token_30, %results_31 = air.execute -> (index) {
@@ -385,9 +384,7 @@ module {
         %async_token_29 = air.execute [%12] {
           memref.dealloc %results_20 : memref<64x64xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
@@ -205,7 +205,6 @@ module {
             %async_token_43 = air.execute [%20] {
               memref.dealloc %results_34 : memref<32x32xi32, 2>
             }
-            air.herd_terminator
           }
           %14 = scf.parallel (%arg12, %arg13) = (%c0_16, %c0_16) to (%c2_15, %c2_15) step (%c1_13, %c1_13) init (%arg11) -> !air.async.token {
             %async_token_30, %results_31 = air.execute -> (index) {
@@ -324,9 +323,7 @@ module {
         %async_token_29 = air.execute [%12] {
           memref.dealloc %results_20 : memref<64x64xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/async_one_core_gemm_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_one_core_gemm_to_npu.mlir
@@ -163,7 +163,6 @@ module {
           %async_token_42 = air.execute [%29] {
             memref.dealloc %results_34 : memref<32x32xi32, 2>
           }
-          air.herd_terminator
         }
         %async_token_29 = air.execute [%16] {
           memref.dealloc %results_26 : memref<32x32xi32, 1>
@@ -179,9 +178,7 @@ module {
         %async_token_32 = air.execute [%24] {
           memref.dealloc %results_24 : memref<32x32xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     %async_token_4 = air.execute [%0] {
       memref.copy %results_2, %arg2 : memref<32x32xi32> to memref<32x32xi32>

--- a/mlir/test/Conversion/AIRToAIE/check_dma_channels.mlir
+++ b/mlir/test/Conversion/AIRToAIE/check_dma_channels.mlir
@@ -19,7 +19,6 @@ func.func @test(%arg0: memref<1024xi32>) {
     air.dma_memcpy_nd (%alloc[] [] [], %arg5[%c0] [%c0_1] [%c0_0]) : (memref<1024xi32, 2>, memref<1024xi32>)
     air.channel.get  @channel_0[] (%alloc[%c0] [%c0_1] [%c0_0]) : (memref<1024xi32, 2>)
     memref.dealloc %alloc : memref<1024xi32, 2>
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/create_and_outline.mlir
+++ b/mlir/test/Conversion/AIRToAIE/create_and_outline.mlir
@@ -57,10 +57,8 @@ module attributes {torch.debug_module_name = "mmult"} {
           memref.dealloc %5 : memref<32x32xi32, 2>
           memref.dealloc %6 : memref<32x32xi32, 2>
         }
-        air.herd_terminator
       }
       memref.copy %1, %arg2 : memref<64x64xi32> to memref<64x64xi32>
-      air.segment_terminator
     }
     return
   }
@@ -79,7 +77,6 @@ func.func @f1() -> () {
   air.herd tile(%tx, %ty) in (%size_x = %cst4, %size_y = %cst1) {
     %src0 = memref.alloc() : memref<1xi32, 2>
     air.channel.put @channel_0[] (%src0[] [] []) : (memref<1xi32, 2>)
-    air.herd_terminator
   }
   return
 }
@@ -122,15 +119,12 @@ func.func @f2() -> () {
       %src0 = memref.alloc() : memref<1xi32, 2>
       air.channel.put @channel_1[] (%src0[] [] []) : (memref<1xi32, 2>)
       memref.dealloc %src0 : memref<1xi32, 2>
-      air.herd_terminator
     }
     air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
       %src0 = memref.alloc() : memref<1xi32, 2>
       air.channel.put @channel_1[] (%src0[] [] []) : (memref<1xi32, 2>)
       memref.dealloc %src0 : memref<1xi32, 2>
-      air.herd_terminator
     }
-    air.segment_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/emit_lock.mlir
+++ b/mlir/test/Conversion/AIRToAIE/emit_lock.mlir
@@ -21,7 +21,6 @@ func.func @func1() -> () {
   %herd_cols = arith.constant 1 : index
   %herd_rows = arith.constant 1 : index
   air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) {
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/insert_trace_packet_flow.mlir
+++ b/mlir/test/Conversion/AIRToAIE/insert_trace_packet_flow.mlir
@@ -23,7 +23,6 @@ func.func @foo(%arg0: i32) {
     %2 = arith.addi %0, %1 :  i32
     %dst0 = memref.alloc() : memref<1xi32, 2>
     memref.store %2, %dst0[%zero] : memref<1xi32, 2>
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/lower_affine_if.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_affine_if.mlir
@@ -86,7 +86,6 @@ module attributes {torch.debug_module_name = "mmult"} {
           linalg.yield %8 : i32
         }
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAIE/lower_air_execute_pattern.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_air_execute_pattern.mlir
@@ -48,7 +48,6 @@ module attributes {torch.debug_module_name = "mmult"} {
       %asyncToken_4 = air.execute [%4, %5] {
         memref.dealloc %6 : memref<32x32xi32, 2>
       } {id = 15 : i32}
-      air.herd_terminator
     }
     memref.copy %1, %arg2 : memref<64x64xi32> to memref<64x64xi32>
     return

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -81,7 +81,6 @@ module attributes {torch.debug_module_name = "mmult"} {
         memref.dealloc %valOut_3 : memref<32x32xi32, 2>
         air.execute_terminator
       } {id = 15 : i32}
-      air.herd_terminator
     }
     memref.copy %1, %arg2 : memref<64x64xi32> to memref<64x64xi32>
     return

--- a/mlir/test/Conversion/AIRToAIE/lower_scf_air_token.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_scf_air_token.mlir
@@ -27,7 +27,6 @@ module attributes {torch.debug_module_name = "mmult"} {
         scf.yield %2 : !air.async.token
       }
       air.wait_all [%1] 
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/AIRToAsync/air_to_async.mlir
+++ b/mlir/test/Conversion/AIRToAsync/air_to_async.mlir
@@ -116,7 +116,6 @@ func.func @herd_1(%arg0: i32, %arg1: i32) -> () {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   air.wait_all [%e2]
   return
@@ -187,7 +186,6 @@ func.func @scf_par(%arg0: memref<256x256xf32>) {
       memref.copy %subview, %alloc : memref<32x32xf32, strided<[256, 1], offset: ?>> to memref<32x32xf32, 2>
       memref.dealloc %alloc : memref<32x32xf32, 2>
     }
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/ConvertToAIR/broadcast_to_channel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/broadcast_to_channel.mlir
@@ -63,7 +63,6 @@ module {
               %9 = air.wait_all async [%8]  {id = 1 : i32}
               scf.yield %9 : !air.async.token
             }
-            air.herd_terminator
           }
           %async_token_2 = air.execute [%4] {
             memref.dealloc %results_1 : memref<64x64xbf16, 1>
@@ -71,9 +70,7 @@ module {
           %5 = air.wait_all async [%4]  {id = 3 : i32}
           scf.yield %5 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/condense_memref_ops_to_air_memcpy.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/condense_memref_ops_to_air_memcpy.mlir
@@ -29,7 +29,6 @@
 // CHECK:  air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%{{.*}}, %[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]]] [%[[CST1_0]], %[[CST1_0]], %[[CST2_0]], %[[CST2_0]], %[[CST4_0]], %[[CST8_0]]] [%[[CST128_0]], %[[CST128_0]], %[[CST8_0]], %[[CST64_0]], %[[CST16_0]], %[[CST1_0]]]) : (memref<1x1x2x2x4x8xi32, 2>, memref<1x1x8x16xi32, 1>)
 // CHECK:  air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%[[CST0_0]], %{{.*}}, %[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]]] [%[[CST1_0]], %[[CST1_0]], %[[CST2_0]], %[[CST2_0]], %[[CST8_0]], %[[CST8_0]]] [%[[CST256_0]], %[[CST256_0]], %[[CST8_0]], %[[CST128_0]], %[[CST16_0]], %[[CST1_0]]]) : (memref<1x1x2x2x8x8xi32, 2>, memref<1x1x16x16xi32, 1>)
 // CHECK:  air.dma_memcpy_nd (%{{.*}}[%{{.*}}, %{{.*}}, %[[CST0_0]], %[[CST0_0]]] [%[[CST1_0]], %[[CST1_0]], %[[CST8_0]], %[[CST16_0]]] [%[[CST128_0]], %[[CST128_0]], %[[CST16_0]], %[[CST1_0]]], %{{.*}}[%[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]], %[[CST0_0]]] [%[[CST1_0]], %[[CST1_0]], %[[CST2_0]], %[[CST4_0]], %[[CST2_0]], %[[CST8_0]]] [%[[CST128_0]], %[[CST128_0]], %[[CST32_0]], %[[CST8_0]], %[[CST64_0]], %[[CST1_0]]]) : (memref<1x1x8x16xi32, 1>, memref<1x1x2x2x4x8xi32, 2>)
-// CHECK:  air.herd_terminator
 // CHECK:  air.dma_memcpy_nd (%{{.*}}[%{{.*}}, %{{.*}}] [%[[CST8]], %[[CST16]]] [%[[CST32]], %[[CST1]]], %{{.*}}[%[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]]] [%[[CST1]], %[[CST1]], %[[CST8]], %[[CST16]]] [%[[CST128]], %[[CST128]], %[[CST16]], %[[CST1]]]) : (memref<8x32xi32>, memref<1x1x8x16xi32, 1>)
 
 #map = affine_map<()[s0] -> (s0 * 8)>
@@ -76,7 +75,6 @@ module {
           memref.dealloc %alloc_11 : memref<1x1x2x2x4x8xi32, 2>
           memref.dealloc %alloc_13 : memref<1x1x2x2x8x8xi32, 2>
           memref.dealloc %alloc_16 : memref<1x1x2x2x4x8xi32, 2>
-          air.herd_terminator
         }
         %subview_6 = memref.subview %alloc_5[0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<1x1x8x16xi32, 1> to memref<8x16xi32, 1>
         %transpose_7 = memref.transpose %subview_6 (d0, d1) -> (d0, d1) : memref<8x16xi32, 1> to memref<8x16xi32, strided<[16, 1]>, 1>
@@ -84,9 +82,7 @@ module {
         memref.dealloc %alloc_3 : memref<1x1x16x16xi32, 1>
         memref.dealloc %alloc : memref<1x1x8x16xi32, 1>
         memref.dealloc %alloc_5 : memref<1x1x8x16xi32, 1>
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel.mlir
@@ -63,7 +63,6 @@ module attributes {torch.debug_module_name = "mmult"} {
         memref.dealloc %alloc_2 : memref<32x32xi32, 2>
         memref.dealloc %alloc_3 : memref<32x32xi32, 2>
       }
-      air.herd_terminator
     }
     return %alloc_0 : memref<64x64xi32>
   }

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_async.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_async.mlir
@@ -84,7 +84,6 @@ module {
               %10 = air.wait_all async [%9]  {id = 1 : i32}
               scf.yield %10 : !air.async.token
             }
-            air.herd_terminator
           }
           %async_token_2 = air.execute [%5] {
             memref.dealloc %results_1 : memref<64x64xbf16, 1>
@@ -92,9 +91,7 @@ module {
           %6 = air.wait_all async [%5]  {id = 3 : i32}
           scf.yield %6 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_canonicalize.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_canonicalize.mlir
@@ -43,7 +43,6 @@ module {
       %async_token_4 = air.execute [%3] {
         memref.dealloc %results_3 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_for_in_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_for_in_herd.mlir
@@ -62,7 +62,6 @@ module {
             }
         }
       }
-      air.herd_terminator
     }
     return %alloc_0 : memref<64x64xi32>
   }
@@ -148,7 +147,6 @@ module {
         }
         scf.yield %3 : !air.async.token
       }
-      air.herd_terminator
     }
     return %results_2 : memref<64x64xi32>
   }
@@ -199,11 +197,8 @@ module {
             %11 = air.wait_all async [%7]
             scf.yield %11 : !air.async.token
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -254,14 +249,11 @@ module {
             %4 = air.dma_memcpy_nd async [%arg18] (%arg16[] [] [], %arg15[%results_10, %arg17] [%c32_6, %c256] [%c2048, %c1]) {id = 1 : i32} : (memref<32x256xi32, 1>, memref<2048x2048xi32>)
             scf.yield %4 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_5 = air.execute [%2] {
           memref.dealloc %results_4 : memref<32x256xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     %async_token_0 = air.execute [%async_token] {
       memref.copy %results, %arg2 : memref<2048x2048xi32> to memref<2048x2048xi32>

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_for_in_partition.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_for_in_partition.mlir
@@ -66,7 +66,6 @@ module {
                     %10 = air.wait_all async [%9]  {id = 1 : i32}
                     scf.yield %10 : !air.async.token
                     }
-                    air.herd_terminator
                 }
                 %async_token_2 = air.execute [%5] {
                     memref.dealloc %results_1 : memref<64x64xbf16, 1>
@@ -77,9 +76,7 @@ module {
             %newarg4 = air.wait_all async [%3]  {id = 3 : i32}
             scf.yield %newarg4 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_par_in_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_par_in_herd.mlir
@@ -111,7 +111,6 @@ module {
           scf.reduce.return %6 : !air.async.token
         }
       }
-      air.herd_terminator
     }
     %async_token_0 = air.execute [%0] {
       memref.copy %results, %arg2 : memref<512x512xi32> to memref<512x512xi32>

--- a/mlir/test/Conversion/ConvertToAIR/insert_launch_and_segment_around_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/insert_launch_and_segment_around_herd.mlir
@@ -17,7 +17,6 @@ func.func @herd(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   return
 }
@@ -35,13 +34,11 @@ func.func @two_herds(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   air.herd @herd_1 tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%arg0, %op1=%arg0) : i32, i32 attributes { } {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   return
 }
@@ -56,7 +53,6 @@ func.func @async_herd(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Conversion/ConvertToAIR/scf_forall_to_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/scf_forall_to_herd.mlir
@@ -60,7 +60,6 @@ func.func @scf2()  {
 //       CHECK:    air.herd @herd_0
 //  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o"} {
 //       CHECK:       func.call @matmul_i32_i32
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }

--- a/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_herd.mlir
@@ -129,7 +129,6 @@ func.func @scf2()  {
 //       CHECK:    air.herd @herd_0
 //  CHECK-SAME:        attributes {link_with = "/path/to/mm_microkernel.o"} {
 //       CHECK:       func.call @matmul_i32_i32
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }
@@ -163,7 +162,6 @@ module {
 //  CHECK-SAME:       {
 //       CHECK:           func.call @matmul_scalar_i32_i32
 //       CHECK:       }
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }
@@ -193,13 +191,10 @@ module {
 // CHECK-LABEL: module {
 //       CHECK:  func.func @shared_herd_name(
 //       CHECK:    air.herd @herd_0
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    air.herd @herd_0
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    air.herd @herd_0
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }
@@ -245,10 +240,8 @@ module {
 // CHECK-LABEL: module {
 //       CHECK:  func.func @unique_herd_name(
 //       CHECK:    air.herd @herd_0
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    air.herd @herd_1
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }
@@ -295,7 +288,6 @@ module {
 //       CHECK:       %[[VAL_0:.*]] = affine.apply
 //       CHECK:       %[[VAL_1:.*]] = affine.apply
 //       CHECK:       memref.subview %{{.*}}[0, 0, %[[VAL_0]], %[[VAL_1]], 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x32x32x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    air.herd @herd_0
 //       CHECK:       %[[VAL_0:.*]] = affine.apply
@@ -305,7 +297,6 @@ module {
 //       CHECK:       %[[VAL_3:.*]] = affine.apply
 //       CHECK:       memref.subview %{{.*}}[0, 0, %[[VAL_2]], %[[VAL_3]]] [1, 1, 64, 64] [1, 1, 1, 1] : memref<1x1x128x128xbf16, 1 : i32> to memref<1x1x64x64xbf16, strided<[16384, 16384, 128, 1], offset: ?>, 1 : i32>
 //       CHECK:       air.dma_memcpy_nd {{.*}} : (memref<1x1x64x64xbf16, strided<[16384, 16384, 128, 1], offset: ?>, 1 : i32>, memref<1x1x16x4x16x4xbf16, strided<[16384, 16384, 16, 4, 512, 1], offset: ?>, 2 : i32>)
-//       CHECK:       air.herd_terminator
 //       CHECK:    }
 //       CHECK:    return
 //       CHECK:  }

--- a/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel.mlir
@@ -66,7 +66,6 @@ module {
               %9 = air.wait_all async [%8]  {id = 1 : i32}
               scf.yield %9 : !air.async.token
             }
-            air.herd_terminator
           }
           %async_token_2 = air.execute [%4] {
             memref.dealloc %results_1 : memref<64x64xbf16, 1>
@@ -74,9 +73,7 @@ module {
           %5 = air.wait_all async [%4]  {id = 3 : i32}
           scf.yield %5 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel_4x4.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel_4x4.mlir
@@ -102,7 +102,6 @@ module {
               %9 = air.wait_all async [%async_token_11]  {id = 1 : i32}
               scf.yield %9 : !air.async.token
             }
-            air.herd_terminator
           }
           %async_token_0 = air.execute [%4] {
             memref.dealloc %results : memref<64x64xbf16, 1>
@@ -110,9 +109,7 @@ module {
           %5 = air.wait_all async [%4]  {id = 3 : i32}
           scf.yield %5 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Dialect/AIR/air_canonicalize.mlir
+++ b/mlir/test/Dialect/AIR/air_canonicalize.mlir
@@ -10,28 +10,24 @@
 
 // CHECK-LABEL: func.func @herd
 // CHECK: air.herd tile ({{.*}}, {{.*}}) in ({{.*}}={{.*}}, {{.*}}={{.*}}) {
-// CHECK-NEXT:   air.herd_terminator
 func.func @herd(%arg0: i32) {
   %cst2 = arith.constant 2 : index
   air.herd tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%arg0, %op1=%arg0, %op2=%arg0, %op3=%arg0) : i32, i32, i32, i32 attributes { } {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   return
 }
 
 // CHECK-LABEL: func.func @herd_async
 // CHECK: air.herd async [{{.*}}] tile ({{.*}}, {{.*}}) in ({{.*}}={{.*}}, {{.*}}={{.*}}) attributes {attr_name = "attrValue"} {
-// CHECK-NEXT:   air.herd_terminator
 func.func @herd_async(%arg0: i32, %e0 : !air.async.token) {
   %cst2 = arith.constant 2 : index
   %e1 = air.herd async [%e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%arg0, %op1=%arg0, %op2=%arg0, %op3=%arg0) : i32, i32, i32, i32 attributes { attr_name="attrValue" } {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   air.wait_all [%e1]
   return
@@ -53,7 +49,6 @@ func.func @herd_async_1() {
   %e0 = air.wait_all async [%t0, %t1]
   %e1 = air.herd async [%t0, %t1, %e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args (%op0=%results) : memref<1xi32> {
     %d0 = air.dma_memcpy_nd async (%op0[] [] [], %op0[] [] []) : (memref<1xi32>, memref<1xi32>)
-    air.herd_terminator
   }
   air.wait_all [%e1]
   return
@@ -67,7 +62,6 @@ func.func @herd_async_2() {
   %t1 = air.wait_all async [%t0]
   %e0 = air.wait_all async [%t0, %t1]
   %e1 = air.herd async [%t0, %t1, %e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) {
-    air.herd_terminator
   }
   air.wait_all [%e1]
   return

--- a/mlir/test/Dialect/AIR/air_herd_launch.mlir
+++ b/mlir/test/Dialect/AIR/air_herd_launch.mlir
@@ -16,7 +16,6 @@ func.func @launch(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   return
 }
@@ -30,7 +29,6 @@ func.func @launch_async(%arg0: i32) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
     %2 = arith.addi %op0, %op1 : i32
-    air.herd_terminator
   }
   air.wait_all [%e0]
   return
@@ -44,7 +42,6 @@ func.func @launch_emptyargs(%arg0: i32) {
   %e1 = air.herd async [%e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) args () {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
-    air.herd_terminator
   }
   air.wait_all [%e0]
   return
@@ -58,7 +55,6 @@ func.func @launch_noargs(%arg0: i32) {
   %e1 = air.herd async [%e0] tile (%x, %y) in (%sx=%cst2, %sy=%cst2) {
     %0 = arith.addi %x, %y : index
     %1 = arith.muli %sx, %sy : index
-    air.herd_terminator
   }
   air.wait_all [%e0]
   return

--- a/mlir/test/Dialect/AIR/air_launch.mlir
+++ b/mlir/test/Dialect/AIR/air_launch.mlir
@@ -20,7 +20,6 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
 
   // CHECK: air.launch (%{{.*}}, %{{.*}}) in (%{{.*}}=%c1, %{{.*}}=%c2) attributes {foo = "bar"} {
   air.launch (%tx, %ty) in (%size_x = %c1, %size_y = %c2) attributes {foo = "bar"} {
-    air.launch_terminator
   }
 
   // CHECK: air.launch (%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c3, %{{.*}}=%c4) {
@@ -29,7 +28,6 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
 
   // CHECK: air.launch async (%{{.*}}) in (%{{.*}}=%c1)
   %t0 = air.launch async (%tx) in (%size_x = %c1) {
-    air.launch_terminator
   }
 
   // CHECK: %{{.*}} = air.launch async [%{{.*}}] (%{{.*}}) in (%{{.*}}=%c2)
@@ -38,7 +36,6 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
 
   // CHECK: air.launch [%{{.*}}, %{{.*}}] (%{{.*}}) in (%{{.*}}=%c3)
   air.launch [%t0, %t1] (%tx) in (%size_x = %c3) {
-    air.launch_terminator
   }
 
   // CHECK: air.launch @memcpy_nd (%{{.*}}, %{{.*}}) in (%{{.*}}=%c4, %{{.*}}=%c1) args(%{{.*}}=%{{.*}}) : memref<16x16xf32> {
@@ -46,7 +43,6 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
     %1 = memref.alloc() : memref<16x16xf32>
     air.dma_memcpy_nd (%1[] [] [], %arg4[] [] []) {id = 1 : i32} : (memref<16x16xf32>, memref<16x16xf32>)
     memref.dealloc %1 : memref<16x16xf32>
-    air.launch_terminator
   }
 
   // CHECK: air.launch @mylaunch () in ()

--- a/mlir/test/Dialect/AIR/air_memcpy_async.mlir
+++ b/mlir/test/Dialect/AIR/air_memcpy_async.mlir
@@ -27,7 +27,6 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     air.dma_memcpy_nd (%1[] [] [], %arg5[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
     air.dma_memcpy_nd (%arg5[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     memref.dealloc %1 : memref<32xi32, 2>
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Dialect/AIR/air_pipeline.mlir
+++ b/mlir/test/Dialect/AIR/air_pipeline.mlir
@@ -35,7 +35,6 @@ module  {
         }
         air.pipeline.terminator
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Dialect/AIR/air_segment.mlir
+++ b/mlir/test/Dialect/AIR/air_segment.mlir
@@ -20,42 +20,34 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
 
   // CHECK: air.segment attributes {foo = "bar"} {
   air.segment attributes {foo = "bar"} {
-    air.segment_terminator
   }
 
   // CHECK: air.segment {
   air.segment args() {
-    air.segment_terminator
   }
 
   // CHECK: air.segment unroll(%{{.*}}, %{{.*}}) in (%{{.*}}=%c1, %{{.*}}=%c2) attributes {foo = "bar"} {
   air.segment unroll (%tx, %ty) in (%size_x = %c1, %size_y = %c2) attributes {foo = "bar"} {
-    air.segment_terminator
   }
 
   // CHECK: air.segment unroll(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c3, %{{.*}}=%c4) {
   air.segment unroll (%tx, %ty, %tz) in (%sx = %c2, %sy = %c3, %sz = %c4) attributes {  } {
-    air.segment_terminator
   }
 
   // CHECK: air.segment async unroll(%{{.*}}) in (%{{.*}}=%c1)
   %t0 = air.segment async unroll (%tx) in (%size_x = %c1) {
-    air.segment_terminator
   }
 
   // CHECK: %{{.*}} = air.segment async [%{{.*}}] unroll(%{{.*}}) in (%{{.*}}=%c2)
   %t1 = air.segment async [%t0] unroll (%tx) in (%size_x = %c2) {
-    air.segment_terminator
   }
   
   // CHECK: %{{.*}} = air.segment @memcpy_nd async [%{{.*}}]
   %t2 = air.segment async [%t1] attributes {sym_name = "memcpy_nd"} {
-    air.segment_terminator
   }
 
   // CHECK: air.segment [%{{.*}}, %{{.*}}] unroll(%{{.*}}) in (%{{.*}}=%c3)
   air.segment [%t0, %t1] unroll (%tx) in (%size_x = %c3) {
-    air.segment_terminator
   }
 
   // CHECK: air.segment @memcpy_nd unroll(%{{.*}}, %{{.*}}) in (%{{.*}}=%c4, %{{.*}}=%c1) args(%{{.*}}=%{{.*}}) : memref<16x16xf32> {
@@ -63,7 +55,6 @@ func.func @test(%arg0 : memref<16x16xf32>, %arg1 : memref<16x16xf32>) -> () {
     %1 = memref.alloc() : memref<16x16xf32>
     air.dma_memcpy_nd (%1[] [] [], %arg4[] [] []) {id = 1 : i32} : (memref<16x16xf32>, memref<16x16xf32>)
     memref.dealloc %1 : memref<16x16xf32>
-    air.segment_terminator
   }
 
   return

--- a/mlir/test/Dialect/AIR/canonicalize_channel.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel.mlir
@@ -22,6 +22,5 @@ module {
   air.launch (%tx, %ty) in (%size_x = %c1, %size_y = %c2) attributes {foo = "bar"} {
     %alloc = memref.alloc() : memref<16x8xi32>
     air.channel.get  @channel_0[] (%alloc[] [] []) : (memref<16x8xi32>)
-    air.launch_terminator
   }
 }

--- a/mlir/test/Dialect/AIR/canonicalize_hierarchy_args.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_hierarchy_args.mlir
@@ -34,11 +34,8 @@ module {
             air.execute_terminator %6 : memref<128xi32, 1>
           } {id = 3 : i32}
           %5 = air.dma_memcpy_nd async [%asyncToken_9] (%valOut_10[] [] [], %arg15[%c0_8] [%c0_8] [%c0_8]) {id = 43 : i32} : (memref<128xi32, 1>, memref<256xi32, 2>)
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Dialect/AIR/transform-ops.mlir
+++ b/mlir/test/Dialect/AIR/transform-ops.mlir
@@ -18,7 +18,6 @@ func.func @get_segment_for_op(%arg0: i32, %arg1: i32) {
     %c1 = arith.constant 1 : index
     air.herd tile (%x, %y) in (%sx=%c1, %sy=%c1) args (%op0=%arg2, %op1=%arg3) : i32, i32 attributes { } {
       %2 = arith.addi %op0, %op1 : i32
-      air.herd_terminator
     }
   }
   return

--- a/mlir/test/Target/AIRHerdToJSON/json_mm_gelu.mlir
+++ b/mlir/test/Target/AIRHerdToJSON/json_mm_gelu.mlir
@@ -80,7 +80,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%1, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -115,7 +114,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%2, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -150,7 +148,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%3, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -185,7 +182,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -220,7 +216,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -255,7 +250,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -290,7 +284,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -325,7 +318,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
               memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %0] [%c64, %c64] [%c1024, %c1], %alloc_4[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -365,7 +357,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%11, %12] [%c32, %c32] [%c64_5, %c1_4], %alloc_10[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
             memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%10, %0] [%c64, %c64] [%c1024, %c1], %alloc_3[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -404,7 +395,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%11, %12] [%c32, %c32] [%c64_5, %c1_4], %alloc_10[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
             memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%10, %0] [%c64, %c64] [%c1024, %c1], %alloc_3[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -443,7 +433,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%11, %12] [%c32, %c32] [%c64_5, %c1_4], %alloc_10[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
             memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%10, %0] [%c64, %c64] [%c1024, %c1], %alloc_3[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
@@ -482,15 +471,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%11, %12] [%c32, %c32] [%c64_5, %c1_4], %alloc_10[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %alloc_9 : memref<32x32xbf16, 2>
             memref.dealloc %alloc_10 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%10, %0] [%c64, %c64] [%c1024, %c1], %alloc_3[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %alloc_2 : memref<64x64xbf16, 1>
           memref.dealloc %alloc_3 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %alloc_1 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Target/AIRHerdToJSON/json_mm_random_shapes.mlir
+++ b/mlir/test/Target/AIRHerdToJSON/json_mm_random_shapes.mlir
@@ -102,7 +102,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -137,7 +136,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -172,7 +170,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -207,7 +204,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -242,7 +238,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -277,7 +272,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -312,7 +306,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -347,7 +340,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -387,7 +379,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -426,7 +417,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -465,7 +455,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -504,15 +493,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Target/AIRHerdToJSON/json_shifted_anchor.mlir
+++ b/mlir/test/Target/AIRHerdToJSON/json_shifted_anchor.mlir
@@ -81,7 +81,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -116,7 +115,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -151,7 +149,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -186,7 +183,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -221,7 +217,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -256,7 +251,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -291,7 +285,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -326,7 +319,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -366,7 +358,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -405,7 +396,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -444,7 +434,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -483,15 +472,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRDependency/air_channel.mlir
+++ b/mlir/test/Transform/AIRDependency/air_channel.mlir
@@ -117,7 +117,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.channel.put @channel_8[%arg17, %arg18] (%12[] [] []) : (memref<32x32xbf16, 2>)
 // CHECK: %[[EVENT31:.*]] = air.execute [%[[EVENT30]]]
             memref.dealloc %12 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           scf.parallel (%arg17, %arg18) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
             %20 = affine.apply #map1()[%arg17]
@@ -132,13 +131,10 @@ module attributes {torch.debug_module_name = "mmult"} {
 // CHECK: %[[EVENT34:.*]] = air.channel.put async{{.*}}@channel_4[]
         air.channel.put @channel_4[] (%19[] [] []) : (memref<64x64xbf16, 1>)
         memref.dealloc %19 : memref<64x64xbf16, 1>
-        air.segment_terminator
       }
 
 // CHECK: %[[EVENT35:.*]] = air.channel.get async{{.*}}@channel_4[]
       air.channel.get @channel_4[] (%arg8[%17, %18] [%c64_new, %c64_new] [%c1024_new, %c1_new]) : (memref<24576x1024xbf16>)
-      
-      air.launch_terminator
     }
     return %1 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
+++ b/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
@@ -39,15 +39,12 @@ module  {
           // CHECK: %[[EVENT8:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT7]]{{.*}}]
           memref.dealloc %3 : memref<128xi32, 1>
           // CHECK: %[[EVENT9:.*]] = air.execute [{{.*}}%[[EVENT8]]{{.*}}]
-          air.herd_terminator
         }
         memref.dealloc %2 : memref<256xi32, 2>
         // CHECK: %[[EVENT10:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
-        air.segment_terminator
       }
       memref.dealloc %1 : memref<512xi32, 3>
       // CHECK: %[[EVENT11:.*]] = air.execute [{{.*}}%[[EVENT3]]{{.*}}]
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
@@ -31,7 +31,6 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
     // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
@@ -31,7 +31,6 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
     // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
-    air.segment_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
@@ -31,7 +31,6 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>
     // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT6]]{{.*}}]
-    air.herd_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependency/func_call.mlir
+++ b/mlir/test/Transform/AIRDependency/func_call.mlir
@@ -25,7 +25,6 @@ module {
       %base_buffer = memref.alloc() : memref<i32, 2 : i32>
       %c0_11 = arith.constant 0 : index
       func.call @matmul_scalar_i32_i32(%base_buffer_lhs, %c0_11, %base_buffer_rhs, %c0_11, %base_buffer, %c0_11) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/linalg_generic.mlir
+++ b/mlir/test/Transform/AIRDependency/linalg_generic.mlir
@@ -51,7 +51,6 @@ module {
       memref.dealloc %2 : memref<64x64xbf16, 2>
       memref.dealloc %3 : memref<64x1xbf16, 2>
       memref.dealloc %4 : memref<64x1xi64, 2>
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/matmul_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_nd.mlir
@@ -74,8 +74,6 @@ module attributes {torch.debug_module_name = "mmult"}  {
         memref.dealloc %9 : memref<32x32xi32, 2>
         // CHECK: = air.execute
       }
-      air.herd_terminator
-      // CHECK: air.herd_terminator
     }
     air.dma_memcpy_nd (%1[%c0, %c0] [%c64, %c64] [%c64, %c1], %4[] [] []) {id = 8 : i32} : (memref<64x64xi32>, memref<64x64xi32, 1>)
     // CHECK: = air.dma_memcpy_nd async

--- a/mlir/test/Transform/AIRDependency/matmul_parallel.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_parallel.mlir
@@ -48,7 +48,6 @@ module attributes {torch.debug_module_name = "mmult"} {
           memref.dealloc %6 : memref<32x32xf32, 2>
           memref.dealloc %7 : memref<32x32xf32, 2>
           memref.dealloc %8 : memref<32x32xf32, 2>
-          air.herd_terminator
         }
       }
     }

--- a/mlir/test/Transform/AIRDependency/matmul_parallel_with_L2.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_parallel_with_L2.mlir
@@ -56,7 +56,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             memref.dealloc %8 : memref<32x32xf32, 2>
             memref.dealloc %9 : memref<32x32xf32, 2>
           }
-          air.herd_terminator
         }
         air.dma_memcpy_nd (%1[%arg3, %arg4] [%c64, %c64] [%c1024, %c1], %4[] [] []) {id = 8 : i32} : (memref<384x1024xf32>, memref<64x64xf32, 1>)
         memref.dealloc %2 : memref<64x64xf32, 1>

--- a/mlir/test/Transform/AIRDependency/memref_extract_strided_metadata.mlir
+++ b/mlir/test/Transform/AIRDependency/memref_extract_strided_metadata.mlir
@@ -22,7 +22,6 @@ module {
       %alloc_1 = memref.alloc() : memref<16x16x4x4xbf16, 2 : i32>
       %base_buffer, %offset, %sizes:4, %strides:4 = memref.extract_strided_metadata %alloc_1 : memref<16x16x4x4xbf16, 2 : i32> -> memref<bf16, 2 : i32>, index, index, index, index, index, index, index, index, index
       func.call @zero_bf16(%base_buffer, %offset) : (memref<bf16, 2 : i32>, index) -> ()
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/parallel_herds.mlir
+++ b/mlir/test/Transform/AIRDependency/parallel_herds.mlir
@@ -45,7 +45,6 @@ module {
           air.dma_memcpy_nd (%7[] [] [], %arg15[%arg18, %3] [%c64, %c64] [%c1024, %c1]) {id = 2 : i32} : (memref<64x64xbf16, 1>, memref<1024x1024xbf16>)
           air.dma_memcpy_nd (%8[] [] [], %arg16[%4, %3] [%c64, %c64] [%c1024, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
           air.herd  tile (%arg19, %arg20) in (%arg21=%c2, %arg22=%c2) {
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %8[] [] []) {id = 4 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %6 : memref<64x64xbf16, 1>
@@ -61,16 +60,13 @@ module {
           air.dma_memcpy_nd (%7[] [] [], %arg15[%arg18, %3] [%c64, %c64] [%c1024, %c1]) {id = 6 : i32} : (memref<64x64xbf16, 1>, memref<1024x1024xbf16>)
           air.dma_memcpy_nd (%8[] [] [], %arg16[%5, %3] [%c64, %c64] [%c1024, %c1]) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<24576x1024xbf16>)
           air.herd  tile (%arg19, %arg20) in (%arg21=%c2, %arg22=%c2) {
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %8[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %6 : memref<64x64xbf16, 1>
           memref.dealloc %7 : memref<64x64xbf16, 1>
           memref.dealloc %8 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/partial_memref.mlir
+++ b/mlir/test/Transform/AIRDependency/partial_memref.mlir
@@ -14,7 +14,6 @@
 // CHECK: %[[EVENT0:.*]] = air.dma_memcpy_nd async [
 // CHECK-NOT: %[[EVENT1:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT0]]
 // CHECK: %[[EVENT2:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT0]]
-// CHECK: air.herd_terminator
 
 #map0 = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 512)>
@@ -34,7 +33,6 @@ module {
       air.dma_memcpy_nd (%3[%1, %arg1] [%c16, %c32] [%c128, %c1], %arg4[%1, %arg1] [%c16, %c32] [%c128, %c1]) {id = 1 : i32} : (memref<128x128xf32, 2>, memref<128x128xf32, 2>)
       air.dma_memcpy_nd (%3[%2, %arg1] [%c16, %c32] [%c128, %c1], %arg4[%1, %arg1] [%c16, %c32] [%c128, %c1]) {id = 2 : i32} : (memref<128x128xf32, 2>, memref<128x128xf32, 2>)
       air.dma_memcpy_nd (%3[%1, %arg1] [%c16, %c32] [%c128, %c1], %arg4[%1, %arg1] [%c16, %c32] [%c128, %c1]) {id = 3 : i32} : (memref<128x128xf32, 2>, memref<128x128xf32, 2>)
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependency/two_layer.mlir
+++ b/mlir/test/Transform/AIRDependency/two_layer.mlir
@@ -47,7 +47,6 @@ module attributes {torch.debug_module_name = "MMult_Mult"} {
         memref.dealloc %6 : memref<32x64xf32, 2>
         memref.dealloc %7 : memref<16x64xf32, 2>
       }
-      air.herd_terminator
     }
     air.herd  tile (%arg4, %arg5) in (%arg6=%c8, %arg7=%c1) args(%arg8=%arg0, %arg9=%2, %arg10=%0) : memref<128x128xf32>, memref<128x128xf32>, memref<128x128xf32> attributes {sym_name = "herd_1"} {
       %c1_0 = arith.constant 1 : index
@@ -70,7 +69,6 @@ module attributes {torch.debug_module_name = "MMult_Mult"} {
       memref.dealloc %4 : memref<16x128xf32, 2>
       memref.dealloc %5 : memref<16x128xf32, 2>
       memref.dealloc %6 : memref<16x128xf32, 2>
-      air.herd_terminator
     }
     memref.copy %0, %arg3 : memref<128x128xf32> to memref<128x128xf32>
     return

--- a/mlir/test/Transform/AIRDependencyCanonicalization/broadcast_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/broadcast_dma.mlir
@@ -118,7 +118,6 @@ module {
           %async_token_19 = air.execute [%11] {
             memref.dealloc %results_18 : memref<32x32xbf16, 2>
           } {id = 14 : i32}
-          air.herd_terminator
         }
         %6 = air.dma_memcpy_nd async [%5] (%results[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %results_6[] [] []) {id = 10 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
         %async_token_7 = air.execute [%5] {

--- a/mlir/test/Transform/AIRDependencyCanonicalization/herd_only.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/herd_only.mlir
@@ -100,7 +100,6 @@ module attributes {torch.debug_module_name = "MMult_Mult"} {
         %8 = air.wait_all async [%async_token_24, %async_token_25, %async_token_26] 
         scf.yield %8 : !air.async.token
       }
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyCanonicalization/prune_redundant_edges.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/prune_redundant_edges.mlir
@@ -47,19 +47,16 @@ module {
             memref.dealloc %valOut_10 : memref<128xi32, 2>
             air.execute_terminator
           } {id = 4 : i32}
-          air.herd_terminator
         }
         %asyncToken_7 = air.execute [%4, %asyncToken_5, %3] {
           memref.dealloc %valOut_6 : memref<256xi32, 1>
           air.execute_terminator
         } {id = 5 : i32}
-        air.segment_terminator
       }
       %asyncToken_2 = air.execute [%2, %1] {
         memref.dealloc %valOut : memref<512xi32>
         air.execute_terminator
       } {id = 6 : i32}
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyCanonicalization/renumber.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/renumber.mlir
@@ -47,19 +47,16 @@ module {
             memref.dealloc %valOut_10 : memref<128xi32, 1>
             air.execute_terminator
           } {id = 4 : i32}
-          air.herd_terminator
         }
         %asyncToken_7 = air.execute [%4, %asyncToken_5, %3] {
           memref.dealloc %valOut_6 : memref<256xi32, 2>
           air.execute_terminator
         } {id = 5 : i32}
-        air.segment_terminator
       }
       %asyncToken_2 = air.execute [%2, %1] {
         memref.dealloc %valOut : memref<512xi32, 1>
         air.execute_terminator
       } {id = 6 : i32}
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/annotate_front_back.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/annotate_front_back.mlir
@@ -50,7 +50,6 @@ func.func @test(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>, %ar
           }
           scf.yield %6 : !air.async.token
         } {unroll = 2 : i32}
-        air.herd_terminator
       }
       %7 = scf.for %arg10 = %c0_1 to %c512_1 step %c64_1 iter_args(%arg11 = %async_token_1) -> (!air.async.token) {
         %8 = air.channel.get async [%arg11]  @channel_1[] (%results_2[][][]) : (memref<32x32xbf16, 1>)
@@ -59,9 +58,7 @@ func.func @test(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>, %ar
       %async_token_2 = air.execute [%7] {
         memref.dealloc %results_2 : memref<32x32xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/broadcast_detection.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/broadcast_detection.mlir
@@ -52,7 +52,6 @@ func.func @matmul(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg
           memref.dealloc %7 : memref<32x32xbf16, 2>
           memref.dealloc %8 : memref<32x32xbf16, 2>
         }
-        air.herd_terminator
       }
       air.dma_memcpy_nd (%0[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %3[] [] []) {id = 8 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
       memref.dealloc %1 : memref<64x64xbf16, 1>
@@ -97,11 +96,8 @@ module {
             }
             memref.dealloc %alloc : memref<256x64xbf16, 1>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -152,13 +148,10 @@ module {
             memref.dealloc %alloc_12 : memref<4x2x4x8xi32, 2 : i32>
             memref.dealloc %alloc_13 : memref<8x4x8x4xi32, 2 : i32>
           }
-          air.herd_terminator
         }
         memref.dealloc %alloc : memref<8x2048xi32, 1 : i32>
         memref.dealloc %alloc_2 : memref<2048x64xi32, 1 : i32>
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
@@ -60,7 +60,6 @@ func.func @channel_put_get(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024
         %async_token_9 = air.execute [%6] {
           memref.dealloc %results_5 : memref<32x32xbf16, 2>
         } {unrolled_iteration = 1 : i32}
-        air.herd_terminator
       }
       %4 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
         %5 = air.channel.get async [%arg17]  @channel_1[] (%results[] [] []) : (memref<32x32xbf16, 1>)
@@ -69,9 +68,7 @@ func.func @channel_put_get(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024
       %async_token_1 = air.execute [%4] {
         memref.dealloc %results : memref<32x32xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -155,7 +152,6 @@ func.func @affine_if(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>
         %async_token_9 = air.execute [%6] {
           memref.dealloc %results_5 : memref<32x32xbf16, 2>
         } {unrolled_iteration = 1 : i32}
-        air.herd_terminator
       }
       %4 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
         %5 = air.channel.get async [%arg17]  @channel_4[] (%results[] [] []) : (memref<32x32xbf16, 1>)
@@ -164,9 +160,7 @@ func.func @affine_if(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>
       %async_token_1 = air.execute [%4] {
         memref.dealloc %results : memref<32x32xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -220,7 +214,6 @@ func.func @scf_for() {
         }
         scf.yield %async_token_0 : !air.async.token
       }
-      air.segment_terminator
     }
     %2 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
       %c512 = arith.constant 512 : index
@@ -284,7 +277,6 @@ func.func @scf_for() {
         }
         scf.yield %async_token_7 : !air.async.token
       }
-      air.segment_terminator
     }
     %3 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
       %c512 = arith.constant 512 : index
@@ -347,9 +339,7 @@ func.func @scf_for() {
         }
         scf.yield %async_token_7 : !air.async.token
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -403,7 +393,6 @@ func.func @scf_parallel() {
         }
         scf.yield %async_token_0 : !air.async.token
       }
-      air.segment_terminator
     }
     %2 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
       %c512 = arith.constant 512 : index
@@ -475,7 +464,6 @@ func.func @scf_parallel() {
         }
         scf.yield %async_token_7 : !air.async.token
       }
-      air.segment_terminator
     }
     %3 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
       %c512 = arith.constant 512 : index
@@ -546,9 +534,7 @@ func.func @scf_parallel() {
         }
         scf.yield %async_token_7 : !air.async.token
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -632,9 +618,7 @@ module {
         %async_token_10 = air.execute [%5] {
           memref.dealloc %results_6 : memref<1x256x112x4xi8, 1>
         } {unrolled_iteration = 1 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/dealias_memref.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/dealias_memref.mlir
@@ -73,14 +73,12 @@ module {
         %async_token_12 = air.execute [%9] {
           memref.dealloc %results_9 : memref<64xi32, 2>
         } {id = 7 : i32}
-        air.herd_terminator
       }
       %6 = air.channel.get async  @channel_2[] (%results[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
       %7 = air.channel.put async [%6]  @channel_3[] (%results[] [] []) {id = 7 : i32} : (memref<64xi32, 1>)
       %async_token_2 = air.execute [%7] {
         memref.dealloc %results : memref<64xi32, 1>
       } {id = 2 : i32}
-      air.segment_terminator
     }
     %2 = air.channel.get async  @channel_3[] (%arg1[] [] []) {id = 8 : i32} : (memref<64xi32>)
     return

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/enforce_loop_carried_dealloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/enforce_loop_carried_dealloc.mlir
@@ -67,14 +67,11 @@ func.func @test1() {
           }
           scf.yield %async_token_10 : !air.async.token
         }
-        air.herd_terminator
       }
       %async_token_1 = air.execute [%3] {
         memref.dealloc %results : memref<32x32xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
@@ -17,8 +17,6 @@
 // CHECK: air.segment
 // CHECK: air.channel.get @channel_0
 // CHECK: air.channel.get @channel_1
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func0
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: air.channel.put @channel_0
@@ -26,8 +24,6 @@
 // AGGRESSIVE: air.segment
 // AGGRESSIVE: air.channel.get @channel_0
 // AGGRESSIVE: air.channel.get @channel_0
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func0
 // AGGL1: air.launch
 // AGGL1: air.channel.put @channel_0
@@ -35,8 +31,6 @@
 // AGGL1: air.segment
 // AGGL1: air.channel.get @channel_0
 // AGGL1: air.channel.get @channel_1
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -55,15 +49,12 @@ module {
         air.channel.get @channel_0[] (%alloc_2[] [] []) : (memref<4x4xi32, 1>)
         air.channel.get @channel_1[] (%alloc_3[] [] []) : (memref<4x4xi32, 1>)
         air.herd @herd_0 tile (%arg12, %arg13) in (%arg14=%c2, %arg15=%c2) {
-          air.herd_terminator
         }
         memref.dealloc %alloc_2 : memref<4x4xi32, 1>
         memref.dealloc %alloc_3 : memref<4x4xi32, 1>
-        air.segment_terminator
       }
       memref.dealloc %alloc_0 : memref<4x4xi32>
       memref.dealloc %alloc_1 : memref<4x4xi32>
-      air.launch_terminator
     }
     return
   }
@@ -83,9 +74,6 @@ module {
 // CHECK: scf.for
 // CHECK: air.channel.get @channel_0
 // CHECK: air.channel.get @channel_1
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func1
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: air.segment
@@ -98,9 +86,6 @@ module {
 // AGGRESSIVE: scf.for
 // AGGRESSIVE: air.channel.get @channel_0
 // AGGRESSIVE: air.channel.get @channel_0
-// AGGRESSIVE: air.herd_terminator
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func1
 // AGGL1: air.launch
 // AGGL1: air.segment
@@ -113,9 +98,6 @@ module {
 // AGGL1: scf.for
 // AGGL1: air.channel.get @channel_0
 // AGGL1: air.channel.get @channel_0
-// AGGL1: air.herd_terminator
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -156,11 +138,8 @@ module {
             memref.dealloc %alloc_6 : memref<4x4xi32, 2>
           }
           memref.dealloc %alloc_4 : memref<4x4xi32, 2>
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -175,8 +154,6 @@ module {
 // CHECK: air.segment
 // CHECK: air.channel.get{{.*}}@channel_0
 // CHECK: air.channel.get{{.*}}@channel_1
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func2
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: air.channel.put{{.*}}@channel_0
@@ -184,8 +161,6 @@ module {
 // AGGRESSIVE: air.segment
 // AGGRESSIVE: air.channel.get{{.*}}@channel_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_0
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func2
 // AGGL1: air.launch
 // AGGL1: air.channel.put{{.*}}@channel_0
@@ -193,8 +168,6 @@ module {
 // AGGL1: air.segment
 // AGGL1: air.channel.get{{.*}}@channel_0
 // AGGL1: air.channel.get{{.*}}@channel_1
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 module {
   air.channel @channel_0 [1, 1]
@@ -231,7 +204,6 @@ module {
         %async_token_9 = air.execute [%5] {
           memref.dealloc %results_7 : memref<4x4xi32, 1>
         }
-        air.segment_terminator
       }
       %async_token_2 = air.execute [%1] {
         memref.dealloc %results : memref<4x4xi32>
@@ -239,7 +211,6 @@ module {
       %async_token_3 = air.execute [%2] {
         memref.dealloc %results_1 : memref<4x4xi32>
       }
-      air.launch_terminator
     }
     return
   }
@@ -255,9 +226,6 @@ module {
 // CHECK: air.herd @herd_0
 // CHECK: air.channel.get{{.*}}@channel_0
 // CHECK: air.channel.get{{.*}}@channel_1
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func3
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: air.channel.put{{.*}}@channel_1
@@ -266,9 +234,6 @@ module {
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_1
 // AGGRESSIVE: air.channel.get{{.*}}@channel_1
-// AGGRESSIVE: air.herd_terminator
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func3
 // AGGL1: air.launch
 // AGGL1: air.channel.put{{.*}}@channel_1
@@ -277,9 +242,6 @@ module {
 // AGGL1: air.herd @herd_0
 // AGGL1: air.channel.get{{.*}}@channel_1
 // AGGL1: air.channel.get{{.*}}@channel_1
-// AGGL1: air.herd_terminator
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {
@@ -335,11 +297,8 @@ module {
             memref.dealloc %alloc : memref<32x32xi32, 2>
             memref.dealloc %alloc_5 : memref<32x32xi32, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -353,7 +312,6 @@ module {
 // CHECK: air.herd @herd_0
 // CHECK: air.channel.get{{.*}}@channel_2
 // CHECK: air.channel.get{{.*}}@channel_3
-// CHECK: air.herd_terminator
 // CHECK: scf.for
 // CHECK-NEXT: scf.for
 // CHECK: air.channel.put{{.*}}@channel_2
@@ -363,16 +321,12 @@ module {
 // CHECK: air.herd @herd_0
 // CHECK: air.channel.get{{.*}}@channel_2
 // CHECK: air.channel.get{{.*}}@channel_3
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func4
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: air.segment @segment_0
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_2
 // AGGRESSIVE: air.channel.get{{.*}}@channel_3
-// AGGRESSIVE: air.herd_terminator
 // AGGRESSIVE: scf.for
 // AGGRESSIVE-NEXT: scf.for
 // AGGRESSIVE: air.channel.put{{.*}}@channel_2
@@ -382,16 +336,12 @@ module {
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_2
 // AGGRESSIVE: air.channel.get{{.*}}@channel_3
-// AGGRESSIVE: air.herd_terminator
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func4
 // AGGL1: air.launch
 // AGGL1: air.segment @segment_0
 // AGGL1: air.herd @herd_0
 // AGGL1: air.channel.get{{.*}}@channel_2
 // AGGL1: air.channel.get{{.*}}@channel_3
-// AGGL1: air.herd_terminator
 // AGGL1: scf.for
 // AGGL1-NEXT: scf.for
 // AGGL1: air.channel.put{{.*}}@channel_2
@@ -401,9 +351,6 @@ module {
 // AGGL1: air.herd @herd_0
 // AGGL1: air.channel.get{{.*}}@channel_2
 // AGGL1: air.channel.get{{.*}}@channel_3
-// AGGL1: air.herd_terminator
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 #map = affine_map<(d0) -> (d0 * 8)>
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
@@ -467,7 +414,6 @@ module {
             }
             scf.yield %14 : !air.async.token
           }
-          air.herd_terminator
         }
         %7 = air.wait_all async 
         %8 = scf.for %arg11 = %c1 to %c8_4 step %c1 iter_args(%arg12 = %7) -> (!air.async.token) {
@@ -512,11 +458,8 @@ module {
               scf.yield %14 : !air.async.token
             }
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     %async_token_2 = air.execute [%0] {
       memref.dealloc %results_1 : memref<2x1x32x256xi32, 1>
@@ -541,8 +484,6 @@ module {
 // CHECK: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // CHECK: air.channel.get{{.*}}@channel_4
 // CHECK: scf.yield
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 // AGGRESSIVE-LABEL: func5
 // AGGRESSIVE: air.launch
 // AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
@@ -552,8 +493,6 @@ module {
 // AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // AGGRESSIVE: air.channel.get{{.*}}@channel_4
 // AGGRESSIVE: scf.yield
-// AGGRESSIVE: air.segment_terminator
-// AGGRESSIVE: air.launch_terminator
 // AGGL1-LABEL: func5
 // AGGL1: air.launch
 // AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
@@ -563,8 +502,6 @@ module {
 // AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // AGGL1: air.channel.get{{.*}}@channel_4
 // AGGL1: scf.yield
-// AGGL1: air.segment_terminator
-// AGGL1: air.launch_terminator
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 32)>
@@ -623,9 +560,7 @@ module {
         %async_token_8 = air.execute [%10] {
           memref.dealloc %results_7 : memref<1x1x64x32xi8, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -639,7 +574,6 @@ module {
 // CHECK: air.segment @segment_0
 // CHECK: air.herd @herd_0
 // CHECK: air.channel.get{{.*}}@channel_6
-// CHECK: air.herd_terminator
 // CHECK: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // CHECK-NEXT: scf.parallel
 // CHECK: air.channel.put{{.*}}@channel_6
@@ -648,16 +582,12 @@ module {
 // CHECK: air.herd @herd_0
 // CHECK: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
 // CHECK: air.channel.get{{.*}}@channel_6
-// CHECK: air.herd_terminator
 // CHECK: air.herd @herd_0
 // CHECK: air.channel.get{{.*}}@channel_6
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
 // AGGRESSIVE-LABEL: func6
 // AGGRESSIVE: air.segment @segment_0
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_6
-// AGGRESSIVE: air.herd_terminator
 // AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // AGGRESSIVE-NEXT: scf.parallel
 // AGGRESSIVE: air.channel.put{{.*}}@channel_6
@@ -666,16 +596,12 @@ module {
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
 // AGGRESSIVE: air.channel.get{{.*}}@channel_6
-// AGGRESSIVE: air.herd_terminator
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: air.channel.get{{.*}}@channel_6
-// AGGRESSIVE: air.herd_terminator
-// AGGRESSIVE: air.segment_terminator
 // AGGL1-LABEL: func6
 // AGGL1: air.segment @segment_0
 // AGGL1: air.herd @herd_0
 // AGGL1: air.channel.get{{.*}}@channel_6
-// AGGL1: air.herd_terminator
 // AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c16{{.*}}step %c1{{.*}}iter_args
 // AGGL1-NEXT: scf.parallel
 // AGGL1: air.channel.put{{.*}}@channel_6
@@ -684,11 +610,8 @@ module {
 // AGGL1: air.herd @herd_0
 // AGGL1: scf.for %{{.*}} = %c1{{.*}}to %c15{{.*}}step %c1
 // AGGL1: air.channel.get{{.*}}@channel_6
-// AGGL1: air.herd_terminator
 // AGGL1: air.herd @herd_0
 // AGGL1: air.channel.get{{.*}}@channel_6
-// AGGL1: air.herd_terminator
-// AGGL1: air.segment_terminator
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {
@@ -729,7 +652,6 @@ module {
       %2 = air.herd @herd_0 async [%async_token_6, %async_token_8]  tile (%arg0, %arg1) in (%arg2=%c2, %arg3=%c2) args(%arg4=%results_7) : memref<1x1x4x8x4x8xi8, 2 : i32> attributes {id = 3 : i32} {
         %7 = air.wait_all async 
         %8 = air.channel.get async [%7]  @channel_2[%arg0, %arg1] (%arg4[] [] []) {id = 14 : i32} : (memref<1x1x4x8x4x8xi8, 2 : i32>)
-        air.herd_terminator
       }
       %3 = scf.for %arg0 = %c1 to %c15 step %c1 iter_args(%arg1 = %async_token_8) -> (!air.async.token) {
         %7 = scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%arg1) -> !air.async.token {
@@ -753,7 +675,6 @@ module {
           %7 = air.wait_all async 
           %8 = air.channel.get async [%7]  @channel_6[%arg0, %arg1] (%arg4[] [] []) {id = 20 : i32} : (memref<1x1x4x8x4x8xi8, 2 : i32>)
         }
-        air.herd_terminator
       }
       %5 = scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%2) -> !air.async.token {
         %async_token_12, %results_13 = air.execute -> (index) {
@@ -770,7 +691,6 @@ module {
       %6 = air.herd @herd_0 async [%4]  tile (%arg0, %arg1) in (%arg2=%c2, %arg3=%c2) args(%arg4=%results_7) : memref<1x1x4x8x4x8xi8, 2 : i32> attributes {id = 5 : i32} {
         %7 = air.wait_all async 
         %8 = air.channel.get async [%7]  @channel_12[%arg0, %arg1] (%arg4[] [] []) {id = 30 : i32} : (memref<1x1x4x8x4x8xi8, 2 : i32>)
-        air.herd_terminator
       }
       %async_token_10 = air.execute {
         memref.dealloc %results_9 : memref<1x1x64x32xi8, 1 : i32>
@@ -778,7 +698,6 @@ module {
       %async_token_11 = air.execute [%6] {
         memref.dealloc %results_7 : memref<1x1x4x8x4x8xi8, 2 : i32>
       }
-      air.segment_terminator
     }
     return
   }
@@ -796,7 +715,6 @@ module {
 // CHECK: scf.for %{{.*}} = %c0{{.*}}to %c64{{.*}}step %c1{{.*}}{
 // CHECK-NEXT: air.channel.put{{.*}}@channel_7{{.*}} : (memref<1x1x32x64xi32, 1 : i32>)
 // CHECK-NEXT: }
-// CHECK: air.segment_terminator
 // AGGRESSIVE-LABEL: func7
 // AGGRESSIVE: air.segment @segment_0
 // AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c64{{.*}}step %c1{{.*}}{
@@ -805,7 +723,6 @@ module {
 // AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}}to %c64{{.*}}step %c1{{.*}}{
 // AGGRESSIVE-NEXT: air.channel.put{{.*}}@channel_7{{.*}} : (memref<1x1x32x64xi32, 1 : i32>)
 // AGGRESSIVE-NEXT: }
-// AGGRESSIVE: air.segment_terminator
 // AGGL1-LABEL: func7
 // AGGL1: air.segment @segment_0
 // AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c64{{.*}}step %c1{{.*}}{
@@ -814,7 +731,6 @@ module {
 // AGGL1: scf.for %{{.*}} = %c0{{.*}}to %c64{{.*}}step %c1{{.*}}{
 // AGGL1-NEXT: air.channel.put{{.*}}@channel_7{{.*}} : (memref<1x1x32x64xi32, 1 : i32>)
 // AGGL1-NEXT: }
-// AGGL1: air.segment_terminator
 
 #set = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 1 >= 0, s1 == 0)>
 module {
@@ -856,7 +772,6 @@ module {
             %10 = air.channel.get async  @channel_3[%arg7, %arg8] (%arg11[] [] []) {id = 17 : i32} : (memref<1x1x8x4x8x4xi32, 2 : i32>)
             affine.yield %10 : !air.async.token
           }
-          air.herd_terminator
         }
         scf.for %arg7 = %c1 to %c63 step %c1 {
           %9 = air.channel.put async [%async_token_1]  @channel_6[] (%results_2[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c2048, %c4, %c512, %c64, %c1]) {id = 22 : i32} : (memref<1x1x32x64xi32, 1 : i32>)
@@ -876,7 +791,6 @@ module {
               affine.yield %10 : !air.async.token
             }
           }
-          air.herd_terminator
         }
         %6 = air.channel.put async [%5]  @channel_10[] (%results_2[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c2048, %c4, %c512, %c64, %c1]) {id = 32 : i32} : (memref<1x1x32x64xi32, 1 : i32>)
         %7 = air.channel.put async [%5]  @channel_11[] (%results_2[%c0, %c0, %c0, %c0, %c0, %c32_0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c2048, %c4, %c512, %c64, %c1]) {id = 33 : i32} : (memref<1x1x32x64xi32, 1 : i32>)
@@ -888,14 +802,11 @@ module {
             %10 = air.channel.get async  @channel_11[%arg7, %arg8] (%arg11[] [] []) {id = 38 : i32} : (memref<1x1x8x4x8x4xi32, 2 : i32>)
             affine.yield %10 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_3 = air.execute [%8] {
           memref.dealloc %results_2 : memref<1x1x32x64xi32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -916,7 +827,6 @@ module {
 // CHECK-NEXT: else
 // CHECK-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // CHECK-NEXT: affine.yield
-// CHECK: air.herd_terminator
 // CHECK: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // CHECK: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // CHECK: air.herd @herd_0
@@ -926,8 +836,6 @@ module {
 // CHECK-NEXT: else
 // CHECK-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // CHECK-NEXT: affine.yield
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
 // AGGRESSIVE-LABEL: func8
 // AGGRESSIVE: air.segment @segment_0
 // AGGRESSIVE: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
@@ -939,7 +847,6 @@ module {
 // AGGRESSIVE-NEXT: else
 // AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // AGGRESSIVE-NEXT: affine.yield
-// AGGRESSIVE: air.herd_terminator
 // AGGRESSIVE: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGRESSIVE: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGRESSIVE: air.herd @herd_0
@@ -949,8 +856,6 @@ module {
 // AGGRESSIVE-NEXT: else
 // AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // AGGRESSIVE-NEXT: affine.yield
-// AGGRESSIVE: air.herd_terminator
-// AGGRESSIVE: air.segment_terminator
 // AGGL1-LABEL: func8
 // AGGL1: air.segment @segment_0
 // AGGL1: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
@@ -962,7 +867,6 @@ module {
 // AGGL1-NEXT: else
 // AGGL1-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // AGGL1-NEXT: affine.yield
-// AGGL1: air.herd_terminator
 // AGGL1: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGL1: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGL1: air.herd @herd_0
@@ -972,8 +876,6 @@ module {
 // AGGL1-NEXT: else
 // AGGL1-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
 // AGGL1-NEXT: affine.yield
-// AGGL1: air.herd_terminator
-// AGGL1: air.segment_terminator
 
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
 module {
@@ -1011,7 +913,6 @@ module {
             %9 = air.channel.get async  @channel_1[%arg7, %arg8] (%arg11[] [] []) {id = 13 : i32} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
             affine.yield %9 : !air.async.token
           }
-          air.herd_terminator
         }
         %5 = air.channel.put async [%4]  @channel_2[] (%results_2[%c0, %c0, %c0, %c0, %c0, %c0] [%c1_0, %c1_0, %c4, %c8, %c4, %c8] [%c2048, %c2048, %c8, %c128, %c32, %c1_0]) {id = 18 : i32} : (memref<1x1x64x32xi32, 1 : i32>)
         %6 = air.channel.put async [%4]  @channel_3[] (%results_2[%c0, %c0, %c0, %c0, %c32, %c0] [%c1_0, %c1_0, %c4, %c8, %c4, %c8] [%c2048, %c2048, %c8, %c128, %c32, %c1_0]) {id = 19 : i32} : (memref<1x1x64x32xi32, 1 : i32>)
@@ -1023,7 +924,6 @@ module {
             %9 = air.channel.get async  @channel_3[%arg7, %arg8] (%arg11[] [] []) {id = 24 : i32} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
             affine.yield %9 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_3 = air.execute [%7] {
           memref.dealloc %results_2 : memref<1x1x64x32xi32, 1 : i32>
@@ -1031,9 +931,7 @@ module {
         %async_token_4 = air.execute [%7] {
           memref.dealloc %results : memref<1x1x4x8x4x8xi32, 2 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_alloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_alloc.mlir
@@ -36,11 +36,8 @@ module {
             }
             scf.yield %async_token_5 : !air.async.token
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_dma.mlir
@@ -56,7 +56,6 @@ module {
             memref.dealloc %7 : memref<32x32xbf16, 2>
             memref.dealloc %8 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
         air.dma_memcpy_nd (%0[%arg3, %arg4] [%c64, %c64] [%c512, %c1], %3[] [] []) {id = 8 : i32} : (memref<512x512xbf16>, memref<64x64xbf16, 1>)
         memref.dealloc %1 : memref<64x64xbf16, 1>

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_dma_in_nested_for.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_dma_in_nested_for.mlir
@@ -70,7 +70,6 @@ module attributes {torch.debug_module_name = "mmult"} {
 // CHECK: scf.yield
                 }
 // CHECK: scf.yield
-                air.herd_terminator
               }
               air.dma_memcpy_nd (%arg12[%arg13, %arg14] [%c128, %c128] [%c1024, %c1_0], %alloc_2[] [] []) {id = 8 : i32} : (memref<256x1024xbf16>, memref<128x128xbf16, 1>)
               memref.dealloc %alloc : memref<128x128xbf16, 1>
@@ -83,9 +82,7 @@ module attributes {torch.debug_module_name = "mmult"} {
 // CHECK: scf.yield
         }
 // CHECK: scf.yield
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_non_pingpong_ops.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_non_pingpong_ops.mlir
@@ -54,7 +54,6 @@ func.func @hoist_ops(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>
           %async_token_9 = air.execute [%async_token_4] {
             memref.dealloc %results_5 : memref<32x32xbf16, 2>
           } 
-          air.herd_terminator
         }
         %4 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
           %5 = air.channel.get async [%arg17]  @channel_1[] (%results[] [] []) : (memref<32x32xbf16, 1>)
@@ -65,9 +64,7 @@ func.func @hoist_ops(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>
         }
         scf.yield %async_token_1 : !air.async.token
       } {unroll = 2}
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -33,7 +33,6 @@
 // CHECK: air.herd @herd_0
 // CHECK: scf.for
 // CHECK: scf.yield
-// CHECK: air.herd_terminator
 
 // CHECK: %[[EVENT0:.*]]:4 = scf.for
 // CHECK: air.channel.get{{.*}}@channel_1
@@ -43,10 +42,6 @@
 // CHECK: air.channel.get{{.*}}@channel_1
 // CHECK: air.channel.put{{.*}}@channel_0
 // CHECK: scf.yield
-
-// CHECK: air.segment_terminator
-
-// CHECK: air.launch_terminator
 
 module {
   air.channel @channel_3 [2, 2]
@@ -100,7 +95,6 @@ module {
             %async_token_46 = air.execute [%18] {
               memref.dealloc %results_42 : memref<32x32xi32, 2>
             }
-            air.herd_terminator
           }
           %12 = scf.parallel (%arg9, %arg10) = (%c0_23, %c0_23) to (%c2, %c2) step (%c1_22, %c1_22) init (%arg8) -> !air.async.token {
             %15 = air.channel.put async [%arg8]  @channel_2[%arg9, %arg10] (%results_27[] [] []) {id = 12 : i32} : (memref<32x32xi32, 1>)
@@ -164,9 +158,7 @@ module {
         %async_token_36 = air.execute [%10] {
           memref.dealloc %results_27 : memref<32x32xi32, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -196,9 +188,6 @@ module {
 // CHECK: scf.for {{.*}} = %[[CST0]] to %[[CST512]] step %[[CST64]] iter_args
 // CHECK: scf.yield
 // CHECK: air.channel.put{{.*}}@channel_0
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {
@@ -231,7 +220,6 @@ module {
             %async_token_4 = air.execute [%6] {
               memref.dealloc %results_2 : memref<32x32xi32, 2>
             }
-            air.herd_terminator
           }
           %4 = scf.parallel (%arg6, %arg7) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%arg5) -> !air.async.token {
             %async_token_1, %results_2 = air.execute -> (index) {
@@ -252,9 +240,7 @@ module {
           %5 = air.wait_all async [%3, %4] 
           scf.yield %5 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -274,10 +260,6 @@ module {
 // CHECK: scf.for %{{.*}} = %c0 to %c256 step %c64 iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (!air.async.token, !air.async.token, !air.async.token, !air.async.token) {
 // CHECK: scf.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !air.async.token, !air.async.token, !air.async.token, !air.async.token
 // CHECK: scf.yield %{{.*}} : !air.async.token
-
-// CHECK: air.herd_terminator
-// CHECK: air.segment_terminator
-// CHECK: air.launch_terminator
 
 module {
   func.func @func2() {
@@ -339,11 +321,8 @@ module {
           %async_token_3 = air.execute [%4] {
             memref.dealloc %results_2 : memref<32x32xi32, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -460,9 +439,7 @@ module {
         %async_token_17 = air.execute [%5] {
           memref.dealloc %results : memref<64x1024xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
@@ -33,11 +33,8 @@ module {
             }
             scf.yield %async_token_5 : !air.async.token
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_scf_for_in_segment.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_scf_for_in_segment.mlir
@@ -33,13 +33,10 @@ module {
         }
         %4 = scf.for %arg10 = %c0 to %c512 step %c64 iter_args(%arg11 = %3) -> (!air.async.token) {
           %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
-            air.herd_terminator
           }
           scf.yield %2 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/ping_pong_transform.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/ping_pong_transform.mlir
@@ -60,9 +60,7 @@ module {
           }
           scf.yield %async_token_1 : !air.async.token
         } {unroll = 2 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -117,9 +115,7 @@ module {
           }
           scf.yield %async_token_dealloc_200 : !air.async.token
         } {unroll = 2 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
@@ -79,16 +79,13 @@ module attributes {torch.debug_module_name = "model"} {
           air.dma_memcpy_nd (%arg19[%7, %8] [%c32, %c32] [%c64_1, %c1_0], %10[] [] []) {id = 7 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
           memref.dealloc %9 : memref<32x32xbf16, 2>
           memref.dealloc %10 : memref<32x32xbf16, 2>
-          air.herd_terminator
         }
         air.dma_memcpy_nd (%arg14[%arg9, %arg10] [%c64_2, %c64_2] [%c1024_0, %c1_1], %new_1[] [] []) {id = 8 : i32} : (memref<64x64xbf16, 1>, memref<64x64xbf16, 1>)
         memref.dealloc %new_0 : memref<64x64xbf16, 1>
         memref.dealloc %new_1 : memref<64x64xbf16, 1>
-        air.segment_terminator
       }
       memref.dealloc %5 : memref<64x64xbf16, 1>
       memref.dealloc %6 : memref<64x64xbf16, 1>
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
@@ -97,9 +97,7 @@ func.func @func0() {
       %async_token_23 = air.execute [%7, %8] {
         memref.dealloc %results_16 : memref<64x64xi32, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -155,9 +153,7 @@ func.func @func1() {
       %async_token_22 = air.execute [%async_token_17] {
         memref.dealloc %results_18 : memref<64x2048xi32, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -172,10 +168,8 @@ func.func @func1() {
 // CHECK-NEXT: memref.alloc() : memref<1x1x16x16x4x4xbf16, 2 : i32>
 // CHECK: %[[EVENT2:.*]] = air.herd @herd_0 async [%[[EVENT1]]]  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
 // CHECK: func.call @linalg_fill_bf16(%{{.*}}, %{{.*}}) : (bf16, memref<1x1x16x16x4x4xbf16, 2 : i32>) -> ()
-// CHECK: air.herd_terminator
 // CHECK: %[[EVENT3:.*]] = air.herd @herd_0 async [%[[EVENT2]]]  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
 // CHECK: func.call @linalg_fill_bf16(%{{.*}}, %{{.*}}) : (bf16, memref<1x1x16x16x4x4xbf16, 2 : i32>) -> ()
-// CHECK: air.herd_terminator
 // CHECK: %[[EVENT4:.*]] = air.herd @herd_0 async  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2, %{{.*}}=%c2) args(%{{.*}}=%[[RESULT1]]) : memref<1x1x16x16x4x4xbf16, 2 : i32>
 // CHECK-DAG: %[[CST256:.*]] = arith.constant 256 : index
 // CHECK-DAG: %[[CST8192:.*]] = arith.constant 8192 : index
@@ -184,7 +178,6 @@ func.func @func1() {
 // CHECK-DAG: %[[CST16:.*]] = arith.constant 16 : index
 // CHECK-DAG: %[[CST0:.*]] = arith.constant 0 : index
 // CHECK: air.channel.put async [{{.*}}]  @channel_12[%{{.*}}, %{{.*}}] (%{{.*}}[%[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]], %[[CST0]]] [%[[CST1]], %[[CST1]], %[[CST16]], %[[CST4]], %[[CST16]], %[[CST4]]] [%[[CST8192]], %[[CST8192]], %[[CST16]], %[[CST4]], %[[CST256]], %[[CST1]]]) {{.*}} : (memref<1x1x16x16x4x4xbf16, 2 : i32>)
-// CHECK: air.herd_terminator
 // CHECK: memref.dealloc %{{.*}} : memref<1x1x16x16x4x4xbf16, 2 : i32>
 
 #map = affine_map<()[s0] -> (s0 * 128)>
@@ -215,7 +208,6 @@ func.func @func2() {
         %async_token_5 = air.execute {
           func.call @linalg_fill_bf16(%cst, %subview) : (bf16, memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>) -> ()
         }
-        air.herd_terminator
       }
       %3 = air.herd @herd_0 async [%2]  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results) : memref<1x1x32x32x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
         %cst = arith.constant 0.000000e+00 : bf16
@@ -235,7 +227,6 @@ func.func @func2() {
             func.call @linalg_fill_bf16(%cst, %subview) : (bf16, memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>) -> ()
           }
         }
-        air.herd_terminator
       }
       %4 = air.herd @herd_0 async  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%results) : memref<1x1x32x32x4x4xbf16, 2 : i32> attributes {id = 5 : i32} {
         %c1 = arith.constant 1 : index
@@ -255,14 +246,11 @@ func.func @func2() {
         %5 = air.wait_all async 
         %6 = air.wait_all async 
         %7 = air.channel.put async [%async_token_2, %async_token_4, %5, %6]  @channel_12[%arg7, %arg8] (%arg11[%c0, %c0, %results_5, %results_3, %c0, %c0] [%c1, %c1, %c16, %c4_1, %c16, %c4_1] [%c16384, %c16384, %c16, %c4_1, %c512, %c1]) {id = 27 : i32} : (memref<1x1x32x32x4x4xbf16, 2 : i32>)
-        air.herd_terminator
       }
       %async_token_0 = air.execute [%4] {
         memref.dealloc %results : memref<1x1x32x32x4x4xbf16, 2 : i32>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -336,14 +324,11 @@ func.func @func3() {
           %5 = vector.transfer_read %arg12[%c0, %c0, %results_5, %results_3, %c0, %c0], %cst {in_bounds = [true, true, true, true, true, true]} : memref<1x1x32x32x4x4xbf16, 2 : i32>, vector<1x1x16x16x4x4xbf16>
           air.execute_terminator %5 : vector<1x1x16x16x4x4xbf16>
         }
-        air.herd_terminator
       }
       %async_token_0 = air.execute {
         memref.dealloc %results : memref<1x1x32x32x4x4xbf16, 2 : i32>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -424,11 +409,8 @@ func.func @func4(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg2
           }
           scf.yield %5 : !air.async.token
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -519,11 +501,8 @@ func.func @func5() {
         %async_token_2 = air.execute [%3] {
           memref.dealloc %results : memref<16x16x4x4xf32, 2 : i32>
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -597,11 +576,8 @@ func.func @func6(%arg0: memref<512x512xi32>, %arg1: memref<512x512xi32>, %arg2: 
           }
           scf.yield %5 : !air.async.token
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -25,8 +25,6 @@ module {
   // CHECK: scf.for{{.*}}iter_args(%[[EVENT1:.*]] = %[[EVENT0]])
   // CHECK: air.herd
   // CHECK: air.channel.get async{{.*}}@channel_0
-  // CHECK: air.herd_terminator
-  // CHECK: air.segment_terminator
 
   func.func @test0(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>, %arg2: memref<1024x1024xbf16>, %arg3: memref<1024x1024xbf16>) {
     %c1 = arith.constant 1 : index
@@ -54,13 +52,10 @@ module {
               air.execute_terminator %alloc : memref<4x4xi32, 2>
             }
             %5 = air.channel.get async [%async_token_27]  @channel_0[%arg21, %arg22] (%results_28[] [] []) : (memref<4x4xi32, 2>)
-            air.herd_terminator
           }
           scf.yield %2 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for.mlir
@@ -40,11 +40,8 @@ func.func @unroll_by_two(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xb
           }
           scf.yield %async_token_5 : !air.async.token
         } {unroll = 2 : i32}
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for_and_hoist_alloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for_and_hoist_alloc.mlir
@@ -48,11 +48,8 @@ func.func @unroll_and_hoist_alloc(%arg0: memref<256x1024xbf16>, %arg1: memref<10
           }
           scf.yield %async_token_5 : !air.async.token
         } {unroll = 2 : i32}
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }

--- a/mlir/test/Transform/AIRHerdPlacement/command_line.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/command_line.mlir
@@ -64,7 +64,6 @@ func.func @test_herd_attr() -> () {
 // CHECK-LABEL: test_two_herd_cl
 // CHECK: air.herd
 // CHECK-SAME: attributes {x_loc = 6 : i64, y_loc = 4 : i64}
-// CHECK: air.herd_terminator
 // CHECK: air.herd
 // CHECK-SAME: attributes {x_loc = 6 : i64, y_loc = 4 : i64}
 func.func @test_two_herd_cl() -> () {
@@ -82,7 +81,6 @@ func.func @test_two_herd_cl() -> () {
 // CHECK-LABEL: test_two_herd_cl_2
 // CHECK: air.herd
 // CHECK-SAME: attributes {x_loc = 6 : i64, y_loc = 4 : i64}
-// CHECK: air.herd_terminator
 // CHECK: air.herd
 // CHECK-SAME: attributes {x_loc = 9 : i64, y_loc = 4 : i64}
 func.func @test_two_herd_cl_2() -> () {

--- a/mlir/test/Transform/AIRHerdPlacement/horizontal_herds.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/horizontal_herds.mlir
@@ -92,7 +92,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -127,7 +126,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -162,7 +160,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -197,7 +194,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -232,7 +228,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -267,7 +262,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -302,7 +296,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -337,16 +330,13 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
           memref.dealloc %13 : memref<64x64xbf16, 1>
           memref.dealloc %14 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu.mlir
@@ -80,7 +80,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -115,7 +114,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -150,7 +148,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -185,7 +182,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -220,7 +216,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -255,7 +250,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -290,7 +284,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -325,7 +318,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -365,7 +357,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -404,7 +395,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -443,7 +433,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -482,15 +471,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_overflow.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_overflow.mlir
@@ -72,7 +72,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -107,7 +106,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -142,7 +140,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -177,7 +174,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -212,7 +208,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -247,7 +242,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -282,7 +276,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -317,7 +310,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -357,7 +349,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -396,7 +387,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -436,7 +426,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -475,15 +464,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_random_shapes.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_random_shapes.mlir
@@ -82,7 +82,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -117,7 +116,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -152,7 +150,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -187,7 +184,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -222,7 +218,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -257,7 +252,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -292,7 +286,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -327,7 +320,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -367,7 +359,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -406,7 +397,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -445,7 +435,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -484,15 +473,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_shifted_anchor.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_shifted_anchor.mlir
@@ -80,7 +80,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -115,7 +114,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -150,7 +148,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -185,7 +182,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -220,7 +216,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -255,7 +250,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -290,7 +284,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -325,7 +318,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -365,7 +357,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 69 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 70 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -404,7 +395,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 75 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 76 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -443,7 +433,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 81 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 82 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
@@ -482,15 +471,12 @@ module attributes {torch.debug_module_name = "mmult"} {
             air.dma_memcpy_nd (%arg24[%16, %17] [%c32, %c32] [%c64_1, %c1_0], %19[] [] []) {id = 87 : i32} : (memref<64x64xbf16, 1>, memref<32x32xbf16, 2>)
             memref.dealloc %18 : memref<32x32xbf16, 2>
             memref.dealloc %19 : memref<32x32xbf16, 2>
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg17[%13, %3] [%c64, %c64] [%c1024, %c1], %15[] [] []) {id = 88 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %14 : memref<64x64xbf16, 1>
           memref.dealloc %15 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRHerdPlacement/time_multiplexing_herds.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/time_multiplexing_herds.mlir
@@ -29,7 +29,6 @@ module {
           %1 = affine.apply #map()[%arg8]
           %subview = memref.subview %arg11[0, 0, %1, %0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x32x32x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>
           linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>)
-          air.herd_terminator
         }
         scf.for %arg7 = %c1 to %c16 step %c1 {
           air.herd @herd_0  tile (%arg8, %arg9) in (%arg10=%c2, %arg11=%c2) args(%arg12=%alloc) : memref<1x1x32x32x4x4xbf16, 2 : i32> {
@@ -38,7 +37,6 @@ module {
             %1 = affine.apply #map()[%arg9]
             %subview = memref.subview %arg12[0, 0, %1, %0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x32x32x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>
             linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 16384, 512, 16, 4, 1], offset: ?>, 2 : i32>)
-            air.herd_terminator
           }
         }
         air.herd @herd_0  tile (%arg7, %arg8) in (%arg9=%c2, %arg10=%c2) args(%arg11=%alloc, %arg12=%alloc_0) : memref<1x1x32x32x4x4xbf16, 2 : i32>, memref<1x1x128x128xbf16, 1 : i32> {
@@ -50,13 +48,10 @@ module {
           %3 = affine.apply #map1()[%arg8]
           %subview_1 = memref.subview %arg12[0, 0, %2, %3] [1, 1, 64, 64] [1, 1, 1, 1] : memref<1x1x128x128xbf16, 1 : i32> to memref<1x1x64x64xbf16, strided<[16384, 16384, 128, 1], offset: ?>, 1 : i32>
           air.dma_memcpy_nd (%subview_1[] [] [], %transpose[] [] []) : (memref<1x1x64x64xbf16, strided<[16384, 16384, 128, 1], offset: ?>, 1 : i32>, memref<1x1x16x4x16x4xbf16, strided<[16384, 16384, 16, 4, 512, 1], offset: ?>, 2 : i32>)
-          air.herd_terminator
         }
         memref.dealloc %alloc_0 : memref<1x1x128x128xbf16, 1 : i32>
         memref.dealloc %alloc : memref<1x1x32x32x4x4xbf16, 2 : i32>
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRHerdPlacement/vertical_herds.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/vertical_herds.mlir
@@ -92,7 +92,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%4, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 8 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -127,7 +126,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%5, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 16 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -162,7 +160,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%6, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 24 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -197,7 +194,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%7, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 32 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -232,7 +228,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%8, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 40 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -267,7 +262,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%9, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 48 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -302,7 +296,6 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%10, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 56 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
@@ -337,16 +330,13 @@ module attributes {torch.debug_module_name = "mmult"} {
               memref.dealloc %18 : memref<32x32xbf16, 2>
               memref.dealloc %19 : memref<32x32xbf16, 2>
             }
-            air.herd_terminator
           }
           air.dma_memcpy_nd (%arg16[%11, %3] [%c64, %c64] [%c1024, %c1], %14[] [] []) {id = 64 : i32} : (memref<24576x1024xbf16>, memref<64x64xbf16, 1>)
           memref.dealloc %12 : memref<64x64xbf16, 1>
           memref.dealloc %13 : memref<64x64xbf16, 1>
           memref.dealloc %14 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %2 : memref<24576x1024xbf16>
   }

--- a/mlir/test/Transform/AIRLinalgCodegen/air_pipeline_reduce.mlir
+++ b/mlir/test/Transform/AIRLinalgCodegen/air_pipeline_reduce.mlir
@@ -34,7 +34,6 @@
 // CHECK:         }
 // CHECK:         memref.copy %[[VAL_15]], %[[VAL_9]] : memref<f32, 2> to memref<f32>
 // CHECK:       }
-// CHECK:       air.herd_terminator
 // CHECK:     }
 // CHECK:     return %[[VAL_3]] : memref<f32>
 #map = affine_map<(d0) -> (d0)>

--- a/mlir/test/Transform/AIRMiscPasses/air_lower_herd_parallel.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_lower_herd_parallel.mlir
@@ -26,7 +26,6 @@ func.func @f0(%arg0: memref<128xf32>, %arg1: memref<128xf32>) -> memref<128xf32>
       air.dma_memcpy_nd (%arg7[%arg8] [%c32] [%c1_0], %alloc_1[] [] []) : (memref<128xf32>, memref<32xf32, 2>)
       memref.dealloc %alloc_1 : memref<32xf32, 2>
     }
-    air.herd_terminator
   }
   return %alloc : memref<128xf32>
 }

--- a/mlir/test/Transform/AIRMiscPasses/air_renumber_dma.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_renumber_dma.mlir
@@ -63,7 +63,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %2 = memref.alloc() {alignment = 128 : i64} : memref<64x64xf32>
     linalg.fill ins(%cst : f32) outs(%2 : memref<64x64xf32>)
@@ -90,7 +89,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %4 = memref.alloc() {alignment = 128 : i64} : memref<64x64xf32>
     linalg.fill ins(%cst : f32) outs(%4 : memref<64x64xf32>)
@@ -116,7 +114,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %6 = memref.alloc() {alignment = 128 : i64} : memref<64x1xi64>
     linalg.fill ins(%c0_i64 : i64) outs(%6 : memref<64x1xi64>)
@@ -151,7 +148,6 @@ module {
       memref.dealloc %20 : memref<64x64xf32, 2>
       memref.dealloc %21 : memref<64x1xf32, 2>
       memref.dealloc %22 : memref<64x1xi64, 2>
-      air.herd_terminator
     }
 
     return %8 : memref<64x1xf32>

--- a/mlir/test/Transform/AIRMiscPasses/air_renumber_dma_global.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_renumber_dma_global.mlir
@@ -64,7 +64,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %2 = memref.alloc() {alignment = 128 : i64} : memref<64x64xf32>
     linalg.fill ins(%cst : f32) outs(%2 : memref<64x64xf32>)
@@ -91,7 +90,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %4 = memref.alloc() {alignment = 128 : i64} : memref<64x64xf32>
     linalg.fill ins(%cst : f32) outs(%4 : memref<64x64xf32>)
@@ -117,7 +115,6 @@ module {
         memref.dealloc %22 : memref<32x32xf32, 2>
         memref.dealloc %23 : memref<32x32xf32, 2>
       }
-      air.herd_terminator
     }
     %6 = memref.alloc() {alignment = 128 : i64} : memref<64x1xi64>
     linalg.fill ins(%c0_i64 : i64) outs(%6 : memref<64x1xi64>)
@@ -152,7 +149,6 @@ module {
       memref.dealloc %20 : memref<64x64xf32, 2>
       memref.dealloc %21 : memref<64x1xf32, 2>
       memref.dealloc %22 : memref<64x1xi64, 2>
-      air.herd_terminator
     }
 
     return %8 : memref<64x1xf32>

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast.mlir
@@ -89,7 +89,6 @@ func.func @func0() {
           %8 = air.wait_all async [%6, %7] 
           scf.yield %8 : !air.async.token
         }
-        air.herd_terminator
       }
       scf.yield %3 : !air.async.token
     }
@@ -177,11 +176,8 @@ func.func @func1() {
           %7 = air.wait_all async [%5, %6]  {id = 1 : i32}
           scf.yield %7 : !air.async.token
         }
-        air.herd_terminator
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -245,14 +241,11 @@ module {
             %7 = air.wait_all async [%arg11, %5]  {id = 1 : i32}
             scf.yield %7 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_3 = air.execute [%2] {
           memref.dealloc %results : memref<8x2048xi32, 1 : i32>
         } {id = 10 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -314,7 +307,6 @@ module {
               %7 = air.dma_memcpy_nd async [%arg16, %async_token_13] (%arg14[] [] [], %arg13[%c0, %c0, %c0, %arg10, %results_14, %c0] [%c1_11, %c1_11, %c4, %c4, %c8_12, %c8_12] [%c16384, %c8192, %c8_12, %c256, %c32, %c1_11]) {broadcast_pattern = #set, id = 1 : i32} : (memref<1x1x4x4x8x8xi32, 2>, memref<1x2x256x32xi32, 1>)
               scf.yield %7 : !air.async.token
             }
-            air.herd_terminator
           }
           %4 = air.wait_all async [%arg8, %3]  {id = 5 : i32}
           scf.yield %4 : !air.async.token
@@ -325,9 +317,7 @@ module {
         %async_token_10 = air.execute [%2] {
           memref.dealloc %results : memref<1x1x4x4x8x8xi32, 2>
         } {id = 12 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_4x4.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_4x4.mlir
@@ -113,7 +113,6 @@ module {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_affine_offset.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_affine_offset.mlir
@@ -107,7 +107,6 @@ module {
             memref.dealloc %valOut_18 : memref<32x32xbf16>
             air.execute_terminator
         } {id = 14 : i32}
-        air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_arith_offset.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_arith_offset.mlir
@@ -104,7 +104,6 @@ module {
             memref.dealloc %valOut_18 : memref<32x32xbf16>
             air.execute_terminator
         } {id = 14 : i32}
-        air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_0.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_0.mlir
@@ -93,7 +93,6 @@ module {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_1.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_dma_broadcast_diag_pattern_1.mlir
@@ -106,7 +106,6 @@ module {
         memref.dealloc %valOut_18 : memref<32x32xbf16, 2>
         air.execute_terminator
       } {id = 14 : i32}
-      air.herd_terminator
     }
     return
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
@@ -99,15 +99,12 @@ func.func @test0(%arg0: memref<512x1024xbf16>, %arg1: memref<1024x512xbf16>, %ar
         %async_token_14 = air.execute [%8] {
           memref.dealloc %results_13 : memref<16x16x4x4xbf16, 2>
         }
-        air.herd_terminator
       }
       %7 = air.channel.put async [%3, %4, %6]  @channel_1[] (%results_5[] [] []) {id = 42 : i32} : (memref<256x256xbf16, 1>)
       %async_token_6 = air.execute [%7] {
         memref.dealloc %results_5 : memref<256x256xbf16, 1>
       }
-      air.segment_terminator
     }
-    air.launch_terminator
   }
   return
 }
@@ -267,14 +264,11 @@ module {
             }
             scf.yield %async_token_13 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_7 = air.execute [%8] {
           memref.dealloc %results_6 : memref<256x2048xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -294,7 +288,6 @@ module {
 // CHECK-COUNT-2: memref.alloc() : memref<8x32xi32, 1>
 // CHECK-COUNT-2: air.channel.get {{.*}} @channel_4
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 // CHECK-COUNT-2: air.channel.put {{.*}} @channel_0
 
 #map = affine_map<()[s0] -> (s0 * 8)>
@@ -360,15 +353,12 @@ module {
           %async_token_17 = air.execute [%6] {
             memref.dealloc %results_16 : memref<8x2x4x4xi32, 2 : i32>
           }
-          air.herd_terminator
         }
         %5 = air.channel.put async [%4]  @channel_5[] (%results_8[] [] []) {id = 12 : i32} : (memref<8x64xi32, 1 : i32>)
         %async_token_9 = air.execute [%5] {
           memref.dealloc %results_8 : memref<8x64xi32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -395,7 +385,6 @@ module {
 // CHECK: air.channel.put {{.*}} @channel_3
 // CHECK: air.herd
 // CHECK: air.channel.get {{.*}} @channel_3
-// CHECK: air.herd_terminator
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 32)>
@@ -478,14 +467,11 @@ module {
             }
             scf.yield %async_token_17 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_8 = air.execute [%5] {
           memref.dealloc %results_7 : memref<2048x64xi32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -519,7 +505,6 @@ module {
 // CHECK: air.channel.get {{.*}} @channel_6
 // CHECK: else
 // CHECK: air.channel.get {{.*}} @channel_7
-// CHECK: air.herd_terminator
 
 #map = affine_map<()[s0] -> (s0 * 128)>
 #map1 = affine_map<()[s0] -> (s0 * 8)>
@@ -628,14 +613,11 @@ module {
             }
             scf.yield %12 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_6 = air.execute [%9] {
           memref.dealloc %results_5 : memref<256x128xi32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -653,7 +635,6 @@ module {
 // CHECK-COUNT-4: memref.alloc() : memref<32x64xi32, 1>
 // CHECK-COUNT-8: air.channel.get {{.*}} @channel_8
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 // CHECK-COUNT-4: air.channel.put {{.*}} @channel_0
 
 #map = affine_map<()[s0] -> (s0 * 128)>
@@ -721,15 +702,12 @@ module {
           %async_token_14 = air.execute [%6] {
             memref.dealloc %results_13 : memref<8x8x4x4xi32, 2 : i32>
           }
-          air.herd_terminator
         }
         %5 = air.channel.put async [%4]  @channel_9[] (%results_6[] [] []) {id = 20 : i32} : (memref<128x64xi32, 1 : i32>)
         %async_token_7 = air.execute [%5] {
           memref.dealloc %results_6 : memref<128x64xi32, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -751,7 +729,6 @@ module {
 // CHECK: air.channel.put {{.*}} @channel_6
 // CHECK: air.channel.put {{.*}} @channel_7
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 
 #map = affine_map<()[s0] -> (s0 * 128)>
 #map1 = affine_map<()[s0] -> (s0 * 8)>
@@ -893,14 +870,11 @@ module {
           %async_token_22 = air.execute [%async_token_21] {
             memref.dealloc %results_20 : memref<8x8x4x4xi32, 2 : i32>
           } {id = 22 : i32}
-          air.herd_terminator
         }
         %async_token_9 = air.execute [%8, %3] {
           memref.dealloc %results_8 : memref<128x256xi32, 1 : i32>
         } {id = 24 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -918,7 +892,6 @@ module {
 // CHECK-COUNT-4: memref.alloc() : memref<1x1x64x256xbf16, 1>
 // CHECK-COUNT-16: air.channel.get {{.*}} @channel_30
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<()[s0] -> (s0 * 64)>
@@ -988,7 +961,6 @@ module {
             air.execute_terminator %7 : index
           }
           %6 = air.channel.put async [%async_token_14, %async_token_16]  @channel_30[%arg6, %arg7] (%arg10[%c0_13, %c0_13, %results_17, %results_15, %c0_13, %c0_13] [%c1_12, %c1_12, %c16, %c4_11, %c16, %c4_11] [%c65536_10, %c65536_10, %c16, %c4_11, %c1024, %c1_12]) {id = 63 : i32} : (memref<1x1x64x64x4x4xbf16, 2 : i32>)
-          air.herd_terminator
         }
         %5 = air.channel.put async [%4]  @channel_31[] (%results_5[%c0, %c0, %c0, %c0] [%c1_3, %c1_3, %c256_2, %c256_2] [%c65536, %c65536, %c256_2, %c1_3]) {id = 64 : i32} : (memref<1x1x256x256xbf16, 1 : i32>)
         %async_token_8 = air.execute [%5] {
@@ -997,9 +969,7 @@ module {
         %async_token_9 = air.execute [%5] {
           memref.dealloc %results_5 : memref<1x1x256x256xbf16, 1 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }
@@ -1017,16 +987,13 @@ module {
 // CHECK: memref.alloc() : memref<1x1x8x16x4x8xbf16, 2 : i32>
 // CHECK-COUNT-4: memref.alloc() : memref<1x1x64x64xbf16, 1>
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 // CHECK-COUNT-4: air.channel.get {{.*}} @channel_0
 // CHECK: air.channel.put {{.*}} @channel_8
 // CHECK: air.channel.put {{.*}} @channel_9
 // CHECK: air.channel.put {{.*}} @channel_10
 // CHECK: air.channel.put {{.*}} @channel_11
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 // CHECK: air.herd
-// CHECK: air.herd_terminator
 
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<()[s0] -> (s0 * 64)>
@@ -1105,7 +1072,6 @@ module {
             }
             affine.yield %26 : !air.async.token
           }
-          air.herd_terminator
         }
         %8 = air.wait_all async [%async_token_23, %7] 
         %9 = scf.for %arg10 = %c0_11 to %c32_6 step %c1_12 iter_args(%arg11 = %async_token_23) -> (!air.async.token) {
@@ -1160,7 +1126,6 @@ module {
               affine.yield %26 : !air.async.token
             }
           }
-          air.herd_terminator
         }
         %22 = air.herd @herd_0 async [%19]  tile (%arg10, %arg11) in (%arg12=%c4, %arg13=%c4) args(%arg14=%results_20) : memref<1x1x8x16x4x8xbf16, 2 : i32> {
           %c1024 = arith.constant 1024 : index
@@ -1197,7 +1162,6 @@ module {
             }
             affine.yield %29 : !air.async.token
           }
-          air.herd_terminator
         }
         %async_token_25 = air.execute [%22] {
           memref.dealloc %results_24 : memref<1x1x256x64xbf16, 1 : i32>
@@ -1205,9 +1169,7 @@ module {
         %async_token_27 = air.execute [%22] {
           memref.dealloc %results_20 : memref<1x1x8x16x4x8xbf16, 2 : i32>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
@@ -30,11 +30,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
@@ -31,11 +31,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
@@ -30,11 +30,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
@@ -31,11 +31,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel.mlir
@@ -119,14 +119,11 @@ module {
           %async_token_22 = air.execute [%13] {
             memref.dealloc %results_19 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
         %async_token_23 = air.execute [%4] {
           memref.dealloc %results_11 : memref<128x128xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
+++ b/mlir/test/Util/Runner/bandwidth_contention/channel_per_core.mlir
@@ -164,14 +164,11 @@ module {
           %async_token_22 = air.execute [%13] {
             memref.dealloc %results_19 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
         %async_token_23 = air.execute [%4] {
           memref.dealloc %results_11 : memref<128x128xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/channel.mlir
+++ b/mlir/test/Util/Runner/channel.mlir
@@ -104,7 +104,6 @@ module {
                 %async_token_22 = air.execute [%13] {
                   memref.dealloc %results_19 : memref<32x32xbf16, 2>
                 }
-                air.herd_terminator
               }
               %async_token_16 = air.execute [%10] {
                 memref.dealloc %results_13 : memref<128x128xbf16, 1>
@@ -122,9 +121,7 @@ module {
           }
           scf.yield %6 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/channel_broadcast.mlir
@@ -107,7 +107,6 @@ module {
               %async_token_14 = air.execute [%13] {
                 memref.dealloc %results_13 : memref<32x32xbf16, 2>
               }
-              air.herd_terminator
             }
             %async_token_15 = air.execute [%12] {
               memref.dealloc %results_11 : memref<128x128xbf16, 1>
@@ -116,9 +115,7 @@ module {
           }
           scf.yield %6 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/core_runners/channel.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel.mlir
@@ -104,7 +104,6 @@ module {
                 %async_token_21 = air.execute [%13] {
                   memref.dealloc %results_19 : memref<32x32xbf16, 2>
                 }
-                air.herd_terminator
               }
               %async_token_16 = air.execute [%10] {
                 memref.dealloc %results_13 : memref<128x128xbf16, 1>
@@ -122,9 +121,7 @@ module {
           }
           scf.yield %6 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
+++ b/mlir/test/Util/Runner/core_runners/channel_broadcast.mlir
@@ -104,15 +104,12 @@ module {
                 }
                 affine.yield %14 : !air.async.token
               }
-              air.herd_terminator
             }
             scf.yield %12 : !air.async.token
           }
           scf.yield %6 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
+++ b/mlir/test/Util/Runner/core_runners/core_to_core_ping_pong.mlir
@@ -81,11 +81,8 @@ module {
             }
             affine.yield %4 : !air.async.token
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/one_by_four_herd_dataflow.mlir
@@ -182,12 +182,9 @@ module {
             }
             affine.yield %6 : !air.async.token
           }
-          air.herd_terminator
         }
         %4 = air.channel.get async [%3]  @channel_4[] (%results_6[%c0, %c0] [%c32, %c32] [%c128, %c1_4]) : (memref<128x128xbf16, 1>)
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
+++ b/mlir/test/Util/Runner/core_runners/two_by_two_herd_dataflow.mlir
@@ -99,11 +99,8 @@ module {
           %async_token_8 = air.execute [%3] {
             memref.dealloc %results_7 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/core_runners/two_herds_per_core_mode.mlir
+++ b/mlir/test/Util/Runner/core_runners/two_herds_per_core_mode.mlir
@@ -46,7 +46,6 @@ module {
             }
             scf.yield %6 : !air.async.token
           }
-          air.herd_terminator
         }
         %3 = air.herd @herd_1 async  tile (%arg4, %arg5) in (%arg6=%c1_0, %arg7=%c2) attributes {id = 4 : i32, x_loc = 0 : i64, y_loc = 1 : i64} {
           %c0 = arith.constant 0 : index
@@ -79,11 +78,8 @@ module {
           %async_token_4 = air.execute [%4] {
             memref.dealloc %results : memref<1x32x32x3xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/cost_function/data_movement.mlir
+++ b/mlir/test/Util/Runner/cost_function/data_movement.mlir
@@ -118,11 +118,8 @@ module {
           %async_token_25 = air.execute [%14] {
             memref.dealloc %results_24 : memref<32x32xi8, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<32x32xi32>
   }

--- a/mlir/test/Util/Runner/cost_function/generic_i32.mlir
+++ b/mlir/test/Util/Runner/cost_function/generic_i32.mlir
@@ -61,11 +61,8 @@ module {
           %async_token_11 = air.execute [%async_token_7] {
             memref.dealloc %results_6 : memref<32x32xi32, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xi32>
   }

--- a/mlir/test/Util/Runner/cost_function/mac_bf16.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_bf16.mlir
@@ -57,11 +57,8 @@ module {
           %async_token_12 = air.execute [%async_token_9] {
             memref.dealloc %results_8 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/cost_function/mac_i32.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_i32.mlir
@@ -57,11 +57,8 @@ module {
           %async_token_12 = air.execute [%async_token_9] {
             memref.dealloc %results_8 : memref<32x32xi32, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xi32>
   }

--- a/mlir/test/Util/Runner/cost_function/mac_i8.mlir
+++ b/mlir/test/Util/Runner/cost_function/mac_i8.mlir
@@ -57,11 +57,8 @@ module {
           %async_token_12 = air.execute [%async_token_9] {
             memref.dealloc %results_8 : memref<32x32xi8, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xi8>
   }

--- a/mlir/test/Util/Runner/custom_op/custom_nonlinear.mlir
+++ b/mlir/test/Util/Runner/custom_op/custom_nonlinear.mlir
@@ -60,11 +60,8 @@ module {
           %async_token_12 = air.execute [%5] {
             memref.dealloc %results_8 : memref<32x32xi8, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<32x32xi8>
   }

--- a/mlir/test/Util/Runner/custom_op/tiny_nn.mlir
+++ b/mlir/test/Util/Runner/custom_op/tiny_nn.mlir
@@ -70,7 +70,6 @@ module {
           %async_token_19 = air.execute [%8] {
             memref.dealloc %results_15 : memref<32xi32, 2>
           } {id = 10 : i32}
-          air.herd_terminator
         }
         %5 = air.dma_memcpy_nd async [%4] (%arg12[%c0_0] [%c0_0] [%c0_0], %results_5[] [] []) {id = 6 : i32} : (memref<32xi32>, memref<32xi32, 1>)
         %async_token_6 = air.execute [%4] {
@@ -82,9 +81,7 @@ module {
         %async_token_8 = air.execute [%5] {
           memref.dealloc %results_5 : memref<32xi32, 1>
         } {id = 13 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/dma.mlir
+++ b/mlir/test/Util/Runner/dma.mlir
@@ -59,9 +59,7 @@ module {
           %5 = air.wait_all async [%arg11, %4] 
           scf.yield %5 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/dma_broadcast.mlir
+++ b/mlir/test/Util/Runner/dma_broadcast.mlir
@@ -89,7 +89,6 @@ module {
               %async_token_11 = air.execute [%7] {
                 memref.dealloc %results_11 : memref<32x32xbf16, 2>
               }
-              air.herd_terminator
             }
             %async_token_12 = air.execute [%6] {
               memref.dealloc %results_6 : memref<128x128xbf16, 1>
@@ -98,9 +97,7 @@ module {
           }
           scf.yield %4 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/hierarchy.mlir
+++ b/mlir/test/Util/Runner/hierarchy.mlir
@@ -80,11 +80,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/multi_token_loop.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop.mlir
@@ -95,9 +95,7 @@ module {
         %async_token_20 = air.execute [%4#1] {
           memref.dealloc %results_12 : memref<128x128xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_blocking.mlir
@@ -101,7 +101,6 @@ module {
             %async_token_27 = air.execute [%5#2] {
               memref.dealloc %results_18 : memref<64x32xbf16, 2>
             }
-            air.herd_terminator
           }
           %async_token_28 = air.execute [%3] {
             memref.dealloc %results_8 : memref<128x128xbf16, 1>
@@ -115,9 +114,7 @@ module {
         %async_token_31 = air.execute [%2] {
           memref.dealloc %results_6 : memref<128x128xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_producer_consumer_pipeline.mlir
@@ -183,7 +183,6 @@ module attributes {torch.debug_module_name = "mmult"} {
             %async_token_41 = air.execute [%12#1] {
               memref.dealloc %results_36 : memref<32x32xf32, 2>
             } {id = 21 : i32}
-            air.herd_terminator
           }
           %async_token_18 = air.execute [%7] {
             memref.dealloc %results_15 : memref<128x128xf32, 1>
@@ -197,9 +196,7 @@ module attributes {torch.debug_module_name = "mmult"} {
         %async_token_13 = air.execute [%2] {
           memref.dealloc %results_12 : memref<128x128xf32, 1>
         } {id = 24 : i32}
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_8 : memref<512x512xf32>
   }

--- a/mlir/test/Util/Runner/multi_token_loop_race.mlir
+++ b/mlir/test/Util/Runner/multi_token_loop_race.mlir
@@ -131,7 +131,6 @@ module {
             %async_token_24 = air.execute [%12] {
               memref.dealloc %results_23 : memref<16x16xbf16, 2>
             }
-            air.herd_terminator
           }
           %async_token_13 = air.execute [%8] {
             memref.dealloc %results_10 : memref<64x64xbf16, 1>
@@ -145,9 +144,7 @@ module {
         %async_token_8 = air.execute [%5] {
           memref.dealloc %results_7 : memref<64x64xbf16, 1>
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/multiple_launches.mlir
+++ b/mlir/test/Util/Runner/multiple_launches.mlir
@@ -30,11 +30,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     %3 = air.launch async [%0] (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
       %4 = air.segment async  args(%arg15=%arg4, %arg16=%arg5, %arg17=%arg6, %arg18=%arg7, %arg19=%arg8, %arg20=%arg9) : index, index, index, index, memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
@@ -47,11 +44,8 @@ module {
           %async_token_5 = air.execute [%async_token_3] {
             memref.dealloc %results_4 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/segment_dataflow.mlir
+++ b/mlir/test/Util/Runner/segment_dataflow.mlir
@@ -111,7 +111,6 @@ module {
           }
           scf.yield %async_token_13 : !air.async.token
         }
-        air.segment_terminator
       }
       %8 = air.wait_all async 
       %9 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %8) -> (!air.async.token) {
@@ -177,7 +176,6 @@ module {
           }
           scf.yield %async_token_17 : !air.async.token
         }
-        air.segment_terminator
       }
       %13 = air.wait_all async 
       %14 = scf.for %arg15 = %c0 to %c1024 step %c256 iter_args(%arg16 = %13) -> (!air.async.token) {
@@ -248,9 +246,7 @@ module {
           }
           scf.yield %async_token_17 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_5 : memref<1024x1024xbf16>
   }

--- a/mlir/test/Util/Runner/segment_dataflow_pipeline.mlir
+++ b/mlir/test/Util/Runner/segment_dataflow_pipeline.mlir
@@ -40,7 +40,6 @@ module {
           }
           scf.yield %async_token_0 : !air.async.token
         }
-        air.segment_terminator
       }
       %2 = air.segment async  attributes {id = 4 : i32, x_loc = 4 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c512 = arith.constant 512 : index
@@ -104,7 +103,6 @@ module {
           }
           scf.yield %async_token_7 : !air.async.token
         }
-        air.segment_terminator
       }
       %3 = air.segment async  attributes {id = 6 : i32, x_loc = 8 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 4 : i64} {
         %c512 = arith.constant 512 : index
@@ -167,9 +165,7 @@ module {
           }
           scf.yield %async_token_7 : !air.async.token
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return
   }

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention.mlir
@@ -51,11 +51,8 @@ module {
           %async_token_8 = air.execute [%async_token_5] {
             memref.dealloc %results_6 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
+++ b/mlir/test/Util/Runner/tile_memory_contention/tile_memory_contention_per_core.mlir
@@ -83,11 +83,8 @@ module {
           %async_token_8 = air.execute [%async_token_5] {
             memref.dealloc %results_6 : memref<32x32xbf16, 2>
           }
-          air.herd_terminator
         }
-        air.segment_terminator
       }
-      air.launch_terminator
     }
     return %results_2 : memref<256x1024xbf16>
   }

--- a/python/test/compiler/linalg_to_air.py
+++ b/python/test/compiler/linalg_to_air.py
@@ -34,7 +34,6 @@ def run(f):
 # CHECK: air.dma_memcpy_nd ({{.*}}) {id = 5 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32, 1>
 # CHECK: air.dma_memcpy_nd ({{.*}}) {id = 6 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32, 1>
 # CHECK: air.dma_memcpy_nd ({{.*}}) {id = 7 : i32} : (memref<64x64xi32, 1>, memref<32x32xi32, 2>
-# CHECK: air.herd_terminator
 # CHECK: air.dma_memcpy_nd ({{.*}}) {id = 8 : i32} : (memref<128x128xi32>, memref<64x64xi32, 1>
 @run
 def matmul_l1_l2_2x2():

--- a/python/test/dialect/air_ops.py
+++ b/python/test/dialect/air_ops.py
@@ -28,7 +28,6 @@ def constructAndPrintInFunc(f):
 # CHECK-LABEL: TEST: launchOp
 # CHECK: air.launch @pyLaunch () in () {
 # CHECK:   %{{.*}} = arith.constant 1 : index
-# CHECK:   air.launch_terminator
 @constructAndPrintInFunc
 def launchOp():
     l = Launch("pyLaunch")
@@ -41,7 +40,6 @@ def launchOp():
 # CHECK-LABEL: TEST: segmentOp
 # CHECK: air.segment @pySegment {
 # CHECK:   %{{.*}} = arith.constant 1 : index
-# CHECK:   air.segment_terminator
 @constructAndPrintInFunc
 def segmentOp():
     s = Segment("pySegment")
@@ -56,7 +54,6 @@ def segmentOp():
 # CHECK: %[[C1:.*]] = arith.constant 2 : index
 # CHECK: air.herd @pyHerd tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%[[C0]], %{{.*}}=%[[C1]]) {
 # CHECK:   %{{.*}} = arith.constant 1 : index
-# CHECK:   air.herd_terminator
 @constructAndPrintInFunc
 def herdOp():
     H = Herd("pyHerd", [2, 2])


### PR DESCRIPTION
`air.herd`, `air.launch` and `air.segment` ops have the `SingleBlockImplicitTerminator` interface but only implement it in the parser. This change makes the terminators more implicit by updating the builders to call `ensureTerminator`, updating the printers to omit printing the terminator, and generally removing the terminator ops from the tests. The python side got a similar update in https://github.com/Xilinx/mlir-air/pull/602