### PR TITLE
AIRSpecializeChannelWrapAndStride: `air.wait_all` ops hoisting fixup

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2060,13 +2060,14 @@ private:
         continue;
       if (!region->isAncestor(operandDefOp->getParentRegion()))
         continue;
-      assert(air::isPure(
-          operandDefOp)); // Pure ops are safe to hoist out of loops.
+      assert(air::isPure(operandDefOp) ||
+             isa<air::WaitAllOp>(operandDefOp)); // Pure ops and wait ops are
+                                                 // safe to hoist out of loops.
       // Get backward slices
       SetVector<Operation *> operandBS;
       getBackwardSlice(operandDefOp, &operandBS, bsOptions);
       for (auto b : operandBS) {
-        assert(air::isPure(b));
+        assert(air::isPure(b) || isa<air::WaitAllOp>(b));
         backwardSlices.insert(b);
       }
       backwardSlices.insert(operandDefOp);


### PR DESCRIPTION
`air.wait_all` ops which are in the same region as target op and produce tokens consumed by the target ops should be allowed to be hoisted together with the target ops.