### PR TITLE
Fixup a bug in `areAsyncDependent` method

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -604,10 +604,6 @@ bool areAsyncDependent(Operation *a, Operation *b) {
     return false;
   if (!token_b)
     return false;
-  if (dep_a.empty())
-    return false;
-  if (dep_b.empty())
-    return false;
   for (auto dep : dep_a)
     if (dep == token_b)
       return true;


### PR DESCRIPTION
When an async `air.channel.put/get` has empty dependency list, the channel-based dependency, arising from contention over data movement channels, is ignored.