### PR TITLE
AIRDependency: Improved `areAsyncDependent` method

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -46,8 +46,6 @@
 #include <string>
 #include <vector>
 
-#include <iostream>
-
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
@@ -4141,6 +4139,9 @@ void identifyTargetOpsInSCFFor(func::FuncOp f, scf::ForOp for_op,
     if (isPure(&o))
       continue; // Pure ops do not touch memory, and therefore do not require
                 // explicit hoisting.
+    if (auto execOp = dyn_cast<air::ExecuteOp>(o))
+      if (isPure(execOp.getChildOp()))
+        continue;
     if (isa<air::WaitAllOp>(o))
       continue;
     // Check if for loop is splittable by tracing air dependency.
@@ -4189,8 +4190,10 @@ struct IsolateAsyncDmaLoopNestInSCFForPattern
 
     identifyTargetOpsInSCFFor(f, for_op, target_ops_set);
     if (target_ops_set.empty())
+      // assert(false);
       return failure();
     if (target_ops_set.size() < 2)
+      // assert(false);
       return failure();
 
     // If necessary, hoist allocs out of the loops, too.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4271,14 +4271,6 @@ struct IsolateAsyncDmaLoopNestInAIRSegmentPattern
     identifyTargetSCFForAndOps(f, hier_op, target_ops_map);
     if (target_ops_map.empty())
       return failure();
-    if (all_of(target_ops_map.begin(), target_ops_map.end(),
-               [&](std::pair<const scf::ForOp, llvm::SetVector<Operation *>>
-                       pair) {
-                 return pair.second.size() <
-                        2; // Must have at least two target ops to start
-                           // splitting the loop.
-               }))
-      return failure();
 
     // If necessary, hoist allocs out of the loops, too.
     RewritePatternSet patterns(f.getContext());
@@ -4338,6 +4330,15 @@ public:
                       IsolateAsyncDmaLoopNestInAIRSegmentPattern>(
           f.getContext());
       (void)applyPatternsAndFoldGreedily(f, std::move(patterns));
+
+      // // Post processing, hoisting air.herd ops out of perfectly nested
+      // scf.for
+      // // loop.
+      // RewritePatternSet patterns_1(f.getContext());
+      // patterns_1.insert<HoistAIRHerdInForPattern,
+      // HoistAIRChannelInAccumPattern>(
+      //     f.getContext(), false);
+      // (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
     }
   }
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4211,6 +4211,14 @@ struct IsolateAsyncDmaLoopNestInAIRLaunchPattern
     identifyTargetSCFForAndOps(f, hier_op, target_ops_map);
     if (target_ops_map.empty())
       return failure();
+    if (all_of(target_ops_map.begin(), target_ops_map.end(),
+               [&](std::pair<const scf::ForOp, llvm::SetVector<Operation *>>
+                       pair) {
+                 return pair.second.size() <
+                        2; // Must have at least two target ops to start
+                           // splitting the loop.
+               }))
+      return failure();
 
     // If necessary, hoist allocs out of the loops, too.
     RewritePatternSet patterns(f.getContext());
@@ -4262,6 +4270,14 @@ struct IsolateAsyncDmaLoopNestInAIRSegmentPattern
 
     identifyTargetSCFForAndOps(f, hier_op, target_ops_map);
     if (target_ops_map.empty())
+      return failure();
+    if (all_of(target_ops_map.begin(), target_ops_map.end(),
+               [&](std::pair<const scf::ForOp, llvm::SetVector<Operation *>>
+                       pair) {
+                 return pair.second.size() <
+                        2; // Must have at least two target ops to start
+                           // splitting the loop.
+               }))
       return failure();
 
     // If necessary, hoist allocs out of the loops, too.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4190,10 +4190,8 @@ struct IsolateAsyncDmaLoopNestInSCFForPattern
 
     identifyTargetOpsInSCFFor(f, for_op, target_ops_set);
     if (target_ops_set.empty())
