### PR TITLE
Xfail timeout

### DIFF
--- a/test/xrt/04_gemm_w_pack/run.lit
+++ b/test/xrt/04_gemm_w_pack/run.lit
@@ -6,3 +6,4 @@
 // RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
 // RUN: clang %S/test.cpp -O3 -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// XFAIL: *

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.lit
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.lit
@@ -6,3 +6,4 @@
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cpp -o kernel.o
 // RUN: %python %S/gen.py -t %S/transform.mlir
 // RUN: %run_on_npu %python %S/run.py aie.xclbin
+// XFAIL: *


### PR DESCRIPTION
XFAIL xrt tests 04 and 12 because they take too long and trigger a timeout on recent drivers.