### PR TITLE
bump mlir-aie, switch to binary seq, use test_utils

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -139,7 +139,7 @@ AIE::ExternalBufferOp air::allocateExternalBufferOp(uint64_t &BufferId,
 
   auto builder = OpBuilder::atBlockBegin(device.getBody());
   AIE::ExternalBufferOp bufferOp = builder.create<AIE::ExternalBufferOp>(
-      builder.getUnknownLoc(), memrefTy, nullptr);
+      builder.getUnknownLoc(), memrefTy, nullptr, nullptr);
 
   std::stringstream ss =
       generateBufferNameInStringStream("extBuf", BufferId, attr, x, y);

--- a/programming_examples/shim_dma_2d/Makefile
+++ b/programming_examples/shim_dma_2d/Makefile
@@ -22,23 +22,23 @@ build/final.py.xclbin: build/air.mlir
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build
 	mkdir -p _build
-	cd _build && ${powershell} cmake -E env CXXFLAGS="-std=c++23 -ggdb" cmake ${srcdir} -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13 -DTARGET_NAME=${targetname} 
+	cd _build && ${powershell} cmake -E env CXXFLAGS="-std=c++23 -ggdb" cmake ${srcdir} -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13 -DTARGET_NAME=${targetname}
 	cd _build && ${powershell} cmake --build . --config Release
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
-run: ${targetname}.exe build/final.xclbin build/final.insts.txt 
-	${powershell} ./$< -x build/final.xclbin -i build/final.insts.txt -k MLIR_AIE
+run: ${targetname}.exe build/final.xclbin build/final.insts.bin 
+	${powershell} ./$< -x build/final.xclbin -i build/final.insts.bin -k MLIR_AIE
 
-run_py: build/final.xclbin build/final.insts.txt 
-	${powershell} python3 ${srcdir}/test.py build/final.xclbin build/final.insts.txt 
+run_py: build/final.xclbin build/final.insts.bin
+	${powershell} python3 ${srcdir}/test.py build/final.xclbin build/final.insts.bin
 
 pyworkflow:
 	mkdir -p pybuild
-	cd pybuild && ${powershell} python3 ${srcdir}/run.py 
+	cd pybuild && ${powershell} python3 ${srcdir}/run.py
 
 clean:
 	rm -rf build _build pybuild tmp ${targetname}.exe

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -91,7 +91,7 @@ class XRTBackend(AirBackend):
         air_module: air.ir.Module,
         xclbin="air.xclbin",
         kernel="MLIR_AIE",
