### PR TITLE
AIRLowering: restrict `wait_all` to only lower to blocking syncs

### DIFF
--- a/mlir/include/air/Transform/AIRDependencyScheduleOpt.h
+++ b/mlir/include/air/Transform/AIRDependencyScheduleOpt.h
@@ -75,12 +75,12 @@ void populateAIRLoopIndexCanonicalizationPatterns(RewritePatternSet &patterns);
 // Populate patterns for canonicalizing offsets, sizes and strides in air
 // channel_interface operations.
 void populateAIRCanonicalizeChannelWrapAndStridePatterns(
-    RewritePatternSet &patterns, int &maxSize);
+    RewritePatternSet &patterns, int &maxSize, bool &enableRepeatAtHighestDim);
 
 // Apply AIRSpecializeChannelWrapAndStridePattern on region.
-void applyAIRSpecializeChannelWrapAndStridePattern(Region *region,
-                                                   int maxNumDims, int maxSize,
-                                                   bool enableForLoopUnrolling);
+void applyAIRSpecializeChannelWrapAndStridePattern(
+    Region *region, int maxNumDims, int maxSize, bool enableForLoopUnrolling,
+    bool enableRepeatAtHighestDim);
 
 // Populate patterns for fusing scf.for loops within air.launch.
 void populateAIRLoopFusionPattern(RewritePatternSet &patterns);

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1059,6 +1059,11 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
     Option<"clDevice", "device", "std::string",
           /*default=*/"\"xcvc1902\"",
            "AIE device to target.">,
+    ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
+               "Shim dma tiling sizes, tiling shim dma bds into smaller repeating ones",
+               "llvm::cl::ZeroOrMore">,
+    Option<"clLoopUnrollDepth", "shim-dma-unroll-depth", "unsigned", /*default=*/"0",
+           "Depth of the perfectly nested shim dma control for loop to unroll until">,
   ];
 }
 

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1062,8 +1062,6 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
     ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
                "Shim dma tiling sizes, tiling shim dma bds into smaller repeating ones",
                "llvm::cl::ZeroOrMore">,
-    Option<"clLoopUnrollDepth", "shim-dma-unroll-depth", "unsigned", /*default=*/"0",
-           "Depth of the perfectly nested shim dma control for loop to unroll until">,
   ];
 }
 

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -159,6 +159,9 @@ LogicalResult foldForLoopNestAsExtendedSizesAndStrides(
     SmallVector<Value> &offsets, SmallVector<Value> &wraps,
     SmallVector<Value> &strides, Value memref);
 
+// Find the largest factor of 'num' which is not larger than 'max'.
+int findLargestFactor(int num, int max);
+
 // Canonicalize wrap and stride lists, by removing redundant dimensions.
 LogicalResult canonicalizeWrapAndStrideList(
     OpBuilder builder, SmallVector<Value> &offsets, SmallVector<Value> &sizes,

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -225,6 +225,14 @@ public:
       return failure();
     }
 
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(op->getBlock());
+      rewriter.create<airrt::HerdLoadOp>(op->getLoc(), rewriter.getI64Type(),
+                                         herd_name_attr.getValue().str(),
+                                         /* operands */ SmallVector<Value>());
+    }
+
     SmallVector<Value, 4> deps;
     for (auto &o : operands)
       if (llvm::isa<airrt::EventType>(o.getType()))
@@ -1012,11 +1020,6 @@ public:
     }
 
     // Generate airrt load op as handle for reloading binaries
-    if (failed(
-            generateLoadForHierarchy<air::HerdOp, airrt::HerdLoadOp>(module))) {
-      emitError(UnknownLoc::get(context), "error generating airrt.herd_load\n");
-      signalPassFailure();
-    }
     if (failed(generateLoadForHierarchy<air::SegmentOp, airrt::SegmentLoadOp>(
             module))) {
       emitError(UnknownLoc::get(context),

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -610,6 +610,8 @@ public:
       if (deps.size())
         rewriter.replaceOpWithNewOp<xilinx::airrt::WaitAllOp>(
             op, xilinx::airrt::EventType::get(op->getContext()), deps);
+      else
+        rewriter.eraseOp(op);
       return success();
     }
 
@@ -905,7 +907,7 @@ LogicalResult ScfParToAffineForConversion(Operation *op) {
   if (!f)
     return failure();
 
-  llvm::SmallSet<Operation *, 8> erased;
+  llvm::SetVector<Operation *> erased;
   SmallVector<scf::ParallelOp> scf_pars;
   f.walk([&](scf::ParallelOp scf_par) { scf_pars.push_back(scf_par); });
   for (auto scf_par : scf_pars) {

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -366,6 +366,31 @@ public:
   }
 };
 
+struct AIRRtWaitAllOpToNpuWaitPattern
+    : public OpRewritePattern<airrt::WaitAllOp> {
+public:
+  using OpRewritePattern<airrt::WaitAllOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(airrt::WaitAllOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumResults() != 0)
+      return failure();
+    for (auto oper : op->getOperands()) {
+      auto airrtDmaOp = oper.getDefiningOp<airrt::DmaMemcpyNdOp>();
+      if (!airrtDmaOp)
+        continue;
+      StringRef metadata =
+          airrtDmaOp->getAttrOfType<mlir::FlatSymbolRefAttr>("metadata")
+              .getValue();
+      rewriter.create<AIEX::NpuDmaWaitOp>(op.getLoc(), metadata);
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+};
+
 AIE::DeviceOp getDeviceForSegmentLoad(Operation *s) {
   auto module = s->getParentOfType<ModuleOp>();
 
@@ -377,93 +402,6 @@ AIE::DeviceOp getDeviceForSegmentLoad(Operation *s) {
       return d;
   }
   return nullptr;
-}
-
-// Splits an Affine for loop into two for loops, by hoisting target operations
-// in for loop to a new for loop located at the same scope.
-void hoistTargetOpsToNewAffineFor(OpBuilder builder, affine::AffineForOp for_op,
-                                  llvm::SetVector<Operation *> target_ops) {
-  // Get loop nest
-  SmallVector<affine::AffineForOp> for_loops;
-  affine::AffineForOp parent_for =
-      target_ops[0]->getParentOfType<affine::AffineForOp>();
-  while (parent_for != for_op) {
-    for_loops.push_back(parent_for);
-    parent_for = parent_for->getParentOfType<affine::AffineForOp>();
-  }
-  for_loops.push_back(for_op);
-
-  // Clone loop nest
-  builder.setInsertionPoint(for_op);
-  IRMapping remap;
-  for (int i = for_loops.size() - 1; i >= 0; i--) {
-    auto new_for_op = builder.create<affine::AffineForOp>(
-        for_loops[i].getLoc(), for_loops[i].getConstantLowerBound(),
-        for_loops[i].getConstantUpperBound());
-    remap.map(for_loops[i].getInductionVar(), new_for_op.getInductionVar());
-    builder.setInsertionPointToStart(new_for_op.getBody());
-    // Bottom of rabbit hole
-    if (i == 0) {
-      for (auto op : target_ops) {
-        builder.clone(*op, remap);
-      }
-    }
-  }
-}
-
-// Build up a queue of aiex::DmaMemcpyNdOps per shim alloc metadata (i.e. per
-// shim dma channel).
-void identifyTargetAffineForAndOps(
-    func::FuncOp f,
-    llvm::MapVector<affine::AffineForOp,
-                    llvm::MapVector<StringRef, llvm::SetVector<Operation *>>>
-        &opQueuePerMeta) {
-  // Ensure memcpy ops operating on the same metadata (i.e. the same shim
-  // dma channel) are hoisted together, to maintain data dependency.
-  for (auto for_op : f.getBody().getOps<affine::AffineForOp>()) {
-    // Get for_op's immediate child op
-    for_op.walk([&](airrt::DmaMemcpyNdOp memcpyOp) {
-      StringRef metadata =
-          memcpyOp->getAttrOfType<mlir::FlatSymbolRefAttr>("metadata")
-              .getValue();
-      // Check if any operand's defining ops needs to be hoisted together.
-      SmallVector<Operation *> oper_def_ops;
-      xilinx::air::getDefiningOpsToOperands(memcpyOp.getOperation(),
-                                            oper_def_ops);
-      for (auto o : oper_def_ops)
-        if (o->getParentRegion() == memcpyOp->getParentRegion())
-          opQueuePerMeta[for_op][metadata].insert(o);
-      opQueuePerMeta[for_op][metadata].insert(memcpyOp.getOperation());
-    });
-  }
-}
-
-// Split affine.for loops to ensure that each loop nest only contains memcpy ops
-// onto a single shim dma channel.
-void isolateAIRRtDmaLoopNests(ModuleOp module) {
-  // Identify affine.for ops and target child ops for hoisting.
-  llvm::MapVector<affine::AffineForOp,
-                  llvm::MapVector<StringRef, llvm::SetVector<Operation *>>>
-      opQueuePerMeta;
-  SmallVector<func::FuncOp> funcOps;
-  module.walk([&](func::FuncOp f) { funcOps.push_back(f); });
-  for (auto f : funcOps) {
-    f.walk(
-        [&](affine::AffineForOp afo) { (void)promoteIfSingleIteration(afo); });
-    identifyTargetAffineForAndOps(f, opQueuePerMeta);
-  }
-
-  // Hoist ops out of each scf.for.
-  llvm::SmallSet<Operation *, 1> erased;
-  for (auto &[affineForBand, queue] : opQueuePerMeta) {
-    for (auto &[metadata, vec] : queue) {
-      OpBuilder builder(affineForBand);
-      hoistTargetOpsToNewAffineFor(builder, affineForBand, vec);
-      erased.insert(affineForBand.getOperation());
-    }
-  }
-  for (auto o : erased)
-    o->erase();
 }
 
 // AIE2 hardware constraints.
@@ -687,165 +625,6 @@ void enforceAIE2WrapLimit(ModuleOp module) {
     tileIllegalWrapDim(memcpy_op);
 }
 
-struct AIRSpecializeAIRRtDmaWrapAndStrideInAffineFor
-    : public OpRewritePattern<affine::AffineForOp> {
-  using OpRewritePattern<affine::AffineForOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(affine::AffineForOp for_op,
-                                PatternRewriter &rewriter) const override {
-    auto loc = for_op->getLoc();
-    auto ctx = for_op->getContext();
-
-    // Declaration of constants
-    auto i64Ty = rewriter.getI64Type();
-    auto i64_zero = rewriter.create<arith::ConstantOp>(
-        loc, i64Ty, IntegerAttr::get(i64Ty, 0));
-    auto i64_one = rewriter.create<arith::ConstantOp>(
-        loc, i64Ty, IntegerAttr::get(i64Ty, 1));
-
-    if (!air::hasNImpureOps(for_op.getBody(), 1))
-      return failure();
-
-    // Check if the loop contains exactly one memcpy op
-    if (llvm::range_size(for_op.getBody()->getOps<airrt::DmaMemcpyNdOp>()) != 1)
-      return failure();
-    airrt::DmaMemcpyNdOp memcpy_op =
-        *(for_op.getBody()->getOps<airrt::DmaMemcpyNdOp>().begin());
-
-    // Fold for loops into memcpy op's wrap and stride fields
-    auto memref = memcpy_op->getOperand(3);
-    auto memref_shape = xilinx::air::getTensorShape(memref.getType());
-    auto oper_begin = memcpy_op.getOperands().begin();
-    SmallVector<Value> offsets(oper_begin + 4, oper_begin + 8);
-    SmallVector<Value> wraps(oper_begin + 8, oper_begin + 12);
-    SmallVector<Value> strides(oper_begin + 12, oper_begin + 15);
-    // Stride field implicit last element one
-    strides.push_back(i64_one);
-
-    (void)air::canonicalizeWrapAndStrideList(
-        rewriter, offsets, wraps, strides,
-        air::getTensorVolume(memref.getType()));
-
-    // If empty offsets/sizes/strides, then populate the lists with default
-    // values.
-    if (offsets.empty() && wraps.empty() && strides.empty())
-      air::populateDefaultWrapsAndStrides(rewriter, memref, offsets, wraps,
-                                          strides);
-
-    auto res = air::foldForLoopNestAsExtendedSizesAndStrides(
-        rewriter, for_op.getOperation(), memcpy_op.getOperation(), offsets,
-        wraps, strides, memref);
-    if (res.failed())
-      return failure();
-
-    if (offsets.size() > 4 || wraps.size() > 4 || strides.size() > 4)
-      return failure();
-
-    (void)air::canonicalizeWrapAndStrideList(
-        rewriter, offsets, wraps, strides,
-        air::getTensorVolume(memref.getType()));
-
-    // Stride field implicit last element one
-    strides.pop_back();
-    while (offsets.size() < 4) {
-      offsets.insert(offsets.begin(), i64_zero);
-    }
-    while (wraps.size() < 4) {
-      wraps.insert(wraps.begin(), i64_one);
-    }
-    while (strides.size() < 3) {
-      strides.insert(strides.begin(), i64_zero);
-    }
-
-    // Stride = 0 means repeat that dimension. If highest dimension (dim 0) is
-    // not used, then move the repeat dimension to dim 0, which is the only dim
-    // with repeat capability. Else, fall back to unrolling BDs.
-    unsigned activeDimsInBetween = 0;
-    for (unsigned i = 1; i < strides.size(); i++) {
-      auto constWrap = mlir::getConstantIntValue(wraps[i]);
-      auto constStride = mlir::getConstantIntValue(strides[i]);
-      if (!constWrap)
-        continue;
-      if (!constStride)
-        continue;
-      if (*constWrap <= 1)
-        continue; // Inactive dimension. Continue.
-      if (*constStride) {
-        // Found active dimension after dim 0. Any subsequent repeat dimension
-        // shall not bump to dim 0 anymore.
-        activeDimsInBetween++;
-        continue;
-      }
-      // This is a repeat dimension.
-      if (mlir::getConstantIntValue(wraps[0]) &&
-          *mlir::getConstantIntValue(wraps[0]) == 1 && !activeDimsInBetween) {
-        // Dimension 0 is available. Move the repeat dimension i to dimension 0.
-        auto tmp = wraps[0];
-        wraps[0] = wraps[i];
-        wraps[i] = tmp;
-        tmp = strides[0];
-        strides[0] = strides[i];
-        strides[i] = tmp;
-        tmp = offsets[0];
-        offsets[0] = offsets[i];
-        offsets[i] = tmp;
-      } else {
-        (void)loopUnrollFull(for_op);
-        return success();
-      }
-    }
-
-    // Create new airrt.dma_memcpy_nd
-    SmallVector<Type, 1> tys;
-    if (memcpy_op->getNumResults())
-      tys.push_back(airrt::EventType::get(ctx));
-
-    SmallVector<Value, 16> opers;
-    auto old_opers = memcpy_op->getOperands();
-    opers.insert(opers.end(), old_opers.begin(), old_opers.begin() + 4);
-    opers[1] = rewriter.create<arith::ConstantOp>(loc, i64Ty,
-                                                  IntegerAttr::get(i64Ty, 0));
-    opers[2] = rewriter.create<arith::ConstantOp>(loc, i64Ty,
-                                                  IntegerAttr::get(i64Ty, 0));
-    opers.insert(opers.end(), offsets.begin(), offsets.end());
-    opers.insert(opers.end(), wraps.begin(), wraps.end());
-    opers.insert(opers.end(), strides.begin(), strides.end());
-
-    // Hoist const ops; create index_cast ops.
-    IRMapping remap;
-    for (unsigned i = 0; i < opers.size(); i++) {
-      auto defOp = opers[i].getDefiningOp<arith::ConstantOp>();
-      if (!defOp)
-        continue;
-      if (opers[i].getType() == memcpy_op->getOperandTypes()[i])
-        continue;
-      opers[i] = rewriter.clone(*defOp, remap)->getResult(0);
-      opers[i] = getValueOrCreateCastToIndexLike(
-          rewriter, loc, memcpy_op->getOperandTypes()[i], opers[i]);
-    }
-
-    // Hoist any pure ops that the new channel op depends on.
-    llvm::SetVector<Operation *> backwardSlices;
-    air::getBackwardSliceInRegion(rewriter, &for_op.getRegion(), opers,
-                                  backwardSlices);
-    for (auto o : backwardSlices)
-      rewriter.clone(*o, remap);
-
-    auto new_dma = rewriter.create<airrt::DmaMemcpyNdOp>(
-        loc, tys, air::lookupOrDefaultRange(opers, remap));
-    new_dma->setAttrs(memcpy_op->getDiscardableAttrDictionary());
-
-    rewriter.replaceAllUsesWith(for_op.getInductionVar(),
-                                rewriter.create<arith::ConstantIndexOp>(
-                                    loc, for_op.getConstantLowerBound()));
-    rewriter.eraseOp(for_op.getOperation());
-
-    return success();
-  }
-
-private:
-};
-
 struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
   void runOnOperation() override {
 
@@ -856,7 +635,6 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
 
     // Purge all wait all ops
     purgeSCFParContainingOnlyWaitAllOps(module);
-    purgeWaitAlls(module);
 
     // Purge airrt.dma x and y fields, as they are obsolete for AIE2.
     purgeAIRRtDmaXAndY(module);
@@ -864,43 +642,18 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // Remove any duplicate shim dma allocations
     purgeDuplicateShimDmaAllocs(module);
 
-    // Separate affine for loop nest into loop nests each containing one dma
-    // memcpy op
-    unrollSCFFors(module);
-    isolateAIRRtDmaLoopNests(module);
-
     // Simplify affine apply ops
     auto ctx = &getContext();
-    RewritePatternSet canoPatterns_0(ctx);
-    xilinx::air::populateAIRLoopIndexCanonicalizationPatterns(canoPatterns_0);
-    (void)applyPatternsGreedily(module, std::move(canoPatterns_0));
 
-    // Specialize affine for loop nest into wraps and strides
-    RewritePatternSet loopFoldPattern(ctx);
-    loopFoldPattern.add<AIRSpecializeAIRRtDmaWrapAndStrideInAffineFor>(ctx);
-    air::populateAIRLoopIndexCanonicalizationPatterns(loopFoldPattern);
-    (void)applyPatternsGreedily(module, std::move(loopFoldPattern));
+    // Unroll for loops
     unrollAffineFors(module);
-
-    // Simplify arith ops (from airrt)
-    RewritePatternSet canoPatterns_1(ctx);
-    arith::IndexCastOp::getCanonicalizationPatterns(canoPatterns_1, ctx);
-    (void)applyPatternsGreedily(module, std::move(canoPatterns_1));
-
-    // Purge all wait ops again after unroll, in case there were loop carried
-    // events which couldn't be purged before
-    purgeWaitAlls(module);
+    unrollSCFFors(module);
 
     // Purge dma ops' async tokens
-    purgeDmaAsyncTokens(module);
+    generateNpuWaitFromAIRRtWaitAll(module);
 
-    // Enforce AIE2 hardware constraint: wrap size limit within [0, 1023].
+    // Enforce AIE2 hardware constraints.
     enforceAIE2WrapLimit(module);
-
-    // Simplify arith ops (from airrt)
-    RewritePatternSet canoPatterns_3(ctx);
-    arith::IndexCastOp::getCanonicalizationPatterns(canoPatterns_3, ctx);
-    (void)applyPatternsGreedily(module, std::move(canoPatterns_3));
 
     ConversionTarget target(getContext());
     target.addIllegalDialect<AIRRtDialect>();
@@ -956,8 +709,8 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     air::populateBufferMemrefToFuncArgsPattern(castPattern);
     (void)applyPatternsGreedily(module, std::move(castPattern));
 
-    // Insert sync op after copying data out to host
-    insertNpuSyncOpForResults(module);
+    // Optimization: purge npu wait on device inbound shim data movements.
+    removeNpuWaitOnInboundMemcpy(module);
 
     // Renumber npu dma ops
     renumberNpuDmaOps(module.getBody());
@@ -992,7 +745,17 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     }
   }
 
-  void purgeDmaAsyncTokens(ModuleOp module) {
+  // Generate npu wait ops from blocking airrt.wait_all ops.
+  void generateNpuWaitFromAIRRtWaitAll(ModuleOp module) {
+
+    // Canonicalize airrt.wait_all, to remove redundant ops.
+    auto ctx = module.getContext();
+    RewritePatternSet patterns(ctx);
+    airrt::WaitAllOp::getCanonicalizationPatterns(patterns, ctx);
+    patterns.insert<AIRRtWaitAllOpToNpuWaitPattern>(ctx);
+    (void)applyPatternsGreedily(module, std::move(patterns));
+
+    // Dma event tokens are no longer needed. Purge them.
     SmallVector<DmaMemcpyNdOp> dmas;
     module.walk([&](DmaMemcpyNdOp dma) { dmas.push_back(dma); });
     for (auto dma : dmas) {
@@ -1003,24 +766,6 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
                                                    dma->getOperands());
         newOp->setAttrs(dma->getDiscardableAttrDictionary());
         dma->erase();
-      }
-    }
-  }
-
-  void purgeWaitAlls(ModuleOp module) {
-    int size = 0;
-    int last_size = 1;
-    while (size < last_size) {
-      SmallVector<WaitAllOp> waits;
-      module.walk([&](WaitAllOp w) { waits.push_back(w); });
-      size = waits.size();
-      last_size = size;
-      for (auto &w : waits) {
-        if (!w->use_empty())
-          continue;
-        w->eraseOperands(0, w->getNumOperands());
-        w.erase();
-        size--;
       }
     }
   }
