### PR TITLE
AIRDependency: Rewrite logic around replacing uses of async tokens to an erased (hoisted) op

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -752,7 +752,6 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
   for (auto erase_op : target_ops) {
     // Reconnect returned tokens.
     rewriter.setInsertionPoint(erase_op);
-    SmallVector<Value> erase_op_results = erase_op->getResults();
     SmallVector<Value> erase_op_async_deps =
         air::getAsyncDependenciesFromOp(erase_op);
     for (auto res : erase_op->getResults()) {


### PR DESCRIPTION
Simplify the code logic. Updating a value's users, while iterating through the op's `getUsers()` method, isn't safe. Use `replaceAllUsesWith` method instead.