### PR TITLE
Switch off `keep-memref-dealloc` option in `air-ping-pong-transform`

### DIFF
--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -430,8 +430,8 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:             aie.use_lock(%[[VAL_2]], Release, 0)
 // CHECK:             aie.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:           }
-// CHECK:           aie.use_lock(%[[VAL_5]], Release, 1)
-// CHECK:           aie.use_lock(%[[VAL_4]], Release, 0)
+// CHECK-DAG:       aie.use_lock(%[[VAL_5]], Release, 1)
+// CHECK-DAG:       aie.use_lock(%[[VAL_4]], Release, 0)
 // CHECK:           aie.end
 // CHECK:         }
 

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -263,8 +263,8 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:    aie.core(%[[VAL_3]]) {
 // CHECK:           aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
 // CHECK:           aie.use_lock(%[[VAL_18]], AcquireGreaterEqual, 1)
-// CHECK:           aie.use_lock(%[[VAL_20]], Release, 1)
-// CHECK:           aie.use_lock(%[[VAL_17]], Release, 1)
+// CHECK-DAG:       aie.use_lock(%[[VAL_20]], Release, 1)
+// CHECK-DAG:       aie.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:           aie.end
 // CHECK:         }
 

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -224,8 +224,8 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:    aie.core(%[[VAL_3]]) {
 // CHECK:           aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
 // CHECK:           aie.use_lock(%[[VAL_18]], AcquireGreaterEqual, 1)
-// CHECK:           aie.use_lock(%[[VAL_20]], Release, 1)
-// CHECK:           aie.use_lock(%[[VAL_17]], Release, 1)
+// CHECK-DAG:       aie.use_lock(%[[VAL_20]], Release, 1)
+// CHECK-DAG:       aie.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:           aie.end
 // CHECK:         }
 

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
@@ -38,8 +38,8 @@
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:     }
-// CHECK:     aie.use_lock({{.*}}, Release, 1)
-// CHECK:     aie.use_lock({{.*}}, Release, 0)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 1)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 0)
 // CHECK:   } {elf_file = 
 // CHECK:   aie.mem(%[[VAL_4]])
 // CHECK:   aie.core(%[[VAL_4]])
@@ -57,8 +57,8 @@
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:     }
-// CHECK:     aie.use_lock({{.*}}, Release, 1)
-// CHECK:     aie.use_lock({{.*}}, Release, 0)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 1)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 0)
 // CHECK:   } {elf_file = 
 // CHECK:   aie.mem(%[[VAL_3]])
 // CHECK:   aie.core(%[[VAL_3]])
@@ -76,8 +76,8 @@
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:     }
-// CHECK:     aie.use_lock({{.*}}, Release, 1)
-// CHECK:     aie.use_lock({{.*}}, Release, 0)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 1)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 0)
 // CHECK:   } {elf_file = 
 // CHECK:   aie.mem(%[[VAL_2]])
 // CHECK:   aie.core(%[[VAL_2]])
@@ -95,8 +95,8 @@
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:       aie.use_lock({{.*}}, Release, 0)
 // CHECK:     }
-// CHECK:     aie.use_lock({{.*}}, Release, 1)
-// CHECK:     aie.use_lock({{.*}}, Release, 0)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 1)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 0)
 // CHECK:   } {elf_file = 
 
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -219,12 +219,6 @@ module {
         %async_token_15 = air.execute [%arg10, %16, %15] {
           linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_11, %results_13 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%results_5 : memref<32x32xi32, 2>)
         }
-        %async_token_16 = air.execute {
-          memref.dealloc %results_11 : memref<32x32xi32, 2>
-        }
-        %async_token_17 = air.execute {
-          memref.dealloc %results_13 : memref<32x32xi32, 2>
-        }
         %17 = affine.if #set()[%arg3, %arg4] -> !air.async.token {
           %20 = air.channel.get async [%16, %15, %arg9]  @channel_0[%arg3, %arg4] (%results_9[] [] []) {id = 8 : i32} : (memref<32x32xi32, 2>)
           affine.yield %20 : !air.async.token
@@ -242,18 +236,18 @@ module {
         %async_token_18 = air.execute [%async_token_15, %18, %17] {
           linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_9, %results_7 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%results_5 : memref<32x32xi32, 2>)
         }
