### PR TITLE
XRTBackend API Cleanup

### DIFF
--- a/python/air/backend/abc.py
+++ b/python/air/backend/abc.py
@@ -47,3 +47,8 @@ class AirBackend(abc.ABC):
         See the description of `Invoker` for the requirements on the returned
         type.
         """
+
+
+class AirBackendError(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/python/air/backend/abc.py
+++ b/python/air/backend/abc.py
@@ -50,5 +50,12 @@ class AirBackend(abc.ABC):
 
 
 class AirBackendError(Exception):
+    """An exception thrown by AIR backends"""
+
     def __init__(self, message):
+        """
+        Constructor for the AirBackendError
+        Args:
+            message: the reason for the exception
+        """
         super().__init__(message)

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -6,46 +6,59 @@
 import air.ir
 import air.passmanager
 
-from .abc import AirBackend
+from .abc import AirBackend, AirBackendError
 
 import air.compiler.util
 import air.compiler.aircc.main as aircc
 
 import numpy as np
 import pyxrt as xrt
+import os
+
+
+class XRTCompileArtifact:
+    def __init__(
+        self,
+        xclbin,
+        kernel,
+        insts,
+    ):
+        self.xclbin = xclbin
+        self.kernel = kernel
+        self.insts = insts
 
 
 class XRTBackend(AirBackend):
     """Main entry-point for the xrt based AIR backend.
 
     Args:
-      verbose: verbose
-      xclbin: xclbin filename to use
-      kernel: kernel name to use
-      insts: instruction filename to use
+      verbose: verbose output
+      experimental_passes: configure aircc to run additional experimental passes
+      omit_while_true_loop: configure aircc to comit the while true loop it traditionally emits.
     """
 
     def __init__(
         self,
         verbose=False,
-        xclbin="air.xclbin",
-        kernel="MLIR_AIE",
-        insts="air.insts.txt",
         experimental_passes=False,
         omit_while_true_loop=False,
     ):
         super().__init__()
-        self.opts_xclbin = xclbin
-        self.opts_kernel = kernel
-        self.opts_insts = insts
         self.verbose = verbose
         self.experimental_passes = experimental_passes
         self.omit_while_true_loop = omit_while_true_loop
+        self.currently_loaded = False
 
     def __del__(self):
         self.unload()
 
-    def compile(self, air_module: air.ir.Module, pipeline=None):
+    def compile(
+        self,
+        air_module: air.ir.Module,
+        xclbin="air.xclbin",
+        kernel="MLIR_AIE",
+        insts="air.insts.txt",
+    ):
         """Compiles an AIR module for the NPU / XRT Runtime with aircc.
 
         The module is expected to be AIR dialect IR. Unless 'pipeline' is
@@ -54,12 +67,16 @@ class XRTBackend(AirBackend):
 
         Args:
           air_module: The MLIR module consisting of funcs in the AIR dialect.
-          pipeline: aircc optimization pipeline to use.
-          verbose: verbose
+          xclbin: xclbin filename to use
+          kernel: kernel name to use
+          insts: instruction filename to use
         Returns:
