### PR TITLE
Programming Example: Data Transfer Transpose

### DIFF
--- a/programming_examples/README.md
+++ b/programming_examples/README.md
@@ -6,10 +6,14 @@ These programming examples are provided so that application programmers can lear
 
 This example demonstrates how data may be moved using shim DMA operations. It also includes extra infrastructure that illustrates different ways to compile, build, run, and test programs written using the mlir-air python bindings.
 
+## [Channel Examples](channel_examples)
+
+This is a collection of simple examples that illustrate how to use channels.
+
 ## [Matrix Scalar Addition](matrix_scalar_add)
 
 This example provides logic to divide in input 2D matrix into *tiles* of data, and add a value to every element in every tile. It includes some description of the fundamental concepts of mlir-air, including *launches*, *herds*, and *channels*.
 
-## [Channel Examples](channel_examples)
+## [Data Transfer Transpose](data_transfer_transpose)
 
-This is a collection of simple examples that illustrate how to use channels.
+Transposes a matrix with using either Channels or `dma_memcpy_nd`.

--- a/programming_examples/data_transfer_transpose/README.md
+++ b/programming_examples/data_transfer_transpose/README.md
@@ -1,3 +1,9 @@
 # Data Transfer Transpose
 
-TODO
+Transposes a matrix with using either Channels or `dma_memcpy_nd`.
+
+#### Build and Run
+
+```bash
+make clean && make
+```

--- a/programming_examples/data_transfer_transpose/README.md
+++ b/programming_examples/data_transfer_transpose/README.md
@@ -1,0 +1,3 @@
+# Data Transfer Transpose
+
+TODO

--- a/programming_examples/data_transfer_transpose/channel/Makefile
+++ b/programming_examples/data_transfer_transpose/channel/Makefile
@@ -1,0 +1,13 @@
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+targetname := $(shell basename ${srcdir})
+
+M ?= 64
+K ?= 32
+
+run:
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K} -v
+
+clean:
+	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/channel/Makefile
+++ b/programming_examples/data_transfer_transpose/channel/Makefile
@@ -1,3 +1,5 @@
+# (c) Copyright 2024 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})
@@ -7,7 +9,7 @@ K ?= 32
 
 run:
 	mkdir -p build
-	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K} -v
+	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K}
 
 clean:
 	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/channel/run.py
+++ b/programming_examples/data_transfer_transpose/channel/run.py
@@ -1,0 +1,47 @@
+# run.py -*- Python -*-
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+import argparse
+import sys
+from pathlib import Path  # if you haven't already done so
+
+# Python paths are a bit complex. Taking solution from : https://stackoverflow.com/questions/16981921/relative-imports-in-python-3
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# Additionally remove the current file's directory from sys.path
+try:
+    sys.path.remove(str(parent))
+except ValueError:  # Already removed
+    pass
+
+from channel.transpose import build_module
+from common import test_main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Builds, runs, and tests the matrix_scalar_add/single_core_channel example",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-m",
+        type=int,
+        default=64,
+        help="The matrix to transpose will be of size M x K, this parameter sets the M value",
+    )
+    parser.add_argument(
+        "-k",
+        type=int,
+        default=32,
+        help="The matrix to transpose will be of size M x K, this parameter sets the k value",
+    )
+    args = parser.parse_args()
+    test_main(build_module, m=args.m, k=args.k, verbose=args.verbose)

--- a/programming_examples/data_transfer_transpose/channel/run_makefile.lit
+++ b/programming_examples/data_transfer_transpose/channel/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/data_transfer_transpose/channel/run_makefile.lit
+++ b/programming_examples/data_transfer_transpose/channel/run_makefile.lit
@@ -1,0 +1,8 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+ // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ //
+ // REQUIRES: ryzen_ai
+ //
+ // RUN: make -f %S/Makefile clean
+ // RUN: make -f %S/Makefile run | FileCheck %s
+ // CHECK: PASS!

--- a/programming_examples/data_transfer_transpose/common.py
+++ b/programming_examples/data_transfer_transpose/common.py
@@ -26,7 +26,11 @@ def test_main(build_module, m, k, verbose=False, experimental_passes=False):
     actual_output_matrix = np.zeros(matrix_shape_t, dtype=matrix_dtype)
     assert expected_output_matrix.shape == actual_output_matrix.shape
 
-    backend = xrt_backend.XRTBackend(verbose=verbose, omit_while_true_loop=True, experimental_passes=experimental_passes)
+    backend = xrt_backend.XRTBackend(
+        verbose=verbose,
+        omit_while_true_loop=True,
+        experimental_passes=experimental_passes,
+    )
 
     if verbose:
         print(input_matrix)

