### PR TITLE
ShrinkMemrefSizesByAccess: Shrink the memref size to the effective size

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -187,7 +187,7 @@ getEffectiveMemrefSizeFromAccessPattern(SmallVector<int> memref_shape,
 std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
 writeAccessPattern(air::ChannelInterface chanOp);
 std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
-writeAccessPattern(memref::SubViewOp subview);
+writeAccessPattern(memref::SubViewOp subview, Region *commonReg = nullptr);
 std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
 writeAccessPattern(mlir::vector::TransferReadOp readOp);
 std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/loop_fusion.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/loop_fusion.mlir
@@ -512,8 +512,8 @@ func.func @func5() {
 
 // CHECK-LABEL: func.func @func6
 // CHECK: memref.alloc() : memref<1x1x8x8x4x4xi32, 2 : i32>
-// CHECK: memref.alloc() : memref<1x1x8x4x8x4xi32, 2 : i32>
-// CHECK: memref.alloc() : memref<1x1x4x8x4x8xi32, 2 : i32>
+// CHECK: memref.alloc() : memref<1x1x1x1x8x4xi32, 2 : i32>
+// CHECK: memref.alloc() : memref<1x1x1x1x4x8xi32, 2 : i32>
 // CHECK: air.herd @herd_0
 // CHECK-DAG: %[[CST0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[CSTINT0:.*]] = arith.constant 0 : i32
@@ -521,8 +521,8 @@ func.func @func5() {
 // CHECK: scf.for
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK: memref.subview %{{.*}}[0, 0, %{{.*}}, %{{.*}}, 0, 0] [1, 1, 1, 1, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi32, 2 : i32> to memref<1x1x1x1x4x8xi32, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
-// CHECK: memref.subview %{{.*}}[0, 0, %{{.*}}, %{{.*}}, 0, 0] [1, 1, 1, 1, 8, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x8x4x8x4xi32, 2 : i32> to memref<1x1x1x1x8x4xi32, strided<[1024, 1024, 128, 32, 4, 1], offset: ?>, 2 : i32>
+// CHECK: memref.subview %{{.*}}[0, 0, %{{.*}}, %{{.*}}, 0, 0] [1, 1, 1, 1, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x1x1x4x8xi32, 2 : i32> to memref<1x1x1x1x4x8xi32, strided<[32, 32, 32, 32, 8, 1], offset: ?>, 2 : i32>
+// CHECK: memref.subview %{{.*}}[0, 0, %{{.*}}, %{{.*}}, 0, 0] [1, 1, 1, 1, 8, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x1x1x8x4xi32, 2 : i32> to memref<1x1x1x1x8x4xi32, strided<[32, 32, 32, 32, 4, 1], offset: ?>, 2 : i32>
 // CHECK: memref.subview %{{.*}}[%[[CST0]], %[[CST0]], %{{.*}}, %{{.*}}, 0, 0] [1, 1, 1, 1, 4, 4] [1, 1, 1, 1, 1, 1] : memref<1x1x8x8x4x4xi32, 2 : i32> to memref<1x1x1x1x4x4xi32, strided<[1024, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
 // CHECK: linalg.generic
 
@@ -940,9 +940,9 @@ func.func @func10(%arg0: memref<8x512xi32>, %arg1: memref<256x512xi32>, %arg2: m
 
 // CHECK-LABEL: func.func @func11
 // CHECK: air.herd
-// CHECK: %[[SUBVIEW0:.*]] = memref.subview{{.*}} : memref<16x16x4x4xf32, 1 : i32> to memref<1x1x4x4xf32, strided<[256, 16, 4, 1], offset: ?>, 1 : i32>
-// CHECK: %[[SUBVIEW1:.*]] = memref.subview{{.*}} : memref<1x16x4xf32, 2 : i32> to memref<1x4xf32, strided<[4, 1], offset: ?>, 2 : i32>
-// CHECK: %[[SUBVIEW2:.*]] = memref.subview{{.*}} : memref<1x1x16x16x4x4xbf16, 2 : i32> to memref<1x1x4x4xbf16, strided<[4096, 4096, 4, 1], offset: ?>, 2 : i32>
+// CHECK: %[[SUBVIEW0:.*]] = memref.subview{{.*}} : memref<1x1x4x4xf32, 1 : i32> to memref<1x1x4x4xf32, strided<[16, 16, 4, 1], offset: ?>, 1 : i32>
+// CHECK: %[[SUBVIEW1:.*]] = memref.subview{{.*}} : memref<1x1x4xf32, 2 : i32> to memref<1x4xf32, strided<[4, 1], offset: ?>, 2 : i32>
+// CHECK: %[[SUBVIEW2:.*]] = memref.subview{{.*}} : memref<1x1x1x1x4x4xbf16, 2 : i32> to memref<1x1x4x4xbf16, strided<[16, 16, 4, 1], offset: ?>, 2 : i32>
 // CHECK: linalg.generic{{.*}} ins(%[[SUBVIEW0]], %[[SUBVIEW1]] {{.*}}outs(%[[SUBVIEW2]]
 
 #map17 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>


### PR DESCRIPTION
…, which is the size being accessed by all users within a common region, which is a more aggressive memref shrinkage scheme.

Input IR:
```

        %63 = scf.for %arg14 = %c0_55 to %c8_54 step %c4_56 iter_args(%arg15 = %62) -> (!air.async.token) {
          %67 = scf.for %arg16 = %c0_55 to %c8_54 step %c4_56 iter_args(%arg17 = %arg15) -> (!air.async.token) {
            %async_token_62, %results_63 = air.execute -> (memref<8x8x8x8x4x4xf32, 2 : i32>) {
              %alloc = memref.alloc() : memref<8x8x8x8x4x4xf32, 2 : i32>
              air.execute_terminator %alloc : memref<8x8x8x8x4x4xf32, 2 : i32>
            }
            %async_token_68, %results_69 = air.execute -> (index) {
              %78 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg14, %arg10]
              air.execute_terminator %78 : index
            }
            %async_token_70, %results_71 = air.execute -> (index) {
              %78 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg16, %arg11]
              air.execute_terminator %78 : index
            }
            %subview = memref.subview %results_63[%results_71, %results_69, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1] : memref<8x8x8x8x4x4xf32, 2 : i32> to memref<1x1x8x8x4x4xf32, strided<[8192, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
            %async_token_72 = air.execute {
              vector.transfer_write %cst, %subview[%c0_55, %c0_55, %c0_55, %c0_55, %c0_55, %c0_55] {in_bounds = [true, true, true, true, true, true]} : vector<1x1x8x8x4x4xf32>, memref<1x1x8x8x4x4xf32, strided<[8192, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
            }
            %70 = air.wait_all async 
            %71 = scf.for %arg18 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg19 = %70) -> (!air.async.token) {
              %78 = scf.for %arg20 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg21 = %arg19) -> (!air.async.token) {
                %79 = scf.for %arg22 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg23 = %arg21) -> (!air.async.token) {
                  %subview_82 = memref.subview %results_63[%results_71, %results_69, %arg20, %arg18, 0, 0] [1, 1, 1, 1, 4, 4] [1, 1, 1, 1, 1, 1] : memref<8x8x8x8x4x4xf32, 2 : i32> to memref<1x1x1x1x4x4xf32, strided<[8192, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
                  %83 = air.wait_all async
                  scf.yield %83 : !air.async.token
                }
                scf.yield %79 : !air.async.token
              }
              scf.yield %78 : !air.async.token
            }
            scf.for %arg18 = %c1_61 to %c7 step %c1_61 {
              %async_token_80, %results_81 = air.execute -> (index) {
                %82 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg14, %arg10]
                air.execute_terminator %82 : index
              }
              %async_token_82, %results_83 = air.execute -> (index) {
                %82 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg16, %arg11]
                air.execute_terminator %82 : index
              }
              %80 = air.wait_all async 
              %81 = scf.for %arg19 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg20 = %80) -> (!air.async.token) {
                %82 = scf.for %arg21 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg22 = %arg20) -> (!air.async.token) {
                  %83 = scf.for %arg23 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg24 = %arg22) -> (!air.async.token) {
                    %subview_86 = memref.subview %results_63[%results_83, %results_81, %arg21, %arg19, 0, 0] [1, 1, 1, 1, 4, 4] [1, 1, 1, 1, 1, 1] : memref<8x8x8x8x4x4xf32, 2 : i32> to memref<1x1x1x1x4x4xf32, strided<[8192, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
                    %87 = air.wait_all async
                    scf.yield %87 : !air.async.token
                  }
                  scf.yield %83 : !air.async.token
                }
                scf.yield %82 : !air.async.token
              }
            }
            %async_token_73, %results_74 = air.execute -> (index) {
              %78 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg14, %arg10]
              air.execute_terminator %78 : index
            }
            %async_token_75, %results_76 = air.execute -> (index) {
              %78 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg16, %arg11]
              air.execute_terminator %78 : index
            }
            %74 = air.wait_all async 
            %75 = scf.for %arg18 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg19 = %74) -> (!air.async.token) {
              %78 = scf.for %arg20 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg21 = %arg19) -> (!air.async.token) {
                %79 = scf.for %arg22 = %c0_55 to %c8_54 step %c1_61 iter_args(%arg23 = %arg21) -> (!air.async.token) {
                  %subview_82 = memref.subview %results_63[%results_76, %results_74, %arg20, %arg18, 0, 0] [1, 1, 1, 1, 4, 4] [1, 1, 1, 1, 1, 1] : memref<8x8x8x8x4x4xf32, 2 : i32> to memref<1x1x1x1x4x4xf32, strided<[8192, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
                  %83 = air.wait_all async
                  scf.yield %83 : !air.async.token
                }
                scf.yield %79 : !air.async.token
              }
              scf.yield %78 : !air.async.token
            }
            %76 = air.channel.put async [%async_token_62, %async_token_73, %async_token_75]  @channel_26[%arg10, %arg11] (%results_63[%results_76, %results_74, %c0_55, %c0_55, %c0_55, %c0_55] [%c1_61, %c1_61, %c8_54, %c4_56, %c8_54, %c4_56] [%c8192, %c1024_57, %c16, %c4_56, %c128_58, %c1_61]) {id = 53 : i32} : (memref<8x8x8x8x4x4xf32, 2 : i32>)
            scf.yield %76 : !air.async.token
          }
          scf.yield %67 : !air.async.token
        }
```

The size of `%results_63` was shrunk to `<2x2x8x8x4x4xf32>` based on analyzing the size of data being accessed in the entire function. Now, it gets shrunk to `<1x1x8x8x4x4xf32>`, which is the size of data accessed by all users within the region common to all, i.e. the `%67 = scf.for %arg16 = %c0_55 to %c8_54 step %c4_56` loop body.