### PR TITLE
Add programming_examples to 'check-all' target

### DIFF
--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -93,3 +93,5 @@ add_lit_testsuite(check-programming-examples "Running the air programming exampl
   ARGS ${AIR_TEST_LIT_ARGS}
   )
 set_target_properties(check-programming-examples PROPERTIES FOLDER "Tests")
+
+add_dependencies(check-all check-programming-examples)


### PR DESCRIPTION
so that I only need to type one thing