### PR TITLE
Support changing the function calls replacing linalg ops in presence of reshape ops 

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3474,7 +3474,6 @@ public:
         op, fnNameAttr.getValue(), TypeRange(),
         ValueRange(ArrayRef<Value>(libFnOperands)));
 
-    module.dump();
     return success();
   }
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3425,13 +3425,34 @@ public:
     if (fnName.empty())
       return failure();
 
+    // Function to get operands of the library call that will
+    // replace the given linalg op.
+    auto getLibFnOperands = [](linalg::LinalgOp op) {
+        SmallVector<Value> operands;
+        for (auto operand : op->getOperands()) {
+            if (auto operation = operand.getDefiningOp()) {
+                if (dyn_cast<memref::ReshapeOp>(operation) || 
+                    dyn_cast<memref::ExpandShapeOp>(operation) ||
+                    dyn_cast<memref::CollapseShapeOp>(operation)) {
+                    operands.push_back(operation->getOperand(0));
+                    continue;
+                }
+            } 
+            operands.push_back(operand);
+        }
+        return operands;
+    };
+
+    auto libFnOperands = getLibFnOperands(op);
+
     // fnName is a dynamic std::string, unique it via a SymbolRefAttr.
     FlatSymbolRefAttr fnNameAttr =
         SymbolRefAttr::get(rewriter.getContext(), fnName);
     auto module = op->getParentOfType<ModuleOp>();
     auto sym = module.lookupSymbol(fnNameAttr.getAttr());
     if (!sym) {
-      auto libFnType = rewriter.getFunctionType(op->getOperandTypes(), {});
+      auto libFnType = rewriter.getFunctionType(
+            ValueRange(ArrayRef<Value>(libFnOperands)).getTypes(), {});
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(module.getBody(),
                                  std::prev(module.getBody()->end()));
@@ -3453,7 +3474,9 @@ public:
     }
 
     rewriter.replaceOpWithNewOp<func::CallOp>(op, fnNameAttr.getValue(),
-                                              TypeRange(), op->getOperands());
+                                              TypeRange(), 
+                                              ValueRange(ArrayRef<Value>(libFnOperands)));
+
     return success();
   }
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,9 +535,8 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk([&](xilinx::air::HerdOp h) {
-      aie_modules.push_back({aie_dev, h});
-    });
+    seg.walk(
+        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
 
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
@@ -3428,19 +3427,19 @@ public:
     // Function to get operands of the library call that will
     // replace the given linalg op.
     auto getLibFnOperands = [](linalg::LinalgOp op) {
-        SmallVector<Value> operands;
-        for (auto operand : op->getOperands()) {
-            if (auto operation = operand.getDefiningOp()) {
-                if (dyn_cast<memref::ReshapeOp>(operation) || 
-                    dyn_cast<memref::ExpandShapeOp>(operation) ||
-                    dyn_cast<memref::CollapseShapeOp>(operation)) {
-                    operands.push_back(operation->getOperand(0));
-                    continue;
-                }
-            } 
-            operands.push_back(operand);
+      SmallVector<Value> operands;
+      for (auto operand : op->getOperands()) {
+        if (auto operation = operand.getDefiningOp()) {
+          if (dyn_cast<memref::ReshapeOp>(operation) ||
+              dyn_cast<memref::ExpandShapeOp>(operation) ||
+              dyn_cast<memref::CollapseShapeOp>(operation)) {
+            operands.push_back(operation->getOperand(0));
+            continue;
+          }
         }
-        return operands;
+        operands.push_back(operand);
+      }
+      return operands;
     };
 
     auto libFnOperands = getLibFnOperands(op);
@@ -3452,7 +3451,7 @@ public:
     auto sym = module.lookupSymbol(fnNameAttr.getAttr());
     if (!sym) {
       auto libFnType = rewriter.getFunctionType(
-            ValueRange(ArrayRef<Value>(libFnOperands)).getTypes(), {});
+          ValueRange(ArrayRef<Value>(libFnOperands)).getTypes(), {});
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(module.getBody(),
                                  std::prev(module.getBody()->end()));
@@ -3473,9 +3472,9 @@ public:
       funcOp.setPrivate();
     }
 
-    rewriter.replaceOpWithNewOp<func::CallOp>(op, fnNameAttr.getValue(),
-                                              TypeRange(), 
-                                              ValueRange(ArrayRef<Value>(libFnOperands)));
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, fnNameAttr.getValue(), TypeRange(),
+        ValueRange(ArrayRef<Value>(libFnOperands)));
 
     return success();
   }
