### PR TITLE
Fixup an issue in the input IR

### DIFF
--- a/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
+++ b/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
@@ -64,7 +64,7 @@ def build_module(vector_size, num_subvectors):
                             tensor_in,
                             c,
                             src_offsets=[_i],
-                            src_sizes=[1024],
+                            src_sizes=[lineWidthInBytes],
                             src_strides=[1],
                         )
 
@@ -80,7 +80,7 @@ def build_module(vector_size, num_subvectors):
                             d,
                             tensor_out,
                             dst_offsets=[_i],
-                            dst_sizes=[1024],
+                            dst_sizes=[lineWidthInBytes],
                             dst_strides=[1],
                         )
 


### PR DESCRIPTION
... where the amount of data moved between src and dst of `dma_memcpy_nd` mismatches.

DDR side memref size is `vector_size` which is 4k. L1 side memref size is `lineWidthInBytes` which is 1k.

