### PR TITLE
Add `depth=-1` mode to `air-par-to-herd/segment/launch`

### DIFF
--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -24,8 +24,10 @@ def ParallelToHerd : Pass<"air-par-to-herd", "ModuleOp"> {
   }];
   let options = [
     Option<"clAssignDepth", "depth", "int",
-          /*default=*/"-1",
-          "Given a nest of parallel for loops, which depth to map to air.herd">,
+          /*default=*/"-2",
+          "Given a nest of parallel for loops, which depth to map to air.herd. "
+          "-1 means converting the innermost parallel loop; any other negative "
+          "value means converting all parallel loops">,
     Option<"clFirstDim", "first-dim", "int",
           /*default=*/"0",
           "Which herd dimension to map to first. Can be zero or one. If set to "
@@ -49,8 +51,10 @@ def ParallelToLaunch : Pass<"air-par-to-launch", "ModuleOp"> {
   }];
   let options = [
     Option<"clAssignDepth", "depth", "int",
-          /*default=*/"-1",
-          "Given a nest of parallel for loops, which depth to map to air.launch">,
+          /*default=*/"-2",
+          "Given a nest of parallel for loops, which depth to map to air.launch"
+          "-1 means converting the innermost parallel loop; any other negative "
+          "value means converting all parallel loops">,
     Option<"clHasSegment", "has-air-segment", "bool", /*default=*/"false",
            "Whether to create an air.segment op in generated air.launch "
            "regions">,
@@ -68,8 +72,10 @@ def ParallelToSegment : Pass<"air-par-to-segment", "ModuleOp"> {
   }];
   let options = [
     Option<"clAssignDepth", "depth", "int",
-          /*default=*/"-1",
-          "Given a nest of parallel for loops, which depth to map to air.segment">,
+          /*default=*/"-2",
+          "Given a nest of parallel for loops, which depth to map to air.segment"
+          "-1 means converting the innermost parallel loop; any other negative "
+          "value means converting all parallel loops">,
   ];
 }
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1165,11 +1165,11 @@ struct ParallelToHerdPass
       if (llvm::any_of(hierOps,
                        [op](Operation *h) { return op->isProperAncestor(h); }))
         return;
-      // Depth = -1 means converting the innermost scf.parallel ops
+      // Depth = -1 means converting the innermost parallel ops
       if (clAssignDepth == -1) {
         SmallVector<Operation *> parOpsInOp;
         op->walk([&parOpsInOp](Operation *o) {
-          if (isa<scf::ParallelOp, affine::AffineParallelOp>(o))
+          if (isa<scf::ForallOp, scf::ParallelOp, affine::AffineParallelOp>(o))
             parOpsInOp.push_back(o);
         });
         if (parOpsInOp.size() > 1)
@@ -1178,12 +1178,12 @@ struct ParallelToHerdPass
         return;
       }
       // Assigning depth to other negative values means converting all
-      // scf.parallel ops
+      // parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;
       }
-      // the number of nested scf.parallel above this one
+      // the number of nested parallel above this one
       int parallel_depth = 0;
       Operation *par = op;
       while ((par = par->getParentOp()))
@@ -1267,7 +1267,7 @@ struct ParallelToLaunchPass
             return op->isProperAncestor(l);
           }))
         return;
-      // Depth = -1 means converting the innermost scf.parallel ops
+      // Depth = -1 means converting the innermost parallel ops
       if (clAssignDepth == -1) {
         SmallVector<Operation *> parOpsInOp;
         op->walk([&parOpsInOp](Operation *o) {
@@ -1280,12 +1280,12 @@ struct ParallelToLaunchPass
         return;
       }
       // Assigning depth to other negative values means converting all
-      // scf.parallel ops
+      // parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;
       }
-      // the number of nested scf.parallel above this one
+      // the number of nested parallel above this one
       int parallel_depth = 0;
       Operation *par = op;
       while ((par = par->getParentOp()))
@@ -1370,7 +1370,7 @@ struct ParallelToSegmentPass
             return op->isProperAncestor(s);
           }))
         return;
