### PR TITLE
Special handling of allocs and stores for reshape ops

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -190,12 +190,14 @@ public:
 
         // Create async execute region for memref.alloc
         else if (auto memalloc_op = dyn_cast<memref::AllocOp>(op)) {
-          // Alloc can be used to specify shapes for operations such as reshape ops.
-          // If this alloc is used to specify shape of a reshap op, ignore this operation.
-          assert(memalloc_op->getNumResults() == 1 && "Number of results of alloc op == 1");
+          // Alloc can be used to specify shapes for operations such 
+          // as reshape ops. If this alloc is used to specify shape of 
+          // a reshap op, ignore this operation.
+          assert(memalloc_op->getNumResults() == 1 && 
+                 "Number of results of alloc op == 1");
           if (!alloc_for_reshape(memalloc_op->getOpResult(0)))
             createAsyncExecute(module_builder, op, "memref::alloc", ExecuteOpID,
-                              memalloc_op.getMemref().getType());
+                               memalloc_op.getMemref().getType());
         }
 
         // Create async execute region for an unknown op which has memref or
@@ -208,10 +210,13 @@ public:
               isCandidateExecute = true;
             }
           }
-          // If a memref store is storing to an alloca for shape, it must not be executed
+          // If a memref store is storing to an alloca for shape, 
+          // it must not be executed.
           if (auto storeOp = dyn_cast<memref::StoreOp>(op)) {
-            if (auto memalloc_op = dyn_cast<memref::AllocOp>(storeOp.getMemRef().getDefiningOp())) {
-              assert(memalloc_op->getNumResults() == 1 && "Number of results of alloc op == 1");
+            if (auto memalloc_op = dyn_cast<memref::AllocOp>(
+                    storeOp.getMemRef().getDefiningOp())) {
+              assert(memalloc_op->getNumResults() == 1 && 
+                     "Number of results of alloc op == 1");
               if (alloc_for_reshape(memalloc_op->getOpResult(0)))
                 isCandidateExecute = false;
             }

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -147,11 +147,6 @@ public:
           createAsyncExecute(module_builder, op, "func::call", ExecuteOpID);
 
         // Create async execute region for memref.alloc
-        else if (auto memalloc_op = dyn_cast<memref::AllocOp>(op))
-          createAsyncExecute(module_builder, op, "memref::alloc", ExecuteOpID,
-                             memalloc_op.getMemref().getType());
-
-        // Create async execute region for memref.alloc
         else if (auto memcast_op = dyn_cast<memref::CastOp>(op))
           createAsyncExecute(module_builder, op, "memref::cast", ExecuteOpID,
                              memcast_op.getDest().getType());
@@ -193,6 +188,16 @@ public:
                                     HierarchyOpID);
         }
 
+        // Create async execute region for memref.alloc
+        else if (auto memalloc_op = dyn_cast<memref::AllocOp>(op)) {
+          // Alloc can be used to specify shapes for operations such as reshape ops.
+          // If this alloc is used to specify shape of a reshap op, ignore this operation.
+          assert(memalloc_op->getNumResults() == 1 && "Number of results of alloc op == 1");
+          if (!alloc_for_reshape(memalloc_op->getOpResult(0)))
+            createAsyncExecute(module_builder, op, "memref::alloc", ExecuteOpID,
+                              memalloc_op.getMemref().getType());
+        }
+
         // Create async execute region for an unknown op which has memref or
         // index-type operands
         else {
@@ -201,6 +206,14 @@ public:
             if (llvm::isa<MemRefType>(operand.getType()) ||
                 llvm::isa<IndexType>(operand.getType())) {
               isCandidateExecute = true;
+            }
+          }
+          // If a memref store is storing to an alloca for shape, it must not be executed
+          if (auto storeOp = dyn_cast<memref::StoreOp>(op)) {
+            if (auto memalloc_op = dyn_cast<memref::AllocOp>(storeOp.getMemRef().getDefiningOp())) {
+              assert(memalloc_op->getNumResults() == 1 && "Number of results of alloc op == 1");
+              if (alloc_for_reshape(memalloc_op->getOpResult(0)))
+                isCandidateExecute = false;
             }
           }
           // No air execute for loop ops
