### PR TITLE
AIRToAIE: Fixup a bug in the error handling at shim channel allocator

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -620,6 +620,7 @@ allocation_info_t ShimDMAAllocator::allocNewDmaChannel(
   }
   int dma_col = dma_columns[colIdx];
   int dma_channel = 0;
+  int colTripCount = 0;
   while (any_of(allocs->begin(), allocs->end(), [&](allocation_info_t &a) {
     return a.dma_channel == AIE::DMAChannel{dir, dma_channel} &&
            a.dma_tile.colIndex() == dma_col && a.dma_tile.rowIndex() == 0;
@@ -627,8 +628,9 @@ allocation_info_t ShimDMAAllocator::allocNewDmaChannel(
     dma_channel++;
     if (dma_channel >= shim_dma_channels) {
       dma_channel = 0;
-      dma_col = dma_columns[colIdx++];
-      if (colIdx == (int)dma_columns.size()) {
+      dma_col = dma_columns[colIdx++ % dma_columns.size()];
+      colTripCount++;
+      if (colTripCount > (int)dma_columns.size()) {
         memcpyOp->emitOpError(
             "failed to map to shim dma channels: out of channels.");
         break;


### PR DESCRIPTION
- The emitOpError was meant to inform the user that the AIRToAIE pass has failed to allocate a shim dma channel due to not able to identify a candidate channel slot.
- There is however a bug where it gives a false failure when mapping to the last legal shim channel (`==` vs `>`).
- This bug will also fail to utilize all legal shim channel mappings when `colAllocConstraint == "same_column"` mode, where the initial shim tile column may not be the 1st column.

Should fix the error which was surfaced in https://github.com/Xilinx/mlir-air/pull/804.