### PR TITLE
Don't pollute source tree during lit testing

### DIFF
--- a/programming_examples/channel_examples/broadcast/multi_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/multi_herd/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/broadcast.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/broadcast/multi_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/multi_herd/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/broadcast.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/broadcast.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/broadcast.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/broadcast/single_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/single_herd/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/broadcast.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/broadcast/single_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/single_herd/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/broadcast.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/broadcast.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/broadcast.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/channel_size/Makefile
+++ b/programming_examples/channel_examples/channel_size/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/channel_size.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/channel_size/Makefile
+++ b/programming_examples/channel_examples/channel_size/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/channel_size.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/channel_size.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/channel_size.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/herd_to_herd.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/herd_to_herd.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/herd_to_herd.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/herd_to_herd.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/herd_to_herd.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/herd_to_herd.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/herd_to_herd.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/herd_to_herd.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/hierarchical/Makefile
+++ b/programming_examples/channel_examples/hierarchical/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/hierarchical.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/hierarchical/Makefile
+++ b/programming_examples/channel_examples/hierarchical/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/hierarchical.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/hierarchical.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/hierarchical.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/worker_to_self/Makefile
+++ b/programming_examples/channel_examples/worker_to_self/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/worker_to_self.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/worker_to_self.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/worker_to_self.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/worker_to_self/Makefile
+++ b/programming_examples/channel_examples/worker_to_self/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/worker_to_self.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/channel_examples/worker_to_worker/Makefile
+++ b/programming_examples/channel_examples/worker_to_worker/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/worker_to_worker.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/worker_to_worker.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/worker_to_worker.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/channel_examples/worker_to_worker/Makefile
+++ b/programming_examples/channel_examples/worker_to_worker/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/worker_to_worker.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/channel/Makefile
+++ b/programming_examples/data_transfer_transpose/channel/Makefile
@@ -13,12 +13,12 @@ print:
 	${powershell} python3 ${srcdir}/transpose.py -p
 
 run_int:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t uint32
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t uint32
 
 run_float:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/data_transfer_transpose/channel/Makefile
+++ b/programming_examples/data_transfer_transpose/channel/Makefile
@@ -21,4 +21,4 @@ run_float:
 	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/data_transfer_transpose/dma/Makefile
+++ b/programming_examples/data_transfer_transpose/dma/Makefile
@@ -13,12 +13,12 @@ print:
 	${powershell} python3 ${srcdir}/transpose.py -p
 
 run_int:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t uint32
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t uint32
 
 run_float:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/data_transfer_transpose/dma/Makefile
+++ b/programming_examples/data_transfer_transpose/dma/Makefile
@@ -21,4 +21,4 @@ run_float:
 	cd build && ${powershell} python3 ${srcdir}/transpose.py -m ${M} -k ${K} -t float32
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/multi_core_channel.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/multi_core_channel.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/multi_core_channel.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/multi_core_channel.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/multi_core_dma.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/multi_core_dma.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/multi_core_dma.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/multi_core_dma.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/multi_launch_channel.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/multi_launch_channel.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/multi_launch_channel.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/multi_launch_channel.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/matrix_scalar_add/single_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_channel/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/single_core_channel.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/single_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_channel/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/single_core_channel.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/single_core_channel.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/single_core_channel.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/matrix_scalar_add/single_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_dma/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/single_core_dma.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/matrix_scalar_add/single_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_dma/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/single_core_dma.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/single_core_dma.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/single_core_dma.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/multi_segment/multi_segment_channel/Makefile
+++ b/programming_examples/multi_segment/multi_segment_channel/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/multi_segment.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/multi_segment/multi_segment_channel/Makefile
+++ b/programming_examples/multi_segment/multi_segment_channel/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/multi_segment.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/multi_segment.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/multi_segment.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/multi_segment/multi_segment_dma/Makefile
+++ b/programming_examples/multi_segment/multi_segment_dma/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/multi_segment.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/multi_segment/multi_segment_dma/Makefile
+++ b/programming_examples/multi_segment/multi_segment_dma/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/multi_segment.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/multi_segment.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/multi_segment.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/passthrough/passthrough_channel/Makefile
+++ b/programming_examples/passthrough/passthrough_channel/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/passthrough_channel.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/passthrough/passthrough_channel/Makefile
+++ b/programming_examples/passthrough/passthrough_channel/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/passthrough_channel.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/passthrough_channel.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/passthrough_channel.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/passthrough/passthrough_dma/Makefile
+++ b/programming_examples/passthrough/passthrough_dma/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/passthrough_dma.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/passthrough/passthrough_dma/Makefile
+++ b/programming_examples/passthrough/passthrough_dma/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/passthrough_dma.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/passthrough_dma.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/passthrough_dma.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/passthrough/passthrough_kernel/Makefile
+++ b/programming_examples/passthrough/passthrough_kernel/Makefile
@@ -13,13 +13,13 @@ all: run
 print:
 	${powershell} python3 ${srcdir}/passthrough_kernel.py -p
 
