### PR TITLE
aircc: switch to one-shot-bufferize

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -150,9 +150,7 @@ def lower_airrt_to_airhost(air_to_aie_module, air_placed_module, air_mlir_filena
     )
 
     aie_ctrl = opts.tmpdir + "/aie_ctrl." + air_mlir_filename
-    pass_pipeline = ",".join(
-        ["airrt-to-llvm", "one-shot-bufferize"]
-    )
+    pass_pipeline = ",".join(["airrt-to-llvm", "one-shot-bufferize"])
     run_passes("builtin.module(" + pass_pipeline + ")", airrt_module, opts, aie_ctrl)
 
     aie_ctrl_refback = opts.tmpdir + "/refback." + air_mlir_filename

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -151,7 +151,7 @@ def lower_airrt_to_airhost(air_to_aie_module, air_placed_module, air_mlir_filena
 
     aie_ctrl = opts.tmpdir + "/aie_ctrl." + air_mlir_filename
     pass_pipeline = ",".join(
-        ["airrt-to-llvm", "func-bufferize", "func.func(finalizing-bufferize)"]
+        ["airrt-to-llvm", "one-shot-bufferize"]
     )
     run_passes("builtin.module(" + pass_pipeline + ")", airrt_module, opts, aie_ctrl)
 


### PR DESCRIPTION
I missed this in last llvm update because it's not tested in CI until push to main.
