### PR TITLE
AIRDependency: fixup issues around op erase in `hoistTargetOpsToNewSCFFor` method

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -70,7 +70,8 @@ void addAsyncDependencyIfNew(Operation *op, Value token);
 bool isAsyncOp(Operation *op);
 bool areAsyncDependent(Operation *a, Operation *b);
 bool isAsyncDependent(Operation *a, Operation *b);
-scf::ForOp hoistTargetOpsToNewSCFFor(OpBuilder builder, scf::ForOp for_op,
+scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
+                                     scf::ForOp for_op,
                                      SmallVector<Operation *> target_ops);
 LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
                                                   scf::ParallelOp par,


### PR DESCRIPTION
- Rewrite block walking to respect IsolateFromAbove trait.
- Use PatternRewriter to delete ops (instead of `Operation`'s `erase` method), for `matchPattern` to work properly.