@@ -3533,9 +3532,8 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk([&](xilinx::air::HerdOp h) {
-    aie_modules.push_back({aie_module, h});
-  });
+  p.walk(
+      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3429,13 +3429,13 @@ public:
     auto getLibFnOperands = [](linalg::LinalgOp op) {
       SmallVector<Value> operands;
       for (auto operand : op->getOperands()) {
-        if (auto operation = operand.getDefiningOp()) {
-          if (dyn_cast<memref::ReshapeOp>(operation) ||
-              dyn_cast<memref::ExpandShapeOp>(operation) ||
-              dyn_cast<memref::CollapseShapeOp>(operation)) {
+        auto operation = operand.getDefiningOp();
+        if (isa_and_present<
+                    memref::ReshapeOp, 
+                    memref::ExpandShapeOp, 
+                    memref::CollapseShapeOp>(operation)) {
             operands.push_back(operation->getOperand(0));
             continue;
-          }
         }
         operands.push_back(operand);
       }

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3531,7 +3531,7 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
   p.walk([&](xilinx::air::HerdOp h) {
-    aie_modules.push_back({aie_module, h}); 
+    aie_modules.push_back({aie_module, h});
   });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,8 +535,8 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk([&](xilinx::air::HerdOp h) { 
-      aie_modules.push_back({aie_dev, h}); 
+    seg.walk([&](xilinx::air::HerdOp h) {
+      aie_modules.push_back({aie_dev, h});
     });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
@@ -3474,6 +3474,7 @@ public:
         op, fnNameAttr.getValue(), TypeRange(),
         ValueRange(ArrayRef<Value>(libFnOperands)));
 
+    module.dump();
     return success();
   }
 
@@ -3530,7 +3531,7 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk([&](xilinx::air::HerdOp h) { 
+  p.walk([&](xilinx::air::HerdOp h) {
     aie_modules.push_back({aie_module, h}); 
   });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,9 +535,8 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk([&](xilinx::air::HerdOp h) {
-        aie_modules.push_back({aie_dev, h});
-    });
+    seg.walk(
+        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
       outlineAIEMemtiles(builder, aie_dev, seg, options);
@@ -3430,12 +3429,10 @@ public:
       SmallVector<Value> operands;
       for (auto operand : op->getOperands()) {
         auto operation = operand.getDefiningOp();
-        if (isa_and_present<
-                    memref::ReshapeOp, 
-                    memref::ExpandShapeOp, 
-                    memref::CollapseShapeOp>(operation)) {
-            operands.push_back(operation->getOperand(0));
-            continue;
+        if (isa_and_present<memref::ReshapeOp, memref::ExpandShapeOp,
+                            memref::CollapseShapeOp>(operation)) {
+          operands.push_back(operation->getOperand(0));
+          continue;
         }
         operands.push_back(operand);
       }
@@ -3532,9 +3529,8 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk([&](xilinx::air::HerdOp h) {
-      aie_modules.push_back({aie_module, h});
-  });
+  p.walk(
+      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,8 +535,9 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk(
-        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
+    seg.walk([&](xilinx::air::HerdOp h) { 
+      aie_modules.push_back({aie_dev, h}); 
+    });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
       outlineAIEMemtiles(builder, aie_dev, seg, options);
@@ -3529,8 +3530,9 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk(
-      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
+  p.walk([&](xilinx::air::HerdOp h) { 
+    aie_modules.push_back({aie_module, h}); 
+  });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,9 +535,9 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk(
-        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
-
+    seg.walk([&](xilinx::air::HerdOp h) {
+        aie_modules.push_back({aie_dev, h});
+    });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
       outlineAIEMemtiles(builder, aie_dev, seg, options);
@@ -3532,8 +3532,9 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk(
-      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
+  p.walk([&](xilinx::air::HerdOp h) {
+      aie_modules.push_back({aie_module, h});
+  });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
@@ -7,58 +7,31 @@
 
 // RUN: air-opt %s -air-linalg-to-func | FileCheck %s
 
-#map = affine_map<(d0) -> (d0 * 128)>
-#map1 = affine_map<(d0) -> (d0 * 64)>
-#map2 = affine_map<()[s0] -> (s0 * 4)>
 module {
   // CHECK: func.func private @linalg_fill_f32_view64x64xf32as2(f32, memref<64x64xf32, 2>) 
   // CHECK: func.func private @linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) 
-  func.func @forward(%arg0: memref<512x128xbf16>, %arg1: memref<32x4x4x128xbf16>, %arg2: memref<512x512xf32>) -> memref<512x512xf32> {
-    %c64 = arith.constant 64 : index
-    %c512 = arith.constant 512 : index
-    %c2048 = arith.constant 2048 : index
-    %c4 = arith.constant 4 : index
-    %c1 = arith.constant 1 : index
-    %c128 = arith.constant 128 : index
+  func.func @test(%arg0: memref<512x512xf32>) -> memref<512x512xf32> {
     %c0 = arith.constant 0 : index
     %c16 = arith.constant 16 : index
     %c32 = arith.constant 32 : index
     %cst = arith.constant 0.000000e+00 : f32
-    scf.forall (%arg3, %arg4) in (4, 4) {
-      %0 = affine.apply #map(%arg3)
-      %1 = affine.apply #map(%arg4)
-      %alloc = memref.alloc() : memref<128x128xbf16, 1>
-      air.dma_memcpy_nd (%alloc[] [] [], %arg0[%0, %c0] [%c128, %c128] [%c128, %c1]) {id = 1 : i32} : (memref<128x128xbf16, 1>, memref<512x128xbf16>)
-      %alloc_0 = memref.alloc() : memref<32x4x128xbf16, 1>
-      air.dma_memcpy_nd (%alloc_0[] [] [], %arg1[%c0, %arg4, %c0, %c0] [%c32, %c1, %c4, %c128] [%c2048, %c512, %c128, %c1]) {id = 2 : i32} : (memref<32x4x128xbf16, 1>, memref<32x4x4x128xbf16>)
-      %alloc_1 = memref.alloc() : memref<128x128xf32, 1>
-      scf.forall (%arg5, %arg6) in (2, 2) {
-        %2 = affine.apply #map1(%arg5)
-        %3 = affine.apply #map1(%arg6)
-        %alloc_2 = memref.alloc() : memref<64x64xf32, 2>
-        linalg.fill ins(%cst : f32) outs(%alloc_2 : memref<64x64xf32, 2>)
+    scf.forall (%arg1, %arg2) in (4, 4) {
+      scf.forall (%arg3, %arg4) in (2, 2) {
+        %alloc_0 = memref.alloc() : memref<64x64xf32, 2>
         // CHECK: linalg_fill_f32_view64x64xf32as2
+        linalg.fill ins(%cst : f32) outs(%alloc_0 : memref<64x64xf32, 2>)
         scf.for %arg7 = %c0 to %c32 step %c16 {
-          %4 = affine.apply #map2()[%arg7]
-          %alloc_3 = memref.alloc() : memref<64x64xbf16, 2>
-          %alloc_4 = memref.alloc() : memref<16x4x64xbf16, 2>
-          air.dma_memcpy_nd (%alloc_3[] [] [], %alloc[%2, %4] [%c64, %c64] [%c128, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 2>, memref<128x128xbf16, 1>)
-          air.dma_memcpy_nd (%alloc_4[] [] [], %alloc_0[%arg7, %c0, %3] [%c16, %c4, %c64] [%c512, %c128, %c1]) {id = 4 : i32} : (memref<16x4x64xbf16, 2>, memref<32x4x128xbf16, 1>)
-          %collapse_shape = memref.collapse_shape %alloc_4 [[0, 1], [2]] : memref<16x4x64xbf16, 2> into memref<64x64xbf16, 2>
-          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%alloc_3, %collapse_shape : memref<64x64xbf16, 2>, memref<64x64xbf16, 2>) outs(%alloc_2 : memref<64x64xf32, 2>)
-          // CHECK: linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(%alloc_3, %alloc_4, %alloc_2) : (memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) -> ()
-          // CHECK-NOT: linalg.matmul
-          memref.dealloc %alloc_3 : memref<64x64xbf16, 2>
-          memref.dealloc %alloc_4 : memref<16x4x64xbf16, 2>
+          %alloc_1 = memref.alloc() : memref<64x64xbf16, 2>
+          %alloc_2 = memref.alloc() : memref<16x4x64xbf16, 2>
+          %collapse_shape = memref.collapse_shape %alloc_2 [[0, 1], [2]] : memref<16x4x64xbf16, 2> into memref<64x64xbf16, 2>
+          // CHECK: linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(%alloc_0, %alloc_1, %alloc) : (memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) -> ()
+          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%alloc_1, %collapse_shape : memref<64x64xbf16, 2>, memref<64x64xbf16, 2>) outs(%alloc_0 : memref<64x64xf32, 2>)
+          memref.dealloc %alloc_1 : memref<64x64xbf16, 2>
+          memref.dealloc %alloc_2 : memref<16x4x64xbf16, 2>
         }
-        air.dma_memcpy_nd (%alloc_1[%2, %3] [%c64, %c64] [%c128, %c1], %alloc_2[] [] []) {id = 5 : i32} : (memref<128x128xf32, 1>, memref<64x64xf32, 2>)
-        memref.dealloc %alloc_2 : memref<64x64xf32, 2>
+        memref.dealloc %alloc_0 : memref<64x64xf32, 2>
       } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
-      air.dma_memcpy_nd (%arg2[%0, %1] [%c128, %c128] [%c512, %c1], %alloc_1[] [] []) {id = 6 : i32} : (memref<512x512xf32>, memref<128x128xf32, 1>)
-      memref.dealloc %alloc : memref<128x128xbf16, 1>
-      memref.dealloc %alloc_0 : memref<32x4x128xbf16, 1>
-      memref.dealloc %alloc_1 : memref<128x128xf32, 1>
     }
-    return %arg2 : memref<512x512xf32>
+    return %arg0 : memref<512x512xf32>
   }
 }

--- a/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
@@ -7,10 +7,50 @@
 
 // RUN: air-opt %s -air-linalg-to-func | FileCheck %s
 
+
+//-----
+//
+// Testing the regular functionality of the pass:
+// linalg ops being replaced with corresponding library calls.
+//
+module {
+  // CHECK: func.func private @linalg_fill_f32_view64x64xf32as2(f32, memref<64x64xf32, 2>) 
+  // CHECK: func.func private @linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(memref<64x64xbf16, 2>, memref<64x64xbf16, 2>, memref<64x64xf32, 2>) 
+  func.func @test1(%arg0: memref<512x512xf32>) -> memref<512x512xf32> {
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    scf.forall (%arg1, %arg2) in (4, 4) {
+      scf.forall (%arg3, %arg4) in (2, 2) {
+        %alloc_0 = memref.alloc() : memref<64x64xf32, 2>
+        // CHECK: linalg_fill_f32_view64x64xf32as2
+        linalg.fill ins(%cst : f32) outs(%alloc_0 : memref<64x64xf32, 2>)
+        scf.for %arg7 = %c0 to %c32 step %c16 {
+          %alloc_1 = memref.alloc() : memref<64x64xbf16, 2>
+          %alloc_2 = memref.alloc() : memref<64x64xbf16, 2>
+          // CHECK: linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2
+          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%alloc_1, %alloc_2 : memref<64x64xbf16, 2>, memref<64x64xbf16, 2>) outs(%alloc_0 : memref<64x64xf32, 2>)
+          memref.dealloc %alloc_1 : memref<64x64xbf16, 2>
+          memref.dealloc %alloc_2 : memref<64x64xbf16, 2>
+        }
+        memref.dealloc %alloc_0 : memref<64x64xf32, 2>
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+    }
+    return %arg0 : memref<512x512xf32>
+  }
+}
+
+
+//-----
+//
+// Testing change in signature of library call 
+// as a result of a shape-altering operation.
+//
 module {
   // CHECK: func.func private @linalg_fill_f32_view64x64xf32as2(f32, memref<64x64xf32, 2>) 
   // CHECK: func.func private @linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) 
-  func.func @test(%arg0: memref<512x512xf32>) -> memref<512x512xf32> {
+  func.func @test2(%arg0: memref<512x512xf32>) -> memref<512x512xf32> {
     %c0 = arith.constant 0 : index
     %c16 = arith.constant 16 : index
     %c32 = arith.constant 32 : index

--- a/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_linalg_to_func.mlir
@@ -1,0 +1,64 @@
+//===- air_linalg_to_func.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===--------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-linalg-to-func | FileCheck %s
+
+#map = affine_map<(d0) -> (d0 * 128)>
+#map1 = affine_map<(d0) -> (d0 * 64)>
+#map2 = affine_map<()[s0] -> (s0 * 4)>
+module {
+  // CHECK: func.func private @linalg_fill_f32_view64x64xf32as2(f32, memref<64x64xf32, 2>) 
+  // CHECK: func.func private @linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) 
+  func.func @forward(%arg0: memref<512x128xbf16>, %arg1: memref<32x4x4x128xbf16>, %arg2: memref<512x512xf32>) -> memref<512x512xf32> {
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+    %c2048 = arith.constant 2048 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    scf.forall (%arg3, %arg4) in (4, 4) {
+      %0 = affine.apply #map(%arg3)
+      %1 = affine.apply #map(%arg4)
+      %alloc = memref.alloc() : memref<128x128xbf16, 1>
+      air.dma_memcpy_nd (%alloc[] [] [], %arg0[%0, %c0] [%c128, %c128] [%c128, %c1]) {id = 1 : i32} : (memref<128x128xbf16, 1>, memref<512x128xbf16>)
+      %alloc_0 = memref.alloc() : memref<32x4x128xbf16, 1>
+      air.dma_memcpy_nd (%alloc_0[] [] [], %arg1[%c0, %arg4, %c0, %c0] [%c32, %c1, %c4, %c128] [%c2048, %c512, %c128, %c1]) {id = 2 : i32} : (memref<32x4x128xbf16, 1>, memref<32x4x4x128xbf16>)
+      %alloc_1 = memref.alloc() : memref<128x128xf32, 1>
+      scf.forall (%arg5, %arg6) in (2, 2) {
+        %2 = affine.apply #map1(%arg5)
+        %3 = affine.apply #map1(%arg6)
+        %alloc_2 = memref.alloc() : memref<64x64xf32, 2>
+        linalg.fill ins(%cst : f32) outs(%alloc_2 : memref<64x64xf32, 2>)
+        // CHECK: linalg_fill_f32_view64x64xf32as2
+        scf.for %arg7 = %c0 to %c32 step %c16 {
+          %4 = affine.apply #map2()[%arg7]
+          %alloc_3 = memref.alloc() : memref<64x64xbf16, 2>
+          %alloc_4 = memref.alloc() : memref<16x4x64xbf16, 2>
+          air.dma_memcpy_nd (%alloc_3[] [] [], %alloc[%2, %4] [%c64, %c64] [%c128, %c1]) {id = 3 : i32} : (memref<64x64xbf16, 2>, memref<128x128xbf16, 1>)
+          air.dma_memcpy_nd (%alloc_4[] [] [], %alloc_0[%arg7, %c0, %3] [%c16, %c4, %c64] [%c512, %c128, %c1]) {id = 4 : i32} : (memref<16x4x64xbf16, 2>, memref<32x4x128xbf16, 1>)
+          %collapse_shape = memref.collapse_shape %alloc_4 [[0, 1], [2]] : memref<16x4x64xbf16, 2> into memref<64x64xbf16, 2>
+          linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%alloc_3, %collapse_shape : memref<64x64xbf16, 2>, memref<64x64xbf16, 2>) outs(%alloc_2 : memref<64x64xf32, 2>)
+          // CHECK: linalg_matmul_view64x64xbf16as2_view64x64xbf16as2_view64x64xf32as2(%alloc_3, %alloc_4, %alloc_2) : (memref<64x64xbf16, 2>, memref<16x4x64xbf16, 2>, memref<64x64xf32, 2>) -> ()
+          // CHECK-NOT: linalg.matmul
+          memref.dealloc %alloc_3 : memref<64x64xbf16, 2>
+          memref.dealloc %alloc_4 : memref<16x4x64xbf16, 2>
+        }
+        air.dma_memcpy_nd (%alloc_1[%2, %3] [%c64, %c64] [%c128, %c1], %alloc_2[] [] []) {id = 5 : i32} : (memref<128x128xf32, 1>, memref<64x64xf32, 2>)
+        memref.dealloc %alloc_2 : memref<64x64xf32, 2>
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+      air.dma_memcpy_nd (%arg2[%0, %1] [%c128, %c128] [%c512, %c1], %alloc_1[] [] []) {id = 6 : i32} : (memref<512x512xf32>, memref<128x128xf32, 1>)
+      memref.dealloc %alloc : memref<128x128xbf16, 1>
+      memref.dealloc %alloc_0 : memref<32x4x128xbf16, 1>
+      memref.dealloc %alloc_1 : memref<128x128xf32, 1>
+    }
+    return %arg2 : memref<512x512xf32>
+  }
+}


### PR DESCRIPTION
This pull request fixes signature of calls to library functions in presence of reshape/expand/collapse ops. This is important because no other way of lowering support such ops currently exists, and this is a way of getting rid of them before generating  code for AIEs.