-      // Depth = -1 means converting the innermost scf.parallel ops
+      // Depth = -1 means converting the innermost parallel ops
       if (clAssignDepth == -1) {
         SmallVector<Operation *> parOpsInOp;
         op->walk([&parOpsInOp](Operation *o) {
@@ -1383,12 +1383,12 @@ struct ParallelToSegmentPass
         return;
       }
       // Assigning depth to other negative values means converting all
-      // scf.parallel ops
+      // parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;
       }
-      // the number of nested scf.parallel above this one
+      // the number of nested parallel above this one
       int parallel_depth = 0;
       Operation *par = op;
       while ((par = par->getParentOp()))

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1188,6 +1188,20 @@ struct ParallelToHerdPass
       if (llvm::any_of(hierOps,
                        [op](Operation *h) { return op->isProperAncestor(h); }))
         return;
+      // Depth = -1 means converting the innermost scf.parallel ops
+      if (clAssignDepth == -1) {
+        SmallVector<Operation *> parOpsInOp;
+        op->walk([&parOpsInOp](Operation *o) {
+          if (isa<scf::ParallelOp, affine::AffineParallelOp>(o))
+            parOpsInOp.push_back(o);
+        });
+        if (parOpsInOp.size() > 1)
+          return;
+        filteredOps.insert(op);
+        return;
+      }
+      // Assigning depth to other negative values means converting all
+      // scf.parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;
@@ -1283,6 +1297,20 @@ struct ParallelToLaunchPass
             return op->isProperAncestor(l);
           }))
         return;
+      // Depth = -1 means converting the innermost scf.parallel ops
+      if (clAssignDepth == -1) {
+        SmallVector<Operation *> parOpsInOp;
+        op->walk([&parOpsInOp](Operation *o) {
+          if (isa<scf::ParallelOp>(o))
+            parOpsInOp.push_back(o);
+        });
+        if (parOpsInOp.size() > 1)
+          return;
+        filteredOps.insert(op);
+        return;
+      }
+      // Assigning depth to other negative values means converting all
+      // scf.parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;
@@ -1379,6 +1407,20 @@ struct ParallelToSegmentPass
             return op->isProperAncestor(s);
           }))
         return;
+      // Depth = -1 means converting the innermost scf.parallel ops
+      if (clAssignDepth == -1) {
+        SmallVector<Operation *> parOpsInOp;
+        op->walk([&parOpsInOp](Operation *o) {
+          if (isa<scf::ParallelOp>(o))
+            parOpsInOp.push_back(o);
+        });
+        if (parOpsInOp.size() > 1)
+          return;
+        filteredOps.insert(op);
+        return;
+      }
+      // Assigning depth to other negative values means converting all
+      // scf.parallel ops
       if (clAssignDepth < 0) {
         filteredOps.insert(op);
         return;

--- a/mlir/test/Conversion/ConvertToAIR/scf_forall_to_herd.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/scf_forall_to_herd.mlir
@@ -6,6 +6,9 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt -split-input-file -verify-diagnostics -air-par-to-herd %s | FileCheck %s
+// RUN: air-opt -split-input-file -verify-diagnostics -air-par-to-herd="depth=-1" %s | FileCheck %s --check-prefix=DEPTHM1
+// RUN: air-opt -split-input-file -verify-diagnostics -air-par-to-herd="depth=0" %s | FileCheck %s --check-prefix=DEPTH0
+// RUN: air-opt -split-input-file -verify-diagnostics -air-par-to-herd="depth=1" %s | FileCheck %s --check-prefix=DEPTH1
 
 // CHECK-LABEL: func.func @scf0() {
 // CHECK: air.herd @herd_0  tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2{{.*}}, %{{.*}}=%c2{{.*}})
@@ -98,6 +101,27 @@ func.func @scf4()  {
 // CHECK: }
 // CHECK: }
 // CHECK: }
+// DEPTHM1-LABEL: func.func @scf5() {
+// DEPTHM1: scf.forall {{.*}} {
+// DEPTHM1: scf.forall {{.*}} {
+// DEPTHM1: air.herd @herd_{{.*}} {
+// DEPTHM1: }
+// DEPTHM1: }
+// DEPTHM1: }
+// DEPTH0-LABEL: func.func @scf5() {
+// DEPTH0: air.herd @herd_{{.*}} {
+// DEPTH0: scf.forall {{.*}} {
+// DEPTH0: scf.forall {{.*}} {
+// DEPTH0: }
+// DEPTH0: }
+// DEPTH0: }
+// DEPTH1-LABEL: func.func @scf5() {
+// DEPTH1: scf.forall {{.*}} {
+// DEPTH1: air.herd @herd_{{.*}} {
+// DEPTH1: scf.forall {{.*}} {
+// DEPTH1: }
+// DEPTH1: }
+// DEPTH1: }
 func.func @scf5()  {
   %src = memref.alloc() : memref<4x4x4xi32, 2 : i32>
   %dst = memref.alloc() : memref<4x4x4xi32, 2 : i32>


### PR DESCRIPTION
… representing converting the innermost loop body into `air.hierarchy` op.

Assigning other negative values to depth means converting all loops; it would be ambiguous to assign depth=-2 as being the second innermost body, because that would be ambiguous.