### PR TITLE
[AIR][IR] Add MLIRLinalgDialect dependency

### DIFF
--- a/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/AIR/IR/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(
   DEPENDS
   MLIRAIRIncGen
   MLIRAIROpInterfacesIncGen
+  MLIRLinalgDialect
 
   LINK_LIBS PUBLIC
   MLIRIR)


### PR DESCRIPTION
-- This commit adds MLIRLinalgDialect dependency to AIR Dialect.

Signed-off-by: Jorn Tuyls <jorn.tuyls@amd.com>

Without the above we get the following build error :-
```
In file included from /home/azureuser/iree-amd-aie/third_party/mlir-air/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp:12:
/home/azureuser/iree-amd-aie/third_party/iree/third_party/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/Linalg.h:95:10: fatal error: 'mlir/Dialect/Linalg/IR/LinalgOpsDialect.h.inc' file not found
   95 | #include "mlir/Dialect/Linalg/IR/LinalgOpsDialect.h.inc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
