### PR TITLE
AIRSpecializeChannelWrapAndStride: More flexible wrap-and-stride offset canonicalization

### DIFF
--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -69,7 +69,7 @@ module {
   // CHECK: put @channel_3[%c0, %c0] (%arg1[%c0, %c0, %c0] [%c4, %c32, %c32] [%c32, %c128, %c1]) : (memref<128x128xf32>)
   // CHECK: put @channel_4[%c0, %c0] (%arg1[%c0, %c0, %c0] [%c4, %c128, %c32] [%c32, %c128, %c1]) : (memref<128x128xf32>)
   // CHECK: get @channel_5[%c0, %c0] (%arg1[%c0, %c0, %c0, %c0] [%c4, %c4, %c32, %c32] [%c4096, %c32, %c128, %c1]) : (memref<128x128xf32>)
-  // CHECK: put @channel_5[] (%alloc_0[%c0, %c18, %c0] [%c4, %c18, %c8] [%c8, %c32, %c1]) : (memref<1x6x6x32xi8, 1>)
+  // CHECK: put @channel_5[] (%alloc_0[%c0, %c0, %c576] [%c4, %c18, %c8] [%c8, %c32, %c1]) : (memref<1x6x6x32xi8, 1>)
 
   func.func @test1(%arg0: memref<128xf32>, %arg1: memref<128x128xf32>) -> memref<128xf32> {
     %c0 = arith.constant 0 : index
@@ -286,9 +286,9 @@ module {
   // Offset propagation with wrap-and-stride canonicalization.
   // CHECK-LABEL: test9
   // CHECK: %[[VAL0:.*]] = affine.apply #map()[%arg1]
-  // CHECK: put  @channel_21[] (%arg0[%c0, %c0, %[[VAL0]], %c0] [%c8, %c2, %c32, %c32] [%c32, %c8192, %c256, %c1]) : (memref<128x256xi32>)
-  // CHECK: air.channel.put  @channel_22[] (%arg2[%c256, %c0, %c0] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (memref<1x2x32x32xi32, 1 : i32>)
-  // CHECK: air.channel.put  @channel_23[] (%arg3[%c128, %c0, %c0] [%c4, %c32, %c8] [%c8, %c32, %c1]) : (memref<2x1x32x32xi32, 1 : i32>)
+  // CHECK: put  @channel_21[] (%arg0[%c0, %c0, %[[VAL0]]] [%c8, %c64, %c32] [%c32, %c256, %c1]) : (memref<128x256xi32>)
+  // CHECK: air.channel.put  @channel_22[] (%arg2[%c0, %c0, %c1024] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (memref<1x2x32x32xi32, 1 : i32>)
+  // CHECK: air.channel.put  @channel_23[] (%arg3[%c0, %c0, %c1024] [%c4, %c32, %c8] [%c8, %c32, %c1]) : (memref<2x1x32x32xi32, 1 : i32>)
   // CHECK: %[[VAL1:.*]] = affine.apply
   // CHECK: put async  @channel_21[] (%arg0[%c0, %[[VAL1]]] [%c8, %c8] [%c0, %c1]) : (memref<128x256xi32>)
 
@@ -459,7 +459,7 @@ module {
   // Offset propagated from scf.for and air.hier induction vars.
   // CHECK-LABEL: test13
   
-  // CHECK: air.channel.put async [%{{.*}}]  @channel_14[] (%{{.*}}[%c0, %1, %results, %c0] [%c8, %c2_0, %c32, %c32] [%c32, %c8192, %c256, %c1]) : (memref<2x128x256xi32>)
+  // CHECK: air.channel.put async [%{{.*}}]  @channel_14[] (%{{.*}}[%c0, %c0, %results, %1] [%c8, %c2_0, %c32, %c32] [%c32, %c8192, %c256, %c1]) : (memref<2x128x256xi32>)
 
   func.func @test13(%arg0: memref<2x128x256xi32>, %arg1: memref<2x256x128xi32>) {
     %c2 = arith.constant 2 : index

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
@@ -1,0 +1,272 @@
+# aie.py -*- Python -*-
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import air
+import air.compiler.util
+from air.dialects import linalg, tensor, arith, func, memref
+from air.ir import *
+import air.passmanager
+from air.dialects import air as airdialect
+from air.compiler.util import run_transform
+import sys
+
+with air.ir.Context() as ctx, Location.unknown():
+
+    ################################################
+    ## Tiling
+    ################################################
+
+    air_tiled_ir_string = """
+    module {
+      func.func @matmul_512x512_512xi32__dispatch_0_matmul_512x512x512_i32(%0 : memref<512x512xi32>, %1 : memref<512x512xi32>, %2 : memref<512x512xi32>) {
+        %c4 = arith.constant 4 : index
+        %c128 = arith.constant 128 : index
+        %c512 = arith.constant 512 : index
+        %c15 = arith.constant 15 : index
+        %c0 = arith.constant 0 : index
+        %c0_i32 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : index
+        %alloc = memref.alloc() : memref<1x1x8x4x8x4xi32, 2 : i32>
+        %alloc_0 = memref.alloc() : memref<1x1x4x8x4x8xi32, 2 : i32>
+        %alloc_1 = memref.alloc() : memref<1x4x32x32xi32, 1 : i32>
+        %alloc_2 = memref.alloc() : memref<4x1x32x32xi32, 1 : i32>
+        %alloc_3 = memref.alloc() : memref<4x4x8x8x4x4xi32, 2 : i32>
+        %alloc_4 = memref.alloc() : memref<4x4x32x32xi32, 1 : i32>
+        scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c512, %c512) step (%c128, %c128) {
+          %subview = memref.subview %2[%arg0, %arg1] [128, 128] [1, 1] : memref<512x512xi32> to memref<128x128xi32, strided<[512, 1], offset: ?>>
+          %subview_5 = memref.subview %0[%arg0, 0] [128, 32] [1, 1] : memref<512x512xi32> to memref<128x32xi32, strided<[512, 1], offset: ?>>
+          %expand_shape = memref.expand_shape %subview_5 [[0, 1], [2, 3]] output_shape [4, 32, 1, 32] : memref<128x32xi32, strided<[512, 1], offset: ?>> into memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+          %transpose = memref.transpose %expand_shape (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+          air.dma_memcpy_nd (%alloc_2[] [] [], %transpose[] [] []) : (memref<4x1x32x32xi32, 1 : i32>, memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+          %subview_6 = memref.subview %1[0, %arg1] [32, 128] [1, 1] : memref<512x512xi32> to memref<32x128xi32, strided<[512, 1], offset: ?>>
+          %expand_shape_7 = memref.expand_shape %subview_6 [[0, 1], [2, 3]] output_shape [1, 32, 4, 32] : memref<32x128xi32, strided<[512, 1], offset: ?>> into memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+          %transpose_8 = memref.transpose %expand_shape_7 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+          air.dma_memcpy_nd (%alloc_1[] [] [], %transpose_8[] [] []) : (memref<1x4x32x32xi32, 1 : i32>, memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+          scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c4, %c4) step (%c1, %c1) {
+            %subview_16 = memref.subview %alloc_2[%arg2, 0, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x1x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32>
+            %expand_shape_17 = memref.expand_shape %subview_16 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 8, 4, 4, 8] : memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32>
+            %transpose_18 = memref.transpose %expand_shape_17 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32> to memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>
+            air.dma_memcpy_nd (%alloc_0[] [] [], %transpose_18[] [] []) : (memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>)
+            %subview_19 = memref.subview %alloc_1[0, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<1x4x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32>
+            %expand_shape_20 = memref.expand_shape %subview_19 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 4, 8, 8, 4] : memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32>
+            %transpose_21 = memref.transpose %expand_shape_20 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32> to memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>
+            air.dma_memcpy_nd (%alloc[] [] [], %transpose_21[] [] []) : (memref<1x1x8x4x8x4xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>)
+            %subview_22 = memref.subview %alloc_3[%arg2, %arg3, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x8x8x4x4xi32, 2 : i32> to memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
+            linalg.fill ins(%c0_i32 : i32) outs(%subview_22 : memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>)
+            linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%alloc_0, %alloc : memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, 2 : i32>) outs(%subview_22 : memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>) {
+            ^bb0(%in: i32, %in_23: i32, %out: i32):
+              %3 = arith.muli %in, %in_23 : i32
+              %4 = arith.addi %out, %3 : i32
+              linalg.yield %4 : i32
+            }
+            scf.reduce 
+          }
+          scf.for %arg2 = %c1 to %c15 step %c1 {
+            %3 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%arg2]
+            %subview_16 = memref.subview %0[%arg0, %3] [128, 32] [1, 1] : memref<512x512xi32> to memref<128x32xi32, strided<[512, 1], offset: ?>>
+            %expand_shape_17 = memref.expand_shape %subview_16 [[0, 1], [2, 3]] output_shape [4, 32, 1, 32] : memref<128x32xi32, strided<[512, 1], offset: ?>> into memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+            %transpose_18 = memref.transpose %expand_shape_17 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+            air.dma_memcpy_nd (%alloc_2[] [] [], %transpose_18[] [] []) : (memref<4x1x32x32xi32, 1 : i32>, memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+            %subview_19 = memref.subview %1[%3, %arg1] [32, 128] [1, 1] : memref<512x512xi32> to memref<32x128xi32, strided<[512, 1], offset: ?>>
+            %expand_shape_20 = memref.expand_shape %subview_19 [[0, 1], [2, 3]] output_shape [1, 32, 4, 32] : memref<32x128xi32, strided<[512, 1], offset: ?>> into memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+            %transpose_21 = memref.transpose %expand_shape_20 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+            air.dma_memcpy_nd (%alloc_1[] [] [], %transpose_21[] [] []) : (memref<1x4x32x32xi32, 1 : i32>, memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+            scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c4, %c4) step (%c1, %c1) {
+              %subview_22 = memref.subview %alloc_2[%arg3, 0, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x1x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32>
+              %expand_shape_23 = memref.expand_shape %subview_22 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 8, 4, 4, 8] : memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32>
+              %transpose_24 = memref.transpose %expand_shape_23 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32> to memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>
+              air.dma_memcpy_nd (%alloc_0[] [] [], %transpose_24[] [] []) : (memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>)
+              %subview_25 = memref.subview %alloc_1[0, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<1x4x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32>
+              %expand_shape_26 = memref.expand_shape %subview_25 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 4, 8, 8, 4] : memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32>
+              %transpose_27 = memref.transpose %expand_shape_26 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32> to memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>
+              air.dma_memcpy_nd (%alloc[] [] [], %transpose_27[] [] []) : (memref<1x1x8x4x8x4xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>)
+              %subview_28 = memref.subview %alloc_3[%arg3, %arg4, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x8x8x4x4xi32, 2 : i32> to memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
+              linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%alloc_0, %alloc : memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, 2 : i32>) outs(%subview_28 : memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>) {
+              ^bb0(%in: i32, %in_29: i32, %out: i32):
+                %4 = arith.muli %in, %in_29 : i32
+                %5 = arith.addi %out, %4 : i32
+                linalg.yield %5 : i32
+              }
+              scf.reduce 
+            }
+          }
+          %subview_9 = memref.subview %0[%arg0, 480] [128, 32] [1, 1] : memref<512x512xi32> to memref<128x32xi32, strided<[512, 1], offset: ?>>
+          %expand_shape_10 = memref.expand_shape %subview_9 [[0, 1], [2, 3]] output_shape [4, 32, 1, 32] : memref<128x32xi32, strided<[512, 1], offset: ?>> into memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+          %transpose_11 = memref.transpose %expand_shape_10 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<4x32x1x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+          air.dma_memcpy_nd (%alloc_2[] [] [], %transpose_11[] [] []) : (memref<4x1x32x32xi32, 1 : i32>, memref<4x1x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+          %subview_12 = memref.subview %1[480, %arg1] [32, 128] [1, 1] : memref<512x512xi32> to memref<32x128xi32, strided<[512, 1], offset: ?>>
+          %expand_shape_13 = memref.expand_shape %subview_12 [[0, 1], [2, 3]] output_shape [1, 32, 4, 32] : memref<32x128xi32, strided<[512, 1], offset: ?>> into memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>>
+          %transpose_14 = memref.transpose %expand_shape_13 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<1x32x4x32xi32, strided<[16384, 512, 32, 1], offset: ?>> to memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>
+          air.dma_memcpy_nd (%alloc_1[] [] [], %transpose_14[] [] []) : (memref<1x4x32x32xi32, 1 : i32>, memref<1x4x32x32xi32, strided<[16384, 32, 512, 1], offset: ?>>)
+          scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c4, %c4) step (%c1, %c1) {
+            %subview_16 = memref.subview %alloc_2[%arg2, 0, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x1x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32>
+            %expand_shape_17 = memref.expand_shape %subview_16 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 8, 4, 4, 8] : memref<1x1x32x32xi32, strided<[1024, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32>
+            %transpose_18 = memref.transpose %expand_shape_17 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x8x4x4x8xi32, strided<[1024, 1024, 128, 32, 8, 1], offset: ?>, 1 : i32> to memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>
+            air.dma_memcpy_nd (%alloc_0[] [] [], %transpose_18[] [] []) : (memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x4x8x4x8xi32, strided<[1024, 1024, 8, 128, 32, 1], offset: ?>, 1 : i32>)
+            %subview_19 = memref.subview %alloc_1[0, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<1x4x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32>
+            %expand_shape_20 = memref.expand_shape %subview_19 [[0], [1], [2, 3], [4, 5]] output_shape [1, 1, 4, 8, 8, 4] : memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32> into memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32>
+            %transpose_21 = memref.transpose %expand_shape_20 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d2, d3, d5) : memref<1x1x4x8x8x4xi32, strided<[4096, 1024, 256, 32, 4, 1], offset: ?>, 1 : i32> to memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>
+            air.dma_memcpy_nd (%alloc[] [] [], %transpose_21[] [] []) : (memref<1x1x8x4x8x4xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 4, 256, 32, 1], offset: ?>, 1 : i32>)
+            %subview_22 = memref.subview %alloc_3[%arg2, %arg3, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x8x8x4x4xi32, 2 : i32> to memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
+            linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%alloc_0, %alloc : memref<1x1x4x8x4x8xi32, 2 : i32>, memref<1x1x8x4x8x4xi32, 2 : i32>) outs(%subview_22 : memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>) {
+            ^bb0(%in: i32, %in_25: i32, %out: i32):
+              %3 = arith.muli %in, %in_25 : i32
+              %4 = arith.addi %out, %3 : i32
+              linalg.yield %4 : i32
+            }
+            %subview_23 = memref.subview %alloc_4[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x4x32x32xi32, 1 : i32> to memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32>
+            %transpose_24 = memref.transpose %subview_22 (d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4, d2, d5) : memref<1x1x8x8x4x4xi32, strided<[4096, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32> to memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 16, 4, 128, 1], offset: ?>, 2 : i32>
+            air.dma_memcpy_nd (%subview_23[] [] [], %transpose_24[] [] []) : (memref<1x1x32x32xi32, strided<[4096, 1024, 32, 1], offset: ?>, 1 : i32>, memref<1x1x8x4x8x4xi32, strided<[4096, 1024, 16, 4, 128, 1], offset: ?>, 2 : i32>)
+            scf.reduce 
+          }
+          %transpose_15 = memref.transpose %alloc_4 (d0, d1, d2, d3) -> (d0, d2, d1, d3) : memref<4x4x32x32xi32, 1 : i32> to memref<4x32x4x32xi32, strided<[4096, 32, 1024, 1]>, 1 : i32>
+          air.dma_memcpy_nd (%subview[] [] [], %transpose_15[] [] []) : (memref<128x128xi32, strided<[512, 1], offset: ?>>, memref<4x32x4x32xi32, strided<[4096, 32, 1024, 1]>, 1 : i32>)
+          scf.reduce 
+        }
+        memref.dealloc %alloc_4 : memref<4x4x32x32xi32, 1 : i32>
+        memref.dealloc %alloc_3 : memref<4x4x8x8x4x4xi32, 2 : i32>
+        memref.dealloc %alloc_2 : memref<4x1x32x32xi32, 1 : i32>
+        memref.dealloc %alloc_1 : memref<1x4x32x32xi32, 1 : i32>
+        memref.dealloc %alloc_0 : memref<1x1x4x8x4x8xi32, 2 : i32>
+        memref.dealloc %alloc : memref<1x1x8x4x8x4xi32, 2 : i32>
+        return
+      }
+    }
+    """
+
+    air_module = Module.parse(air_tiled_ir_string)
+
+    ################################################
+    ## Binding scf.paralell to air hierarchies
+    ################################################
+
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "buffer-results-to-out-params",
+                "air-par-to-herd{depth=1}",
+                "air-par-to-launch{has-air-segment=true}",
+                "air-copy-to-dma",
+                "canonicalize",
+                "cse",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    ###############################################
+    # Extract event dependency and optimize schedule
+    ###############################################
+
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "air-dependency",
+                "air-dependency-schedule-opt",
+                "air-specialize-dma-broadcast",
+                "air-dma-to-channel",
+                "canonicalize",
+                "cse",
+                "air-dependency-canonicalize",
+                "canonicalize",
+                "cse",
+                "air-isolate-async-dma-loop-nests",
+                "canonicalize",
+                "cse",
+                "air-fuse-channels",
+                "canonicalize",
+                "cse",
+                ### Scaling to 4 AIE columns
+                "func.func(air-split-l2-memref)",
+                "air-isolate-async-dma-loop-nests",
+                ###
+                "canonicalize",
+                "cse",
+                "func.func(air-loop-fusion)",
+                "air-label-scf-for-to-ping-pong",
+                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "canonicalize",
+                "cse",
+                "air-specialize-channel-wrap-and-stride",
+                "canonicalize",
+                "cse",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    ################################################
+    ## Place herd to segment
+    ################################################
+
+    air_async_module = Module.parse(str(air_module))
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "func.func(air-collapse-herd{max-col-size=4})",
+                "canonicalize",
+                "cse",
+                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
+                "canonicalize",
+                "cse",
+                "func.func(air-renumber-dma)",
+                "func.func(convert-linalg-to-loops)",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    ################################################
+    ## MLIR-AIR to MLIR-AIE
+    ################################################
+
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "canonicalize",
+                "cse",
+                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
+                "canonicalize",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    ################################################
+    ## MLIR-AIR runtime lowering
+    ################################################
+
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "air-to-std",
+                "canonicalize",
+                "symbol-dce",
+                "func.func(affine-loop-opt{affine-opt-tile-sizes=2,2})",
+                "func.func(air-unroll-outer-affine-loops{depth=2})",
+                "affine-expand-index-ops",
+                "airrt-to-npu",
+                "canonicalize",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+    with open("aie.mlir", "w") as f:
+        f.write(str(air_module))

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
@@ -1,0 +1,9 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// REQUIRES: ryzen_ai, valid_xchess_license
+
+// RUN: %python %S/aie.py
+// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
@@ -1,0 +1,235 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#define M 512
+#define N 512
+#define K 512
+
+#define A_VOLUME M *K
+#define B_VOLUME N *K
+#define C_VOLUME M *N
+
+#define A_DATATYPE int32_t
+#define B_DATATYPE int32_t
+#define C_DATATYPE int32_t
+
+constexpr int A_SIZE = (A_VOLUME * sizeof(A_DATATYPE));
+constexpr int B_SIZE = (B_VOLUME * sizeof(B_DATATYPE));
+constexpr int C_SIZE = (C_VOLUME * sizeof(C_DATATYPE));
+constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+template <typename T>
+void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
+  for (size_t m1 = 0; m1 < M; m1++) {
+    for (size_t n1 = 0; n1 < N; n1++) {
+      size_t idx = m1 * N + n1;
+      r[idx] = (T)(0);
+      for (size_t k1 = 0; k1 < K; k1++) {
+        T _a = a[k1 + m1 * K];
+        T _b = b[n1 + k1 * N];
+        r[idx] += _a * _b;
+      }
+    }
+  }
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_a =
+      xrt::bo(device, A_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_b =
+      xrt::bo(device, B_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_c =
+      xrt::bo(device, C_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+  A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
+  std::vector<A_DATATYPE> AVec;
+  for (int i = 0; i < A_VOLUME; i++)
+    AVec.push_back(rand() % UINT16_MAX);
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
+  B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
+  std::vector<B_DATATYPE> BVec;
+  for (int i = 0; i < B_VOLUME; i++)
+    BVec.push_back(rand() % UINT16_MAX);
+  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
+  C_DATATYPE *bufC = bo_c.map<C_DATATYPE *>();
+  std::vector<C_DATATYPE> CVec;
+  for (int i = 0; i < C_VOLUME; i++)
+    CVec.push_back(0);
+  memcpy(bufC, CVec.data(), (CVec.size() * sizeof(C_DATATYPE)));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
+  run.wait();
+
+  bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  C_DATATYPE *bufOut = bo_c.map<C_DATATYPE *>();
+
+  int errors = 0;
+  int max_errors = 100;
+
+  std::vector<C_DATATYPE> output_ref0;
+  output_ref0 = CVec;
+  mm_out(AVec, BVec, output_ref0);
+
+  for (uint32_t i = 0; i < C_VOLUME; i++) {
+    if (bufOut[i] != output_ref0[i]) {
+      errors++;
+      if (errors < max_errors) {
+        std::cout << "\nerror, id " << i << " expected "
+                  << std::to_string(output_ref0[i]) << ", got"
+                  << std::to_string(bufOut[i]) << "\n";
+      }
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nerror count: " << errors << "\n\n";
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
Previously, when the wrap-and-stride canonicalizer deletes any dimension `i` in the lists, it only attempts to compose any non-zero `offsets[i]` to its next dimension `offsets[i+1]`. This PR attempts to relax this constraint.