### PR TITLE
Remove ubuntu20.04 from CI runner matrix

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ Assert, Release ]
-        ubuntu_version: [ 20.04, 22.04 ]
+        ubuntu_version: [ 22.04 ]
 
     steps:
       # Clone the repo and its submodules. Do shallow clone to save clone
@@ -49,24 +49,6 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get install -y ninja-build clang lld
-
-      - name: Upgrade gcc
-        if: matrix.ubuntu_version == '20.04'
-        run: |
-          sudo apt install build-essential manpages-dev software-properties-common
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          GCC_VERSION=11
-          sudo apt update && sudo apt install gcc-$GCC_VERSION g++-$GCC_VERSION
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-9 \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 110 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-$GCC_VERSION \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-$GCC_VERSION \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-$GCC_VERSION
 
       - name: Install libboost
         run: sudo apt-get install -y libboost-all-dev && sudo apt-get clean

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -79,7 +79,7 @@ jobs:
         run: echo "::set-output name=hash::$(md5sum $(echo utils/clone-mlir-aie.sh))"
 
       - name: Ccache for C++ compilation
-        uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.build_type }}-${{ runner.os }}-${{ matrix.ubuntu_version }}
           max-size: 1G

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ Assert, Release ]
-        ubuntu_version: [ 20.04, 22.04 ]
+        ubuntu_version: [ 22.04 ]
 
     steps:
       # Clone the repo and its submodules. Do shallow clone to save clone
@@ -45,24 +45,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-
-      - name: Upgrade gcc
-        if: matrix.ubuntu_version == '20.04'
-        run: |
-          sudo apt install build-essential manpages-dev software-properties-common
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          GCC_VERSION=11
-          sudo apt update && sudo apt install gcc-$GCC_VERSION g++-$GCC_VERSION
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-9 \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 110 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION \
-            --slave /usr/bin/gcov gcov /usr/bin/gcov-$GCC_VERSION \
-            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-$GCC_VERSION \
-            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-$GCC_VERSION
 
       - name: Install packages
         run: sudo apt-get install -y libboost-all-dev clang lld && sudo apt-get clean

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -75,7 +75,7 @@ jobs:
         run: echo "::set-output name=hash::$(md5sum $(echo utils/clone-mlir-aie.sh))"
 
       - name: Ccache for C++ compilation
-        uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.build_type }}-${{ runner.os }}-${{ matrix.ubuntu_version }}
           max-size: 1G

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: Ccache for C++ compilation
-        uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-generatedocs-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Ccache for C++ compilation
-        uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-lintformat-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   # Run apt package manager in the CI in non-interactive mode.
-  # Otherwise, on Ubuntu 20.04 the installation of tzdata asking question
   DEBIAN_FRONTEND: noninteractive
 
 jobs:


### PR DESCRIPTION
Ubuntu 20.04 runner is now retired on GitHub.