### PR TITLE
AIRIsolateAsyncDmaLoopNests: More generic loop splitting

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4163,8 +4163,8 @@ public:
         for (auto pair : target_ops_map) {
           OpBuilder builder(pair.first);
           for (auto op : pair.second) {
-            (void)hoistTargetOpsToNewSCFFor(
-                builder, pair.first, SmallVector<Operation *>{op});
+            (void)hoistTargetOpsToNewSCFFor(builder, pair.first,
+                                            SmallVector<Operation *>{op});
           }
         }
       }
@@ -4177,8 +4177,8 @@ public:
         for (auto pair : target_ops_map) {
           OpBuilder builder(pair.first);
           for (auto op : pair.second) {
-            (void)hoistTargetOpsToNewSCFFor(
-                builder, pair.first, SmallVector<Operation *>{op});
+            (void)hoistTargetOpsToNewSCFFor(builder, pair.first,
+                                            SmallVector<Operation *>{op});
           }
         }
       }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4163,7 +4163,7 @@ public:
         for (auto pair : target_ops_map) {
           OpBuilder builder(pair.first);
           for (auto op : pair.second) {
-            auto newForOp = hoistTargetOpsToNewSCFFor(
+            (void)hoistTargetOpsToNewSCFFor(
                 builder, pair.first, SmallVector<Operation *>{op});
           }
         }
@@ -4177,7 +4177,7 @@ public:
         for (auto pair : target_ops_map) {
           OpBuilder builder(pair.first);
           for (auto op : pair.second) {
-            auto newForOp = hoistTargetOpsToNewSCFFor(
+            (void)hoistTargetOpsToNewSCFFor(
                 builder, pair.first, SmallVector<Operation *>{op});
           }
         }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -583,10 +583,8 @@ void addAsyncDependencyIfNewImpl(scf::ParallelOp op, Value token) {
   }
 }
 void addAsyncDependencyIfNew(Operation *op, Value token) {
-  if (!isAsyncOp(op)) {
-    op->emitOpError("op does not have async interface");
+  if (!isAsyncOp(op))
     return;
-  }
   if (auto async_op = dyn_cast<air::AsyncOpInterface>(op)) {
     addAsyncDependencyIfNewImpl(async_op, token);
   } else if (auto for_op = dyn_cast<scf::ForOp>(op)) {

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -676,6 +676,13 @@ scf::ForOp hoistTargetOpsToNewSCFFor(OpBuilder builder, scf::ForOp for_op,
       continue;
     // Clone operands' defining ops.
     for (auto operand : op->getOperands()) {
+      if (isa<air::AsyncTokenType>(operand.getType())) {
+        // Reconnect deps to loop induction vars.
+        if (!remap.contains(operand))
+          remap.map(operand,
+                    getLoopCarriedTokenFromScfOp(new_for_op, "argument"));
+        continue;
+      }
       if (!operand.getDefiningOp())
         continue;
       if (operand.getDefiningOp()->getParentOp() != for_op.getOperation())


### PR DESCRIPTION
- Fixup async token during loop splitting.
- Exhaustively search for splitting opportunities in all regions.
- TODO: test for the new [HoistMemallocInForPattern](https://github.com/Xilinx/mlir-air/pull/681/commits/5df01afdc5fc9ab5eb934f8d5ac58e61d7ad4cce) mode.
- TODO: test for splitting deeply nested loops; test for splitting dependency chain out of for loop nest.