### PR TITLE
AIRCopyToDma: Unranked memref support

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -317,11 +317,11 @@ def air_DmaMemcpyNdOp: air_Op<"dma_memcpy_nd",
   let summary = "dma operator";
   let arguments = (
     ins Variadic<air_AsyncToken>:$async_dependencies,
-        AnyMemRef:$dst,
+        AnyRankedOrUnrankedMemRef:$dst,
         Variadic<Index>:$dst_offsets,
         Variadic<Index>:$dst_sizes,
         Variadic<Index>:$dst_strides,
-        AnyMemRef:$src,
+        AnyRankedOrUnrankedMemRef:$src,
         Variadic<Index>:$src_offsets,
         Variadic<Index>:$src_sizes,
         Variadic<Index>:$src_strides

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -46,88 +46,6 @@ using namespace xilinx;
 
 static std::atomic<uint64_t> DmaMemcpyOpID;
 
-static FailureOr<air::DmaMemcpyNdOp>
-matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
-  auto loc = op.getLoc();
-  Value src = op.getSource();
-  Value dst = op.getTarget();
-
-  rewriter.setInsertionPoint(op);
-
-  // It must already be a memref
-  auto src_type = llvm::dyn_cast<MemRefType>(src.getType());
-  auto dst_type = llvm::dyn_cast<MemRefType>(dst.getType());
-  if (!src_type)
-    return failure();
-
-  if ((src_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) &&
-      (dst_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3))
-    return failure();
-
-  if (!(src_type.hasStaticShape() || dst_type.hasStaticShape()))
-    return failure();
-
-  SmallVector<Value, 4> src_offsets, dst_offsets;
-  SmallVector<Value, 4> src_strides, dst_strides;
-  SmallVector<Value, 4> src_sizes, dst_sizes;
-  auto extractOperandsFromSubview = [&](memref::SubViewOp subview,
-                                        auto &offsets, auto &sizes,
-                                        auto &strides) {
-    auto subview_offsets = subview.getOffsets().begin();
-    auto static_offsets = subview.getStaticOffsets();
-    auto static_sizes = subview.getStaticSizes();
-    auto static_strides = subview.getStaticStrides();
-    auto loc = subview.getLoc();
-
-    // get the strides and offsets from the memref type
-    auto inferredType =
-        llvm::cast<MemRefType>(memref::SubViewOp::inferResultType(
-            subview.getSourceType(), static_offsets, static_sizes,
-            static_strides));
-    int64_t offset;
-    SmallVector<int64_t, 4> layout_strides;
-    auto successStrides =
-        inferredType.getStridesAndOffset(layout_strides, offset);
-    if (failed(successStrides)) {
-      llvm::outs() << "Failed to get strides\n";
-      return; // failure();
-    }
-
-    for (auto o : static_offsets) {
-      if (o >= 0)
-        offsets.push_back(rewriter.create<arith::ConstantIndexOp>(loc, o));
-      else
-        offsets.push_back(*subview_offsets++);
-    }
-    for (auto s : static_sizes)
-      sizes.push_back(rewriter.create<arith::ConstantIndexOp>(loc, s));
-    for (auto s : layout_strides)
-      strides.push_back(rewriter.create<arith::ConstantIndexOp>(loc, s));
-  };
-
-  if (auto subview = src.getDefiningOp<memref::SubViewOp>()) {
-    extractOperandsFromSubview(subview, src_offsets, src_sizes, src_strides);
-    src = subview.getSource();
-  }
-
-  if (auto subview = dst.getDefiningOp<memref::SubViewOp>()) {
-    extractOperandsFromSubview(subview, dst_offsets, dst_sizes, dst_strides);
-    dst = subview.getSource();
-  }
-
-  SmallVector<Value, 4> deps;
-  SmallVector<Type, 4> tys;
-  auto dma = rewriter.create<air::DmaMemcpyNdOp>(
-      loc, tys, deps, dst, dst_offsets, dst_sizes, dst_strides, src,
-      src_offsets, src_sizes, src_strides);
-  dma->setAttr(
-      "id", mlir::IntegerAttr::get(mlir::IntegerType::get(op->getContext(), 32),
-                                   ++DmaMemcpyOpID));
-
-  rewriter.eraseOp(op);
-  return dma;
-}
-
 static void extractOperandsFromSubview(memref::SubViewOp subview,
                                        OpBuilder &builder,
                                        SmallVector<Value, 4> &offsets,
@@ -161,6 +79,127 @@ static void extractOperandsFromSubview(memref::SubViewOp subview,
     sizes.push_back(builder.create<arith::ConstantIndexOp>(loc, s));
   for (auto s : layout_strides)
     strides.push_back(builder.create<arith::ConstantIndexOp>(loc, s));
+}
+
+static void extractOperandsFromReinterpretCast(
+    memref::ReinterpretCastOp reinterpretCast, OpBuilder &builder,
+    SmallVector<Value, 4> &offsets, SmallVector<Value, 4> &sizes,
+    SmallVector<Value, 4> &strides) {
+  auto reinterpretCast_offsets = reinterpretCast.getOffsets().begin();
+  auto static_offsets = reinterpretCast.getStaticOffsets();
+  auto static_sizes = reinterpretCast.getStaticSizes();
+  auto loc = reinterpretCast.getLoc();
+
+  // Fixup an issue in the reinterpretCast output memref's strided layout giving
+  // false dynamic strides
+  auto constifyStridesInStridedLayout =
+      [](MemRefType rankedMemRefType,
+         memref::ReinterpretCastOp reinterpretCast) {
+        StridedLayoutAttr stridedLayout =
+            dyn_cast<StridedLayoutAttr>(rankedMemRefType.getLayout());
+        SmallVector<int64_t> correctedStaticStrides(
+            stridedLayout.getStrides().size(), 0);
+        for (auto [index, stride] :
+             llvm::enumerate(reinterpretCast.getMixedStrides())) {
+          if (auto constStride = getConstantIntValue(stride))
+            correctedStaticStrides[index] = *constStride;
+          else
+            correctedStaticStrides[index] = stridedLayout.getStrides()[index];
+        }
+        auto correctedStridedLayout = StridedLayoutAttr::get(
+            reinterpretCast->getContext(), stridedLayout.getOffset(),
+            ArrayRef(correctedStaticStrides));
+        return MemRefType::Builder(rankedMemRefType)
+            .setShape(rankedMemRefType.getShape())
+            .setLayout(correctedStridedLayout);
+      };
+
+  MemRefType reinterpretCastType = constifyStridesInStridedLayout(
+      reinterpretCast.getType(), reinterpretCast);
+
+  // get the strides and offsets from the memref type
+  int64_t offset;
+  SmallVector<int64_t, 4> layout_strides;
+  auto successStrides =
+      reinterpretCastType.getStridesAndOffset(layout_strides, offset);
+  if (failed(successStrides)) {
+    llvm::outs() << "Failed to get strides\n";
+    return; // failure();
+  }
+
+  for (auto o : static_offsets) {
+    if (o >= 0)
+      offsets.push_back(builder.create<arith::ConstantIndexOp>(loc, o));
+    else
+      offsets.push_back(*reinterpretCast_offsets++);
+  }
+  for (auto s : static_sizes)
+    sizes.push_back(builder.create<arith::ConstantIndexOp>(loc, s));
+  for (auto s : layout_strides)
+    strides.push_back(builder.create<arith::ConstantIndexOp>(loc, s));
+  while (offsets.size() < sizes.size())
+    offsets.insert(offsets.begin(),
+                   builder.create<arith::ConstantIndexOp>(loc, 0));
+}
+
+static FailureOr<air::DmaMemcpyNdOp>
+matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
+  auto loc = op.getLoc();
+  Value src = op.getSource();
+  Value dst = op.getTarget();
+
+  rewriter.setInsertionPoint(op);
+
+  // It must already be a memref
+  auto src_type = llvm::dyn_cast<MemRefType>(src.getType());
+  auto dst_type = llvm::dyn_cast<MemRefType>(dst.getType());
+  if (!src_type)
+    return failure();
+
+  if ((src_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) &&
+      (dst_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3))
+    return failure();
+
+  if (!(src_type.hasStaticShape() || dst_type.hasStaticShape()))
+    return failure();
+
+  SmallVector<Value, 4> src_offsets, dst_offsets;
+  SmallVector<Value, 4> src_strides, dst_strides;
+  SmallVector<Value, 4> src_sizes, dst_sizes;
+
+  if (auto subview = src.getDefiningOp<memref::SubViewOp>()) {
+    extractOperandsFromSubview(subview, rewriter, src_offsets, src_sizes,
+                               src_strides);
+    src = subview.getSource();
+  } else if (auto reinterpretCast =
+                 src.getDefiningOp<memref::ReinterpretCastOp>()) {
+    extractOperandsFromReinterpretCast(reinterpretCast, rewriter, src_offsets,
+                                       src_sizes, src_strides);
+    src = reinterpretCast.getSource();
+  }
+
+  if (auto subview = dst.getDefiningOp<memref::SubViewOp>()) {
+    extractOperandsFromSubview(subview, rewriter, dst_offsets, dst_sizes,
+                               dst_strides);
+    dst = subview.getSource();
+  } else if (auto reinterpretCast =
+                 dst.getDefiningOp<memref::ReinterpretCastOp>()) {
+    extractOperandsFromReinterpretCast(reinterpretCast, rewriter, dst_offsets,
+                                       dst_sizes, dst_strides);
+    dst = reinterpretCast.getSource();
+  }
+
+  SmallVector<Value, 4> deps;
+  SmallVector<Type, 4> tys;
+  auto dma = rewriter.create<air::DmaMemcpyNdOp>(
+      loc, tys, deps, dst, dst_offsets, dst_sizes, dst_strides, src,
+      src_offsets, src_sizes, src_strides);
+  dma->setAttr(
+      "id", mlir::IntegerAttr::get(mlir::IntegerType::get(op->getContext(), 32),
+                                   ++DmaMemcpyOpID));
+
+  rewriter.eraseOp(op);
+  return dma;
 }
 
 static void

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2457,11 +2457,13 @@ public:
       int src_memspace = -1;
       int dst_memspace = -1;
       if (dma_op.getSrcMemref())
