### PR TITLE
Explicitly enforce `tmpdir` when `aircc` calls `aiecc`

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -585,6 +585,7 @@ def run(mlir_module, args=None):
                     "--aie-generate-npu",
                     "--no-compile-host",
                     "--npu-insts-name=" + insts_file,
+                    "--tmpdir=" + opts.tmpdir,
                 ]
                 + aiecc_output_file_options
                 + aiecc_existing_xclbin_options


### PR DESCRIPTION
…, to avoid inconsistency in where the `aie` project gets created.