### PR TITLE
AIRCC: Remove experimental passes from aircc.py

### DIFF
--- a/programming_examples/channel_examples/broadcast/multi_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/multi_herd/broadcast.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         IMAGE_SIZE
     )
 
-    runner = XRTRunner(verbose=args.verbose, experimental_passes=True)
+    runner = XRTRunner(verbose=args.verbose)
     exit(
         runner.run_test(
             mlir_module,

--- a/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         IMAGE_SIZE
     )
 
-    runner = XRTRunner(verbose=args.verbose, experimental_passes=True)
+    runner = XRTRunner(verbose=args.verbose)
     exit(
         runner.run_test(
             mlir_module,

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
@@ -137,5 +137,5 @@ if __name__ == "__main__":
     input_a = np.full(IMAGE_SIZE, 0x2, dtype=INOUT_DATATYPE)
     output_b = np.full(IMAGE_SIZE, 0x5, dtype=INOUT_DATATYPE)
 
-    runner = XRTRunner(verbose=args.verbose, experimental_passes=False)
+    runner = XRTRunner(verbose=args.verbose)
     exit(runner.run_test(mlir_module, inputs=[input_a], expected_outputs=[output_b]))

--- a/programming_examples/shim_dma_2d/Makefile
+++ b/programming_examples/shim_dma_2d/Makefile
@@ -13,7 +13,7 @@ build/air.mlir: ${srcdir}/${targetname}.py
 
 build/final.xclbin: build/air.mlir
 	mkdir -p ${@D}
-	cd build && aircc.py -xbridge -o ${@F} --tmpdir tmp --device npu1_1col --host-target x86_64 --experimental-passes $(<:%=../%)
+	cd build && aircc.py -xbridge -o ${@F} --tmpdir tmp --device npu1_1col --host-target x86_64 $(<:%=../%)
 
 build/final.py.xclbin: build/air.mlir
 	mkdir -p ${@D}

--- a/programming_examples/shim_dma_2d/README.md
+++ b/programming_examples/shim_dma_2d/README.md
@@ -24,7 +24,7 @@ For illustrative purposes, we provide three different ways to run and test this 
 
 ### Method 1: Run and test with AIR utility functions
 
-This is the cleanest and simplest method of specifying a workflow to run AIR MLIR on an NPU, and uses code in the [run.py](run.py) file. The utility class ```XRTRunner``` simplifies setting up input/output data and allows the user to specify the input and an expected output using ```numpy``` ```ndarray```s. Behind the scenes, ```XRTRunner``` calls ```aircc.py``` with the default set of pipelines and passes, and has ```experimental_passes``` enabled by default to signify we also want to run additional passes which should increase efficiency.
+This is the cleanest and simplest method of specifying a workflow to run AIR MLIR on an NPU, and uses code in the [run.py](run.py) file. The utility class ```XRTRunner``` simplifies setting up input/output data and allows the user to specify the input and an expected output using ```numpy``` ```ndarray```s. Behind the scenes, ```XRTRunner``` calls ```aircc.py``` with the default set of pipelines and passes.
 ```bash
 make pyworkflow
 ```

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -46,23 +46,26 @@ class XRTBackend(AirBackend):
     def __init__(
         self,
         verbose=False,
-        experimental_passes=False,
         omit_while_true_loop=False,
         omit_pingpong=False,
+        lower_linalg_to_func=False,
+        air_loop_fusion=False,
     ):
         """Constructor for XRTBackend
 
         Args:
             verbose: verbose output
-            experimental_passes: configure aircc to run additional experimental passes
             omit_while_true_loop: configure aircc to omit the while true loop it traditionally emits.
             omit_pingpong: configure aircc to omit the generation of ping-pong buffering.
+            lower_linalg_to_func: configure aircc to lower linalg.generic to function calls, or loops.
+            air_loop_fusion: configure aircc to add air-loop-fusion experimental pass.
         """
         super().__init__()
         self.verbose = verbose
-        self.experimental_passes = experimental_passes
         self.omit_while_true_loop = omit_while_true_loop
         self.omit_pingpong = omit_pingpong
+        self.lower_linalg_to_func = lower_linalg_to_func
+        self.air_loop_fusion = air_loop_fusion
         self.currently_loaded = False
 
     def __del__(self):
@@ -113,14 +116,17 @@ class XRTBackend(AirBackend):
             if self.verbose:
                 aircc_options = aircc_options + ["-v"]
 
-            if self.experimental_passes:
-                aircc_options += ["--experimental-passes"]
-
             if self.omit_while_true_loop:
                 aircc_options += ["--omit-while-true-loop"]
 
             if self.omit_pingpong:
                 aircc_options += ["--omit-ping-pong-transform"]
+
+            if self.lower_linalg_to_func:
+                aircc_options += ["--lower-linalg-to-func"]
+
+            if self.air_loop_fusion:
+                aircc_options += ["--air-loop-fusion"]
 
             aircc.run(air_module, aircc_options)
 

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -60,6 +60,7 @@ class XRTBackend(AirBackend):
             omit_pingpong: configure aircc to omit the generation of ping-pong buffering.
             lower_linalg_to_func: configure aircc to lower linalg.generic to function calls, or loops.
             air_loop_fusion: configure aircc to add air-loop-fusion experimental pass.
+            runtime_loop_tiling_sizes: configure aircc to add extra runtime loop tiling using the experimental affine-loop-opt pass.
         """
         super().__init__()
         self.verbose = verbose

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -50,6 +50,7 @@ class XRTBackend(AirBackend):
         omit_pingpong=False,
         lower_linalg_to_func=False,
         air_loop_fusion=False,
+        runtime_loop_tiling_sizes: list[int] = [4, 4],
     ):
         """Constructor for XRTBackend
 
@@ -66,6 +67,7 @@ class XRTBackend(AirBackend):
         self.omit_pingpong = omit_pingpong
         self.lower_linalg_to_func = lower_linalg_to_func
         self.air_loop_fusion = air_loop_fusion
+        self.runtime_loop_tiling_sizes = runtime_loop_tiling_sizes
         self.currently_loaded = False
 
     def __del__(self):
@@ -112,6 +114,10 @@ class XRTBackend(AirBackend):
                 "-i",
                 insts,
             ]
+
+            aircc_options += ["--air-runtime-loop-tiling-sizes"]
+            for s in self.runtime_loop_tiling_sizes:
+                aircc_options += [str(s)]
 
             if self.verbose:
                 aircc_options = aircc_options + ["-v"]

--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -57,14 +57,16 @@ class XRTRunner:
     def __init__(
         self,
         verbose: bool = False,
-        experimental_passes: bool = True,
         omit_while_true_loop: bool = True,
         omit_pingpong: bool = False,
+        lower_linalg_to_func: bool = False,
+        air_loop_fusion: bool = False,
     ):
         self.verbose = verbose
-        self.experimental_passes = experimental_passes
         self.omit_while_true_loop = omit_while_true_loop
         self.omit_pingpong = omit_pingpong
+        self.lower_linalg_to_func = lower_linalg_to_func
+        self.air_loop_fusion = air_loop_fusion
 
     def run_test(
         self,
@@ -79,9 +81,10 @@ class XRTRunner:
 
         backend = XRTBackend(
             verbose=self.verbose,
-            experimental_passes=self.experimental_passes,
             omit_while_true_loop=self.omit_while_true_loop,
             omit_pingpong=self.omit_pingpong,
+            lower_linalg_to_func=self.lower_linalg_to_func,
+            air_loop_fusion=self.air_loop_fusion,
         )
 
         # run the module - slots are input/output for now, assume non-overlapping inputs/outputs

--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -61,12 +61,14 @@ class XRTRunner:
         omit_pingpong: bool = False,
         lower_linalg_to_func: bool = False,
         air_loop_fusion: bool = False,
+        runtime_loop_tiling_sizes: list[int] = [4, 4],
     ):
         self.verbose = verbose
         self.omit_while_true_loop = omit_while_true_loop
         self.omit_pingpong = omit_pingpong
         self.lower_linalg_to_func = lower_linalg_to_func
         self.air_loop_fusion = air_loop_fusion
+        self.runtime_loop_tiling_sizes = runtime_loop_tiling_sizes
 
     def run_test(
         self,
@@ -85,6 +87,7 @@ class XRTRunner:
             omit_pingpong=self.omit_pingpong,
             lower_linalg_to_func=self.lower_linalg_to_func,
             air_loop_fusion=self.air_loop_fusion,
+            runtime_loop_tiling_sizes=self.runtime_loop_tiling_sizes,
         )
 
         # run the module - slots are input/output for now, assume non-overlapping inputs/outputs

--- a/python/air/compiler/aircc/cl_arguments.py
+++ b/python/air/compiler/aircc/cl_arguments.py
@@ -110,13 +110,6 @@ def parse_args(args=None):
         help="Target AIE device",
     )
     parser.add_argument(
-        "--experimental-passes",
-        dest="experimental_passes",
-        default=False,
-        action="store_true",
-        help="Whether to run experimental passes or not. This will only change the behavior for this program for npu devices",
-    )
-    parser.add_argument(
         "--omit-while-true-loop",
         dest="omit_while_true_loop",
         default=False,
@@ -129,6 +122,20 @@ def parse_args(args=None):
         default=False,
         action="store_true",
         help="Whether to run passes which generate ping-pong buffering patterns or not. This will only change the behavior for this program for npu devices",
+    )
+    parser.add_argument(
+        "--lower-linalg-to-func",
+        dest="lower_linalg_to_func",
+        default=False,
+        action="store_true",
+        help="Whether to run pass which lowers linalg.generic ops to function calls. If False, then they lower to loops.",
+    )
+    parser.add_argument(
+        "--air-loop-fusion",
+        dest="air_loop_fusion",
+        default=False,
+        action="store_true",
+        help="Adds air-loop-fusion pass to the compiler pipeline. It is an experimental pass which tries to enforce loop fusion for lowring to efficient DMA BDs",
     )
 
     opts = parser.parse_args(args)

--- a/python/air/compiler/aircc/cl_arguments.py
+++ b/python/air/compiler/aircc/cl_arguments.py
@@ -137,6 +137,14 @@ def parse_args(args=None):
         action="store_true",
         help="Adds air-loop-fusion pass to the compiler pipeline. It is an experimental pass which tries to enforce loop fusion for lowring to efficient DMA BDs",
     )