-        insts="air.insts.txt",
+        insts="air.insts.bin",
     ):
         """Compiles an AIR module for the NPU / XRT Runtime with aircc.
 
@@ -207,10 +207,9 @@ class XRTBackend(AirBackend):
         self.kernel = xrt.kernel(self.context, xkernel.get_name())
 
         # load the instructions as a numpy array
-        with open(artifact.insts, "r") as f:
-            instr_text = f.read().split("\n")
-            instr_text = [l for l in instr_text if l != ""]
-            self.instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+        with open(artifact.insts, "rb") as f:
+            instr_data = f.read()
+            self.instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
         self.bo_instr = xrt.bo(
             self.device,

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -546,7 +546,7 @@ def run(mlir_module, args=None):
                 insts_file = opts.insts_file
             else:
                 assert xclbin_file.endswith(".xclbin")
-                insts_file = opts.output_file.removesuffix(".xclbin") + ".insts.txt"
+                insts_file = opts.output_file.removesuffix(".xclbin") + ".insts.bin"
             aiecc_options = (["-v"] if opts.verbose else []) + [
                 "--no-aiesim",
                 "--xchesscc" if opts.xchesscc else "--no-xchesscc",

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -62,6 +62,17 @@ config.substitutions.append(
 )
 config.substitutions.append(("%aietools", config.vitis_aietools_dir))
 
+test_lib_path = os.path.join(
+    config.aie_obj_root, "runtime_lib", config.runtime_test_target, "test_lib"
+)
+config.substitutions.append(
+    (
+        "%test_utils_flags",
+        "-lboost_program_options -lboost_filesystem "
+        + f"-I{test_lib_path}/include -L{test_lib_path}/lib -ltest_utils",
+    )
+)
+
 # for xchesscc_wrapper
 llvm_config.with_environment("AIETOOLS", config.vitis_aietools_dir)
 

--- a/test/xrt/01_air_to_npu/run.lit
+++ b/test/xrt/01_air_to_npu/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai
 // RUN: %python %S/gen.py --trace-size 65536 --trace-offset 65536
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt --trace_sz 65536
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin --trace_sz 65536

--- a/test/xrt/01_air_to_npu/test.cpp
+++ b/test/xrt/01_air_to_npu/test.cpp
@@ -194,7 +194,7 @@ int main(int argc, const char *argv[]) {
 
   if (trace_size > 0) {
     test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/01_air_to_npu/test.cpp
+++ b/test/xrt/01_air_to_npu/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -29,34 +31,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
-
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   for (size_t m1 = 0; m1 < M; m1++) {
@@ -69,15 +43,6 @@ void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
         r[idx] += _a * _b;
       }
     }
-  }
-}
-
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
   }
 }
 
@@ -116,11 +81,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)
@@ -228,7 +193,7 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
                     vm["trace_file"].as<std::string>());
   }
 

--- a/test/xrt/04_gemm_w_pack/run.lit
+++ b/test/xrt/04_gemm_w_pack/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai
 // RUN: %python %S/gen.py
-// RUN: clang %S/test.cpp -O3 -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: clang %S/test.cpp -O3 -o test.exe -std=c++11 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/04_gemm_w_pack/test.cpp
+++ b/test/xrt/04_gemm_w_pack/test.cpp
@@ -79,7 +79,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/04_gemm_w_pack/test.cpp
+++ b/test/xrt/04_gemm_w_pack/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -28,34 +30,6 @@ constexpr int C_SIZE = (C_VOLUME * sizeof(C_DATATYPE));
 constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
@@ -101,11 +75,11 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/05_extern_func/run.lit
+++ b/test/xrt/05_extern_func/run.lit
@@ -9,5 +9,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1_4col row-offset=2 col-offset=0" -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run.py
+++ b/test/xrt/05_extern_func/run.py
@@ -10,10 +10,9 @@ out_size = 1024
 
 out_size_bytes = out_size * 4
 
-with open("insts.txt", "r") as f:
-    instr_text = f.read().split("\n")
-    instr_text = [l for l in instr_text if l != ""]
-    instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+with open("insts.bin", "rb") as f:
+    instr_data = f.read()
+    instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
 opts_xclbin = "aie.xclbin"
 opts_kernel = "MLIR_AIE"

--- a/test/xrt/06_add_shim_bf16/run.py
+++ b/test/xrt/06_add_shim_bf16/run.py
@@ -12,7 +12,7 @@ in_size = out_size = 128 * 128
 in_size_bytes = in_size * 2
 out_size_bytes = out_size * 4
 
-with open("air.insts.txt", "r") as f:
+with open("air.insts.bin", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/07_extern_linalg/run.py
+++ b/test/xrt/07_extern_linalg/run.py
@@ -12,10 +12,9 @@ in_size = out_size = 128 * 128
 in_size_bytes = in_size * 2
 out_size_bytes = out_size * 2
 
-with open("air.insts.txt", "r") as f:
-    instr_text = f.read().split("\n")
-    instr_text = [l for l in instr_text if l != ""]
-    instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+with open("air.insts.bin", "rb") as f:
+    instr_data = f.read()
+    instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
 opts_xclbin = "air.xclbin"
 opts_kernel = "MLIR_AIE"

--- a/test/xrt/08_gemm_extern_vec/matrix_multiplication.h
+++ b/test/xrt/08_gemm_extern_vec/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/08_gemm_extern_vec/run.lit
+++ b/test/xrt/08_gemm_extern_vec/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/08_gemm_extern_vec/test.cpp
+++ b/test/xrt/08_gemm_extern_vec/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/09_gemm_extern_vec_4x4/matrix_multiplication.h
+++ b/test/xrt/09_gemm_extern_vec_4x4/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/09_gemm_extern_vec_4x4/run.lit
+++ b/test/xrt/09_gemm_extern_vec_4x4/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/09_gemm_extern_vec_4x4/test.cpp
+++ b/test/xrt/09_gemm_extern_vec_4x4/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/10_gemm_peeling_extern_vec/matrix_multiplication.h
+++ b/test/xrt/10_gemm_peeling_extern_vec/matrix_multiplication.h
@@ -59,7 +59,6 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
   test_utils::check_arg_file_exists(vm, "instr");
 }
 
-
 // --------------------------------------------------------------------------
 // Matrix / Float / Math
 // --------------------------------------------------------------------------

--- a/test/xrt/10_gemm_peeling_extern_vec/matrix_multiplication.h
+++ b/test/xrt/10_gemm_peeling_extern_vec/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,28 +55,10 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 // --------------------------------------------------------------------------
 // Matrix / Float / Math

--- a/test/xrt/10_gemm_peeling_extern_vec/run.lit
+++ b/test/xrt/10_gemm_peeling_extern_vec/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/10_gemm_peeling_extern_vec/test.cpp
+++ b/test/xrt/10_gemm_peeling_extern_vec/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/11_gemm_bias_fusion/run.lit
+++ b/test/xrt/11_gemm_bias_fusion/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/11_gemm_bias_fusion/test.cpp
+++ b/test/xrt/11_gemm_bias_fusion/test.cpp
@@ -44,8 +44,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
-
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> bias,
             std::vector<T> &r) {
@@ -95,7 +93,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/11_gemm_bias_fusion/test.cpp
+++ b/test/xrt/11_gemm_bias_fusion/test.cpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -42,33 +44,7 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> bias,
@@ -115,11 +91,11 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -21,10 +21,9 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("air.insts.bin", "r") as f:
-    instr_text = f.read().split("\n")
-    instr_text = [l for l in instr_text if l != ""]
-    instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+with open("air.insts.bin", "rb") as f:
+    instr_data = f.read()
+    instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
 opts_xclbin = sys.argv[1]
 opts_kernel = "MLIR_AIE"

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -21,7 +21,7 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("air.insts.txt", "r") as f:
+with open("air.insts.bin", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/13_conv2d_i32/run.lit
+++ b/test/xrt/13_conv2d_i32/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/13_conv2d_i32/test.cpp
+++ b/test/xrt/13_conv2d_i32/test.cpp
@@ -87,15 +87,6 @@ void conv_out_nhwc_hwcf(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -243,8 +234,8 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/13_conv2d_i32/test.cpp
+++ b/test/xrt/13_conv2d_i32/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -34,33 +36,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void conv_out_nchw_fchw(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
@@ -157,11 +132,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/13_conv2d_i32/test.cpp
+++ b/test/xrt/13_conv2d_i32/test.cpp
@@ -36,7 +36,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void conv_out_nchw_fchw(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   for (size_t batch = 0; batch < BATCH; batch++) {
@@ -136,7 +135,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/14_conv2d_i8_extern_vec/run.lit
+++ b/test/xrt/14_conv2d_i8_extern_vec/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/conv.cc -o conv.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt --trace_sz 262144
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin --trace_sz 262144

--- a/test/xrt/14_conv2d_i8_extern_vec/test.cpp
+++ b/test/xrt/14_conv2d_i8_extern_vec/test.cpp
@@ -47,7 +47,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename Tin, typename Tout>
 void conv_out_nchw_fchw(std::vector<Tin> a, std::vector<Tin> b,
                         std::vector<Tout> &r) {
@@ -149,7 +148,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/14_conv2d_i8_extern_vec/test.cpp
+++ b/test/xrt/14_conv2d_i8_extern_vec/test.cpp
@@ -100,15 +100,6 @@ void conv_out_nhwc_hwcf(std::vector<Tin> a, std::vector<Tin> b,
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -287,8 +278,8 @@ int main(int argc, const char *argv[]) {
   std::cout << "NPU gflops: " << macs / (1000 * npu_time_total) << std::endl;
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/14_conv2d_i8_extern_vec/test.cpp
+++ b/test/xrt/14_conv2d_i8_extern_vec/test.cpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -45,33 +47,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename Tin, typename Tout>
 void conv_out_nchw_fchw(std::vector<Tin> a, std::vector<Tin> b,
@@ -170,11 +145,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/matrix_multiplication.h
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/run.lit
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/test.cpp
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/matrix_multiplication.h
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/test.cpp
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/matrix_multiplication.h
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/run.lit
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/test.cpp
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -61,7 +63,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -24,7 +24,7 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("air.insts.txt", "r") as f:
+with open("air.insts.bin", "r") as f:
     instr_text = f.read().split("\n")
     instr_text = [l for l in instr_text if l != ""]
     instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -24,10 +24,9 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("air.insts.bin", "r") as f:
-    instr_text = f.read().split("\n")
-    instr_text = [l for l in instr_text if l != ""]
-    instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+with open("air.insts.bin", "rb") as f:
+    instr_data = f.read()
+    instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
 opts_xclbin = sys.argv[1]
 opts_kernel = "MLIR_AIE"

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
@@ -24,10 +24,9 @@ in_a_size_bytes = (in_a_size[0] * in_a_size[1]) * 2
 in_b_size_bytes = (in_b_size[0] * in_b_size[1]) * 2
 out_size_bytes = (out_size[0] * out_size[1]) * 4
 
-with open("air.insts.txt", "r") as f:
-    instr_text = f.read().split("\n")
-    instr_text = [l for l in instr_text if l != ""]
-    instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+with open("air.insts.bin", "rb") as f:
+    instr_data = f.read()
+    instr_v = np.frombuffer(instr_data, dtype=np.uint32)
 
 opts_xclbin = sys.argv[1]
 opts_kernel = "MLIR_AIE"

--- a/test/xrt/20_batch_matmul_i32/run.lit
+++ b/test/xrt/20_batch_matmul_i32/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/20_batch_matmul_i32/test.cpp
+++ b/test/xrt/20_batch_matmul_i32/test.cpp
@@ -49,15 +49,6 @@ void bmm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -205,8 +196,8 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/20_batch_matmul_i32/test.cpp
+++ b/test/xrt/20_batch_matmul_i32/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -30,33 +32,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void bmm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
@@ -119,11 +94,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/20_batch_matmul_i32/test.cpp
+++ b/test/xrt/20_batch_matmul_i32/test.cpp
@@ -32,7 +32,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void bmm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   for (size_t b1 = 0; b1 < B; b1++) {
@@ -98,7 +97,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/21_conv2d_depthwise_i32/run.lit
+++ b/test/xrt/21_conv2d_depthwise_i32/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/21_conv2d_depthwise_i32/test.cpp
+++ b/test/xrt/21_conv2d_depthwise_i32/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -33,33 +35,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void conv_out_depthwise_nhwc_hwc(std::vector<T> a, std::vector<T> b,
@@ -129,11 +104,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/21_conv2d_depthwise_i32/test.cpp
+++ b/test/xrt/21_conv2d_depthwise_i32/test.cpp
@@ -35,7 +35,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void conv_out_depthwise_nhwc_hwc(std::vector<T> a, std::vector<T> b,
                                  std::vector<T> &r) {
@@ -108,7 +107,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/21_conv2d_depthwise_i32/test.cpp
+++ b/test/xrt/21_conv2d_depthwise_i32/test.cpp
@@ -59,15 +59,6 @@ void conv_out_depthwise_nhwc_hwc(std::vector<T> a, std::vector<T> b,
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -215,8 +206,8 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/22_conv2d_stride2_i32/run.lit
+++ b/test/xrt/22_conv2d_stride2_i32/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/22_conv2d_stride2_i32/test.cpp
+++ b/test/xrt/22_conv2d_stride2_i32/test.cpp
@@ -64,15 +64,6 @@ void conv_out_s2_nchw_fchw(std::vector<T> a, std::vector<T> b,
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -220,8 +211,8 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/22_conv2d_stride2_i32/test.cpp
+++ b/test/xrt/22_conv2d_stride2_i32/test.cpp
@@ -36,7 +36,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void conv_out_s2_nchw_fchw(std::vector<T> a, std::vector<T> b,
                            std::vector<T> &r) {
@@ -113,7 +112,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/22_conv2d_stride2_i32/test.cpp
+++ b/test/xrt/22_conv2d_stride2_i32/test.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -34,33 +36,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void conv_out_s2_nchw_fchw(std::vector<T> a, std::vector<T> b,
@@ -134,11 +109,11 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/23_ctrlpkt_config/run.lit
+++ b/test/xrt/23_ctrlpkt_config/run.lit
@@ -8,5 +8,5 @@
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.txt -c ctrlpkt_dma_seq.txt -p ctrlpkt.txt -v 2

--- a/test/xrt/23_ctrlpkt_config/run.lit
+++ b/test/xrt/23_ctrlpkt_config/run.lit
@@ -4,9 +4,9 @@
 // REQUIRES: ryzen_ai
 // RUN: %python %S/aie.py
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.txt aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.txt -c ctrlpkt_dma_seq.txt -p ctrlpkt.txt -v 2
+// RUN: %run_on_npu ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/test.cpp
+++ b/test/xrt/23_ctrlpkt_config/test.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include "experimental/xrt_kernel.h"
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -37,33 +39,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
@@ -128,26 +103,26 @@ int main(int argc, const char *argv[]) {
 
   int trace_size = vm["trace_sz"].as<int>();
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-  check_arg_file_exists(vm, "ctrlpktInstr");
-  check_arg_file_exists(vm, "ctrlpkts");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "ctrlpktInstr");
+  test_utils::check_arg_file_exists(vm, "ctrlpkts");
 
   int verbosity = vm["verbosity"].as<int>();
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 
   std::vector<uint32_t> ctrlpkt_instr_v =
-      load_instr_sequence(vm["ctrlpktInstr"].as<std::string>());
+       test_utils::load_instr_binary(vm["ctrlpktInstr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Control packet sequence instr count: "
               << ctrlpkt_instr_v.size() << "\n";
 
   std::vector<uint32_t> ctrlPackets =
-      load_instr_sequence(vm["ctrlpkts"].as<std::string>());
+       test_utils::load_instr_binary(vm["ctrlpkts"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Control packet ui32 raw data count: " << ctrlPackets.size()
               << "\n";

--- a/test/xrt/23_ctrlpkt_config/test.cpp
+++ b/test/xrt/23_ctrlpkt_config/test.cpp
@@ -39,7 +39,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   for (size_t m1 = 0; m1 < M; m1++) {
@@ -111,18 +110,18 @@ int main(int argc, const char *argv[]) {
   int verbosity = vm["verbosity"].as<int>();
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 
   std::vector<uint32_t> ctrlpkt_instr_v =
-       test_utils::load_instr_binary(vm["ctrlpktInstr"].as<std::string>());
+      test_utils::load_instr_binary(vm["ctrlpktInstr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Control packet sequence instr count: "
               << ctrlpkt_instr_v.size() << "\n";
 
   std::vector<uint32_t> ctrlPackets =
-       test_utils::load_instr_binary(vm["ctrlpkts"].as<std::string>());
+      test_utils::load_instr_binary(vm["ctrlpkts"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Control packet ui32 raw data count: " << ctrlPackets.size()
               << "\n";

--- a/test/xrt/23_ctrlpkt_config/test.cpp
+++ b/test/xrt/23_ctrlpkt_config/test.cpp
@@ -54,15 +54,6 @@ void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   }
 }
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -269,8 +260,8 @@ int main(int argc, const char *argv[]) {
   }
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (!errors) {

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/matrix_multiplication.h
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -64,26 +53,7 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run.lit
@@ -6,14 +6,14 @@
 // RUN: %python %S/aie.py
 // RUN: %python %S/aie2.py
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.txt aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 // RUN: %python %S/aie2.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.txt aie2.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.txt
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.txt
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu ./test.exe -x base.xclbin -k MLIR_AIE

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/test.cpp
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/test.cpp
@@ -26,8 +26,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include "test_utils.h"
 #include "matrix_multiplication.h"
+#include "test_utils.h"
 
 constexpr int M = 512;
 constexpr int K1 = 512;

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/test.cpp
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/test.cpp
@@ -1,7 +1,7 @@
 //===- test.cpp -------------------------------------------000---*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
+// See https://llvm.org/LICENSE.bin for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
@@ -21,10 +21,12 @@
 #include <stdfloat>
 
 #include "experimental/xrt_kernel.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+#include "test_utils.h"
 #include "matrix_multiplication.h"
 
 constexpr int M = 512;
@@ -67,22 +69,22 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr1_v =
-      matmul_common::load_instr_sequence("aie_run_seq.txt");
+      test_utils::load_instr_binary("aie_run_seq.bin");
 
   std::vector<uint32_t> ctrlpkt_instr1_v =
-      matmul_common::load_instr_sequence("ctrlpkt_dma_seq.txt");
+      test_utils::load_instr_binary("ctrlpkt_dma_seq.bin");
 
   std::vector<uint32_t> ctrlPackets1 =
-      matmul_common::load_instr_sequence("ctrlpkt.txt");
+      test_utils::load_instr_binary("ctrlpkt.bin");
 
   std::vector<uint32_t> instr2_v =
-      matmul_common::load_instr_sequence("aie2_run_seq.txt");
+      test_utils::load_instr_binary("aie2_run_seq.bin");
 
   std::vector<uint32_t> ctrlpkt_instr2_v =
-      matmul_common::load_instr_sequence("aie2_ctrlpkt_dma_seq.txt");
+      test_utils::load_instr_binary("aie2_ctrlpkt_dma_seq.bin");
 
   std::vector<uint32_t> ctrlPackets2 =
-      matmul_common::load_instr_sequence("aie2_ctrlpkt.txt");
+      test_utils::load_instr_binary("aie2_ctrlpkt.bin");
 
   // Start the XRT test code
   // Get a device handle

--- a/test/xrt/25_batch_matmul_bf16/matrix_multiplication.h
+++ b/test/xrt/25_batch_matmul_bf16/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/25_batch_matmul_bf16/run.lit
+++ b/test/xrt/25_batch_matmul_bf16/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/25_batch_matmul_bf16/test.cpp
+++ b/test/xrt/25_batch_matmul_bf16/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -59,7 +61,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/26_vecmat_i8/matrix_multiplication.h
+++ b/test/xrt/26_vecmat_i8/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -70,27 +59,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/26_vecmat_i8/run.lit
+++ b/test/xrt/26_vecmat_i8/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/vm.cc -o vm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/26_vecmat_i8/test.cpp
+++ b/test/xrt/26_vecmat_i8/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -69,7 +71,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/26_vecmat_i8/test.cpp
+++ b/test/xrt/26_vecmat_i8/test.cpp
@@ -48,15 +48,6 @@ constexpr bool VERIFY = true;
 
 namespace po = boost::program_options;
 
-void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
-  std::ofstream fout(path);
-  uint32_t *traceOut = (uint32_t *)traceOutPtr;
-  for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
-    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
-    fout << std::endl;
-  }
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
@@ -220,8 +211,8 @@ int main(int argc, const char *argv[]) {
   std::cout << "Max NPU gflops: " << macs / (1000 * npu_time_max) << std::endl;
 
   if (trace_size > 0) {
-    write_out_trace(((char *)bufC) + C_SIZE, trace_size,
-                    vm["trace_file"].as<std::string>());
+    test_utils::write_out_trace(((char *)bufC) + C_SIZE, trace_size,
+                                vm["trace_file"].as<std::string>());
   }
 
   if (VERIFY && !errors) {

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
@@ -41,7 +41,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
   for (size_t m1 = 0; m1 < M; m1++) {
@@ -90,7 +89,7 @@ int main(int argc, const char *argv[]) {
   test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-       test_utils::load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/test.cpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -39,33 +41,6 @@ constexpr int TRACE_SIZE = (0 * sizeof(uint32_t));
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
 
 template <typename T>
 void mm_out(std::vector<T> a, std::vector<T> b, std::vector<T> &r) {
@@ -111,11 +86,11 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
+       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/xrt/28_gemm_loop_nest_bf16/matrix_multiplication.h
+++ b/test/xrt/28_gemm_loop_nest_bf16/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/28_gemm_loop_nest_bf16/run.lit
+++ b/test/xrt/28_gemm_loop_nest_bf16/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/28_gemm_loop_nest_bf16/test.cpp
+++ b/test/xrt/28_gemm_loop_nest_bf16/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/matrix_multiplication.h
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/matrix_multiplication.h
@@ -14,6 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
+#include "test_utils.h"
+
 #include <boost/program_options.hpp>
 #include <cmath>
 
@@ -24,19 +26,6 @@ namespace po = boost::program_options;
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
 
 void add_default_options(po::options_description &desc) {
   desc.add_options()("help,h", "produce help message")(
@@ -66,27 +55,8 @@ void parse_options(int argc, const char *argv[], po::options_description &desc,
     std::exit(1);
   }
 
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-}
-
-// --------------------------------------------------------------------------
-// AIE Specifics
-// --------------------------------------------------------------------------
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run.lit
@@ -5,5 +5,5 @@
 
 // RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // RUN: %python %S/gen.py
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.txt
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin

--- a/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/test.cpp
+++ b/test/xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/test.cpp
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
+
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
@@ -58,7 +60,7 @@ int main(int argc, const char *argv[]) {
   srand(time(NULL));
 
   std::vector<uint32_t> instr_v =
-      matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=9ba3ce0a332b7a9bb644ab141001bbc6660d9b06
+export HASH=6f2fa9c617ea61010a8dbe32722d1414b18043fc
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,7 +14,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=d2e07e2d9c5a9640995ebda9fde10c07585dc5de
+export HASH=9ba3ce0a332b7a9bb644ab141001bbc6660d9b06
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then


### PR DESCRIPTION
* Updates for binary runtime sequence after bumping mlir-aie.
* Use mlir-aie test_utils to reduce duplicated code.