-        %async_token_19 = air.execute {
-          memref.dealloc %results_9 : memref<32x32xi32, 2>
-        }
-        %async_token_20 = air.execute {
-          memref.dealloc %results_7 : memref<32x32xi32, 2>
-        }
         %19 = air.wait_all async [%17, %18] 
         scf.yield %async_token_15, %async_token_18, %async_token_18, %19 : !air.async.token, !air.async.token, !air.async.token, !air.async.token
       }
       %14 = air.channel.put async [%13#1]  @channel_5[%arg3, %arg4] (%results_5[] [] []) {id = 12 : i32} : (memref<32x32xi32, 2>)
       %async_token_14 = air.execute [%14] {
         memref.dealloc %results_5 : memref<32x32xi32, 2>
+      }
+      %async_token_19 = air.execute {
+        memref.dealloc %results_9 : memref<32x32xi32, 2>
+      }
+      %async_token_20 = air.execute {
+        memref.dealloc %results_7 : memref<32x32xi32, 2>
       }
     }
     return

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_aie2.mlir
@@ -230,12 +230,6 @@ module {
               %async_token_44 = air.execute [%arg19, %22, %21] {
                 linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_40, %results_42 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%results_34 : memref<32x32xi32, 2>)
               }
-              %async_token_45 = air.execute {
-                memref.dealloc %results_40 : memref<32x32xi32, 2>
-              }
-              %async_token_46 = air.execute {
-                memref.dealloc %results_42 : memref<32x32xi32, 2>
-              }
               %23 = affine.if #set()[%arg12, %arg13] -> !air.async.token {
                 %26 = air.channel.get async [%22, %21, %arg18]  @channel_0[%arg12, %arg13] (%results_38[] [] []) {id = 15 : i32} : (memref<32x32xi32, 2>)
                 affine.yield %26 : !air.async.token
@@ -253,18 +247,18 @@ module {
               %async_token_47 = air.execute [%async_token_44, %24, %23] {
                 linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%results_38, %results_36 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%results_34 : memref<32x32xi32, 2>)
               }
