### PR TITLE
AIRChannelFusion: Disable connecting time-multiplexed channels with async tokens

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4090,12 +4090,8 @@ private:
     remapAllParentLoopArgs(remap, a, b);
     OpBuilder builder(a);
     builder.setInsertionPoint(a->getBlock()->getTerminator());
-    auto new_b = cloneOpAndOperands(builder, remap, b);
+    cloneOpAndOperands(builder, remap, b);
     eraseParentLoopIfEmpty(*b);
-    auto async_b = dyn_cast<air::AsyncOpInterface>(new_b);
-    if (async_b.getAsyncToken())
-      async_b.addAsyncDependency(
-          dyn_cast<air::AsyncOpInterface>(a.getOperation()).getAsyncToken());
   }
   void mergeChannelOpsTemporally(air::ChannelInterface a,
                                  air::ChannelInterface b,


### PR DESCRIPTION
Previously, when multiple `air.channel.put/get` ops get fused to the same channel, an async token will be assigned. This is now disabled because the downstream `AIRIsolateAsyncDmaLoopNest` pass respects puts/gets sharing the same channel as being asynchrounously dependent (contention over shared data movement resource, channel).