### PR TITLE
AIRToAIE: Refactor `cloneL2AndL3MemcpysToDeviceOp`

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -77,7 +77,8 @@ LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
                                                   scf::ParallelOp par,
                                                   Operation *originalChanOp,
                                                   IRMapping remap);
-
+void populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
+    RewritePatternSet &patterns);
 //===----------------------------------------------------------------------===//
 // Dependency graph
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -877,6 +877,141 @@ LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
   return success();
 }
 
+// Unroll scf.parallel ops.
+LogicalResult unrollScfParallel(OpBuilder builder, scf::ParallelOp par,
+                                Operation *originalChanOp, IRMapping remap) {
+
+  SmallVector<int, 2> lbs_spatial, ubs_spatial;
+  air::getSizesFromSpatialLoop(par.getOperation(), lbs_spatial, ubs_spatial);
+  std::vector<unsigned> par_size;
+  unsigned par_vol = 1;
+  for (unsigned i = 0; i < lbs_spatial.size(); i++) {
+    par_size.push_back(ubs_spatial[i] - lbs_spatial[i] + 1);
+    par_vol *= ubs_spatial[i] - lbs_spatial[i] + 1;
+  }
+  Operation *curr_new_op = nullptr;
+  for (unsigned iter = 0; iter < par_vol; iter++) {
+    IRMapping localRemap = remap;
+    std::vector<unsigned> position =
+        air::getMDVectorFromIterator(par_size, iter);
+    for (unsigned i = 0; i < position.size(); i++) {
+      localRemap.map(par.getInductionVars()[i],
+                     builder.create<arith::ConstantIndexOp>(
+                         builder.getUnknownLoc(),
+                         position[i] * *getConstantIntValue(par.getStep()[i]) +
+                             *getConstantIntValue(par.getLowerBound()[i])));
+    }
+    // Clone ops
+    for (auto &op : par.getBody()->without_terminator()) {
+      curr_new_op = builder.clone(op, localRemap);
+    }
+  }
+
+  if (auto parToken = getAsyncTokenFromOp(par)) {
+    if (auto tailToken = getAsyncTokenFromOp(curr_new_op)) {
+      parToken.replaceAllUsesWith(tailToken);
+    } else {
+      parToken.replaceAllUsesWith(
+          builder
+              .create<air::WaitAllOp>(
+                  builder.getUnknownLoc(),
+                  air::AsyncTokenType::get(builder.getContext()),
+                  SmallVector<Value>{})
+              .getAsyncToken());
+    }
+  }
+  return success();
+}
+
+// Unroll air.channel.put/get in scf.parallel.
+struct unrollAIRChannelPutInScfParallelPattern
+    : public OpRewritePattern<air::ChannelPutOp> {
+  using OpRewritePattern<air::ChannelPutOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(air::ChannelPutOp put,
+                                PatternRewriter &rewriter) const override {
+    scf::ParallelOp parParentOp = put->getParentOfType<scf::ParallelOp>();
+    SmallVector<scf::ParallelOp> parOps;
+    while (parParentOp) {
+      parOps.push_back(parParentOp);
+      parParentOp = parParentOp->getParentOfType<scf::ParallelOp>();
+    }
+    if (parOps.empty())
+      return failure();
+    IRMapping remap;
+    for (auto par : parOps) {
+      rewriter.setInsertionPoint(par);
+      auto res = unrollScfParallel(rewriter, par, put.getOperation(), remap);
+      if (res.failed())
+        return failure();
+      rewriter.eraseOp(par);
+    }
+    return success();
+  }
+
+private:
+};
+struct unrollAIRChannelGetInScfParallelPattern
+    : public OpRewritePattern<air::ChannelGetOp> {
+  using OpRewritePattern<air::ChannelGetOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(air::ChannelGetOp get,
+                                PatternRewriter &rewriter) const override {
+    scf::ParallelOp parParentOp = get->getParentOfType<scf::ParallelOp>();
+    SmallVector<scf::ParallelOp> parOps;
+    while (parParentOp) {
+      parOps.push_back(parParentOp);
+      parParentOp = parParentOp->getParentOfType<scf::ParallelOp>();
+    }
+    if (parOps.empty())
+      return failure();
+    IRMapping remap;
+    for (auto par : parOps) {
+      rewriter.setInsertionPoint(par);
+      auto res = unrollScfParallel(rewriter, par, get.getOperation(), remap);
+      if (res.failed())
+        return failure();
+      rewriter.eraseOp(par);
+    }
+    return success();
+  }
+
+private:
+};
+
+// Erase empty async scf.parallel ops. Non-empty reduce op region, if filled
+// with air.wait_all, doesn't get automatically canonicalized.
+struct EmptyAIRAsyncScfParallelRemovalPattern
+    : public OpRewritePattern<scf::ParallelOp> {
+  using OpRewritePattern<scf::ParallelOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::ParallelOp par,
+                                PatternRewriter &rewriter) const override {
+    if (llvm::all_of(par.getBody()->without_terminator(), [](Operation &op) {
+          return air::isPure(&op) || isa<air::WaitAllOp>(op);
+        })) {
+      rewriter.replaceOpWithNewOp<air::WaitAllOp>(
+          par, air::AsyncTokenType::get(par->getContext()),
+          getAsyncDependenciesFromOp(par));
+      return success();
+    }
+    return failure();
+  }
+
+private:
+};
+
+void populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
+    RewritePatternSet &patterns) {
+  MLIRContext *ctx = patterns.getContext();
+  patterns.insert<unrollAIRChannelPutInScfParallelPattern,
+                  unrollAIRChannelGetInScfParallelPattern,
+                  EmptyAIRAsyncScfParallelRemovalPattern>(ctx);
+  air::WaitAllOp::getCanonicalizationPatterns(patterns, ctx);
+  air::ExecuteOp::getCanonicalizationPatterns(patterns, ctx);
+  affine::AffineApplyOp::getCanonicalizationPatterns(patterns, ctx);
+}
+
 //===----------------------------------------------------------------------===//
 // Dependency graph
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -761,10 +761,10 @@ std::vector<unsigned>
 air::convertVecOfConstIndexToVecOfUInt(SmallVector<Value> svec) {
   std::vector<unsigned> output;
   for (auto v : svec) {
-    auto op = v.getDefiningOp<arith::ConstantIndexOp>();
-    if (!op)
+    auto constOp = getConstantIntValue(v);
+    if (!constOp)
       return std::vector<unsigned>();
-    output.push_back(op.value());
+    output.push_back(*constOp);
   }
   return output;
 }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -381,8 +381,8 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 
 // DMA bd program taking into account hoisted partial pixel copies
 // CHECK: aie.device
