### PR TITLE
AIRToAIE: Refactor core lock release strategy

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -56,10 +56,6 @@ std::vector<AIE::BDDimLayoutAttr>
 getWrapsAndStrides(SmallVector<Value> memcpy_sizes,
                    SmallVector<Value> memcpy_strides, MLIRContext *ctx);
 
-bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
-                                SmallVector<Value> memcpy_strides,
-                                Value memref);
-
 std::pair<int64_t, int64_t>
 getLockValuePair(const AIE::AIETargetModel &targetModel, Value buffer_memref);
 

--- a/mlir/include/air/Transform/AIRDependencyScheduleOpt.h
+++ b/mlir/include/air/Transform/AIRDependencyScheduleOpt.h
@@ -76,6 +76,11 @@ std::unique_ptr<mlir::Pass> createAIRShrinkMemrefSizesByAccess();
 // variables are canonicalized
 void populateAIRLoopIndexCanonicalizationPatterns(RewritePatternSet &patterns);
 
+// Populate patterns for canonicalizing offsets, sizes and strides in air
+// channel_interface operations.
+void populateAIRCanonicalizeChannelWrapAndStridePatterns(
+    RewritePatternSet &patterns, int &maxSize);
+
 // Apply AIRSpecializeChannelWrapAndStridePattern on region.
 void applyAIRSpecializeChannelWrapAndStridePattern(Region *region,
                                                    int maxNumDims, int maxSize,

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -174,8 +174,7 @@ void populateDefaultWrapsAndStrides(OpBuilder builder, Value memref,
 // Check if the wraps and strides imply the default (contiguous, row-major) data
 // access pattern.
 bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
-                                SmallVector<Value> memcpy_strides,
-                                Value memref);
+                                SmallVector<Value> memcpy_strides);
 // Get the memref size along a given dimension, that the access pattern actually
 // covers.
 SmallVector<int64_t>

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1844,7 +1844,7 @@ public:
       auto memref = op.getMemref();
       auto memrefShape = air::getTensorShape(memref.getType());
       // The default data access pattern is contiguous and row major.
-      if (isDefaultDataAccessPattern(op.getSizes(), op.getStrides(), memref))
+      if (isDefaultDataAccessPattern(op.getSizes(), op.getStrides()))
         continue;
       if (op.getStrides().size() != memrefShape.size())
         return false;
@@ -2810,8 +2810,7 @@ public:
     auto wraps_and_strides =
         AIE::BDDimLayoutArrayAttr::get(ndcpy->getContext(), ArrayRef(dims));
     bool useDefaultDataAccessPattern =
-        UsesSemaphoreLocks ? isDefaultDataAccessPattern(sizes, strides, memref)
-                           : true;
+        UsesSemaphoreLocks ? isDefaultDataAccessPattern(sizes, strides) : true;
     AIE::DMABDOp aieDmaBdOp = nullptr;
     if (wraps_and_strides.getValue().empty() || useDefaultDataAccessPattern)
       aieDmaBdOp = b.create<AIE::DMABDOp>(

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -3068,9 +3068,8 @@ AIRSpecializeChannelWrapAndStrideImpl(Region *region, int maxNumDims = -1,
 
   // Canonicalize wrap and stride list to remove redundant dimensions
   RewritePatternSet preproc_wns_patterns(ctx);
-  preproc_wns_patterns.insert<AIRCanonicalizeChannelGetOpWrapAndStrideList,
-                              AIRCanonicalizeChannelPutOpWrapAndStrideList>(
-      ctx, maxSize);
+  populateAIRCanonicalizeChannelWrapAndStridePatterns(preproc_wns_patterns,
+                                                      maxSize);
   (void)applyPatternsGreedily(*region, std::move(preproc_wns_patterns));
 
   RewritePatternSet patterns(ctx);
@@ -3094,9 +3093,7 @@ AIRSpecializeChannelWrapAndStrideImpl(Region *region, int maxNumDims = -1,
 
   // Canonicalize wrap and stride list to remove redundant dimensions
   RewritePatternSet cano_patterns(ctx);
-  cano_patterns.insert<AIRCanonicalizeChannelGetOpWrapAndStrideList,
-                       AIRCanonicalizeChannelPutOpWrapAndStrideList>(
-      ctx, maxNumDims);
+  populateAIRCanonicalizeChannelWrapAndStridePatterns(cano_patterns, maxSize);
   ExecuteOp::getCanonicalizationPatterns(cano_patterns, ctx);
   (void)applyPatternsGreedily(*region, std::move(cano_patterns));
 
@@ -6213,6 +6210,13 @@ std::unique_ptr<Pass> createAIRShrinkMemrefSizesByAccess() {
 void populateAIRLoopIndexCanonicalizationPatterns(RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
   patterns.insert<CanonicalizeAffineApplyOnLoopInductionVar>(ctx);
+}
+
+void populateAIRCanonicalizeChannelWrapAndStridePatterns(
+    RewritePatternSet &patterns, int &maxSize) {
+  MLIRContext *ctx = patterns.getContext();
+  patterns.insert<AIRCanonicalizeChannelPutOpWrapAndStrideList,
+                  AIRCanonicalizeChannelGetOpWrapAndStrideList>(ctx, maxSize);
 }
 
 void applyAIRSpecializeChannelWrapAndStridePattern(

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -924,8 +924,7 @@ FailureOr<Value> tileChannelOpByFactor(
             originalApplyOperands = llvm::to_vector(opers);
           } else {
             if (air::isDefaultDataAccessPattern(originalChanOp.getSizes(),
-                                                originalChanOp.getStrides(),
-                                                originalChanOp.getMemref()))
+                                                originalChanOp.getStrides()))
               originalApplyOperands.push_back(zeroIdx);
             else
               originalApplyOperands.push_back(


### PR DESCRIPTION
The previous core lock release action was placed at either (1) dealloc or (2) end of the bb, both of which imply the end of lifetime for the buffer. This, however, creates extra challenges when one buffer is write-accessed by DMA at multiple time phases.

This PR rewrites the lock release allocation strategy to better generalize to more complex core programs.