### PR TITLE
Update run.lit

### DIFF
--- a/test/xrt/04_gemm_w_pack/run.lit
+++ b/test/xrt/04_gemm_w_pack/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 // RUN: %python %S/gen.py
-// RUN: clang %S/test.cpp -O3 -o test.exe -std=c++11 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: clang %S/test.cpp -O3 -o test.exe -std=c++17 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %run_on_npu1% ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin
 // RUN: %run_on_npu2% ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin


### PR DESCRIPTION
Update test to compile with `-std=c++17` for because xrt requires it.

Otherwise [this happens](https://github.com/Xilinx/mlir-air/actions/runs/15123450578/job/42574523788#step:6:1269):
```
In file included from /home/github/actions-runner/_work/mlir-air/mlir-air/test/xrt/04_gemm_w_pack/test.cpp:9:
In file included from /home/github/actions-runner/_work/mlir-air/mlir-air/mlir-aie/install/runtime_lib/x86_64/test_lib/include/test_utils.h:30:
In file included from /opt/xilinx/xrt/include/xrt/xrt_device.h:11:
/opt/xilinx/xrt/include/xrt/experimental/xrt_xclbin.h:639:21: error: no type named 'string_view' in namespace 'std'
  639 |   xclbin(const std::string_view& data);
      |                ~~~~~^
```