### PR TITLE
AIRDmaToChannel: Apply async dependence inheritance with `affine.if` hoisting

### DIFF
--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -709,8 +709,11 @@ static void HoistingAffineIf(affine::AffineIfOp op) {
 
     // Clone ops
     module_builder.restoreInsertionPoint(insertionPointAtHierOp);
-    (void)cloneOpsInBlock(&herd.getBody().front(), module_builder, remap,
-                          externalGetPut[dma_index]);
+    auto clonedOps = cloneOpsInBlock(&herd.getBody().front(), module_builder,
+                                     remap, externalGetPut[dma_index]);
+    for (auto o : clonedOps)
+      for (auto d : air::getAsyncDependenciesFromOp(hier_op))
+        air::addAsyncDependencyIfNew(o, d);
     dma_index++;
   }
 


### PR DESCRIPTION
Input IR:
```
%13 = air.dma_memcpy_nd async [%async_token_17, %arg16] (%results_8[] [] [], %arg9...
%15 = air.herd @herd_0 async [%13, ...]  tile (%arg17, %arg18) in (%arg19=%c4, %arg20=%c4) args(%arg21=%results_8, %arg22=%results_4)... {
  ...
  %17 = affine.if #set()[%arg17, %arg18] -> !air.async.token {
    ...
    %19 = air.dma_memcpy_nd async (%arg22[] [] [], %arg21...
    ...
```
Output IR:
```
%12 = air.channel.get async [%async_token_17, %arg16]  @channel_4[] (%results_8...
...
%13 = air.channel.put async [..., %12]  @channel_0[] (%results_14...
...
%14 = air.channel.put async [..., %12]  @channel_1[] (%results_14...
...
%15 = air.channel.put async [..., %12]  @channel_2[] (%results_14...
...
%16 = air.channel.put async [..., %12]  @channel_3[] (%results_14...
%17 = air.herd @herd_0 async [%12, ...]  tile (%arg11, %arg12) in (%arg13=%c4_2, %arg14=%c4_2) args(%arg15=%results_14, %arg16=%results_12)...
```

Depends on https://github.com/Xilinx/mlir-air/pull/840.