### PR TITLE
Dependency: Improve `scf.parallel` loop unrolling

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -73,10 +73,8 @@ bool isAsyncDependent(Operation *a, Operation *b);
 scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
                                      scf::ForOp for_op,
                                      SmallVector<Operation *> target_ops);
-LogicalResult unrollAIRChannelPutGetInScfParallel(OpBuilder builder,
-                                                  scf::ParallelOp par,
-                                                  Operation *originalChanOp,
-                                                  IRMapping remap);
+LogicalResult unrollScfParallel(OpBuilder builder, scf::ParallelOp par,
+                                Operation *originalChanOp, IRMapping remap);
 void populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
     RewritePatternSet &patterns);
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1536,8 +1536,9 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         // loop.
         OpBuilder builder(par);
         IRMapping remap;
-        (void)air::unrollAIRChannelPutGetInScfParallel(builder, par, user,
+        (void)air::unrollScfParallel(builder, par, user,
                                                        remap);
+        
         erased.insert(par);
       } else if ((isa<air::ChannelPutOp>(user) &&
                   splitTypeAttr.str() == "MM2SChannels") ||

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1536,9 +1536,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         // loop.
         OpBuilder builder(par);
         IRMapping remap;
-        (void)air::unrollScfParallel(builder, par, user,
-                                                       remap);
-        
+        (void)air::unrollScfParallel(builder, par, user, remap);
         erased.insert(par);
       } else if ((isa<air::ChannelPutOp>(user) &&
                   splitTypeAttr.str() == "MM2SChannels") ||


### PR DESCRIPTION
…by also unrolling async token reduction tree. 

Remove the legacy `unrollAIRChannelPutGetInScfParallel` method.

Enable conversion of `scf.for` from sync to async form.