### PR TITLE
Fixup data layout in programming examples

### DIFF
--- a/programming_examples/matrix_scalar_add/common.py
+++ b/programming_examples/matrix_scalar_add/common.py
@@ -5,13 +5,13 @@ import numpy as np
 import air.backend.xrt as xrt_backend
 import filelock
 
-IMAGE_WIDTH = 32
-IMAGE_HEIGHT = 16
-IMAGE_SIZE = [IMAGE_WIDTH, IMAGE_HEIGHT]
+IMAGE_WIDTH = 16
+IMAGE_HEIGHT = 32
+IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 
-TILE_WIDTH = 16
-TILE_HEIGHT = 8
-TILE_SIZE = [TILE_WIDTH, TILE_HEIGHT]
+TILE_WIDTH = 8
+TILE_HEIGHT = 16
+TILE_SIZE = [TILE_HEIGHT, TILE_WIDTH]
 
 assert IMAGE_WIDTH % TILE_WIDTH == 0
 assert IMAGE_HEIGHT % TILE_HEIGHT == 0
@@ -67,7 +67,7 @@ def test_main(build_module, experimental_passes, verbose=False):
 
         row = i // IMAGE_WIDTH
         col = i % IMAGE_WIDTH
-        tile_num = (row // TILE_HEIGHT) * (IMAGE_HEIGHT // TILE_HEIGHT) + (
+        tile_num = (row // TILE_HEIGHT) * (IMAGE_WIDTH // TILE_WIDTH) + (
             col // TILE_WIDTH
         )
 

--- a/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
@@ -51,8 +51,8 @@ def build_module():
             # Transfer one tile of data per worker
             for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
                 for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = IMAGE_HEIGHT * h
-                    offset1 = IMAGE_HEIGHT * w
+                    offset0 = TILE_HEIGHT * h
+                    offset1 = TILE_WIDTH * w
 
                     # Put data into the channel tile by tile
                     ChannelPut(
@@ -66,8 +66,8 @@ def build_module():
             # Transfer one tile of data per worker
             for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
                 for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = IMAGE_HEIGHT * h
-                    offset1 = IMAGE_HEIGHT * w
+                    offset0 = TILE_HEIGHT * h
+                    offset1 = TILE_WIDTH * w
 
                     # Write data back out to the channel tile by tile
                     ChannelGet(
@@ -109,7 +109,7 @@ def build_module():
                             for j in range_(TILE_HEIGHT):
                                 for i in range_(TILE_WIDTH):
                                     # Load the input value from tile_in
-                                    val_in = load(tile_in, [i, j])
+                                    val_in = load(tile_in, [j, i])
 
                                     # Compute the output value
                                     val_out = arith.addi(
@@ -121,7 +121,7 @@ def build_module():
                                     )
 
                                     # Store the output value in tile_out
-                                    store(val_out, tile_out, [i, j])
+                                    store(val_out, tile_out, [j, i])
                                     yield_([])
                                 yield_([])
 

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
@@ -6,4 +6,4 @@
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile run | FileCheck %s
  // CHECK: PASS!
- // XFAIL: *
+ 

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/run_makefile.lit
@@ -6,4 +6,3 @@
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile run | FileCheck %s
  // CHECK: PASS!
- 

--- a/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
+++ b/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
@@ -46,8 +46,8 @@ def build_module():
             for tile_index0 in range_(IMAGE_HEIGHT // TILE_HEIGHT):
                 for tile_index1 in range_(IMAGE_WIDTH // TILE_WIDTH):
                     # Convert the type of the tile size variable to the Index type
-                    tile_size0 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
-                    tile_size1 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
+                    tile_size0 = arith.ConstantOp.create_index(TILE_HEIGHT)
+                    tile_size1 = arith.ConstantOp.create_index(TILE_WIDTH)
 
                     # Calculate the offset into the channel data, which is based on which tile index
                     # we are at using tile_index0 and tile_index1 (our loop vars).
@@ -111,7 +111,7 @@ def build_module():
                         for j in range_(TILE_HEIGHT):
                             for i in range_(TILE_WIDTH):
                                 # Load the input value from tile_in
-                                val_in = load(tile_in, [i, j])
+                                val_in = load(tile_in, [j, i])
 
                                 # Compute the output value
                                 val_out = arith.addi(
@@ -122,7 +122,7 @@ def build_module():
                                 store(
                                     val_out,
                                     tile_out,
-                                    [i, j],
+                                    [j, i],
                                 )
                                 yield_([])
                             yield_([])

--- a/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
+++ b/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
@@ -65,8 +65,8 @@ def build_module():
                             tile_out = AllocOp(tile_type, [], [])
 
                             # Convert the type of the tile size variable to the Index type
-                            tile_size0 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
-                            tile_size1 = arith.ConstantOp.create_index(IMAGE_HEIGHT)
+                            tile_size0 = arith.ConstantOp.create_index(TILE_HEIGHT)
+                            tile_size1 = arith.ConstantOp.create_index(TILE_WIDTH)
 
                             # Calculate the offset into the channel data, which is based on our loop vars
                             offset0 = arith.MulIOp(tile_size0, tile_index0)
@@ -74,7 +74,7 @@ def build_module():
                             tile_num = arith.MulIOp(
                                 tile_index0,
                                 arith.ConstantOp.create_index(
-                                    IMAGE_HEIGHT // TILE_HEIGHT
+                                    IMAGE_WIDTH // TILE_WIDTH
                                 ),
                             )
                             tile_num = arith.AddIOp(tile_num, tile_index1)
@@ -92,7 +92,7 @@ def build_module():
                             for j in range_(TILE_HEIGHT):
                                 for i in range_(TILE_WIDTH):
                                     # Load the input value from tile_in
-                                    val_in = load(tile_in, [i, j])
+                                    val_in = load(tile_in, [j, i])
 
                                     # Compute the output value
                                     val_out = arith.addi(
@@ -100,7 +100,7 @@ def build_module():
                                     )
 
                                     # Store the output value in tile_out
-                                    store(val_out, tile_out, [i, j])
+                                    store(val_out, tile_out, [j, i])
                                     yield_([])
                                 yield_([])
 


### PR DESCRIPTION
This PR makes changes to the `matrix_scalar_add` programming examples to fixup the following issues:
- The original example's `common.py` testbench expects data layout in DDR as [IMAGE_WIDTH, IMAGE_HEIGHT], but many L2 memrefs have shape [TILE_HEIGHT, TILE_WIDTH].
- The rest of the examples viewed accesses to those memrefs as single pointers. While correctness is maintained in most tests, there were many cases where data access pattern does not align with the n-d memref shape. 