--- a/programming_examples/data_transfer_transpose/common.py
+++ b/programming_examples/data_transfer_transpose/common.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import air.backend.xrt as xrt_backend
+import filelock
+
+# TODO: check with different data types
+# INOUT_ELEM_SIZE = np.dtype(INOUT_DATATYPE).itemsize
+# INOUT_SIZE_BYTES = INOUT_SIZE * INOUT_ELEM_SIZE
+
+
+def test_main(build_module, m, k, verbose=False):
+    mlir_module = build_module(m, k)
+
+    matrix_shape = (m, k)
+    matrix_shape_t = (k, m)
+    # TODO: configure with different data types
+    matrix_dtype = np.uint32
+
+    # Generate a random matrix
+    input_matrix = np.random.randint(
+        low=0, high=2**32 - 1, size=matrix_shape, dtype=matrix_dtype
+    )
+    expected_output_matrix = np.transpose(input_matrix)
+    actual_output_matrix = np.zeros(matrix_shape_t, dtype=matrix_dtype)
+    assert expected_output_matrix.shape == actual_output_matrix.shape
+
+    backend = xrt_backend.XRTBackend(verbose=verbose, omit_while_true_loop=True)
+
+    if verbose:
+        print(input_matrix)
+
+    # Run the module
+    with filelock.FileLock("/tmp/npu.lock"):
+        transpose = backend.compile_and_load(mlir_module)
+        (_, actual_output_matrix) = transpose(input_matrix, actual_output_matrix)
+    backend.unload()
+
+    actual_output_matrix = actual_output_matrix.reshape(matrix_shape_t)
+    assert expected_output_matrix.shape == actual_output_matrix.shape
+
+    if verbose:
+        print("======== ORIGINAL ========")
+        print(input_matrix)
+        print("======== EXPECTED ========")
+        print(expected_output_matrix)
+        print("======== ACTUAL ==========")
+        print(actual_output_matrix)
+
+    # check output, should have all values incremented
+    errors = 0
+    for m_index in range(m):
+        for k_index in range(k):
+            expected_value = expected_output_matrix.item((k_index, m_index))
+            actual_value = actual_output_matrix.item((k_index, m_index))
+
+            if not (actual_value == expected_value):
+                """
+                print(
+                    f"IM {i} [{m_index}, {k_index}] should be 0x{expected_value:x}, is 0x{actual_value:x}\n"
+                )
+                """
+                errors += 1
+
+    if errors == 0:
+        print("PASS!")
+        exit(0)
+    else:
+        print("failed. errors=", errors)
+        exit(-1)

--- a/programming_examples/data_transfer_transpose/common.py
+++ b/programming_examples/data_transfer_transpose/common.py
@@ -10,7 +10,7 @@ import filelock
 # INOUT_SIZE_BYTES = INOUT_SIZE * INOUT_ELEM_SIZE
 
 
-def test_main(build_module, m, k, verbose=False):
+def test_main(build_module, m, k, verbose=False, experimental_passes=False):
     mlir_module = build_module(m, k)
 
     matrix_shape = (m, k)
@@ -26,7 +26,7 @@ def test_main(build_module, m, k, verbose=False):
     actual_output_matrix = np.zeros(matrix_shape_t, dtype=matrix_dtype)
     assert expected_output_matrix.shape == actual_output_matrix.shape
 
-    backend = xrt_backend.XRTBackend(verbose=verbose, omit_while_true_loop=True)
+    backend = xrt_backend.XRTBackend(verbose=verbose, omit_while_true_loop=True, experimental_passes=experimental_passes)
 
     if verbose:
         print(input_matrix)

--- a/programming_examples/data_transfer_transpose/dma/Makefile
+++ b/programming_examples/data_transfer_transpose/dma/Makefile
@@ -1,0 +1,13 @@
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+targetname := $(shell basename ${srcdir})
+
+M ?= 64
+K ?= 32
+
+run:
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K} -v
+
+clean:
+	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/dma/Makefile
+++ b/programming_examples/data_transfer_transpose/dma/Makefile
@@ -1,3 +1,5 @@
+# (c) Copyright 2024 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})
@@ -7,7 +9,7 @@ K ?= 32
 
 run:
 	mkdir -p build
-	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K} -v
+	cd build && ${powershell} python3 ${srcdir}/run.py -m ${M} -k ${K}
 
 clean:
 	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/dma/run.py
+++ b/programming_examples/data_transfer_transpose/dma/run.py
@@ -44,4 +44,6 @@ if __name__ == "__main__":
         help="The matrix to transpose will be of size M x K, this parameter sets the k value",
     )
     args = parser.parse_args()
-    test_main(build_module, m=args.m, k=args.k, verbose=args.verbose, experimental_passes=True)
+    test_main(
+        build_module, m=args.m, k=args.k, verbose=args.verbose, experimental_passes=True
+    )

--- a/programming_examples/data_transfer_transpose/dma/run.py
+++ b/programming_examples/data_transfer_transpose/dma/run.py
@@ -44,4 +44,4 @@ if __name__ == "__main__":
         help="The matrix to transpose will be of size M x K, this parameter sets the k value",
     )
     args = parser.parse_args()
