### PR TITLE
update mlir-aie + some updates for aie2p

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -57,12 +57,12 @@ bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
                                 SmallVector<Value> memcpy_strides,
                                 Value memref);
 
-std::pair<int64_t, int64_t> getLockValuePair(const AIE::AIETargetModel &targetModel,
-                                             Value buffer_memref);
+std::pair<int64_t, int64_t>
+getLockValuePair(const AIE::AIETargetModel &targetModel, Value buffer_memref);
 
-std::pair<int64_t, int64_t> getLockValuePair(const AIE::AIETargetModel &targetModel,
-                                             Value buffer_memref,
-                                             air::ChannelOp air_chan);
+std::pair<int64_t, int64_t>
+getLockValuePair(const AIE::AIETargetModel &targetModel, Value buffer_memref,
+                 air::ChannelOp air_chan);
 
 struct allocation_info_t {
   AIE::TileOp dma_tile = nullptr;

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -57,10 +57,10 @@ bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
                                 SmallVector<Value> memcpy_strides,
                                 Value memref);
 
-std::pair<int64_t, int64_t> getLockValuePair(AIE::AIEArch arch,
+std::pair<int64_t, int64_t> getLockValuePair(const AIE::AIETargetModel &targetModel,
                                              Value buffer_memref);
 
-std::pair<int64_t, int64_t> getLockValuePair(AIE::AIEArch arch,
+std::pair<int64_t, int64_t> getLockValuePair(const AIE::AIETargetModel &targetModel,
                                              Value buffer_memref,
                                              air::ChannelOp air_chan);
 

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -218,10 +218,9 @@ air::getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
   return output;
 }
 
-std::pair<int64_t, int64_t> air::getLockValuePair(AIE::AIEArch arch,
+std::pair<int64_t, int64_t> air::getLockValuePair(const AIE::AIETargetModel &targetModel,
                                                   Value buffer_memref) {
-  bool isAIE2 = (arch == AIE::AIEArch::AIE2);
-  if (!isAIE2)
+  if (isa<AIE::AIE1TargetModel>(targetModel))
     return std::make_pair(0, 0);
 
   // Infer semaphore lock values using buffer op
@@ -261,17 +260,17 @@ std::pair<int64_t, int64_t> air::getLockValuePair(AIE::AIEArch arch,
                           llvm::divideCeilSigned(write_counter, read_counter));
 }
 
-std::pair<int64_t, int64_t> air::getLockValuePair(AIE::AIEArch arch,
+std::pair<int64_t, int64_t> air::getLockValuePair(const AIE::AIETargetModel &targetModel,
                                                   Value buffer_memref,
                                                   air::ChannelOp air_chan) {
-  bool isAIE2 = (arch == AIE::AIEArch::AIE2);
-  if (!isAIE2)
+  if (isa<AIE::AIE1TargetModel>(targetModel))
     return std::make_pair(0, 0);
+
   if (!llvm::isa<MemRefType>(buffer_memref.getType()))
     return std::make_pair(-1, -1);
 
   if (!air_chan)
-    return getLockValuePair(arch, buffer_memref);
+    return getLockValuePair(targetModel, buffer_memref);
 
   // Infer semaphore lock values using air.channel. This method enables
   // ping-pong compute-communication overlap.
@@ -418,8 +417,8 @@ DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
     air_chan = getChannelDeclarationThroughSymbol(air_chan_op);
   }
   const auto &target_model = device.getTargetModel();
-  bool isAIE2 = (target_model.getTargetArch() == AIE::AIEArch::AIE2);
-  bool isAIE1 = (target_model.getTargetArch() == AIE::AIEArch::AIE1);
+  bool isAIE2 = isa<AIE::AIE2TargetModel>(target_model);
+  bool isAIE1 = isa<AIE::AIE1TargetModel>(target_model);
 
   if (isAIE1) {
     for (size_t i = 0; i < lock_allocation_list.size(); i++) {
@@ -480,9 +479,9 @@ DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
   std::pair<int64_t, int64_t> init_pair;
   if (target_model.isMemTile(col, row))
     init_pair =
-        getLockValuePair(target_model.getTargetArch(), bufferOp->getResult(0));
+        getLockValuePair(target_model, bufferOp->getResult(0));
   else
-    init_pair = getLockValuePair(target_model.getTargetArch(),
+    init_pair = getLockValuePair(target_model,
                                  bufferOp->getResult(0), air_chan);
   auto init = std::max(init_pair.first, init_pair.second);
 

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -218,8 +218,9 @@ air::getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
   return output;
 }
 
-std::pair<int64_t, int64_t> air::getLockValuePair(const AIE::AIETargetModel &targetModel,
-                                                  Value buffer_memref) {
+std::pair<int64_t, int64_t>
+air::getLockValuePair(const AIE::AIETargetModel &targetModel,
+                      Value buffer_memref) {
   if (isa<AIE::AIE1TargetModel>(targetModel))
     return std::make_pair(0, 0);
 
@@ -260,9 +261,9 @@ std::pair<int64_t, int64_t> air::getLockValuePair(const AIE::AIETargetModel &tar
                           llvm::divideCeilSigned(write_counter, read_counter));
 }
 
-std::pair<int64_t, int64_t> air::getLockValuePair(const AIE::AIETargetModel &targetModel,
-                                                  Value buffer_memref,
-                                                  air::ChannelOp air_chan) {
+std::pair<int64_t, int64_t>
+air::getLockValuePair(const AIE::AIETargetModel &targetModel,
+                      Value buffer_memref, air::ChannelOp air_chan) {
   if (isa<AIE::AIE1TargetModel>(targetModel))
     return std::make_pair(0, 0);
 
@@ -478,11 +479,10 @@ DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
   }
   std::pair<int64_t, int64_t> init_pair;
   if (target_model.isMemTile(col, row))
-    init_pair =
-        getLockValuePair(target_model, bufferOp->getResult(0));
+    init_pair = getLockValuePair(target_model, bufferOp->getResult(0));
   else
-    init_pair = getLockValuePair(target_model,
-                                 bufferOp->getResult(0), air_chan);
+    init_pair =
+        getLockValuePair(target_model, bufferOp->getResult(0), air_chan);
   auto init = std::max(init_pair.first, init_pair.second);
 
   OpBuilder builder(bufferOp);

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=a0fef4fd8d253d0a088128ddb625ca368f9b2f83
+export HASH=779bbd147cd4c934aa0728afa52b1bda076e28f6
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then


### PR DESCRIPTION
This PR updates the use of mlir-aie `AIETargetModel` after https://github.com/Xilinx/mlir-aie/pull/1911. Also starts to add in some AIE2p (strix) support, although that support is not tested.