### PR TITLE
AIRSpecializeChannelWrapAndStride: Hoist loop-invariant pure ops for dominance

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -232,8 +232,9 @@ evaluateConstantsInMap(AffineMap map,
 
 // Extend the lookupOrDefault method to operate on a vector of values.
 Value lookupOrDefaultRange(Value v, IRMapping &remap);
-SmallVector<Value> lookupOrDefaultRange(SmallVector<Value> vec,
+SmallVector<Value> lookupOrDefaultRange(SmallVectorImpl<Value> &vec,
                                         IRMapping &remap);
+SmallVector<Value> lookupOrDefaultRange(OperandRange vec, IRMapping &remap);
 
 // Extend isPure method to operate on air.execute.
 bool isPure(Operation *op);

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -45,7 +45,8 @@ HerdOp getHerdArgOwner(Value val);
 // Get the parent air.hierarchy op of a tile id
 HierarchyInterface getHierarchyArgOwner(Value val);
 // Get the scf parent op from scf.yield op
-template <typename T> T getScfParentOpFromYieldOp(Operation *yield) {
+template <typename T>
+T getScfParentOpFromYieldOp(Operation *yield) {
   return dyn_cast_if_present<T>(yield->getParentOp());
 }
 
@@ -228,6 +229,14 @@ std::optional<int64_t>
 evaluateConstantsInMap(AffineMap map,
                        SmallVector<std::optional<int64_t>> const_inputs,
                        MLIRContext *ctx);
+
+// Extend the lookupOrDefault method to operate on a vector of values.
+Value lookupOrDefaultRange(Value v, IRMapping &remap);
+SmallVector<Value> lookupOrDefaultRange(SmallVector<Value> vec,
+                                        IRMapping &remap);
+
+// Extend isPure method to operate on air.execute.
+bool isPure(Operation *op);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2001,17 +2001,41 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
     }
     SmallVector<Value, 1> deps =
         for_op.getOperands().drop_front(for_op.getNumControlOperands());
+
+    // Hoist any pure ops that the new channel op depends on.
+    auto new_opers = llvm::concat<Value>(
+        SmallVector<Value>{channel_ops[0].getMemref()},
+        channel_ops[0].getIndices(), offsets, wraps, strides);
+    IRMapping remap;
+    auto clonedOps = cloneDefiningOpsInRegion(
+        rewriter, &for_op.getRegion(), llvm::to_vector(new_opers), remap);
+    for (auto cloned : clonedOps) {
+      clearAsyncDependenciesOfAsyncOp(cloned);
+      for (auto token : deps)
+        addAsyncDependencyIfNew(cloned, token);
+      if (auto token = getAsyncTokenFromOp(cloned))
+        deps.push_back(token);
+    }
+
+    // Create specialized air.channel.put/get.
     if (isa<air::ChannelPutOp>(channel_ops[0]))
       new_chan_op = rewriter.create<air::ChannelPutOp>(
           loc, tys, deps, channel_ops[0].getChanName(),
-          channel_ops[0].getIndices(), channel_ops[0].getMemref(), offsets,
-          wraps, strides);
+          air::lookupOrDefaultRange(channel_ops[0].getIndices(), remap),
+          air::lookupOrDefaultRange(channel_ops[0].getMemref(), remap),
+          air::lookupOrDefaultRange(offsets, remap),
+          air::lookupOrDefaultRange(wraps, remap),
+          air::lookupOrDefaultRange(strides, remap));
     else if (isa<air::ChannelGetOp>(channel_ops[0]))
       new_chan_op = rewriter.create<air::ChannelGetOp>(
           loc, tys, deps, channel_ops[0].getChanName(),
-          channel_ops[0].getIndices(), channel_ops[0].getMemref(), offsets,
-          wraps, strides);
+          air::lookupOrDefaultRange(channel_ops[0].getIndices(), remap),
+          air::lookupOrDefaultRange(channel_ops[0].getMemref(), remap),
+          air::lookupOrDefaultRange(offsets, remap),
+          air::lookupOrDefaultRange(wraps, remap),
+          air::lookupOrDefaultRange(strides, remap));
 