-// CHECK:         %[[VAL_0:.*]] = aie.tile(2, 2)
-// CHECK:         %[[VAL_1:.*]] = aie.tile(2, 0)
+// CHECK-DAG:         %[[VAL_0:.*]] = aie.tile(2, 2)
+// CHECK-DAG:         %[[VAL_1:.*]] = aie.tile(2, 0)
 // CHECK:         %[[VAL_2:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32}
 // CHECK:         %[[VAL_3:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32}
 // CHECK:         %[[VAL_4:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32}

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -1115,3 +1115,121 @@ func.func @func15(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
   }
   return
 }
+
+// -----
+
+// Lowering complex loop structures around channel.puts/gets into BD task repeat counts (aie.mem).
+//
+// CHECK:      aie.mem
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK-NEXT: ^bb1:
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 0 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: aie.end
+// CHECK-NEXT: ^bb3:
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 7)
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 1 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK:      @func16
+
+air.channel @channel_0 [1, 1]
+air.channel @channel_1 [1, 1]
+func.func @func16(%arg0 : memref<5xi32>, %arg1 : memref<96xi32>, %arg2 : memref<9xi32>, %ub : index) -> () {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c12 = arith.constant 12 : index
+  air.channel.put @channel_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<5xi32>)
+  scf.for %arg3 = %c0 to %c8 step %c1 {
+    air.channel.put @channel_0[] (%arg1[] [] []) {id = 2 : i32} : (memref<96xi32>)
+  }
+  air.segment @segment0 args (%ub_seg=%ub) : index {
+    %c0_0 = arith.constant 0 : index
+    %c1_0 = arith.constant 1 : index
+    %c8_0 = arith.constant 8 : index
+    %c12_0 = arith.constant 12 : index
+    %herd_cols = arith.constant 1 : index
+    %herd_rows = arith.constant 1 : index
+    %tok_5 = air.herd async tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args (%ub_herd=%ub_seg) : index attributes { sym_name="herd4"} {
+      %c0_1 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %c8_1 = arith.constant 8 : index
+      %c12_1 = arith.constant 12 : index
+      %buf0 = memref.alloc() : memref<5xi32, 2>
+      %tok_6 = air.channel.get async @channel_0[] (%buf0[] [] []) {id = 7 : i32} : (memref<5xi32, 2>)
+      %tok_7 = scf.for %arg5 = %c0_1 to %c8_1 step %c1_1 iter_args(%arg14 = %tok_6) -> (!air.async.token) {
+        %buf1 = memref.alloc() : memref<96xi32, 2>
+        %tok_5 = air.channel.get async [%arg14] @channel_0[] (%buf1[] [] []) {id = 8 : i32} : (memref<96xi32, 2>)
+        memref.dealloc %buf1 : memref<96xi32, 2>
+        scf.yield %tok_5 : !air.async.token
+      }
+      memref.dealloc %buf0 : memref<5xi32, 2>
+    }
+  }
+  return
+}
+
+// -----
+
+// Lowering complex loop structures around channel.puts/gets into BD task repeat counts (aie.memtile_dma).
+//
+// CHECK:      aie.memtile_dma
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK-NEXT: ^bb1:
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 0 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: aie.end
+// CHECK-NEXT: ^bb3:
+// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 7)
+// CHECK:      aie.dma_bd({{.*}}) {task_id = 1 : i32}
+// CHECK:      aie.next_bd ^bb2
+// CHECK: @func17
+air.channel @channel_0 [1, 1]
+air.channel @channel_1 [1, 1]
+func.func @func17(%arg0 : memref<5xi32>, %arg1 : memref<96xi32>, %arg2 : memref<9xi32>, %ub : index) -> () {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c12 = arith.constant 12 : index
+  air.channel.put @channel_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<5xi32>)
+  scf.for %arg3 = %c0 to %c8 step %c1 {
+    air.channel.put @channel_0[] (%arg1[] [] []) {id = 2 : i32} : (memref<96xi32>)
+  }
+  air.segment @segment0 args (%ub_seg=%ub) : index {
+    %c0_0 = arith.constant 0 : index
+    %c1_0 = arith.constant 1 : index
+    %c8_0 = arith.constant 8 : index
+    %c12_0 = arith.constant 12 : index
+    %herd_cols = arith.constant 1 : index
+    %herd_rows = arith.constant 1 : index
+    %memtile0 = memref.alloc() : memref<5xi32, 1>
+    %tok_0 = air.channel.get async @channel_0[] (%memtile0[] [] []) {id = 3 : i32} : (memref<5xi32, 1>)
+    %tok_1 = air.channel.put async [%tok_0] @channel_1[] (%memtile0[] [] []) {id = 4 : i32} : (memref<5xi32, 1>)
+    %tok_2 = scf.for %arg4 = %c0_0 to %c8_0 step %c1_0 iter_args(%arg14 = %tok_1) -> (!air.async.token) {
+      %memtile1 = memref.alloc() : memref<96xi32, 1>
+      %tok_3 = air.channel.get async [%arg14] @channel_0[] (%memtile1[] [] []) {id = 5 : i32} : (memref<96xi32, 1>)
+      %tok_4 = air.channel.put async [%tok_3] @channel_1[] (%memtile1[] [] []) {id = 6 : i32} : (memref<96xi32, 1>)
+      memref.dealloc %memtile1 : memref<96xi32, 1>
+      scf.yield %tok_4 : !air.async.token
+    }
+    memref.dealloc %memtile0 : memref<5xi32, 1>
+    %tok_5 = air.herd async tile(%tx, %ty) in (%size_x = %herd_cols, %size_y = %herd_rows) args (%ub_herd=%ub_seg) : index attributes { sym_name="herd4"} {
+      %c0_1 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %c8_1 = arith.constant 8 : index
+      %c12_1 = arith.constant 12 : index
+      %buf0 = memref.alloc() : memref<5xi32, 2>
+      %tok_6 = air.channel.get async @channel_1[] (%buf0[] [] []) {id = 7 : i32} : (memref<5xi32, 2>)
+      %tok_7 = scf.for %arg5 = %c0_1 to %c8_1 step %c1_1 iter_args(%arg14 = %tok_6) -> (!air.async.token) {
+        %buf1 = memref.alloc() : memref<96xi32, 2>
+        %tok_5 = air.channel.get async [%arg14] @channel_1[] (%buf1[] [] []) {id = 8 : i32} : (memref<96xi32, 2>)
+        memref.dealloc %buf1 : memref<96xi32, 2>
+        scf.yield %tok_5 : !air.async.token
+      }
+      memref.dealloc %buf0 : memref<5xi32, 2>
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
@@ -22,10 +22,10 @@
 // CHECK-COUNT-6:    aie.lock(%[[VAL_6]], {{.*}})
 // CHECK-COUNT-6:    aie.lock(%[[VAL_7]], {{.*}})
 // CHECK:    aie.buffer(%[[VAL_2]]) {{{.*}}} : memref<64x64xi32, 1>
-// CHECK:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<64x128xi32, 1>
-// CHECK:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<128x64xi32, 1>
-// CHECK:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<64x128xi32, 1>
-// CHECK:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<128x64xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<64x128xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<128x64xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<64x128xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<128x64xi32, 1>
 // CHECK-COUNT-20:    aie.buffer({{.*}}) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK:   aie.mem(%[[VAL_7]])
 // CHECK:   aie.core(%[[VAL_7]]) {

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
@@ -23,10 +23,10 @@
 // CHECK-COUNT-6:    aie.lock(%[[tile_0_3]], {{.*}})
 // CHECK-COUNT-6:    aie.lock(%[[tile_1_3]], {{.*}})
 // CHECK:    aie.buffer(%[[tile_0_1]]) {{{.*}}} : memref<64x64xi32, 1>
-// CHECK:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<64x128xi32, 1>
-// CHECK:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<128x64xi32, 1>
-// CHECK:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<64x128xi32, 1>
-// CHECK:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<128x64xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<64x128xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<128x64xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<64x128xi32, 1>
+// CHECK-DAG:    aie.buffer(%[[tile_1_1]]) {{{.*}}} : memref<128x64xi32, 1>
 // CHECK-COUNT-20:    aie.buffer({{.*}}) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK:    aie.flow(%[[tile_0_0]], DMA : 0, %[[tile_0_1]], DMA : 0)
 // CHECK:    aie.flow(%[[tile_1_0]], DMA : 0, %[[tile_1_1]], DMA : 0)


### PR DESCRIPTION
Previously, the `cloneL2AndL3MemcpysToDeviceOp` method only clones the memcpy ops around L2 and L3 memories to `aie.device` op's region, followed by converting them to memtile BDs in the `AIRToAIE` pass . 

This PR rewrites the method by outlining all operations in `air.segment` and `air.launch` associated with L2 and L3 memcpys. Specifically, any loop nests ancestor to those memcpy ops get outlined to `aie.device` region, too. This enables the iteration spaces surrounding memcpy ops to properly lower to repeat counts around BD tasks.

Depends on https://github.com/Xilinx/mlir-air/pull/811.