### PR TITLE
AIRToAIE: Lowering to BD task queue for complex loop nests around `air.channel.put/get` ops

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -47,7 +47,10 @@ bool areIdenticalVectors(std::vector<unsigned> &a, std::vector<unsigned> &b);
 int64_t get1DOffset(SmallVector<Value> memcpy_offsets,
                     SmallVector<Value> memcpy_strides);
 
-int getRepeatCount(Operation *memcpy_op);
+// Given a vector of memcpy operations, return a map of their repeat counts,
+// relative to a common ancestor region.
+llvm::MapVector<int, llvm::SetVector<Operation *>>
+getRepeatCounts(std::vector<Operation *> memcpy_ops);
 
 std::vector<AIE::BDDimLayoutAttr>
 getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
@@ -200,7 +203,8 @@ simpleDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
                            ShimDMAAllocator &shim_dma_alloc,
                            MemTileDMAAllocator &memtile_dma_alloc,
                            TileDMAAllocator &tile_dma_alloc);
-template <typename T> int foundInVector(T item, std::vector<T> vec);
+template <typename T>
+int foundInVector(T item, std::vector<T> vec);
 int getSCFForLoopDepth(Operation *o);
 bool groupingMemcpysByLoop(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2595,66 +2595,98 @@ public:
     Block *channel_head = nullptr;
     Block *end_bb = nullptr;
 
-    for (auto &p : dma_memcpys) {
-      AIE::DMAChannelDir dir = p.first.first;
-      int chan = p.first.second;
-      Block *start_bb = new Block();
-      mem.getBody().push_back(start_bb);
+    for (auto &[dma_chan, memcpy_ops] : dma_memcpys) {
+      AIE::DMAChannelDir dir = dma_chan.first;
+      int chan = dma_chan.second;
 
-      Block *first_bd = new Block();
-      mem.getBody().push_back(first_bd);
-      Block *next_bd = nullptr;
-      for (size_t i = 0; i < p.second.size(); i++) {
-        auto memcpyOp = cast<air::MemcpyInterface>(p.second[i]);
-        Block *bd;
-        if (i == 0)
-          bd = first_bd;
-        else
-          bd = next_bd;
-        auto b = OpBuilder::atBlockEnd(bd);
-        if (i == p.second.size() - 1) {
-          b.create<AIE::NextBDOp>(loc, first_bd);
-        } else {
-          next_bd = new Block();
-          mem.getBody().push_back(next_bd);
-          b.create<AIE::NextBDOp>(loc, next_bd);
-        }
-        bufferOpTy bufferOp = dmaAlloc.getBuffer(BufferId, x, y, memcpyOp);
-        auto locks =
-            dmaAlloc.getLockForDMA(memcpyOp, x, y, bufferOp.getOperation());
-        generateDmaBd<bufferOpTy>(loc, dir, locks, x, y, targetModel, bd,
-                                  memcpyOp, bufferOp, chan);
-      }
+      // Map key: repeat counts. Map value: vector of memcpy operations sharing
+      // the same repeat count.
+      llvm::MapVector<int, llvm::SetVector<Operation *>> repeat_counts =
+          air::getRepeatCounts(memcpy_ops);
 
-      int repeat_count = 1;
-      if (p.second.size() == 1)
-        repeat_count = air::getRepeatCount(p.second[0]);
+      // Note: we designate each unique repeat value in repeat_counts map with a
+      // new BD task. If there is only one repeat value for all memcpy ops
+      // associated to the channel, then there is no need to do repeat count; we
+      // generate BDs in infinite loop mode instead.
+      bool infiniteBDLoopMode = repeat_counts.size() == 1;
 
-      if (!channel_head) {
-        channel_head = start_bb;
+      unsigned taskId = 0;
+      // For every BD task
+      for (auto &[rep, task_ops] : repeat_counts) {
+        // The block containing aie.dma_start
+        Block *start_bb = new Block();
+        mem.getBody().push_back(start_bb);
+
+        // The last block containing aie.end
         end_bb = new Block();
         mem.getBody().push_back(end_bb);
-        auto b = OpBuilder::atBlockBegin(channel_head);
-        b.create<AIE::DMAStartOp>(loc, dir, chan, repeat_count, first_bd,
-                                  end_bb);
-        b.setInsertionPointToEnd(end_bb);
-        b.create<AIE::EndOp>(loc);
-      } else {
-        auto b = OpBuilder::atBlockBegin(start_bb);
-        b.create<AIE::DMAStartOp>(
-            loc, dir, chan, repeat_count, first_bd,
-            channel_head->getTerminator()->getSuccessor(1));
-        channel_head->getTerminator()->setSuccessor(start_bb, 1);
+        auto end_bb_builder = OpBuilder::atBlockBegin(end_bb);
+        end_bb_builder.setInsertionPointToEnd(end_bb);
+        end_bb_builder.create<AIE::EndOp>(loc);
+
+        // First bd in task
+        Block *first_bd = new Block();
+        first_bd->insertBefore(end_bb);
+        Block *next_bd = nullptr;
+        for (size_t i = 0; i < task_ops.size(); i++) {
+          auto memcpyOp = cast<air::MemcpyInterface>(task_ops[i]);
+          Block *bd;
+          if (i == 0)
+            bd = first_bd;
+          else
+            bd = next_bd;
+          auto b = OpBuilder::atBlockEnd(bd);
+          if (i == task_ops.size() - 1) {
+            if (infiniteBDLoopMode)
+              b.create<AIE::NextBDOp>(loc, first_bd);
+            else
+              b.create<AIE::NextBDOp>(loc, end_bb);
+          } else {
+            next_bd = new Block();
+            next_bd->insertBefore(end_bb);
+            b.create<AIE::NextBDOp>(loc, next_bd);
+          }
+          bufferOpTy bufferOp = dmaAlloc.getBuffer(BufferId, x, y, memcpyOp);
+          auto locks =
+              dmaAlloc.getLockForDMA(memcpyOp, x, y, bufferOp.getOperation());
+          auto newBD = generateDmaBd<bufferOpTy>(
+              loc, dir, locks, x, y, targetModel, bd, memcpyOp, bufferOp, chan);
+          // Attribute task_id is necessary to ensure that BDs do not get shared
+          // across tasks, otherwise MLIR may fold BDs and cause BD sharing
+          // across tasks.
+          // TODO: check if mlir-aie enables BD sharing across tasks. If so,
+          // then this attribute is no longer necessary.
+          newBD->setAttr(
+              "task_id",
+              IntegerAttr::get(IntegerType::get(b.getContext(), 32), taskId));
+        }
+
+        AIE::DMAStartOp startOp = nullptr;
+        if (infiniteBDLoopMode)
+          rep = 0;
+        if (!channel_head) {
+          channel_head = start_bb;
+          auto b = OpBuilder::atBlockBegin(channel_head);
+          startOp =
+              b.create<AIE::DMAStartOp>(loc, dir, chan, rep, first_bd, end_bb);
+        } else {
+          auto b = OpBuilder::atBlockBegin(start_bb);
+          startOp = b.create<AIE::DMAStartOp>(
+              loc, dir, chan, rep, first_bd,
+              channel_head->getTerminator()->getSuccessor(1));
+          channel_head->getTerminator()->setSuccessor(start_bb, 1);
+        }
+        taskId++;
       }
     }
   }
 
   template <typename bufferOpTy>
-  void generateDmaBd(mlir::Location loc, AIE::DMAChannelDir dir,
-                     std::pair<AIE::LockOp, AIE::LockOp> locks, int x, int y,
-                     const AIE::AIETargetModel &targetModel, Block *bd,
-                     air::MemcpyInterface memcpyOp, bufferOpTy bufferOp,
-                     int chan) {
+  AIE::DMABDOp generateDmaBd(mlir::Location loc, AIE::DMAChannelDir dir,
+                             std::pair<AIE::LockOp, AIE::LockOp> locks, int x,
+                             int y, const AIE::AIETargetModel &targetModel,
+                             Block *bd, air::MemcpyInterface memcpyOp,
+                             bufferOpTy bufferOp, int chan) {
     bool UsesSemaphoreLocks =
         targetModel.hasProperty(AIE::AIETargetModel::UsesSemaphoreLocks);
     bool isMM2S = (dir == AIE::DMAChannelDir::MM2S);
@@ -2741,6 +2773,7 @@ public:
       aieDmaBdOp->setAttr("packet", pktInfoAttr);
     b.create<AIE::UseLockOp>(loc, relLockOp, AIE::LockAction::Release,
                              lockRelValue);
+    return aieDmaBdOp;
   }
 
   AIE::ShimDMAOp getShimDMAOp(AIE::TileOp tile) {

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -189,39 +189,76 @@ air::getRepeatCounts(std::vector<Operation *> memcpy_ops) {
 
   // Check if all of memcpy_ops only map to one same dma bd. If true, then
   // return that there is only one single repeat count, i.e. a single bd task.
-  bool areAllIdenticalBDs = llvm::all_of(memcpy_ops, [&](Operation *op) {
-    if (auto chanOpFront = dyn_cast<air::ChannelInterface>(memcpy_ops[0])) {
-      // Check if all air.channel_interface ops map to equivalent BDs.
-      auto chanOp = dyn_cast<air::ChannelInterface>(op);
-      if (!chanOp)
-        return false;
-      if (chanOp.getMemref() != chanOpFront.getMemref())
-        return false;
-      if (chanOpFront.getOffsets().size() != chanOp.getOffsets().size() ||
-          chanOpFront.getSizes().size() != chanOp.getSizes().size() ||
-          chanOpFront.getStrides().size() != chanOp.getStrides().size())
-        return false;
-      auto zipped_operands = llvm::zip_equal(
-          llvm::concat<Value>(chanOpFront.getOffsets(), chanOpFront.getSizes(),
-                              chanOpFront.getStrides()),
-          llvm::concat<Value>(chanOp.getOffsets(), chanOp.getSizes(),
-                              chanOp.getStrides()));
-      bool offsetsAllEquivalent =
-          llvm::all_of(zipped_operands, [](std::tuple<Value, Value> pair) {
-            return isEqualConstantIntOrValue(std::get<0>(pair),
-                                             std::get<1>(pair));
-          });
-      return offsetsAllEquivalent;
-    } else {
-      // Check if all air.dma_memcpy_nd ops are equivalent.
-      return OperationEquivalence::isEquivalentTo(
-          memcpy_ops.front(), op, OperationEquivalence::IgnoreLocations);
+  auto chansMappedToEquivalentBDs = [](air::ChannelInterface chanA,
+                                       air::ChannelInterface chanB) {
+    if (chanA.getMemref() != chanB.getMemref())
+      return false;
+    if (chanA.getOffsets().size() != chanB.getOffsets().size() ||
+        chanA.getSizes().size() != chanB.getSizes().size() ||
+        chanA.getStrides().size() != chanB.getStrides().size())
+      return false;
+    auto zipped_operands = llvm::zip_equal(
+        llvm::concat<Value>(chanA.getOffsets(), chanA.getSizes(),
+                            chanA.getStrides()),
+        llvm::concat<Value>(chanB.getOffsets(), chanB.getSizes(),
+                            chanB.getStrides()));
+    bool wrapsAndStridesAllEquivalent =
+        llvm::all_of(zipped_operands, [](std::tuple<Value, Value> pair) {
+          return isEqualConstantIntOrValue(std::get<0>(pair),
+                                           std::get<1>(pair));
+        });
+    return wrapsAndStridesAllEquivalent;
+  };
+  auto dmasMappedToEquivalentBDs = [](air::DmaMemcpyNdOp dmaA,
+                                      air::DmaMemcpyNdOp dmaB) {
+    return OperationEquivalence::isEquivalentTo(
+        dmaA, dmaB, OperationEquivalence::IgnoreLocations);
+  };
+  auto memcpyIMappedToEquivalentBDs =
+      [chansMappedToEquivalentBDs, dmasMappedToEquivalentBDs](Operation *opA,
+                                                              Operation *opB) {
+        if (auto chanA = dyn_cast<air::ChannelInterface>(opA))
+          if (auto chanB = dyn_cast<air::ChannelInterface>(opB))
+            return chansMappedToEquivalentBDs(chanA, chanB);
+        if (auto dmaA = dyn_cast<air::DmaMemcpyNdOp>(opA))
+          if (auto dmaB = dyn_cast<air::DmaMemcpyNdOp>(opB))
+            return dmasMappedToEquivalentBDs(dmaA, dmaB);
+        return false; // Unknown or different air::MemcpyInterface op types.
+      };
+
+  // Canonicalize a chain of memcpy ops as candidates to map to dma bds, by
+  // removing repetitive patterns.
+  auto getUniqueBDPattern = [memcpyIMappedToEquivalentBDs](
+                                llvm::SetVector<Operation *> memcpyIOps) {
+    // Get a vector of unique BDs.
+    llvm::SetVector<Operation *> uniqueBDPattern;
+    auto opIt = memcpyIOps.begin();
+    while (opIt != memcpyIOps.end() &&
+           llvm::none_of(uniqueBDPattern,
+                         [opIt, memcpyIMappedToEquivalentBDs](Operation *op1) {
+                           return memcpyIMappedToEquivalentBDs(*opIt, op1);
+                         })) {
+      uniqueBDPattern.insert(*opIt);
+      opIt++;
     }
-  });
-  if (areAllIdenticalBDs) {
-    repeatCounts[0] = memcpyIOps;
-    return repeatCounts;
-  }
+
+    unsigned idx = 0;
+    while (opIt != memcpyIOps.end()) {
+      // BD repetition found. Check if repeating pattern.
+      if (!memcpyIMappedToEquivalentBDs(*opIt, uniqueBDPattern[idx]))
+        return llvm::SetVector<Operation *>{}; // Chain isn't repeating. Return
+                                               // an empty vector.
+      opIt++;
+      idx = (++idx) % uniqueBDPattern.size();
+    }
+
+    // Repeating BD chain successfully detected.
+    return uniqueBDPattern;
+  };
+
+  auto uniqueMemcpyIPattern = getUniqueBDPattern(memcpyIOps);
+  if (!uniqueMemcpyIPattern.empty())
+    memcpyIOps = uniqueMemcpyIPattern;
 
   // Get the deepest region which is ancestor to all memcpyIOps.
   Region *commonRegion = memcpyIOps.front()->getParentRegion();

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -177,24 +177,46 @@ int64_t air::get1DOffset(SmallVector<Value> memcpy_offsets,
   return one_d_offset;
 }
 
-// Get the repeat_count value from an air::ChannelPut/GetOp.
-int air::getRepeatCount(Operation *memcpy_op) {
-  auto chan_op = dyn_cast<air::ChannelInterface>(memcpy_op);
-  if (!chan_op)
-    return 1;
-  if (chan_op.getStrides().empty() || chan_op.getSizes().empty())
-    return 1;
-  if (getConstantIntValue(chan_op.getStrides()[0]) &&
-      getConstantIntValue(chan_op.getSizes()[0])) {
-    auto const_highest_stride = getConstantIntValue(chan_op.getStrides()[0]);
-    auto const_highest_size = getConstantIntValue(chan_op.getSizes()[0]);
-    auto const_highest_offset = getConstantIntValue(chan_op.getOffsets()[0]);
-    if (*const_highest_stride == 0 && !const_highest_offset) {
-      // Highest dimension data access pattern is repeat.
-      return *const_highest_size;
-    }
+// Given a vector of memcpy operations, return a map of their repeat counts,
+// relative to a common ancestor region.
+llvm::MapVector<int, llvm::SetVector<Operation *>>
+air::getRepeatCounts(std::vector<Operation *> memcpy_ops) {
+  llvm::MapVector<int, llvm::SetVector<Operation *>> repeatCounts;
+  llvm::SetVector<Operation *> memcpyIOps;
+  for (auto o : memcpy_ops) {
+    memcpyIOps.insert(o);
   }
-  return 1;
+
+  // Get the deepest region which is ancestor to all memcpyIOps.
+  Region *commonRegion = memcpyIOps.front()->getParentRegion();
+  while (!llvm::all_of(memcpyIOps, [commonRegion](Operation *o) {
+    return commonRegion->isAncestor(o->getParentRegion());
+  })) {
+    commonRegion = commonRegion->getParentRegion();
+    if (!commonRegion)
+      return repeatCounts;
+  }
+
+  // Get each memcpy op's repeat count, relative to the common region.
+  for (auto o : memcpyIOps) {
+    int tripCount = 1;
+    Region *currRegion = o->getParentRegion();
+    while (commonRegion->isAncestor(currRegion)) {
+      Operation *parent = currRegion->getParentOp();
+      currRegion = currRegion->getParentRegion();
+      auto affineFor = dyn_cast<affine::AffineForOp>(parent);
+      auto scfFor = dyn_cast<scf::ForOp>(parent);
+      if (affineFor && affineFor.hasConstantBounds()) {
+        tripCount *= *air::getStaticAffineForTripCountAsInt(affineFor);
+      } else if (scfFor && air::getStaticScfForTripCountAsInt(scfFor)) {
+        tripCount *= *air::getStaticScfForTripCountAsInt(scfFor);
+      }
+    }
+    // In English, repeat count is trip count minus one.
+    repeatCounts[tripCount - 1].insert(o);
+  }
+
+  return repeatCounts;
 }
 
 std::vector<AIE::BDDimLayoutAttr>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
@@ -19,7 +19,7 @@
 // CHECK:         %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<32x32xbf16, 2>
 
 // CHECK:    aie.mem(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_7]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -36,7 +36,7 @@
 // CHECK:         }
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 2>, 0, 1024)

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -335,15 +335,13 @@ func.func @core_to_core_ping_pong() {
 // CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
-// CHECK:         ^bb2:  // 3 preds: ^bb1, ^bb3, ^bb4
-// CHECK:           aie.end
-// CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 3)
-// CHECK:         ^bb4:  // pred: ^bb3
+// CHECK:         ^bb2:  // pred: ^bb1
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 1 : i32}
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:           aie.next_bd ^bb2
+// CHECK:           aie.next_bd ^bb1
+// CHECK:         ^bb3:  // pred: ^bb0
+// CHECK:           aie.end
 // CHECK:         }
 
 // CHECK:    aie.core(%[[VAL_1]])  {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -20,7 +20,7 @@
 // CHECK:         %[[VAL_10:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<32x32xbf16, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_9]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -46,7 +46,7 @@
 // CHECK:         aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 
 // CHECK:    aie.memtile_dma(%[[VAL_0]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 1>, 0, 1024)
@@ -109,7 +109,7 @@ func.func @multi_memcpys_over_time() {
 // CHECK:         %[[VAL_14:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<32x32xbf16, 2>
 
 // CHECK:    aie.mem(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -133,7 +133,7 @@ func.func @multi_memcpys_over_time() {
 // CHECK:         }
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -213,7 +213,7 @@ func.func @core_to_core_ping_pong() {
 // CHECK:         %[[VAL_14:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<32x32xbf16, 2>
 
 // CHECK:    aie.mem(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -237,7 +237,7 @@ func.func @core_to_core_ping_pong() {
 // CHECK:         }
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2>, 0, 1024)
@@ -329,19 +329,21 @@ func.func @core_to_core_ping_pong() {
 // CHECK:         %[[VAL_12:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<1x1x4x8x4x8xi32, 2 : i32>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
-// CHECK:         ^bb2:
-// CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:           aie.next_bd ^bb1
-// CHECK:         ^bb3:
+// CHECK:         ^bb2:  // 3 preds: ^bb1, ^bb3, ^bb4
 // CHECK:           aie.end
+// CHECK:         ^bb3:
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 3)
+// CHECK:         ^bb4:  // pred: ^bb3
+// CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 1 : i32}
+// CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:           aie.next_bd ^bb2
 // CHECK:         }
 
 // CHECK:    aie.core(%[[VAL_1]])  {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -329,18 +329,13 @@ func.func @core_to_core_ping_pong() {
 // CHECK:         %[[VAL_12:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<1x1x4x8x4x8xi32, 2 : i32>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:           aie.next_bd ^bb2
-// CHECK:         ^bb2:  // pred: ^bb1
-// CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
-// CHECK:           aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
-// CHECK:         ^bb3:  // pred: ^bb0
+// CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           aie.end
 // CHECK:         }
 

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:         %[[VAL_13:.*]] = aie.buffer(%[[VAL_12]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_12]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_14]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2>, 0, 1024)
@@ -59,7 +59,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_16:.*]] = aie.buffer(%[[VAL_12]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_12]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_14]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2>, 0, 1024)
@@ -68,7 +68,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_15]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_16]] : memref<512xi32, 2>, 0, 512)
@@ -117,7 +117,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
@@ -126,7 +126,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
@@ -178,7 +178,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
@@ -187,7 +187,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
@@ -240,7 +240,7 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
@@ -249,7 +249,7 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
@@ -392,7 +392,7 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_0]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb6, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb6)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
@@ -401,7 +401,7 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
@@ -413,7 +413,7 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb6:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb7, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb7, ^bb3)
 // CHECK:         ^bb7:
 // CHECK:           aie.use_lock(%[[VAL_5]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
