### PR TITLE
AIRDependency: Determine whether to add a dependency based on dominance info

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -255,6 +255,11 @@ void getBackwardSliceInRegion(OpBuilder builder, Region *region,
 // func op's arguments.
 void populateBufferMemrefToFuncArgsPattern(RewritePatternSet &patterns);
 
+// Find a common region that contains all ops, or ancestors of ops, until a
+// specified region.
+Region *findCommonRegionContainingAllAncestors(SmallVector<Operation *> ops,
+                                               Operation *until);
+
 } // namespace air
 } // namespace xilinx
 

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -258,7 +258,7 @@ void populateBufferMemrefToFuncArgsPattern(RewritePatternSet &patterns);
 // Find a common region that contains all ops, or ancestors of ops, until a
 // specified region.
 Region *findCommonRegionContainingAllAncestors(SmallVector<Operation *> ops,
-                                               Operation *until);
+                                               Operation *until = nullptr);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1754,6 +1754,8 @@ air::findCommonRegionContainingAllAncestors(SmallVector<Operation *> ops,
     if (until && region->getParentOp() == until)
       return nullptr;
     region = region->getParentRegion();
+    if (!region)
+      return nullptr;
   }
   return region;
 }

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1375,8 +1375,10 @@ air::writeAccessPattern(mlir::vector::TransferReadOp readOp) {
   OpBuilder builder(readOp);
   std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
       pattern;
-  [[maybe_unused]] auto vectorTy = llvm::cast<VectorType>(readOp.getVector().getType());
-  [[maybe_unused]] auto memrefTy = llvm::cast<MemRefType>(readOp.getSource().getType());
+  [[maybe_unused]] auto vectorTy =
+      llvm::cast<VectorType>(readOp.getVector().getType());
+  [[maybe_unused]] auto memrefTy =
+      llvm::cast<MemRefType>(readOp.getSource().getType());
   assert(vectorTy && "Not a vector");
   assert(memrefTy && "Not a memref");
   // Initialize wraps and strides based on the unshrunk memref shape.
@@ -1400,8 +1402,10 @@ air::writeAccessPattern(mlir::vector::TransferWriteOp writeOp) {
   OpBuilder builder(writeOp);
   std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
       pattern;
-  [[maybe_unused]] auto memrefTy = llvm::cast<MemRefType>(writeOp.getSource().getType());
-  [[maybe_unused]] auto vectorTy = llvm::cast<VectorType>(writeOp.getVector().getType());
+  [[maybe_unused]] auto memrefTy =
+      llvm::cast<MemRefType>(writeOp.getSource().getType());
+  [[maybe_unused]] auto vectorTy =
+      llvm::cast<VectorType>(writeOp.getVector().getType());
   assert(memrefTy && "Not a memref");
   assert(vectorTy && "Not a vector");
   // Initialize wraps and strides based on the unshrunk memref shape.
@@ -1734,4 +1738,22 @@ private:
 void air::populateBufferMemrefToFuncArgsPattern(RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
   patterns.insert<BufferMemrefToFuncArgsPattern>(ctx);
+}
+
+// Find a common region that contains all ops, or ancestors of ops, until it
+// reaches a specified parent op.
+Region *
+air::findCommonRegionContainingAllAncestors(SmallVector<Operation *> ops,
+                                            Operation *until) {
+  Region *region = ops.front()->getParentRegion();
+  while (llvm::any_of(ops, [region](Operation *op) {
+    return !region->isAncestor(op->getParentRegion());
+  })) {
+    // Failed to find any shared region within the parent IsolatedFromAbove op
+    // body.
+    if (until && region->getParentOp() == until)
+      return nullptr;
+    region = region->getParentRegion();
+  }
+  return region;
 }


### PR DESCRIPTION
... instead of relying on globally declared "op_history" vectors to keep track of op dominance, which is hacky.