-        src_memspace = llvm::cast<MemRefType>(dma_op.getSrcMemref().getType())
-                           .getMemorySpaceAsInt();
+        src_memspace =
+            llvm::cast<BaseMemRefType>(dma_op.getSrcMemref().getType())
+                .getMemorySpaceAsInt();
       if (dma_op.getDstMemref())
-        dst_memspace = llvm::cast<MemRefType>(dma_op.getDstMemref().getType())
-                           .getMemorySpaceAsInt();
+        dst_memspace =
+            llvm::cast<BaseMemRefType>(dma_op.getDstMemref().getType())
+                .getMemorySpaceAsInt();
       bool isL1Memcpy = (src_memspace == (int)air::MemorySpace::L1) ||
                         (dst_memspace == (int)air::MemorySpace::L1);
       if (dma_op->getParentOfType<xilinx::air::HerdOp>() && isL1Memcpy) {

--- a/mlir/test/Conversion/ConvertToAIR/linalg_copy_to_4d_air_memcpy.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/linalg_copy_to_4d_air_memcpy.mlir
@@ -7,11 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-copy-to-dma  -cse -canonicalize | FileCheck %s
-// XFAIL: *
-//CHECK:          air.dma_memcpy_4d (%6, %{{.*}}, [%c0, %c0, %c0, %c0], [%c0, %arg10, %arg9, %4], %c5184, %c64, %c16) {id = 1 : i32} : (memref<1x16x18x18xf32, 2>, memref<1x64x66x66xf32>, [index, index, index, index], [index, index, index, index], index, index, index) -> ()
-//CHECK:          air.dma_memcpy_4d (%7, %{{.*}}, [%c0, %c0, %c0, %c0], [%5, %arg10, %c0, %c0], %c4608, %c64, %c16) {id = 2 : i32} : (memref<32x16x3x3xf32, 2>, memref<128x64x3x3xf32>, [index, index, index, index], [index, index, index, index], index, index, index) -> ()
-//CHECK:          air.dma_memcpy_4d (%8, %{{.*}}, [%c0, %c0, %c0, %c0], [%c0, %5, %arg9, %4], %c8192, %c128, %c32) {id = 3 : i32} : (memref<1x32x16x16xf32, 2>, memref<1x128x64x64xf32>, [index, index, index, index], [index, index, index, index], index, index, index) -> ()
-//CHECK:          air.dma_memcpy_4d (%{{.*}}, %8, [%c0, %5, %arg9, %4], [%c0, %c0, %c0, %c0], %c8192, %c128, %c32) {id = 4 : i32} : (memref<1x128x64x64xf32>, memref<1x32x16x16xf32, 2>, [index, index, index, index], [index, index, index, index], index, index, index) -> ()
+
+//CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%c0{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] [%c1{{.*}}, %c16{{.*}}, %c18{{.*}}, %c18{{.*}}] [%c278784{{.*}}, %c4356{{.*}}, %c66{{.*}}, %c1{{.*}}])
+//CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%{{.*}}, %{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c32{{.*}}, %c16{{.*}}, %c3{{.*}}, %c3{{.*}}] [%c576{{.*}}, %c9{{.*}}, %c3{{.*}}, %c1{{.*}}])
+//CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%c0{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] [%c1{{.*}}, %c32{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c524288{{.*}}, %c4096{{.*}}, %c64{{.*}}, %c1{{.*}}])
+//CHECK: air.dma_memcpy_nd (%{{.*}}[%c0{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] [%c1{{.*}}, %c32{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c524288{{.*}}, %c4096{{.*}}, %c64{{.*}}, %c1{{.*}}], %{{.*}}[] [] [])
+
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0 * 278784 + d1 * 4356 + d2 * 66 + d3 + 67)>
 #map1 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 278784 + s0 + d1 * 4356 + d2 * 66 + d3)>
 #map2 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 576 + s0 + d1 * 9 + d2 * 3 + d3)>
