### PR TITLE
AIRIsolateAsyncDmaLoopNests: Rewrite loop splitting and `air.herd` hoisting/merging as patterns and apply greedily

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -50,6 +50,7 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
     ArrayRef<BlockArgument> getSize();
     OperandRange getSizeOperands();
     unsigned getNumKernelOperands();
+    OperandRange getKernelOperands();
     Value getKernelOperand(unsigned i);
     ArrayRef<BlockArgument> getKernelArguments();
     BlockArgument getKernelArgument(unsigned i);
@@ -59,6 +60,27 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
         return id_attr.getInt();
       }
       return -1;
+    }
+    
+    /// Return the kernel argument that corresponds to the given operand.
+    /// Return an "empty" block argument if the given value is not a kernel
+    /// operand.
+    BlockArgument getTiedKernelArgument(Value Oper) {
+      auto kernelOperands = getKernelOperands();
+      auto it = llvm::find(kernelOperands, Oper);
+      if (it == kernelOperands.end())
+        return {};
+      return getKernelArgument(std::distance(kernelOperands.begin(), it));
+    }
+    /// Return the operand that corresponds to the given kernel argument.
+    /// Return "nullptr" if the given block argument is not a kernel argument
+    /// of this op.
+    Value getTiedKernelOperand(BlockArgument bbArg) {
+      auto args = getKernelArguments();
+      auto it = llvm::find(args, bbArg);
+      if (it == args.end())
+        return {};
+      return getKernelOperand(std::distance(args.begin(), it));
     }
   }];
   let hasCanonicalizer = 1;
@@ -109,6 +131,7 @@ def air_SegmentOp : air_Op<"segment", [air_AsyncOpInterface,
     ArrayRef<BlockArgument> getSize();
     OperandRange getSizeOperands();
     unsigned getNumKernelOperands();
+    OperandRange getKernelOperands();
     Value getKernelOperand(unsigned i);
     ArrayRef<BlockArgument> getKernelArguments();
     BlockArgument getKernelArgument(unsigned i);
@@ -150,6 +173,26 @@ def air_SegmentOp : air_Op<"segment", [air_AsyncOpInterface,
         return a.getInt();
       }
       return std::optional<uint64_t>();
+    }
+    /// Return the kernel argument that corresponds to the given operand.
+    /// Return an "empty" block argument if the given value is not a kernel
+    /// operand.
+    BlockArgument getTiedKernelArgument(Value Oper) {
+      auto kernelOperands = getKernelOperands();
+      auto it = llvm::find(kernelOperands, Oper);
+      if (it == kernelOperands.end())
+        return {};
+      return getKernelArgument(std::distance(kernelOperands.begin(), it));
+    }
+    /// Return the operand that corresponds to the given kernel argument.
+    /// Return "nullptr" if the given block argument is not a kernel argument
+    /// of this op.
+    Value getTiedKernelOperand(BlockArgument bbArg) {
+      auto args = getKernelArguments();
+      auto it = llvm::find(args, bbArg);
+      if (it == args.end())
+        return {};
+      return getKernelOperand(std::distance(args.begin(), it));
     }
   }];
   let hasCanonicalizer = 1;
@@ -201,6 +244,7 @@ def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
     ArrayRef<BlockArgument> getSize();
     OperandRange getSizeOperands();
     unsigned getNumKernelOperands();
+    OperandRange getKernelOperands();
     Value getKernelOperand(unsigned i);
     ArrayRef<BlockArgument> getKernelArguments();
     BlockArgument getKernelArgument(unsigned i);
@@ -229,6 +273,27 @@ def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
     }
     uint64_t getNumCols();
     uint64_t getNumRows();
+
+    /// Return the kernel argument that corresponds to the given operand.
+    /// Return an "empty" block argument if the given value is not a kernel
+    /// operand.
+    BlockArgument getTiedKernelArgument(Value Oper) {
+      auto kernelOperands = getKernelOperands();
+      auto it = llvm::find(kernelOperands, Oper);
+      if (it == kernelOperands.end())
+        return {};
+      return getKernelArgument(std::distance(kernelOperands.begin(), it));
+    }
+    /// Return the operand that corresponds to the given kernel argument.
+    /// Return "nullptr" if the given block argument is not a kernel argument
+    /// of this op.
+    Value getTiedKernelOperand(BlockArgument bbArg) {
+      auto args = getKernelArguments();
+      auto it = llvm::find(args, bbArg);
+      if (it == args.end())
+        return {};
+      return getKernelOperand(std::distance(args.begin(), it));
+    }
   }];
   let hasCanonicalizer = 1;
 }

