### PR TITLE
AIRSegmentLoopFusion: Avoid circular dependency after loop fusion

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -5092,6 +5092,8 @@ struct AIRSegmentLoopFusionPattern : public OpRewritePattern<air::SegmentOp> {
     });
     for (auto put_parent : put_parents) {
       auto get_parent = put_get_mapping[put_parent];
+      if (put_parent == get_parent)
+        continue;
       if (put_parent->isBeforeInBlock(get_parent))
         put_parent->moveAfter(get_parent);
       Value get_parent_token = nullptr;


### PR DESCRIPTION
- Avoid the possibility that during the channel put/get dependency reconstruction after loop fusion, a circular dep is created which breaks ssa domination.