### PR TITLE
AIRSplitL2Memref: Preserve dependency when an async op gets erased

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1681,7 +1681,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         OpBuilder b(e);
         res.replaceAllUsesWith(
             b.create<air::WaitAllOp>(e->getLoc(), air::AsyncTokenType::get(ctx),
-                                     SmallVector<Value>{})
+                                     air::getAsyncDependenciesFromOp(e))
                 .getAsyncToken());
       }
     }


### PR DESCRIPTION
…using the replacement air.wait_all's dependency list.