@@ -508,7 +508,7 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {{{.*}}} : memref<16x8xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_0]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_4]] : memref<16x8xi32, 2>, 0, 128)
@@ -517,7 +517,7 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_5]] : memref<16x8xi32, 2>, 0, 128)

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -17,7 +17,7 @@
 // CHECK:  %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32}
 // CHECK:  %[[VAL_7:.*]] = aie.buffer(%[[VAL_1]]) {{.*}} : memref<1024xi32, 2>
 // CHECK:  aie.mem(%[[VAL_1]]) {
-// CHECK:    aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:    aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:    aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
@@ -32,7 +32,7 @@
 // CHECK:    aie.end
 // CHECK:  aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:  aie.shim_dma(%[[VAL_2]]) {
-// CHECK:    aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:    aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:    aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
@@ -73,7 +73,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: %[[VAL_12:.*]] = aie.buffer(%[[VAL_2]]) {{.*}} : memref<1024xi32, 2>
 // CHECK: %[[VAL_13:.*]] = aie.buffer(%[[VAL_2]]) {{.*}} : memref<512xi32, 2>
 // CHECK: aie.mem(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
@@ -82,7 +82,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
@@ -98,7 +98,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: aie.flow(%[[VAL_3]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK: aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_3]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
@@ -107,7 +107,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
@@ -151,7 +151,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_12:.*]] = aie.buffer(%[[VAL_7]]) {{{.*}}} : memref<1024xi32, 2>
 // CHECK:         %[[VAL_13:.*]] = aie.buffer(%[[VAL_7]]) {{{.*}}} : memref<512xi32, 2>
 // CHECK:    aie.mem(%[[VAL_7]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
