### PR TITLE
Update `upload-artifact` to v4

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -154,7 +154,7 @@ jobs:
           cat clang-format.diff
 
       - name: Upload clang-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: clang-format.diff
           name: format_diffs
@@ -176,7 +176,7 @@ jobs:
           cat black-format.diff
 
       - name: Upload black-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: black-format.diff
           name: format_diffs

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload clang-tidy fixes
         if: ${{ steps.clang-tidy-fixes.outputs.FIXES }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: fixes.yml
           name: clang-tidy-fixes.yml

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -157,7 +157,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: clang-format.diff
-          name: format_diffs
+          name: clang_format_diffs
 
       - name: Check C/C++ format
         uses: reviewdog/action-suggester@v1
@@ -179,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: black-format.diff
-          name: format_diffs
+          name: black_format_diffs
 
       - name: Check Python format
         if: success() || failure()


### PR DESCRIPTION
V3 is scheduled to deprecate on 30th Jan. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/