+    parser.add_argument(
+        "--air-runtime-loop-tiling-sizes",
+        type=int,
+        nargs="+",  # Accept one or more integers
+        dest="runtime_loop_tiling_sizes",
+        default=[4, 4],
+        help="Adds tiling factors to be applied to the runtime host affine loop nest. It is an experimental pass which enforces extra innermost tilings at runtime, to comply with constraints of certain hardware",
+    )
 
     opts = parser.parse_args(args)
     return opts

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -492,7 +492,9 @@ def run(mlir_module, args=None):
                         "func.func(air-opt-shim-dma-bds{device=" + opts.device + "})",
                         "air-to-std",
                         "symbol-dce",
-                        "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
+                        "func.func(affine-loop-opt{affine-opt-tile-sizes="
+                        + ",".join(str(s) for s in opts.runtime_loop_tiling_sizes)
+                        + "})",
                         "func.func(air-unroll-outer-affine-loops{depth=2})",
                         "affine-expand-index-ops",
                         "canonicalize",

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -411,8 +411,9 @@ def run(mlir_module, args=None):
 
     with mlir_module.context as ctx:
         _, air_mlir_filename = os.path.split(opts.air_mlir_file)
+        # num_tile_rows = 4
         air_collapse_herd_to_cols_pass = (
-            "func.func(air-collapse-herd{" + f"max-col-size={opts.num_cols} " + "})"
+            "func.func(air-collapse-herd{" + f"max-col-size={4} " + "})"
         )
         air_place_pass = (
             "air-place-herds{"
@@ -462,7 +463,7 @@ def run(mlir_module, args=None):
         air_to_aie_pass = air_to_aie_pass + f" row-offset={opts.row_offset}"
         air_to_aie_pass = air_to_aie_pass + f" col-offset={opts.col_offset}"
         air_to_aie_pass = air_to_aie_pass + f" device={opts.device}"
-        if opts.trace_size > 0:
+        if int(opts.trace_size) > 0:
             air_to_aie_pass = air_to_aie_pass + " insert-trace-packet-flow=true"
         air_to_aie_pass = air_to_aie_pass + "}"
         pass_pipeline = ",".join([air_to_aie_pass])

--- a/test/xrt/12_matmul_transform_1x4_bf16/gen.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/gen.py
@@ -9,6 +9,7 @@ from air.ir import *
 import air.passmanager
 from air._mlir_libs._air import run_transform
 from air.dialects.air import module_builder
+from air.backend.xrt import XRTBackend
 
 import argparse
 
@@ -106,9 +107,6 @@ transform.with_pdl_patterns {
 transform_ir = Module.parse(transform_ir_string, context=context)
 run_transform(transform_ir, air_module)
 
-with open("air_tiled.mlir", "w") as f:
-    f.write(str(air_module))
-
 ################################################
 ## Binding parallel loops to air hierarchies
 ################################################
@@ -132,120 +130,13 @@ pipeline = (
 pm = air.passmanager.PassManager.parse(pipeline, context=context)
 pm.run(air_module.operation)
 
-with open("air_sync.mlir", "w") as f:
-    f.write(str(air_module))
+###############################################
+# Run compile and load
+###############################################
 
-################################################
-## Extract event dependency and optimize schedule
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-dependency",
-            "air-dependency-schedule-opt",
-            "air-specialize-dma-broadcast",
-            "air-dma-to-channel",
-            "canonicalize",
-            "cse",
-            "air-dependency-canonicalize",
-            "canonicalize",
-            "cse",
-            "func.func(air-loop-fusion)",
-            "air-label-scf-for-to-ping-pong",
-            "air-ping-pong-transform",
-            "canonicalize",
-            "cse",
-            "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-            "canonicalize",
-            "cse",
-        ]
-    )
-    + ")"
+backend = XRTBackend(
+    air_loop_fusion=True,
+    runtime_loop_tiling_sizes=[1, 1],
+    lower_linalg_to_func=True,
 )
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_input.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## Place herd to segment
-################################################
-
-air_async_module = Module.parse(str(air_module), context=context)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-collapse-herd)",
-            "canonicalize",
-            "cse",
-            "air-place-herds{num-rows=4 num-cols=1 row-anchor=2 col-anchor=0}",
-            "canonicalize",
-            "cse",
-            "func.func(air-renumber-dma)",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("air_placed.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR to MLIR-AIE
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_decomp_aiecc.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR runtime lowering
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-            "air-to-std",
-            "symbol-dce",
-            "airrt-to-npu",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aie.mlir", "w") as f:
-    f.write(str(air_module))
-
-import aie.compiler.aiecc.main as aiecc
-
-aiecc_options = [
-    "--no-aiesim",
-    "--xchesscc",
-    "--xbridge",
-    "--aie-generate-cdo",
-    "--aie-generate-npu",
-    "--no-compile-host",
-    "--npu-insts-name=insts.txt",
-    "--xclbin-name=aie.xclbin",
-    "aie.mlir",
-]
-aiecc.run(air_module, aiecc_options)
+module_function = backend.compile_and_load(air_module)

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.lit
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.lit
@@ -5,4 +5,4 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cpp -o kernel.o
 // RUN: %python %S/gen.py -t %S/transform.mlir
-// RUN: %run_on_npu %python %S/run.py aie.xclbin
+// RUN: %run_on_npu %python %S/run.py air.xclbin

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -21,7 +21,7 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("insts.txt", "r") as f:
+with open("air.insts.txt", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/13_conv2d_i32/gen.py
+++ b/test/xrt/13_conv2d_i32/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -102,101 +97,11 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[1, 1],
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=2 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-                "func.func(convert-linalg-to-loops)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/13_conv2d_i32/run.lit
+++ b/test/xrt/13_conv2d_i32/run.lit
@@ -3,7 +3,6 @@
 
 // REQUIRES: ryzen_ai, valid_xchess_license
 
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/14_conv2d_i8_extern_vec/aie.py
+++ b/test/xrt/14_conv2d_i8_extern_vec/aie.py
@@ -3,15 +3,9 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
 from air.dialects.air import module_builder
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
@@ -117,8 +111,22 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-dependency-canonicalize",
                 "canonicalize",
                 "cse",
-                "func.func(air-split-l2-memref)",
                 "air-isolate-async-dma-loop-nests",
+                "canonicalize",
+                "cse",
+                "air-fuse-channels",
+                "canonicalize",
+                "cse",
+                ### Scaling to 4 AIE columns
+                "func.func(air-split-l2-memref)",
+                "canonicalize",
+                "cse",
+                "air-isolate-async-dma-loop-nests",
+                ###
+                "canonicalize",
+                "cse",
+                "func.func(air-fuse-alloc-dealloc)",
+                "func.func(air-shrink-memref-sizes-by-access)",
                 "func.func(air-loop-fusion)",
                 "air-label-scf-for-to-ping-pong",
                 "air-ping-pong-transform",

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
@@ -1,16 +1,11 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
@@ -161,113 +156,11 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                ### Scaling to 4 AIE columns
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                ###
-                "canonicalize",
-                "cse",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        air_loop_fusion=True,
+        lower_linalg_to_func=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-                "func.func(air-unroll-outer-affine-loops{depth=2})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/run.lit
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/run.lit
@@ -4,7 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -160,114 +155,12 @@ with air.ir.Context() as ctx, Location.unknown():
     pm = air.passmanager.PassManager.parse(pipeline)
     pm.run(air_module.operation)
 
-    ###############################################
-    # Extract event dependency and optimize schedule
-    ###############################################
+###############################################
+# Run compile and load
+###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                ### Scaling to 4 AIE columns
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                ###
-                "canonicalize",
-                "cse",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-                "func.func(air-unroll-outer-affine-loops{depth=2})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+backend = XRTBackend(
+    air_loop_fusion=True,
+    lower_linalg_to_func=True,
+)
+module_function = backend.compile_and_load(air_module)

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
@@ -5,6 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
@@ -139,6 +139,6 @@ pm.run(air_module.operation)
 backend = XRTBackend(
     air_loop_fusion=True,
     lower_linalg_to_func=True,
-    runtime_loop_tiling_sizes=[2, 2],
+    runtime_loop_tiling_sizes=[1, 1],
 )
 module_function = backend.compile_and_load(air_module)

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 ctx = Context()
 
 ################################################
-## Tiling
+## Input SCF and Linalg IR
 ################################################
 
 air_tiled_ir_string = """
@@ -114,9 +109,6 @@ module {
 """
 air_module = Module.parse(air_tiled_ir_string, context=ctx)
 
-with open("air_tiled.mlir", "w") as f:
-    f.write(str(air_module))
-
 ################################################
 ## Binding scf.paralell to air hierarchies
 ################################################
@@ -140,127 +132,13 @@ pipeline = (
 pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
 pm.run(air_module.operation)
 
-with open("air_sync.mlir", "w") as f:
-    f.write(str(air_module))
-
 ###############################################
-# Extract event dependency and optimize schedule
+# Run compile and load
 ###############################################
 
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-dependency",
-            "air-dependency-schedule-opt",
-            "air-specialize-dma-broadcast",
-            "air-dma-to-channel",
-            "canonicalize",
-            "cse",
-            "air-dependency-canonicalize",
-            "canonicalize",
-            "cse",
-            "func.func(air-loop-fusion)",
-            "air-label-scf-for-to-ping-pong",
-        ]
-    )
-    + ")"
+backend = XRTBackend(
+    air_loop_fusion=True,
+    lower_linalg_to_func=True,
+    runtime_loop_tiling_sizes=[2, 2],
 )
-pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
-pm.run(air_module.operation)
-
-with open("air_fusion.mlir", "w") as f:
-    f.write(str(air_module))
-
-# Not sure why parsing the ir solves the segmentation fault...
-air_module = Module.parse(str(air_module), context=ctx)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-ping-pong-transform",
-            "canonicalize",
-            "cse",
-            "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-            "canonicalize",
-            "cse",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
-pm.run(air_module.operation)
-with open("aircc_input.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## Place herd to segment
-################################################
-
-air_async_module = Module.parse(str(air_module), context=ctx)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-collapse-herd)",
-            "canonicalize",
-            "cse",
-            "air-place-herds{num-rows=4 num-cols=1 row-anchor=2 col-anchor=0}",
-            "canonicalize",
-            "cse",
-            "func.func(air-renumber-dma)",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
-pm.run(air_module.operation)
-with open("air_placed.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR to MLIR-AIE
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "canonicalize",
-            "cse",
-            "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
-pm.run(air_module.operation)
-with open("aircc_decomp_aiecc.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR runtime lowering
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-            "air-to-std",
-            "canonicalize",
-            "symbol-dce",
-            "func.func(affine-loop-opt{affine-opt-tile-sizes=16,16})",
-            "func.func(air-unroll-outer-affine-loops{depth=4})",
-            "affine-expand-index-ops",
-            "airrt-to-npu",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=ctx)
-pm.run(air_module.operation)
-with open("aie.mlir", "w") as f:
-    f.write(str(air_module))
+module_function = backend.compile_and_load(air_module)

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/run.lit
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/run.lit
@@ -5,6 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
@@ -115,5 +115,6 @@ pm.run(air_module.operation)
 backend = XRTBackend(
     air_loop_fusion=True,
     lower_linalg_to_func=True,
+    runtime_loop_tiling_sizes=[2, 2],
 )
 module_function = backend.compile_and_load(air_module)

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/gen.py
@@ -1,19 +1,13 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, arith, func
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air._mlir_libs._air import run_transform
-from air.dialects.air import module_builder
-
-import argparse
 
 
 ################################################
-## Tiling
+## Input SCF and Linalg IR
 ################################################
 
 air_tiled_ir_string = """
@@ -91,9 +85,6 @@ module {
 context = Context()
 air_module = Module.parse(air_tiled_ir_string, context)
 
-with open("air_tiled.mlir", "w") as f:
-    f.write(str(air_module))
-
 ################################################
 ## Binding parallel loops to air hierarchies
 ################################################
@@ -117,146 +108,12 @@ pipeline = (
 pm = air.passmanager.PassManager.parse(pipeline, context=context)
 pm.run(air_module.operation)
 
-with open("air_sync.mlir", "w") as f:
-    f.write(str(air_module))
+###############################################
+# Run compile and load
+###############################################
 
-################################################
-## Extract event dependency and optimize schedule
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-dependency",
-            "air-dependency-schedule-opt",
-            "air-specialize-dma-broadcast",
-            "air-dma-to-channel",
-            "canonicalize",
-            "cse",
-            "air-dependency-canonicalize",
-            "canonicalize",
-            "cse",
-            "canonicalize",
-            "cse",
-            "func.func(air-loop-fusion)",
-            "air-label-scf-for-to-ping-pong",
-        ]
-    )
-    + ")"
+backend = XRTBackend(
+    air_loop_fusion=True,
+    lower_linalg_to_func=True,
 )
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-
-with open("air_fusion.mlir", "w") as f:
-    f.write(str(air_module))
-
-# Not sure why parsing the ir solves the segmentation fault...
-with open("air_fusion.mlir", "r") as f:
-    air_module = f.read()
-
-air_module = Module.parse(str(air_module), context=context)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-ping-pong-transform",
-            "canonicalize",
-            "cse",
-            "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-            "canonicalize",
-            "cse",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_input.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## Place herd to segment
-################################################
-
-air_async_module = Module.parse(str(air_module), context=context)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-collapse-herd)",
-            "canonicalize",
-            "cse",
-            "air-place-herds{num-rows=4 num-cols=1 row-anchor=2 col-anchor=0}",
-            "canonicalize",
-            "cse",
-            "func.func(air-renumber-dma)",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("air_placed.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR to MLIR-AIE
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_decomp_aiecc.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR runtime lowering
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-            "air-to-std",
-            "symbol-dce",
-            "canonicalize",
-            "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-            "func.func(air-unroll-outer-affine-loops{depth=4})",
-            "affine-expand-index-ops",
-            "canonicalize",
-            "cse",
-            "airrt-to-npu",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aie.mlir", "w") as f:
-    f.write(str(air_module))
-
-import aie.compiler.aiecc.main as aiecc
-
-aiecc_options = [
-    "--no-aiesim",
-    "--xchesscc",
-    "--xbridge",
-    "--aie-generate-cdo",
-    "--aie-generate-npu",
-    "--no-compile-host",
-    "--npu-insts-name=insts.txt",
-    "--xclbin-name=aie.xclbin",
-    "aie.mlir",
-]
-aiecc.run(air_module, aiecc_options)
+module_function = backend.compile_and_load(air_module)

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.lit
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cpp -o kernel.o
-// RUN: %python %S/gen.py -t %S/transform.mlir
-// RUN: %run_on_npu %python %S/run.py aie.xclbin
+// RUN: %python %S/gen.py
+// RUN: %run_on_npu %python %S/run.py air.xclbin

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -24,7 +24,7 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("insts.txt", "r") as f:
+with open("air.insts.txt", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
@@ -7,7 +7,7 @@ import air.passmanager
 
 
 ################################################
-## Tiling
+## Input SCF and Linalg IR
 ################################################
 
 air_tiled_ir_string = """
@@ -82,9 +82,6 @@ module {
 
 context = Context()
 air_module = Module.parse(air_tiled_ir_string, context)
-
-with open("air_tiled.mlir", "w") as f:
-    f.write(str(air_module))
 
 ################################################
 ## Binding parallel loops to air hierarchies

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/gen.py
@@ -1,15 +1,9 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, arith, func
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air._mlir_libs._air import run_transform
-from air.dialects.air import module_builder
-
-import argparse
 
 
 ################################################
@@ -115,143 +109,12 @@ pipeline = (
 pm = air.passmanager.PassManager.parse(pipeline, context=context)
 pm.run(air_module.operation)
 
-with open("air_sync.mlir", "w") as f:
-    f.write(str(air_module))
+###############################################
+# Run compile and load
+###############################################
 
-################################################
-## Extract event dependency and optimize schedule
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-dependency",
-            "air-dependency-schedule-opt",
-            "air-specialize-dma-broadcast",
-            "air-dma-to-channel",
-            "canonicalize",
-            "cse",
-            "air-dependency-canonicalize",
-            "canonicalize",
-            "cse",
-            "func.func(air-loop-fusion)",
-            "air-label-scf-for-to-ping-pong",
-        ]
-    )
-    + ")"
+backend = XRTBackend(
+    air_loop_fusion=True,
+    lower_linalg_to_func=True,
 )
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-
-with open("air_fusion.mlir", "w") as f:
-    f.write(str(air_module))
-
-# Not sure why parsing the ir solves the segmentation fault...
-with open("air_fusion.mlir", "r") as f:
-    air_module = f.read()
-
-air_module = Module.parse(str(air_module), context=context)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-ping-pong-transform",
-            "canonicalize",
-            "cse",
-            "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-            "canonicalize",
-            "cse",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_input.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## Place herd to segment
-################################################
-
-air_async_module = Module.parse(str(air_module), context=context)
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-collapse-herd)",
-            "canonicalize",
-            "cse",
-            "air-place-herds{num-rows=4 num-cols=1 row-anchor=2 col-anchor=0}",
-            "canonicalize",
-            "cse",
-            "func.func(air-renumber-dma)",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("air_placed.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR to MLIR-AIE
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-            "canonicalize",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aircc_decomp_aiecc.mlir", "w") as f:
-    f.write(str(air_module))
-
-################################################
-## MLIR-AIR runtime lowering
-################################################
-
-pipeline = (
-    "builtin.module("
-    + ",".join(
-        [
-            "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-            "air-to-std",
-            "symbol-dce",
-            "canonicalize",
-            "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-            "func.func(air-unroll-outer-affine-loops{depth=2})",
-            "affine-expand-index-ops",
-            "canonicalize",
-            "airrt-to-npu",
-        ]
-    )
-    + ")"
-)
-pm = air.passmanager.PassManager.parse(pipeline, context=context)
-pm.run(air_module.operation)
-with open("aie.mlir", "w") as f:
-    f.write(str(air_module))
-
-import aie.compiler.aiecc.main as aiecc
-
-aiecc_options = [
-    "--no-aiesim",
-    "--xchesscc",
-    "--xbridge",
-    "--aie-generate-cdo",
-    "--aie-generate-npu",
-    "--no-compile-host",
-    "--npu-insts-name=insts.txt",
-    "--xclbin-name=aie.xclbin",
-    "aie.mlir",
-]
-aiecc.run(air_module, aiecc_options)
+module_function = backend.compile_and_load(air_module)

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.lit
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cpp -o kernel.o
-// RUN: %python %S/gen.py -t %S/transform.mlir
-// RUN: %run_on_npu %python %S/run.py aie.xclbin
+// RUN: %python %S/gen.py
+// RUN: %run_on_npu %python %S/run.py air.xclbin

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
@@ -24,7 +24,7 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("insts.txt", "r") as f:
+with open("air.insts.txt", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/20_batch_matmul_i32/gen.py
+++ b/test/xrt/20_batch_matmul_i32/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -160,110 +155,10 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                "canonicalize",
-                "cse",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-                "func.func(convert-linalg-to-loops)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=2,2,2})",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/20_batch_matmul_i32/gen.py
+++ b/test/xrt/20_batch_matmul_i32/gen.py
@@ -160,5 +160,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[8, 1],  # Note: [4, 4] gives numeric error. Why?
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/20_batch_matmul_i32/run.lit
+++ b/test/xrt/20_batch_matmul_i32/run.lit
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // REQUIRES: ryzen_ai
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/21_conv2d_depthwise_i32/gen.py
+++ b/test/xrt/21_conv2d_depthwise_i32/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -98,101 +93,10 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-                "func.func(convert-linalg-to-loops)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/21_conv2d_depthwise_i32/gen.py
+++ b/test/xrt/21_conv2d_depthwise_i32/gen.py
@@ -98,5 +98,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[2, 4],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/21_conv2d_depthwise_i32/run.lit
+++ b/test/xrt/21_conv2d_depthwise_i32/run.lit
@@ -3,7 +3,6 @@
 
 // REQUIRES: ryzen_ai, valid_xchess_license
 
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/22_conv2d_stride2_i32/gen.py
+++ b/test/xrt/22_conv2d_stride2_i32/gen.py
@@ -103,6 +103,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
-        runtime_loop_tiling_sizes=[8],
+        runtime_loop_tiling_sizes=[1, 1],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/22_conv2d_stride2_i32/gen.py
+++ b/test/xrt/22_conv2d_stride2_i32/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -103,101 +98,10 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=2 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-                "func.func(convert-linalg-to-loops)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/22_conv2d_stride2_i32/gen.py
+++ b/test/xrt/22_conv2d_stride2_i32/gen.py
@@ -103,5 +103,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[8],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/22_conv2d_stride2_i32/run.lit
+++ b/test/xrt/22_conv2d_stride2_i32/run.lit
@@ -3,7 +3,6 @@
 
 // REQUIRES: ryzen_ai, valid_xchess_license
 
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/25_batch_matmul_bf16/gen.py
+++ b/test/xrt/25_batch_matmul_bf16/gen.py
@@ -162,5 +162,6 @@ with air.ir.Context() as ctx, Location.unknown():
     backend = XRTBackend(
         lower_linalg_to_func=True,
         air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[2, 2],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/25_batch_matmul_bf16/gen.py
+++ b/test/xrt/25_batch_matmul_bf16/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -161,109 +156,11 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                "canonicalize",
-                "cse",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        lower_linalg_to_func=True,
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=2,2,2})",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/25_batch_matmul_bf16/gen.py
+++ b/test/xrt/25_batch_matmul_bf16/gen.py
@@ -162,6 +162,6 @@ with air.ir.Context() as ctx, Location.unknown():
     backend = XRTBackend(
         lower_linalg_to_func=True,
         air_loop_fusion=True,
-        runtime_loop_tiling_sizes=[2, 2],
+        runtime_loop_tiling_sizes=[1, 1],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/25_batch_matmul_bf16/run.lit
+++ b/test/xrt/25_batch_matmul_bf16/run.lit
@@ -4,7 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/26_vecmat_i8/gen.py
+++ b/test/xrt/26_vecmat_i8/gen.py
@@ -1,22 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.dialects.air import module_builder
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -124,102 +118,11 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        lower_linalg_to_func=True,
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=2 num-cols=1 row-anchor=2 col-anchor="
-                + str(0)
-                + "}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ###############################################
-    # MLIR-AIR runtime lowering
-    ###############################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(air-unroll-outer-affine-loops{depth=4})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/26_vecmat_i8/run.lit
+++ b/test/xrt/26_vecmat_i8/run.lit
@@ -4,7 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/vm.cc -o vm.o
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
@@ -162,5 +162,6 @@ with air.ir.Context() as ctx, Location.unknown():
     backend = XRTBackend(
         lower_linalg_to_func=True,
         air_loop_fusion=True,
+        runtime_loop_tiling_sizes=[2, 2],
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -161,114 +156,11 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                ### Scaling to 4 AIE columns
-                "func.func(air-split-l2-memref)",
-                "air-isolate-async-dma-loop-nests",
-                ###
-                "canonicalize",
-                "cse",
-                "func.func(air-loop-fusion)",
-                "air-label-scf-for-to-ping-pong",
-                "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        lower_linalg_to_func=True,
+        air_loop_fusion=True,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-                "func.func(convert-linalg-to-loops)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR runtime lowering
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=2,2})",
-                "func.func(air-unroll-outer-affine-loops{depth=2})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
@@ -160,7 +160,6 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        lower_linalg_to_func=True,
         air_loop_fusion=True,
         runtime_loop_tiling_sizes=[2, 2],
     )

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
@@ -3,7 +3,6 @@
 
 // REQUIRES: ryzen_ai, valid_xchess_license
 
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/28_gemm_loop_nest_bf16/gen.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/gen.py
@@ -122,9 +122,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        omit_while_true_loop=False,
         omit_pingpong=True,
         lower_linalg_to_func=True,
