### PR TITLE
Update prototype workflow building air using wheels

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -15,6 +15,13 @@
 ##===----------------------------------------------------------------------===##
 
 export commithash=3c709802d31b5bc5ed3af8284b40593ff39b9eec
+DATETIME=2025051423
+WHEEL_VERSION=21.0.0.$DATETIME+${commithash:0:8}
+
+if [ x"$1" == x--get-wheel-version ]; then
+  echo $WHEEL_VERSION
+  exit 0
+fi
 
 target_dir=llvm
 

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -15,6 +15,21 @@
 ##===----------------------------------------------------------------------===##
 
 export HASH=5a67804a8458dfb0afc227ee2f38c8dff7fff62f
+DATETIME=2025052104
+WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
+
+if [ x"$1" == x--get-wheel-version ]; then
+  echo $WHEEL_VERSION
+  exit 0
+fi
+
+MLIR_PYTHON_EXTRAS_SHORTHASH=f08db06
+
+if [ x"$1" == x--get-mlir-python-extras-version ]; then
+  echo $MLIR_PYTHON_EXTRAS_SHORTHASH
+  exit 0
+fi
+
 target_dir=mlir-aie
 
 if [[ ! -d $target_dir ]]; then

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML>=5.3.1, <=6.0.1
+PyYAML>=6.0.2
 aiofiles
 filelock==3.13.1
 lit


### PR DESCRIPTION
The goal is to update mlir-air build workflow to a similar workflow as mlir-aie.
- TODO: Update CI xrt tests to use peano instead of chess.
- TODO: Release mlir-air wheels.