### PR TITLE
Run aircc experimental passes for Matrix Scalar Add examples which don't use channels

### DIFF
--- a/programming_examples/matrix_scalar_add/common.py
+++ b/programming_examples/matrix_scalar_add/common.py
@@ -32,7 +32,7 @@ def print_matrix(matrix_array):
         print("")
 
 
-def test_main(build_module, verbose=False):
+def test_main(build_module, experimental_passes, verbose=False):
     mlir_module = build_module()
 
     input_a = np.arange(1, INOUT_SIZE + 1, dtype=INOUT_DATATYPE)
@@ -41,8 +41,11 @@ def test_main(build_module, verbose=False):
         input_a[i] = i + 0x1000
         input_b[i] = 0x00DEFACED
 
-    # TODO(hunhoffe): need to figure out why single-core-dma fails with experimental_passes=True
-    backend = xrt_backend.XRTBackend(verbose=verbose, omit_while_true_loop=True)
+    backend = xrt_backend.XRTBackend(
+        verbose=verbose,
+        omit_while_true_loop=True,
+        experimental_passes=experimental_passes,
+    )
 
     if verbose:
         print_matrix(input_b)

--- a/programming_examples/matrix_scalar_add/multi_core_channel/run.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/run.py
@@ -33,4 +33,4 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
-    test_main(build_module, verbose=args.verbose)
+    test_main(build_module, experimental_passes=False, verbose=args.verbose)

--- a/programming_examples/matrix_scalar_add/multi_core_dma/run.py
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/run.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
-    test_main(build_module, verbose=args.verbose)
+    test_main(build_module, experimental_passes=True, verbose=args.verbose)

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/run.py
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/run.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
-    test_main(build_module, verbose=args.verbose)
+    test_main(build_module, experimental_passes=False, verbose=args.verbose)

--- a/programming_examples/matrix_scalar_add/single_core_channel/run.py
+++ b/programming_examples/matrix_scalar_add/single_core_channel/run.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
-    test_main(build_module, verbose=args.verbose)
+    test_main(build_module, experimental_passes=False, verbose=args.verbose)

--- a/programming_examples/matrix_scalar_add/single_core_dma/run.py
+++ b/programming_examples/matrix_scalar_add/single_core_dma/run.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
-    test_main(build_module, verbose=args.verbose)
+    test_main(build_module, experimental_passes=True, verbose=args.verbose)


### PR DESCRIPTION
Based on https://github.com/Xilinx/mlir-air/issues/628, it seems the dependency pass is not supported for channels so we exclude the channel examples but allow the others to run with the experimental passes.