-        air_loop_fusion=False,
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/28_gemm_loop_nest_bf16/gen.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/gen.py
@@ -1,4 +1,4 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT

--- a/test/xrt/28_gemm_loop_nest_bf16/gen.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/gen.py
@@ -1,21 +1,16 @@
 # aie.py -*- Python -*-
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -99,9 +94,9 @@ with air.ir.Context() as ctx, Location.unknown():
     """
     air_module = Module.parse(air_tiled_ir_string)
 
-    ################################################
-    ## Binding scf.paralell to air hierarchies
-    ################################################
+    ###############################################
+    # Binding scf.paralell to air hierarchies
+    ###############################################
 
     pipeline = (
         "builtin.module("
@@ -123,116 +118,13 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                ### Scaling to 4 AIE columns
-                "func.func(air-split-l2-memref)",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                ###
-                "canonicalize",
-                "cse",
-                "func.func(air-fuse-alloc-dealloc)",
-                "func.func(air-shrink-memref-sizes-by-access)",
-                # "air-label-scf-for-to-ping-pong", #TODO: Add support for ping pong buffering
-                # "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        omit_while_true_loop=False,
+        omit_pingpong=True,
+        lower_linalg_to_func=True,
+        air_loop_fusion=False,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ###############################################
-    # MLIR-AIR runtime lowering
-    ###############################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-                "func.func(air-unroll-outer-affine-loops{depth=2})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/28_gemm_loop_nest_bf16/run.lit
+++ b/test/xrt/28_gemm_loop_nest_bf16/run.lit
@@ -4,7 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/gen.py
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/gen.py
@@ -1,21 +1,16 @@
-# aie.py -*- Python -*-
+# gen.py -*- Python -*-
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import air
-import air.compiler.util
-from air.dialects import linalg, tensor, arith, func, memref
+from air.backend.xrt import XRTBackend
 from air.ir import *
 import air.passmanager
-from air.dialects import air as airdialect
-from air.compiler.util import run_transform
-import sys
 
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################
-    ## Tiling
+    ## Input SCF and Linalg IR
     ################################################
 
     air_tiled_ir_string = """
