### PR TITLE
AIRLinalgCodegen: Switch to using `dyn_cast_if_present`

### DIFF
--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -355,7 +355,7 @@ struct RemoveExtraAllocPattern : public OpRewritePattern<memref::CopyOp> {
                                 PatternRewriter &rewriter) const override {
 
     auto existingAlloc =
-        dyn_cast<memref::AllocOp>(op.getOperand(0).getDefiningOp());
+        dyn_cast_if_present<memref::AllocOp>(op.getOperand(0).getDefiningOp());
     if (!existingAlloc)
       return failure();
 


### PR DESCRIPTION
… in case if operand 0 has no defining op.