### PR TITLE
Bump mlir-aie to f85a4a974fd59c82c878656d2b1536b4c2e74453

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1557,12 +1557,14 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
             /*enable_packet*/ 1, /*out_of_order_id*/ 0,
             /*packet_id*/ flowID, pkt_type,
             /* d0_size */ 0, /* d0_stride */ 0, /* d1_size */ 0,
-            /* d1_stride */ 0, /* d2_stride */ 0,
+            /* d1_stride */ 0, /* d2_size */ 0, /* d2_stride */ 0,
             /* iteration_current */ 0, /* iteration_size */ 0,
             /* iteration_stride */ 0, /* next_bd */ 0, dstRowIndex,
             /* use_next_bd */ 0,
             /* valid_bd */ 1, /* lock_rel_val */ 0, /* lock_rel_id */ 0,
-            /* lock_acq_enable */ 0, /* lock_acq_val */ 0, /* lock_acq_id */ 0);
+            /* lock_acq_enable */ 0, /* lock_acq_val */ 0, /* lock_acq_id */ 0,
+            /* d0_zero_before*/ 0, /* d1_zero_before*/ 0, /* d2_zero_before*/ 0,
+            /* d0_zero_after*/ 0, /* d1_zero_after*/ 0, /* d2_zero_after*/ 0);
         uint32_t addr = (dstColIndex << target_model.getColumnShift()) |
                         (0x1D004 + bdID * 0x20);
         builder.create<AIEX::NpuAddressPatchOp>(builder.getUnknownLoc(), addr,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3318,7 +3318,7 @@ public:
 
       for (auto herd : herds) {
         std::vector<Attribute> dma_allocations;
-        if (!device.getTargetModel().isNPU()) {
+        if (!device.getTargetModel().hasProperty(AIE::AIETargetModel::IsNPU)) {
           // AIE1 dma metadata format
           getDmaAllocationMetadata(builder, ctx, herd, shimDmaAlloc.s2mm_allocs,
                                    AIE::DMAChannelDir::S2MM,
@@ -3354,7 +3354,7 @@ public:
       }
       for (auto seg : segs) {
         std::vector<Attribute> dma_allocations;
-        if (!device.getTargetModel().isNPU()) {
+        if (!device.getTargetModel().hasProperty(AIE::AIETargetModel::IsNPU)) {
           // AIE1 memtile dma metadata format
           getDmaAllocationMetadata(builder, ctx, seg, shimDmaAlloc.mm2s_allocs,
                                    AIE::DMAChannelDir::MM2S,

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=779bbd147cd4c934aa0728afa52b1bda076e28f6
+export HASH=f85a4a974fd59c82c878656d2b1536b4c2e74453
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then


### PR DESCRIPTION
- In `air-to-aie`, query the device-specific property as possible, instead of directly querying the device architecture.