### PR TITLE
AIRIsolateAsyncDmaLoopNest: Splitting an `scf.for` loop nest based on op dependency

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4300,10 +4300,6 @@ struct IsolateAsyncDmaLoopNestInSCFForPattern
     SmallVector<llvm::SetVector<Operation *>> target_ops_sets;
 
     identifyTargetOpsInSCFFor(f, for_op, target_ops_sets);
-    // std::cout << "\nscf for op\n";
-    // for (auto o : target_ops_set){
-    //   std::cout << air::to_string(o) << " ";
-    // }
     if (target_ops_sets.empty())
       return failure();
     if (target_ops_sets.size() < 2)
@@ -4315,16 +4311,6 @@ struct IsolateAsyncDmaLoopNestInSCFForPattern
     (void)applyPatternsAndFoldGreedily(f, std::move(patterns));
 
     // Hoist ops out of each scf.for.
-    // for (auto op : target_ops_set) {
-    //   auto newForOp = hoistTargetOpsToNewSCFFor(rewriter, for_op,
-    //                                             SmallVector<Operation
-    //                                             *>{op});
-    //   if (!newForOp)
-    //     continue;
-    //   // Redo async dependency tracing.
-    //   air::dependencyTracer depTracer;
-    //   depTracer.traceDependencyFromScfForOp(newForOp);
-    // }
     for (auto set : target_ops_sets) {
       auto newForOp =
           hoistTargetOpsToNewSCFFor(rewriter, for_op, set.takeVector());


### PR DESCRIPTION
When `AIRIsolateAsyncDmaLoopNest` pass splits an `scf.for` loop nest based on async dependency, it can now split the nest into multiple imperfect loop nests, each containing a partition of the original loop nest's innermost body. Partitioning is performed based on async dependency.

A number of minor code fixups to enable this feature:
- Clean up redundant logic in `getAsyncTokenFromOp` method.
- The dependency reconstruction logic that comes after the loop splitting is rewritten; iterating through `getUses()` while updating uses is unsafe.