### PR TITLE
Enable `scf.for` on integer type

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -136,7 +136,7 @@ public:
                      memref::CopyOp>(op))
           createAsyncExecute(rewriter, op);
         else if (isa<memref::CastOp, affine::AffineApplyOp, arith::AddIOp,
-                     arith::MulIOp>(op))
+                     arith::MulIOp, arith::IndexCastOp>(op))
           createAsyncExecute(rewriter, op, op->getResult(0).getType());
         else if (auto hierarchy_op = dyn_cast<air::HierarchyInterface>(op))
           createAsyncHierarchyImpls(rewriter, hierarchy_op);

--- a/mlir/test/Transform/AIRDependency/scf_for.mlir
+++ b/mlir/test/Transform/AIRDependency/scf_for.mlir
@@ -1,0 +1,147 @@
+//===- scf_for.mlir --------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+module {
+
+  // Scf.for on IndexType.
+
+  // CHECK-LABEL: func0
+  // CHECK: scf.for{{.*}}iter_args(%[[ITERARG0:.*]] = %{{.*}})
+  // CHECK: %[[EXECTOK0:.*]], %[[EXECVAL0:.*]] = air.execute [%[[ITERARG0]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK1:.*]], %[[EXECVAL1:.*]] = air.execute [%[[EXECTOK0]], %[[ITERARG0]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+
+  // CHECK: scf.for{{.*}}iter_args(%[[ITERARG1:.*]] = %{{.*}})
+  // CHECK: %[[EXECTOK2:.*]], %[[EXECVAL2:.*]] = air.execute [%[[ITERARG1]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK3:.*]], %[[EXECVAL3:.*]] = air.execute [%[[EXECTOK2]], %[[ITERARG1]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK5:.*]], %[[EXECVAL5:.*]] = air.execute [%[[ITERARG1]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK7:.*]], %[[EXECVAL7:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK5]], %[[EXECTOK3]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK8:.*]], %[[EXECVAL8:.*]] = air.execute
+  // CHECK-NEXT: memref.alloc
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]], %[[EXECTOK7]]]
+  // CHECK: air.dma_memcpy_nd async [%[[ITERARG1]], %[[DMA0]]]
+  // CHECK: scf.yield
+  // CHECK: scf.yield
+
+  func.func @func0(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: index, %arg3: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c4_i32 = arith.constant 4 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = arith.muli %arg2, %c128 : index
+    %2 = arith.muli %arg3, %c64 : index
+    scf.for %arg4 = %c0 to %c32 step %c1 {
+      %4 = arith.muli %arg4, %c4 : index
+      %5 = arith.addi %0, %4 : index
+      scf.for %arg5 = %c0 to %c32 step %c1 {
+        %6 = arith.muli %arg5, %c2 : index
+        %7 = arith.addi %2, %6 : index
+        %9 = arith.muli %5, %c128 : index
+        %11 = arith.addi %9, %7 : index
+        %alloc = memref.alloc() : memref<4x2xf32, 2 : i32>
+        air.dma_memcpy_nd (%alloc[] [] [], %arg0[%c0, %11] [%c4, %c2] [%c128, %c1]) {id = 1 : i32} : (memref<4x2xf32, 2 : i32>, memref<*xf32>)
+        air.dma_memcpy_nd (%arg1[%c0, %11] [%c4, %c2] [%c128, %c1], %alloc[] [] []) {id = 2 : i32} : (memref<*xf32>, memref<4x2xf32, 2 : i32>)
+      }
+    }
+    return
+  }
+
+  // Scf.for on IntegerType.
+
+  // CHECK-LABEL: func1
+  // CHECK: scf.for{{.*}}iter_args(%[[ITERARG0:.*]] = %{{.*}})
+  // CHECK: %[[EXECTOK0:.*]], %[[EXECVAL0:.*]] = air.execute [%[[ITERARG0]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK1:.*]], %[[EXECVAL1:.*]] = air.execute [%[[EXECTOK0]], %[[ITERARG0]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+
+  // CHECK: scf.for{{.*}}iter_args(%[[ITERARG1:.*]] = %{{.*}})
+  // CHECK: %[[EXECTOK2:.*]], %[[EXECVAL2:.*]] = air.execute [%[[ITERARG1]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK3:.*]], %[[EXECVAL3:.*]] = air.execute [%[[EXECTOK2]], %[[ITERARG1]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK4:.*]], %[[EXECVAL4:.*]] = air.execute [%[[ITERARG1]]]
+  // CHECK-NEXT: arith.index_cast
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK5:.*]], %[[EXECVAL5:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK4]]]
+  // CHECK-NEXT: arith.muli
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK6:.*]], %[[EXECVAL6:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK3]]]
+  // CHECK-NEXT: arith.index_cast
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK7:.*]], %[[EXECVAL7:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK6]], %[[EXECTOK5]]]
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[EXECTOK8:.*]], %[[EXECVAL8:.*]] = air.execute
+  // CHECK-NEXT: memref.alloc
+  // CHECK-NEXT: air.execute_terminator
+  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]], %[[EXECTOK7]]]
+  // CHECK: air.dma_memcpy_nd async [%[[ITERARG1]], %[[DMA0]]]
+  // CHECK: scf.yield
+  // CHECK: scf.yield
+
+  func.func @func1(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: index, %arg3: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c4_i32 = arith.constant 4 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = arith.muli %arg2, %c128 : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = arith.muli %arg3, %c64 : index
+    %3 = arith.index_cast %2 : index to i32
+    scf.for %arg4 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+      %4 = arith.muli %arg4, %c4_i32 : i32
+      %5 = arith.addi %1, %4 : i32
+      scf.for %arg5 = %c0_i32 to %c32_i32 step %c1_i32  : i32 {
+        %6 = arith.muli %arg5, %c2_i32 : i32
+        %7 = arith.addi %3, %6 : i32
+        %8 = arith.index_cast %5 : i32 to index
+        %9 = arith.muli %8, %c128 : index
+        %10 = arith.index_cast %7 : i32 to index
+        %11 = arith.addi %9, %10 : index
+        %alloc = memref.alloc() : memref<4x2xf32, 2 : i32>
+        air.dma_memcpy_nd (%alloc[] [] [], %arg0[%c0, %11] [%c4, %c2] [%c128, %c1]) {id = 1 : i32} : (memref<4x2xf32, 2 : i32>, memref<*xf32>)
+        air.dma_memcpy_nd (%arg1[%c0, %11] [%c4, %c2] [%c128, %c1], %alloc[] [] []) {id = 2 : i32} : (memref<*xf32>, memref<4x2xf32, 2 : i32>)
+      }
+    }
+    return
+  }
+}
+

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-channel-wrap-and-stride.mlir
@@ -651,4 +651,92 @@ module {
     }
     return
   }
