### PR TITLE
AIRSegmentLoopFusion: A number of fixups and improvements around async dependency

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -69,6 +69,7 @@ Value getAsyncTokenFromOp(Operation *op);
 void addAsyncDependencyIfNew(Operation *op, Value token);
 bool isAsyncOp(Operation *op);
 bool areAsyncDependent(Operation *a, Operation *b);
+bool isAsyncDependent(Operation *a, Operation *b);
 scf::ForOp hoistTargetOpsToNewSCFFor(OpBuilder builder, scf::ForOp for_op,
                                      SmallVector<Operation *> target_ops);
 LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,


### PR DESCRIPTION
- Trace async token users through `air.wait_all`;
- Move fused loop to just before the last loop being fused, to avoid any ssa dominance issue;
- More informative failure message when broken dependence between `air.channel.get`---as data producer---and `air.channel.put`---as data consumer---is detected in the generated fused `scf.for` loop.