-${srcdir}/build/passThrough.cc.o: ${srcdir}/passThrough.cc
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
+build/passThrough.cc.o: ${srcdir}/passThrough.cc
+	mkdir -p build
+	cd build && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
 
-run: ${srcdir}/build/passThrough.cc.o
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/passthrough_kernel.py
+run: build/passThrough.cc.o
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/passthrough_kernel.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/passthrough/passthrough_kernel/Makefile
+++ b/programming_examples/passthrough/passthrough_kernel/Makefile
@@ -6,23 +6,14 @@ targetname := $(shell basename ${srcdir})
 
 include ${srcdir}/../../makefile-common
 
-# mlir-aie dir should be one up from the install dir, if it is defined
-# if it is not defined, assume it's been cloned in ../mlir-aie
-ifeq (${MLIR_AIE_INSTALL_DIR},)
-	MLIR_AIE_DIR := $(shell realpath $(srcdir)/../../../mlir-aie)
-else
-	MLIR_AIE_DIR := $(shell realpath ${MLIR_AIE_INSTALL_DIR}/../)
-endif
-
 targetname = passThroughKernel
-VPATH := ${MLIR_AIE_DIR}/aie_kernels/generic
 
 all: run
 
 print:
 	${powershell} python3 ${srcdir}/passthrough_kernel.py -p
 
-${srcdir}/build/passThrough.cc.o: ${VPATH}/passThrough.cc
+${srcdir}/build/passThrough.cc.o: ${srcdir}/passThrough.cc
 	mkdir -p ${srcdir}/build
 	cd ${srcdir}/build && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
 

--- a/programming_examples/passthrough/passthrough_kernel/Makefile
+++ b/programming_examples/passthrough/passthrough_kernel/Makefile
@@ -22,4 +22,4 @@ run: build/passThrough.cc.o
 	cd build && ${powershell} python3 ${srcdir}/passthrough_kernel.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__

--- a/programming_examples/passthrough/passthrough_kernel/passThrough.cc
+++ b/programming_examples/passthrough/passthrough_kernel/passThrough.cc
@@ -1,0 +1,78 @@
+//===- passThrough.cc -------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// #define __AIENGINE__ 1
+#define NOCPP
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <aie_api/aie.hpp>
+
+template <typename T, int N>
+__attribute__((noinline)) void passThrough_aie(T *restrict in, T *restrict out,
+                                               const int32_t height,
+                                               const int32_t width) {
+  event0();
+
+  v64uint8 *restrict outPtr = (v64uint8 *)out;
+  v64uint8 *restrict inPtr = (v64uint8 *)in;
+
+  for (int j = 0; j < (height * width); j += N) // Nx samples per loop
+    chess_prepare_for_pipelining chess_loop_range(6, ) { *outPtr++ = *inPtr++; }
+
+  event1();
+}
+
+extern "C" {
+
+#if BIT_WIDTH == 8
+
+void passThroughLine(uint8_t *in, uint8_t *out, int32_t lineWidth) {
+  printf("passThroughLine BIT_WIDTH\n");
+  passThrough_aie<uint8_t, 64>(in, out, 1, lineWidth);
+}
+
+void passThroughTile(uint8_t *in, uint8_t *out, int32_t tileHeight,
+                     int32_t tileWidth) {
+  printf("passThroughTile BIT_WIDTH\n");
+  passThrough_aie<uint8_t, 64>(in, out, tileHeight, tileWidth);
+}
+
+#elif BIT_WIDTH == 16
+
+void passThroughLine(int16_t *in, int16_t *out, int32_t lineWidth) {
+  printf("passThroughLine BIT_WIDTH\n");
+  passThrough_aie<int16_t, 32>(in, out, 1, lineWidth);
+}
+
+void passThroughTile(int16_t *in, int16_t *out, int32_t tileHeight,
+                     int32_t tileWidth) {
+  printf("passThroughTile BIT_WIDTH\n");
+  passThrough_aie<int16_t, 32>(in, out, tileHeight, tileWidth);
+}
+
+#else // 32
+
+void passThroughLine(int32_t *in, int32_t *out, int32_t lineWidth) {
+  printf("passThroughLine BIT_WIDTH\n");
+  passThrough_aie<int32_t, 16>(in, out, 1, lineWidth);
+}
+
+void passThroughTile(int32_t *in, int32_t *out, int32_t tileHeight,
+                     int32_t tileWidth) {
+  printf("passThroughTile BIT_WIDTH\n");
+  passThrough_aie<int32_t, 16>(in, out, tileHeight, tileWidth);
+}
+
+#endif
+
+} // extern "C"