--- a/mlir/include/air/Dialect/AIR/AIROpBase.td
+++ b/mlir/include/air/Dialect/AIR/AIROpBase.td
@@ -167,6 +167,9 @@ def air_HierarchyInterface : OpInterface<"HierarchyInterface"> {
     "ArrayRef<BlockArgument>", "getKernelArguments"
     >,
     InterfaceMethod<"description",
+    "OperandRange", "getKernelOperands"
+    >,
+    InterfaceMethod<"description",
     "Value", "getKernelOperand", (ins "unsigned":$i)
     >,
     InterfaceMethod<"description",
@@ -177,6 +180,12 @@ def air_HierarchyInterface : OpInterface<"HierarchyInterface"> {
     >,
     InterfaceMethod<"description",
     "int32_t", "getId"
+    >,
+    InterfaceMethod<"description",
+    "BlockArgument", "getTiedKernelArgument", (ins "Value":$i)
+    >,
+    InterfaceMethod<"description",
+    "Value", "getTiedKernelOperand", (ins "BlockArgument":$i)
     >,
   ];
 }

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -591,6 +591,10 @@ unsigned LaunchOp::getNumKernelOperands() {
   return getNumOperands() - getAsyncDependencies().size() - getNumDims();
 }
 
+OperandRange LaunchOp::getKernelOperands() {
+  return getOperands().drop_front(getAsyncDependencies().size() + getNumDims());
+}
+
 Value LaunchOp::getKernelOperand(unsigned i) {
   return getOperand(getAsyncDependencies().size() + getNumDims() + i);
 }
@@ -853,6 +857,10 @@ unsigned SegmentOp::getNumKernelOperands() {
   return getNumOperands() - getAsyncDependencies().size() - getNumDims();
 }
 
+OperandRange SegmentOp::getKernelOperands() {
+  return getOperands().drop_front(getAsyncDependencies().size() + getNumDims());
+}
+
 Value SegmentOp::getKernelOperand(unsigned i) {
   return getOperand(getAsyncDependencies().size() + getNumDims() + i);
 }
