### PR TITLE
Surface errors from dma allocation in air-to-aie pass

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -72,9 +72,13 @@ struct allocation_info_t {
   int64_t tile_channel = -1;
   std::vector<int32_t> dma_id;
   std::vector<Operation *> memcpyOps;
+  bool valid();
+  AIE::TileOp getDmaTile();
   bool foundAlloc(air::ChannelOp channel_op);
   bool foundAlloc(int32_t col, int32_t row, air::MemcpyInterface memcpyOp);
   bool foundAlloc(int32_t col, int32_t row, int chan);
+  bool foundAlloc(AIE::DMAChannel channel);
+  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
   bool foundAlloc(int32_t col, int32_t row);
   bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
   bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
@@ -191,18 +195,20 @@ public:
                             air::allocation_info_t alloc, bool isMM2S);
 };
 
-void simpleDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
-                                ShimDMAAllocator &shim_dma_alloc,
-                                MemTileDMAAllocator &memtile_dma_alloc,
-                                TileDMAAllocator &tile_dma_alloc);
+LogicalResult
+simpleDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
+                           ShimDMAAllocator &shim_dma_alloc,
+                           MemTileDMAAllocator &memtile_dma_alloc,
+                           TileDMAAllocator &tile_dma_alloc);
 template <typename T> int foundInVector(T item, std::vector<T> vec);
 int getSCFForLoopDepth(Operation *o);
 bool groupingMemcpysByLoop(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 
-void groupedByLoopDMAChannelAllocation(
-    std::vector<MemcpyBundleAsFlow> &memcpy_flows,
-    ShimDMAAllocator &shim_dma_alloc, MemTileDMAAllocator &memtile_dma_alloc,
-    TileDMAAllocator &tile_dma_alloc);
+LogicalResult
+groupedByLoopDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
+                                  ShimDMAAllocator &shim_dma_alloc,
+                                  MemTileDMAAllocator &memtile_dma_alloc,
+                                  TileDMAAllocator &tile_dma_alloc);
 
 } // namespace air
 } // namespace xilinx


### PR DESCRIPTION
In #792 a new [error check was introduced](https://github.com/Xilinx/mlir-air/pull/792/files#diff-8d6afa88df8c805248a435c324ed1e306a9b7936f3ddf295bad6b349b1d4d199R630) which [triggers an error](https://github.com/Xilinx/mlir-air/actions/runs/12006641982/job/33465616032) in `test/airhost/40_air_8x4_2d_square`

The error message before this PR is fairly cryptic. Here it is from CI logs:
```
2024-11-25T09:27:30.6542054Z RUN: at line 11: /mlir-air/build_assert/bin/aircc.py -xchesscc -xbridge -row-offset=4 -col-offset=16 /mlir-air/test/airhost/40_air_8x4_2d_square/air.mlir -o /mlir-air/build_assert/test/airhost/40_air_8x4_2d_square/Output/air.a
2024-11-25T09:27:30.6545626Z + /mlir-air/build_assert/bin/aircc.py -xchesscc -xbridge -row-offset=4 -col-offset=16 /mlir-air/test/airhost/40_air_8x4_2d_square/air.mlir -o /mlir-air/build_assert/test/airhost/40_air_8x4_2d_square/Output/air.a
2024-11-25T09:27:30.6549210Z python3: /mlir-air/mlir-aie/mlir/src/python/MLIRPythonExtension.Core/IRModule.h:434: mlir::python::PyMlirContext::ErrorCapture::~ErrorCapture(): Assertion `errors.empty() && "unhandled captured errors"' failed.
2024-11-25T09:27:30.6553447Z /mlir-air/build_assert/test/airhost/40_air_8x4_2d_square/Output/run.lit.script: line 3: 18249 Aborted                 (core dumped) /mlir-air/build_assert/bin/aircc.py -xchesscc -xbridge -row-offset=4 -col-offset=16 /mlir-air/test/airhost/40_air_8x4_2d_square/air.mlir -o /mlir-air/build_assert/test/airhost/40_air_8x4_2d_square/Output/air.a
2024-11-25T09:27:30.6555872Z 
```
The assert happens because there was an `emitOpError` call but the pass carried on as if there was no failure and returned success.

After this PR I can see the error message from the point of failure because the pass fails correctly:
```
Traceback (most recent call last):
  File "/work/acdc/build/install/bin/aircc.py", line 13, in <module>
    main()
  File "/work/acdc/build/install/python/air/compiler/aircc/main.py", line 492, in main
    run(module)
  File "/work/acdc/build/install/python/air/compiler/aircc/main.py", line 423, in run
    run_passes(
  File "/work/acdc/build/install/python/air/compiler/aircc/main.py", line 121, in run_passes
    PassManager.parse(pass_pipeline).run(mlir_module.operation)
air._mlir_libs._site_initialize.<locals>.MLIRError: Failure while executing pass pipeline:
error: "-":16:11: 'air.dma_memcpy_nd' op failed to map to shim dma channels: out of channels.
 note: "-":16:11: see current operation: "air.dma_memcpy_nd"(%107, %152, %152, %151, %151, %151, %152, %153, %152, %149, %151, %151, %150, %152) <{operandSegmentSizes = array<i32: 0, 1, 2, 2, 2, 1, 2, 2, 2>}> {id = 1 : i32} : (memref<8x8xi32, 2>, index, index, index, index, index, index, memref<256x16xi32>, index, index, index, index, index, index) -> ()
