### PR TITLE
AIRCC: When lowering to airhost, use `--compile-host` flag in `aiecc`

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -330,6 +330,7 @@ def lower_airrt_to_airhost(air_to_aie_module, air_placed_module, air_mlir_filena
             + ["--host-target", aiecc_target]
             + ["--tmpdir", aiecc_dir]
             + ["--no-aiesim"]
+            + ["--compile-host"]
             + ["--xbridge" if opts.xbridge else "--no-xbridge"]
             + ["--xchesscc" if opts.xchesscc else "--no-xchesscc"]
             + [aiecc_file]


### PR DESCRIPTION
… to force generating `aie_inc.cpp`.