@@ -23,13 +24,13 @@ module attributes {torch.debug_module_name = "Conv2D"}  {
     %cst = arith.constant 0.000000e+00 : f32
     %true = arith.constant true
     %0 = memref.get_global @__constant_128x64x3x3xf32 : memref<128x64x3x3xf32>
-    assert %true, "expect groups to be 1"
+    // assert %true, "expect groups to be 1"
     %1 = memref.alloc() : memref<1x64x66x66xf32>
-    linalg.fill(%cst, %1) : f32, memref<1x64x66x66xf32> 
+    linalg.fill ins(%cst : f32) outs(%1 : memref<1x64x66x66xf32>)
     %2 = memref.alloc() : memref<1x64x66x66xf32>
-    linalg.copy(%1, %2) : memref<1x64x66x66xf32>, memref<1x64x66x66xf32> 
+    linalg.copy ins(%1 : memref<1x64x66x66xf32>) outs(%2 : memref<1x64x66x66xf32> )
     %3 = memref.subview %2[0, 0, 1, 1] [1, 64, 64, 64] [1, 1, 1, 1] : memref<1x64x66x66xf32> to memref<1x64x64x64xf32, #map0>
-    linalg.copy(%arg0, %3) : memref<1x64x64x64xf32>, memref<1x64x64x64xf32, #map0> 
+    linalg.copy ins(%arg0 : memref<1x64x64x64xf32>) outs(%3 : memref<1x64x64x64xf32, #map0> )
     %c32 = arith.constant 32 : index
     %c16 = arith.constant 16 : index
     %c128 = arith.constant 128 : index
@@ -44,17 +45,17 @@ module attributes {torch.debug_module_name = "Conv2D"}  {
           %7 = memref.alloc() : memref<1x16x18x18xf32, 2>
           %8 = memref.alloc() : memref<32x16x3x3xf32, 2>
           %9 = memref.alloc() : memref<1x32x16x16xf32, 2>
-          linalg.copy(%4, %7) : memref<1x16x18x18xf32, #map1>, memref<1x16x18x18xf32, 2> 
-          linalg.copy(%5, %8) : memref<32x16x3x3xf32, #map2>, memref<32x16x3x3xf32, 2> 
-          linalg.copy(%6, %9) : memref<1x32x16x16xf32, #map3>, memref<1x32x16x16xf32, 2> 
+          linalg.copy ins(%4 : memref<1x16x18x18xf32, #map1>) outs(%7 : memref<1x16x18x18xf32, 2> )
+          linalg.copy ins(%5 : memref<32x16x3x3xf32, #map2>) outs(%8 : memref<32x16x3x3xf32, 2> )
+          linalg.copy ins(%6 : memref<1x32x16x16xf32, #map3>) outs(%9 : memref<1x32x16x16xf32, 2> )
           linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%7, %8 : memref<1x16x18x18xf32, 2>, memref<32x16x3x3xf32, 2>) outs(%9 : memref<1x32x16x16xf32, 2>)
-          linalg.copy(%9, %6) : memref<1x32x16x16xf32, 2>, memref<1x32x16x16xf32, #map3> 
+          linalg.copy ins(%9 : memref<1x32x16x16xf32, 2>) outs(%6 : memref<1x32x16x16xf32, #map3> )
           memref.dealloc %7 : memref<1x16x18x18xf32, 2>
           memref.dealloc %8 : memref<32x16x3x3xf32, 2>
           memref.dealloc %9 : memref<1x32x16x16xf32, 2>
         }
       }
-      scf.yield
+      scf.reduce
     }
     return
   }

--- a/mlir/test/Conversion/ConvertToAIR/memref_copy_to_air_memcpy.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/memref_copy_to_air_memcpy.mlir
@@ -1,0 +1,70 @@
+//===- memref_copy_to_air_memcpy.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-copy-to-dma
+
+// Ranked memref.
+// CHECK: func.func @func0
+// CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%{{.*}}, %c0{{.*}}] [%c16{{.*}}, %c64{{.*}}] [%c64{{.*}}, %c1{{.*}}])
+// CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%c0{{.*}}, %{{.*}}] [%c64{{.*}}, %c16{{.*}}] [%c64{{.*}}, %c1{{.*}}])
+// CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%{{.*}}, %{{.*}}] [%c16{{.*}}, %c16{{.*}}] [%c64{{.*}}, %c1{{.*}}])
+// CHECK: air.dma_memcpy_nd (%{{.*}}[%{{.*}}, %{{.*}}] [%c16{{.*}}, %c16{{.*}}] [%c64{{.*}}, %c1{{.*}}], %{{.*}}[] [] [])
+#map = affine_map<(d0, d1)[s0] -> (d0 * 64 + s0 + d1)>
+#map0 = affine_map<(d0, d1, d2)[s0] -> (d0 * 524288 + s0 + d1 * 512 + d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+module  {
+  func.func @func0(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) -> memref<64x64xf32> {
+    %c64 = arith.constant 64 : index
+    %c16 = arith.constant 16 : index
+    %c0 = arith.constant 0 : index
+    %0 = memref.alloc() : memref<64x64xf32>
+    scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c64, %c64) step (%c16, %c16) {
+      %1 = memref.subview %arg0[%arg2, 0] [16, 64] [1, 1] : memref<64x64xf32> to memref<16x64xf32, #map>
+      %2 = memref.subview %arg1[0, %arg3] [64, 16] [1, 1] : memref<64x64xf32> to memref<64x16xf32, #map>
+      %3 = memref.subview %0[%arg2, %arg3] [16, 16] [1, 1] : memref<64x64xf32> to memref<16x16xf32, #map>
+      %4 = memref.alloc() : memref<16x64xf32, 2>
+      %5 = memref.alloc() : memref<64x16xf32, 2>
+      %6 = memref.alloc() : memref<16x16xf32, 2>
+      memref.copy %1, %4 : memref<16x64xf32, #map> to memref<16x64xf32, 2>
+      memref.copy %2, %5 : memref<64x16xf32, #map> to memref<64x16xf32, 2>
+      memref.copy %3, %6 : memref<16x16xf32, #map> to memref<16x16xf32, 2>
+      linalg.matmul ins(%4, %5 : memref<16x64xf32, 2>, memref<64x16xf32, 2>) outs(%6 : memref<16x16xf32, 2>)
+      memref.copy %6, %3 : memref<16x16xf32, 2> to memref<16x16xf32, #map>
+      memref.dealloc %4 : memref<16x64xf32, 2>
+      memref.dealloc %5 : memref<64x16xf32, 2>
+      memref.dealloc %6 : memref<16x16xf32, 2>
+    }
+    return %0 : memref<64x64xf32>
+  }
+  
+// Unranked memref.
+// CHECK: func.func @func1
+// CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%c0{{.*}}, %{{.*}}] [%c32{{.*}}, %c32{{.*}}] [%c64{{.*}}, %c1{{.*}}])
+// CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%c0{{.*}}, %{{.*}}] [%c32{{.*}}, %c32{{.*}}] [%c64{{.*}}, %c1{{.*}}])
+  func.func @func1(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: memref<*xf32>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c64 = arith.constant 64 : index
+    %c32_i32 = arith.constant 32 : i32
+    %0 = arith.muli %arg6, %c32_i32 : i32
+    %1 = arith.index_cast %0 : i32 to index
+    %2 = arith.muli %arg7, %c32_i32 : i32
+    %3 = arith.index_cast %2 : i32 to index
+    %4 = arith.muli %1, %c64 : index
+    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%4], sizes: [32, 32], strides: [%c64, 1] : memref<*xf32> to memref<32x32xf32, strided<[?, 1], offset: ?>>
+    %alloc = memref.alloc() : memref<32x32xf32, 2>
+    memref.copy %reinterpret_cast, %alloc : memref<32x32xf32, strided<[?, 1], offset: ?>> to memref<32x32xf32, 2>
+    %5 = bufferization.to_tensor %alloc restrict writable : memref<32x32xf32, 2> to tensor<32x32xf32>
+    %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [%3], sizes: [32, 32], strides: [%c64, 1] : memref<*xf32> to memref<32x32xf32, strided<[?, 1], offset: ?>>
+    %alloc_1 = memref.alloc() : memref<32x32xf32, 2>
+    memref.copy %reinterpret_cast_0, %alloc_1 : memref<32x32xf32, strided<[?, 1], offset: ?>> to memref<32x32xf32, 2>
+    %6 = bufferization.to_tensor %alloc_1 restrict writable : memref<32x32xf32, 2> to tensor<32x32xf32>
+    %7 = tensor.empty() : tensor<32x32xf32>
+    %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %9 = linalg.matmul ins(%5, %6 : tensor<32x32xf32>, tensor<32x32xf32>) outs(%8 : tensor<32x32xf32>) -> tensor<32x32xf32>
+    return
+  }
+}


### PR DESCRIPTION
- Add support for unramked memrefs as sources or destinations to `linalg.copy` / `memref.copy` lowering.
- Add support for `memref.reinterpret_cast` which is `memref.subview` for unranked memrefs.