### PR TITLE
Prevent redundant shim allocations from occuring

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,9 +535,8 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk([&](xilinx::air::HerdOp h) {
-      aie_modules.push_back({aie_dev, h});
-    });
+    seg.walk(
+        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
       outlineAIEMemtiles(builder, aie_dev, seg, options);
@@ -2222,21 +2221,20 @@ public:
     }
   }
 
-  void annotateMetadataPerShimAIRChannel(air::ChannelInterface chan_o,
+  bool annotateMetadataPerShimAIRChannel(air::ChannelInterface chan_o,
                                          MemRefType memref_ty,
                                          StringAttr dma_name_attr) {
     auto ctx = chan_o->getContext();
     auto internalIndices = chan_o.getIndices();
-
+    bool shim_chans_annotated = false;
     int subChannelIdx = 0;
     for (auto the_other_chan_o : getTheOtherChannelOpThroughSymbol(chan_o)) {
-      if (the_other_chan_o->hasAttr("metadata"))
-        continue;
       // Many on shim, one on air.hierarchy.
       if (!internalIndices.empty() &&
           internalIndices.size() == the_other_chan_o.getIndices().size()) {
         // Check if the two end points of the connection match
         bool matchingSubChannel = true;
+        bool allConstantIndices = false;
         for (unsigned i = 0; i < internalIndices.size(); i++) {
           Value internalIdx = internalIndices[i];
           Value externalIdx = the_other_chan_o.getIndices()[i];
@@ -2245,6 +2243,8 @@ public:
           if (constInternalIdx && constExternalIdx) {
             if (*constInternalIdx != *constExternalIdx)
               matchingSubChannel = false;
+            else
+              allConstantIndices = true;
           } else if (constInternalIdx && !constExternalIdx) {
             if (!scf::getParallelForInductionVarOwner(externalIdx))
               matchingSubChannel = false;
@@ -2259,61 +2259,82 @@ public:
           }
         }
         if (matchingSubChannel) {
-          if (subChannelIdx) {
-            the_other_chan_o->setAttr(
-                "metadata",
-                FlatSymbolRefAttr::get(
-                    ctx, mlir::StringAttr::get(
-                             ctx, dma_name_attr.str() + "_" +
-                                      std::to_string(subChannelIdx))));
+          shim_chans_annotated = true;
+          if (!the_other_chan_o->hasAttr("metadata")) {
+            if (subChannelIdx) {
+              the_other_chan_o->setAttr(
+                  "metadata",
+                  FlatSymbolRefAttr::get(
+                      ctx, mlir::StringAttr::get(
+                               ctx, dma_name_attr.str() + "_" +
+                                        std::to_string(subChannelIdx))));
+            } else {
+              the_other_chan_o->setAttr(
+                  "metadata", FlatSymbolRefAttr::get(ctx, dma_name_attr));
+            }
+            break;
           } else {
-            the_other_chan_o->setAttr(
-                "metadata", FlatSymbolRefAttr::get(ctx, dma_name_attr));
+            if (allConstantIndices)
+              shim_chans_annotated = false;
           }
           subChannelIdx++;
         }
-      } else // One on shim, one on air.hierarchy.
-        the_other_chan_o->setAttr("metadata",
-                                  FlatSymbolRefAttr::get(ctx, dma_name_attr));
+      } else { // One on shim, one on air.hierarchy.
+        if (!the_other_chan_o->hasAttr("metadata")) {
+          the_other_chan_o->setAttr("metadata",
+                                    FlatSymbolRefAttr::get(ctx, dma_name_attr));
+          shim_chans_annotated = true;
+          break;
+        }
+      }
     }
+    return shim_chans_annotated;
   }
 
   // AIE2 metadata format is symbolic linked to shim dma ops
-  void labelAIRDmaOpsWithMetadata(air::HierarchyInterface hier,
+  bool labelAIRDmaOpsWithMetadata(air::HierarchyInterface hier,
                                   int target_op_id, StringAttr dma_name_attr,
                                   MemRefType memref_ty) {
     // Label air.dmamemcpynd ops with symbolic ref. to shimdmaalloc op
+    bool dmaops_labeled = false;
     hier.walk([&](air::MemcpyInterface o) {
       if (o.getId() == target_op_id && !o->hasAttr("metadata")) {
-        if (isa<air::DmaMemcpyNdOp>(o.getOperation()))
+        if (isa<air::DmaMemcpyNdOp>(o.getOperation())) {
           o->setAttr("metadata",
                      FlatSymbolRefAttr::get(hier->getContext(), dma_name_attr));
-        else if (auto chan_o =
-                     dyn_cast<air::ChannelInterface>(o.getOperation()))
-          annotateMetadataPerShimAIRChannel(chan_o, memref_ty, dma_name_attr);
+          dmaops_labeled = true;
+        } else if (auto chan_o =
+                       dyn_cast<air::ChannelInterface>(o.getOperation())) {
+          dmaops_labeled |= annotateMetadataPerShimAIRChannel(chan_o, memref_ty,
+                                                              dma_name_attr);
+        }
       }
     });
+    return dmaops_labeled;
   }
 
-  void labelAIRDmaOpsWithMetadata(
+  bool labelAIRDmaOpsWithMetadata(
       std::vector<air::ChannelInterface> channel_ops,
       std::string specializedChanName,
       std::map<std::string, std::string> chan_to_chan_map) {
+    bool dmaops_labeled = false;
     for (auto o : channel_ops) {
       if (o.getChanName().str() == specializedChanName) {
         auto dma_name_attr =
             StringAttr::get(o->getContext(), "air_" + specializedChanName);
         o->setAttr("metadata",
                    FlatSymbolRefAttr::get(o->getContext(), dma_name_attr));
-
+        dmaops_labeled = true;
       } else if (o.getChanName().str() ==
                  chan_to_chan_map[specializedChanName]) {
         auto dma_name_attr =
             StringAttr::get(o->getContext(), "air_" + specializedChanName);
         o->setAttr("metadata",
                    FlatSymbolRefAttr::get(o->getContext(), dma_name_attr));
+        dmaops_labeled = true;
       }
     }
+    return dmaops_labeled;
   }
 
   // Create channel name as string, in case if repetition due to channel
@@ -2354,13 +2375,6 @@ public:
             tileOp->getParentOfType<AIE::DeviceOp>(), dma_name);
         auto dma_name_attr = builder.getStringAttr(dma_name);
 
-        builder.create<AIE::ShimDMAAllocationOp>(
-            builder.getUnknownLoc(), SymbolRefAttr::get(ctx, dma_name_attr),
-            AIE::DMAChannelDirAttr::get(ctx, dir),
-            builder.getI64IntegerAttr(chan),
-            builder.getI64IntegerAttr(tileOp.getCol()),
-            builder.getBoolAttr(false));
-
         air::MemcpyInterface tile_side_memcpy = nullptr;
         herd.walk([&](air::MemcpyInterface o) {
           if (o.getId() == original_id)
@@ -2368,8 +2382,8 @@ public:
         });
 
         // Create memref.global op with memref shape
-        MemRefType memref_ty;
         if (tile_side_memcpy) {
+          MemRefType memref_ty = nullptr;
           if (auto tile_side_dmamemcpy = dyn_cast<air::DmaMemcpyNdOp>(
                   tile_side_memcpy.getOperation())) {
             if (isMM2S)
@@ -2383,28 +2397,43 @@ public:
             memref_ty =
                 llvm::cast<MemRefType>(tile_side_chan.getMemref().getType());
           }
+          assert(memref_ty != nullptr &&
+                 "Memref type for shim DMA allocation not initialized!");
 
-          builder.create<memref::GlobalOp>(builder.getUnknownLoc(), dma_name,
-                                           builder.getStringAttr("public"),
-                                           memref_ty, nullptr, false, nullptr);
+          // Label airrt.dmamemcpynd ops with symbolic ref. to shimdmaalloc op
+          auto dmaop_labeled = labelAIRDmaOpsWithMetadata(
+              herd, original_id,
+              builder.getStringAttr("airMemcpyId" +
+                                    std::to_string(original_id)),
+              memref_ty);
+          // Only create global SHIM DMA allocation op if the relevant
+          // DMA ops have been successfully annotated.
+          if (dmaop_labeled) {
+            builder.create<AIE::ShimDMAAllocationOp>(
+                builder.getUnknownLoc(), SymbolRefAttr::get(ctx, dma_name_attr),
+                AIE::DMAChannelDirAttr::get(ctx, dir),
+                builder.getI64IntegerAttr(chan),
+                builder.getI64IntegerAttr(tileOp.getCol()),
+                builder.getBoolAttr(false));
+            builder.create<memref::GlobalOp>(builder.getUnknownLoc(), dma_name,
+                                             builder.getStringAttr("public"),
+                                             memref_ty, nullptr, false,
+                                             nullptr);
+          }
         }
-
-        // Label airrt.dmamemcpynd ops with symbolic ref. to shimdmaalloc op
-        labelAIRDmaOpsWithMetadata(
-            herd, original_id,
-            builder.getStringAttr("airMemcpyId" + std::to_string(original_id)),
-            memref_ty);
       }
     }
   }
