### PR TITLE
AIRRtToNpu: Purge all logic trying to cast `runtime_sequence` arg types to be strictly i32

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -761,7 +761,7 @@ struct AIRSpecializeAIRRtDmaWrapAndStrideInAffineFor
       wraps.insert(wraps.begin(), i64_one);
     }
     while (strides.size() < 3) {
-      strides.insert(strides.begin(), i64_one);
+      strides.insert(strides.begin(), i64_zero);
     }
 
     // Stride = 0 means repeat that dimension. If highest dimension (dim 0) is

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -958,8 +958,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // Unroll any affine for loops
     unrollAffineFors(module);
 
-    // Cast buffers to i32 types; buffer npu.dma_memcpy_nd memref to function's
-    // argument list.
+    // Buffer npu.dma_memcpy_nd memref to function's argument list.
     RewritePatternSet castPattern(ctx);
     air::populateBufferMemrefToFuncArgsPattern(castPattern);
     (void)applyPatternsGreedily(module, std::move(castPattern));

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -126,19 +126,7 @@ struct DmaToNpuPattern : public OpConversionPattern<DmaMemcpyNdOp> {
     unsigned int bitwidth = memrefTy.getElementTypeBitWidth();
     if (bitwidth != 32 && bitwidth != 16 && bitwidth != 8)
       return failure();
-    unsigned int div = 32 / bitwidth;
-    unsigned int numElements = memrefTy.getNumElements() / div;
-    SmallVector<int64_t> shape{numElements};
-    MemRefType newMemrefTy =
-        MemRefType::get(shape, rewriter.getIntegerType(32));
 
-    Value divV = rewriter.create<arith::ConstantIndexOp>(op->getLoc(), div);
-    auto divOp = [&](Value v) {
-      if (div == 1)
-        return v;
-      return rewriter.create<arith::CeilDivUIOp>(op->getLoc(), v, divV)
-          .getResult();
-    };
     SmallVector<Value> offsets;
     SmallVector<int64_t> staticOffsets;
     if (auto const_int = getConstantIntValue(adaptor.getOffset3()))
@@ -154,9 +142,9 @@ struct DmaToNpuPattern : public OpConversionPattern<DmaMemcpyNdOp> {
     else
       offsets.push_back(adaptor.getOffset1());
     if (auto const_int = getConstantIntValue(adaptor.getOffset0()))
-      staticOffsets.push_back(*const_int / div);
+      staticOffsets.push_back(*const_int);
     else
-      offsets.push_back(divOp(adaptor.getOffset0()));
+      offsets.push_back(adaptor.getOffset0());
     SmallVector<Value> sizes;
     SmallVector<int64_t> staticSizes;
     if (auto const_int = getConstantIntValue(adaptor.getLength3()))
@@ -172,23 +160,23 @@ struct DmaToNpuPattern : public OpConversionPattern<DmaMemcpyNdOp> {
     else
       sizes.push_back(adaptor.getLength1());
     if (auto const_int = getConstantIntValue(adaptor.getLength0()))
-      staticSizes.push_back(std::max((int64_t)1, *const_int / div));
+      staticSizes.push_back(std::max((int64_t)1, *const_int));
     else
-      sizes.push_back(divOp(adaptor.getLength0()));
+      sizes.push_back(adaptor.getLength0());
     SmallVector<Value> strides;
     SmallVector<int64_t> staticStrides;
     if (auto const_int = getConstantIntValue(adaptor.getStride3()))
-      staticStrides.push_back(*const_int / div);
+      staticStrides.push_back(*const_int);
     else
-      strides.push_back(divOp(adaptor.getStride3()));
+      strides.push_back(adaptor.getStride3());
     if (auto const_int = getConstantIntValue(adaptor.getStride2()))
-      staticStrides.push_back(*const_int / div);
+      staticStrides.push_back(*const_int);
     else
-      strides.push_back(divOp(adaptor.getStride2()));
+      strides.push_back(adaptor.getStride2());
     if (auto const_int = getConstantIntValue(adaptor.getStride1()))
-      staticStrides.push_back(*const_int / div);
+      staticStrides.push_back(*const_int);
     else
-      strides.push_back(divOp(adaptor.getStride1()));
+      strides.push_back(adaptor.getStride1());
     staticStrides.push_back(1);
 
     StringRef metadata;
@@ -200,12 +188,6 @@ struct DmaToNpuPattern : public OpConversionPattern<DmaMemcpyNdOp> {
           FlatSymbolRefAttr::get(op->getContext(),
                                  rewriter.getStringAttr("MetadataNotFound"))
               .getValue();
-
-    if (bitwidth != 32)
-      memref = rewriter
-                   .create<UnrealizedConversionCastOp>(op.getLoc(), newMemrefTy,
-                                                       memref)
-                   .getResult(0);
 
     AIE::PacketInfoAttr packet =
         op->getAttrOfType<AIE::PacketInfoAttr>("packet");
@@ -393,77 +375,6 @@ public:
     return success();
   }
 };
-
-static LogicalResult CastFunctionArgs(func::FuncOp funcOp,
-                                      PatternRewriter &rewriter) {
-  // only run on npu control functions
-  bool hasNpuOps = false;
-  funcOp.walk([&](AIEX::NpuDmaMemcpyNdOp dma) { hasNpuOps = true; });
-  if (!hasNpuOps)
-    return failure();
-
-  // cast all the function args to i32 types.
-  // this is in support of npu.dma_memcpy_nd which only allow 32bit types
-  mlir::FunctionType funcType = funcOp.getFunctionType();
-  SmallVector<Type> argTypes(funcType.getInputs());
-  for (int i = 0, e = argTypes.size(); i < e; i++) {
-    auto memrefTy = dyn_cast<MemRefType>(argTypes[i]);
-    if (!memrefTy)
-      continue;
-
-    unsigned int bitwidth = memrefTy.getElementTypeBitWidth();
-    if (bitwidth != 16 && bitwidth != 8)
-      continue;
-
-    unsigned int div = 32 / bitwidth;
-    unsigned int numElements = memrefTy.getNumElements() / div;
-    SmallVector<int64_t> shape{numElements};
-    MemRefType newMemrefTy =
-        MemRefType::get(shape, rewriter.getIntegerType(32));
-    argTypes[i] = newMemrefTy;
-    auto &entry = funcOp.front();
-    entry.insertArgument(i, newMemrefTy, rewriter.getUnknownLoc());
-    rewriter.setInsertionPointToStart(&entry);
-    auto cast = rewriter.create<UnrealizedConversionCastOp>(
-        rewriter.getUnknownLoc(), memrefTy, entry.getArgument(i));
-    // With memref shape collapsed to 1d, the multi-dimensional offset also
-    // needs to be collapsed.
-    SmallVector<Operation *> users;
-    for (auto user : entry.getArgument(i + 1).getUsers()) {
-      if (auto cast_user = dyn_cast<UnrealizedConversionCastOp>(user)) {
-        assert(cast_user.getNumResults() == 1);
-        for (auto cast_r_user : cast_user.getResult(0).getUsers())
-          users.push_back(cast_r_user);
-      } else
-        users.push_back(user);
-    }
-    for (Operation *user : users) {
-      if (auto dmaUser = dyn_cast<AIEX::NpuDmaMemcpyNdOp>(user)) {
-        int oneDOffset = *getConstantIntValue(dmaUser.getMixedOffsets().back());
-        for (int j = dmaUser.getMixedOffsets().size() - 2; j >= 0; j--)
-          oneDOffset += *getConstantIntValue(dmaUser.getMixedOffsets()[j]) *
-                        *getConstantIntValue(dmaUser.getMixedStrides()[j]);
-        rewriter.setInsertionPoint(dmaUser);
-        const std::vector<int64_t> newStaticOffsets = {0, 0, 0, oneDOffset};
-        AIE::PacketInfoAttr packet =
-            dmaUser.getPacket() ? *dmaUser.getPacket() : nullptr;
-        rewriter.create<AIEX::NpuDmaMemcpyNdOp>(
-            rewriter.getUnknownLoc(), dmaUser.getX(), dmaUser.getY(),
-            dmaUser.getMemref(), SmallVector<Value>{}, dmaUser.getSizes(),
-            dmaUser.getStrides(), ArrayRef(newStaticOffsets),
-            dmaUser.getStaticSizes(), dmaUser.getStaticStrides(), packet,
-            dmaUser.getMetadata(), dmaUser.getId());
-        rewriter.eraseOp(dmaUser);
-      }
-    }
-    entry.getArgument(i + 1).replaceAllUsesWith(cast.getResult(0));
-    entry.eraseArgument(i + 1);
-  }
-  auto newFuncType =
-      FunctionType::get(funcOp.getContext(), argTypes, funcType.getResults());
-  funcOp.setType(newFuncType);
-  return success();
-}
 
 AIE::DeviceOp getDeviceForSegmentLoad(Operation *s) {
   auto module = s->getParentOfType<ModuleOp>();
@@ -1051,7 +962,6 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // argument list.
     RewritePatternSet castPattern(ctx);
     air::populateBufferMemrefToFuncArgsPattern(castPattern);
-    castPattern.add(CastFunctionArgs);
     (void)applyPatternsGreedily(module, std::move(castPattern));
 
     // Insert sync op after copying data out to host

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -517,10 +517,10 @@ module {
 // Dealing with scenarios where wrap dimension in airrt.dma_memcpy_nd goes beyond the [0, 1023] hardware limit (test case 2).
 
 // CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func10(%[[ARG0:.*]]: memref<2654208xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 32][128, 3456, 1152, 1]) {id = 0 : i64, metadata = @airMemcpyId21} : memref<2654208xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 32][128, 3456, 1152, 1]) {id = 1 : i64, metadata = @airMemcpyId21} : memref<2654208xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 32][128, 3456, 1152, 1]) {id = 2 : i64, metadata = @airMemcpyId21} : memref<2654208xi32>
+// CHECK:  aiex.runtime_sequence @func10(%[[ARG0:.*]]: memref<2304x2304xbf16>)
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 0 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 1 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 2 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 module {
@@ -561,8 +561,8 @@ module {
 // 16-bit type conversion
 
 // CHECK-LABEL: aiex.runtime_sequence @func11
-// CHECK-SAME: %arg0: memref<8192xi32>
-// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][4, 4, 32, 16][2048, 16, 64, 1]){{.*}}: memref<8192xi32>
+// CHECK-SAME: %arg0: memref<128x128xbf16>
+// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][4, 4, 32, 32][4096, 32, 128, 1]){{.*}}: memref<128x128xbf16>
 module {
   aie.device(npu1_1col) {
     func.func @func11(%arg0: memref<128x128xbf16>, %arg1: memref<128x128xbf16>) {
@@ -583,8 +583,8 @@ module {
 // 16-bit conversion with dma operands that aren't function arguments
 
 // CHECK-LABEL: func.func @func12
-// CHECK-SAME: %arg0: memref<16xi32>
-// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 16][0, 0, 0, 1]) {{.*}} : memref<16xi32>
+// CHECK-SAME: %arg0: memref<32xbf16>
+// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 32][0, 0, 0, 1]) {{.*}} : memref<32xbf16>
 module {
  func.func @func12() {
     %c1_i32 = arith.constant 1 : i32
@@ -624,7 +624,7 @@ module {
 // CHECK-LABEL: func13
 // CHECK-NOT: memref.alloc
 // CHECK: memref.assume_alignment
-// CHECK-SAME: memref<16xi32>
+// CHECK-SAME: memref<32xbf16>
 // CHECK-NOT: memref.alloc
 // CHECK: return
 module {
@@ -648,8 +648,8 @@ module {
 // Multi-dimensional offset collapsing
 
 // CHECK-LABEL: func.func @func14
-// CHECK-SAME: %arg0: memref<512xi32>
-// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 264][1, 1, 16, 8][0, 0, 16, 1]) {id = 0 : i64, metadata = @md0} : memref<512xi32>
+// CHECK-SAME: %arg0: memref<32x32xbf16>
+// CHECK-NEXT: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 16, 16][1, 1, 16, 16][0, 0, 32, 1]) {id = 0 : i64, metadata = @md0} : memref<32x32xbf16>
 module {
  func.func @func14(%arg0 : memref<32x32xbf16>) {
     %c1_i32 = arith.constant 1 : i32
@@ -695,15 +695,15 @@ module {
 // CHECK: aie.shim_dma_allocation @airMemcpyId12(MM2S, 1, 0)
 // CHECK: aie.shim_dma_allocation @airMemcpyId22(MM2S, 1, 0)
 // CHECK-LABEL: aiex.runtime_sequence @func16
-// CHECK-SAME: %[[VAL_0:.*]]: memref<262144xi32>, %[[VAL_1:.*]]: memref<262144xi32>, %[[VAL_2:.*]]: memref<131072xi32>) {
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 0][2, 4, 256, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId7} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 131072][2, 4, 256, 128][0, 128, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][2, 2, 512, 128][128, 131072, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][2, 2, 512, 128][128, 131072, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId12} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 0][2, 2, 64, 128][65536, 128, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId45} : memref<131072xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 16384][2, 2, 64, 128][65536, 128, 256, 1]) {id = 5 : i64, metadata = @airMemcpyId46} : memref<131072xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 32768][2, 2, 64, 128][65536, 128, 256, 1]) {id = 0 : i64, metadata = @airMemcpyId47} : memref<131072xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 49152][2, 2, 64, 128][65536, 128, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId48} : memref<131072xi32>
+// CHECK-SAME: %[[VAL_0:.*]]: memref<512x1024xbf16>, %[[VAL_1:.*]]: memref<1024x512xbf16>, %[[VAL_2:.*]]: memref<512x512xbf16>) {
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 0][2, 4, 256, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId7} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 256, 0][2, 4, 256, 256][0, 256, 1024, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][2, 2, 512, 256][256, 262144, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<1024x512xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][2, 2, 512, 256][256, 262144, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId12} : memref<1024x512xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId45} : memref<512x512xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 64, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId46} : memref<512x512xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 128, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId47} : memref<512x512xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 192, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId48} : memref<512x512xbf16>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 1 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 // CHECK: aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
@@ -933,10 +933,10 @@ module {
 // Outermost wrap must be in range [1:64] for AIE2.
 
 // CHECK-LABEL: func21
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][38, 2, 64, 32][77824, 32, 1216, 1]) {id = 0 : i64, metadata = @airMemcpyId10} : memref<11829248xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 2957312][38, 2, 64, 32][77824, 32, 1216, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<11829248xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 5914624][38, 2, 64, 32][77824, 32, 1216, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<11829248xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 8871936][38, 2, 64, 32][77824, 32, 1216, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<11829248xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][38, 2, 64, 64][155648, 64, 2432, 1]) {id = 0 : i64, metadata = @airMemcpyId10} : memref<9728x2432xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 5914624][38, 2, 64, 64][155648, 64, 2432, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<9728x2432xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 11829248][38, 2, 64, 64][155648, 64, 2432, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<9728x2432xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 17743872][38, 2, 64, 64][155648, 64, 2432, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<9728x2432xbf16>
 // CHECK: return
 
 #map = affine_map<()[s0] -> (s0 * 128)>

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -255,8 +255,8 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK:  aiex.runtime_sequence @func5(%[[ARG0:.*]]: memref<8x8xi32>, %[[ARG1:.*]]: memref<8x8xi32>, %[[ARG2:.*]]: memref<8x8xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][2, 1, 1, 32][0, 1, 1, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 32][2, 1, 1, 32][0, 1, 1, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][2, 1, 1, 32][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 32][2, 1, 1, 32][0, 0, 0, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
 // CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][0, 0, 0, 0][2, 2, 8, 4][0, 4, 8, 1]) {id = 2 : i64, metadata = @airMemcpyId5} : memref<8x8xi32>
 // CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][2, 2, 4, 4][32, 4, 8, 1]) {id = 3 : i64, metadata = @airMemcpyId16} : memref<8x8xi32>
 
@@ -310,9 +310,9 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK:  aiex.runtime_sequence @func6(%[[ARG0:.*]]: memref<8x16xi32>, %[[ARG1:.*]]: memref<16x32xi32>, %[[ARG2:.*]]: memref<8x32xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][2, 1, 1, 128][0, 1, 1, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][0, 0, 0, 0][1, 2, 16, 16][1, 16, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][1, 2, 8, 16][1, 16, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][2, 1, 1, 128][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][0, 0, 0, 0][1, 2, 16, 16][0, 16, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][1, 2, 8, 16][0, 16, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
 
 #map = affine_map<()[s0] -> (s0 * 8)>
 #map1 = affine_map<()[s0] -> (s0 * 16)>
@@ -812,10 +812,10 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK:  aiex.runtime_sequence @func18(%[[ARG0:.*]]: memref<8192x32768xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][1, 4, 64, 64][1, 64, 32768, 1]) {id = 0 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 64, 0][1, 4, 64, 64][1, 64, 32768, 1]) {id = 1 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 128, 0][1, 4, 64, 64][1, 64, 32768, 1]) {id = 2 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 192, 0][1, 4, 64, 64][1, 64, 32768, 1]) {id = 3 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 0 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 64, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 1 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 128, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 2 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 192, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 3 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 module {
@@ -973,7 +973,7 @@ module {
 // Offset field with (1) for loop induction variable, (2) affine map, and (3) existing non-singleton stride.
 
 // CHECK-LABEL: func22
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 2, 8, 512][1, 4096, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId31} : memref<2x64x64xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 2, 8, 512][0, 4096, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId31} : memref<2x64x64xi32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 
 #map = affine_map<()[s0] -> (s0 * 64)>

--- a/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
@@ -117,16 +117,16 @@ module {
 // Bf16 datatype support.
 
 // CHECK-LABEL: aie.device(npu1_1col)
-// CHECK: aiex.runtime_sequence @func2(%[[VAL_0:.*]]: memref<2097152xi32>, %[[VAL_1:.*]]: memref<2097152xi32>, %[[VAL_2:.*]]: memref<2097152xi32>) {
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 0][4, 8, 128, 128][0, 128, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 131072][4, 8, 128, 128][0, 128, 1024, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 262144][4, 8, 128, 128][0, 128, 1024, 1]) {id = 2 : i64, metadata = @airMemcpyId4} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 393216][4, 8, 128, 128][0, 128, 1024, 1]) {id = 3 : i64, metadata = @airMemcpyId4} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 64][64, 524288, 1024, 1]) {id = 4 : i64, metadata = @airMemcpyId7} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 64][64, 524288, 1024, 1]) {id = 5 : i64, metadata = @airMemcpyId7} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 64][64, 524288, 1024, 1]) {id = 6 : i64, metadata = @airMemcpyId7} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 64][64, 524288, 1024, 1]) {id = 7 : i64, metadata = @airMemcpyId7} : memref<2097152xi32>
-// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 0][4, 4, 128, 64][131072, 64, 1024, 1]) {id = 8 : i64, metadata = @airMemcpyId26} : memref<2097152xi32>
+// CHECK: aiex.runtime_sequence @func2(%[[VAL_0:.*]]: memref<2048x2048xbf16>, %[[VAL_1:.*]]: memref<2048x2048xbf16>, %[[VAL_2:.*]]: memref<2048x2048xbf16>) {
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 0, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 128, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 256, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 2 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_0]][0, 0, 384, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 3 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 4 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 5 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 6 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 7 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(0, 0, %[[VAL_2]][0, 0, 0, 0][4, 4, 128, 128][262144, 128, 2048, 1]) {id = 8 : i64, metadata = @airMemcpyId26} : memref<2048x2048xbf16>
 
 module {
   aie.device(npu1_1col) {

--- a/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
@@ -16,116 +16,116 @@
 // CHECK: memref.global "public" @airMemcpyId4 : memref<128x256xbf16, 1>
 // CHECK: aie.shim_dma_allocation @airMemcpyId10(MM2S, 1, 0)
 // CHECK: memref.global "public" @airMemcpyId10 : memref<32x8x8x16xbf16, 1>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 65536][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 131072][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65536][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196608][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65544][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131080][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196616][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65552][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131088][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196624][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 196608][1, 4, 128, 128][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][32, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 65560][32, 8, 8, 8][2048, 32, 256, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131096][32, 8, 8, 8][2048, 32, 256, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 196632][32, 8, 8, 8][2048, 32, 256, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<262144xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
@@ -21,68 +21,68 @@
 // CHECK: memref.global "public" @airMemcpyId5 : memref<16x8x8x16xbf16, 1>
 
 
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 8192][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 8192][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 8192][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 8192][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 16384][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 16384][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 16384][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 16384][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 24576][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 24576][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 8][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 24576][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 16][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 24576][1, 4, 128, 16][0, 16, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<32768xi32>
-// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 24][16, 8, 8, 8][2048, 32, 256, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32768xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
+// CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 


### PR DESCRIPTION
... because downstream compiler no longer requires that to be performed at this level.