### PR TITLE
AIRSpecializeChannelWrapAndStride: Remove obsolete logic around `scf.for` pattern matching

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1936,9 +1936,6 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
       }
       return counter == N;
     };
-    if (auto parent_for = dyn_cast<scf::ForOp>(for_op->getParentOp()))
-      if (hasNElements(parent_for.getBody(), 1))
-        return failure();
 
     if (!hasNElements(for_op.getBody(), 1))
       return failure();


### PR DESCRIPTION
The logic was written under the assumption that the target pattern was only scanning for for ops from an `air.hierarchy` op's direct children ops. This assumption is no longer true as the pattern matching is rewritten to greedily scan for ops, regardless of their relative hierarchy to any parent `air.hierarchy` op.