+
   void createShimDMAAllocationOpsFromSegment(
       OpBuilder builder, MLIRContext *ctx, air::SegmentOp seg,
       std::vector<allocation_info_t> allocs, bool isMM2S,
       std::map<int, int> chan_renumber_reverse_map) {
     std::set<int64_t> dma_ids;
     seg.walk([&](air::MemcpyInterface o) {
-      if (!o->getParentOfType<air::HerdOp>())
+      if (!o->getParentOfType<air::HerdOp>()) {
         dma_ids.insert(o.getId());
+      }
     });
 
     for (auto &t : allocs) {
@@ -2413,6 +2442,7 @@ public:
       AIE::DMAChannelDir dir =
           isMM2S ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
 
+      // llvm::SmallSet<int> unused_original_id;
       for (int64_t id : t.dma_id) {
         int original_id = chan_renumber_reverse_map.size()
                               ? chan_renumber_reverse_map[id]
@@ -2429,21 +2459,14 @@ public:
         if (sym)
           continue;
 
-        builder.create<AIE::ShimDMAAllocationOp>(
-            builder.getUnknownLoc(), SymbolRefAttr::get(ctx, dma_name_attr),
-            AIE::DMAChannelDirAttr::get(ctx, dir),
-            builder.getI64IntegerAttr(chan),
-            builder.getI64IntegerAttr(tileOp.getCol()),
-            builder.getBoolAttr(false));
-
         // Create memref.global op with memref shape
         air::MemcpyInterface tile_side_memcpy = nullptr;
-        MemRefType memref_ty;
         seg.walk([&](air::MemcpyInterface o) {
           if (o.getId() == original_id)
             tile_side_memcpy = o;
         });
         if (tile_side_memcpy) {
+          MemRefType memref_ty = nullptr;
           if (auto tile_side_dmamemcpy = dyn_cast<air::DmaMemcpyNdOp>(
                   tile_side_memcpy.getOperation())) {
             if (isMM2S)
@@ -2457,13 +2480,27 @@ public:
             memref_ty =
                 llvm::cast<MemRefType>(tile_side_chan.getMemref().getType());
           }
+          assert(memref_ty != nullptr &&
+                 "Memref type for shim DMA allocation not initialized!");
 
-          builder.create<memref::GlobalOp>(builder.getUnknownLoc(), dma_name,
-                                           builder.getStringAttr("public"),
-                                           memref_ty, nullptr, false, nullptr);
+          // Label airrt.dmamemcpynd ops with symbolic ref. to shimdmaalloc op
+          auto dmaop_labeled = labelAIRDmaOpsWithMetadata(
+              seg, original_id, dma_name_attr, memref_ty);
+          // Only create global SHIM DMA allocation op if the relevant
+          // DMA ops have been successfully annotated.
+          if (dmaop_labeled) {
+            builder.create<AIE::ShimDMAAllocationOp>(
+                builder.getUnknownLoc(), SymbolRefAttr::get(ctx, dma_name_attr),
+                AIE::DMAChannelDirAttr::get(ctx, dir),
+                builder.getI64IntegerAttr(chan),
+                builder.getI64IntegerAttr(tileOp.getCol()),
+                builder.getBoolAttr(false));
+            builder.create<memref::GlobalOp>(builder.getUnknownLoc(), dma_name,
+                                             builder.getStringAttr("public"),
+                                             memref_ty, nullptr, false,
+                                             nullptr);
+          }
         }
-        // Label airrt.dmamemcpynd ops with symbolic ref. to shimdmaalloc op
-        labelAIRDmaOpsWithMetadata(seg, original_id, dma_name_attr, memref_ty);
       }
     }
   }
