### PR TITLE
AIRFuseChannels: A number of hotfixes

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3654,18 +3654,18 @@ private:
     for (int i = 0; i < (int)max_loop_nest_count; i++)
       if (i != outermostScfFor)
         controlLoopIndices.push_back(i);
-    // TODO: Assuming b_loop_nest is before a_loop_nest. Always true? TODO:
+    // TODO: Assuming a_loop_nest is before b_loop_nest. Always true? TODO:
     // formalize using async dep.
     unsigned index = 0;
-    if (a_loop_nest.size() > b_loop_nest.size()) {
+    if (a_loop_nest.size() < b_loop_nest.size()) {
       for (auto i : controlLoopIndices) {
-        if (!areEquivalentControlLoops(a_loop_nest[i], b_loop_nest[index++]))
+        if (!areEquivalentControlLoops(a_loop_nest[index++], b_loop_nest[i]))
           return notMergeable;
       }
       // Check if the skipped scf.for loop has LB >= 1. This is a sign of
       // peeling, indicating opportunity of merge by unpeeling into LB.
       auto outerMostScfFor =
-          dyn_cast<scf::ForOp>(a_loop_nest[outermostScfFor]->getParentOp());
+          dyn_cast<scf::ForOp>(b_loop_nest[outermostScfFor]->getParentOp());
       assert(outerMostScfFor);
       if (auto constLB = getConstantIntValue(outerMostScfFor.getLowerBound()))
         if (*constLB < 1)
@@ -3673,12 +3673,12 @@ private:
       return mergeableToLB;
     } else {
       for (auto i : controlLoopIndices) {
-        if (!areEquivalentControlLoops(a_loop_nest[index++], b_loop_nest[i]))
+        if (!areEquivalentControlLoops(a_loop_nest[i], b_loop_nest[index++]))
           return notMergeable;
       }
       // Merge by unpeeling into UB.
       auto outerMostScfFor =
-          dyn_cast<scf::ForOp>(b_loop_nest[outermostScfFor]->getParentOp());
+          dyn_cast<scf::ForOp>(a_loop_nest[outermostScfFor]->getParentOp());
       assert(outerMostScfFor);
       return mergeableToUB;
     }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3883,12 +3883,13 @@ private:
     IRMapping remap;
     remapAllParentLoopArgs(remap, a, b);
     OpBuilder builder(a);
+    builder.setInsertionPoint(a->getBlock()->getTerminator());
     auto new_b = cloneOpAndOperands(builder, remap, b);
     eraseParentLoopIfEmpty(*b);
-    auto async_a = dyn_cast<air::AsyncOpInterface>(a.getOperation());
-    if (async_a.getAsyncToken())
-      async_a.addAsyncDependency(
-          dyn_cast<air::AsyncOpInterface>(new_b).getAsyncToken());
+    auto async_b = dyn_cast<air::AsyncOpInterface>(new_b);
+    if (async_b.getAsyncToken())
+      async_b.addAsyncDependency(
+          dyn_cast<air::AsyncOpInterface>(a.getOperation()).getAsyncToken());
   }
   void mergeChannelOpsTemporally(air::ChannelInterface a,
                                  air::ChannelInterface b,
@@ -3923,12 +3924,10 @@ private:
     std::vector<air::ChannelGetOp> b_gets =
         getChannelGetOpThroughSymbol(chan_b);
     // Interleave puts and gets
-    for (unsigned i = 0; i < a_puts.size(); i++) {
+    for (unsigned i = 0; i < a_puts.size(); i++)
       mergeChannelOps(a_puts[i], b_puts[i]);
-    }
-    for (unsigned i = 0; i < a_gets.size(); i++) {
+    for (unsigned i = 0; i < a_gets.size(); i++)
       mergeChannelOps(a_gets[i], b_gets[i]);
-    }
   }
   void mergeChannelOpsTemporally(air::ChannelOp chan_a, air::ChannelOp chan_b,
                                  std::string mergeByLBOrUB) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3706,10 +3706,7 @@ private:
           (!areTheSameSSAValueLists(bSizes, b_puts[i].getSizes())) ||
           (!areTheSameSSAValueLists(bStrides, b_puts[i].getStrides())))
         return notMergeable; // Inconsistent memory use for all puts