-          An opaque, backend specific compiled artifact object that can be
-          passed to `load`.
+          An XRTCompile object
         """
+        if self.currently_loaded:
+            raise AirBackendError(
+                "Cannot use XRTBackend to compile while the artifact is currently loaded. Call unload() first."
+            )
 
         with air.ir.Context():
 
@@ -74,7 +91,9 @@ class XRTBackend(AirBackend):
                 "-xchesscc",
                 "-xbridge",
                 "-o",
-                self.opts_xclbin,
+                xclbin,
+                "-i",
+                insts,
             ]
 
             if self.verbose:
@@ -88,33 +107,47 @@ class XRTBackend(AirBackend):
 
             aircc.run(air_module, aircc_options)
 
-        return air_module
+        return XRTCompileArtifact(xclbin, kernel, insts)
 
-    def load(self, module):
+    def load(self, artifact: XRTCompileArtifact):
         """Load a compiled artifact into the air runtime.
 
         Returns: A callable that can be used to invoke the loaded module.
             The callable takes a list of numpy arrays. Each numpy array is
             assumed to be an input/output tensor. The callable also returns a
             list of numpy arrays, one for each tensor."""
+        if self.currently_loaded:
+            raise AirBackendError(
+                "Cannot use XRTBackend to compile while the artifact is currently loaded. Call unload() first."
+            )
+
+        if not os.path.isfile(artifact.xclbin):
+            raise AirBackendError(
+                f"Cannot load XRTCompileArtifact because {artifact.xclbin} xclbin file does not exist"
+            )
+        if not os.path.isfile(artifact.insts):
+            raise AirBackendError(
+                f"Cannot load XRTCompileArtifact because {artifact.insts} insts file does not exist"
+            )
 
         # create the device, xclbin and context
         self.device = xrt.device(0)
-        self.xclbin = xrt.xclbin(self.opts_xclbin)
+        self.xclbin = xrt.xclbin(artifact.xclbin)
         self.device.register_xclbin(self.xclbin)
         self.context = xrt.hw_context(self.device, self.xclbin.get_uuid())
 
         # find and load the kernel
         kernels = self.xclbin.get_kernels()
         try:
-            xkernel = [k for k in kernels if self.opts_kernel in k.get_name()][0]
+            xkernel = [k for k in kernels if artifact.kernel in k.get_name()][0]
         except:
-            print(f"Kernel '{self.opts_kernel}' not found in '{self.opts_xclbin}'")
-            exit(-1)
+            raise AirBackendError(
+                f"Kernel '{artifact.kernel}' not found in '{self.xclbin}'"
+            )
         self.kernel = xrt.kernel(self.context, xkernel.get_name())
 
         # load the instructions as a numpy array
-        with open(self.opts_insts, "r") as f:
+        with open(artifact.insts, "r") as f:
             instr_text = f.read().split("\n")
             instr_text = [l for l in instr_text if l != ""]
             self.instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
@@ -168,9 +201,11 @@ class XRTBackend(AirBackend):
 
     def unload(self):
         """Unload any loaded module and shutdown the air runtime."""
-        self.kernel = None
-        self.context = None
-        self.xclbin = None
-        self.device = None
-        self.bo_instr = None
-        self.instr_v = None
+        if self.currently_loaded:
+            self.kernel = None
+            self.context = None
+            self.xclbin = None
+            self.device = None
+            self.bo_instr = None
+            self.instr_v = None
+            self.currently_loaded = False

--- a/python/air/compiler/aircc/cl_arguments.py
+++ b/python/air/compiler/aircc/cl_arguments.py
@@ -22,6 +22,12 @@ def parse_args(args=None):
     )
     parser.add_argument("-o", dest="output_file", default="", help="Output filename")
     parser.add_argument(
+        "-i",
+        dest="insts_file",
+        default="",
+        help="Output insts file name. Only used for compilation on an NPU.",
+    )
+    parser.add_argument(
         "--tmpdir",
         metavar="tmpdir",
         default="air_project",

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -446,12 +446,14 @@ def run(mlir_module, args=None):
                 + ")"
             )
             run_passes(air_to_npu_passes, air_to_npu_module, opts, air_to_npu_file)
+            xclbin_file = "aie.xclbin"
             if opts.output_file:
                 xclbin_file = opts.output_file
-                insts_file = opts.output_file.removesuffix(".xclbin") + ".insts.txt"
+            if opts.insts_file:
+                insts_file = opts.insts_file
             else:
-                xclbin_file = "aie.xclbin"
-                insts_file = "aie.insts.txt"
+                assert xclbin_file.endswith(".xclbin")
+                insts_file = opts.output_file.removesuffix(".xclbin") + ".insts.txt"
             aiecc_options = (["-v"] if opts.verbose else []) + [
                 "--no-aiesim",
                 "--xchesscc" if opts.xchesscc else "--no-xchesscc",


### PR DESCRIPTION
There are a few things about the `XRTBackend` that are a bit unintuitive:
* You can't actually set the insts file path (unused parameters)
* There are unneeded parameters (`module` in `load()`)
* There aren't safety checks for the state that is saved in the backend during `load()`

This PR cleans up a few aspects of `XRTBackend` to ensure parameters make sense and are used as one would expect.