### PR TITLE
AIRLowering: Remove redundant `scf.for` that its own canonicalizer fails to remove

### DIFF
--- a/mlir/test/Conversion/AIRLowering/air_deps.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_deps.mlir
@@ -27,10 +27,7 @@ func.func @execute() {
 
 // CHECK-LABEL: func.func @scf_for
 // CHECK: %[[V0:.*]] = airrt.wait_all : !airrt.event
-// CHECK: %[[V1:.*]] = scf.for %arg0 = %c0 to %c64 step %c1 iter_args(%[[V3:.*]] = %[[V0]]) -> (!airrt.event) {
-// CHECK:   %[[V2:.*]] = airrt.wait_all %[[V3]] : !airrt.event
-// CHECK:   scf.yield %[[V2]] : !airrt.event
-// CHECK: airrt.wait_all %[[V1]]
+// CHECK: airrt.wait_all %[[V0]]
 func.func @scf_for() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index


### PR DESCRIPTION
Currently, the `scf.for` canonicalizer is not able to remove empty loop body with nothing but `wait_all`, if any of them is merging multiple air async tokens passed in via `iter_arg`.

For example. the `scf.for` below will not get canonicalized by the `scf::ForOp::getCanonicalizationPatterns`: 

```
  %1:2 = scf.for %arg10 = %c0 to %c64 step %c1 iter_args(%iter_arg = %0, %iter_arg_1 = %8) -> (!air.async.token, !air.async.token) {
    %2 = air.wait_all async [%iter_arg, %iter_arg_1]
    scf.yield %2,  %iter_arg_1: !air.async.token, !air.async.token
  }
```