@@ -160,7 +160,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
@@ -178,7 +178,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_7]], DMA : 0)
 // CHECK:         aie.flow(%[[VAL_7]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
@@ -187,7 +187,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
@@ -243,7 +243,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_23:.*]] = aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_3]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
@@ -252,7 +252,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
@@ -273,7 +273,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_3]], DMA : 0, %[[VAL_2]], DMA : 1)
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 1, %[[VAL_4]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_4]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
@@ -282,7 +282,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
@@ -291,7 +291,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: }
 
 // CHECK: aie.memtile_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
@@ -300,21 +300,21 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
@@ -17,7 +17,7 @@
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_5]] : memref<1024xi32, 2>, 0, 1024)
@@ -32,7 +32,7 @@
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_1]], DMA : 0)
 
 // CHECK:    aie.shim_dma(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
@@ -71,7 +71,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
@@ -80,7 +80,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_6]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
@@ -100,7 +100,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_3]], DMA : 1, %[[VAL_2]], DMA : 1)
 
 // CHECK:    aie.shim_dma(%[[VAL_3]])  {
-// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
@@ -109,7 +109,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
@@ -151,7 +151,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_9:.*]] = aie.buffer(%[[VAL_5]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_5]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_6]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
@@ -160,7 +160,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_7]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
@@ -180,7 +180,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_5]], DMA : 0, %[[VAL_2]], DMA : 0)
 
 // CHECK:    aie.shim_dma(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
 // CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