@@ -132,116 +127,13 @@ with air.ir.Context() as ctx, Location.unknown():
     pm.run(air_module.operation)
 
     ###############################################
-    # Extract event dependency and optimize schedule
+    # Run compile and load
     ###############################################
 
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "air-dependency",
-                "air-dependency-schedule-opt",
-                "air-specialize-dma-broadcast",
-                "air-dma-to-channel",
-                "canonicalize",
-                "cse",
-                "air-dependency-canonicalize",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                "canonicalize",
-                "cse",
-                "air-fuse-channels",
-                "canonicalize",
-                "cse",
-                ### Scaling to 4 AIE columns
-                "func.func(air-split-l2-memref)",
-                "canonicalize",
-                "cse",
-                "air-isolate-async-dma-loop-nests",
-                ###
-                "canonicalize",
-                "cse",
-                "func.func(air-fuse-alloc-dealloc)",
-                "func.func(air-shrink-memref-sizes-by-access)",
-                # "air-label-scf-for-to-ping-pong", #TODO: Add ping pong buffering
-                # "air-ping-pong-transform",
-                "canonicalize",
-                "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
-                "canonicalize",
-                "cse",
-            ]
-        )
-        + ")"
+    backend = XRTBackend(
+        omit_while_true_loop=False,
+        omit_pingpong=True,
+        lower_linalg_to_func=True,
+        air_loop_fusion=False,
     )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## Place herd to segment
