### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+cmake/                  @erwei-xilinx @fifield
+docs/                   @eddierichter-amd @erwei-xilinx @fifield @jgmelber
+mlir/                   @erwei-xilinx @fifield
+programming_examples/   @jgmelber
+python/                 @fifield @jgmelber
+runtime_lib/aircpu/     @fifield
+runtime_lib/airhost/    @eddierichter-amd
+runtime_lib/test/       @eddierichter-amd
+test/xrt/               @erwei-xilinx @fifield
+test/airhost/           @eddierichter-amd @fifield
+tools/                  @erwei-xilinx @fifield
+utils/                  @erwei-xilinx @fifield

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+.github/                @eddierichter-amd @erwei-xilinx @fifield @jgmelber
 cmake/                  @erwei-xilinx @fifield
 docs/                   @eddierichter-amd @erwei-xilinx @fifield @jgmelber
 mlir/                   @erwei-xilinx @fifield


### PR DESCRIPTION
Add codeowners file to generate review requests on github.

I added @eddierichter-amd @erwei-xilinx @fifield and @jgmelber as owners of various directories. Folks can add/remove themselves if they care to get/not get review requests, but everything should have at least one owner.