@@ -3190,7 +3227,6 @@ public:
       std::map<std::string, std::string> chan_to_chan_map;
 
       if (clUseObjFifo) {
-
         cloneL2AndL3MemcpysToDeviceOp(builder, device, module, true, false);
         specializeHerdAffineIf(device);
         lowerAirExecute(device);
@@ -3202,7 +3238,6 @@ public:
         lowerAIRChannels(device, shimTileAlloc, bufferToMemtileMap);
         allocL1Buffers(device, tileToHerdMap, BufferId);
       } else {
-
         cloneL2AndL3MemcpysToDeviceOp(builder, device, module, true, true);
         specializeHerdAffineIf(device);
         lowerAirExecute(device);
@@ -3530,9 +3565,8 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk([&](xilinx::air::HerdOp h) {
-    aie_modules.push_back({aie_module, h});
-  });
+  p.walk(
+      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -535,8 +535,9 @@ void createAIEModulesAndOutlineCores(
                      StringAttr::get(builder.getContext(), segment_name));
 
     aie_dev.getRegion().emplaceBlock();
-    seg.walk(
-        [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_dev, h}); });
+    seg.walk([&](xilinx::air::HerdOp h) {
+      aie_modules.push_back({aie_dev, h});
+    });
     // If the device has memtiles, then outline memtiles
     if (aie_dev.getTargetModel().getNumMemTileRows()) {
       outlineAIEMemtiles(builder, aie_dev, seg, options);
@@ -3573,8 +3574,9 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
                                        /*.trace_size = */ 0,
                                        /* .device = */ *device};
   std::vector<std::pair<ModuleOp, xilinx::air::HerdOp>> aie_modules;
