### PR TITLE
AIRIsolateAsyncLoopNest: Add a pattern to make `air.herd` op async within an `scf.for` strictly async

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3965,78 +3965,6 @@ private:
   }
 };
 
-// Build a set of child ops from the body of one scf.for op, each of which is to
-// be hoisted into a new loop.
-void identifyTargetOpsInSCFFor(
-    func::FuncOp f, scf::ForOp for_op,
-    SmallVector<llvm::SetVector<Operation *>> &target_ops_sets) {
-  int for_op_token_count = 0;
-  for (auto v : for_op->getResults())
-    if (isa<air::AsyncTokenType>(v.getType()))
-      for_op_token_count++;
-  if (for_op_token_count > 1)
-    return; // This for op has more than one loop-carried dep token,
-            // suggesting pipelining pattern. Will be handelled by
-            // -air-unroll-loop-for-pipelining-pattern instead.
-  SmallVector<Operation *> candidate_ops;
-  for (auto &o : for_op.getBody()->getOperations()) {
-    // Get for_op's immediate child op
-    if (!isAsyncOp(&o))
-      continue; // This pass requires an async IR.
-
-    if (o.getParentOfType<air::HerdOp>())
-      continue; // Skip over herd op's body for now. TODO: generalize this.
-    if (o.getParentOfType<affine::AffineIfOp>())
-      continue; // Skip over if-else bodies for now. TODO: generalize this.
-    if (air::isPure(&o))
-      continue; // Pure ops do not touch memory, and therefore do not require
-                // explicit hoisting.
-    if (isa<air::WaitAllOp>(o))
-      continue;
-    candidate_ops.push_back(&o);
-  }
-  // Group candidate_ops based on async dependencies.
-  for (auto o : candidate_ops) {
-    auto it =
-        llvm::find_if(target_ops_sets, [&](llvm::SetVector<Operation *> set) {
-          return llvm::any_of(
-              set, [&](Operation *op) { return areAsyncDependent(op, o); });
-        });
-    if (it == target_ops_sets.end()) {
-      auto newSetVec = llvm::SetVector<Operation *>();
-      newSetVec.insert(o);
-      target_ops_sets.push_back(newSetVec);
-    } else {
-      it->insert(o);
-    }
-  }
-
-  for (auto o : candidate_ops) {
-    // Check if any memref.alloc needs to be hoisted.
-    SmallVector<Value, 2> operand_memrefs;
-    for (auto operand : o->getOperands()) {
-      if (!operand)
-        continue;
-      if (isa<MemRefType>(operand.getType()))
-        operand_memrefs.push_back(operand);
-    }
-    for (auto memref : operand_memrefs) {
-      if (!memref)
-        continue;
-      auto memrefDefOp = memref.getDefiningOp();
-      if (!memrefDefOp)
-        continue;
-      if (for_op->isProperAncestor(memrefDefOp)) {
-        if (auto exec = dyn_cast<air::ExecuteOp>(memrefDefOp))
-          memrefDefOp = &exec.getChildOps().front();
-        memrefDefOp->setAttr(
-            "hoist_alloc",
-            mlir::BoolAttr::get(memrefDefOp->getContext(), true));
-      }
-    }
-  }
-}
-
 struct IsolateAsyncDmaLoopNestInSCFForPattern
     : public OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
@@ -4077,6 +4005,77 @@ struct IsolateAsyncDmaLoopNestInSCFForPattern
   }
 
 private:
+  // Build a set of child ops from the body of one scf.for op, each of which is
+  // to be hoisted into a new loop.
+  void identifyTargetOpsInSCFFor(
+      func::FuncOp f, scf::ForOp for_op,
+      SmallVector<llvm::SetVector<Operation *>> &target_ops_sets) const {
+    int for_op_token_count = 0;
+    for (auto v : for_op->getResults())
+      if (isa<air::AsyncTokenType>(v.getType()))
+        for_op_token_count++;
+    if (for_op_token_count > 1)
+      return; // This for op has more than one loop-carried dep token,
+              // suggesting pipelining pattern. Will be handelled by
+              // -air-unroll-loop-for-pipelining-pattern instead.
+    SmallVector<Operation *> candidate_ops;
+    for (auto &o : for_op.getBody()->getOperations()) {
+      // Get for_op's immediate child op
+      if (!isAsyncOp(&o))
+        continue; // This pass requires an async IR.
+
+      if (o.getParentOfType<air::HerdOp>())
+        continue; // Skip over herd op's body for now. TODO: generalize this.
+      if (o.getParentOfType<affine::AffineIfOp>())
+        continue; // Skip over if-else bodies for now. TODO: generalize this.
+      if (air::isPure(&o))
+        continue; // Pure ops do not touch memory, and therefore do not require
+                  // explicit hoisting.
+      if (isa<air::WaitAllOp>(o))
+        continue;
+      candidate_ops.push_back(&o);
+    }
+    // Group candidate_ops based on async dependencies.
+    for (auto o : candidate_ops) {
+      auto it =
+          llvm::find_if(target_ops_sets, [&](llvm::SetVector<Operation *> set) {
+            return llvm::any_of(
+                set, [&](Operation *op) { return areAsyncDependent(op, o); });
+          });
+      if (it == target_ops_sets.end()) {
+        auto newSetVec = llvm::SetVector<Operation *>();
+        newSetVec.insert(o);
+        target_ops_sets.push_back(newSetVec);
+      } else {
+        it->insert(o);
+      }
+    }
+
+    for (auto o : candidate_ops) {
+      // Check if any memref.alloc needs to be hoisted.
+      SmallVector<Value, 2> operand_memrefs;
+      for (auto operand : o->getOperands()) {
+        if (!operand)
+          continue;
+        if (isa<MemRefType>(operand.getType()))
+          operand_memrefs.push_back(operand);
+      }
+      for (auto memref : operand_memrefs) {
+        if (!memref)
+          continue;
+        auto memrefDefOp = memref.getDefiningOp();
+        if (!memrefDefOp)
+          continue;
+        if (for_op->isProperAncestor(memrefDefOp)) {
+          if (auto exec = dyn_cast<air::ExecuteOp>(memrefDefOp))
+            memrefDefOp = &exec.getChildOps().front();
+          memrefDefOp->setAttr(
+              "hoist_alloc",
+              mlir::BoolAttr::get(memrefDefOp->getContext(), true));
+        }
+      }
+    }
+  }
 };
 
 // A pass which hoists dma ops out of shared for loops, into perfectly nested
