### PR TITLE
Refactor `air.execute`'s `getBody()` and `getChildOp()` methods

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -462,7 +462,7 @@ def air_ExecuteOp : air_Op<"execute", [SingleBlockImplicitTerminator<"ExecuteTer
          Variadic<AnyType>:$results
   );
   let summary = "Asynchronous code region";
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region SizedRegion<1>:$region);
   let description = [{
     Defines a code region to be dispatched asynchronously at runtime. All operations in
     the region must be executed sequentially.
@@ -477,7 +477,15 @@ def air_ExecuteOp : air_Op<"execute", [SingleBlockImplicitTerminator<"ExecuteTer
   }];
 
   let extraClassDeclaration = [{
-    Operation * getChildOp();
+    Block &getBody() { return getRegion().front(); }
+    llvm::iplist<Operation> &getChildOps() { return getBody().getOperations(); }
+    SmallVector<Operation *> getYieldedChildOps() {
+      SmallVector<Operation *> ops;
+      for (auto oper : getBody().getTerminator()->getOperands())
+        if (oper.getDefiningOp() && getRegion().isAncestor(oper.getDefiningOp()->getParentRegion()))
+          ops.push_back(oper.getDefiningOp());
+      return ops;
+    }
     int32_t getId() {
       if (auto id_attr = (*this)->getAttrOfType<IntegerAttr>("id")) {
         return id_attr.getInt();

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -655,7 +655,7 @@ LogicalResult lowerAirExecute(Operation *op) {
 
   llvm::SmallSet<Operation *, 8> erased;
   module->walk([&](air::ExecuteOp exe) {
-    auto &bb = exe.getBody().front();
+    auto &bb = exe.getRegion().front();
     unsigned idx = 0;
 
     OpBuilder builder(exe);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -718,7 +718,7 @@ struct LowerAIRExecutePattern : public OpRewritePattern<air::ExecuteOp> {
 
   LogicalResult matchAndRewrite(air::ExecuteOp op,
                                 PatternRewriter &rewriter) const override {
-    auto &bb = op.getBody().front();
+    auto &bb = op.getRegion().front();
     unsigned idx = 0;
     for (auto &arg : bb.getArguments()) {
       arg.replaceAllUsesWith(op.getOperand(idx));

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -1026,9 +1026,12 @@ uint64_t HerdOp::getNumRows() {
 //
 
 LogicalResult ExecuteOp::verify() {
-  assert(getOperation()->getNumRegions() == 1 && "ExecuteOp has zero region!");
-  assert(!getRegion().empty() && "ExecuteOp should have non-empty region");
-  assert(!getBody().empty() && "ExecuteOp should have non-empty body");
+  if (getOperation()->getNumRegions() != 1)
+    return emitOpError("ExecuteOp has zero region.");
+  if (getRegion().empty())
+    return emitOpError("ExecuteOp should have non-empty region.");
+  if (getBody().empty())
+    return emitOpError("ExecuteOp should have non-empty body.");
 
   return success();
 }

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -1087,12 +1087,6 @@ void ExecuteOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   patterns.add(CanonicalizeAsyncOpDeps<ExecuteOp>);
 }
 
-Operation *ExecuteOp::getChildOp() {
-  auto child_op =
-      &getOperation()->getRegion(0).getBlocks().front().getOperations().front();
-  return child_op;
-}
-
 //
 // WaitAllOp
 //

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -1027,6 +1027,7 @@ uint64_t HerdOp::getNumRows() {
 
 LogicalResult ExecuteOp::verify() {
   assert(getOperation()->getNumRegions() == 1 && "ExecuteOp has zero region!");
+  assert(!getRegion().empty() && "ExecuteOp should have non-empty region");
   assert(!getBody().empty() && "ExecuteOp should have non-empty body");
 
   return success();

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -260,7 +260,7 @@ public:
       f.walk([&](Operation *op) {
         Operation *sink_op = nullptr;
         if (auto async_execute_op = dyn_cast<air::ExecuteOp>(op)) {
-          for (auto &bb : async_execute_op.getBody()) {
+          for (auto &bb : async_execute_op.getRegion()) {
             for (auto &child_op : bb.getOperations()) {
               if (!dyn_cast<air::ExecuteTerminatorOp>(child_op))
                 sink_op = &child_op;
@@ -694,7 +694,7 @@ private:
                   mlir::IntegerType::get(op->getContext(), 32), ++ExecuteOpID));
 
     // Insert op to the new async execute region's body.
-    Block *async_region_bb = builder.createBlock(&async_region.getBody());
+    Block *async_region_bb = builder.createBlock(&async_region.getRegion());
     builder.setInsertionPointToStart(async_region_bb);
 
     // Handle cases when the operand(s) of the given op that is
@@ -757,7 +757,7 @@ private:
                   mlir::IntegerType::get(op->getContext(), 32), ++ExecuteOpID));
 
     // Insert op to the new async execute region's body.
-    Block *async_region_bb = builder.createBlock(&async_region.getBody());
+    Block *async_region_bb = builder.createBlock(&async_region.getRegion());
     builder.setInsertionPointToStart(async_region_bb);
     auto op_cloned = builder.clone(*op);
     builder.create<xilinx::air::ExecuteTerminatorOp>(builder.getUnknownLoc(),
@@ -1989,7 +1989,7 @@ private:
   }
   bool isNotLoopCarriedOp(air::AsyncOpInterface op) {
     if (auto exec_op = dyn_cast<air::ExecuteOp>(op.getOperation())) {
-      auto &bb = exec_op.getBody().front();
+      auto &bb = exec_op.getRegion().front();
       Operation &child_op = bb.getOperations().front();
       return isNotLoopCarriedOp(&child_op);
     } else
@@ -2005,7 +2005,7 @@ private:
     for (auto user : token.getUsers()) {
       if (user->getBlock() == block) {
         if (auto async_user = dyn_cast<air::ExecuteOp>(user)) {
-          auto &bb = async_user.getBody().front();
+          auto &bb = async_user.getRegion().front();
           Operation &child_op = bb.getOperations().front();
           if (!isNotLoopCarriedOp(&child_op))
             isOnlyUsedByNoCarryOps = false;

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -260,12 +260,9 @@ public:
       f.walk([&](Operation *op) {
         Operation *sink_op = nullptr;
         if (auto async_execute_op = dyn_cast<air::ExecuteOp>(op)) {
-          for (auto &bb : async_execute_op.getRegion()) {
-            for (auto &child_op : bb.getOperations()) {
-              if (!dyn_cast<air::ExecuteTerminatorOp>(child_op))
-                sink_op = &child_op;
-            }
-          }
+          for (auto &child_op : async_execute_op.getChildOps())
+            if (!dyn_cast<air::ExecuteTerminatorOp>(child_op))
+              sink_op = &child_op;
         } else if (isa<xilinx::air::DmaMemcpyNdOp>(op)) {
           sink_op = op;
         } else if (isa<xilinx::air::ChannelInterface>(op)) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3317,7 +3317,8 @@ public:
               auto async_exec = builder.create<xilinx::air::ExecuteOp>(
                   user->getLoc(), air::AsyncTokenType::get(alloc->getContext()),
                   SmallVector<Value>{});
-              Block *async_exec_bb = builder.createBlock(&async_exec.getBody());
+              Block *async_exec_bb =
+                  builder.createBlock(&async_exec.getRegion());
               builder.setInsertionPointToStart(async_exec_bb);
               builder.create<memref::DeallocOp>(user->getLoc(), new_memref);
               builder.create<air::ExecuteTerminatorOp>(user->getLoc());
@@ -4492,7 +4493,7 @@ struct ShrinkMemrefSizesByAccessPattern
         auto newExecOp = rewriter.create<air::ExecuteOp>(
             execOp->getLoc(), air::AsyncTokenType::get(rewriter.getContext()),
             newMemrefType, execOp.getAsyncDependencies());
-        Block *async_exec_bb = rewriter.createBlock(&newExecOp.getBody());
+        Block *async_exec_bb = rewriter.createBlock(&newExecOp.getRegion());
         rewriter.setInsertionPointToStart(async_exec_bb);
         auto newAlloc =
             rewriter.create<memref::AllocOp>(alloc->getLoc(), newMemrefType);

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1193,10 +1193,12 @@ class AIRDemoteDmaToAIRHierarchyConversion
       }
 
       for (auto b : backwardSlice) {
-        if (auto execOp = dyn_cast<air::ExecuteOp>(b)) {
-          getBackwardSlice(&execOp.getChildOps().front(), &backwardSlice,
-                           bsOptions);
-          backwardSlice.insert(&execOp.getChildOps().front());
+        auto execOp = dyn_cast<air::ExecuteOp>(b);
+        if (!execOp)
+          continue;
+        for (auto &childOp : execOp.getChildOps()) {
+          getBackwardSlice(&childOp, &backwardSlice, bsOptions);
+          backwardSlice.insert(&childOp);
         }
       }
 

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -196,8 +196,8 @@ static Operation *getCoreComputeOpFromExecuteOp(Operation *op) {
   // We assume all linalg ops (except for linalg.copy) and func.call ops do
   // computations only and do not participate in data movement.
   if (auto exec = dyn_cast<air::ExecuteOp>(op)) {
-    if (isa<linalg::LinalgOp, func::CallOp>(exec.getChildOp()))
-      return exec.getChildOp();
+    if (isa<linalg::LinalgOp, func::CallOp>(&exec.getChildOps().front()))
+      return &exec.getChildOps().front();
   }
   return nullptr;
 }
@@ -1194,8 +1194,9 @@ class AIRDemoteDmaToAIRHierarchyConversion
 
       for (auto b : backwardSlice) {
         if (auto execOp = dyn_cast<air::ExecuteOp>(b)) {
-          getBackwardSlice(execOp.getChildOp(), &backwardSlice, bsOptions);
-          backwardSlice.insert(execOp.getChildOp());
+          getBackwardSlice(&execOp.getChildOps().front(), &backwardSlice,
+                           bsOptions);
+          backwardSlice.insert(&execOp.getChildOps().front());
         }
       }
 

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1140,7 +1140,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::partitionMemref(
       auto execOp =
           builder.create<air::ExecuteOp>(loc, air::AsyncTokenType::get(ctx),
                                          newMemrefType, SmallVector<Value>{});
-      Block *async_bb = builder.createBlock(&execOp.getBody());
+      Block *async_bb = builder.createBlock(&execOp.getRegion());
       builder.setInsertionPointToStart(async_bb);
       auto childMemAlloc = builder.create<memref::AllocOp>(loc, newMemrefType);
       builder.create<xilinx::air::ExecuteTerminatorOp>(
@@ -1156,7 +1156,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::partitionMemref(
         auto execOp = builder.create<air::ExecuteOp>(
             loc, air::AsyncTokenType::get(ctx),
             execDeallocOp.getAsyncDependencies());
-        Block *async_bb = builder.createBlock(&execOp.getBody());
+        Block *async_bb = builder.createBlock(&execOp.getRegion());
         builder.setInsertionPointToStart(async_bb);
         builder.create<memref::DeallocOp>(loc, newMemref);
         builder.create<xilinx::air::ExecuteTerminatorOp>(loc);

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -317,7 +317,7 @@ private:
       for (std::vector<Operation *>::reverse_iterator i = op_history.rbegin();
            i != op_history.rend(); ++i) {
         if (auto exec_op = dyn_cast<air::ExecuteOp>(*i)) {
-          Operation *op = exec_op.getChildOp();
+          Operation *op = &exec_op.getChildOps().front();
           // If the async op is affine.apply
           if (auto apply_op = dyn_cast<affine::AffineApplyOp>(op)) {
             // Can only propagate affine.apply ops with single operand.
@@ -903,7 +903,8 @@ Value tileChannelOpByFactor(air::ChannelInterface originalChanOp, int factor,
     originalApplyOutput = affineApplyOp->getResult(0);
   } else if (affineApplyOp && isa<air::ExecuteOp>(affineApplyOp)) {
     auto execOp = dyn_cast<air::ExecuteOp>(affineApplyOp);
-    originalApplyOperands = execOp.getChildOp()->getOperands();
+    auto childFront = &execOp.getChildOps().front();
+    originalApplyOperands = childFront->getOperands();
     originalApplyOutput = affineApplyOp->getResult(1);
   } else {
     originalApplyOperands.push_back(zeroIdx);
@@ -998,9 +999,7 @@ scf::ForOp getScfForFromVal(Value val) {
   if (!defOp)
     return scf::ForOp();
   if (auto exec = dyn_cast<air::ExecuteOp>(defOp)) {
-    auto exec_child = exec.getChildOp();
-    if (!exec_child)
-      return scf::ForOp();
+    auto exec_child = &exec.getChildOps().front();
     for (auto oper : exec_child->getOperands())
       if (auto res = scf::getForInductionVarOwner(oper))
         return res;
@@ -1026,7 +1025,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::partitionMemref(
   Operation *deallocOp = nullptr;
   for (auto user : memref.getUsers()) {
     if (auto execOp = dyn_cast<air::ExecuteOp>(user->getParentOp())) {
-      if (isa<memref::DeallocOp>(execOp.getChildOp())) {
+      if (isa<memref::DeallocOp>(execOp.getChildOps().front())) {
         deallocOp = execOp;
         break;
       }
@@ -1188,8 +1187,8 @@ void AIRSplitL2MemrefForBufferConstraintPass::partitionMemref(
         auto defOp = op.getOffsets()[*offsetDim].getDefiningOp();
         affine::AffineApplyOp apply = dyn_cast<affine::AffineApplyOp>(defOp);
         air::ExecuteOp exec = dyn_cast<air::ExecuteOp>(defOp);
-        if (exec && isa<affine::AffineApplyOp>(exec.getChildOp()))
-          apply = dyn_cast<affine::AffineApplyOp>(exec.getChildOp());
+        if (exec && isa<affine::AffineApplyOp>(exec.getChildOps().front()))
+          apply = dyn_cast<affine::AffineApplyOp>(exec.getChildOps().front());
         assert(apply && "Apply op not found. NYI.");
         for (auto oper : apply->getOperands())
           if (getConstantIntValue(oper))
@@ -1340,8 +1339,8 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
             affine::AffineApplyOp apply =
                 dyn_cast<affine::AffineApplyOp>(offsetDefOp);
             if (auto exec = dyn_cast<air::ExecuteOp>(offsetDefOp))
-              if (auto exec_child_apply =
-                      dyn_cast<affine::AffineApplyOp>(exec.getChildOp()))
+              if (auto exec_child_apply = dyn_cast<affine::AffineApplyOp>(
+                      exec.getChildOps().front()))
                 apply = exec_child_apply;
             if (apply)
               allocOp->setAttr("affine_map",

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -158,7 +158,7 @@ void traceDependentHerdId(Operation *async_op,
   // Get child op if async_op is air.execute
   Operation *op = nullptr;
   if (auto air_execute_op = dyn_cast<air::ExecuteOp>(async_op)) {
-    op = air_execute_op.getChildOp();
+    op = &air_execute_op.getChildOps().front();
   } else {
     op = async_op;
   }
@@ -819,8 +819,8 @@ LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
                 dyn_cast<mlir::affine::AffineApplyOp>(oper.getDefiningOp()))
           position_apply = apply_op;
         else if (auto exec = dyn_cast<air::ExecuteOp>(oper.getDefiningOp())) {
-          if (auto apply_op =
-                  dyn_cast<mlir::affine::AffineApplyOp>(exec.getChildOp()))
+          if (auto apply_op = dyn_cast<mlir::affine::AffineApplyOp>(
+                  exec.getChildOps().front()))
             position_apply = apply_op;
         }
         if (position_apply) {
@@ -1407,7 +1407,7 @@ dependencyCanonicalizer::getVertexFromOp(Operation *op,
   std::pair<Graph::VertexId, dependencyGraph *> output;
   if (auto execute_op = dyn_cast<xilinx::air::ExecuteOp>(op)) {
     if (front_or_back == "front") {
-      auto execute_front_op = execute_op.getChildOp();
+      auto execute_front_op = &execute_op.getChildOps().front();
       std::pair<std::string, unsigned> entry_pair =
           getTypeIdPairFromOp(execute_front_op);
       output.first = dep_ctx.op_to_v[entry_pair];
@@ -1870,7 +1870,7 @@ void dependencyCanonicalizer::removeUnusedExecuteOp(func::FuncOp func) {
   func.walk([&](air::ExecuteOp op) {
     // Check the type of op inside the execute. Only remove ops with no side
     // effects
-    auto child_op = op.getChildOp();
+    auto child_op = &op.getChildOps().front();
     if (dyn_cast<memref::AllocOp>(child_op) ||
         dyn_cast<affine::AffineApplyOp>(child_op)) {
       // The second result is the ssa value yielded from child op inside execute

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -134,12 +134,12 @@ void traceDependentInductionVar(air::AsyncOpInterface async_op,
   // Get child op if async_op is air.execute
   Operation *op = nullptr;
   if (auto air_region_op = dyn_cast<air::ExecuteOp>(async_op.getOperation())) {
-    if (air_region_op.getBody().front().getOperations().size() != 2) {
+    if (air_region_op.getRegion().front().getOperations().size() != 2) {
       air_region_op->emitOpError("air::ExecuteOp should have only one child "
                                  "operation beside the terminator");
       return;
     }
-    for (auto &child_op : air_region_op.getBody().front().getOperations()) {
+    for (auto &child_op : air_region_op.getRegion().front().getOperations()) {
       if (!dyn_cast<air::ExecuteTerminatorOp>(child_op))
         op = &child_op;
     }
@@ -1414,7 +1414,7 @@ dependencyCanonicalizer::getVertexFromOp(Operation *op,
       output.second = dep_ctx.op_to_g[entry_pair];
     } else if (front_or_back == "back") {
       auto execute_end_op =
-          execute_op.getBody().getBlocks().front().getTerminator();
+          execute_op.getRegion().getBlocks().front().getTerminator();
       std::pair<std::string, unsigned> entry_pair =
           getTypeIdPairFromOp(execute_end_op);
       output.first = dep_ctx.op_to_v[entry_pair];
@@ -1971,7 +1971,7 @@ void dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
     SmallVector<Value, 1> sink_op_scalar_outs;
     // Pick the first op that is not a shape altering op.
     Operation *child_op = nullptr;
-    for (auto &op : exec_op.getBody().front().getOperations()) {
+    for (auto &op : exec_op.getRegion().front().getOperations()) {
       child_op = &op;
       if (!isa_and_present<memref::ReshapeOp, memref::ExpandShapeOp,
                            memref::CollapseShapeOp>(child_op)) {

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -218,7 +218,7 @@ public:
         c.op->emitOpError("has mismatching event type").attachNote()
             << "Has 'execute' as event type, but op isn't of type "
                "air::ExecuteOp";
-      auto child_op = dyn_cast<air::ExecuteOp>(c.op).getChildOp();
+      auto child_op = &dyn_cast<air::ExecuteOp>(c.op).getChildOps().front();
       if (auto Op = mlir::dyn_cast<linalg::LinalgOp>(child_op)) {
         uint64_t compute_xfer_cost = 0;
         uint64_t compute_op_cost = getComputeCostFromCostModel(d, child_op);
@@ -815,7 +815,8 @@ unsigned lookUpMemorySpaceIntFromString(std::string memory_space) {
   return output;
 }
 
-template <typename T> void push_back_if_unique(std::vector<T> &vec, T entry) {
+template <typename T>
+void push_back_if_unique(std::vector<T> &vec, T entry) {
   if (std::find(vec.begin(), vec.end(), entry) == vec.end()) {
     vec.push_back(entry);
   }

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -327,7 +327,7 @@ public:
     } else if (auto Op = dyn_cast<air::ChannelGetOp>(op)) {
       return (bool)this->checkResourceFulfillmentForOp(Op);
     } else if (auto Op = dyn_cast<air::ExecuteOp>(op)) {
-      auto child_op = Op.getChildOp();
+      auto child_op = &Op.getChildOps().front();
       if (name == "AllocOp") {
         auto Op = dyn_cast<memref::AllocOp>(child_op);
         return this->checkResourceFulfillmentForOp(Op);
@@ -715,7 +715,7 @@ private:
                                 std::string name = "") {
     if (op) {
       if (auto exec_op = dyn_cast<air::ExecuteOp>(op)) {
-        auto child_op = exec_op.getChildOp();
+        auto child_op = &exec_op.getChildOps().front();
         // Memory allocation/deallocation
         if (name == "AllocOp") {
           auto Op = dyn_cast<memref::AllocOp>(child_op);


### PR DESCRIPTION
- Rename the single region in `air.execute` to `region` instead of `body`.
- Add `getBody` method to get the op's single block.
- Replace `getChildOp` with `getChildOps` which returns a list of all child ops within each `air.execute` body.