### PR TITLE
Set `air-loop-fusion` option to off for some xrt tests

### DIFF
--- a/test/xrt/10_gemm_peeling_extern_vec/gen.py
+++ b/test/xrt/10_gemm_peeling_extern_vec/gen.py
@@ -136,7 +136,5 @@ with air.ir.Context() as ctx, Location.unknown():
     # Run compile and load
     ###############################################
 
-    backend = XRTBackend(
-        air_loop_fusion=True,
-    )
+    backend = XRTBackend()
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
@@ -159,7 +159,6 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        air_loop_fusion=True,
         lower_linalg_to_func="mm.o",
     )
     module_function = backend.compile_and_load(air_module)

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
@@ -159,7 +159,6 @@ with air.ir.Context() as ctx, Location.unknown():
 ###############################################
 
 backend = XRTBackend(
-    air_loop_fusion=True,
     lower_linalg_to_func="mm.o",
 )
 module_function = backend.compile_and_load(air_module)

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
@@ -160,7 +160,6 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        air_loop_fusion=True,
         runtime_loop_tiling_sizes=[2, 2],
     )
     module_function = backend.compile_and_load(air_module)


### PR DESCRIPTION
...as pack-peel tiling strategy doesn't need it.