--- a/programming_examples/segment_alloc/Makefile
+++ b/programming_examples/segment_alloc/Makefile
@@ -10,8 +10,8 @@ print:
 	${powershell} python3 ${srcdir}/segment_alloc.py -p
 
 run:
-	mkdir -p ${srcdir}/build
-	cd ${srcdir}/build && ${powershell} python3 ${srcdir}/segment_alloc.py
+	mkdir -p build
+	cd build && ${powershell} python3 ${srcdir}/segment_alloc.py
 
 clean:
-	rm -rf ${srcdir}/build ${srcdir}/__pycache__
+	rm -rf build ${srcdir}/__pycache__

--- a/programming_examples/segment_alloc/Makefile
+++ b/programming_examples/segment_alloc/Makefile
@@ -14,4 +14,4 @@ run:
 	cd build && ${powershell} python3 ${srcdir}/segment_alloc.py
 
 clean:
-	rm -rf build ${srcdir}/__pycache__
+	rm -rf build __pycache__


### PR DESCRIPTION
Update programming examples to run in the build dir during lit testing, instead of polluting the source tree.

i.e. avoid this:
```
$ git clean -xfd
Removing channel_examples/__pycache__/
Removing channel_examples/broadcast/multi_herd/build/
Removing channel_examples/broadcast/single_herd/build/
Removing channel_examples/channel_size/build/
Removing channel_examples/herd_to_herd/__pycache__/
Removing channel_examples/herd_to_herd/multi_segment/build/
Removing channel_examples/herd_to_herd/single_segment/build/
Removing channel_examples/hierarchical/build/
Removing channel_examples/worker_to_self/build/
Removing channel_examples/worker_to_worker/build/
Removing data_transfer_transpose/__pycache__/
Removing data_transfer_transpose/channel/build/
Removing data_transfer_transpose/dma/build/
Removing matrix_scalar_add/__pycache__/
Removing matrix_scalar_add/aie.mlir
Removing matrix_scalar_add/air.mlir
Removing matrix_scalar_add/build/
Removing matrix_scalar_add/multi_core_channel/build/
Removing matrix_scalar_add/multi_core_dma/build/
Removing matrix_scalar_add/multi_launch_channel/build/
Removing matrix_scalar_add/out.m.ir
Removing matrix_scalar_add/single_core_channel/build/
Removing matrix_scalar_add/single_core_dma/build/
Removing multi_segment/__pycache__/
Removing multi_segment/multi_segment_channel/build/
Removing multi_segment/multi_segment_dma/build/
Removing passthrough/__pycache__/
Removing passthrough/passthrough_channel/build/
Removing passthrough/passthrough_dma/build/
Removing passthrough/passthrough_kernel/build/
Removing segment_alloc/build/
Removing shim_dma_2d/__pycache__/
```

Also remove dependence on mlir-aie source tree in passthrough example.