@@ -4115,6 +4114,7 @@ public:
       air::SegmentOp::getCanonicalizationPatterns(patterns_1, f.getContext());
       air::HerdOp::getCanonicalizationPatterns(patterns_1, f.getContext());
       air::WaitAllOp::getCanonicalizationPatterns(patterns_1, f.getContext());
+      scf::ForOp::getCanonicalizationPatterns(patterns_1, f.getContext());
       (void)applyPatternsAndFoldGreedily(f, std::move(patterns_1));
     }
   }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -735,12 +735,6 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
                        yield_operands)
                    ->getResult(0)});
 
-  // Update dependency to hoisted ops
-  for (auto herd : new_for_op.getOps<air::HerdOp>()) {
-    clearAsyncDependenciesOfAsyncOp(herd);
-    herd.addAsyncDependency(
-        getLoopCarriedTokenFromScfOp(new_for_op, "argument"));
-  }
   for (auto erase_op : target_ops) {
     // Reconnect returned tokens.
     rewriter.setInsertionPoint(erase_op);

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_non_pingpong_ops.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_non_pingpong_ops.mlir
@@ -11,7 +11,7 @@
 // CHECK-LABEL: hoist_ops
 // CHECK: %[[EVENT0:.*]] = scf.for {{.*}} iter_args(%[[EVENT1:.*]] = {{.*}}
 // CHECK: %[[EVENT2:.*]] = air.herd @herd_0 async [%[[EVENT1]]]  tile
-// CHECK: %[[EVENT3:.*]] = air.wait_all async [%[[EVENT2]]]
+// CHECK: %[[EVENT3:.*]] = air.wait_all async [%[[EVENT1]]]
 // CHECK: scf.yield %[[EVENT3]]
 // CHECK: %[[EVENT4:.*]] = scf.for {{.*}} iter_args(%[[EVENT5:.*]] = {{.*}}
 // CHECK: memref.alloc() {hoist_alloc = "true"}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -21,7 +21,6 @@
 
 // CHECK: air.herd @herd_0
 // CHECK: scf.for
-// CHECK: scf.yield
 
 // CHECK: scf.for
 // CHECK: scf.parallel
@@ -181,10 +180,9 @@ module {
 // CHECK-DAG: %[[CST0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[CST64:.*]] = arith.constant 64 : index
 // CHECK-DAG: %[[CST512:.*]] = arith.constant 512 : index
-// CHECK: scf.for {{.*}} = %[[CST0]] to %[[CST512]] step %[[CST64]] iter_args
+// CHECK: scf.for {{.*}} = %[[CST0]] to %[[CST512]] step %[[CST64]]
 // CHECK: linalg.fill
 // CHECK: air.channel.put{{.*}}@channel_0
-// CHECK: scf.yield
 
 // CHECK: scf.for {{.*}} = %[[SEGCST0]] to %[[SEGCST512]] step %[[SEGCST64]] iter_args
 // CHECK: scf.parallel
@@ -527,12 +525,10 @@ module {
 // CHECK: scf.for{{.*}}{
 // CHECK: air.channel.put{{.*}}@ChanIn
 // CHECK: scf.yield
-// CHECK: scf.yield
 
 // CHECK: scf.for{{.*}}{
 // CHECK: scf.for{{.*}}{
 // CHECK: air.channel.get{{.*}}@ChanOut
-// CHECK: scf.yield
 // CHECK: scf.yield
 
 module {
@@ -694,7 +690,6 @@ module {
 // CHECK: air.channel.put{{.*}}(%{{.*}}[%[[ARG1]], %[[RES0]]]
 // CHECK: air.channel.put{{.*}}(%{{.*}}[%[[ARG1]], %[[ARG0]]]
 // CHECK: scf.yield
-// CHECK: scf.yield
 // CHECK: scf.for %[[ARG1:.*]] = %{{.*}} to %{{.*}}
 // CHECK: %[[TOK0:.*]], %[[RES0:.*]] = air.execute
 // CHECK-NEXT: affine.apply
@@ -740,6 +735,83 @@ module {
           scf.yield %8 : !air.async.token
         }
         scf.yield %3 : !air.async.token
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Check air.herd op hoisting from a chain of loop-carried dependency.
+
+// CHECK-LABEL: func.func @func9
+// CHECK: air.launch
+// CHECK: air.segment
+
+// CHECK: air.herd
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: linalg.fill
+
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c8{{.*}} step %c1{{.*}}
+// CHECK: air.channel.get
+// CHECK: scf.yield
+// CHECK: scf.yield
+// CHECK: scf.yield
+
+// CHECK: air.herd
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c8{{.*}} step %c1{{.*}}
+// CHECK: linalg.fill
+
+module {
+  air.channel @channel_0 [1, 1]
+  func.func @func9(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>, %arg2: memref<512x512xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg3) in (%arg4=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @segment_0 async  attributes {id = 2 : i32} {
+        %c4 = arith.constant 4 : index
+        %c0 = arith.constant 0 : index
+        %c8 = arith.constant 8 : index
+        %c1_0 = arith.constant 1 : index
+        %c512 = arith.constant 512 : index
+        %c256 = arith.constant 256 : index
+        %async_token_9, %results_10 = air.execute -> (memref<4x4x16x16x4x4xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<4x4x16x16x4x4xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<4x4x16x16x4x4xbf16, 2 : i32>
+        }
+        %2 = air.wait_all async [%async_token_9] 
+        %3 = scf.for %arg5 = %c0 to %c512 step %c256 iter_args(%arg6 = %2) -> (!air.async.token) {
+          %4 = scf.for %arg7 = %c0 to %c512 step %c256 iter_args(%arg8 = %arg6) -> (!air.async.token) {
+            %5 = air.herd @herd_0 async [%arg8]  tile (%arg9, %arg10) in (%arg11=%c4, %arg12=%c4) args(%arg13=%results_10) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 3 : i32, link_with = "mm.o"} {
+              %cst = arith.constant 0.000000e+00 : bf16
+              %subview = memref.subview %arg13[%arg9, %arg10, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
+              %async_token_17 = air.execute {
+                linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
+              }
+            }
+            %6 = scf.for %arg9 = %c0 to %c8 step %c1_0 iter_args(%arg10 = %5) -> (!air.async.token) {
+              %7 = air.channel.get async [%arg10]  @channel_0[] (%results_10[] [] []) {id = 4 : i32} : (memref<4x4x16x16x4x4xbf16, 2 : i32>)
+              %8 = air.herd @herd_0 async [%arg10]  tile (%arg11, %arg12) in (%arg13=%c4, %arg14=%c4) args(%arg15=%results_10) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
+                %cst = arith.constant 0.000000e+00 : bf16
+                %subview = memref.subview %arg15[%arg11, %arg12, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
+                %async_token_17 = air.execute {
+                  linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
+                }
+              }
+              scf.yield %8 : !air.async.token
+            }
+            scf.yield %6 : !air.async.token
+          }
+          scf.yield %4 : !air.async.token
+        }
+        %async_token_11 = air.execute [%3] {
+          memref.dealloc %results_10 : memref<4x4x16x16x4x4xbf16, 2 : i32>
+        }
       }
     }
     return


### PR DESCRIPTION
Adds `MakeHerdOpAsyncInScfForLoopPattern` pattern which converts any herd within an scf.for loop to be strictly async in the body. Specifically, an input IR of the following form

```
%4 = scf.for %arg7 = %c0 to %c512 step %c256 iter_args(%arg8 = %arg6) -> (!air.async.token) {
  %5 = air.herd @herd_0 async [%arg8]  tile () in () {...}
  %6 = scf.for %arg9 = %c0 to %c8 step %c1_0 iter_args(%arg10 = %5) -> (!air.async.token) {
    %7 = air.herd @herd_0 async [%arg10 ]  tile () in () {...}
  }
  %8 = air.herd @herd_0 async [%6]  tile () in () {...}
  ...
```
gets converted to 
```
%5 = air.herd @herd_0 async [%arg8]  tile () in () {
  %4 = scf.for %arg7 = %c0 to %c512 step %c256 {...}
}
%7 = air.herd @herd_0 async [%arg10 ]  tile () in () {
  %4 = scf.for %arg7 = %c0 to %c512 step %c256 {
    %6 = scf.for %arg9 = %c0 to %c8 step %c1_0 {...}
  }
}
%8 = air.herd @herd_0 async [%arg8]  tile () in () {
 %4 = scf.for %arg7 = %c0 to %c512 step %c256 {...}
}
```
Where the async tokens around the herd op represent a schedule where the execution of the herd is asynchrounously parallel to other ops in the loop body. This enables subsequent token motions such as `HoistOpsNotUsingPingPongPattern` and `IsolateAsyncDmaLoopNestInSCFForPattern`.