@@ -589,6 +602,29 @@ private:
   uint64_t HierarchyOpID;
   uint64_t WaitAllOpID;
   uint64_t ChannelOpID;
+
+  //===----------------------------------------------------------------------===//
+  // Handling lingering reshape-related ops
+  //===----------------------------------------------------------------------===//
+
+  bool alloc_for_reshape(mlir::Value val) {
+    for (auto user : val.getUsers()) {
+      // If one of the user is a herd, segment or a launch op,
+      // explore the hierarchy further.
+      if (auto hier_op = dyn_cast<xilinx::air::HierarchyInterface>(user)) {
+        for (int i = 0, e = hier_op.getNumKernelOperands(); i < e; i++) {
+          if (hier_op.getKernelOperand(i) == val) {
+            if (alloc_for_reshape(hier_op.getKernelArgument(i)))
+              return true;
+          }
+        }
+      } else if (auto reshape = dyn_cast<memref::ReshapeOp>(user)) {
+        if (reshape.getShape() == val)
+          return true;
+      }
+    }
+    return false;
+  }
 
   //===----------------------------------------------------------------------===//
   // Creating async events

--- a/mlir/test/Transform/AIRDependency/reshape_matmul_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/reshape_matmul_nd.mlir
@@ -1,0 +1,106 @@
+//===- matmul_nd.mlir ------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2022, Xilinx Inc. All rights reserved.
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+module attributes {torch.debug_module_name = "mmult"}  {
+  func.func @forward(%arg0: memref<64x64xi32>, %arg1: memref<64x16x4xi32>, %arg2: memref<?x?xi32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c2 = arith.constant 2 : index
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c1 = arith.constant 1 : index
+    %0 = memref.alloc() : memref<64x64xi32>
+    // CHECK: = air.execute
+    // CHECK: air.execute_terminator
+    linalg.fill ins(%c0_i32 : i32) outs(%0 : memref<64x64xi32>)
+    // CHECK: = air.execute
+    %1 = memref.cast %arg2 : memref<?x?xi32> to memref<64x64xi32>
+    // CHECK: = air.execute
+    // CHECK: air.execute_terminator
+    linalg.copy ins(%0 : memref<64x64xi32>) outs(%1 : memref<64x64xi32>)
+    // CHECK: = air.execute
+    %2 = memref.alloc() : memref<64x64xi32, 1>
+    // CHECK: = air.execute
+    // CHECK: air.execute_terminator
+    %3 = memref.alloc() : memref<64x16x4xi32, 1>
+    // CHECK: = air.execute
+    // CHECK: air.execute_terminator
+    %4 = memref.alloc() : memref<64x64xi32, 1>
+    // CHECK: = air.execute
+    // CHECK: air.execute_terminator
+    air.dma_memcpy_nd (%2[] [] [], %arg0[%c0, %c0] [%c64, %c64] [%c64, %c1]) {id = 1 : i32} : (memref<64x64xi32, 1>, memref<64x64xi32>)
+    // CHECK: = air.dma_memcpy_nd async
+    air.dma_memcpy_nd (%3[] [] [], %arg1[%c0, %c0, %c0] [%c64, %c16, %c4] [%c64, %c4, %c1]) {id = 2 : i32} : (memref<64x16x4xi32, 1>, memref<64x16x4xi32>)
+    // CHECK: = air.dma_memcpy_nd async
+    air.dma_memcpy_nd (%4[] [] [], %1[%c0, %c0] [%c64, %c64] [%c64, %c1]) {id = 3 : i32} : (memref<64x64xi32, 1>, memref<64x64xi32>)
+    // CHECK: = air.dma_memcpy_nd async
+    air.herd tile (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) args(%arg7=%2, %arg8=%3, %arg9=%4) : memref<64x64xi32, 1>,memref<64x16x4xi32, 1>,memref<64x64xi32, 1>attributes {sym_name = "herd_0"} {
+    // CHECK: = air.herd @herd_0 async
+      %c8 = arith.constant 8 : index
+      %c32_0 = arith.constant 32 : index
+      %c0_0 = arith.constant 0 : index
+      %c4_0 = arith.constant 4 : index
+      %c64_1 = arith.constant 64 : index
+      %c1_2 = arith.constant 1 : index
+      %shape = memref.alloc() : memref<2xindex>
+      // CHECK-NOT: = air.execute
+      // CHECK-NOT: air.execute_terminator
+      memref.store %c32_0, %shape[%c0_0] : memref<2xindex>
+      // CHECK-NOT: = air.execute
+      // CHECK-NOT: air.execute_terminator
+      memref.store %c32_0, %shape[%c1_2] : memref<2xindex>
+      // CHECK-NOT: = air.execute
+      // CHECK-NOT: air.execute_terminator
+      %5 = arith.muli %arg3, %c32_0 : index
+      // CHECK: = air.execute
+      // CHECK: air.execute_terminator
+      %6 = arith.muli %arg4, %c8 : index
+      // CHECK: = air.execute
+      // CHECK: air.execute_terminator
+      %7 = arith.muli %arg4, %c32_0 : index
+      // CHECK: = air.execute
+      // CHECK: air.execute_terminator
+      // CHECK: = air.wait_all async
+      scf.for %arg10 = %c0_0 to %c64_1 step %c32_0 {
+        %8 = memref.alloc() : memref<32x32xi32, 2>
+        %9 = memref.alloc() : memref<32x8x4xi32, 2>
+        %10 = memref.alloc() : memref<32x32xi32, 2>
+        air.dma_memcpy_nd (%8[] [] [], %arg7[%5, %arg10] [%c32_0, %c32_0] [%c64_1, %c1_2]) {id = 4 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32, 1>)
+        // CHECK: = air.dma_memcpy_nd async
+        air.dma_memcpy_nd (%9[] [] [], %arg8[%arg10, %6, %c0_0] [%c32_0, %c8, %c4_0] [%c64_1, %c4_0, %c1_2]) {id = 5 : i32} : (memref<32x8x4xi32, 2>, memref<64x16x4xi32, 1>)
+        // CHECK: = air.dma_memcpy_nd async
+        air.dma_memcpy_nd (%10[] [] [], %arg9[%5, %7] [%c32_0, %c32_0] [%c64_1, %c1_2]) {id = 6 : i32} : (memref<32x32xi32, 2>, memref<64x64xi32, 1>)
+        // CHECK: = air.dma_memcpy_nd async
+        %reshape = memref.reshape %9(%shape) : (memref<32x8x4xi32, 2>, memref<2xindex>) -> memref<32x32xi32, 2>
+        linalg.matmul ins(%8, %reshape : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%10 : memref<32x32xi32, 2>)
+        // CHECK: = air.execute
+        air.dma_memcpy_nd (%arg9[%5, %7] [%c32_0, %c32_0] [%c64_1, %c1_2], %10[] [] []) {id = 7 : i32} : (memref<64x64xi32, 1>, memref<32x32xi32, 2>)
+        // CHECK: = air.dma_memcpy_nd async
+        memref.dealloc %8 : memref<32x32xi32, 2>
+        // CHECK: = air.execute
+        memref.dealloc %9 : memref<32x8x4xi32, 2>
+        // CHECK: = air.execute
+        memref.dealloc %10 : memref<32x32xi32, 2>
+        // CHECK: = air.execute
+      }
+    }
+    air.dma_memcpy_nd (%1[%c0, %c0] [%c64, %c64] [%c64, %c1], %4[] [] []) {id = 8 : i32} : (memref<64x64xi32>, memref<64x64xi32, 1>)
+    // CHECK: = air.dma_memcpy_nd async
+    memref.dealloc %2 : memref<64x64xi32, 1>
+    // CHECK: = air.execute
+    memref.dealloc %3 : memref<64x16x4xi32, 1>
+    // CHECK: = air.execute
+    memref.dealloc %4 : memref<64x64xi32, 1>
+    // CHECK: = air.execute
+    return
+  }
+}


### PR DESCRIPTION
Handling scenarios when reshape ops are lingering around in the code to reshape tensors/matrices. memref.reshape ops require shapes to be specified using memref.allocs and memref.store operations. The changes to the AIRDependency pass accounts for these scenarios so as to avoid  creating async execute ops for memref.allocs and memref.store ops associated with memref.reshapes ops.