### PR TITLE
Add a canonicalizer for `air.async_token`s representing loop-carried dependency

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4316,6 +4316,10 @@ public:
       patterns_1
           .insert<HoistAIRHerdInForPattern, HoistAIRChannelInAccumPattern>(
               f.getContext(), false);
+      air::LaunchOp::getCanonicalizationPatterns(patterns_1, f.getContext());
+      air::SegmentOp::getCanonicalizationPatterns(patterns_1, f.getContext());
+      air::HerdOp::getCanonicalizationPatterns(patterns_1, f.getContext());
+      air::WaitAllOp::getCanonicalizationPatterns(patterns_1, f.getContext());
       (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
     }
   }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -686,20 +686,6 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
   if (hasNChannelOps(for_op.getBody(), 1))
     return for_op;
 
-  // Preprocess target ops by canonicalizing dependencies in target ops' region.
-  for (auto target_op : target_ops) {
-    for (auto &region : target_op->getRegions()) {
-      llvm::SetVector<Value> region_args;
-      getUsedValuesDefinedAbove(region, region_args);
-      for (auto arg : region_args) {
-        if (isa<air::AsyncTokenType>(arg.getType())) {
-          replaceAllUsesInRegionWith(
-              arg, getLoopCarriedTokenFromScfOp(for_op, "argument"), region);
-        }
-      }
-    }
-  }
-
   rewriter.setInsertionPoint(for_op);
   IRMapping remap;
   auto new_for_op = rewriter.create<scf::ForOp>(

--- a/mlir/test/Dialect/AIR/air_canonicalize.mlir
+++ b/mlir/test/Dialect/AIR/air_canonicalize.mlir
@@ -67,7 +67,7 @@ func.func @herd_async_2() {
   return
 }
 
-// CHECK-LABEL: segmnet_async
+// CHECK-LABEL: segment_async
 // CHECK: air.segment @segment_0 async
 // CHECK: %[[TOKEN0:.*]] = air.wait_all async 
 // CHECK-NEXT: %[[TOKEN1:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN4:.*]] = %[[TOKEN0]]) -> (!air.async.token) {
@@ -77,7 +77,7 @@ func.func @herd_async_2() {
 // CHECK-NEXT: }
 // CHECK-NEXT: scf.yield %[[TOKEN2]] : !air.async.token
 // CHECK-NEXT: }
-func.func @segmnet_async() {
+func.func @segment_async() {
   %7 = air.segment @segment_0 async  {
     %c0 = arith.constant 0 : index
     %c256 = arith.constant 256 : index
@@ -102,7 +102,7 @@ func.func @segmnet_async() {
   return
 }
 
-// CHECK-LABEL: segmnet_async_1
+// CHECK-LABEL: segment_async_1
 // CHECK: air.segment @segment_0 async
 // CHECK: %[[TOKEN0:.*]], %[[RES0:.*]] = air.execute -> (memref<4x4x64x64xbf16, 1 : i32>) {
 // CHECK: %[[TOKEN2:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN5:.*]] = %[[TOKEN0]]) -> (!air.async.token) {
@@ -115,7 +115,7 @@ func.func @segmnet_async() {
 // CHECK-NEXT: }
 // CHECK-NEXT: scf.yield %[[TOKEN3]] : !air.async.token
 // CHECK-NEXT: }
-func.func @segmnet_async_1() {
+func.func @segment_async_1() {
   %7 = air.segment @segment_0 async  {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -146,7 +146,7 @@ func.func @segmnet_async_1() {
   return
 }
 
-// CHECK-LABEL: segmnet_async_2
+// CHECK-LABEL: segment_async_2
 // CHECK: air.segment @segment_0 async
 // CHECK: %[[TOKEN0:.*]], %[[RES0:.*]] = air.execute -> (memref<4x4x64x64xbf16, 1 : i32>) {
 // CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
@@ -158,7 +158,7 @@ func.func @segmnet_async_1() {
 // CHECK-NEXT: scf.yield %[[TOKEN4]] : !air.async.token
 // CHECK-NEXT: }
 // CHECK-NEXT: }
-func.func @segmnet_async_2() {
+func.func @segment_async_2() {
   %7 = air.segment @segment_0 async  {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/mlir/test/Dialect/AIR/air_canonicalize.mlir
+++ b/mlir/test/Dialect/AIR/air_canonicalize.mlir
@@ -105,8 +105,7 @@ func.func @segmnet_async() {
 // CHECK-LABEL: segmnet_async_1
 // CHECK: air.segment @segment_0 async
 // CHECK: %[[TOKEN0:.*]], %[[RES0:.*]] = air.execute -> (memref<4x4x64x64xbf16, 1 : i32>) {
-// CHECK: %[[TOKEN1:.*]] = air.wait_all async 
-// CHECK-NEXT: %[[TOKEN2:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN5:.*]] = %[[TOKEN1]]) -> (!air.async.token) {
+// CHECK: %[[TOKEN2:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN5:.*]] = %[[TOKEN0]]) -> (!air.async.token) {
 // CHECK-NEXT: %[[TOKEN3:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN6:.*]] = %[[TOKEN5]]) -> (!air.async.token) {
 // CHECK-NEXT: %[[TOKEN4:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[TOKEN7:.*]] = %[[TOKEN6]]) -> (!air.async.token) {
 // CHECK-NEXT: %[[TOKEN8:.*]] = air.channel.put async [%[[TOKEN7]]]


### PR DESCRIPTION
- Enforce that loop-carried dependency tokens must be passed in through iter_args.
- Depends on https://github.com/Xilinx/mlir-air/pull/820