### PR TITLE
AIRParToHerd: Set herd depth to `-1` for all npu-xrt tests

### DIFF
--- a/python/test/compiler/linalg_to_air.py
+++ b/python/test/compiler/linalg_to_air.py
@@ -69,7 +69,7 @@ def matmul_l1_l2_2x2():
         air.compiler.util.LINALG_TENSOR_TO_MEMREF_PIPELINE, context=module.context
     ).run(module.operation)
     PassManager.parse(
-        "builtin.module(air-linalg-codegen{l1-tile-size=32,32,32 l2-tile-size=64,64,64},air-par-to-herd{depth=1},air-copy-to-dma)",
+        "builtin.module(air-linalg-codegen{l1-tile-size=32,32,32 l2-tile-size=64,64,64},air-par-to-herd{depth=-1},air-copy-to-dma)",
         context=module.context,
     ).run(module.operation)
     print(module)

--- a/python/test/torch_mlir_e2e/mul_cpu.py
+++ b/python/test/torch_mlir_e2e/mul_cpu.py
@@ -35,7 +35,7 @@ def pipeline(module):
                     "canonicalize",
                     "cse",
                     "air-linalg-codegen",
-                    "air-par-to-herd{depth=0}",
+                    "air-par-to-herd{depth=-1}",
                     "air-copy-to-dma",
                     "canonicalize",
                     "cse",

--- a/test/xrt/01_air_to_npu/aie.py
+++ b/test/xrt/01_air_to_npu/aie.py
@@ -104,7 +104,7 @@ pipeline = (
     + ",".join(
         [
             "buffer-results-to-out-params",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=true}",
             "air-copy-to-dma",
             "canonicalize",

--- a/test/xrt/04_gemm_w_pack/aie.py
+++ b/test/xrt/04_gemm_w_pack/aie.py
@@ -88,7 +88,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/08_gemm_extern_vec/aie.py
+++ b/test/xrt/08_gemm_extern_vec/aie.py
@@ -111,7 +111,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/09_gemm_extern_vec_4x4/aie.py
+++ b/test/xrt/09_gemm_extern_vec_4x4/aie.py
@@ -115,7 +115,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/10_gemm_peeling_extern_vec/aie.py
+++ b/test/xrt/10_gemm_peeling_extern_vec/aie.py
@@ -124,7 +124,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/11_gemm_bias_fusion/aie.py
+++ b/test/xrt/11_gemm_bias_fusion/aie.py
@@ -174,7 +174,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/12_matmul_transform_1x4_bf16/gen.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/gen.py
@@ -119,7 +119,7 @@ pipeline = (
         [
             "air-copy-to-dma",
             "air-linalg-to-func{link-with=kernel.o}",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=1}",
             "canonicalize",
             "cse",

--- a/test/xrt/13_conv2d_i32/aie.py
+++ b/test/xrt/13_conv2d_i32/aie.py
@@ -88,7 +88,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/14_conv2d_i8_extern_vec/aie.py
+++ b/test/xrt/14_conv2d_i8_extern_vec/aie.py
@@ -87,7 +87,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=conv.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/aie.py
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/aie.py
@@ -147,7 +147,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/aie.py
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/aie.py
@@ -147,7 +147,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
@@ -128,7 +128,7 @@ pipeline = (
             "air-copy-to-dma",
             "buffer-results-to-out-params",
             "air-linalg-to-func{link-with=mm.o}",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=true}",
             "canonicalize",
             "cse",

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
@@ -104,7 +104,7 @@ pipeline = (
         [
             "air-copy-to-dma",
             "air-linalg-to-func{link-with=kernel.o}",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=1}",
             "canonicalize",
             "cse",

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
@@ -102,7 +102,7 @@ pipeline = (
         [
             "air-copy-to-dma",
             "air-linalg-to-func{link-with=kernel.o}",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=1}",
             "canonicalize",
             "cse",

--- a/test/xrt/20_batch_matmul_i32/aie.py
+++ b/test/xrt/20_batch_matmul_i32/aie.py
@@ -146,7 +146,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/21_conv2d_depthwise_i32/aie.py
+++ b/test/xrt/21_conv2d_depthwise_i32/aie.py
@@ -84,7 +84,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/22_conv2d_stride2_i32/aie.py
+++ b/test/xrt/22_conv2d_stride2_i32/aie.py
@@ -89,7 +89,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/23_ctrlpkt_config/aie.py
+++ b/test/xrt/23_ctrlpkt_config/aie.py
@@ -109,7 +109,7 @@ pipeline = (
     + ",".join(
         [
             "buffer-results-to-out-params",
-            "air-par-to-herd{depth=1}",
+            "air-par-to-herd{depth=-1}",
             "air-par-to-launch{has-air-segment=true}",
             "air-copy-to-dma",
             "canonicalize",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
@@ -147,7 +147,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
@@ -148,7 +148,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/25_batch_matmul_bf16/aie.py
+++ b/test/xrt/25_batch_matmul_bf16/aie.py
@@ -147,7 +147,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/26_vecmat_i8/aie.py
+++ b/test/xrt/26_vecmat_i8/aie.py
@@ -110,7 +110,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=vm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/aie.py
@@ -147,7 +147,7 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 "buffer-results-to-out-params",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/28_gemm_loop_nest_bf16/aie.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/aie.py
@@ -109,7 +109,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "buffer-results-to-out-params",
                 "air-linalg-to-func{link-with=mm.o}",
-                "air-par-to-herd{depth=1}",
+                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",


### PR DESCRIPTION
`Depth = -1` means converting the inner-most `scf.forall/paralle`l op into `herd`.