+    // Clear all external uses of for_op before erasing it.
     for (auto res : for_op.getResults()) {
       if (isa<air::AsyncTokenType>(res.getType())) {
         res.replaceAllUsesWith(
@@ -2024,6 +2048,37 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
   }
 
 private:
+  // Clone backward slices of a list of values, opers.
+  SmallVector<Operation *> cloneDefiningOpsInRegion(OpBuilder builder,
+                                                    Region *region,
+                                                    SmallVector<Value> opers,
+                                                    IRMapping &remap) const {
+    SmallVector<Operation *> clonedOps;
+    SetVector<Operation *> backwardSlices;
+    BackwardSliceOptions bsOptions{
+        [&](Operation *o) { return region->isAncestor(o->getParentRegion()); }};
+    if (!region)
+      return clonedOps;
+    for (auto operand : opers) {
+      auto operandDefOp = operand.getDefiningOp();
+      if (!operandDefOp)
+        continue;
+      if (!region->isAncestor(operandDefOp->getParentRegion()))
+        continue;
+      assert(air::isPure(
+          operandDefOp)); // Pure ops are safe to hoist out of loops.
+      // Get backward slices
+      SetVector<Operation *> operandBS;
+      getBackwardSlice(operandDefOp, &operandBS, bsOptions);
+      for (auto b : operandBS)
+        if (air::isPure(b))
+          backwardSlices.insert(b);
+      backwardSlices.insert(operandDefOp);
+    }
+    for (auto op : backwardSlices)
+      clonedOps.push_back(builder.clone(*op, remap));
+    return clonedOps;
+  }
 };
 
 // This pattern should be executed after
@@ -2045,13 +2100,8 @@ struct AIRUnrollScfForIntoBDChain : public OpRewritePattern<scf::ForOp> {
           continue;
         else if (isa<air::WaitAllOp>(o))
           continue;
-        else if (isPure(&o))
+        else if (air::isPure(&o))
           continue;
-        else if (auto exec = dyn_cast<air::ExecuteOp>(o)) {
-          auto childOp = exec.getChildOp();
-          if (childOp && isPure(childOp))
-            continue;
-        }
         return false;
       }
       return true;
@@ -2087,13 +2137,13 @@ struct AIRUnrollAffineForIntoBDChain
           continue;
         else if (isa<air::WaitAllOp>(o))
           continue;
-        else if (isPure(&o))
+        else if (air::isPure(&o))
           continue;
-        else if (auto exec = dyn_cast<air::ExecuteOp>(o)) {
-          auto childOp = exec.getChildOp();
-          if (childOp && isPure(childOp))
-            continue;
-        }
+        // else if (auto exec = dyn_cast<air::ExecuteOp>(o)) {
+        //   auto childOp = exec.getChildOp();
+        //   if (childOp && isPure(childOp))
+        //     continue;
+        // }
         return false;
       }
       return true;
@@ -4118,28 +4168,12 @@ private:
                                 Operation *op) {
     SetVector<Operation *> backwardSlice;
     BackwardSliceOptions bsOptions{[&](Operation *o) {
-      return !isa<scf::ForOp>(o) && !isa<scf::ParallelOp>(o) &&
-             !isa<air::HierarchyInterface>(o);
+      return !isa<LoopLikeOpInterface>(o) && !isa<air::HierarchyInterface>(o);
     }};
     getBackwardSlice(op, &backwardSlice, bsOptions);
-    for (auto operand : op->getOperands()) {
-      if (operand.getDefiningOp() &&
-          isa<arith::ConstantIndexOp>(operand.getDefiningOp()))
-        backwardSlice.insert(operand.getDefiningOp());
-    }
-    for (auto b : backwardSlice) {
-      if (isa<arith::ConstantIndexOp>(b))
+    for (auto b : backwardSlice)
+      if (air::isPure(b))
         builder.clone(*b, remap);
-      else if (b->getNumResults() == 1 &&
-               isa<IndexType>(b->getResult(0).getType()))
-        builder.clone(*b, remap);
-      else if (auto exec = dyn_cast<air::ExecuteOp>(b)) {
-        auto child_op = exec.getChildOp();
-        if (child_op->getNumResults() == 1 &&
-            isa<IndexType>(child_op->getResult(0).getType()))
-          builder.clone(*b, remap);
-      }
-    }
     auto new_op = builder.clone(*op, remap);
     return new_op;
   }