-    ################################################
-
-    air_async_module = Module.parse(str(air_module))
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-collapse-herd{max-col-size=4})",
-                "canonicalize",
-                "cse",
-                "air-place-herds{num-rows=4 num-cols=4 row-anchor=2 col-anchor=0}",
-                "canonicalize",
-                "cse",
-                "func.func(air-renumber-dma)",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ################################################
-    ## MLIR-AIR to MLIR-AIE
-    ################################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "canonicalize",
-                "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true}",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-
-    ###############################################
-    # MLIR-AIR runtime lowering
-    ###############################################
-
-    pipeline = (
-        "builtin.module("
-        + ",".join(
-            [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
-                "air-to-std",
-                "canonicalize",
-                "symbol-dce",
-                "func.func(affine-loop-opt{affine-opt-tile-sizes=4,4})",
-                "func.func(air-unroll-outer-affine-loops{depth=2})",
-                "affine-expand-index-ops",
-                "airrt-to-npu",
-                "canonicalize",
-            ]
-        )
-        + ")"
-    )
-    pm = air.passmanager.PassManager.parse(pipeline)
-    pm.run(air_module.operation)
-    with open("aie.mlir", "w") as f:
-        f.write(str(air_module))
+    module_function = backend.compile_and_load(air_module)

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/gen.py
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/gen.py
@@ -131,9 +131,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        omit_while_true_loop=False,
         omit_pingpong=True,
         lower_linalg_to_func=True,
-        air_loop_fusion=False,
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
@@ -5,6 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/aie.py
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
+// RUN: %python %S/gen.py
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt


### PR DESCRIPTION
Those passes are now default passes for npu.

Also added a number of flags to control whether some passes get called.