-      // assert(false);
       return failure();
     if (target_ops_set.size() < 2)
-      // assert(false);
       return failure();
 
     // If necessary, hoist allocs out of the loops, too.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -46,6 +46,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::air;
@@ -4115,107 +4117,80 @@ private:
   }
 };
 
-// Build a map of scf.for ops to a set of ops, each of which is to be hoisted
-// into a new loop.
-void identifyTargetSCFForAndOps(
-    func::FuncOp f, std::vector<air::HierarchyInterface> hierOps,
-    std::map<scf::ForOp, llvm::SetVector<Operation *>> &target_ops_map) {
-  for (auto hier_op : hierOps) {
-    // Identify the target for loops and their target child ops
-    for (auto for_op : hier_op->getRegion(0).getOps<scf::ForOp>()) {
-      for_op.walk([&](air::MemcpyInterface memcpyOp) {
-        // Get for_op's immediate child op
-        if (!dyn_cast<air::AsyncOpInterface>(memcpyOp.getOperation())
-                 .getAsyncToken())
-          return; // This pass requires an async IR.
-        int for_op_token_count = 0;
-        for (auto v : for_op->getResults())
-          if (isa<air::AsyncTokenType>(v.getType()))
-            for_op_token_count++;
-        if (for_op_token_count > 1)
-          return; // This for op has more than one loop-carried dep token,
-                  // suggesting pipelining pattern. Will be handelled by
-                  // -air-unroll-loop-for-pipelining-pattern instead.
-        Operation *parent = memcpyOp.getOperation();
-        while (parent->getParentOp() != for_op.getOperation()) {
-          parent = parent->getParentOp();
-        }
-        if (isa<air::HierarchyInterface>(parent))
-          return;
-        if (isa<affine::AffineIfOp>(parent))
-          return;
-        // Check if for loop is splittable by tracing air dependency.
-        for (auto op : target_ops_map[for_op]) {
-          if (areAsyncDependent(op, parent)) {
-            target_ops_map.erase(for_op);
-            return;
-          }
-        }
-        target_ops_map[for_op].insert(parent);
-        // Check if any memref.alloc needs to be hoisted.
-        if (memcpyOp.getSrcMemref() && !memcpyOp.getSrcMemref().getDefiningOp())
-          return;
-        if (memcpyOp.getSrcMemref() &&
-            for_op->isProperAncestor(memcpyOp.getSrcMemref().getDefiningOp())) {
-          Operation *memref_def = memcpyOp.getSrcMemref().getDefiningOp();
-          if (auto exec = dyn_cast<air::ExecuteOp>(memref_def))
-            memref_def = exec.getBody()
-                             .getBlocks()
-                             .front()
-                             .getTerminator()
-                             ->getOperand(0)
-                             .getDefiningOp();
-          memref_def->setAttr(
-              "hoist_alloc",
-              mlir::BoolAttr::get(memref_def->getContext(), true));
-        }
-        if (memcpyOp.getDstMemref() && !memcpyOp.getDstMemref().getDefiningOp())
-          return;
-        if (memcpyOp.getDstMemref() &&
-            for_op->isProperAncestor(memcpyOp.getDstMemref().getDefiningOp())) {
-          Operation *memref_def = memcpyOp.getDstMemref().getDefiningOp();
-          if (auto exec = dyn_cast<air::ExecuteOp>(memref_def))
-            memref_def = exec.getBody()
-                             .getBlocks()
-                             .front()
-                             .getTerminator()
-                             ->getOperand(0)
-                             .getDefiningOp();
-          memref_def->setAttr(
-              "hoist_alloc",
-              mlir::BoolAttr::get(memref_def->getContext(), true));
-        }
-      });
+// Build a set of child ops from the body of one scf.for op, each of which is to
+// be hoisted into a new loop.
+void identifyTargetOpsInSCFFor(func::FuncOp f, scf::ForOp for_op,
+                               llvm::SetVector<Operation *> &target_ops_set) {
+  int for_op_token_count = 0;
+  for (auto v : for_op->getResults())
+    if (isa<air::AsyncTokenType>(v.getType()))
+      for_op_token_count++;
+  if (for_op_token_count > 1)
+    return; // This for op has more than one loop-carried dep token,
+            // suggesting pipelining pattern. Will be handelled by
+            // -air-unroll-loop-for-pipelining-pattern instead.
+  for (auto &o : for_op.getBody()->getOperations()) {
+    // Get for_op's immediate child op
+    if (!isAsyncOp(&o))
+      continue; // This pass requires an async IR.
+
+    if (o.getParentOfType<air::HerdOp>())
+      continue; // Skip over herd op's body for now. TODO: generalize this.
+    if (o.getParentOfType<affine::AffineIfOp>())
+      continue; // Skip over if-else bodies for now. TODO: generalize this.
+    if (isPure(&o))
+      continue; // Pure ops do not touch memory, and therefore do not require
+                // explicit hoisting.
+    if (isa<air::WaitAllOp>(o))
+      continue;
+    // Check if for loop is splittable by tracing air dependency.
+    if (llvm::any_of(target_ops_set,
+                     [&](Operation *op) { return areAsyncDependent(op, &o); }))
+      continue;
+    target_ops_set.insert(&o);
+    // Check if any memref.alloc needs to be hoisted.
+    SmallVector<Value, 2> operand_memrefs;
+    for (auto operand : o.getOperands()) {
+      if (!operand)
+        continue;
+      if (isa<MemRefType>(operand.getType()))
+        operand_memrefs.push_back(operand);
+    }
+    for (auto memref : operand_memrefs) {
+      if (!memref)
+        continue;
+      auto memrefDefOp = memref.getDefiningOp();
+      if (!memrefDefOp)
+        continue;
+      if (for_op->isProperAncestor(memrefDefOp)) {
+        if (auto exec = dyn_cast<air::ExecuteOp>(memrefDefOp))
+          memrefDefOp = exec.getChildOp();
+        memrefDefOp->setAttr(
+            "hoist_alloc",
+            mlir::BoolAttr::get(memrefDefOp->getContext(), true));
+      }
     }
   }
 }
 
-struct IsolateAsyncDmaLoopNestInAIRLaunchPattern
-    : public OpRewritePattern<air::LaunchOp> {
-  using OpRewritePattern<air::LaunchOp>::OpRewritePattern;
+struct IsolateAsyncDmaLoopNestInSCFForPattern
+    : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(air::LaunchOp op,
+  LogicalResult matchAndRewrite(scf::ForOp for_op,
                                 PatternRewriter &rewriter) const override {
 
-    auto f = op->getParentOfType<func::FuncOp>();
+    auto f = for_op->getParentOfType<func::FuncOp>();
     if (!f)
       return failure();
 
-    // Identify scf.for ops and target child ops for hoisting.
-    std::map<scf::ForOp, llvm::SetVector<Operation *>> target_ops_map;
-    std::vector<air::HierarchyInterface> hier_op;
-    hier_op.push_back(op);
+    // Identify target child ops for hoisting.
+    llvm::SetVector<Operation *> target_ops_set;
 
-    identifyTargetSCFForAndOps(f, hier_op, target_ops_map);
-    if (target_ops_map.empty())
+    identifyTargetOpsInSCFFor(f, for_op, target_ops_set);
+    if (target_ops_set.empty())
       return failure();
-    if (all_of(target_ops_map.begin(), target_ops_map.end(),
-               [&](std::pair<const scf::ForOp, llvm::SetVector<Operation *>>
-                       pair) {
-                 return pair.second.size() <
-                        2; // Must have at least two target ops to start
-                           // splitting the loop.
-               }))
+    if (target_ops_set.size() < 2)
       return failure();
 
     // If necessary, hoist allocs out of the loops, too.
@@ -4224,77 +4199,15 @@ struct IsolateAsyncDmaLoopNestInAIRLaunchPattern
     (void)applyPatternsAndFoldGreedily(f, std::move(patterns));
 
     // Hoist ops out of each scf.for.
-    for (auto pair : target_ops_map) {
-      rewriter.setInsertionPoint(pair.first);
-      for (auto op : pair.second) {
-        auto newForOp = hoistTargetOpsToNewSCFFor(rewriter, pair.first,
-                                                  SmallVector<Operation *>{op});
-        if (!newForOp)
-          continue;
-        // Redo async dependency tracing.
-        air::dependencyTracer depTracer;
-        depTracer.traceDependencyFromScfForOp(newForOp);
-      }
+    for (auto op : target_ops_set) {
+      auto newForOp = hoistTargetOpsToNewSCFFor(rewriter, for_op,
+                                                SmallVector<Operation *>{op});
+      if (!newForOp)
+        continue;
+      // Redo async dependency tracing.
+      air::dependencyTracer depTracer;
+      depTracer.traceDependencyFromScfForOp(newForOp);
     }
-
-    // Post processing, hoisting air.herd ops out of perfectly nested scf.for
-    // loop.
-    RewritePatternSet patterns_1(f.getContext());
-    patterns_1.insert<HoistAIRHerdInForPattern, HoistAIRChannelInAccumPattern>(
-        f.getContext(), false);
-    (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
-
-    return success();
-  }
-
-private:
-};
-
-struct IsolateAsyncDmaLoopNestInAIRSegmentPattern
-    : public OpRewritePattern<air::SegmentOp> {
-  using OpRewritePattern<air::SegmentOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(air::SegmentOp op,
-                                PatternRewriter &rewriter) const override {
-
-    auto f = op->getParentOfType<func::FuncOp>();
-    if (!f)
-      return failure();
-
-    // Identify scf.for ops and target child ops for hoisting.
-    std::map<scf::ForOp, llvm::SetVector<Operation *>> target_ops_map;
-    std::vector<air::HierarchyInterface> hier_op;
-    hier_op.push_back(op);
-
-    identifyTargetSCFForAndOps(f, hier_op, target_ops_map);
-    if (target_ops_map.empty())
-      return failure();
-
-    // If necessary, hoist allocs out of the loops, too.
-    RewritePatternSet patterns(f.getContext());
-    patterns.insert<HoistMemallocInForPattern>(f.getContext(), false);
-    (void)applyPatternsAndFoldGreedily(f, std::move(patterns));
-
-    // Hoist ops out of each scf.for.
-    for (auto pair : target_ops_map) {
-      rewriter.setInsertionPoint(pair.first);
-      for (auto op : pair.second) {
-        auto newForOp = hoistTargetOpsToNewSCFFor(rewriter, pair.first,
-                                                  SmallVector<Operation *>{op});
-        if (!newForOp)
-          continue;
-        // Redo async dependency tracing.
-        air::dependencyTracer depTracer;
-        depTracer.traceDependencyFromScfForOp(newForOp);
-      }
-    }
-
-    // Post processing, hoisting air.herd ops out of perfectly nested scf.for
-    // loop.
-    RewritePatternSet patterns_1(f.getContext());
-    patterns_1.insert<HoistAIRHerdInForPattern, HoistAIRChannelInAccumPattern>(
-        f.getContext(), false);
-    (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
 
     return success();
   }
@@ -4323,20 +4236,20 @@ public:
     module.walk([&](func::FuncOp op) { funcOps.push_back(op); });
 
     for (auto f : funcOps) {
-      RewritePatternSet patterns(f.getContext());
-      patterns.insert<IsolateAsyncDmaLoopNestInAIRLaunchPattern,
-                      IsolateAsyncDmaLoopNestInAIRSegmentPattern>(
-          f.getContext());
-      (void)applyPatternsAndFoldGreedily(f, std::move(patterns));
+      SmallVector<Operation *> forOps;
+      module.walk([&](scf::ForOp op) { forOps.push_back(op); });
 
-      // // Post processing, hoisting air.herd ops out of perfectly nested
-      // scf.for
-      // // loop.
-      // RewritePatternSet patterns_1(f.getContext());
-      // patterns_1.insert<HoistAIRHerdInForPattern,
-      // HoistAIRChannelInAccumPattern>(
-      //     f.getContext(), false);
-      // (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
+      RewritePatternSet patterns(f.getContext());
+      patterns.insert<IsolateAsyncDmaLoopNestInSCFForPattern>(f.getContext());
+      (void)applyOpPatternsAndFold(forOps, std::move(patterns));
+
+      // Post processing, hoisting air.herd ops out of perfectly nested scf.for
+      // loop.
+      RewritePatternSet patterns_1(f.getContext());
+      patterns_1
+          .insert<HoistAIRHerdInForPattern, HoistAIRChannelInAccumPattern>(
+              f.getContext(), false);
+      (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
     }
   }
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -608,6 +608,8 @@ bool isAsyncOp(Operation *op) {
   return false;
 }
 
+// Air dependency comes in two forms: production and consumption of the same
+// async token, and usage of the same air.channel.
 bool areAsyncDependent(Operation *a, Operation *b) {
   SmallVector<Value> dep_a = getAsyncDependenciesFromOp(a);
   Value token_a = getAsyncTokenFromOp(a);
@@ -626,6 +628,12 @@ bool areAsyncDependent(Operation *a, Operation *b) {
       return true;
   for (auto dep : dep_b)
     if (dep == token_a)
+      return true;
+
+  auto chanA = dyn_cast<air::ChannelInterface>(a);
+  auto chanB = dyn_cast<air::ChannelInterface>(b);
+  if (chanA && chanB)
+    if (chanA.getChanName() == chanB.getChanName())
       return true;
   return false;
 }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -633,8 +633,21 @@ bool areAsyncDependent(Operation *a, Operation *b) {
   auto chanA = dyn_cast<air::ChannelInterface>(a);
   auto chanB = dyn_cast<air::ChannelInterface>(b);
   if (chanA && chanB)
-    if (chanA.getChanName() == chanB.getChanName())
+    if (chanA.getChanName() == chanB.getChanName()) {
+      if (chanA.getIndices().size() != chanB.getIndices().size())
+        return true;
+      for (unsigned i = 0; i < chanA.getIndices().size(); i++) {
+        auto constIdxA = getConstantIntValue(chanA.getIndices()[i]);
+        auto constIdxB = getConstantIntValue(chanB.getIndices()[i]);
+        if (!constIdxA)
+          return true;
+        if (!constIdxB)
+          return true;
+        if (*constIdxA != *constIdxB)
+          return false;
+      }
       return true;
+    }
   return false;
 }
 

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -386,11 +386,11 @@ module {
         %4 = affine.apply #map()[%arg1]
         %5 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%4, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
         %6 = affine.apply #map1()[%arg1]
-        %7 = air.channel.put async [%arg7]  @channel_0[%c1, %c0] (%arg5[%6, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %7 = air.channel.put async [%arg7]  @channel_1[%c1, %c0] (%arg5[%6, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
         %8 = affine.apply #map2()[%arg1]
-        %9 = air.channel.put async [%arg7]  @channel_0[%c2_0, %c0] (%arg5[%8, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 3 : i32} : (memref<512x1024xbf16>)
+        %9 = air.channel.put async [%arg7]  @channel_2[%c2_0, %c0] (%arg5[%8, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 3 : i32} : (memref<512x1024xbf16>)
         %10 = affine.apply #map3()[%arg1]
-        %11 = air.channel.put async [%arg7]  @channel_0[%c3, %c0] (%arg5[%10, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 4 : i32} : (memref<512x1024xbf16>)
+        %11 = air.channel.put async [%arg7]  @channel_3[%c3, %c0] (%arg5[%10, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 4 : i32} : (memref<512x1024xbf16>)
         %12 = air.wait_all async [%5, %7, %9, %11] 
         scf.yield %12 : !air.async.token
       }
@@ -421,9 +421,9 @@ module {
         %4 = air.wait_all async 
         %5 = scf.for %arg6 = %c0_5 to %c1024_6 step %c256_7 iter_args(%arg7 = %4) -> (!air.async.token) {
           %6 = air.channel.get async [%arg7]  @channel_0[%c0_5, %c0_5] (%results[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 13 : i32} : (memref<64x1024xbf16, 1>)
-          %7 = air.channel.get async [%arg7]  @channel_0[%c1_4, %c0_5] (%results_9[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 14 : i32} : (memref<64x1024xbf16, 1>)
-          %8 = air.channel.get async [%arg7]  @channel_0[%c2_2, %c0_5] (%results_11[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 15 : i32} : (memref<64x1024xbf16, 1>)
-          %9 = air.channel.get async [%arg7]  @channel_0[%c3_1, %c0_5] (%results_13[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 16 : i32} : (memref<64x1024xbf16, 1>)
+          %7 = air.channel.get async [%arg7]  @channel_1[%c1_4, %c0_5] (%results_9[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 14 : i32} : (memref<64x1024xbf16, 1>)
+          %8 = air.channel.get async [%arg7]  @channel_2[%c2_2, %c0_5] (%results_11[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 15 : i32} : (memref<64x1024xbf16, 1>)
+          %9 = air.channel.get async [%arg7]  @channel_3[%c3_1, %c0_5] (%results_13[%c0_5, %arg6] [%c64_3, %c256_7] [%c1024_6, %c1_4]) {id = 16 : i32} : (memref<64x1024xbf16, 1>)
           %10 = air.wait_all async [%6, %7, %8, %9] 
           scf.yield %10 : !air.async.token
         }
@@ -439,6 +439,57 @@ module {
         %async_token_17 = air.execute [%5] {
           memref.dealloc %results : memref<64x1024xbf16, 1>
         }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func4
+
+// CHECK: scf.for{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0
+// CHECK-NEXT: air.wait_all
+// CHECK-NEXT: scf.yield
+// CHECK-NEXT: }
+// CHECK: scf.for{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_1
+// CHECK-NEXT: air.channel.put{{.*}}@channel_2
+// CHECK-NEXT: air.wait_all
+// CHECK-NEXT: scf.yield
+// CHECK-NEXT: }
+
+#map = affine_map<()[s0] -> (s0 * 256)>
+#map1 = affine_map<()[s0] -> (s0 * 256 + 64)>
+#map2 = affine_map<()[s0] -> (s0 * 256 + 128)>
+#map3 = affine_map<()[s0] -> (s0 * 256 + 192)>
+module {
+  air.channel @channel_0 [4, 1]
+  func.func @func4(%arg0: memref<512x1024xbf16>) {
+    %c2 = arith.constant 2 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c2, %arg4=%c2) args(%arg5=%arg0) : memref<512x1024xbf16> attributes {id = 1 : i32} {
+      %c64 = arith.constant 64 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c1024 = arith.constant 1024 : index
+      %c256 = arith.constant 256 : index
+      %1 = air.wait_all async
+      %2 = scf.for %arg6 = %c0 to %c1024 step %c256 iter_args(%arg7 = %1) -> (!air.async.token) {
+        // %7 depends on %5 due to shared usage of @channel_0
+        %5 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
+        %7 = air.channel.put async [%arg7]  @channel_0[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %12 = air.wait_all async [%5, %7] 
+        scf.yield %12 : !air.async.token
+      }
+      %3 = scf.for %arg6 = %c0 to %c1024 step %c256 iter_args(%arg7 = %1) -> (!air.async.token) {
+        // %7 depends on %5 due to production and consumption over async token %5
+        %5 = air.channel.put async [%arg7]  @channel_1[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
+        %7 = air.channel.put async [%5]  @channel_2[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %12 = air.wait_all async [%7] 
+        scf.yield %12 : !air.async.token
       }
     }
     return

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -494,7 +494,7 @@ module {
         scf.yield %12 : !air.async.token
       }
       %4 = scf.for %arg6 = %c0 to %c1024 step %c256 iter_args(%arg7 = %1) -> (!air.async.token) {
-        // %7 depends on %5 due to production and consumption over async token %5
+        // Same channel SymbolRef but different subchannels
         %5 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
         %6 = air.channel.put async [%arg7]  @channel_0[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
         %7 = air.channel.put async [%arg7]  @channel_0[%c2_0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -461,6 +461,14 @@ module {
 // CHECK-NEXT: air.wait_all
 // CHECK-NEXT: scf.yield
 // CHECK-NEXT: }
+// CHECK: scf.for %{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}]
+// CHECK: scf.for %{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}]
+// CHECK: scf.for %{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}]
+// CHECK: scf.for %{{.*}}{
+// CHECK-NEXT: air.channel.put{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}]
 
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<()[s0] -> (s0 * 256 + 64)>

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -472,15 +472,17 @@ module {
     %c2 = arith.constant 2 : index
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c2, %arg4=%c2) args(%arg5=%arg0) : memref<512x1024xbf16> attributes {id = 1 : i32} {
       %c64 = arith.constant 64 : index
+      %c3 = arith.constant 3 : index
+      %c2_0 = arith.constant 2 : index
       %c1 = arith.constant 1 : index
       %c0 = arith.constant 0 : index
       %c1024 = arith.constant 1024 : index
       %c256 = arith.constant 256 : index
       %1 = air.wait_all async
       %2 = scf.for %arg6 = %c0 to %c1024 step %c256 iter_args(%arg7 = %1) -> (!air.async.token) {
-        // %7 depends on %5 due to shared usage of @channel_0
+        // %7 depends on %5 due to shared usage of @channel_0[%c0, %c0]
         %5 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
-        %7 = air.channel.put async [%arg7]  @channel_0[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %7 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
         %12 = air.wait_all async [%5, %7] 
         scf.yield %12 : !air.async.token
       }
@@ -489,6 +491,15 @@ module {
         %5 = air.channel.put async [%arg7]  @channel_1[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
         %7 = air.channel.put async [%5]  @channel_2[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
         %12 = air.wait_all async [%7] 
+        scf.yield %12 : !air.async.token
+      }
+      %4 = scf.for %arg6 = %c0 to %c1024 step %c256 iter_args(%arg7 = %1) -> (!air.async.token) {
+        // %7 depends on %5 due to production and consumption over async token %5
+        %5 = air.channel.put async [%arg7]  @channel_0[%c0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 1 : i32} : (memref<512x1024xbf16>)
+        %6 = air.channel.put async [%arg7]  @channel_0[%c1, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %7 = air.channel.put async [%arg7]  @channel_0[%c2_0, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %8 = air.channel.put async [%arg7]  @channel_0[%c3, %c0] (%arg5[%c0, %arg6] [%c64, %c256] [%c1024, %c1]) {id = 2 : i32} : (memref<512x1024xbf16>)
+        %12 = air.wait_all async [%5, %7] 
         scf.yield %12 : !air.async.token
       }
     }


### PR DESCRIPTION
- Air dependency comes in two forms: production and consumption of the same async token, and usage of the same `air.channel`.
- With the above change made on the `areAsyncDependent` method, changes made in https://github.com/Xilinx/mlir-air/pull/681 are needed to fixup a subsequent bug arising from `AIRIsolateAsyncDmaLoopNests` pass.