@@ -1195,12 +940,15 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     return std::nullopt;
   }
 
-  void insertNpuSyncOpForResults(ModuleOp module) {
+  // Remove npu wait op on inbound dma data movements.
+  // TODO: this is an aggressive optimization which might prove problematic for
+  // some applications. To be revised.
+  void removeNpuWaitOnInboundMemcpy(ModuleOp module) {
     SmallVector<mlir::func::FuncOp> funcOps;
     module.walk([&](mlir::func::FuncOp f) { funcOps.push_back(f); });
     for (auto f : funcOps) {
-      SmallVector<AIEX::NpuDmaMemcpyNdOp> dmas;
-      f.walk([&](AIEX::NpuDmaMemcpyNdOp dma) { dmas.push_back(dma); });
+      SmallVector<AIEX::NpuDmaWaitOp> waits;
+      f.walk([&](AIEX::NpuDmaWaitOp wait) { waits.push_back(wait); });
       auto d = f->getParentOfType<AIE::DeviceOp>();
 
       SmallVector<AIE::ShimDMAAllocationOp> shimDmaAllocOps;
@@ -1227,44 +975,15 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       if (!d)
         continue;
       OpBuilder builder(f);
-      for (auto dma : dmas) {
-        auto infoOp = getAllocOpForSymbolWithCaching(dma.getMetadata());
+      for (auto wait : waits) {
+        auto infoOp = getAllocOpForSymbolWithCaching(wait.getSymbol());
         if (!infoOp)
           continue;
-        if (infoOp->getChannelDir() != AIE::DMAChannelDir::S2MM)
+        if (infoOp->getChannelDir() != AIE::DMAChannelDir::MM2S)
           continue;
-        // Found dma op copying results to host
-        auto col = builder.getI32IntegerAttr(infoOp->getCol());
-        auto row = builder.getI32IntegerAttr(0);
-        auto dir = builder.getI32IntegerAttr(0);
-        auto chan = builder.getI32IntegerAttr(infoOp->getChannelIndex());
-        auto col_num = builder.getI32IntegerAttr(1);
-        auto row_num = builder.getI32IntegerAttr(1);
-        builder.setInsertionPointAfter(dma);
-        builder.create<AIEX::NpuSyncOp>(dma->getLoc(), col, row, dir, chan,
-                                        col_num, row_num);
+        // Found dma op copying results from host to device
+        wait->erase();
       }
-
-      // Attempt to make npu.sync ops contiguous if they are not operating on
-      // the same channel.
-      SmallVector<AIEX::NpuSyncOp> previsouSyncs;
-      f.walk([&](Operation *op) {
-        if (auto sync = dyn_cast<AIEX::NpuSyncOp>(op))
-          previsouSyncs.push_back(sync);
-        else if (auto dma = dyn_cast<AIEX::NpuDmaMemcpyNdOp>(op)) {
-          auto infoOp = getAllocOpForSymbolWithCaching(dma.getMetadata());
-          if (!infoOp)
-            return;
-          if (previsouSyncs.empty())
-            return;
-          if (infoOp->getChannelDir() == AIE::DMAChannelDir::S2MM) {
-            for (auto prevSync : previsouSyncs)
-              prevSync->moveAfter(op);
-          } else if (infoOp->getChannelDir() == AIE::DMAChannelDir::MM2S) {
-            previsouSyncs.clear();
-          }
-        }
-      });
     }
   }
 

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -373,7 +373,9 @@ public:
 
   LogicalResult matchAndRewrite(airrt::WaitAllOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getNumResults() != 0)
+    if (llvm::none_of(op->getOperands(), [](Value oper) {
+          return (bool)oper.getDefiningOp<airrt::DmaMemcpyNdOp>();
+        }))
       return failure();
     for (auto oper : op->getOperands()) {
       auto airrtDmaOp = oper.getDefiningOp<airrt::DmaMemcpyNdOp>();

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -651,7 +651,9 @@ void lowerAirExecute(AIE::DeviceOp d) {
   RewritePatternSet patterns(ctx);
   int maxSize = isa<AIE::AIE1TargetModel>(AIE::getTargetModel(d)) ? -1 : 1023;
   patterns.insert<LowerAIRExecutePattern>(ctx);
-  air::populateAIRCanonicalizeChannelWrapAndStridePatterns(patterns, maxSize);
+  bool enableRepeatAtHighestDim = false;
+  air::populateAIRCanonicalizeChannelWrapAndStridePatterns(
+      patterns, maxSize, enableRepeatAtHighestDim);
   (void)applyPatternsGreedily(d, std::move(patterns));
 }
 

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -175,8 +175,10 @@ public:
           // No air execute for subview ops
           if (isa<mlir::OffsetSizeAndStrideOpInterface>(op))
             isCandidateExecute = false;
-          // No air execute for memref.extract_strided_metadata ops.
-          if (isa<memref::ExtractStridedMetadataOp>(op))
+          // No air execute for memref.extract_strided_metadata and
+          // memref.AssumeAlignmentOp ops.
+          if (isa<memref::ExtractStridedMetadataOp, memref::AssumeAlignmentOp>(
+                  op))
             isCandidateExecute = false;
           // No air execute for terminators
           if (op->mightHaveTrait<OpTrait::IsTerminator>()) {

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -182,10 +182,6 @@ public:
           if (op->mightHaveTrait<OpTrait::IsTerminator>()) {
             isCandidateExecute = false;
           }
-          // No air execute in linalg.generic
-          if (op->getParentOfType<mlir::linalg::GenericOp>()) {
-            isCandidateExecute = false;
-          }
           if (isCandidateExecute) {
             if (op->getNumResults())
               createAsyncExecute(rewriter, op,

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2189,8 +2189,16 @@ struct AIRCanonicalizeChannelPutOpWrapAndStrideList
     SmallVector<Value> sizes = op.getSizes();
     SmallVector<Value> strides = op.getStrides();
 
-    if (enableRepeatAtHighestDim && !strides.empty() &&
-        *getConstantIntValue(strides.front()) == 0) {
+    // When highest-dimension repeat is active, (1) enableRepeatAtHighestDim
+    // option is switched on, (2) wrap-and-stride list isn't empty (i.e. data
+    // isn't 1-d streamed in), (3) highest stride is zero, and (4) highest wrap
+    // is not one.
+    bool highestDimRepeatActive = enableRepeatAtHighestDim &&
+                                  !strides.empty() &&
+                                  *getConstantIntValue(strides.front()) == 0 &&
+                                  *getConstantIntValue(sizes.front()) != 1;
+
+    if (highestDimRepeatActive) {
       // If repeat is enabled at the highest dimension, then the highest
       // dimension must be preserved.
       return failure();
@@ -2241,8 +2249,16 @@ struct AIRCanonicalizeChannelGetOpWrapAndStrideList
     SmallVector<Value> sizes = op.getSizes();
     SmallVector<Value> strides = op.getStrides();
 
-    if (enableRepeatAtHighestDim && !strides.empty() &&
-        *getConstantIntValue(strides.front()) == 0) {
+    // When highest-dimension repeat is active, (1) enableRepeatAtHighestDim
+    // option is switched on, (2) wrap-and-stride list isn't empty (i.e. data
+    // isn't 1-d streamed in), (3) highest stride is zero, and (4) highest wrap
+    // is not one.
+    bool highestDimRepeatActive = enableRepeatAtHighestDim &&
+                                  !strides.empty() &&
+                                  *getConstantIntValue(strides.front()) == 0 &&
+                                  *getConstantIntValue(sizes.front()) != 1;
+
+    if (highestDimRepeatActive) {
       // If repeat is enabled at the highest dimension, then the highest
       // dimension must be preserved.
       return failure();

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -762,10 +762,6 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
           newWaitAll.getAsyncToken());
     }
   }
-  // Erasing the original ops backwards, to avoid erasing op that still has
-  // valid uses.
-  for (auto erase_op : llvm::reverse(target_ops))
-    rewriter.eraseOp(erase_op);
   for (auto user : for_op.getResults().front().getUsers()) {
     air::addAsyncDependencyIfNew(user, air::getAsyncTokenFromOp(new_for_op));
   }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -751,21 +751,6 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
                        yield_operands)
                    ->getResult(0)});
 
-  IRMapping waitAllRemap;
-  for (auto erase_op : target_ops) {
-    if (air::isAsyncOp(erase_op)) {
-      // Reconnect returned tokens.
-      rewriter.setInsertionPoint(erase_op);
-      auto newWaitAll = air::replaceAsyncOpWithWaitAll(rewriter, waitAllRemap,
-                                                       erase_op, true);
-      air::getAsyncTokenFromOp(erase_op).replaceAllUsesWith(
-          newWaitAll.getAsyncToken());
-    }
-  }
-  for (auto user : for_op.getResults().front().getUsers()) {
-    air::addAsyncDependencyIfNew(user, air::getAsyncTokenFromOp(new_for_op));
-  }
-
   return new_for_op;
 }
 

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -892,6 +892,9 @@ LogicalResult eraseWrapNStrideDim(OpBuilder builder,
     auto const_size = getConstantIntValue(sizes[erase_dim]);
     if (!const_size)
       return false; // non-static wrap, NYI.
+    if (sizes.size() - 1 == erase_dim)
+      return false; // Already the last wrap dimension.
+    //   return false;
     auto const_size_next = getConstantIntValue(sizes[erase_dim + 1]);
     if (!const_size_next)
       return false; // non-static wrap, NYI.
@@ -1350,6 +1353,8 @@ bool air::isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
     assert(stepsize && "non-static stride");
     auto wrap = mlir::getConstantIntValue(memcpy_sizes[i]);
     assert(wrap && "non-static wrap");
+    if (*wrap == 1 && *stepsize == 0)
+      continue; // dummy dimension.
     if (*stepsize != stride_factor)
       return false;
     stride_factor *= *wrap;

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -892,9 +892,8 @@ LogicalResult eraseWrapNStrideDim(OpBuilder builder,
     auto const_size = getConstantIntValue(sizes[erase_dim]);
     if (!const_size)
       return false; // non-static wrap, NYI.
-    if (sizes.size() - 1 == erase_dim)
+    if ((int)sizes.size() - 1 == erase_dim)
       return false; // Already the last wrap dimension.
-    //   return false;
     auto const_size_next = getConstantIntValue(sizes[erase_dim + 1]);
     if (!const_size_next)
       return false; // non-static wrap, NYI.

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -241,3 +241,56 @@ module {
     return
   }
 }
+
+// -----
+
+// Check for the generation of a blocking airrt.wait_all at the end of an air.launch.
+
+// CHECK-LABEL:   func.func @air_dep_in_launch
+// CHECK: affine.for
+// CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: %[[TOKEN1:.*]] = airrt.dma_memcpy_nd
+// CHECK: %[[TOKEN2:.*]] = airrt.dma_memcpy_nd
+// CHECK: %[[TOKEN3:.*]] = airrt.dma_memcpy_nd
+// CHECK: airrt.wait_all %[[TOKEN3]]
+
+module {
+  air.channel @channel_0 [1, 1]
+  air.channel @channel_1 [1, 1]
+  air.channel @channel_2 [1, 1]
+  func.func @air_dep_in_launch(%arg0: memref<512xbf16>, %arg1: memref<512xbf16>, %arg2: memref<512xbf16>) {
+    %c2 = arith.constant 2 : index
+    %0 = air.launch async () in () args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<512xbf16>, memref<512xbf16>, memref<512xbf16> {
+      %1 = air.channel.put async  @channel_0[] (%arg7[] [] []) {metadata = @airMemcpyId13} : (memref<512xbf16>)
+      %5 = air.channel.put async  @channel_1[] (%arg8[] [] []) {metadata = @airMemcpyId17} : (memref<512xbf16>)
+      %9 = air.channel.get async [%1, %5]  @channel_2[] (%arg9[] [] []) {metadata = @airMemcpyId94} : (memref<512xbf16>)
+      %13 = air.segment @segment_0 async {
+        %async_token_16, %results_17 = air.execute -> (memref<512xbf16, 1>) {
+          %alloc = memref.alloc() : memref<512xbf16, 1>
+          air.execute_terminator %alloc : memref<512xbf16, 1>
+        }
+        %async_token_30, %results_31 = air.execute -> (memref<512xbf16, 1>) {
+          %alloc = memref.alloc() : memref<512xbf16, 1>
+          air.execute_terminator %alloc : memref<512xbf16, 1>
+        }
+        %async_token_38, %results_39 = air.execute -> (memref<512xbf16, 1>) {
+          %alloc = memref.alloc() : memref<512xbf16, 1>
+          air.execute_terminator %alloc : memref<512xbf16, 1>
+        }
+        %14 = air.channel.get async [%async_token_38]  @channel_0[] (%results_39[] [] []) {id = 13 : i32} : (memref<512xbf16, 1>)
+        %18 = air.channel.get async [%async_token_30]  @channel_1[] (%results_31[] [] []) {id = 17 : i32} : (memref<512xbf16, 1>)
+        %71 = air.channel.put async [%14, %18]  @channel_2[] (%results_17[] [] []) {id = 94 : i32} : (memref<512xbf16, 1>)
+        %async_token_40 = air.execute [%14] {
+          memref.dealloc %results_39 : memref<512xbf16, 1>
+        }
+        %async_token_44 = air.execute [%18] {
+          memref.dealloc %results_31 : memref<512xbf16, 1>
+        }
+        %async_token_51 = air.execute [%71] {
+          memref.dealloc %results_17 : memref<512xbf16, 1>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -250,9 +250,11 @@ module {
 // CHECK: affine.for
 // CHECK: airrt.segment_load "segment_0" : i64
 // CHECK: %[[TOKEN1:.*]] = airrt.dma_memcpy_nd
+// CHECK: %[[WAIT1:.*]] = airrt.wait_all %[[TOKEN1]]
 // CHECK: %[[TOKEN2:.*]] = airrt.dma_memcpy_nd
+// CHECK: %[[WAIT2:.*]] = airrt.wait_all %[[TOKEN2]]
 // CHECK: %[[TOKEN3:.*]] = airrt.dma_memcpy_nd
-// CHECK: airrt.wait_all %[[TOKEN1]], %[[TOKEN2]], %[[TOKEN3]]
+// CHECK: airrt.wait_all %[[TOKEN3]], %[[WAIT1]], %[[WAIT2]]
 
 module {
   air.channel @channel_0 [1, 1]

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -59,9 +59,9 @@ module {
 // CHECK: affine.for %{{.*}} 0 to 1
 // CHECK: affine.for %{{.*}} 0 to 1
 // CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: airrt.herd_load "herd_0" () : () -> i64
 // CHECK: airrt.dma_memcpy_nd(%c3_i32, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%c4_i32, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-// CHECK: airrt.herd_load "herd_0" () : () -> i64
 
 module {
   air.channel @channel_3 [2, 2]
@@ -124,13 +124,13 @@ module {
 
 // CHECK-LABEL:   func.func @par_with_for_put_get
 // CHECK: airrt.segment_load "segment_0" : i64
+// CHECK: airrt.herd_load "herd_0" () : () -> i64
 // CHECK: affine.for %{{.*}} 0 to 2
 // CHECK:   affine.for %{{.*}} 0 to 2
 // CHECK:     airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:     scf.for
 // CHECK:       airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:       scf.yield
-// CHECK: airrt.herd_load "herd_0" () : () -> i64
 module {
   air.channel @channel_5 [2, 2]
   air.channel @channel_4 [2, 2]
@@ -199,8 +199,8 @@ module {
 // CHECK-LABEL:   func.func @one_d_scf_parallel
 // CHECK: affine.for
 // CHECK: airrt.segment_load "segment_0" : i64
-// CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<128xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
 // CHECK: airrt.herd_load "herd_0" () : () -> i64
+// CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<128xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 module {
@@ -252,7 +252,7 @@ module {
 // CHECK: %[[TOKEN1:.*]] = airrt.dma_memcpy_nd
 // CHECK: %[[TOKEN2:.*]] = airrt.dma_memcpy_nd
 // CHECK: %[[TOKEN3:.*]] = airrt.dma_memcpy_nd
-// CHECK: airrt.wait_all %[[TOKEN3]]
+// CHECK: airrt.wait_all %[[TOKEN1]], %[[TOKEN2]], %[[TOKEN3]]
 
 module {
   air.channel @channel_0 [1, 1]
@@ -290,6 +290,7 @@ module {
           memref.dealloc %results_17 : memref<512xbf16, 1>
         }
       }
+      %15 = air.wait_all async [%1, %5, %9]
     }
     return
   }

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -59,9 +59,9 @@ module {
 // CHECK: affine.for %{{.*}} 0 to 1
 // CHECK: affine.for %{{.*}} 0 to 1
 // CHECK: airrt.segment_load "segment_0" : i64
-// CHECK: airrt.herd_load "herd_0" () : () -> i64
 // CHECK: airrt.dma_memcpy_nd(%c3_i32, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK: airrt.dma_memcpy_nd(%c4_i32, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
+// CHECK: airrt.herd_load "herd_0" () : () -> i64
 
 module {
   air.channel @channel_3 [2, 2]
@@ -124,13 +124,13 @@ module {
 
 // CHECK-LABEL:   func.func @par_with_for_put_get
 // CHECK: airrt.segment_load "segment_0" : i64
-// CHECK: airrt.herd_load "herd_0" () : () -> i64
 // CHECK: affine.for %{{.*}} 0 to 2
 // CHECK:   affine.for %{{.*}} 0 to 2
 // CHECK:     airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:     scf.for
 // CHECK:       airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<32x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
 // CHECK:       scf.yield
+// CHECK: airrt.herd_load "herd_0" () : () -> i64
 module {
   air.channel @channel_5 [2, 2]
   air.channel @channel_4 [2, 2]
@@ -199,8 +199,8 @@ module {
 // CHECK-LABEL:   func.func @one_d_scf_parallel
 // CHECK: affine.for
 // CHECK: airrt.segment_load "segment_0" : i64
-// CHECK: airrt.herd_load "herd_0" () : () -> i64
 // CHECK: airrt.dma_memcpy_nd(%{{.*}}, %{{.*}}, %{{.*}}, %arg0[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}, %{{.*}}]) : (i32, i64, i64, memref<128xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+// CHECK: airrt.herd_load "herd_0" () : () -> i64
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 module {

--- a/mlir/test/Conversion/AIRLowering/air_deps.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_deps.mlir
@@ -10,7 +10,6 @@
 // CHECK-LABEL: func.func @execute
 // CHECK: %[[V0:.*]] = memref.alloc() {alignment = 128 : i64} : memref<64x64xi32>
 // CHECK: %[[E0:.*]] = airrt.wait_all : !airrt.event
-// CHECK: airrt.wait_all %[[E0]]
 // CHECK: memref.dealloc %[[V0]] : memref<64x64xi32>
 // CHECK: %[[E1:.*]] = airrt.wait_all : !airrt.event
 // CHECK: airrt.wait_all %[[E1]]

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -7,7 +7,7 @@
 
 // RUN: air-opt -airrt-to-npu -canonicalize -cse --split-input-file %s | FileCheck %s
 
-// Synchronous airrt.dma_memcpy_nd
+// Synchronous airrt.dma_memcpy_nd.
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK: aie.shim_dma_allocation @airMemcpyId7(S2MM, 0, 0)
@@ -17,7 +17,6 @@
 // CHECK: aiex.runtime_sequence @func0(%[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId2} : memref<64xi32>
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<64xi32>
-// CHECK:   aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 // CHECK: }
 // CHECK: {sym_name = "segment0"}
 
@@ -57,7 +56,7 @@ module {
 // CHECK: aiex.runtime_sequence @func1(%[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId2} : memref<64xi32>
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<64xi32>
-// CHECK:   aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK:   aiex.npu.dma_wait {symbol = @airMemcpyId7}
 // CHECK: }
 // CHECK: } {sym_name = "segment0"}
 
@@ -84,6 +83,7 @@ module {
     %1 = airrt.wait_all : !airrt.event
     %c7_i32 = arith.constant 7 : i32
     %2 = airrt.dma_memcpy_nd(%c7_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+    airrt.wait_all %0, %2
     return
   }
 }
@@ -106,7 +106,7 @@ module {
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][1, 1, 32, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<32x32xi32>
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][1, 1, 32, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId5} : memref<32x32xi32>
 // CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 0, 0][1, 1, 32, 32][0, 0, 32, 1]) {id = 3 : i64, metadata = @airMemcpyId16} : memref<32x32xi32>
-// CHECK:   aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK:   aiex.npu.dma_wait {symbol = @airMemcpyId16}
 // CHECK: }
 // CHECK: } {sym_name = "segment_0"}
 
@@ -144,6 +144,7 @@ module {
         %7 = airrt.dma_memcpy_nd(%c6_i32, %2, %3, %arg0[%c0_i64, %c0_i64, %4, %c0_i64], [%c1_i64, %c1_i64, %c32_i64, %c32_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @airMemcpyId6} : (i32, i64, i64, memref<32x32xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
         %8 = airrt.dma_memcpy_nd(%c7_i32, %2, %3, %arg1[%c0_i64, %c0_i64, %c0_i64, %5], [%c1_i64, %c1_i64, %c32_i64, %c32_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<32x32xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
         %9 = airrt.dma_memcpy_nd(%c16_i32, %2, %3, %arg2[%c0_i64, %c0_i64, %4, %5], [%c1_i64, %c1_i64, %c32_i64, %c32_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @airMemcpyId16} : (i32, i64, i64, memref<32x32xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+        airrt.wait_all %6, %7, %8, %9
         %p = airrt.segment_load "segment_0" : i64
       }
     }
@@ -157,7 +158,14 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_2col) {
 // CHECK:  aiex.runtime_sequence @func3(%[[ARG0:.*]]: memref<8x8xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][2, 2, 4, 4][32, 4, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @airMemcpyId14}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 4][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @airMemcpyId14}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 4, 0][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @airMemcpyId14}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 4, 4][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @airMemcpyId14}
 
 #map = affine_map<()[s0] -> (s0 * 4)>
 module {
@@ -190,6 +198,7 @@ module {
             %4 = arith.index_cast %0 : index to i64
             %5 = arith.index_cast %1 : index to i64
             %6 = airrt.dma_memcpy_nd(%c14_i32, %2, %3, %arg0[%c0_i64, %c0_i64, %4, %5], [%c1_i64, %c1_i64, %c4_i64, %c4_i64], [%c0_i64, %c0_i64, %c8_i64]) {metadata = @airMemcpyId14} : (i32, i64, i64, memref<8x8xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+            airrt.wait_all %6
           }
         }
         %p = airrt.segment_load "segment_0" : i64
@@ -205,7 +214,14 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_2col)
 // CHECK:  aiex.runtime_sequence @func4(%[[ARG0:.*]]: memref<8x8xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][2, 2, 4, 4][32, 4, 8, 1]) {id = 0 : i64, metadata = @air_channel_1} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @air_channel_1} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @air_channel_1}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 4][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @air_channel_1} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @air_channel_1}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 4, 0][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @air_channel_1} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @air_channel_1}
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 4, 4][1, 1, 4, 4][0, 0, 8, 1]) {id = 0 : i64, metadata = @air_channel_1} : memref<8x8xi32>
+// CHECK:  aiex.npu.dma_wait {symbol = @air_channel_1}
 
 #map = affine_map<()[s0] -> (s0 * 4)>
 module {
@@ -240,177 +256,9 @@ module {
             %4 = arith.index_cast %0 : index to i64
             %5 = arith.index_cast %1 : index to i64
             %6 = airrt.dma_memcpy_nd(%c14_i32, %2, %3, %arg0[%c0_i64, %c0_i64, %4, %5], [%c1_i64, %c1_i64, %c4_i64, %c4_i64], [%c0_i64, %c0_i64, %c8_i64]) {metadata = @air_channel_1} : (i32, i64, i64, memref<8x8xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
+            airrt.wait_all %6
           }
         }
-        %p = airrt.segment_load "segment_0" : i64
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Unroll repeat pattern
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func5(%[[ARG0:.*]]: memref<8x8xi32>, %[[ARG1:.*]]: memref<8x8xi32>, %[[ARG2:.*]]: memref<8x8xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][2, 1, 1, 32][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 32][2, 1, 1, 32][0, 0, 0, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<8x8xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][2, 2, 8, 4][0, 4, 8, 1]) {id = 2 : i64, metadata = @airMemcpyId5} : memref<8x8xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG2]][0, 0, 0, 0][2, 2, 4, 4][32, 4, 8, 1]) {id = 3 : i64, metadata = @airMemcpyId16} : memref<8x8xi32>
-
-#map = affine_map<()[s0] -> (s0 * 4)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    %tile_0_1 = aie.tile(0, 1)
-    %tile_0_2 = aie.tile(0, 2)
-    %tile_0_3 = aie.tile(0, 3)
-    %tile_0_4 = aie.tile(0, 4)
-    %tile_0_5 = aie.tile(0, 5)
-    aie.shim_dma_allocation @airMemcpyId16(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId16 : memref<4x4xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId4 : memref<4x8xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId5 : memref<8x4xi32, 1>
-  } {sym_name = "segment_0"}
-  airrt.module_metadata{
-  }
-  func.func @func5(%arg0: memref<8x8xi32>, %arg1: memref<8x8xi32>, %arg2: memref<8x8xi32>) {
-    %c4_i64 = arith.constant 4 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c16_i32 = arith.constant 16 : i32
-    %c5_i32 = arith.constant 5 : i32
-    %c4_i32 = arith.constant 4 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    affine.for %arg3 = 0 to 2 {
-      affine.for %arg4 = 0 to 2 {
-        %0 = affine.apply #map()[%arg3]
-        %1 = arith.index_cast %arg3 : index to i64
-        %2 = arith.index_cast %arg4 : index to i64
-        %3 = arith.index_cast %0 : index to i64
-        %4 = airrt.dma_memcpy_nd(%c4_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %3, %c0_i64], [%c1_i64, %c1_i64, %c4_i64, %c8_i64], [%c0_i64, %c0_i64, %c8_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<8x8xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %5 = affine.apply #map()[%arg4]
-        %6 = arith.index_cast %5 : index to i64
-        %7 = airrt.dma_memcpy_nd(%c5_i32, %1, %2, %arg1[%c0_i64, %c0_i64, %c0_i64, %6], [%c1_i64, %c1_i64, %c8_i64, %c4_i64], [%c0_i64, %c0_i64, %c8_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<8x8xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %8 = airrt.dma_memcpy_nd(%c16_i32, %1, %2, %arg2[%c0_i64, %c0_i64, %3, %6], [%c1_i64, %c1_i64, %c4_i64, %c4_i64], [%c0_i64, %c0_i64, %c8_i64]) {metadata = @airMemcpyId16} : (i32, i64, i64, memref<8x8xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %p = airrt.segment_load "segment_0" : i64
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Populate repeat dimension (highest dimension)
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func6(%[[ARG0:.*]]: memref<8x16xi32>, %[[ARG1:.*]]: memref<16x32xi32>, %[[ARG2:.*]]: memref<8x32xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][2, 1, 1, 128][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][1, 2, 16, 16][0, 16, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG2]][0, 0, 0, 0][1, 2, 8, 16][0, 16, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
-
-#map = affine_map<()[s0] -> (s0 * 8)>
-#map1 = affine_map<()[s0] -> (s0 * 16)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    aie.shim_dma_allocation @airMemcpyId12(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId12 : memref<1x1x8x16xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId4 : memref<1x1x8x16xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId5 : memref<1x1x16x16xi32, 1>
-  } {sym_name = "segment_0"}
-  airrt.module_metadata{
-  }
-  func.func @func6(%arg0: memref<8x16xi32>, %arg1: memref<16x32xi32>, %arg2: memref<8x32xi32>) {
-    %c32_i64 = arith.constant 32 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c16_i64 = arith.constant 16 : i64
-    %c12_i32 = arith.constant 12 : i32
-    %c5_i32 = arith.constant 5 : i32
-    %c4_i32 = arith.constant 4 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    affine.for %arg3 = 0 to 1 {
-      affine.for %arg4 = 0 to 2 {
-        %0 = affine.apply #map()[%arg3]
-        %1 = arith.index_cast %arg3 : index to i64
-        %2 = arith.index_cast %arg4 : index to i64
-        %3 = arith.index_cast %0 : index to i64
-        %4 = airrt.dma_memcpy_nd(%c4_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %3, %c0_i64], [%c1_i64, %c1_i64, %c8_i64, %c16_i64], [%c0_i64, %c0_i64, %c16_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<8x16xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %5 = affine.apply #map1()[%arg4]
-        %6 = arith.index_cast %5 : index to i64
-        %7 = airrt.dma_memcpy_nd(%c5_i32, %1, %2, %arg1[%c0_i64, %c0_i64, %c0_i64, %6], [%c1_i64, %c1_i64, %c16_i64, %c16_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x32xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %8 = airrt.dma_memcpy_nd(%c12_i32, %1, %2, %arg2[%c0_i64, %c0_i64, %3, %6], [%c1_i64, %c1_i64, %c8_i64, %c16_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @airMemcpyId12} : (i32, i64, i64, memref<8x32xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %p = airrt.segment_load "segment_0" : i64
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Unroll repeat pattern + populate repeat dimension
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func7(%[[ARG0:.*]]: memref<2048x512xi32>, %[[ARG1:.*]]: memref<512x2048xi32>, %[[ARG2:.*]]: memref<2048x2048xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][4, 8, 64, 64][0, 64, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId20} : memref<2048x512xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 0][4, 8, 64, 64][0, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId20} : memref<2048x512xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 0][4, 8, 64, 64][0, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId20} : memref<2048x512xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 0][4, 8, 64, 64][0, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId20} : memref<2048x512xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][4, 4, 512, 64][0, 64, 2048, 1]) {id = 4 : i64, metadata = @airMemcpyId21} : memref<512x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG2]][0, 0, 0, 0][4, 4, 64, 64][131072, 64, 2048, 1]) {id = 5 : i64, metadata = @airMemcpyId26} : memref<2048x2048xi32>
-
-#map = affine_map<()[s0] -> (s0 * 64)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    aie.shim_dma_allocation @airMemcpyId26(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId26 : memref<64x64xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId20(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId20 : memref<64x64xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId21(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId21 : memref<64x64xi32, 1>
-  } {sym_name = "segment_0"}
-  airrt.module_metadata{
-  }
-  func.func @func7(%arg0: memref<2048x512xi32>, %arg1: memref<512x2048xi32>) {
-    %c2048_i64 = arith.constant 2048 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c512_i64 = arith.constant 512 : i64
-    %c64_i64 = arith.constant 64 : i64
-    %c26_i32 = arith.constant 26 : i32
-    %c15_i32 = arith.constant 15 : i32
-    %c14_i32 = arith.constant 14 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    %alloc = memref.alloc() : memref<2048x2048xi32>
-    affine.for %arg3 = 0 to 4 {
-      affine.for %arg4 = 0 to 4 {
-        %0 = affine.apply #map()[%arg3]
-        %1 = arith.index_cast %arg3 : index to i64
-        %2 = arith.index_cast %arg4 : index to i64
-        %3 = arith.index_cast %0 : index to i64
-        %4 = airrt.dma_memcpy_nd(%c14_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %3, %c0_i64], [%c1_i64, %c8_i64, %c64_i64, %c64_i64], [%c0_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId20} : (i32, i64, i64, memref<2048x512xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %5 = affine.apply #map()[%arg4]
-        %6 = arith.index_cast %arg3 : index to i64
-        %7 = arith.index_cast %arg4 : index to i64
-        %8 = arith.index_cast %5 : index to i64
-        %9 = airrt.dma_memcpy_nd(%c15_i32, %6, %7, %arg1[%c0_i64, %c0_i64, %c0_i64, %8], [%c1_i64, %c1_i64, %c512_i64, %c64_i64], [%c0_i64, %c0_i64, %c2048_i64]) {metadata = @airMemcpyId21} : (i32, i64, i64, memref<512x2048xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %10 = affine.apply #map()[%arg3]
-        %11 = affine.apply #map()[%arg4]
-        %12 = arith.index_cast %arg3 : index to i64
-        %13 = arith.index_cast %arg4 : index to i64
-        %14 = arith.index_cast %10 : index to i64
-        %15 = arith.index_cast %11 : index to i64
-        %16 = airrt.dma_memcpy_nd(%c26_i32, %12, %13, %alloc[%c0_i64, %c0_i64, %14, %15], [%c1_i64, %c1_i64, %c64_i64, %c64_i64], [%c0_i64, %c0_i64, %c2048_i64]) {metadata = @airMemcpyId26} : (i32, i64, i64, memref<2048x2048xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
         %p = airrt.segment_load "segment_0" : i64
       }
     }
@@ -424,7 +272,6 @@ module {
 
 // CHECK-LABEL: @func8
 // CHECK: aiex.npu.dma_memcpy_nd
-// CHECK: aiex.npu.sync
 module {
   aie.device(npu1_1col) {
     aie.shim_dma_allocation @airMemcpyId7(S2MM, 0, 0)
@@ -438,120 +285,6 @@ module {
     %c64_i64 = arith.constant 64 : i64
     %p = airrt.herd_load "herd" () : () -> i64
     airrt.dma_memcpy_nd(%c7_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-    return
-  }
-}
-
-// -----
-
-// Dealing with scenarios where wrap dimension in airrt.dma_memcpy_nd goes beyond the [0, 1023] hardware limit.
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func9(%[[ARG0:.*]]: memref<2048x2048xi32>, %[[ARG1:.*]]: memref<2048x2048xi32>, %[[ARG2:.*]]: memref<2048x2048xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][4, 8, 64, 256][0, 256, 2048, 1]) {id = 0 : i64, metadata = @airMemcpyId14} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 0][4, 8, 64, 256][0, 256, 2048, 1]) {id = 1 : i64, metadata = @airMemcpyId14} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 0][4, 8, 64, 256][0, 256, 2048, 1]) {id = 2 : i64, metadata = @airMemcpyId14} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 0][4, 8, 64, 256][0, 256, 2048, 1]) {id = 3 : i64, metadata = @airMemcpyId14} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][4, 4, 512, 64][64, 1048576, 2048, 1]) {id = 4 : i64, metadata = @airMemcpyId15} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][4, 4, 512, 64][64, 1048576, 2048, 1]) {id = 5 : i64, metadata = @airMemcpyId15} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][4, 4, 512, 64][64, 1048576, 2048, 1]) {id = 6 : i64, metadata = @airMemcpyId15} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG1]][0, 0, 0, 0][4, 4, 512, 64][64, 1048576, 2048, 1]) {id = 7 : i64, metadata = @airMemcpyId15} : memref<2048x2048xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG2]][0, 0, 0, 0][4, 4, 64, 64][131072, 64, 2048, 1]) {id = 8 : i64, metadata = @airMemcpyId26} : memref<2048x2048xi32>
-
-#map = affine_map<()[s0] -> (s0 * 64)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    aie.shim_dma_allocation @airMemcpyId26(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId26 : memref<64x64xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId14(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId14 : memref<64x256xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId20(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId20 : memref<64x256xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId15(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId15 : memref<256x64xi32, 1>
-    aie.shim_dma_allocation @airMemcpyId21(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId21 : memref<256x64xi32, 1>
-  } {sym_name = "segment_0"}
-  airrt.module_metadata{
-  }
-  func.func @func9(%arg0: memref<2048x2048xi32>, %arg1: memref<2048x2048xi32>) {
-    %c64_i64 = arith.constant 64 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c2048_i64 = arith.constant 2048 : i64
-    %c256_i64 = arith.constant 256 : i64
-    %c26_i32 = arith.constant 26 : i32
-    %c15_i32 = arith.constant 15 : i32
-    %c14_i32 = arith.constant 14 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    %alloc = memref.alloc() : memref<2048x2048xi32>
-    affine.for %arg3 = 0 to 4 {
-      affine.for %arg4 = 0 to 4 {
-        %0 = affine.apply #map()[%arg3]
-        %1 = arith.index_cast %arg3 : index to i64
-        %2 = arith.index_cast %arg4 : index to i64
-        %3 = arith.index_cast %0 : index to i64
-        %4 = airrt.dma_memcpy_nd(%c14_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %3, %c0_i64], [%c1_i64, %c8_i64, %c64_i64, %c256_i64], [%c0_i64, %c256_i64, %c2048_i64]) {metadata = @airMemcpyId20} : (i32, i64, i64, memref<2048x2048xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %5 = affine.apply #map()[%arg4]
-        %6 = arith.index_cast %arg3 : index to i64
-        %7 = arith.index_cast %arg4 : index to i64
-        %8 = arith.index_cast %5 : index to i64
-        %9 = airrt.dma_memcpy_nd(%c15_i32, %6, %7, %arg1[%c0_i64, %c0_i64, %c0_i64, %8], [%c1_i64, %c1_i64, %c2048_i64, %c64_i64], [%c0_i64, %c0_i64, %c2048_i64]) {metadata = @airMemcpyId21} : (i32, i64, i64, memref<2048x2048xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %10 = affine.apply #map()[%arg3]
-        %11 = affine.apply #map()[%arg4]
-        %12 = arith.index_cast %arg3 : index to i64
-        %13 = arith.index_cast %arg4 : index to i64
-        %14 = arith.index_cast %10 : index to i64
-        %15 = arith.index_cast %11 : index to i64
-        %16 = airrt.dma_memcpy_nd(%c26_i32, %12, %13, %alloc[%c0_i64, %c0_i64, %14, %15], [%c1_i64, %c1_i64, %c64_i64, %c64_i64], [%c0_i64, %c0_i64, %c2048_i64]) {metadata = @airMemcpyId26} : (i32, i64, i64, memref<2048x2048xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %p = airrt.segment_load "segment_0" : i64
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Dealing with scenarios where wrap dimension in airrt.dma_memcpy_nd goes beyond the [0, 1023] hardware limit (test case 2).
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func10(%[[ARG0:.*]]: memref<2304x2304xbf16>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 0 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 1 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][3, 768, 3, 64][256, 6912, 2304, 1]) {id = 2 : i64, metadata = @airMemcpyId21} : memref<2304x2304xbf16>
-
-#map = affine_map<()[s0] -> (s0 * 64)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    aie.shim_dma_allocation @airMemcpyId21(MM2S, 0, 2)
-    memref.global "public" @airMemcpyId21 : memref<256x64xbf16, 1>
-  } {sym_name = "segment_0"}
-  airrt.module_metadata{
-  }
-  func.func @func10(%arg2: memref<2304x2304xbf16>) {
-    %c64_i64 = arith.constant 64 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c2304_i64 = arith.constant 2304 : i64
-    %c256_i64 = arith.constant 256 : i64
-    %c26_i32 = arith.constant 26 : i32
-    %c15_i32 = arith.constant 15 : i32
-    %c14_i32 = arith.constant 14 : i32
-    %c21_i32 = arith.constant 21 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    affine.for %arg0 = 0 to 3 {
-      affine.for %arg1 = 0 to 3 {
-        %p = airrt.segment_load "segment_0" : i64
-        %34 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg1]
-        %39 = arith.index_cast %arg0 : index to i64
-        %40 = arith.index_cast %arg1 : index to i64
-        %41 = arith.index_cast %34 : index to i64
-        %42 = airrt.dma_memcpy_nd(%c21_i32, %39, %40, %arg2[%c0_i64, %c0_i64, %c0_i64, %41], [%c1_i64, %c1_i64, %c2304_i64, %c64_i64], [%c0_i64, %c0_i64, %c2304_i64]) {metadata = @airMemcpyId21} : (i32, i64, i64, memref<2304x2304xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-      }
-    }
     return
   }
 }
@@ -645,25 +378,6 @@ module {
 
 // -----
 
-// Multi-dimensional offset collapsing
-
-// CHECK-LABEL: func.func @func14
-// CHECK-SAME: %arg0: memref<32x32xbf16>
-// CHECK-NEXT: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 16, 16][1, 1, 16, 16][0, 0, 32, 1]) {id = 0 : i64, metadata = @md0} : memref<32x32xbf16>
-module {
- func.func @func14(%arg0 : memref<32x32xbf16>) {
-    %c1_i32 = arith.constant 1 : i32
-    %c0_i64 = arith.constant 0 : i64
-    %c1_i64 = arith.constant 1 : i64
-    %c16_i64 = arith.constant 16 : i64
-    %c32_i64 = arith.constant 32 : i64
-    airrt.dma_memcpy_nd(%c1_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c16_i64, %c16_i64], [%c1_i64, %c1_i64, %c16_i64, %c16_i64], [%c0_i64, %c0_i64, %c32_i64]) {metadata = @md0} : (i32, i64, i64, memref<32x32xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64])
-    return
-  }
-}
-
-// -----
-
 // Loop carried event
 
 // CHECK-LABEL: func.func @func15
@@ -677,112 +391,6 @@ module {
     %11:1 = scf.for %arg6 = %c0 to %c2048 step %c512 iter_args(%arg7 = %9) -> (!airrt.event) {
       %12 = airrt.wait_all : !airrt.event
       scf.yield %12 : !airrt.event
-    }
-    return
-  }
-}
-
-// -----
-
-// Multiple Shim DMAs.
-
-// CHECK: aie.shim_dma_allocation @airMemcpyId45(S2MM, 0, 0)
-// CHECK: aie.shim_dma_allocation @airMemcpyId46(S2MM, 1, 0)
-// CHECK: aie.shim_dma_allocation @airMemcpyId47(S2MM, 0, 1)
-// CHECK: aie.shim_dma_allocation @airMemcpyId48(S2MM, 1, 1)
-// CHECK: aie.shim_dma_allocation @airMemcpyId7(MM2S, 0, 0)
-// CHECK: aie.shim_dma_allocation @airMemcpyId17(MM2S, 0, 0)
-// CHECK: aie.shim_dma_allocation @airMemcpyId12(MM2S, 1, 0)
-// CHECK: aie.shim_dma_allocation @airMemcpyId22(MM2S, 1, 0)
-// CHECK-LABEL: aiex.runtime_sequence @func16
-// CHECK-SAME: %[[VAL_0:.*]]: memref<512x1024xbf16>, %[[VAL_1:.*]]: memref<1024x512xbf16>, %[[VAL_2:.*]]: memref<512x512xbf16>) {
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][2, 4, 256, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId7} : memref<512x1024xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 256, 0][2, 4, 256, 256][0, 256, 1024, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<512x1024xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][2, 2, 512, 256][256, 262144, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<1024x512xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][2, 2, 512, 256][256, 262144, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId12} : memref<1024x512xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 0, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId45} : memref<512x512xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 64, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId46} : memref<512x512xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 128, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId47} : memref<512x512xbf16>
-// CHECK: aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 192, 0][2, 2, 64, 256][131072, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId48} : memref<512x512xbf16>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 1 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-// CHECK: aiex.npu.sync {channel = 1 : i32, column = 1 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-
-#map = affine_map<()[s0] -> (s0 * 256)>
-#map1 = affine_map<()[s0] -> (s0 * 256 + 64)>
-#map2 = affine_map<()[s0] -> (s0 * 256 + 128)>
-#map3 = affine_map<()[s0] -> (s0 * 256 + 192)>
-module {
-  aie.device(npu1_1col) {
-    aie.shim_dma_allocation @airMemcpyId45(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId45 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId46(S2MM, 1, 0)
-    memref.global "public" @airMemcpyId46 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId47(S2MM, 0, 1)
-    memref.global "public" @airMemcpyId47 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId48(S2MM, 1, 1)
-    memref.global "public" @airMemcpyId48 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId7(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId7 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId17(MM2S, 0, 0)
-    memref.global "public" @airMemcpyId17 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId12(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId12 : memref<256x256xbf16, 1>
-    aie.shim_dma_allocation @airMemcpyId22(MM2S, 1, 0)
-    memref.global "public" @airMemcpyId22 : memref<256x256xbf16, 1>
-  } {sym_name = "segment_0"}
-  func.func @func16(%arg0: memref<512x1024xbf16>, %arg1: memref<1024x512xbf16>, %arg2: memref<512x512xbf16>) {
-    %c64_i64 = arith.constant 64 : i64
-    %c512_i64 = arith.constant 512 : i64
-    %c4_i64 = arith.constant 4 : i64
-    %c1024_i64 = arith.constant 1024 : i64
-    %c256_i64 = arith.constant 256 : i64
-    %c45_i32 = arith.constant 45 : i32
-    %c12_i32 = arith.constant 12 : i32
-    %c7_i32 = arith.constant 7 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    affine.for %arg3 = 0 to 2 {
-      affine.for %arg4 = 0 to 2 {
-        %0 = affine.apply #map()[%arg3]
-        %1 = arith.index_cast %arg3 : index to i64
-        %2 = arith.index_cast %arg4 : index to i64
-        %3 = arith.index_cast %0 : index to i64
-        %4 = airrt.dma_memcpy_nd(%c7_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %3, %c0_i64], [%c1_i64, %c4_i64, %c256_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId7} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %5 = affine.apply #map()[%arg4]
-        %6 = arith.index_cast %arg3 : index to i64
-        %7 = arith.index_cast %arg4 : index to i64
-        %8 = arith.index_cast %5 : index to i64
-        %9 = airrt.dma_memcpy_nd(%c12_i32, %6, %7, %arg1[%c0_i64, %c0_i64, %c0_i64, %8], [%c1_i64, %c1_i64, %c1024_i64, %c256_i64], [%c0_i64, %c0_i64, %c512_i64]) {metadata = @airMemcpyId12} : (i32, i64, i64, memref<1024x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %10 = affine.apply #map()[%arg4]
-        %11 = affine.apply #map()[%arg3]
-        %12 = arith.index_cast %arg3 : index to i64
-        %13 = arith.index_cast %arg4 : index to i64
-        %14 = arith.index_cast %11 : index to i64
-        %15 = arith.index_cast %10 : index to i64
-        %16 = airrt.dma_memcpy_nd(%c45_i32, %12, %13, %arg2[%c0_i64, %c0_i64, %14, %15], [%c1_i64, %c1_i64, %c64_i64, %c256_i64], [%c0_i64, %c0_i64, %c512_i64]) {metadata = @airMemcpyId45} : (i32, i64, i64, memref<512x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %17 = affine.apply #map1()[%arg3]
-        %18 = arith.index_cast %arg3 : index to i64
-        %19 = arith.index_cast %arg4 : index to i64
-        %20 = arith.index_cast %17 : index to i64
-        %21 = arith.index_cast %10 : index to i64
-        %22 = airrt.dma_memcpy_nd(%c45_i32, %18, %19, %arg2[%c0_i64, %c0_i64, %20, %21], [%c1_i64, %c1_i64, %c64_i64, %c256_i64], [%c0_i64, %c0_i64, %c512_i64]) {metadata = @airMemcpyId46} : (i32, i64, i64, memref<512x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %23 = affine.apply #map2()[%arg3]
-        %24 = arith.index_cast %arg3 : index to i64
-        %25 = arith.index_cast %arg4 : index to i64
-        %26 = arith.index_cast %23 : index to i64
-        %27 = arith.index_cast %10 : index to i64
-        %28 = airrt.dma_memcpy_nd(%c45_i32, %24, %25, %arg2[%c0_i64, %c0_i64, %26, %27], [%c1_i64, %c1_i64, %c64_i64, %c256_i64], [%c0_i64, %c0_i64, %c512_i64]) {metadata = @airMemcpyId47} : (i32, i64, i64, memref<512x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %29 = affine.apply #map3()[%arg3]
-        %30 = arith.index_cast %arg3 : index to i64
-        %31 = arith.index_cast %arg4 : index to i64
-        %32 = arith.index_cast %29 : index to i64
-        %33 = arith.index_cast %10 : index to i64
-        %34 = airrt.dma_memcpy_nd(%c45_i32, %30, %31, %arg2[%c0_i64, %c0_i64, %32, %33], [%c1_i64, %c1_i64, %c64_i64, %c256_i64], [%c0_i64, %c0_i64, %c512_i64]) {metadata = @airMemcpyId48} : (i32, i64, i64, memref<512x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %35 = airrt.wait_all %16, %22, %28, %34 : !airrt.event
-        %p = airrt.segment_load "segment_0" : i64
-      }
     }
     return
   }
@@ -812,10 +420,22 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK:  aiex.runtime_sequence @func18(%[[ARG0:.*]]: memref<8192x32768xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 0 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 1 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 2 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 0][1, 4, 64, 64][0, 64, 32768, 1]) {id = 3 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 64, 64][0, 0, 32768, 1]) {id = 0 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 64][1, 1, 64, 64][0, 0, 32768, 1]) {id = 1 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 128][1, 1, 64, 64][0, 0, 32768, 1]) {id = 2 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 192][1, 1, 64, 64][0, 0, 32768, 1]) {id = 3 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 0][1, 1, 64, 64][0, 0, 32768, 1]) {id = 4 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 64][1, 1, 64, 64][0, 0, 32768, 1]) {id = 5 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 128][1, 1, 64, 64][0, 0, 32768, 1]) {id = 6 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 64, 192][1, 1, 64, 64][0, 0, 32768, 1]) {id = 7 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 0][1, 1, 64, 64][0, 0, 32768, 1]) {id = 8 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 64][1, 1, 64, 64][0, 0, 32768, 1]) {id = 9 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 128][1, 1, 64, 64][0, 0, 32768, 1]) {id = 10 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 128, 192][1, 1, 64, 64][0, 0, 32768, 1]) {id = 11 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 0][1, 1, 64, 64][0, 0, 32768, 1]) {id = 12 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 64][1, 1, 64, 64][0, 0, 32768, 1]) {id = 13 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 128][1, 1, 64, 64][0, 0, 32768, 1]) {id = 14 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
+// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 192, 192][1, 1, 64, 64][0, 0, 32768, 1]) {id = 15 : i64, metadata = @airMemcpyId26} : memref<8192x32768xi32>
 
 #map = affine_map<()[s0] -> (s0 * 64)>
 module {
@@ -844,50 +464,6 @@ module {
         %14 = arith.index_cast %10 : index to i64
         %15 = arith.index_cast %11 : index to i64
         %16 = airrt.dma_memcpy_nd(%c26_i32, %12, %13, %alloc[%c0_i64, %c0_i64, %14, %15], [%c1_i64, %c1_i64, %c64_i64, %c64_i64], [%c0_i64, %c0_i64, %c32768_i64]) {metadata = @airMemcpyId26} : (i32, i64, i64, memref<8192x32768xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-        %p = airrt.segment_load "segment_0" : i64
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Big memref.
-
-// CHECK-LABEL: aie.device(npu1_1col)
-// CHECK:  aiex.runtime_sequence @func19(%[[ARG0:.*]]: memref<308x2432xi32>)
-// CHECK:  aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][4, 19, 28, 128][0, 128, 2432, 1]) {id = 0 : i64, metadata = @airMemcpyId26} : memref<308x2432xi32>
-
-#map = affine_map<()[s0] -> (s0 * 64)>
-module {
-  aie.device(npu1_1col) {
-    %tile_0_0 = aie.tile(0, 0)
-    aie.shim_dma_allocation @airMemcpyId26(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId26 : memref<64x64xi32, 1>
-  } {sym_name = "segment_0"}
-  func.func @func19() {
-    %c2432_i64 = arith.constant 2432 : i64
-    %c8_i64 = arith.constant 8 : i64
-    %c512_i64 = arith.constant 512 : i64
-    %c128_i64 = arith.constant 128 : i64
-    %c64_i64 = arith.constant 64 : i64
-    %c28_i64 = arith.constant 28 : i64
-    %c26_i32 = arith.constant 26 : i32
-    %c19_i64 = arith.constant 19 : i64
-    %c14_i32 = arith.constant 14 : i32
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i64 = arith.constant 0 : i64
-    %alloc = memref.alloc() : memref<308x2432xi32>
-    affine.for %arg3 = 0 to 4 {
-      affine.for %arg4 = 0 to 1 {
-        %10 = affine.apply #map()[%arg3]
-        %11 = affine.apply #map()[%arg4]
-        %12 = arith.index_cast %arg3 : index to i64
-        %13 = arith.index_cast %arg4 : index to i64
-        %14 = arith.index_cast %10 : index to i64
-        %15 = arith.index_cast %11 : index to i64
-        %16 = airrt.dma_memcpy_nd(%c26_i32, %12, %13, %alloc[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c19_i64, %c28_i64, %c128_i64], [%c0_i64, %c128_i64, %c2432_i64]) {metadata = @airMemcpyId26} : (i32, i64, i64, memref<308x2432xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
         %p = airrt.segment_load "segment_0" : i64
       }
     }
@@ -962,55 +538,6 @@ module {
         %2 = arith.index_cast %arg4 : index to i64
         %3 = arith.index_cast %0 : index to i64
         %4 = airrt.dma_memcpy_nd(%c10_i32, %1, %2, %arg0[%c0_i64, %c0_i64, %c0_i64, %3], [%c152_i64, %c2_i64, %c64_i64, %c64_i64], [%c155648_i64, %c64_i64, %c2432_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<9728x2432xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Offset field with (1) for loop induction variable, (2) affine map, and (3) existing non-singleton stride.
-
-// CHECK-LABEL: func22
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 2, 8, 512][0, 4096, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId31} : memref<2x64x64xi32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-
-#map = affine_map<()[s0] -> (s0 * 64)>
-module {
-  aie.device(npu1_1col) {
-    aie.shim_dma_allocation @airMemcpyId31(S2MM, 0, 0)
-    memref.global "public" @airMemcpyId31 : memref<1x2x2x32x32xi32, 1 : i32>
-  } {sym_name = "batch_matmul_dispatch_0_batch_matmul_2x64x64x64_i32_0"}
-  func.func @func22(%arg0: memref<2x64x64xi32>) {
-    %c32_i64 = arith.constant 32 : i64
-    %c2_i64 = arith.constant 2 : i64
-    %c1_i64 = arith.constant 1 : i64
-    %c64_i64 = arith.constant 64 : i64
-    %c2048_i64 = arith.constant 2048 : i64
-    %c4096_i64 = arith.constant 4096 : i64
-    %c31_i32 = arith.constant 31 : i32
-    %c7_i32 = arith.constant 7 : i32
-    %c6_i32 = arith.constant 6 : i32
-    %c0_i64 = arith.constant 0 : i64
-    affine.for %arg3 = 0 to 1 {
-      affine.for %arg4 = 0 to 2 {
-        affine.for %arg5 = 0 to 1 {
-          affine.for %arg6 = 0 to 1 {
-            %p = airrt.segment_load "batch_matmul_dispatch_0_batch_matmul_2x64x64x64_i32_0" : i64
-            %20 = affine.apply #map()[%arg6]
-            %21 = affine.apply #map()[%arg5]
-            %22 = arith.index_cast %arg4 : index to i64
-            %23 = arith.index_cast %arg4 : index to i64
-            %24 = arith.index_cast %21 : index to i64
-            %25 = arith.index_cast %20 : index to i64
-            %26 = airrt.dma_memcpy_nd(%c31_i32, %22, %c0_i64, %arg0[%c0_i64, %23, %24, %25], [%c1_i64, %c1_i64, %c64_i64, %c64_i64], [%c0_i64, %c4096_i64, %c64_i64]) {metadata = @airMemcpyId31} : (i32, i64, i64, memref<2x64x64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
-            affine.for %arg7 = 0 to 1 {
-              %h = airrt.herd_load "herd_0" () : () -> i64
-              %h_0 = airrt.herd_load "herd_0" () : () -> i64
-            }
-          }
-        }
       }
     }
     return

--- a/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
@@ -118,15 +118,9 @@ module {
 
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK: aiex.runtime_sequence @func2(%[[VAL_0:.*]]: memref<2048x2048xbf16>, %[[VAL_1:.*]]: memref<2048x2048xbf16>, %[[VAL_2:.*]]: memref<2048x2048xbf16>) {
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 128, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 1 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 256, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 2 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 384, 0][4, 8, 128, 256][0, 256, 2048, 1]) {id = 3 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 4 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 5 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 6 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][4, 4, 512, 128][128, 1048576, 2048, 1]) {id = 7 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
-// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 0, 0][4, 4, 128, 128][262144, 128, 2048, 1]) {id = 8 : i64, metadata = @airMemcpyId26} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_0]][0, 0, 0, 0][1, 8, 128, 256][0, 256, 2048, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_1]][0, 0, 0, 0][1, 4, 512, 128][0, 1048576, 2048, 1]) {id = 1 : i64, metadata = @airMemcpyId7} : memref<2048x2048xbf16>
+// CHECK:   aiex.npu.dma_memcpy_nd(%[[VAL_2]][0, 0, 0, 0][1, 1, 128, 128][0, 0, 2048, 1]) {id = 2 : i64, metadata = @airMemcpyId26} : memref<2048x2048xbf16>
 
 module {
   aie.device(npu1_1col) {
@@ -168,8 +162,8 @@ module {
     memref.assume_alignment %6, 64 : memref<2048x2048xbf16>
     %8 = airrt.wait_all : !airrt.event
     %9 = airrt.wait_all %8, %5, %2 : !airrt.event
-    affine.for %arg0 = 0 to 4 {
-      affine.for %arg1 = 0 to 4 {
+    affine.for %arg0 = 0 to 1 {
+      affine.for %arg1 = 0 to 1 {
         %10 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%arg0]
         %11 = airrt.wait_all : !airrt.event
         %12 = airrt.wait_all %11 : !airrt.event

--- a/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
@@ -22,112 +22,112 @@
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131072][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262144][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393216][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131088][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262160][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393232][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131104][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262176][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393248][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 256][0, 256, 1024, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x1024xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][32, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 131120][32, 8, 8, 16][4096, 64, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 262192][32, 8, 8, 16][4096, 64, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 393264][32, 8, 8, 16][4096, 64, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId10} : memref<128x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId29} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 
 module {
   aie.device(npu1_4col) {
@@ -199,6 +199,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %0, %1, %2
     %p_0 = airrt.segment_load "forward_0" : i64
     %3 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %4 = airrt.dma_memcpy_nd(%c10_i32, %c0_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -233,6 +234,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %3, %4, %5
     %p_1 = airrt.segment_load "forward_0" : i64
     %6 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %7 = airrt.dma_memcpy_nd(%c10_i32, %c0_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -267,6 +269,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %6, %7, %8
     %p_2 = airrt.segment_load "forward_0" : i64
     %9 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %10 = airrt.dma_memcpy_nd(%c10_i32, %c0_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -301,6 +304,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %9, %10, %11
     %p_3 = airrt.segment_load "forward_0" : i64
     %12 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %13 = airrt.dma_memcpy_nd(%c10_i32, %c1_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -335,6 +339,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %12, %13, %14
     %p_4 = airrt.segment_load "forward_0" : i64
     %15 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %16 = airrt.dma_memcpy_nd(%c10_i32, %c1_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -369,6 +374,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %15, %16, %17
     %p_5 = airrt.segment_load "forward_0" : i64
     %18 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %19 = airrt.dma_memcpy_nd(%c10_i32, %c1_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -403,6 +409,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %18, %19, %20
     %p_6 = airrt.segment_load "forward_0" : i64
     %21 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %22 = airrt.dma_memcpy_nd(%c10_i32, %c1_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -437,6 +444,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %21, %22, %23
     %p_7 = airrt.segment_load "forward_0" : i64
     %24 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %25 = airrt.dma_memcpy_nd(%c10_i32, %c2_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -471,6 +479,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %24, %25, %26
     %p_8 = airrt.segment_load "forward_0" : i64
     %27 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %28 = airrt.dma_memcpy_nd(%c10_i32, %c2_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -505,6 +514,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %27, %28, %29
     %p_9 = airrt.segment_load "forward_0" : i64
     %30 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %31 = airrt.dma_memcpy_nd(%c10_i32, %c2_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -539,6 +549,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %30, %31, %32
     %p_10 = airrt.segment_load "forward_0" : i64
     %33 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %34 = airrt.dma_memcpy_nd(%c10_i32, %c2_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -573,6 +584,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %33, %34, %35
     %p_11 = airrt.segment_load "forward_0" : i64
     %36 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %37 = airrt.dma_memcpy_nd(%c10_i32, %c3_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -607,6 +619,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %36, %37, %38
     %p_12 = airrt.segment_load "forward_0" : i64
     %39 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %40 = airrt.dma_memcpy_nd(%c10_i32, %c3_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -641,6 +654,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %39, %40, %41
     %p_13 = airrt.segment_load "forward_0" : i64
     %42 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %43 = airrt.dma_memcpy_nd(%c10_i32, %c3_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -675,6 +689,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %42, %43, %44
     %p_14 = airrt.segment_load "forward_0" : i64
     %45 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c256_i64], [%c0_i64, %c256_i64, %c1024_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x1024xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %46 = airrt.dma_memcpy_nd(%c10_i32, %c3_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId10} : (i32, i64, i64, memref<128x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -709,6 +724,7 @@ module {
       }
       %54 = airrt.wait_all %50#1, %53#1 : !airrt.event
     }
+    airrt.wait_all %45, %46, %47
     return %arg2 : memref<512x512xf32>
   }
 }

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
@@ -24,67 +24,67 @@
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 128, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 256, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 0][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 128][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 256][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 // CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][1, 4, 128, 32][0, 32, 128, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<512x128xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 48][16, 8, 8, 16][4096, 64, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x8x8x64xbf16>
 // CHECK: aiex.npu.dma_memcpy_nd(%arg2[0, 0, 384, 384][1, 1, 128, 128][0, 0, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId19} : memref<512x512xf32>
-// CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 
 module {
   aie.device(npu1_4col) {
@@ -123,6 +123,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %0, %1, %2
     %p_0 = airrt.segment_load "forward_0" : i64
     %3 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %4 = airrt.dma_memcpy_nd(%c5_i32, %c0_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -130,6 +131,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %3, %4, %5
     %p_1 = airrt.segment_load "forward_0" : i64
     %6 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %7 = airrt.dma_memcpy_nd(%c5_i32, %c0_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -137,6 +139,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %6, %7, %8
     %p_2 = airrt.segment_load "forward_0" : i64
     %9 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %10 = airrt.dma_memcpy_nd(%c5_i32, %c0_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -144,6 +147,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %9, %10, %11
     %p_3 = airrt.segment_load "forward_0" : i64
     %12 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %13 = airrt.dma_memcpy_nd(%c5_i32, %c1_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -151,6 +155,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %12, %13, %14
     %p_4 = airrt.segment_load "forward_0" : i64
     %15 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %16 = airrt.dma_memcpy_nd(%c5_i32, %c1_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -158,6 +163,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %15, %16, %17
     %p_5 = airrt.segment_load "forward_0" : i64
     %18 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %19 = airrt.dma_memcpy_nd(%c5_i32, %c1_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -165,6 +171,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %18, %19, %20
     %p_6 = airrt.segment_load "forward_0" : i64
     %21 = airrt.dma_memcpy_nd(%c4_i32, %c1_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c128_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %22 = airrt.dma_memcpy_nd(%c5_i32, %c1_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -172,6 +179,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %21, %22, %23
     %p_7 = airrt.segment_load "forward_0" : i64
     %24 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %25 = airrt.dma_memcpy_nd(%c5_i32, %c2_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -179,6 +187,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %24, %25, %26
     %p_8 = airrt.segment_load "forward_0" : i64
     %27 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %28 = airrt.dma_memcpy_nd(%c5_i32, %c2_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -186,6 +195,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %27, %28, %29
     %p_9 = airrt.segment_load "forward_0" : i64
     %30 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %31 = airrt.dma_memcpy_nd(%c5_i32, %c2_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -193,6 +203,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %30, %31, %32
     %p_10 = airrt.segment_load "forward_0" : i64
     %33 = airrt.dma_memcpy_nd(%c4_i32, %c2_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c256_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %34 = airrt.dma_memcpy_nd(%c5_i32, %c2_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -200,6 +211,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %33, %34, %35
     %p_11 = airrt.segment_load "forward_0" : i64
     %36 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %37 = airrt.dma_memcpy_nd(%c5_i32, %c3_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -207,6 +219,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %36, %37, %38
     %p_12 = airrt.segment_load "forward_0" : i64
     %39 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c1_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %40 = airrt.dma_memcpy_nd(%c5_i32, %c3_i64, %c1_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -214,6 +227,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %39, %40, %41
     %p_13 = airrt.segment_load "forward_0" : i64
     %42 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c2_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %43 = airrt.dma_memcpy_nd(%c5_i32, %c3_i64, %c2_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c32_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -221,6 +235,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %42, %43, %44
     %p_14 = airrt.segment_load "forward_0" : i64
     %45 = airrt.dma_memcpy_nd(%c4_i32, %c3_i64, %c3_i64, %arg0[%c0_i64, %c0_i64, %c384_i64, %c0_i64], [%c1_i64, %c4_i64, %c128_i64, %c32_i64], [%c0_i64, %c32_i64, %c128_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<512x128xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
     %46 = airrt.dma_memcpy_nd(%c5_i32, %c3_i64, %c3_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c48_i64], [%c16_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<16x8x8x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
@@ -228,6 +243,7 @@ module {
     affine.for %arg3 = 0 to 1 {
       %h = airrt.herd_load "herd_0" () : () -> i64
     }
+    airrt.wait_all %45, %46, %47
     return %arg2 : memref<512x512xf32>
   }
 }

--- a/mlir/test/Dialect/AIRRt/airrt_canonicalize.mlir
+++ b/mlir/test/Dialect/AIRRt/airrt_canonicalize.mlir
@@ -17,11 +17,8 @@ func.func @wait_all_0() -> () {
 
 // CHECK-LABEL: wait_all_1
 // CHECK-SAME: (%[[E0:.*]]: !airrt.event, %[[E1:.*]]: !airrt.event, %[[E2:.*]]: !airrt.event) -> !airrt.event {
-// CHECK-NEXT:   {{.*}} = airrt.wait_all %[[E0]] : !airrt.event
-// CHECK-NEXT:   {{.*}} = airrt.wait_all %[[E1]] : !airrt.event
-// CHECK-NEXT:   {{.*}} = airrt.wait_all %[[E2]] : !airrt.event
-// CHECK-NEXT:   %[[E6:.*]] = airrt.wait_all : !airrt.event
-// CHECK-NEXT: return %[[E6]]
+// CHECK-NEXT:   %[[E4:.*]] = airrt.wait_all %[[E0]], %[[E1]], %[[E2]] : !airrt.event
+// CHECK-NEXT: return %[[E4]]
 func.func @wait_all_1(%e0 : !airrt.event, %e1 : !airrt.event, %e2 : !airrt.event) -> (!airrt.event) {
   %1 = airrt.wait_all %e0 : !airrt.event
   %2 = airrt.wait_all %e1 : !airrt.event

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -29,14 +29,14 @@ module {
 
   // NPUTILED-LABEL: func0
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]] @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]] @channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT5:.*]] = air.channel.put async [%[[PUT4]]] @channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]]]
+  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async [%[[PUT6]]] @channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT1]], %[[PUT3]], %[[PUT5]], %[[PUT7]]]
   
   // AIE1-LABEL: func0
   // AIE1-COUNT-3: scf.for
@@ -97,18 +97,18 @@ module {
   // NPUTILED-LABEL: func1
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async [%[[PUT1]]] @channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]] @channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT4:.*]] = air.channel.put async [%[[PUT3]]] @channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT8:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT6:.*]] = air.channel.put async [%[[PUT5]]] @channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async [%[[PUT6]]] @channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT8:.*]] = air.channel.put async [%[[PUT7]]] @channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT9:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT10:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT11:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT12:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[PUT8]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[PUT12]]]
+  // NPUTILED-NEXT: %[[PUT10:.*]] = air.channel.put async [%[[PUT9]]] @channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT11:.*]] = air.channel.put async [%[[PUT10]]] @channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT12:.*]] = air.channel.put async [%[[PUT11]]] @channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT4]], %[[PUT8]], %[[PUT12]]]
   
   // AIE1-LABEL: func1
   // AIE1-COUNT-3: scf.for
@@ -294,7 +294,7 @@ module {
   // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c32{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
   // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c8{{.*}}, %c4{{.*}}] [%c0{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<8x8xi32>)
   // NPUTILED: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c4{{.*}}, %c4{{.*}}] [%c32{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId16} : (memref<8x8xi32>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[GET0]]] 
+  // NPUTILED: air.wait_all [%[[PUT1]], %[[PUT2]], %[[GET0]]] 
   
   // AIE1-LABEL: func5
   // AIE1-COUNT-2: scf.for
@@ -387,22 +387,25 @@ module {
   // NPUTILED-LABEL: func7
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
   // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
   // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT1]], %[[PUT2]], %[[GET0]]] 
   // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
-  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%[[PUT3]]]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
   // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
   // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT4]], %[[PUT5]], %[[GET1]]] 
   // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
-  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%[[PUT6]]]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
   // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
   // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT7]], %[[PUT8]], %[[GET2]]] 
   // NPUTILED: %[[PUT9:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
-  // NPUTILED: %[[PUT10:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT10:.*]] = air.channel.put async [%[[PUT9]]]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
   // NPUTILED: %[[PUT11:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
   // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[GET0]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[GET1]], %[[PUT6]], %[[PUT7]], %[[PUT8]], %[[GET2]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[GET3]]] 
+  // NPUTILED: air.wait_all [%[[PUT10]], %[[PUT11]], %[[GET3]]] 
   
   // AIE1-LABEL: func7
   // AIE1-COUNT-2: scf.for
@@ -457,26 +460,29 @@ module {
   // NPUTILED-LABEL: func8
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
   // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
   // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT1]], %[[PUT3]], %[[GET0]]] 
   // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%[[PUT4]]]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
   // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%[[PUT6]]]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
   // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT5]], %[[PUT7]], %[[GET1]]] 
   // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT9:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT9:.*]] = air.channel.put async [%[[PUT8]]]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
   // NPUTILED: %[[PUT10:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT11:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT11:.*]] = air.channel.put async [%[[PUT10]]]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
   // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT9]], %[[PUT11]], %[[GET2]]] 
   // NPUTILED: %[[PUT12:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT13:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT13:.*]] = air.channel.put async [%[[PUT12]]]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
   // NPUTILED: %[[PUT14:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
-  // NPUTILED: %[[PUT15:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT15:.*]] = air.channel.put async [%[[PUT14]]]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
   // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[GET0]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[GET1]], %[[PUT8]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[GET2]], %[[PUT12]], %[[PUT13]], %[[PUT14]], %[[PUT15]], %[[GET3]]] 
+  // NPUTILED: air.wait_all [%[[PUT13]], %[[PUT15]], %[[GET3]]] 
   
   // AIE1-LABEL: func8
   // AIE1-COUNT-2: scf.for
@@ -525,15 +531,23 @@ module {
 
   // NPUTILED-LABEL: func9
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[PUT8]]] 
+  // NPUTILED: air.wait_all [%[[PUT0]]] 
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT1]]] 
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT2]]] 
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT3]]] 
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT4]]] 
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT5]]] 
+  // NPUTILED: %[[PUT6:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT6]]] 
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT7]]] 
+  // NPUTILED: %[[PUT8:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT8]]] 
   
   // AIE1-LABEL: func9
   // AIE1-COUNT-2: scf.for
@@ -583,14 +597,14 @@ module {
   // NPUTILED-LABEL: func10
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
   // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
-  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
   // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
   // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId46} : (memref<512x512xbf16>)
   // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId47} : (memref<512x512xbf16>)
   // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId48} : (memref<512x512xbf16>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
+  // NPUTILED: air.wait_all [%[[PUT1]], %[[PUT3]], %[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
   
   // AIE1-LABEL: func10
   // AIE1-COUNT-2: scf.for
@@ -648,8 +662,9 @@ module {
   // NPUTILED-LABEL: func11
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%alloc[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c19{{.*}}, %c28{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c128{{.*}}, %c2432{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]]]
   // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%alloc[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c19{{.*}}, %c28{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c128{{.*}}, %c2432{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
-  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]]]
+  // NPUTILED: air.wait_all [%[[PUT1]]]
   
   // AIE1-LABEL: func11
   // AIE1-COUNT-2: scf.for

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1_4col" | FileCheck %s
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1_4col shim-dma-tile-sizes=2,2" | FileCheck %s --check-prefix=NPUTILED
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=xcvc1902" | FileCheck %s --check-prefix=AIE1
 
 // Optimize logical air.channel.put/get op into efficient shim dma block descriptor (BD).
@@ -24,6 +25,16 @@ module {
   // CHECK-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
   // CHECK: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
   // CHECK-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+
+  // NPUTILED-LABEL: func0
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
   
   // AIE1-LABEL: func0
   // AIE1-COUNT-3: scf.for
@@ -81,6 +92,21 @@ module {
   // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
   // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
   
+  // NPUTILED-LABEL: func1
+  // NPUTILED: air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  
   // AIE1-LABEL: func1
   // AIE1-COUNT-3: scf.for
   // AIE1-COUNT-4: air.channel.put
@@ -126,6 +152,12 @@ module {
   // CHECK: air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
   // CHECK: air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
   
+  // NPUTILED-LABEL: func2
+  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
+  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
+  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
+  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+
   // AIE1-LABEL: func2
   // AIE1-COUNT-2: scf.for
   // AIE1-COUNT-4: air.channel.get
@@ -168,6 +200,9 @@ module {
   // CHECK-COUNT-4: air.dma_memcpy_nd
   // CHECK-COUNT-4: }
   
+  // NPUTILED-LABEL: func3
+  // NPUTILED-COUNT-256: air.dma_memcpy_nd
+
   // AIE1-LABEL: func3
   // AIE1-COUNT-3: scf.for
   // AIE1: air.herd
@@ -217,6 +252,12 @@ module {
 
   // CHECK: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
   
+  // NPUTILED-LABEL: func4
+  // NPUTILED: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
+  // NPUTILED-NEXT: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c64{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
+  // NPUTILED-NEXT: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
+  // NPUTILED-NEXT: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
+
   // AIE1-LABEL: func4
   // AIE1-COUNT-2: scf.for
   // AIE1: air.channel.put

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -73,13 +73,12 @@ module {
     return
   }
 
-  // CHECK-LABEL: func1
-
   // Three scf.for loop nested around air.channle.put containing two effective wrap-and-stride dimensions. 
   // This test is different from func0 in two ways:
   // The first air.channel.put, after wrap-and-stride canonicalization, is capable of folding all three scf.for loops in the nest into wraps and strides.
   // The second to fourth air.channel.puts can only fold one inner-most for loop into wrap-and-stride list due to having non-zero offsets at 3rd dimension.
 
+  // CHECK-LABEL: func1
   // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
   // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
   // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
@@ -146,11 +145,10 @@ module {
     return
   }
 
-  // CHECK-LABEL: func2
-
   // Two scf.for loop nested around air.channle.get containing two effective wrap-and-stride dimensions. 
   // Both for loops can be folded into the wrap-and-stride list; no scf.for loop remains.
 
+  // CHECK-LABEL: func2
   // CHECK: %[[GET0:.*]] = air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
   // CHECK: %[[GET1:.*]] = air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
   // CHECK: %[[GET2:.*]] = air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
@@ -197,10 +195,9 @@ module {
     return
   }
 
-  // CHECK-LABEL: func3
-
   // Hoisting air.herd op out of any parent scf.for loop nest.
 
+  // CHECK-LABEL: func3
   // CHECK: air.herd
   // CHECK-COUNT-3: scf.for
   // CHECK-COUNT-4: air.dma_memcpy_nd
@@ -252,10 +249,9 @@ module {
     return
   }
 
-  // CHECK-LABEL: func4
-
   // No air.launch or air.segment.
 
+  // CHECK-LABEL: func4
   // CHECK: air.channel.put  @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c32{{.*}}, %c32{{.*}}] [%c4096{{.*}}, %c32{{.*}}, %c128{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<128x128xbf16>)
   
   // NPUTILED-LABEL: func4
@@ -281,4 +277,468 @@ module {
     }
     return
   }
+
+  // Repeat dimension promotion.
+
+  // CHECK-LABEL: func5
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c32{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c32{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c8{{.*}}, %c4{{.*}}] [%c0{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<8x8xi32>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c4{{.*}}, %c4{{.*}}] [%c32{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId16} : (memref<8x8xi32>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[GET0]]] 
+
+  // NPUTILED-LABEL: func5
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c32{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c32{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c8{{.*}}, %c4{{.*}}] [%c0{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<8x8xi32>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c4{{.*}}, %c4{{.*}}] [%c32{{.*}}, %c4{{.*}}, %c8{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId16} : (memref<8x8xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[GET0]]] 
+  
+  // AIE1-LABEL: func5
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1: air.channel.put
+  // AIE1: air.channel.get
+  // AIE1-COUNT-2: }
+
+  func.func @func5(%arg0: memref<8x8xi32>, %arg1: memref<8x8xi32>, %arg2: memref<8x8xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c2 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c2 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%arg3]
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%4, %c0] [%c4, %c8] [%c8, %c1]) {metadata = @airMemcpyId4} : (memref<8x8xi32>)
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%arg4]
+        %put1 = air.channel.put async [%arg8]  @channel_1[] (%arg1[%c0, %5] [%c8, %c4] [%c8, %c1]) {metadata = @airMemcpyId5} : (memref<8x8xi32>)
+        %get0 = air.channel.get async [%arg8]  @channel_2[] (%arg2[%4, %5] [%c4, %c4] [%c8, %c1]) {metadata = @airMemcpyId16} : (memref<8x8xi32>)
+        %w = air.wait_all async [%put0, %put1, %get0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // Repeat dimension promotion.
+
+  // CHECK-LABEL: func6
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x16xi32>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[GET0]]] 
+
+  // NPUTILED-LABEL: func6
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x16xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[GET0]]] 
+  
+  // AIE1-LABEL: func6
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1: air.channel.put
+  // AIE1: air.channel.get
+  // AIE1-COUNT-2: }
+
+  
+  func.func @func6(%arg0: memref<8x16xi32>, %arg1: memref<16x32xi32>, %arg2: memref<8x32xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c2 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%arg3, %c0] [%c8, %c16] [%c16, %c1]) {metadata = @airMemcpyId4} : (memref<8x16xi32>)
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%arg4]
+        %put1 = air.channel.put async [%arg8]  @channel_1[] (%arg1[%c0, %5] [%c16, %c16] [%c32, %c1]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
+        %get0 = air.channel.get async [%arg8]  @channel_2[] (%arg2[%arg3, %5] [%c8, %c16] [%c32, %c1]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
+        %w = air.wait_all async [%put0, %put1, %get0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // Repeat dimension promotion.
+
+  // CHECK-LABEL: func7
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async [%[[PUT1]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // CHECK: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // CHECK: %[[PUT4:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c131072{{.*}}, %c64{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[GET0]]] 
+
+  // NPUTILED-LABEL: func7
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+  // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+  // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT9:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT10:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c64] [%c0, %c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+  // NPUTILED: %[[PUT11:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c2, %c512, %c64] [%c0, %c64, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+  // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[GET0]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[GET1]], %[[PUT6]], %[[PUT7]], %[[PUT8]], %[[GET2]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[GET3]]] 
+  
+  // AIE1-LABEL: func7
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1: air.channel.put
+  // AIE1: air.channel.get
+  // AIE1-COUNT-2: }
+
+  func.func @func7(%arg0: memref<2048x512xi32>, %arg1: memref<512x2048xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+    %c2048 = arith.constant 2048 : index
+    %alloc = memref.alloc() : memref<2048x2048xi32>
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg3]
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%c0, %4, %c0] [%c8, %c64, %c64] [%c64, %c512, %c1]) {metadata = @airMemcpyId20} : (memref<2048x512xi32>)
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg4]
+        %put1 = air.channel.put async [%arg8]  @channel_1[] (%arg1[%c0, %5] [%c512, %c64] [%c2048, %c1]) {metadata = @airMemcpyId21} : (memref<512x2048xi32>)
+        %get0 = air.channel.get async [%arg8]  @channel_2[] (%alloc[%4, %5] [%c64, %c64] [%c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+        %w = air.wait_all async [%put0, %put1, %get0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // NPU wrap size limit: [0, 1023].
+
+  // CHECK-LABEL: func8
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[PUT0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async [%[[PUT1]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT3:.*]] = air.channel.put async [%[[PUT2]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c8{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT4:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c64{{.*}}, %c1048576{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT5:.*]] = air.channel.put async [%[[PUT4]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c64{{.*}}, %c1048576{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT6:.*]] = air.channel.put async [%[[PUT5]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c64{{.*}}, %c1048576{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // CHECK: %[[PUT7:.*]] = air.channel.put async [%[[PUT6]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c64{{.*}}, %c1048576{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c4{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c131072{{.*}}, %c64{{.*}}, %c2048{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[GET0]]] 
+
+  // NPUTILED-LABEL: func8
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c0, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c64, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c0, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT9:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT10:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT11:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c0] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c0] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT12:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c128, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT13:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0, %c0, %c192, %c0] [%c2, %c8, %c64, %c256] [%c0, %c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT14:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[PUT15:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0, %c0, %c0, %c128] [%c2, %c4, %c512, %c64] [%c64, %c1048576, %c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+  // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[] (%alloc[%c0, %c0, %c128, %c128] [%c2, %c2, %c64, %c64] [%c131072, %c64, %c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[GET0]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[GET1]], %[[PUT8]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[GET2]], %[[PUT12]], %[[PUT13]], %[[PUT14]], %[[PUT15]], %[[GET3]]] 
+  
+  // AIE1-LABEL: func8
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1: air.channel.put
+  // AIE1: air.channel.get
+  // AIE1-COUNT-2: }
+  
+  func.func @func8(%arg0: memref<2048x2048xi32>, %arg1: memref<2048x2048xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c2048 = arith.constant 2048 : index
+    %alloc = memref.alloc() : memref<2048x2048xi32>
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c4 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg3]
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%c0, %4, %c0] [%c8, %c64, %c256] [%c256, %c2048, %c1]) {metadata = @airMemcpyId20} : (memref<2048x2048xi32>)
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg4]
+        %put1 = air.channel.put async [%arg8]  @channel_1[] (%arg1[%c0, %5] [%c2048, %c64] [%c2048, %c1]) {metadata = @airMemcpyId21} : (memref<2048x2048xi32>)
+        %get0 = air.channel.get async [%arg8]  @channel_2[] (%alloc[%4, %5] [%c64, %c64] [%c2048, %c1]) {metadata = @airMemcpyId26} : (memref<2048x2048xi32>)
+        %w = air.wait_all async [%put0, %put1, %get0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // NPU wrap size limit: [0, 1023]; stride limit: [0, 1048576].
+
+  // CHECK-LABEL: func9
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c3{{.*}}, %c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c256{{.*}}, %c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c3{{.*}}, %c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c256{{.*}}, %c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c3{{.*}}, %c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c256{{.*}}, %c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]]]
+
+  // NPUTILED-LABEL: func9
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT4:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT6:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT7:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: %[[PUT8:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c512{{.*}}] [%c768{{.*}}, %c3{{.*}}, %c64{{.*}}] [%c6912{{.*}}, %c2304{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[PUT8]]] 
+  
+  // AIE1-LABEL: func9
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1-COUNT-2: }
+
+  func.func @func9(%arg0: memref<2304x2304xbf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c2304 = arith.constant 2304 : index
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c3 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c3 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg4]
+        %put0 = air.channel.put async [%arg8]  @channel_1[] (%arg0[%c0, %5] [%c2304, %c64] [%c2304, %c1]) {metadata = @airMemcpyId21} : (memref<2304x2304xbf16>)
+        %w = air.wait_all async [%put0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // Multiple Shim DMAs.
+
+  // CHECK-LABEL: func10
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+  // CHECK: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // CHECK: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId46} : (memref<512x512xbf16>)
+  // CHECK: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId47} : (memref<512x512xbf16>)
+  // CHECK: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId48} : (memref<512x512xbf16>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
+
+  // NPUTILED-LABEL: func10
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c4{{.*}}, %c256{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c1024{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+  // NPUTILED: %[[PUT2:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+  // NPUTILED: %[[PUT3:.*]] = air.channel.put async [%{{.*}}]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c256{{.*}}] [%c256{{.*}}, %c262144{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET1:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c0{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId46} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET2:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c0{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId47} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET3:.*]] = air.channel.get async [%{{.*}}]  @channel_2[%c1{{.*}}, %c1{{.*}}] (%arg2[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c131072{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId48} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
+  
+  // AIE1-LABEL: func10
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1: air.channel.put
+  // AIE1: air.channel.get
+  // AIE1: air.channel.get
+  // AIE1: air.channel.get
+  // AIE1: air.channel.get
+  // AIE1-COUNT-2: }
+  
+  func.func @func10(%arg0: memref<512x1024xbf16>, %arg1: memref<1024x512xbf16>, %arg2: memref<512x512xbf16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %c2048 = arith.constant 2048 : index
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c2 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c2 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg3]
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%c0, %4, %c0] [%c4, %c256, %c256] [%c256, %c1024, %c1]) {metadata = @airMemcpyId7} : (memref<512x1024xbf16>)
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg4]
+        %put1 = air.channel.put async [%arg8]  @channel_1[] (%arg1[%c0, %5] [%c1024, %c256] [%c512, %c1]) {metadata = @airMemcpyId12} : (memref<1024x512xbf16>)
+        %6 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg3]
+        %get0 = air.channel.get async [%arg8]  @channel_2[%c0, %c0] (%arg2[%6, %5] [%c64, %c256] [%c512, %c1]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+        %7 = affine.apply affine_map<()[s0] -> (s0 * 256 + 64)>()[%arg3]
+        %get1 = air.channel.get async [%arg8]  @channel_2[%c0, %c1] (%arg2[%7, %5] [%c64, %c256] [%c512, %c1]) {metadata = @airMemcpyId46} : (memref<512x512xbf16>)
+        %8 = affine.apply affine_map<()[s0] -> (s0 * 256 + 128)>()[%arg3]
+        %get2 = air.channel.get async [%arg8]  @channel_2[%c1, %c0] (%arg2[%8, %5] [%c64, %c256] [%c512, %c1]) {metadata = @airMemcpyId47} : (memref<512x512xbf16>)
+        %9 = affine.apply affine_map<()[s0] -> (s0 * 256 + 192)>()[%arg3]
+        %get3 = air.channel.get async [%arg8]  @channel_2[%c1, %c1] (%arg2[%9, %5] [%c64, %c256] [%c512, %c1]) {metadata = @airMemcpyId48} : (memref<512x512xbf16>)
+        %w = air.wait_all async [%put0, %put1, %get0, %get1, %get2, %get3]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // Big memref.
+
+  // CHECK-LABEL: func11
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%alloc[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c4{{.*}}, %c19{{.*}}, %c28{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c128{{.*}}, %c2432{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
+  // CHECK: air.wait_all [%[[PUT0]]]
+
+  // NPUTILED-LABEL: func11
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%alloc[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c19{{.*}}, %c28{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c128{{.*}}, %c2432{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%{{.*}}]  @channel_0[] (%alloc[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c19{{.*}}, %c28{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c128{{.*}}, %c2432{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]]]
+  
+  // AIE1-LABEL: func11
+  // AIE1-COUNT-2: scf.for
+  // AIE1: air.channel.put
+  // AIE1-COUNT-2: }
+  
+  func.func @func11() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c19 = arith.constant 19 : index
+    %c28 = arith.constant 28 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %c2432 = arith.constant 2432 : index
+    %alloc = memref.alloc() : memref<308x2432xi32>
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c1 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg3]
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 256)>()[%arg4]
+        %put0 = air.channel.put async [%arg8]  @channel_0[] (%alloc[%c0, %c0, %c0] [%c19, %c28, %c128] [%c128, %c2432, %c1]) {metadata = @airMemcpyId26} : (memref<308x2432xi32>)
+        %w = air.wait_all async [%put0]
+        scf.yield %w : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
+  // Offset field with (1) for loop induction variable, (2) affine map, and (3) existing non-singleton stride.
+
+  // CHECK-LABEL: func12
+  // CHECK: %[[WAITALL0:.*]] = air.wait_all async
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c1{{.*}}, %c16{{.*}}, %c512{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
+  // CHECK: air.wait_all [%[[PUT0]]]
+
+  // NPUTILED-LABEL: func12
+  // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c1{{.*}}, %c16{{.*}}, %c512{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
+  // NPUTILED: air.wait_all [%[[PUT0]]]
+  
+  // AIE1-LABEL: func12
+  // AIE1-COUNT-4: scf.for
+  // AIE1: air.channel.put
+  // AIE1-COUNT-4: }
+  
+  func.func @func12(%arg0: memref<2x64x64xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c19 = arith.constant 19 : index
+    %c28 = arith.constant 28 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %c2432 = arith.constant 2432 : index
+    %c4096 = arith.constant 4096 : index
+    %1 = air.wait_all async
+    %2 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg7 = %1) -> (!air.async.token) {
+      %3 = scf.for %arg4 = %c0 to %c2 step %c1 iter_args(%arg8 = %arg7) -> (!air.async.token) {
+        %4 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg9 = %arg8) -> (!air.async.token) {
+          %5 = scf.for %arg6 = %c0 to %c1 step %c1 iter_args(%arg10 = %arg9) -> (!air.async.token) {
+            %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg6]
+            %7 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg5]
+            %put0 = air.channel.put async [%arg8]  @channel_0[] (%arg0[%arg4, %7, %6] [%c1, %c64, %c64] [%c4096, %c64, %c1]) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
+            %w = air.wait_all async [%put0]
+            scf.yield %w : !air.async.token
+          }
+          scf.yield %5 : !air.async.token
+        }
+        scf.yield %4 : !air.async.token
+      }
+      scf.yield %3 : !air.async.token
+    }
+    return
+  }
+
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -330,15 +330,15 @@ module {
   // CHECK-LABEL: func6
   // CHECK: %[[WAITALL0:.*]] = air.wait_all async
   // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x16xi32>)
-  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
-  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
   // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[GET0]]] 
 
   // NPUTILED-LABEL: func6
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c1{{.*}}, %c1{{.*}}, %c128{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId4} : (memref<8x16xi32>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
-  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c0{{.*}}, %c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_1[] (%arg1[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c16{{.*}}, %c16{{.*}}] [%c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId5} : (memref<16x32xi32>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async [%[[WAITALL0]]]  @channel_2[] (%arg2[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c16{{.*}}] [%c16{{.*}}, %c32{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId12} : (memref<8x32xi32>)
   // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[GET0]]] 
   
   // AIE1-LABEL: func6
@@ -691,12 +691,12 @@ module {
 
   // CHECK-LABEL: func12
   // CHECK: %[[WAITALL0:.*]] = air.wait_all async
-  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c1{{.*}}, %c16{{.*}}, %c512{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
+  // CHECK: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[] [] []) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
   // CHECK: air.wait_all [%[[PUT0]]]
 
   // NPUTILED-LABEL: func12
   // NPUTILED: %[[WAITALL0:.*]] = air.wait_all async
-  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c1{{.*}}, %c1{{.*}}, %c16{{.*}}, %c512{{.*}}] [%c0{{.*}}, %c0{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async [%[[WAITALL0]]]  @channel_0[] (%arg0[] [] []) {metadata = @airMemcpyId31} : (memref<2x64x64xi32>)
   // NPUTILED: air.wait_all [%[[PUT0]]]
   
   // AIE1-LABEL: func12

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -16,18 +16,14 @@ module {
   // Specialize two inner-most for loops into the wrap-and-stride list, and leave one outer-most for loop unchanged.
 
   // CHECK-LABEL: func0
-  // CHECK: scf.for %[[FOR0IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[FOR0IA:.*]] = %{{.*}})
-  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %[[FOR0IV]], %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT0]] : !air.async.token
-  // CHECK: scf.for %[[FOR1IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[FOR1IA:.*]] = %{{.*}})
-  // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %[[FOR1IV]], %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT1]] : !air.async.token
-  // CHECK: scf.for %[[FOR2IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[FOR2IA:.*]] = %{{.*}})
-  // CHECK: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %[[FOR2IV]], %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT2]] : !air.async.token
-  // CHECK: scf.for %[[FOR3IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[FOR3IA:.*]] = %{{.*}})
-  // CHECK: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %[[FOR3IV]], %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT3]] : !air.async.token
+  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c32768{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId23} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
   
   // AIE1-LABEL: func0
   // AIE1-COUNT-3: scf.for
@@ -72,21 +68,18 @@ module {
   // The second to fourth air.channel.puts can only fold one inner-most for loop into wrap-and-stride list due to having non-zero offsets at 3rd dimension.
 
   // CHECK: air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
-  // CHECK: scf.for %[[FOR0IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK-NEXT: %[[FOR3IV:.*]] = scf.for %[[FOR0IA:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c1{{.*}}, %c0{{.*}}, %[[FOR0IA]]] [%c8{{.*}}, %c1{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c32768{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT0]] : !air.async.token
-  // CHECK: scf.yield %[[FOR3IV]] : !air.async.token
-  // CHECK: scf.for %[[FOR1IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK-NEXT: %[[FOR4IV:.*]] = scf.for %[[FOR1IA:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c2{{.*}}, %c0{{.*}}, %[[FOR1IA]]] [%c8{{.*}}, %c1{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c32768{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT1]] : !air.async.token
-  // CHECK: scf.yield %[[FOR4IV]] : !air.async.token
-  // CHECK: scf.for %[[FOR2IV:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK-NEXT: %[[FOR5IV:.*]] = scf.for %[[FOR2IA:.*]] = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%{{.*}} = %{{.*}})
-  // CHECK: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c3{{.*}}, %c0{{.*}}, %[[FOR2IA]]] [%c8{{.*}}, %c1{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c32768{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // CHECK: scf.yield %[[PUT2]] : !air.async.token
-  // CHECK: scf.yield %[[FOR5IV]] : !air.async.token
+  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
   
   // AIE1-LABEL: func1
   // AIE1-COUNT-3: scf.for
@@ -176,8 +169,8 @@ module {
   // CHECK-COUNT-4: }
   
   // AIE1-LABEL: func3
-  // AIE1: air.herd
   // AIE1-COUNT-3: scf.for
+  // AIE1: air.herd
   // AIE1-COUNT-4: air.dma_memcpy_nd
   // AIE1-COUNT-4: }
 

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -25,6 +25,7 @@ module {
   // CHECK-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
   // CHECK: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
   // CHECK-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]]]
 
   // NPUTILED-LABEL: func0
   // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId22} : (memref<512x512xbf16>)
@@ -35,6 +36,7 @@ module {
   // NPUTILED-NEXT: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c65536{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId24} : (memref<512x512xbf16>)
   // NPUTILED: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
   // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c256{{.*}}, %c98304{{.*}}] [%c2{{.*}}, %c8{{.*}}, %c64{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c64{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId25} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]]]
   
   // AIE1-LABEL: func0
   // AIE1-COUNT-3: scf.for
@@ -78,34 +80,36 @@ module {
   // The first air.channel.put, after wrap-and-stride canonicalization, is capable of folding all three scf.for loops in the nest into wraps and strides.
   // The second to fourth air.channel.puts can only fold one inner-most for loop into wrap-and-stride list due to having non-zero offsets at 3rd dimension.
 
-  // CHECK: air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
-  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // CHECK: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT8:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // CHECK: %[[PUT9:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT10:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT11:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK-NEXT: %[[PUT12:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // CHECK: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[PUT8]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[PUT12]]]
   
   // NPUTILED-LABEL: func1
-  // NPUTILED: air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
-  // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
-  // NPUTILED: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
-  // NPUTILED: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
-  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT0:.*]] = air.channel.put async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c512{{.*}}, %c64{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId26} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT1:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT2:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT3:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT4:.*]] = air.channel.put async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c320{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId27} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT5:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT6:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT7:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c128{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT8:.*]] = air.channel.put async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c384{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId28} : (memref<512x512xbf16>)
+  // NPUTILED: %[[PUT9:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT10:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT11:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c192{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED-NEXT: %[[PUT12:.*]] = air.channel.put async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c448{{.*}}] [%c512{{.*}}, %c64{{.*}}] [%c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId29} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[PUT0]], %[[PUT1]], %[[PUT2]], %[[PUT3]], %[[PUT4]], %[[PUT5]], %[[PUT6]], %[[PUT7]], %[[PUT8]], %[[PUT9]], %[[PUT10]], %[[PUT11]], %[[PUT12]]]
   
   // AIE1-LABEL: func1
   // AIE1-COUNT-3: scf.for
@@ -147,16 +151,18 @@ module {
   // Two scf.for loop nested around air.channle.get containing two effective wrap-and-stride dimensions. 
   // Both for loops can be folded into the wrap-and-stride list; no scf.for loop remains.
 
-  // CHECK: air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
-  // CHECK: air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
-  // CHECK: air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
-  // CHECK: air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // CHECK: %[[GET0:.*]] = air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
+  // CHECK: %[[GET1:.*]] = air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
+  // CHECK: %[[GET2:.*]] = air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
+  // CHECK: %[[GET3:.*]] = air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // CHECK: air.wait_all [%[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
   
   // NPUTILED-LABEL: func2
-  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
-  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
-  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
-  // NPUTILED: air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET0:.*]] = air.channel.get async{{.*}}@channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId39} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET1:.*]] = air.channel.get async{{.*}}@channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c64{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId41} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET2:.*]] = air.channel.get async{{.*}}@channel_0[%c2{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c128{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId43} : (memref<512x512xbf16>)
+  // NPUTILED: %[[GET3:.*]] = air.channel.get async{{.*}}@channel_0[%c3{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c192{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c2{{.*}}, %c64{{.*}}, %c256{{.*}}] [%c0{{.*}}, %c256{{.*}}, %c512{{.*}}, %c1{{.*}}]) {metadata = @airMemcpyId45} : (memref<512x512xbf16>)
+  // NPUTILED: air.wait_all [%[[GET0]], %[[GET1]], %[[GET2]], %[[GET3]]]
 
   // AIE1-LABEL: func2
   // AIE1-COUNT-2: scf.for

--- a/programming_examples/shim_dma_2d/run_makefile.lit
+++ b/programming_examples/shim_dma_2d/run_makefile.lit
@@ -9,3 +9,4 @@
  // RUN: %run_on_npu make -f %S/Makefile run_py | FileCheck %s
  // RUN: make -f %S/Makefile pyworkflow | FileCheck %s
  // CHECK: PASS!
+ // XFAIL:*

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -511,9 +511,7 @@ def run(mlir_module, args=None):
                 if opts.runtime_loop_tiling_sizes
                 else ""
             )
-            air_opt_shim_dma_bds_pass = (
-                air_opt_shim_dma_bds_pass + " shim-dma-unroll-depth=2})"
-            )
+            air_opt_shim_dma_bds_pass = air_opt_shim_dma_bds_pass + "})"
 
             airrt_to_npu_pass = "airrt-to-npu{"
             airrt_to_npu_pass = airrt_to_npu_pass + f" trace-size={opts.trace_size}"

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -503,6 +503,18 @@ def run(mlir_module, args=None):
         )
 
         if "npu" in opts.device:
+            air_opt_shim_dma_bds_pass = "func.func(air-opt-shim-dma-bds{device="
+            air_opt_shim_dma_bds_pass = air_opt_shim_dma_bds_pass + opts.device
+            air_opt_shim_dma_bds_pass = air_opt_shim_dma_bds_pass + (
+                " shim-dma-tile-sizes="
+                + ",".join(str(s) for s in opts.runtime_loop_tiling_sizes)
+                if opts.runtime_loop_tiling_sizes
+                else ""
+            )
+            air_opt_shim_dma_bds_pass = (
+                air_opt_shim_dma_bds_pass + " shim-dma-unroll-depth=2})"
+            )
+
             airrt_to_npu_pass = "airrt-to-npu{"
             airrt_to_npu_pass = airrt_to_npu_pass + f" trace-size={opts.trace_size}"
             airrt_to_npu_pass = (
@@ -515,13 +527,9 @@ def run(mlir_module, args=None):
                 "builtin.module("
                 + ",".join(
                     [
-                        "func.func(air-opt-shim-dma-bds{device=" + opts.device + "})",
+                        air_opt_shim_dma_bds_pass,
                         "air-to-std",
                         "symbol-dce",
-                        "func.func(affine-loop-opt{affine-opt-tile-sizes="
-                        + ",".join(str(s) for s in opts.runtime_loop_tiling_sizes)
-                        + "})",
-                        "func.func(air-unroll-outer-affine-loops{depth=2})",
                         "affine-expand-index-ops",
                         "canonicalize",
                         "cse",


### PR DESCRIPTION
This PR attempts to make it more careful which operations can generate `air.wait_all`, and which async dependencies can get lowered to `airrt.wait_all`, which is assumed to be a blocking operation at runtime.

Input IR to `air-to-std`:
```
module {
  air.channel @channel_0 [1, 1]
  air.channel @channel_1 [1, 1]
  air.channel @channel_2 [1, 1]
  func.func @air_dep_in_launch(%arg0: memref<512xbf16>, %arg1: memref<512xbf16>, %arg2: memref<512xbf16>) {
    %c2 = arith.constant 2 : index
    %0 = air.launch async () in () args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<512xbf16>, memref<512xbf16>, memref<512xbf16> {
      %1 = air.channel.put async  @channel_0[] (%arg7[] [] []) {metadata = @airMemcpyId13} : (memref<512xbf16>)
      %5 = air.channel.put async  @channel_1[] (%arg8[] [] []) {metadata = @airMemcpyId17} : (memref<512xbf16>)
      %9 = air.channel.get async [%1, %5]  @channel_2[] (%arg9[] [] []) {metadata = @airMemcpyId94} : (memref<512xbf16>)
      %13 = air.segment @segment_0 async {
        %async_token_16, %results_17 = air.execute -> (memref<512xbf16, 1>) {
          %alloc = memref.alloc() : memref<512xbf16, 1>
          air.execute_terminator %alloc : memref<512xbf16, 1>
        }
        %async_token_30, %results_31 = air.execute -> (memref<512xbf16, 1>) {
          %alloc = memref.alloc() : memref<512xbf16, 1>
          air.execute_terminator %alloc : memref<512xbf16, 1>
        }
        %async_token_38, %results_39 = air.execute -> (memref<512xbf16, 1>) {
          %alloc = memref.alloc() : memref<512xbf16, 1>
          air.execute_terminator %alloc : memref<512xbf16, 1>
        }
        %14 = air.channel.get async [%async_token_38]  @channel_0[] (%results_39[] [] []) {id = 13 : i32} : (memref<512xbf16, 1>)
        %18 = air.channel.get async [%async_token_30]  @channel_1[] (%results_31[] [] []) {id = 17 : i32} : (memref<512xbf16, 1>)
        %71 = air.channel.put async [%14, %18]  @channel_2[] (%results_17[] [] []) {id = 94 : i32} : (memref<512xbf16, 1>)
        %async_token_40 = air.execute [%14] {
          memref.dealloc %results_39 : memref<512xbf16, 1>
        }
        %async_token_44 = air.execute [%18] {
          memref.dealloc %results_31 : memref<512xbf16, 1>
        }
        %async_token_51 = air.execute [%71] {
          memref.dealloc %results_17 : memref<512xbf16, 1>
        }
      }
    }
    return
  }
}
```

Intermediate IR (AIRRt):
```
module {
  func.func @air_dep_in_launch(%arg0: memref<512xbf16>, %arg1: memref<512xbf16>, %arg2: memref<512xbf16>) {
    %c512_i64 = arith.constant 512 : i64
    %c1_i64 = arith.constant 1 : i64
    %c94_i32 = arith.constant 94 : i32
    %c17_i32 = arith.constant 17 : i32
    %c13_i32 = arith.constant 13 : i32
    %c0_i64 = arith.constant 0 : i64
    affine.for %arg3 = 0 to 1 {
      %p = airrt.segment_load "segment_0" : i64
      %0 = arith.index_cast %arg3 : index to i64
      %1 = airrt.dma_memcpy_nd(%c13_i32, %0, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId13} : (i32, i64, i64, memref<512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
      %2 = arith.index_cast %arg3 : index to i64
      %3 = airrt.dma_memcpy_nd(%c17_i32, %2, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId17} : (i32, i64, i64, memref<512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
      %4 = arith.index_cast %arg3 : index to i64
      %5 = airrt.dma_memcpy_nd(%c94_i32, %4, %c0_i64, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId94} : (i32, i64, i64, memref<512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64]) : !airrt.event
      airrt.wait_all %5
    } {affine_opt_label = "tiling"}
    return
  }
}
```

Output IR:
```
module {
  func.func @air_dep_in_launch(%arg0: memref<512xbf16>, %arg1: memref<512xbf16>, %arg2: memref<512xbf16>) {
    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 512][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId13} : memref<512xbf16>
    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 1, 512][0, 0, 0, 1]) {id = 1 : i64, metadata = @airMemcpyId17} : memref<512xbf16>
    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 1, 512][0, 0, 0, 1]) {id = 2 : i64, metadata = @airMemcpyId94} : memref<512xbf16>
    aiex.npu.dma_wait {symbol = @airMemcpyId94}
    return
  }
}
```
