### PR TITLE
Programming Example `matrix_scalar_add/multi_core_channel` Fix

### DIFF
--- a/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
@@ -20,21 +20,25 @@ from air.dialects.air import *
 from air.dialects.memref import AllocOp, DeallocOp, load, store
 from air.dialects.func import FuncOp
 from air.dialects.scf import for_, yield_
-from air.dialects.affine import apply as affine_apply
 
 range_ = for_
 
 from common import *
 
 
+def format_name(prefix, index_0, index_1):
+    return f"{prefix}{index_0:02}{index_1:02}"
+
+
 @module_builder
 def build_module():
     memrefTyInOut = MemRefType.get(IMAGE_SIZE, T.i32())
 
-    # Create two channels which will send/receive the
-    # input/output data respectively
-    ChannelOp("ChanIn", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
-    ChannelOp("ChanOut", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
+    # Create an input/output channel pair per worker
+    for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+        for w in range(IMAGE_WIDTH // TILE_WIDTH):
+            ChannelOp(format_name("ChanIn", h, w))
+            ChannelOp(format_name("ChanOut", h, w))
 
     # We will send an image worth of data in and out
     @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
@@ -44,142 +48,89 @@ def build_module():
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
 
-            # Transform data into contiguous tiles
-            for tile_index0 in range_(IMAGE_HEIGHT // TILE_HEIGHT):
-                for tile_index1 in range_(IMAGE_WIDTH // TILE_WIDTH):
-                    # Convert the type of the tile size variable to the Index type
-                    tile_size0 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
-                    tile_size1 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
-
-                    # Calculate the offset into the channel data, which is based on which tile index
-                    # we are at using tile_index0 and tile_index1 (our loop vars).
-                    # tile_index0 and tile_index1 are dynamic so we have to use specialized
-                    # operations do to calculations on them
-                    offset0 = arith.MulIOp(tile_size0, tile_index0)
-                    offset1 = arith.MulIOp(tile_size1, tile_index1)
+            # Transfer one tile of data per worker
+            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+                for w in range(IMAGE_WIDTH // TILE_WIDTH):
+                    offset0 = IMAGE_HEIGHT * h
+                    offset1 = IMAGE_HEIGHT * w
 
                     # Put data into the channel tile by tile
                     ChannelPut(
-                        "ChanIn",
+                        format_name("ChanIn", h, w),
                         a,
-                        indices=[1, 1],
                         offsets=[offset0, offset1],
                         sizes=[TILE_HEIGHT, TILE_WIDTH],
                         strides=[IMAGE_WIDTH, 1],
                     )
+
+            # Transfer one tile of data per worker
+            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+                for w in range(IMAGE_WIDTH // TILE_WIDTH):
+                    offset0 = IMAGE_HEIGHT * h
+                    offset1 = IMAGE_HEIGHT * w
 
                     # Write data back out to the channel tile by tile
                     ChannelGet(
-                        "ChanOut",
+                        format_name("ChanOut", h, w),
                         b,
-                        indices=[1, 1],
                         offsets=[offset0, offset1],
                         sizes=[TILE_HEIGHT, TILE_WIDTH],
                         strides=[IMAGE_WIDTH, 1],
                     )
-                    yield_([])
-                yield_([])
 
             # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+            @segment(name="seg")
+            def segment_body():
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We are hoping to map each tile to a different compute core.
-                @herd(
-                    name="xaddherd",
-                    sizes=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH],
-                    operands=[arg2, arg3],
-                )
-                def herd_body(tx, ty, sx, sy, a, b):
-                    scaled_index_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(IMAGE_HEIGHT),
-                            )
-                        ],
-                    )
-                    create_tile_index_hight = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(IMAGE_HEIGHT // TILE_HEIGHT),
-                            )
-                        ],
-                    )
-                    create_tile_index = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineSymbolExpr.get(1),
-                            )
-                        ],
-                    )
-                    # offset0 = affine_apply(scaled_index_map, [tx])
-                    tile_index_hight = affine_apply(create_tile_index_hight, [tx])
-                    compute_tile_id = affine_apply(
-                        create_tile_index, [tile_index_hight, ty]
-                    )
+                # Transfer one tile of data per worker
+                for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+                    for w in range(IMAGE_WIDTH // TILE_WIDTH):
 
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+                        @herd(name=format_name("xaddherd", h, w), sizes=[1, 1])
+                        def herd_body(_tx, _ty, _sx, _sy):
+                            # We want to store our data in L1 memory
+                            mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
 
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=TILE_SIZE,
-                        element_type=T.i32(),
-                        memory_space=mem_space,
-                    )
-
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in = AllocOp(tile_type, [], [])
-                    tile_out = AllocOp(tile_type, [], [])
-
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    ChannelGet(
-                        "ChanIn",
-                        tile_in,
-                        indices=[1, 1],
-                    )
-
-                    # Access every value in the tile
-                    for j in range_(TILE_HEIGHT):
-                        for i in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val_in = load(tile_in, [i, j])
-
-                            # Compute the output value
-                            # TODO(hunhoffe): is there any guarantee it will get a tiles worth of data that corresponds to the tile id?
-                            val_out = arith.addi(
-                                val_in, arith.index_cast(T.i32(), compute_tile_id)
+                            # This is the type definition of the tile
+                            tile_type = MemRefType.get(
+                                shape=TILE_SIZE,
+                                element_type=T.i32(),
+                                memory_space=mem_space,
                             )
 
-                            # Store the output value in tile_out
-                            store(
-                                val_out,
-                                tile_out,
-                                [i, j],
-                            )
-                            yield_([])
-                        yield_([])
+                            # We must allocate a buffer of tile size for the input/output
+                            tile_in = AllocOp(tile_type, [], [])
+                            tile_out = AllocOp(tile_type, [], [])
 
-                    # Copy the output tile into the output
-                    ChannelPut(
-                        "ChanOut",
-                        tile_out,
-                        indices=[1, 1],
-                    )
+                            # Copy a tile from the input image (a) into the L1 memory region (tile_in)
+                            ChannelGet(format_name("ChanIn", h, w), tile_in)
 
-                    # Deallocate our L1 buffers
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
+                            # Access every value in the tile
+                            for j in range_(TILE_HEIGHT):
+                                for i in range_(TILE_WIDTH):
+                                    # Load the input value from tile_in
+                                    val_in = load(tile_in, [i, j])
+
+                                    # Compute the output value
+                                    val_out = arith.addi(
+                                        val_in,
+                                        arith.ConstantOp(
+                                            T.i32(),
+                                            (IMAGE_HEIGHT // TILE_HEIGHT) * h + w,
+                                        ),
+                                    )
+
+                                    # Store the output value in tile_out
+                                    store(val_out, tile_out, [i, j])
+                                    yield_([])
+                                yield_([])
+
+                            # Copy the output tile into the output
+                            ChannelPut(format_name("ChanOut", h, w), tile_out)
+
+                            # Deallocate our L1 buffers
+                            DeallocOp(tile_in)
+                            DeallocOp(tile_out)
 
 
 if __name__ == "__main__":

--- a/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
@@ -33,8 +33,8 @@ def build_module():
 
     # Create two channels which will send/receive the
     # input/output data respectively
-    ChannelOp("ChanIn")
-    ChannelOp("ChanOut")
+    ChannelOp("ChanIn", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
+    ChannelOp("ChanOut", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
 
     # We will send an image worth of data in and out
     @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
@@ -62,6 +62,7 @@ def build_module():
                     ChannelPut(
                         "ChanIn",
                         a,
+                        indices=[1, 1],
                         offsets=[offset0, offset1],
                         sizes=[TILE_HEIGHT, TILE_WIDTH],
                         strides=[IMAGE_WIDTH, 1],
@@ -71,6 +72,7 @@ def build_module():
                     ChannelGet(
                         "ChanOut",
                         b,
+                        indices=[1, 1],
                         offsets=[offset0, offset1],
                         sizes=[TILE_HEIGHT, TILE_WIDTH],
                         strides=[IMAGE_WIDTH, 1],
@@ -144,6 +146,7 @@ def build_module():
                     ChannelGet(
                         "ChanIn",
                         tile_in,
+                        indices=[1, 1],
                     )
 
                     # Access every value in the tile
@@ -171,6 +174,7 @@ def build_module():
                     ChannelPut(
                         "ChanOut",
                         tile_out,
+                        indices=[1, 1],
                     )
 
                     # Deallocate our L1 buffers

--- a/programming_examples/matrix_scalar_add/multi_core_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/run_makefile.lit
@@ -6,4 +6,3 @@
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile run | FileCheck %s
  // CHECK: PASS!
- // XFAIL: *

--- a/programming_examples/matrix_scalar_add/multi_core_dma/multi_core_dma.py
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/multi_core_dma.py
@@ -50,16 +50,6 @@ def build_module():
                     operands=[arg2, arg3],
                 )
                 def herd_body(tx, ty, sx, sy, a, b):
-                    scaled_index_map_height = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(TILE_HEIGHT),
-                            )
-                        ],
-                    )
                     scaled_index_map_width = AffineMap.get(
                         0,
                         1,
@@ -70,7 +60,7 @@ def build_module():
                             )
                         ],
                     )
