### PR TITLE
Fixup a bug in `MakeAsyncScfForPattern`

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -498,7 +498,7 @@ struct MakeAsyncScfForPattern : public OpRewritePattern<scf::ForOp> {
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    if (air::getAsyncDependenciesFromOp(forOp).empty())
+    if (!air::getAsyncDependenciesFromOp(forOp).empty())
       return failure();
     if (!isa<air::AsyncTokenType>(token.getType()))
       return failure();


### PR DESCRIPTION
The pattern converts non-async `scf.for` loops into async `scf.for` by adding one extra `air.AsyncTokenType` `iter_arg`. It should only apply to `scf.for` _without_ any existing async dependencies.