@@ -4231,12 +4265,9 @@ void identifyTargetOpsInSCFFor(func::FuncOp f, scf::ForOp for_op,
       continue; // Skip over herd op's body for now. TODO: generalize this.
     if (o.getParentOfType<affine::AffineIfOp>())
       continue; // Skip over if-else bodies for now. TODO: generalize this.
-    if (isPure(&o))
+    if (air::isPure(&o))
       continue; // Pure ops do not touch memory, and therefore do not require
                 // explicit hoisting.
-    if (auto execOp = dyn_cast<air::ExecuteOp>(o))
-      if (isPure(execOp.getChildOp()))
-        continue;
     if (isa<air::WaitAllOp>(o))
       continue;
     // Check if for loop is splittable by tracing air dependency.

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -208,10 +208,6 @@ replaceAffineIfOpWithChannelOpAndClone(OpBuilder builder, IRMapping &remap,
   }
 }
 
-static Value lookupOrDefaultRange(Value v, IRMapping &remap) {
-  return remap.lookupOrDefault(v);
-}
-
 static Operation *getCoreComputeOpFromExecuteOp(Operation *op) {
   // We assume all linalg ops (except for linalg.copy) and func.call ops do
   // computations only and do not participate in data movement.
@@ -222,26 +218,17 @@ static Operation *getCoreComputeOpFromExecuteOp(Operation *op) {
   return nullptr;
 }
 
-static SmallVector<Value> lookupOrDefaultRange(SmallVector<Value> vec,
-                                               IRMapping &remap) {
-  SmallVector<Value> output;
-  for (auto v : vec) {
-    output.push_back(remap.lookupOrDefault(v));
-  }
-  return output;
-}
-
 template <typename T>
 static LogicalResult
 cloneScfLoopUsingRemap(OpBuilder builder, IRMapping &remap, T loop_op,
                        air::ChannelInterface externalGetPut = nullptr) {
 
-  T new_loop_op =
-      builder.create<T>(builder.getUnknownLoc(),
-                        lookupOrDefaultRange(loop_op.getLowerBound(), remap),
-                        lookupOrDefaultRange(loop_op.getUpperBound(), remap),
-                        lookupOrDefaultRange(loop_op.getStep(), remap),
-                        lookupOrDefaultRange(getLoopTokens(loop_op), remap));
+  T new_loop_op = builder.create<T>(
+      builder.getUnknownLoc(),
+      air::lookupOrDefaultRange(loop_op.getLowerBound(), remap),
+      air::lookupOrDefaultRange(loop_op.getUpperBound(), remap),
+      air::lookupOrDefaultRange(loop_op.getStep(), remap),
+      air::lookupOrDefaultRange(getLoopTokens(loop_op), remap));
 
   OpBuilder::InsertionGuard guard(builder);
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -586,7 +586,11 @@ void addAsyncDependencyIfNewImpl(scf::ParallelOp op, Value token) {
   }
 }
 void addAsyncDependencyIfNew(Operation *op, Value token) {
+  if (!op)
+    return;
   if (!isAsyncOp(op))
+    return;
+  if (!token)
     return;
   if (auto async_op = dyn_cast<air::AsyncOpInterface>(op)) {
     addAsyncDependencyIfNewImpl(async_op, token);
@@ -599,6 +603,8 @@ void addAsyncDependencyIfNew(Operation *op, Value token) {
 }
 
 bool isAsyncOp(Operation *op) {
+  if (!op)
+    return false;
   for (auto result : op->getResults()) {
     if (llvm::isa<air::AsyncTokenType>(result.getType())) {
       return true;

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1577,8 +1577,27 @@ air::evaluateConstantsInMap(AffineMap map,
     newmap =
         newmap.replace(getAffineSymbolExpr(i, ctx), c, 0, map.getNumSymbols());
   }
-  // auto c = getAffineConstantExpr(const_input, ctx);
-  // auto newmap = map.replace(getAffineSymbolExpr(0, ctx), c, 0, 1);
   output = simplifyAffineMap(newmap).getSingleConstantResult();
   return output;
+}
+
+// Extend the lookupOrDefault method to operate on a vector of values.
+Value air::lookupOrDefaultRange(Value v, IRMapping &remap) {
+  return remap.lookupOrDefault(v);
+}
+SmallVector<Value> air::lookupOrDefaultRange(SmallVector<Value> vec,
+                                             IRMapping &remap) {
+  SmallVector<Value> output;
+  for (auto v : vec) {
+    output.push_back(remap.lookupOrDefault(v));
+  }
+  return output;
+}
+
+// Extend isPure method to operate on air.execute.
+bool air::isPure(Operation *op) {
+  bool result = mlir::isPure(op);
+  if (auto execOp = dyn_cast<air::ExecuteOp>(op))
+    result = mlir::isPure(execOp.getChildOp());
+  return result;
 }

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1585,7 +1585,15 @@ air::evaluateConstantsInMap(AffineMap map,
 Value air::lookupOrDefaultRange(Value v, IRMapping &remap) {
   return remap.lookupOrDefault(v);
 }
-SmallVector<Value> air::lookupOrDefaultRange(SmallVector<Value> vec,
+SmallVector<Value> air::lookupOrDefaultRange(SmallVectorImpl<Value> &vec,
+                                             IRMapping &remap) {
+  SmallVector<Value> output;
+  for (auto v : vec) {
+    output.push_back(remap.lookupOrDefault(v));
+  }
+  return output;
+}
+SmallVector<Value> air::lookupOrDefaultRange(OperandRange vec,
                                              IRMapping &remap) {
   SmallVector<Value> output;
   for (auto v : vec) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -289,6 +289,8 @@ module {
   // CHECK: put  @channel_21[] (%arg0[%c0, %c0, %[[VAL0]], %c0] [%c8, %c2, %c32, %c32] [%c32, %c8192, %c256, %c1]) : (memref<128x256xi32>)
   // CHECK: air.channel.put  @channel_22[] (%arg2[%c256, %c0, %c0] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (memref<1x2x32x32xi32, 1 : i32>)
   // CHECK: air.channel.put  @channel_23[] (%arg3[%c128, %c0, %c0] [%c4, %c32, %c8] [%c8, %c32, %c1]) : (memref<2x1x32x32xi32, 1 : i32>)
+  // CHECK: %[[VAL1:.*]] = affine.apply
+  // CHECK: put async  @channel_21[] (%arg0[%c0, %[[VAL1]]] [%c8, %c8] [%c0, %c1]) : (memref<128x256xi32>)
 
   func.func @test9(%arg0: memref<128x256xi32>, %arg1: index, %arg2: memref<1x2x32x32xi32, 1 : i32>, %arg3: memref<2x1x32x32xi32, 1 : i32>) {
     %c0 = arith.constant 0 : index
@@ -306,6 +308,10 @@ module {
     air.channel.put  @channel_21[] (%arg0[%c0, %c0, %results, %c0, %c0] [%c8, %c2, %c1, %c32, %c32] [%c32, %c8192, %c32, %c256, %c1]) : (memref<128x256xi32>)
     air.channel.put  @channel_22[] (%arg2[%c0, %c1, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c1024, %c4, %c256, %c32, %c1]) : (memref<1x2x32x32xi32, 1 : i32>)
     air.channel.put  @channel_23[] (%arg3[%c1, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c4, %c8, %c4, %c8] [%c1024, %c1024, %c8, %c128, %c32, %c1]) : (memref<2x1x32x32xi32, 1 : i32>)
+    scf.for %arg4 = %c0 to %c8 step %c1 {
+      %0 = affine.apply #map()[%arg1]
+      %1 = air.channel.put async @channel_21[] (%arg0[%0] [%c8] [%c1]) : (memref<128x256xi32>)
+    }
     return
   }
 


### PR DESCRIPTION
Below shows the standard case that the pass has been supporting, where the `affine.apply` can get folded into the `scf.for` loop bounds:
```
    scf.for %arg4 = %c0 to %c8 step %c1 {
      %0 = affine.apply #map()[%arg4]
      %1 = air.channel.put async @channel_21[] (%arg0[%0] [%c8] [%c1]) : (memref<128x256xi32>)
    }
```
However, user-provided code could come in the following form too:
```
    scf.for %arg4 = %c0 to %c8 step %c1 {
      %0 = affine.apply #map()[%arg1]
      %1 = air.channel.put async @channel_21[] (%arg0[%0] [%c8] [%c1]) : (memref<128x256xi32>)
    }
```
Where the `affine.apply` cannot fold into the loop due to `%arg1` not being the loop induction variable. In such case, the pass should hoist the `affine.apply` out of the for loop in order to fix value domination, since `affine.apply` is a pure op that doesn't touch memory and can therefore hoist safely.