-                    create_tile_index_hight = AffineMap.get(
+                    create_tile_index_height = AffineMap.get(
                         0,
                         1,
                         [
@@ -92,9 +82,9 @@ def build_module():
                     )
                     offset0 = affine_apply(scaled_index_map_width, [tx])
                     offset1 = affine_apply(scaled_index_map_width, [ty])
-                    tile_index_hight = affine_apply(create_tile_index_hight, [tx])
+                    tile_index_height = affine_apply(create_tile_index_height, [tx])
                     compute_tile_id = affine_apply(
-                        create_tile_index, [tile_index_hight, ty]
+                        create_tile_index, [tile_index_height, ty]
                     )
 
                     # We want to store our data in L1 memory
@@ -132,11 +122,7 @@ def build_module():
                             )
 
                             # Store the output value in tile_out
-                            store(
-                                val_out,
-                                tile_out,
-                                [i, j],
-                            )
+                            store(val_out, tile_out, [i, j])
                             yield_([])
                         yield_([])
 

--- a/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
+++ b/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
@@ -77,13 +77,13 @@ def build_module():
                 yield_([])
 
             # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+            @segment(name="seg")
+            def segment_body():
 
                 # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
                 # We just need one compute core, so we ask for a 1x1 herd
-                @herd(name="xaddherd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(tx, ty, sx, sy, a, b):
+                @herd(name="xaddherd", sizes=[1, 1])
+                def herd_body(_tx, _ty, _sx, _sy):
 
                     # We want to store our data in L1 memory
                     mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)

--- a/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
+++ b/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
@@ -44,7 +44,7 @@ def build_module():
                 # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
                 # We just need one compute core, so we ask for a 1x1 herd
                 @herd(name="xaddherd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(tx, ty, sx, sy, a, b):
+                def herd_body(_tx, _ty, _sx, _sy, a, b):
 
                     # We want to store our data in L1 memory
                     mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)


### PR DESCRIPTION
This PR submits a form of the `matrix_scalar_add/multi_core_channel` that works. Ideally, I would be able to use the herd `size` argument to create a 2x2 herd for this example, but since I haven't yet discovered how to do an `scf.if` or an `affine.if` based on the herd `tx` and `ty` parameters, I instead created 4 1x1 herds using a python loop to automate code generation of each herd.