-    test_main(build_module, m=args.m, k=args.k, verbose=args.verbose)
+    test_main(build_module, m=args.m, k=args.k, verbose=args.verbose, experimental_passes=True)

--- a/programming_examples/data_transfer_transpose/dma/run.py
+++ b/programming_examples/data_transfer_transpose/dma/run.py
@@ -1,0 +1,47 @@
+# run.py -*- Python -*-
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+import argparse
+import sys
+from pathlib import Path  # if you haven't already done so
+
+# Python paths are a bit complex. Taking solution from : https://stackoverflow.com/questions/16981921/relative-imports-in-python-3
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# Additionally remove the current file's directory from sys.path
+try:
+    sys.path.remove(str(parent))
+except ValueError:  # Already removed
+    pass
+
+from dma.transpose import build_module
+from common import test_main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Builds, runs, and tests the matrix_scalar_add/single_core_channel example",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-m",
+        type=int,
+        default=64,
+        help="The matrix to transpose will be of size M x K, this parameter sets the M value",
+    )
+    parser.add_argument(
+        "-k",
+        type=int,
+        default=32,
+        help="The matrix to transpose will be of size M x K, this parameter sets the k value",
+    )
+    args = parser.parse_args()
+    test_main(build_module, m=args.m, k=args.k, verbose=args.verbose)

--- a/programming_examples/data_transfer_transpose/dma/run_makefile.lit
+++ b/programming_examples/data_transfer_transpose/dma/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/data_transfer_transpose/dma/run_makefile.lit
+++ b/programming_examples/data_transfer_transpose/dma/run_makefile.lit
@@ -1,0 +1,8 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+ // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ //
+ // REQUIRES: ryzen_ai
+ //
+ // RUN: make -f %S/Makefile clean
+ // RUN: make -f %S/Makefile run | FileCheck %s
+ // CHECK: PASS!

--- a/programming_examples/data_transfer_transpose/dma/transpose.py
+++ b/programming_examples/data_transfer_transpose/dma/transpose.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+import sys
+from pathlib import Path  # if you haven't already done so
+
+# Python paths are a bit complex. Taking solution from : https://stackoverflow.com/questions/16981921/relative-imports-in-python-3
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# Additionally remove the current file's directory from sys.path
+try:
+    sys.path.remove(str(parent))
+except ValueError:  # Already removed
+    pass
+
+from air.ir import *
+from air.dialects.air import *
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.func import FuncOp
+from air.dialects.scf import for_, yield_
+
+range_ = for_
+
+from common import *
+
+
+@module_builder
+def build_module(m, k):
+    memrefTyIn = MemRefType.get(shape=[m, k], element_type=T.i32())
+    memrefTyOut = MemRefType.get(shape=[k, m], element_type=T.i32())
+
+    # We will send an image worth of data in and out
+    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
+    def transpose(arg0, arg1):
+
+        # The arguments are the input and output
+        @launch(operands=[arg0, arg1])
+        def launch_body(a, b):
+
+            # The arguments are still the input and the output
+            @segment(name="seg", operands=[a, b])
+            def segment_body(arg2, arg3):
+
+                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
+                # We just need one compute core, so we ask for a 1x1 herd
+                @herd(name="herd", sizes=[1, 1], operands=[arg2, arg3])
+                def herd_body(_tx, _ty, _sx, _sy, a, b):
+
+                    # We want to store our data in L1 memory
+                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+
+                    # This is the type definition of the tensor
+                    tensor_type = MemRefType.get(
+                        shape=[m * k],  # Read as one large array
+                        element_type=T.i32(),
+                        memory_space=mem_space,
+                    )
+
+                    # We must allocate a buffer of tile size for the input/output
+                    tensor_in = AllocOp(tensor_type, [], [])
+                    tensor_out = AllocOp(tensor_type, [], [])
+
+                    # The strides below are configured to read across all rows in the same column
+                    # Stride of K in dim/wrap 2 skips an entire row to read a full column
+                    dma_memcpy_nd(
+                        tensor_in,
+                        a,
+                    )
+
+                    dma_memcpy_nd(
+                        b,
+                        tensor_in,
+                        src_sizes=[1, k, m],
+                        src_strides=[1, 1, k],
+                    )
+
+                    # Deallocate our L1 buffer
+                    DeallocOp(tensor_in)
+                    DeallocOp(tensor_out)
+
+
+if __name__ == "__main__":
+    module = build_module()
+    print(module)


### PR DESCRIPTION
This example is based on the [DMA Transpose](https://github.com/Xilinx/mlir-aie/blob/cd33847b76a7c3b9f08ea303421778af8291787a/programming_examples/basic/dma_transpose/aie2.py) example in mlir-aie.

There are two versions, one that uses channels and one that uses `dma_memcpy_nd`