@@ -189,7 +189,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -15,7 +15,7 @@
 // CHECK:  %[[VAL_3:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32}
 // CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {{.*}} : memref<1024xi32, 2>
 // CHECK:  %[[VAL_5:.*]] = aie.mem(%[[VAL_0]]) {
-// CHECK:    %[[VAL_6:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:    %[[VAL_6:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
 // CHECK:    aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
@@ -61,7 +61,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {{.*}} : memref<1024xi32, 2>
 // CHECK: %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {{.*}} : memref<512xi32, 2>
 // CHECK: %[[VAL_8:.*]] = aie.mem(%[[VAL_0]]) {
-// CHECK:   %[[VAL_9:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   %[[VAL_9:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
@@ -70,7 +70,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   %[[VAL_10:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   %[[VAL_10:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
@@ -126,7 +126,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_7:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
@@ -135,7 +135,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
@@ -204,7 +204,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_23:.*]] = aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_3]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
@@ -213,7 +213,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
@@ -235,7 +235,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 1, %[[VAL_4]], DMA : 0)
 
 // CHECK: aie.memtile_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
@@ -244,21 +244,21 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
@@ -468,21 +468,21 @@ func.func @func6(%arg5 : memref<8x8xi32>) {
 // Multi-dimensional memref copy to wraps and strides
 // CHECK: aie.device(npu1_4col)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
 // CHECK:   aie.use_lock({{.*}}, Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:  // pred: ^bb5
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd({{.*}} : memref<8x16xi32, 1>, 0, 16, [<size = 4, stride = 16>, <size = 4, stride = 1>])
 // CHECK:   aie.use_lock({{.*}}, Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:  // pred: ^bb0
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK: ^bb6:  // 2 preds: ^bb5, ^bb6
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
@@ -524,7 +524,7 @@ func.func @func7(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // Multi-dimensional memref copy to wraps and strides, with offsets having more dims than memref type.
 // CHECK: aie.device(npu1_4col)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd({{.*}} : memref<64x256xi32, 1>, 8192, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
@@ -561,15 +561,15 @@ func.func @func8(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // 1D scf.parallel iteration space support.
 // CHECK: aie.device(npu1_4col)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 0, 32)
-// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 32, 32)
 // CHECK: @func9
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -623,15 +623,15 @@ func.func @func9(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // Tile / memtile DMA repeat count support.
 // CHECK: aie.device(npu1_4col)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2>, 0, 8192)
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2>, 0, 8192)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1>, 0, 8192)
-// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1>, 0, 8192)
 // CHECK: @func10
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -685,15 +685,15 @@ func.func @func10(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // Bf16 datatype support.
 // CHECK: aie.device(npu1_4col)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2>, 0, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2>, 0, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:   memref<32x256xbf16, 1>, 0, 8192)
-// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK:   memref<32x256xbf16, 1>, 0, 8192)
 // CHECK: @func11
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -958,7 +958,7 @@ module {
 // CHECK: %[[tile_2_1:.*]] = aie.tile(0, 1)
 // CHECK: %[[tile_2_3:.*]] = aie.tile(0, 2)
 // CHECK:  %[[VAL_0:.*]] = aie.mem(%[[tile_2_3]]) {
-// CHECK:    %[[VAL_1:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 1)
+// CHECK:    %[[VAL_1:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%{{.*}}, AcquireGreaterEqual, 1)
 // CHECK:    aie.dma_bd(%{{.*}} : memref<1x1x16x16x4x4xf32, 2 : i32>, 0, 4096, [<size = 64, stride = 4>, <size = 16, stride = 256>, <size = 4, stride = 1>])
@@ -1111,6 +1111,60 @@ func.func @func15(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
     air.herd tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) attributes { sym_name="herd4"} {
       %buf0 = memref.alloc() : memref<1024xi32, 2>
       memref.dealloc %buf0 : memref<1024xi32, 2>
+    }
+  }
+  return
+}
+
+// -----
+
+// Lowering complex loop structures around channel.puts/gets into BD task repeat counts (aie.mem).
+//
+// CHECK:      aie.mem
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK-NEXT: ^bb1:
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 0 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: aie.end
+// CHECK-NEXT: ^bb3:
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 7)
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 1 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK:      @func16
+
+air.channel @channel_0 [1, 1]
+air.channel @channel_1 [1, 1]
+func.func @func16(%arg0 : memref<5xi32>, %arg1 : memref<96xi32>, %arg2 : memref<9xi32>, %ub : index) -> () {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c12 = arith.constant 12 : index
+  air.channel.put @channel_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<5xi32>)
+  scf.for %arg3 = %c0 to %c8 step %c1 {
+    air.channel.put @channel_0[] (%arg1[] [] []) {id = 2 : i32} : (memref<96xi32>)
+  }
+  air.segment @segment0 args (%ub_seg=%ub) : index {
+    %c0_0 = arith.constant 0 : index
+    %c1_0 = arith.constant 1 : index
+    %c8_0 = arith.constant 8 : index
+    %c12_0 = arith.constant 12 : index
+    %herd_cols = arith.constant 1 : index
+    %herd_rows = arith.constant 1 : index
+    %tok_5 = air.herd async tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args (%ub_herd=%ub_seg) : index attributes { sym_name="herd4"} {
+      %c0_1 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %c8_1 = arith.constant 8 : index
+      %c12_1 = arith.constant 12 : index
+      %buf0 = memref.alloc() : memref<5xi32, 2>
+      %tok_6 = air.channel.get async @channel_0[] (%buf0[] [] []) {id = 7 : i32} : (memref<5xi32, 2>)
+      %tok_7 = scf.for %arg5 = %c0_1 to %c8_1 step %c1_1 iter_args(%arg14 = %tok_6) -> (!air.async.token) {
+        %buf1 = memref.alloc() : memref<96xi32, 2>
+        %tok_5 = air.channel.get async [%arg14] @channel_0[] (%buf1[] [] []) {id = 8 : i32} : (memref<96xi32, 2>)
+        memref.dealloc %buf1 : memref<96xi32, 2>
+        scf.yield %tok_5 : !air.async.token
+      }
+      memref.dealloc %buf0 : memref<5xi32, 2>
     }
   }
   return

--- a/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
@@ -24,7 +24,7 @@
 // CHECK: %[[VAL13:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: %[[VAL14:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: aie.mem(%[[VAL1]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
@@ -60,7 +60,7 @@
 // CHECK: aie.flow(%[[VAL1]], DMA : 0, %[[VAL0]], DMA : 1)
 // CHECK: aie.flow(%[[VAL0]], DMA : 1, %[[VAL2]], DMA : 0)
 // CHECK: aie.memtile_dma(%[[VAL0]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
@@ -74,14 +74,14 @@
 // CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL5]], Release, 1)
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL4]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
@@ -154,7 +154,7 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK: %[[VAL13:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: %[[VAL14:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: aie.mem(%[[VAL1]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
@@ -190,7 +190,7 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK: aie.flow(%[[VAL1]], DMA : 0, %[[VAL0]], DMA : 1)
 // CHECK: aie.flow(%[[VAL0]], DMA : 1, %[[VAL2]], DMA : 0)
 // CHECK: aie.memtile_dma(%[[VAL0]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7, repeat_count = 1)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
@@ -204,14 +204,14 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL5]], Release, 1)
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL4]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)


### PR DESCRIPTION
This PR aims to support the lowering of the following `air.channel` code pattern:
```
      %tok_6 = air.channel.get async @channel_0[] (%buf0[] [] []) {id = 7 : i32} : (memref<5xi32, 2>)
      %tok_7 = scf.for %arg5 = %c0_1 to %c8_1 step %c1_1 iter_args(%arg14 = %tok_6) -> (!air.async.token) {
        %tok_5 = air.channel.get async [%arg14] @channel_0[] (%buf1[] [] []) {id = 8 : i32} : (memref<96xi32, 2>)
      }
```
into
```
    aie.dma_start(S2MM, 0, ^bb1, ^bb3)
  ^bb1:
    aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
    aie.dma_bd(%[[VAL_12]] : memref<5xi32, 2>, 0, 5) {task_id = 0 : i32}
    aie.use_lock(%[[VAL_8]], Release, 1)
    aie.next_bd ^bb2
  ^bb2:
    aie.end
  ^bb3:
    aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 7)
  ^bb4:
    aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
    aie.dma_bd(%[[VAL_12]] : memref<96xi32, 2>, 0, 96) {task_id = 1 : i32}
    aie.use_lock(%[[VAL_8]], Release, 1)
    aie.next_bd ^bb2
```

Where the two `get` ops, sharing `channel @channel_0`, get mapped to two BD tasks each containing one BD. The first task isn't repeated; the second task gets enqueued with a repeat count of 7, i.e. get executed 8 times.