-              %async_token_48 = air.execute {
-                memref.dealloc %results_38 : memref<32x32xi32, 2>
-              }
-              %async_token_49 = air.execute {
-                memref.dealloc %results_36 : memref<32x32xi32, 2>
-              }
               %25 = air.wait_all async [%23, %24] 
               scf.yield %async_token_44, %async_token_47, %async_token_47, %25 : !air.async.token, !air.async.token, !air.async.token, !air.async.token
             }
             %20 = air.channel.put async [%19#1]  @channel_8[%arg12, %arg13] (%results_34[] [] []) {id = 19 : i32} : (memref<32x32xi32, 2>)
             %async_token_43 = air.execute [%20] {
               memref.dealloc %results_34 : memref<32x32xi32, 2>
+            }
+            %async_token_48 = air.execute {
+              memref.dealloc %results_38 : memref<32x32xi32, 2>
+            }
+            %async_token_49 = air.execute {
+              memref.dealloc %results_36 : memref<32x32xi32, 2>
             }
           }
           %14 = scf.parallel (%arg12, %arg13) = (%c0_16, %c0_16) to (%c2_15, %c2_15) step (%c1_13, %c1_13) init (%arg11) -> !air.async.token {
@@ -341,12 +335,6 @@ module {
             %36 = air.channel.put async [%arg16]  @channel_3[] (%results_28[%arg15, %c32] [%c32, %c32] [%c64_14, %c1_13]) {id = 11 : i32} : (memref<128x64xi32, 1>)
             scf.yield %36 : !air.async.token
           }
-          %async_token_30 = air.execute {
-            memref.dealloc %results_26 : memref<64x128xi32, 1>
-          }
-          %async_token_31 = air.execute {
-            memref.dealloc %results_28 : memref<128x64xi32, 1>
-          }
           %23 = air.wait_all async [%13, %14, %22, %20, %18, %16] 
           %24 = air.channel.get async [%14, %13, %arg12]  @channel_5[] (%results_24[] [] []) {id = 21 : i32} : (memref<64x128xi32, 1>)
           %25 = air.channel.get async [%14, %13, %arg12]  @channel_6[] (%results_22[] [] []) {id = 22 : i32} : (memref<128x64xi32, 1>)
@@ -370,12 +358,6 @@ module {
             %36 = air.channel.put async [%arg16]  @channel_3[] (%results_22[%arg15, %c32] [%c32, %c32] [%c64_14, %c1_13]) {id = 26 : i32} : (memref<128x64xi32, 1>)
             scf.yield %36 : !air.async.token
           }
-          %async_token_32 = air.execute {
-            memref.dealloc %results_24 : memref<64x128xi32, 1>
-          }
-          %async_token_33 = air.execute {
-            memref.dealloc %results_22 : memref<128x64xi32, 1>
-          }
           %34 = air.wait_all async [%24, %25, %33, %31, %29, %27] 
           %35 = air.wait_all async [%24, %25] 
           scf.yield %23, %34, %34, %35 : !air.async.token, !air.async.token, !air.async.token, !air.async.token
@@ -383,6 +365,12 @@ module {
         %12 = air.channel.put async [%10, %11#1]  @channel_9[] (%results_20[] [] []) {id = 20 : i32} : (memref<64x64xi32, 1>)
         %async_token_29 = air.execute [%12] {
           memref.dealloc %results_20 : memref<64x64xi32, 1>
+        }
+        %async_token_32 = air.execute {
+          memref.dealloc %results_24 : memref<64x128xi32, 1>
+        }
+        %async_token_33 = air.execute {
+          memref.dealloc %results_22 : memref<128x64xi32, 1>
         }
       }
     }

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -17,8 +17,8 @@
 // CHECK:   aie.use_lock({{.*}}, Release, 0)
 // CHECK:   aie.use_lock({{.*}}, Release, 0)
 // CHECK: }
-// CHECK: aie.use_lock({{.*}}, Release, 1)
-// CHECK: aie.use_lock({{.*}}, Release, 0)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 1)
+// CHECK-DAG: aie.use_lock({{.*}}, Release, 0)
 #map = affine_map<()[s0] -> (s0 * 32)>
 #set0 = affine_set<(d0, d1)[s0] : (d0 >= 0, d1 - s0 == 0, s0 >= 0, -s0 + 1 >= 0)>
 #set1 = affine_set<(d0, d1)[s0] : (d0 - s0 == 0, d1 >= 0, s0 >= 0, -s0 + 1 >= 0)>

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -41,7 +41,7 @@ def get_experimental_passes(omit_pingpong=True):
         EXPERIMENTAL_PASSES += [
             "func.func(air-loop-fusion)",
             "air-label-scf-for-to-ping-pong",
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
         ]
     EXPERIMENTAL_PASSES += [
         "air-isolate-async-dma-loop-nests",

--- a/test/xrt/01_air_to_npu/aie.py
+++ b/test/xrt/01_air_to_npu/aie.py
@@ -149,7 +149,7 @@ pipeline = (
     "builtin.module("
     + ",".join(
         [
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "air-dealias-memref",
             "canonicalize",
             "cse",

--- a/test/xrt/04_gemm_w_pack/aie.py
+++ b/test/xrt/04_gemm_w_pack/aie.py
@@ -131,7 +131,7 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/08_gemm_extern_vec/aie.py
+++ b/test/xrt/08_gemm_extern_vec/aie.py
@@ -154,7 +154,7 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/09_gemm_extern_vec_4x4/aie.py
+++ b/test/xrt/09_gemm_extern_vec_4x4/aie.py
@@ -165,7 +165,7 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/10_gemm_peeling_extern_vec/aie.py
+++ b/test/xrt/10_gemm_peeling_extern_vec/aie.py
@@ -161,7 +161,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/11_gemm_bias_fusion/aie.py
+++ b/test/xrt/11_gemm_bias_fusion/aie.py
@@ -207,9 +207,15 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-fuse-channels{aggressive-mode=L1}",
                 "canonicalize",
                 "cse",
+                ### Scaling to 4 AIE columns
+                "func.func(air-split-l2-memref)",
+                "canonicalize",
+                "cse",
+                "air-isolate-async-dma-loop-nests",
+                ###
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/12_matmul_transform_1x4_bf16/gen.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/gen.py
@@ -153,7 +153,7 @@ pipeline = (
             "cse",
             "func.func(air-loop-fusion)",
             "air-label-scf-for-to-ping-pong",
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "canonicalize",
             "cse",
             "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/13_conv2d_i32/aie.py
+++ b/test/xrt/13_conv2d_i32/aie.py
@@ -121,7 +121,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-isolate-async-dma-loop-nests",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/14_conv2d_i8_extern_vec/aie.py
+++ b/test/xrt/14_conv2d_i8_extern_vec/aie.py
@@ -120,7 +120,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-isolate-async-dma-loop-nests",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/aie.py
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/aie.py
@@ -190,7 +190,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/aie.py
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/aie.py
@@ -190,7 +190,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
@@ -177,7 +177,7 @@ pipeline = (
     "builtin.module("
     + ",".join(
         [
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "canonicalize",
             "cse",
             "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
@@ -159,7 +159,7 @@ pipeline = (
     "builtin.module("
     + ",".join(
         [
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "canonicalize",
             "cse",
             "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
@@ -155,7 +155,7 @@ pipeline = (
     "builtin.module("
     + ",".join(
         [
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "canonicalize",
             "cse",
             "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/20_batch_matmul_i32/aie.py
+++ b/test/xrt/20_batch_matmul_i32/aie.py
@@ -185,7 +185,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/21_conv2d_depthwise_i32/aie.py
+++ b/test/xrt/21_conv2d_depthwise_i32/aie.py
@@ -117,7 +117,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-isolate-async-dma-loop-nests",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/22_conv2d_stride2_i32/aie.py
+++ b/test/xrt/22_conv2d_stride2_i32/aie.py
@@ -122,7 +122,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-isolate-async-dma-loop-nests",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/23_ctrlpkt_config/aie.py
+++ b/test/xrt/23_ctrlpkt_config/aie.py
@@ -142,7 +142,7 @@ pipeline = (
             "canonicalize",
             "cse",
             "air-label-scf-for-to-ping-pong",
-            "air-ping-pong-transform{keep-memref-dealloc=true}",
+            "air-ping-pong-transform",
             "air-dealias-memref",
             "canonicalize",
             "cse",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
@@ -190,7 +190,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
@@ -191,7 +191,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/25_batch_matmul_bf16/aie.py
+++ b/test/xrt/25_batch_matmul_bf16/aie.py
@@ -186,7 +186,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/26_vecmat_i8/aie.py
+++ b/test/xrt/26_vecmat_i8/aie.py
@@ -189,7 +189,6 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                # "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true insert-trace-packet-flow=true}",
                 "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
                 "canonicalize",
             ]
@@ -213,7 +212,6 @@ with air.ir.Context() as ctx, Location.unknown():
                 "symbol-dce",
                 "func.func(air-unroll-outer-affine-loops{depth=4})",
                 "affine-expand-index-ops",
-                # "airrt-to-npu{trace-offset=4096 trace-size=262144}",
                 "airrt-to-npu",
                 "canonicalize",
             ]

--- a/test/xrt/26_vecmat_i8/aie.py
+++ b/test/xrt/26_vecmat_i8/aie.py
@@ -143,7 +143,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-isolate-async-dma-loop-nests",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
@@ -190,7 +190,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform{keep-memref-dealloc=true}",
+                "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/28_gemm_loop_nest_bf16/aie.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/aie.py
@@ -155,7 +155,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "func.func(air-fuse-alloc-dealloc)",
                 "func.func(air-shrink-memref-sizes-by-access)",
                 # "air-label-scf-for-to-ping-pong", #TODO: Add support for ping pong buffering
-                # "air-ping-pong-transform{keep-memref-dealloc=true}",
+                # "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/aie.py
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/aie.py
@@ -165,7 +165,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "func.func(air-fuse-alloc-dealloc)",
                 "func.func(air-shrink-memref-sizes-by-access)",
                 # "air-label-scf-for-to-ping-pong", #TODO: Add ping pong buffering
-                # "air-ping-pong-transform{keep-memref-dealloc=true}",
+                # "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
                 "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",


### PR DESCRIPTION
... because the new core lock release strategy no longer relies on `memref.dealloc` to find the end of the data lifetime.

Previously, when the `air-ping-pong-transform` pass emits `memref.dealloc` ops to signal end of lifetime, it is abusing the  `memref.dealloc`: the `alloc` is outside of the pipeline for loop but `alloc` is inside, falsefully representing duplicate deallocation of memrefs. This is now deprecated.