### PR TITLE
AIRDependency: Ensure input `air.wait_all`'s "async" keyword is respected

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -1651,11 +1651,8 @@ Graph::VertexId dependencyCanonicalizer::addVertexFromExecuteOp(
 Graph::VertexId dependencyCanonicalizer::addVertexFromWaitAllOp(
     xilinx::air::WaitAllOp op, dependencyGraph *G, dependencyContext &dep_ctx) {
   // Note: disabled parsing wait_all op inside of reduce op
-  for (auto u : op.getAsyncToken().getUsers()) {
-    if (dyn_cast<scf::ReduceReturnOp>(u)) {
-      return 0;
-    }
-  }
+  if (op->getParentOfType<scf::ReduceOp>())
+    return 0;
   return addVertexFromOp(op, dep_ctx.WaitAllOpID, "wait_all", "WaitAllOp",
                          graphNodeProperties("control"), G, dep_ctx);
 }

--- a/mlir/test/Transform/AIRDependency/air_channel.mlir
+++ b/mlir/test/Transform/AIRDependency/air_channel.mlir
@@ -256,10 +256,10 @@ module {
 // CHECK: %[[HERD:.*]] = air.herd @herd_0 async
 // CHECK: %[[TOKEN0:.*]] = air.channel.get async [{{.*}}]  @ChanA[]
 // CHECK-NEXT: %[[TOKEN1:.*]] = air.channel.get async [{{.*}}]  @ChanB[]
-// CHECK-NEXT: air.wait_all async [{{.*}}%[[TOKEN0]], %[[TOKEN1]]]
-// CHECK: air.wait_all async [%[[HERD]]]
+// CHECK-NEXT: air.wait_all [{{.*}}%[[TOKEN0]], %[[TOKEN1]]]
+// CHECK: air.wait_all [%[[HERD]]]
 // CHECK: %[[TOKEN2:.*]] = air.channel.get async [{{.*}}]  @ChanC[]
-// CHECK-NEXT: air.wait_all async [%[[TOKEN2]]]
+// CHECK-NEXT: air.wait_all [%[[TOKEN2]]]
 
 module {
   air.channel @ChanA []


### PR DESCRIPTION
Input IR may come with `air.wait_all` with and without async token returned. The `air-dependency` pass should respect that, whereas the previous implementation is forcing an async token to be always returned.