### PR TITLE
Fix license/copyright in programming examples files

### DIFF
--- a/programming_examples/channel_examples/herd_to_herd/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/channel_examples/herd_to_herd/run_makefile.lit
+++ b/programming_examples/channel_examples/herd_to_herd/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/matrix_scalar_add/multi_core_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/matrix_scalar_add/multi_core_dma/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/matrix_scalar_add/single_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_channel/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/matrix_scalar_add/single_core_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/single_core_channel/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/matrix_scalar_add/single_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_dma/Makefile
@@ -1,3 +1,5 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 targetname := $(shell basename ${srcdir})

--- a/programming_examples/matrix_scalar_add/single_core_dma/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/single_core_dma/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/shim_dma_2d/CMakeLists.txt
+++ b/programming_examples/shim_dma_2d/CMakeLists.txt
@@ -1,8 +1,5 @@
-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-# (c) Copyright 2023 Advanced Micro Devices, Inc.
+# (c) Copyright 2024 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 
 # parameters
 # -DBOOST_ROOT: Path to Boost install

--- a/programming_examples/shim_dma_2d/Makefile
+++ b/programming_examples/shim_dma_2d/Makefile
@@ -1,10 +1,5 @@
-##===- Makefile -----------------------------------------------------------===##
-# 
-# This file licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# 
-##===----------------------------------------------------------------------===##
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/programming_examples/shim_dma_2d/run_makefile.lit
+++ b/programming_examples/shim_dma_2d/run_makefile.lit
@@ -1,5 +1,5 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ // SPDX-License-Identifier: MIT
  //
  // REQUIRES: ryzen_ai
  //

--- a/programming_examples/shim_dma_2d/test.cpp
+++ b/programming_examples/shim_dma_2d/test.cpp
@@ -1,3 +1,5 @@
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 #include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>


### PR DESCRIPTION
* Add missing copyright information
* Set license to MIT