+
+  // Scf.for on integer type.
+  // CHECK-LABEL: test18
+  // CHECK: air.channel.put async {{.*}} @channel_0[%c0{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c32{{.*}}, %c32{{.*}}, %c4{{.*}}, %c2{{.*}}] [%c512{{.*}}, %c2{{.*}}, %c128{{.*}}, %c1{{.*}}])
+  // CHECK: air.channel.put async {{.*}} @channel_0[%c1{{.*}}, %c0{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c16384{{.*}}] [%c32{{.*}}, %c32{{.*}}, %c4{{.*}}, %c2{{.*}}] [%c512{{.*}}, %c2{{.*}}, %c128{{.*}}, %c1{{.*}}])
+  // CHECK: air.channel.put async {{.*}} @channel_0[%c0{{.*}}, %c1{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c64{{.*}}] [%c32{{.*}}, %c32{{.*}}, %c4{{.*}}, %c2{{.*}}] [%c512{{.*}}, %c2{{.*}}, %c128{{.*}}, %c1{{.*}}])
+  // CHECK: air.channel.put async {{.*}} @channel_0[%c1{{.*}}, %c1{{.*}}] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c16448{{.*}}] [%c32{{.*}}, %c32{{.*}}, %c4{{.*}}, %c2{{.*}}] [%c512{{.*}}, %c2{{.*}}, %c128{{.*}}, %c1{{.*}}])
+
+  func.func @test18(%arg0: memref<*xf32>, %arg1: memref<*xf32>) {
+    %0 = air.segment @kernel_0 async  args(%arg2=%arg0) : memref<*xf32> {
+      %c1_i32 = arith.constant 1 : i32
+      %c32_i32 = arith.constant 32 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %c2_i32 = arith.constant 2 : i32
+      %c4_i32 = arith.constant 4 : i32
+      %c64 = arith.constant 64 : index
+      %c128 = arith.constant 128 : index
+      %c4 = arith.constant 4 : index
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %1 = air.wait_all async 
+      %2 = scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) init (%1) -> !air.async.token {
+        %async_token, %results = air.execute -> (index) {
+          %5 = arith.muli %arg3, %c128 : index
+          air.execute_terminator %5 : index
+        }
+        %async_token_0, %results_1 = air.execute [%async_token] -> (i32) {
+          %5 = arith.index_cast %results : index to i32
+          air.execute_terminator %5 : i32
+        }
+        %async_token_2, %results_3 = air.execute -> (index) {
+          %5 = arith.muli %arg4, %c64 : index
+          air.execute_terminator %5 : index
+        }
+        %async_token_4, %results_5 = air.execute [%async_token_2] -> (i32) {
+          %5 = arith.index_cast %results_3 : index to i32
+          air.execute_terminator %5 : i32
+        }
+        %3 = air.wait_all async [%async_token_0, %async_token_4] 
+        %4 = scf.for %arg5 = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%arg6 = %3) -> (!air.async.token)  : i32 {
+          %async_token_6, %results_7 = air.execute [%arg6] -> (i32) {
+            %6 = arith.muli %arg5, %c4_i32 : i32
+            air.execute_terminator %6 : i32
+          }
+          %async_token_8, %results_9 = air.execute [%async_token_6] -> (i32) {
+            %6 = arith.addi %results_1, %results_7 : i32
+            air.execute_terminator %6 : i32
+          }
+          %5 = scf.for %arg7 = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%arg8 = %async_token_8) -> (!air.async.token)  : i32 {
+            %async_token_10, %results_11 = air.execute [%arg8] -> (i32) {
+              %7 = arith.muli %arg7, %c2_i32 : i32
+              air.execute_terminator %7 : i32
+            }
+            %async_token_12, %results_13 = air.execute [%async_token_10] -> (i32) {
+              %7 = arith.addi %results_5, %results_11 : i32
+              air.execute_terminator %7 : i32
+            }
+            %async_token_14, %results_15 = air.execute [%arg8] -> (index) {
+              %7 = arith.index_cast %results_9 : i32 to index
+              air.execute_terminator %7 : index
+            }
+            %async_token_16, %results_17 = air.execute [%async_token_14] -> (index) {
+              %7 = arith.muli %results_15, %c128 : index
+              air.execute_terminator %7 : index
+            }
+            %async_token_18, %results_19 = air.execute [%async_token_12] -> (index) {
+              %7 = arith.index_cast %results_13 : i32 to index
+              air.execute_terminator %7 : index
+            }
+            %async_token_20, %results_21 = air.execute [%async_token_18, %async_token_16] -> (index) {
+              %7 = arith.addi %results_17, %results_19 : index
+              air.execute_terminator %7 : index
+            }
+            %6 = air.channel.put async [%async_token_20]  @channel_0[%arg3, %arg4] (%arg2[%c0, %results_21] [%c4, %c2] [%c128, %c1]) {id = 1 : i32} : (memref<*xf32>)
+            scf.yield %6 : !air.async.token
+          }
+          scf.yield %5 : !air.async.token
+        }
+        scf.reduce(%4 : !air.async.token) {
+        ^bb0(%arg5: !air.async.token, %arg6: !air.async.token):
+          %5 = air.wait_all async [%arg5, %arg6] 
+          scf.reduce.return %5 : !air.async.token
+        }
+      }
+    }
+    return
+  }
 }


### PR DESCRIPTION
For loops in triton generates `scf.for` loops with bounds, step and induction variable in integer type, rather than the default index type.