### PR TITLE
Make `check-air-e2e` and `check-programming-examples` independent 

### DIFF
--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -103,7 +103,12 @@ add_lit_testsuite(check-programming-examples-chess "Running AIR programming exam
 )
 set_target_properties(check-programming-examples-chess PROPERTIES FOLDER "Tests")
 
-# Meta target to run both
-add_custom_target(check-programming-examples DEPENDS check-programming-examples-peano check-programming-examples-chess)
+# Unfiltered full test suite
+add_lit_testsuite(check-programming-examples "Running AIR programming examples (all backends)"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TEST_DEPENDS}
+  ARGS ${AIR_TEST_LIT_ARGS}
+)
+set_target_properties(check-programming-examples PROPERTIES FOLDER "Tests")
 
 add_dependencies(check-all check-programming-examples)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,12 +104,18 @@ add_lit_testsuite(check-air-e2e-chess "Running AIR E2E tests (Chess backend only
 )
 set_target_properties(check-air-e2e-chess PROPERTIES FOLDER "Tests")
 
+# Unfiltered full test suite
+add_lit_testsuite(check-air-e2e "Running AIR E2E tests (all backends)"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TEST_DEPENDS}
+  ARGS ${AIR_TEST_LIT_ARGS}
+)
+set_target_properties(check-air-e2e PROPERTIES FOLDER "Tests")
+
 add_custom_target(build-check-air)
+add_dependencies(check-air-e2e build-check-air)
 add_dependencies(check-air-e2e-peano build-check-air)
 add_dependencies(check-air-e2e-chess build-check-air)
-
-# Meta target to run both
-add_custom_target(check-air-e2e DEPENDS check-air-e2e-peano check-air-e2e-chess)
 
 if(NOT TARGET check-all)
   add_custom_target(check-all)


### PR DESCRIPTION
…from their peano and chess counterparts.

So that the lit test names which do not contain either peano or chess can still run under `check-air-e2e` or `check-programming-examples`.