### PR TITLE
When omitting ping-pong transformations, omit air-loop-fusion too

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -36,10 +36,10 @@ def get_experimental_passes(omit_pingpong=True):
         "air-dependency-canonicalize",
         "canonicalize",
         "cse",
-        "func.func(air-loop-fusion)",
     ]
     if not omit_pingpong:
         EXPERIMENTAL_PASSES += [
+            "func.func(air-loop-fusion)",
             "air-label-scf-for-to-ping-pong",
             "air-ping-pong-transform{keep-memref-dealloc=true}",
         ]


### PR DESCRIPTION
`air-loop-fusion` pass was meant to facilitate ping-pong transformations; performing this pass without ping-pong transformations could lead to generation of code patterns (allocs and deallocs fused into for loops) which can no longer be processed, specifically, by `air-isolate-async-dma-loop-nests`.