### PR TITLE
Switch Ryzen AI runner to use Ryzen AI SW for build

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -21,6 +21,7 @@ concurrency:
 env:
   DEBIAN_FRONTEND: noninteractive
   XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
+  VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
 
 jobs:
   build-repo:
@@ -69,7 +70,7 @@ jobs:
           mkdir build
           pushd build
 
-          export PATH=$PATH:/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
           cmake .. \
             -GNinja \
             -DPython3_EXECUTABLE=$(which python) \
@@ -106,7 +107,7 @@ jobs:
 
           sudo prlimit -lunlimited --pid $$
           
-          export PATH=$PATH:/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -89,7 +89,7 @@ jobs:
             -DXRT_ROOT=/opt/xilinx/xrt \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON \
-            -DAIE_VITIS_COMPONENTS='AIE;AIE2' \
+            -DAIE_VITIS_COMPONENTS='AIE2;AIE2P' \
             -DAIE_INCLUDE_INTEGRATION_TESTS=OFF
 
           ninja install

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -47,7 +47,7 @@ config.excludes = []
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.air_obj_root, "test")
+config.test_exec_root = os.path.join(config.air_obj_root, "programming_examples")
 air_runtime_lib = os.path.join(
     config.air_obj_root, "runtime_lib", config.runtime_test_target
 )

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/vm.cc
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/vm.cc
@@ -92,16 +92,18 @@ void vecmat_vectorized(const T_in *__restrict pA, const T_out *__restrict pA_s,
 
           BS0 = aie::load_v<MMUL::size_C>(pB_s1);
           pB_s1 += MMUL::size_C;
-          accfloat_C00 = mac(accfloat_C00,
-                             to_float<float, T_accum, MMUL::size_C>(
-                                 C00.template to_vector<T_accum>()),
-                             mul(pA_s[i], BS0).template to_vector<float>());
+          accfloat_C00 =
+              mac(accfloat_C00,
+                  to_float<float, aie::vector<T_accum, MMUL::size_C>>(
+                      C00.template to_vector<T_accum>()),
+                  mul(pA_s[i], BS0).template to_vector<float>());
           BS1 = aie::load_v<MMUL::size_C>(pB_s2);
           pB_s2 += MMUL::size_C;
-          accfloat_C01 = mac(accfloat_C01,
-                             to_float<float, T_accum, MMUL::size_C>(
-                                 C01.template to_vector<T_accum>()),
-                             mul(pA_s[i], BS1).template to_vector<float>());
+          accfloat_C01 =
+              mac(accfloat_C01,
+                  to_float<float, aie::vector<T_accum, MMUL::size_C>>(
+                      C01.template to_vector<T_accum>()),
+                  mul(pA_s[i], BS1).template to_vector<float>());
 
           C00.zero = true;
           C01.zero = true;

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -347,7 +347,7 @@ def lower_airrt_to_airhost(air_to_aie_module, air_placed_module, air_mlir_filena
         with open(cpp_file, "w") as f:
             f.write(emit_wrapper(segment, inc_file))
 
-        cmd = [opts.cc, "-std=c++11", "-g", "-I."]
+        cmd = [opts.cc, "-std=c++17", "-g", "-I."]
 
         # set flags for cross-compilation
         cmd += ["--sysroot=%s" % opts.sysroot] if opts.sysroot else []


### PR DESCRIPTION
Switch Ryzen AI workflow from Vitis 2023.2 to Ryzen AI SW Vitis AIE Essentials, to get aie2p support.