@@ -1112,6 +1120,10 @@ OperandRange HerdOp::getSizeOperands() {
 
 unsigned HerdOp::getNumKernelOperands() {
   return getNumOperands() - getAsyncDependencies().size() - getNumDims();
+}
+
+OperandRange HerdOp::getKernelOperands() {
+  return getOperands().drop_front(getAsyncDependencies().size() + getNumDims());
 }
 
 Value HerdOp::getKernelOperand(unsigned i) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -743,7 +743,7 @@ module {
 
 // -----
 
-// Check air.herd op hoisting from a chain of loop-carried dependency.
+// Check air.herd ops greedily hoisted from a chain of loop-carried dependency, and merged into one.
 
 // CHECK-LABEL: func.func @func9
 // CHECK: air.launch
@@ -752,18 +752,29 @@ module {
 // CHECK: air.herd
 // CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
 // CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: air.execute {
 // CHECK: linalg.fill
+// CHECK: }
 
-// CHECK: air.herd
-// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
-// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
 // CHECK: scf.for %{{.*}} = %c0{{.*}} to %c8{{.*}} step %c1{{.*}}
+// CHECK: air.execute {
 // CHECK: linalg.fill
+// CHECK: }
+// CHECK: }
 
-// CHECK: air.herd
-// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
-// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: air.execute {
 // CHECK: linalg.fill
+// CHECK: }
+
+// CHECK: }
+// CHECK: }
+// CHECK: }
+
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}}
+// CHECK: air.channel.put{{.*}}@channel_0
+// CHECK: }
+// CHECK: }
 
 module {
   air.channel @channel_0 [1, 1]


### PR DESCRIPTION
The pass now consists of three key patterns: (1) `IsolateAsyncDmaLoopNestInSCFForPattern`, (2) `HoistAIRHerdsToSharedRegionPattern` and (3) `MergeAIRHerdsPattern`, applied as pattern matching and folded greedily.

(1) attempts to split a for loop body by partitioning the body block based on async dependency, generating perfect for-loop nests of asynchronously parallelizable threads as innermost body.

(2) attempts to hoist `air.herd`s with the same symbol name to a shared common region.

(3) attempts to merge `air.herd`s with the same symbol name and within a same region into one.

Input IR:

```
        %3 = scf.for %arg5 = %c0 to %c512 step %c256 iter_args(%arg6 = %2) -> (!air.async.token) {
          %4 = scf.for %arg7 = %c0 to %c512 step %c256 iter_args(%arg8 = %arg6) -> (!air.async.token) {
            %5 = air.herd @herd_0 async [%arg8]  tile (%arg9, %arg10) in (%arg11=%c4, %arg12=%c4) args(%arg13=%results_10) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 3 : i32, link_with = "mm.o"} {
              %cst = arith.constant 0.000000e+00 : bf16
              %subview = memref.subview %arg13[%arg9, %arg10, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
              %async_token_17 = air.execute {
                linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
              }
            }
            %6 = scf.for %arg9 = %c0 to %c8 step %c1_0 iter_args(%arg10 = %5) -> (!air.async.token) {
              %7 = air.herd @herd_0 async [%arg10]  tile (%arg11, %arg12) in (%arg13=%c4, %arg14=%c4) args(%arg15=%results_10) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
                %cst = arith.constant 0.000000e+00 : bf16
                %subview = memref.subview %arg15[%arg11, %arg12, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
                %async_token_17 = air.execute {
                  linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
                }
              }
              scf.yield %7 : !air.async.token
            }
            %8 = air.herd @herd_0 async [%6]  tile (%arg11, %arg12) in (%arg13=%c4, %arg14=%c4) args(%arg15=%results_10) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
              %cst = arith.constant 0.000000e+00 : bf16
              %subview = memref.subview %arg15[%arg11, %arg12, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
              %async_token_17 = air.execute {
                linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
              }
            }
            %9 = air.channel.put async [%arg8]  @channel_0[] (%results_15[] [] []) : (memref<4x1x64x64xbf16, 1 : i32>)
            %10 = air.wait_all async [%8, %9]
            scf.yield %10 : !air.async.token
          }
          scf.yield %4 : !air.async.token
        }
```

Output IR:

```
        %3 = air.herd @herd_0 async [%2]  tile (%arg5, %arg6) in (%arg7=%c4, %arg8=%c4) args(%arg9=%results) : memref<4x4x16x16x4x4xbf16, 2 : i32> attributes {id = 4 : i32, link_with = "mm.o"} {
          %c1_4 = arith.constant 1 : index
          %c8 = arith.constant 8 : index
          %cst = arith.constant 0.000000e+00 : bf16
          %c256_5 = arith.constant 256 : index
          %c0_6 = arith.constant 0 : index
          %c512_7 = arith.constant 512 : index
          %5 = air.wait_all async 
          %6 = scf.for %arg10 = %c0_6 to %c512_7 step %c256_5 iter_args(%arg11 = %5) -> (!air.async.token) {
            %7 = scf.for %arg12 = %c0_6 to %c512_7 step %c256_5 iter_args(%arg13 = %arg11) -> (!air.async.token) {
              %subview = memref.subview %arg9[%arg5, %arg6, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
              %async_token_8 = air.execute {
                linalg.fill ins(%cst : bf16) outs(%subview : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
              }
              scf.for %arg14 = %c0_6 to %c8 step %c1_4 {
                %subview_11 = memref.subview %arg9[%arg5, %arg6, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
                %async_token_12 = air.execute {
                  linalg.fill ins(%cst : bf16) outs(%subview_11 : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
                }
              }
              %subview_9 = memref.subview %arg9[%arg5, %arg6, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<4x4x16x16x4x4xbf16, 2 : i32> to memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
              %async_token_10 = air.execute {
                linalg.fill ins(%cst : bf16) outs(%subview_9 : memref<1x1x16x16x4x4xbf16, strided<[16384, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
              }
              %8 = air.wait_all async 
              scf.yield %8 : !air.async.token
            }
            scf.yield %7 : !air.async.token
          }
        }
```