-    if ((!areTheSameMemref(aMemref, bMemref)) ||
-        (!areTheSameSSAValueLists(aOffsets, bOffsets)) ||
-        (!areTheSameSSAValueLists(aSizes, bSizes)) ||
-        (!areTheSameSSAValueLists(aStrides, bStrides)))
+    if ((!areTheSameMemref(aMemref, bMemref)))
       return notMergeable;
     aMemref = a_gets[0].getMemref();
     aOffsets = a_gets[0].getOffsets();

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4721,11 +4721,12 @@ struct AIRSegmentLoopFusionPattern : public OpRewritePattern<air::SegmentOp> {
     auto hasNElements = [](Block *block, unsigned N) {
       unsigned counter = 0;
       for (auto &o : block->getOperations()) {
-        if (o.mightHaveTrait<OpTrait::IsTerminator>())
-          continue;
-        if (isa<air::WaitAllOp>(o))
-          continue;
-        counter++;
+        if (isa<air::ChannelInterface>(o))
+          counter++;
+        else if (isa<LoopLikeOpInterface>(o))
+          counter++;
+        else if (isa<mlir::linalg::LinalgOp>(o))
+          counter++;
       }
       return counter == N;
     };

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -371,7 +371,10 @@ static air::ChannelOp
 createChannelOpWithBCast(OpBuilder builder, ModuleOp module, std::string cname,
                          Location loc, SmallVector<int64_t, 2> bcast_sizes) {
   auto insertionCheckpoint = builder.saveInsertionPoint();
-  builder.setInsertionPointToStart(module.getBody());
+  Operation *o = &module.getBody()->front();
+  while (dyn_cast_or_null<air::ChannelOp>(o))
+    o = o->getNextNode();
+  builder.setInsertionPoint(o);
 
   auto channel_op = builder.create<air::ChannelOp>(
       loc, cname, builder.getI64ArrayAttr(bcast_sizes));

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1480,8 +1480,11 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         auto loc = chanUserOp->getLoc();
         auto ctx = chanUserOp->getContext();
         OpBuilder builder(chanUserOp);
-        builder.setInsertionPointToStart(
-            chanUserOp->getParentOfType<ModuleOp>().getBody());
+        Operation *o =
+            &chanUserOp->getParentOfType<ModuleOp>().getBody()->front();
+        while (dyn_cast_or_null<air::ChannelOp>(o))
+          o = o->getNextNode();
+        builder.setInsertionPoint(o);
         SmallVector<Type, 4> tys = {
             air::AsyncTokenType::get(chanUserOp->getContext())};
         auto cname =

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel.mlir
@@ -10,10 +10,10 @@
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module attributes {torch.debug_module_name = "mmult"} {
-// CHECK: air.channel @channel_3 [2, 2]
-// CHECK: air.channel @channel_2 [2, 2]
-// CHECK: air.channel @channel_1 [2, 2]
 // CHECK: air.channel @channel_0 [2, 2]
+// CHECK: air.channel @channel_1 [2, 2]
+// CHECK: air.channel @channel_2 [2, 2]
+// CHECK: air.channel @channel_3 [2, 2]
 // CHECK-LABEL: func.func @mmult
   func.func @mmult(%arg0: memref<64x64xi32>, %arg1: memref<64x64xi32>) -> memref<64x64xi32> {
     %c2 = arith.constant 2 : index

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_async.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_async.mlir
@@ -11,8 +11,8 @@
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 32)>
 module {
-// CHECK: air.channel @channel_1 [2, 2]
 // CHECK: air.channel @channel_0 [1, 1]
+// CHECK: air.channel @channel_1 [2, 2]
 // CHECK-LABEL: func.func @mmult
   func.func @mmult(%arg0: memref<512x512xbf16>) {
     %c8 = arith.constant 8 : index

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_canonicalize.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_canonicalize.mlir
@@ -9,8 +9,8 @@
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 module {
-// CHECK: air.channel @channel_1 [2, 2]
 // CHECK: air.channel @channel_0 [2, 2]
+// CHECK: air.channel @channel_1 [2, 2]
   func.func @matmul_on_buffers(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>, %arg2: memref<64x64xf32>) {
     %c2 = arith.constant 2 : index
 // CHECK: %[[EVENT0:.*]] = scf.parallel (%[[VALUE0:.*]], %[[VALUE1:.*]]) ={{.*}}init

--- a/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_par_in_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/dma_to_channel_nested_par_in_herd.mlir
@@ -11,9 +11,9 @@
 #set = affine_set<(d0, d1)[s0] : (d0 - s0 == 0, d1 >= 0, -d1 + 1 >= 0, s0 >= 0, -s0 + 1 >= 0)>
 #set1 = affine_set<(d0, d1)[s0] : (d0 >= 0, -d0 + 1 >= 0, d1 - s0 == 0, s0 >= 0, -s0 + 1 >= 0)>
 module {
-// CHECK: air.channel @channel_2 [2, 2]
-// CHECK: air.channel @channel_1 [1, 2] {broadcast_shape = [2, 2]}
 // CHECK: air.channel @channel_0 [2, 1] {broadcast_shape = [2, 2]}
+// CHECK: air.channel @channel_1 [1, 2] {broadcast_shape = [2, 2]}
+// CHECK: air.channel @channel_2 [2, 2]
 // CHECK-LABEL: func.func @mmult
   func.func @mmult(%arg0: memref<512x512xi32>, %arg1: memref<512x512xi32>, %arg2: memref<512x512xi32>) {
     %c2 = arith.constant 2 : index

--- a/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel.mlir
@@ -13,8 +13,8 @@
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
 #set1 = affine_set<()[s0, s1] : (s0 - 1 == 0, s1 >= 0, -s1 + 1 >= 0)>
 module {
-// CHECK: air.channel @channel_1 [1, 1] {broadcast_shape = [1, 2]}
 // CHECK: air.channel @channel_0 [1, 1] {broadcast_shape = [1, 2]}
+// CHECK: air.channel @channel_1 [1, 1] {broadcast_shape = [1, 2]}
   func.func @mmult(%arg0: memref<512x512xbf16>) {
     %c8 = arith.constant 8 : index
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c8, %arg4=%c8) args(%arg5=%arg0) : memref<512x512xbf16> attributes {id = 3 : i32} {

--- a/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel_4x4.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/specialized_broadcast_to_channel_4x4.mlir
@@ -14,10 +14,10 @@
 #set2 = affine_set<()[s0, s1] : (s0 - 2 == 0, s1 >= 0, -s1 + 3 >= 0)>
 #set3 = affine_set<()[s0, s1] : (s0 - 3 == 0, s1 >= 0, -s1 + 3 >= 0)>
 module {
-// CHECK: air.channel @channel_3 [1, 1] {broadcast_shape = [1, 4]}
-// CHECK: air.channel @channel_2 [1, 1] {broadcast_shape = [1, 4]}
-// CHECK: air.channel @channel_1 [1, 1] {broadcast_shape = [1, 4]}
 // CHECK: air.channel @channel_0 [1, 1] {broadcast_shape = [1, 4]}
+// CHECK: air.channel @channel_1 [1, 1] {broadcast_shape = [1, 4]}
+// CHECK: air.channel @channel_2 [1, 1] {broadcast_shape = [1, 4]}
+// CHECK: air.channel @channel_3 [1, 1] {broadcast_shape = [1, 4]}
   func.func @matmul(%arg0: memref<512x512xbf16>) {
     %c8 = arith.constant 8 : index
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c8, %arg4=%c8) args(%arg5=%arg0) : memref<512x512xbf16> attributes {id = 3 : i32} {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
@@ -814,68 +814,74 @@ module {
 
 // -----
 
-// Fusing air.channels when there are no scf.for loops to merge into.
+// Fusing air.channels when there are no scf.for loops (NFL) to merge into.
 
 // CHECK-LABEL: func8
 // CHECK: air.segment @segment_0
-// CHECK: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// CHECK: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // CHECK: air.herd @herd_0
 // CHECK: affine.if
-// CHECK-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// CHECK-NEXT: affine.yield
-// CHECK-NEXT: else
-// CHECK-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// CHECK-NEXT: affine.yield
-// CHECK: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// CHECK: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// CHECK: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// CHECK: affine.yield
+// CHECK: else
+// CHECK: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// CHECK: affine.yield
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// CHECK-NEXT: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// CHECK-NEXT: scf.yield
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// CHECK-NEXT: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// CHECK-NEXT: scf.yield
 // CHECK: air.herd @herd_0
 // CHECK: affine.if
-// CHECK-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// CHECK-NEXT: affine.yield
-// CHECK-NEXT: else
-// CHECK-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// CHECK-NEXT: affine.yield
+// CHECK: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// CHECK: affine.yield
+// CHECK: else
+// CHECK: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// CHECK: affine.yield
 // AGGRESSIVE-LABEL: func8
 // AGGRESSIVE: air.segment @segment_0
-// AGGRESSIVE: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// AGGRESSIVE: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: affine.if
-// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGRESSIVE-NEXT: affine.yield
-// AGGRESSIVE-NEXT: else
-// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGRESSIVE-NEXT: affine.yield
-// AGGRESSIVE: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// AGGRESSIVE: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGRESSIVE: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGRESSIVE: affine.yield
+// AGGRESSIVE: else
+// AGGRESSIVE: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGRESSIVE: affine.yield
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGRESSIVE-NEXT: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGRESSIVE-NEXT: scf.yield
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGRESSIVE-NEXT: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGRESSIVE-NEXT: scf.yield
 // AGGRESSIVE: air.herd @herd_0
 // AGGRESSIVE: affine.if
-// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGRESSIVE-NEXT: affine.yield
-// AGGRESSIVE-NEXT: else
-// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGRESSIVE-NEXT: affine.yield
+// AGGRESSIVE: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGRESSIVE: affine.yield
+// AGGRESSIVE: else
+// AGGRESSIVE: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGRESSIVE: affine.yield
 // AGGL1-LABEL: func8
 // AGGL1: air.segment @segment_0
-// AGGL1: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// AGGL1: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
 // AGGL1: air.herd @herd_0
 // AGGL1: affine.if
-// AGGL1-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGL1-NEXT: affine.yield
-// AGGL1-NEXT: else
-// AGGL1-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGL1-NEXT: affine.yield
-// AGGL1: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
-// AGGL1: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGL1: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGL1: affine.yield
+// AGGL1: else
+// AGGL1: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGL1: affine.yield
+// AGGL1: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGL1-NEXT: air.channel.put{{.*}}@channel_2{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGL1-NEXT: scf.yield
+// AGGL1: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGL1-NEXT: air.channel.put{{.*}}@channel_3{{.*}} : (memref<1x1x64x32xi32, 1 : i32>)
+// AGGL1-NEXT: scf.yield
 // AGGL1: air.herd @herd_0
 // AGGL1: affine.if
-// AGGL1-NEXT: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGL1-NEXT: affine.yield
-// AGGL1-NEXT: else
-// AGGL1-NEXT: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
-// AGGL1-NEXT: affine.yield
+// AGGL1: air.channel.get{{.*}}@channel_2{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGL1: affine.yield
+// AGGL1: else
+// AGGL1: air.channel.get{{.*}}@channel_3{{.*}} : (memref<1x1x4x8x4x8xi32, 2 : i32>)
+// AGGL1: affine.yield
 
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
 module {
@@ -930,6 +936,114 @@ module {
         }
         %async_token_4 = air.execute [%7] {
           memref.dealloc %results : memref<1x1x4x8x4x8xi32, 2 : i32>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// No-for-loop (NFL) mode: avoid fusing into a new for loop if differing data access pattern.
+// Note: see L3-side channel puts in example below not being fused into a new for loop.
+
+// CHECK-LABEL: func9
+// CHECK: air.launch
+// CHECK: air.channel.put{{.*}}@channel_4{{.*}} : (memref<512x256xi8>)
+// CHECK: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// CHECK: air.channel.put{{.*}}@channel_4{{.*}} : (memref<512x256xi8>)
+// CHECK: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// CHECK: air.segment @segment_0
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// CHECK-NEXT: air.channel.get{{.*}}@channel_4{{.*}} : (memref<2x1x128x128xi8, 1 : i32>)
+// CHECK-NEXT: scf.yield
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// CHECK-NEXT: air.channel.get{{.*}}@channel_5{{.*}} : (memref<1x2x128x16xi8, 1 : i32>)
+// CHECK-NEXT: scf.yield
+// AGGRESSIVE: air.launch
+// AGGRESSIVE: air.channel.put{{.*}}@channel_5{{.*}} : (memref<512x256xi8>)
+// AGGRESSIVE: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// AGGRESSIVE: air.channel.put{{.*}}@channel_5{{.*}} : (memref<512x256xi8>)
+// AGGRESSIVE: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// AGGRESSIVE: air.segment @segment_0
+// AGGRESSIVE: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_5{{.*}} : (memref<1x2x128x16xi8, 1 : i32>)
+// AGGRESSIVE-NEXT: air.channel.get{{.*}}@channel_5{{.*}} : (memref<2x1x128x128xi8, 1 : i32>)
+// AGGRESSIVE-NEXT: scf.yield
+// AGGL1: air.launch
+// AGGL1: air.channel.put{{.*}}@channel_4{{.*}} : (memref<512x256xi8>)
+// AGGL1: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// AGGL1: air.channel.put{{.*}}@channel_4{{.*}} : (memref<512x256xi8>)
+// AGGL1: air.channel.put{{.*}}@channel_5{{.*}} : (memref<256x32xi8>)
+// AGGL1: air.segment @segment_0
+// AGGL1: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGL1-NEXT: air.channel.get{{.*}}@channel_4{{.*}} : (memref<2x1x128x128xi8, 1 : i32>)
+// AGGL1-NEXT: scf.yield
+// AGGL1: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// AGGL1-NEXT: air.channel.get{{.*}}@channel_5{{.*}} : (memref<1x2x128x16xi8, 1 : i32>)
+// AGGL1-NEXT: scf.yield
+
+#map = affine_map<()[s0] -> (s0 * 256)>
+#map1 = affine_map<()[s0] -> (s0 * 32)>
+module {
+  air.channel @channel_5 [1, 1]
+  air.channel @channel_4 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_0 [1, 1]
+  func.func @func9(%arg0: memref<512x256xi8>, %arg1: memref<256x32xi8>, %arg2: memref<512x32xi32>, %arg3: memref<512x32xi32>) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %0 = air.launch async (%arg4, %arg5) in (%arg6=%c2, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<512x256xi8>, memref<256x32xi8> attributes {id = 1 : i32} {
+      %c4096 = arith.constant 4096 : index
+      %c16 = arith.constant 16 : index
+      %c32 = arith.constant 32 : index
+      %c1_0 = arith.constant 1 : index
+      %c256 = arith.constant 256 : index
+      %c128 = arith.constant 128 : index
+      %c32768 = arith.constant 32768 : index
+      %c0 = arith.constant 0 : index
+      %c2_1 = arith.constant 2 : index
+      %async_token, %results = air.execute -> (index) {
+        %6 = affine.apply #map()[%arg4]
+        air.execute_terminator %6 : index
+      }
+      %1 = air.channel.put async [%async_token]  @channel_0[] (%arg8[%c0, %c0, %results, %c0] [%c2_1, %c1_0, %c128, %c128] [%c32768, %c128, %c256, %c1_0]) {id = 1 : i32} : (memref<512x256xi8>)
+      %async_token_2, %results_3 = air.execute -> (index) {
+        %6 = affine.apply #map1()[%arg5]
+        air.execute_terminator %6 : index
+      }
+      %2 = air.channel.put async [%async_token_2]  @channel_1[] (%arg9[%c0, %c0, %c0, %results_3] [%c1_0, %c2_1, %c128, %c16] [%c4096, %c16, %c32, %c1_0]) {id = 2 : i32} : (memref<256x32xi8>)
+      %async_token_4, %results_5 = air.execute -> (index) {
+        %6 = affine.apply #map()[%arg4]
+        air.execute_terminator %6 : index
+      }
+      %3 = air.channel.put async [%async_token_4]  @channel_4[] (%arg8[%c0, %c0, %results_5, %c128] [%c2_1, %c1_0, %c128, %c128] [%c32768, %c128, %c256, %c1_0]) {id = 3 : i32} : (memref<512x256xi8>)
+      %async_token_6, %results_7 = air.execute -> (index) {
+        %6 = affine.apply #map1()[%arg5]
+        air.execute_terminator %6 : index
+      }
+      %4 = air.channel.put async [%async_token_6]  @channel_5[] (%arg9[%c0, %c0, %c128, %results_7] [%c1_0, %c2_1, %c128, %c16] [%c4096, %c16, %c32, %c1_0]) {id = 4 : i32} : (memref<256x32xi8>)
+      %5 = air.segment @segment_0 async  attributes {id = 2 : i32} {
+        %6 = air.wait_all async 
+        %7 = air.wait_all async 
+        %async_token_8, %results_9 = air.execute -> (memref<1x2x128x16xi8, 1 : i32>) {
+          %alloc = memref.alloc() : memref<1x2x128x16xi8, 1 : i32>
+          air.execute_terminator %alloc : memref<1x2x128x16xi8, 1 : i32>
+        }
+        %async_token_10, %results_11 = air.execute -> (memref<2x1x128x128xi8, 1 : i32>) {
+          %alloc = memref.alloc() : memref<2x1x128x128xi8, 1 : i32>
+          air.execute_terminator %alloc : memref<2x1x128x128xi8, 1 : i32>
+        }
+        %8 = air.channel.get async [%7, %async_token_10]  @channel_0[] (%results_11[] [] []) {id = 7 : i32} : (memref<2x1x128x128xi8, 1 : i32>)
+        %9 = air.channel.get async [%6, %async_token_8]  @channel_1[] (%results_9[] [] []) {id = 8 : i32} : (memref<1x2x128x16xi8, 1 : i32>)
+        %10 = air.channel.get async [%8]  @channel_4[] (%results_11[] [] []) {id = 13 : i32} : (memref<2x1x128x128xi8, 1 : i32>)
+        %11 = air.channel.get async [%9]  @channel_5[] (%results_9[] [] []) {id = 14 : i32} : (memref<1x2x128x16xi8, 1 : i32>)
+        %async_token_12 = air.execute [%10] {
+          memref.dealloc %results_11 : memref<2x1x128x128xi8, 1 : i32>
+        }
+        %async_token_13 = air.execute [%11] {
+          memref.dealloc %results_9 : memref<1x2x128x16xi8, 1 : i32>
         }
       }
     }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
@@ -631,10 +631,11 @@ func.func @func7() {
 
 // CHECK: scf.for %{{.*}} = %c0 to %c1024 step %c256
 // CHECK: air.channel.get async [{{.*}}]  @channel_8
+// CHECK-NEXT: air.channel.get async [{{.*}}]  @channel_8
 // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c256 step %c64
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_0
 // CHECK-NEXT: scf.yield
-// CHECK: air.channel.get async [{{.*}}]  @channel_8
+// CHECK-NEXT: }
 // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c256 step %c64
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_1
 // CHECK-NEXT: scf.yield
@@ -642,10 +643,11 @@ func.func @func7() {
 
 // CHECK: scf.for %{{.*}} = %c0 to %c256 step %c64
 // CHECK: air.channel.get async [{{.*}}]  @channel_9
+// CHECK-NEXT: air.channel.get async [{{.*}}]  @channel_9
 // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c64 step %c16
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2
 // CHECK-NEXT: scf.yield
-// CHECK: air.channel.get async [{{.*}}]  @channel_9
+// CHECK-NEXT: }
 // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c64 step %c16
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_3
 // CHECK-NEXT: scf.yield
@@ -744,15 +746,15 @@ func.func @func8(%arg0: memref<512x1024xbf16>, %arg1: memref<256x4x4x128xbf16>, 
 // CHECK-LABEL: func.func @func9
 // CHECK: air.segment
 // CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
-// CHECK: air.channel.get async [{{.*}}]  @channel_1[]
-// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}]
-// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}]
-// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}]
-// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}]
 // CHECK: air.channel.get async [{{.*}}]  @channel_0[]
+// CHECK-NEXT: air.channel.get async [{{.*}}]  @channel_1[]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}]
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}]
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}]
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}]
 // CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}]
 // CHECK: scf.yield
 

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/segment_loop_fusion.mlir
@@ -738,3 +738,125 @@ func.func @func8(%arg0: memref<512x1024xbf16>, %arg1: memref<256x4x4x128xbf16>, 
   }
   return %arg2 : memref<512x512xf32>
 }
+
+// Scf.parallel unrolling in pre-processing pipeline; scf.for with multiple air.channel ops operating on the same channel (from AIRFuseChannels).
+
+// CHECK-LABEL: func.func @func9
+// CHECK: air.segment
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c2{{.*}} step %c1{{.*}}
+// CHECK: air.channel.get async [{{.*}}]  @channel_1[]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}]
+// CHECK: air.channel.get async [{{.*}}]  @channel_0[]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}]
+// CHECK-NEXT: air.channel.put async [{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}]
+// CHECK: scf.yield
+
+#map13 = affine_map<()[s0] -> (s0 * 256)>
+#map14 = affine_map<()[s0] -> (s0 * 32)>
+func.func @func9(%arg0: memref<512x256xi8>, %arg1: memref<256x32xi8>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %0 = air.launch async (%arg4, %arg5) in (%arg6=%c2, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<512x256xi8>, memref<256x32xi8> attributes {id = 1 : i32} {
+    %c4096 = arith.constant 4096 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c1_0 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %c128 = arith.constant 128 : index
+    %c32768 = arith.constant 32768 : index
+    %c0 = arith.constant 0 : index
+    %c2_1 = arith.constant 2 : index
+    %async_token, %results = air.execute -> (index) {
+      %4 = affine.apply #map13()[%arg4]
+      air.execute_terminator %4 : index
+    }
+    %1 = scf.for %arg10 = %c0 to %c2_1 step %c1_0 iter_args(%arg11 = %async_token) -> (!air.async.token) {
+      %4 = air.channel.put async [%arg11]  @channel_0[] (%arg8[%c0, %c0, %results, %c0] [%c2_1, %c1_0, %c128, %c128] [%c32768, %c128, %c256, %c1_0]) {id = 1 : i32} : (memref<512x256xi8>)
+      scf.yield %4 : !air.async.token
+    }
+    %async_token_2, %results_3 = air.execute -> (index) {
+      %4 = affine.apply #map14()[%arg5]
+      air.execute_terminator %4 : index
+    }
+    %2 = scf.for %arg10 = %c0 to %c2_1 step %c1_0 iter_args(%arg11 = %async_token_2) -> (!air.async.token) {
+      %4 = air.channel.put async [%arg11]  @channel_1[] (%arg9[%c0, %c0, %c0, %results_3] [%c1_0, %c2_1, %c128, %c16] [%c4096, %c16, %c32, %c1_0]) {id = 2 : i32} : (memref<256x32xi8>)
+      scf.yield %4 : !air.async.token
+    }
+    %3 = air.segment @segment_0 async  attributes {id = 2 : i32} {
+      %c16384 = arith.constant 16384 : index
+      %c8 = arith.constant 8 : index
+      %c512 = arith.constant 512 : index
+      %c4 = arith.constant 4 : index
+      %c2048 = arith.constant 2048 : index
+      %c32_4 = arith.constant 32 : index
+      %c16_5 = arith.constant 16 : index
+      %c4096_6 = arith.constant 4096 : index
+      %c1_7 = arith.constant 1 : index
+      %c128_8 = arith.constant 128 : index
+      %c0_9 = arith.constant 0 : index
+      %c2_10 = arith.constant 2 : index
+      %async_token_11, %results_12 = air.execute -> (memref<1x1x2x16x8x8xi8, 2 : i32>) {
+        %alloc = memref.alloc() : memref<1x1x2x16x8x8xi8, 2 : i32>
+        air.execute_terminator %alloc : memref<1x1x2x16x8x8xi8, 2 : i32>
+      }
+      %async_token_13, %results_14 = air.execute -> (memref<1x1x16x32x4x8xi8, 2 : i32>) {
+        %alloc = memref.alloc() : memref<1x1x16x32x4x8xi8, 2 : i32>
+        air.execute_terminator %alloc : memref<1x1x16x32x4x8xi8, 2 : i32>
+      }
+      %async_token_15, %results_16 = air.execute -> (memref<1x2x128x16xi8, 1 : i32>) {
+        %alloc = memref.alloc() : memref<1x2x128x16xi8, 1 : i32>
+        air.execute_terminator %alloc : memref<1x2x128x16xi8, 1 : i32>
+      }
+      %async_token_17, %results_18 = air.execute -> (memref<2x1x128x128xi8, 1 : i32>) {
+        %alloc = memref.alloc() : memref<2x1x128x128xi8, 1 : i32>
+        air.execute_terminator %alloc : memref<2x1x128x128xi8, 1 : i32>
+      }
+      %4 = scf.for %arg10 = %c0_9 to %c2_10 step %c1_7 iter_args(%arg11 = %async_token_17) -> (!air.async.token) {
+        %9 = air.channel.get async [%arg11, %arg11]  @channel_0[] (%results_18[] [] []) {id = 7 : i32} : (memref<2x1x128x128xi8, 1 : i32>)
+        scf.yield %9 : !air.async.token
+      }
+      %5 = scf.for %arg10 = %c0_9 to %c2_10 step %c1_7 iter_args(%arg11 = %async_token_15) -> (!air.async.token) {
+        %9 = air.channel.get async [%arg11, %arg11]  @channel_1[] (%results_16[] [] []) {id = 8 : i32} : (memref<1x2x128x16xi8, 1 : i32>)
+        scf.yield %9 : !air.async.token
+      }
+      %6 = scf.parallel (%arg10, %arg11) = (%c0_9, %c0_9) to (%c2_10, %c2_10) step (%c1_7, %c1_7) init (%async_token_17) -> !air.async.token {
+        %9 = scf.for %arg12 = %c0_9 to %c2_10 step %c1_7 iter_args(%arg13 = %async_token_17) -> (!air.async.token) {
+          %10 = air.channel.put async [%arg13]  @channel_2[%arg10, %arg11] (%results_18[%arg10, %c0_9, %c0_9, %c0_9, %c0_9, %c0_9] [%c1_7, %c1_7, %c16_5, %c32_4, %c4, %c8] [%c16384, %c16384, %c8, %c512, %c128_8, %c1_7]) {id = 9 : i32} : (memref<2x1x128x128xi8, 1 : i32>)
+          %11 = air.channel.put async [%10, %arg13]  @channel_2[%arg10, %arg11] (%results_16[%c0_9, %arg11, %c0_9, %c0_9, %c0_9, %c0_9] [%c1_7, %c1_7, %c2_10, %c16_5, %c8, %c8] [%c4096_6, %c2048, %c8, %c128_8, %c16_5, %c1_7]) {id = 10 : i32} : (memref<1x2x128x16xi8, 1 : i32>)
+          scf.yield %10 : !air.async.token
+        }
+        scf.reduce(%9 : !air.async.token) {
+        ^bb0(%arg12: !air.async.token, %arg13: !air.async.token):
+          %10 = air.wait_all async [%arg12, %arg13] 
+          scf.reduce.return %10 : !air.async.token
+        }
+      }
+      %7 = air.herd @herd_0 async [%async_token_11, %async_token_13, %async_token_15, %async_token_17]  tile (%arg10, %arg11) in (%arg12=%c2_10, %arg13=%c2_10) args(%arg14=%results_14, %arg15=%results_12) : memref<1x1x16x32x4x8xi8, 2 : i32>, memref<1x1x2x16x8x8xi8, 2 : i32> attributes {id = 3 : i32} {
+        %9 = air.channel.get async  @channel_2[%arg10, %arg11] (%arg14[] [] []) {id = 11 : i32} : (memref<1x1x16x32x4x8xi8, 2 : i32>)
+        %10 = air.channel.get async [%9]  @channel_2[%arg10, %arg11] (%arg15[] [] []) {id = 12 : i32} : (memref<1x1x2x16x8x8xi8, 2 : i32>)
+      }
+      %8 = air.herd @herd_0 async [%7]  tile (%arg10, %arg11) in (%arg12=%c2_10, %arg13=%c2_10) args(%arg14=%results_14, %arg15=%results_12) : memref<1x1x16x32x4x8xi8, 2 : i32>, memref<1x1x2x16x8x8xi8, 2 : i32> attributes {id = 4 : i32} {
+        %9 = air.channel.get async  @channel_2[%arg10, %arg11] (%arg14[] [] []) {id = 20 : i32} : (memref<1x1x16x32x4x8xi8, 2 : i32>)
+        %10 = air.channel.get async  @channel_2[%arg10, %arg11] (%arg15[] [] []) {id = 21 : i32} : (memref<1x1x2x16x8x8xi8, 2 : i32>)
+      }
+      %async_token_19 = air.execute [%8] {
+        memref.dealloc %results_18 : memref<2x1x128x128xi8, 1 : i32>
+      }
+      %async_token_20 = air.execute [%8] {
+        memref.dealloc %results_16 : memref<1x2x128x16xi8, 1 : i32>
+      }
+      %async_token_21 = air.execute [%8] {
+        memref.dealloc %results_14 : memref<1x1x16x32x4x8xi8, 2 : i32>
+      }
+      %async_token_22 = air.execute [%8] {
+        memref.dealloc %results_12 : memref<1x1x2x16x8x8xi8, 2 : i32>
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
@@ -13,9 +13,9 @@
 // CHECK: [[$MAP1:#map[0-9]+]] = affine_map<()[s0] -> (s0 * 256 + 64)>
 // CHECK: [[$MAP2:#map[0-9]+]] = affine_map<()[s0] -> (s0 * 256 + 128)>
 // CHECK: [[$MAP3:#map[0-9]+]] = affine_map<()[s0] -> (s0 * 256 + 192)>
-// CHECK: air.channel @channel_2 [4, 1]
 // CHECK: air.channel @channel_1 [1, 1]
 // CHECK: air.channel @channel_0 [4, 4]
+// CHECK: air.channel @channel_2 [4, 1]
 // CHECK-LABEL: func.func @test0
 // CHECK: air.launch
 // CHECK-DAG: %[[CST3:.*]] = arith.constant 3 : index


### PR DESCRIPTION
- In non-aggressive mode, relax the check that puts to the two channels (to be fused) must have the same offsets, wraps and strides. This is because if the get side share the exact same destination, then the two channels must be fused, otherwise there is going to be a race condition, where multiple DMA channels are writing to the same destination.
- In aggressive mode, fixup a couple of places where channel's original ordering in the code wasn't respected.