-  p.walk(
-      [&](xilinx::air::HerdOp h) { aie_modules.push_back({aie_module, h}); });
+  p.walk([&](xilinx::air::HerdOp h) {
+    aie_modules.push_back({aie_module, h});
+  });
   std::map<AIE::TileOp, air::HerdOp> tileToHerdMap;
   for (auto &p : aie_modules) {
     ModuleOp aie_module = std::get<0>(p);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2451,7 +2451,6 @@ public:
       AIE::DMAChannelDir dir =
           isMM2S ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
 
-      // llvm::SmallSet<int> unused_original_id;
       for (int64_t id : t.dma_id) {
         int original_id = chan_renumber_reverse_map.size()
                               ? chan_renumber_reverse_map[id]

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2420,6 +2420,14 @@ public:
                                              memref_ty, nullptr, false,
                                              nullptr);
           }
+        } else {
+          // Just generate a SHIM DMA op
+          builder.create<AIE::ShimDMAAllocationOp>(
+              builder.getUnknownLoc(), SymbolRefAttr::get(ctx, dma_name_attr),
+              AIE::DMAChannelDirAttr::get(ctx, dir),
+              builder.getI64IntegerAttr(chan),
+              builder.getI64IntegerAttr(tileOp.getCol()),
+              builder.getBoolAttr(false));
         }
       }
     }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -33,7 +33,7 @@
 // CHECK:    aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:    aie.end
 // CHECK:  aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
-// CHECK-NOT:  aie.shim_dma_allocation
+// CHECK:  aie.shim_dma_allocation @airMemcpyId0(MM2S, 0, 2)
 // CHECK: @func1
 func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
   %herd_cols = arith.constant 1 : index

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2.mlir
@@ -33,7 +33,7 @@
 // CHECK:    aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:    aie.end
 // CHECK:  aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
-// CHECK:  aie.shim_dma_allocation @airMemcpyId0(MM2S, 0, 2)
+// CHECK-NOT:  aie.shim_dma_allocation
 // CHECK: @func1
 func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
   %herd_cols = arith.constant 1 : index
@@ -1079,4 +1079,37 @@ module {
     }
     return
   }
+}
+
+
+// -----
+
+// Ensure redundant shim DMA allocations do not occur
+//
+// CHECK:         aie.flow
+// CHECK-NEXT: aie.shim_dma_allocation @airMemcpyId2(MM2S, 0, 2)
+// CHECK-NEXT: memref.global "public" @airMemcpyId2 : memref<1024xi32, 1>
+// CHECK: @func15
+air.channel @channel_2 [1, 1]
+air.channel @channel_3 [1, 1]
+func.func @func15(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c512 = arith.constant 512 : index
+  %c1024 = arith.constant 1024 : index
+  air.channel.put @channel_2[] (%arg0[] [] []) {id = 1 : i32} : (memref<1024xi32>)
+  air.segment @segment0 {
+    %herd_cols = arith.constant 1 : index
+    %herd_rows = arith.constant 1 : index
+    %memtile0 = memref.alloc() : memref<1024xi32, 1>
+    %memtile1 = memref.alloc() : memref<1024xi32, 1>
+    air.channel.get @channel_2[] (%memtile0[] [] []) {id = 2 : i32} : (memref<1024xi32, 1>)
+    air.channel.get @channel_2[] (%memtile1[] [] []) {id = 3 : i32} : (memref<1024xi32, 1>)
+    memref.dealloc %memtile0 : memref<1024xi32, 1>
+    air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) attributes { sym_name="herd4"} {
+      %buf0 = memref.alloc() : memref<1024xi32, 2>
+      memref.dealloc %buf0 : memref<1024xi32, 2>
+    }
+  }
+  return
 }


### PR DESCRIPTION
Currently, in certain situations, shim allocations and memref.global definitions associated with them get unnecessarily allocated. This pull request prevents that from happening.