### PR TITLE
Add air runner example simulating the matrix multiplication example from programming examples

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -144,7 +144,6 @@ jobs:
           ninja check-air-cpp
           ninja check-air-mlir
           ninja check-air-python
-          ninja check-air-runner
           popd
           rm -rf build_assert
         env:
@@ -173,7 +172,7 @@ jobs:
             -DLLVM_USE_LINKER=lld \
             -DCMAKE_INSTALL_PREFIX=install
           make -j$(nproc)
-          make check-air-cpp check-air-mlir check-air-python check-air-runner
+          make check-air-cpp check-air-mlir check-air-python
           popd
           rm -rf build_release
         env:

--- a/programming_examples/matrix_multiplication/bf16/mm.cc
+++ b/programming_examples/matrix_multiplication/bf16/mm.cc
@@ -294,8 +294,8 @@ extern "C" {
 
 #define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
                                  mlir_type_out, r, s, t)                       \
-  void matmul_##mlir_type_in##_##mlir_type_out(ctype_in *a_in, ctype_in *b_in, \
-                                               ctype_out *c_out) {             \
+  void op_has_no_registered_library_name(ctype_in *a_in, ctype_in *b_in,       \
+                                         ctype_out *c_out) {                   \
     matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
         DIM_M, DIM_K, DIM_N>(a_in, b_in, c_out);                               \
   }

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -5,15 +5,30 @@ from ml_dtypes import bfloat16
 
 from air.ir import *
 from air.dialects.affine import apply as affine_apply
+from air.dialects.linalg import fill
 from air.dialects.air import *
 from air.dialects.arith import ConstantOp
 from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.func import FuncOp, CallOp
+from air.dialects.func import FuncOp
 from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
+from air.extras import types as extrasT
+from air.dialects.linalg.opdsl.lang import *
 
 range_ = for_
+
+
+@linalg_structured_op()
+def block_matmul(
+    A=TensorDef(T, S.a, S.c, S.f, S.d, S.g, S.i),
+    B=TensorDef(T, S.b, S.c, S.e, S.f, S.i, S.h),
+    C=TensorDef(T, S.b, S.a, S.e, S.d, S.g, S.h, output=True),
+):
+    domain(D.a, D.b, D.c, D.d, D.e, D.f, D.g, D.h, D.i)
+    C[D.b, D.a, D.e, D.d, D.g, D.h] += (
+        A[D.a, D.c, D.f, D.d, D.g, D.i] * B[D.b, D.c, D.e, D.f, D.i, D.h]
+    )
 
 
 @module_builder
@@ -48,7 +63,7 @@ def build_module(
     memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
 
     # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
     a_l1_size = [
         1,
         1,
@@ -114,19 +129,6 @@ def build_module(
         element_type=xrt_dtype_out,
         memory_space=l1_mem_space,
     )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_bf16_view1x1x16x16x4x4xbf16as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    matmul_func = FuncOp(
-        "matmul_bf16_bf16",
-        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, matmul_func]:
-        func.attributes["link_with"] = StringAttr.get("mm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
 
     @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
     def matmul_bf16(arg0, arg1, arg2):
@@ -159,7 +161,7 @@ def build_module(
                 a_size_l2 = [herd_m, 1, tile_m, tile_k_l2]
                 b_size_l2 = [1, herd_n, tile_k_l2, tile_n]
                 c_size_l2 = [herd_m, herd_n, tile_m, tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
+                l2_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L2)
                 l2MemrefTyA = MemRefType.get(
                     shape=a_size_l2,
                     element_type=xrt_dtype_in,
@@ -239,9 +241,7 @@ def build_module(
                         strides=[1, 1, 1, 1, 1, 1],
                     )
                     zero_const = ConstantOp(FloatAttr.get(xrt_dtype_out, 0.0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_subview])
-
-                herd_body.attributes["link_with"] = StringAttr.get("mm.o")
+                    zero_fill = fill(zero_const, outs=[l1_c_subview])
 
                 for i in range_(0, k // tile_k_l2):
                     # Affine map for k (l2) loop iv
@@ -361,13 +361,8 @@ def build_module(
                                 ],
                                 strides=[1, 1, 1, 1, 1, 1],
                             )
-                            matmul = CallOp(
-                                matmul_func,
-                                [_l1_a, _l1_b, l1_c_subview],
-                            )
+                            matmul = block_matmul(_l1_a, _l1_b, outs=[l1_c_subview])
                             yield_([])
-
-                        herd_body.attributes["link_with"] = StringAttr.get("mm.o")
 
                     yield_([])
 
@@ -438,8 +433,6 @@ def build_module(
                         ],
                     )
 
-                herd_body.attributes["link_with"] = StringAttr.get("mm.o")
-
                 dma_memcpy_nd(
                     l3_c_data_s,
                     l2_c_data,
@@ -488,7 +481,7 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "--m", type=int, default=M, help="K dimension size in a (MxK) * (KxN) matmul"
+        "--m", type=int, default=M, help="M dimension size in a (MxK) * (KxN) matmul"
     )
     parser.add_argument(
         "--k", type=int, default=K, help="K dimension size in a (MxK) * (KxN) matmul"
@@ -600,6 +593,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[2, 2],
+            lower_linalg_to_func="mm.o",
         )
         exit(
             runner.run_test(
@@ -616,6 +610,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[2, 2],
+            lower_linalg_to_func="mm.o",
         )
         module_function = backend.compile(mlir_module)
 

--- a/programming_examples/matrix_multiplication/i16/mm.cc
+++ b/programming_examples/matrix_multiplication/i16/mm.cc
@@ -183,8 +183,8 @@ extern "C" {
 
 #define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
                                  mlir_type_out, r, s, t)                       \
-  void matmul_##mlir_type_in##_##mlir_type_out(ctype_in *a_in, ctype_in *b_in, \
-                                               ctype_out *c_out) {             \
+  void op_has_no_registered_library_name(ctype_in *a_in, ctype_in *b_in,       \
+                                         ctype_out *c_out) {                   \
     matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
         DIM_M, DIM_K, DIM_N>(a_in, b_in, c_out);                               \
   }

--- a/programming_examples/matrix_multiplication/i8/mm.cc
+++ b/programming_examples/matrix_multiplication/i8/mm.cc
@@ -221,8 +221,8 @@ extern "C" {
 
 #define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
                                  mlir_type_out, r, s, t)                       \
-  void matmul_##mlir_type_in##_##mlir_type_out(ctype_in *a_in, ctype_in *b_in, \
-                                               ctype_out *c_out) {             \
+  void op_has_no_registered_library_name(ctype_in *a_in, ctype_in *b_in,       \
+                                         ctype_out *c_out) {                   \
     matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
         DIM_M, DIM_K, DIM_N>(a_in, b_in, c_out);                               \
   }
@@ -243,7 +243,7 @@ extern "C" {
 
 #define zero_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,              \
                                mlir_type_out, r, s, t)                         \
-  void linalg_fill_##mlir_type_out##_view1x1x16x16x4x4x##mlir_type_out##as2(   \
+  void linalg_fill_##mlir_type_out##_view1x1x16x16x4x8x##mlir_type_out##as2(   \
       ctype_out *c_out) {                                                      \
     zero_vectorized<ctype_out, DIM_M, DIM_N>(c_out);                           \
   }

--- a/programming_examples/matrix_multiplication/i8/run.py
+++ b/programming_examples/matrix_multiplication/i8/run.py
@@ -4,15 +4,30 @@ import argparse
 
 from air.ir import *
 from air.dialects.affine import apply as affine_apply
+from air.dialects.linalg import fill
 from air.dialects.air import *
 from air.dialects.arith import ConstantOp
 from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.func import FuncOp, CallOp
+from air.dialects.func import FuncOp
 from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
+from air.extras import types as extrasT
+from air.dialects.linalg.opdsl.lang import *
 
 range_ = for_
+
+
+@linalg_structured_op()
+def block_matmul(
+    A=TensorDef(T, S.a, S.c, S.f, S.d, S.g, S.i),
+    B=TensorDef(T, S.b, S.c, S.e, S.f, S.i, S.h),
+    C=TensorDef(U, S.b, S.a, S.e, S.d, S.g, S.h, output=True),
+):
+    domain(D.a, D.b, D.c, D.d, D.e, D.f, D.g, D.h, D.i)
+    C[D.b, D.a, D.e, D.d, D.g, D.h] += (
+        TypeFn.cast_signed(U, A[D.a, D.c, D.f, D.d, D.g, D.i])
+    ) * (TypeFn.cast_signed(U, B[D.b, D.c, D.e, D.f, D.i, D.h]))
 
 
 @module_builder
@@ -47,7 +62,7 @@ def build_module(
     memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
 
     # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
     a_l1_size = [
         1,
         1,
@@ -113,19 +128,6 @@ def build_module(
         element_type=xrt_dtype_out,
         memory_space=l1_mem_space,
     )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_i16_view1x1x16x16x4x4xi16as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    matmul_func = FuncOp(
-        "matmul_i8_i16",
-        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, matmul_func]:
-        func.attributes["link_with"] = StringAttr.get("mm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
 
     @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
     def matmul_bf16(arg0, arg1, arg2):
@@ -158,7 +160,7 @@ def build_module(
                 a_size_l2 = [herd_m, 1, tile_m, tile_k_l2]
                 b_size_l2 = [1, herd_n, tile_k_l2, tile_n]
                 c_size_l2 = [herd_m, herd_n, tile_m, tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
+                l2_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L2)
                 l2MemrefTyA = MemRefType.get(
                     shape=a_size_l2,
                     element_type=xrt_dtype_in,
@@ -238,9 +240,7 @@ def build_module(
                         strides=[1, 1, 1, 1, 1, 1],
                     )
                     zero_const = ConstantOp(IntegerAttr.get(xrt_dtype_out, 0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_subview])
-
-                herd_body.attributes["link_with"] = StringAttr.get("mm.o")
+                    zero_fill = fill(zero_const, outs=[l1_c_subview])
 
                 for i in range_(0, k // tile_k_l2):
                     # Affine map for k (l2) loop iv
@@ -360,13 +360,8 @@ def build_module(
                                 ],
                                 strides=[1, 1, 1, 1, 1, 1],
                             )
-                            matmul = CallOp(
-                                matmul_func,
-                                [_l1_a, _l1_b, l1_c_subview],
-                            )
+                            matmul = block_matmul(_l1_a, _l1_b, outs=[l1_c_subview])
                             yield_([])
-
-                        herd_body.attributes["link_with"] = StringAttr.get("mm.o")
 
                     yield_([])
 
@@ -437,8 +432,6 @@ def build_module(
                         ],
                     )
 
-                herd_body.attributes["link_with"] = StringAttr.get("mm.o")
-
                 dma_memcpy_nd(
                     l3_c_data_s,
                     l2_c_data,
@@ -487,7 +480,7 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "--m", type=int, default=M, help="K dimension size in a (MxK) * (KxN) matmul"
+        "--m", type=int, default=M, help="M dimension size in a (MxK) * (KxN) matmul"
     )
     parser.add_argument(
         "--k", type=int, default=K, help="K dimension size in a (MxK) * (KxN) matmul"
@@ -598,6 +591,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[2, 2],
+            lower_linalg_to_func="mm.o",
         )
         exit(
             runner.run_test(
@@ -614,6 +608,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[2, 2],
+            lower_linalg_to_func="mm.o",
         )
         module_function = backend.compile(mlir_module)
 

--- a/test/airrunner/matmul_bf16_vectorized/Makefile
+++ b/test/airrunner/matmul_bf16_vectorized/Makefile
@@ -1,0 +1,16 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+programming_examples_dir := ${srcdir}/../../../programming_examples
+matmul_example_dir := ${programming_examples_dir}/matrix_multiplication/bf16
+BUILD_DIR := build
+
+all: run
+
+run:
+	mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && ${powershell} python3 ${matmul_example_dir}/run.py -p --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 > input.mlir
+	cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/mmult_aie2.py 
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/test/airrunner/matmul_bf16_vectorized/mmult_aie2.py
+++ b/test/airrunner/matmul_bf16_vectorized/mmult_aie2.py
@@ -1,0 +1,154 @@
+# mmult_aie2.py -*- Python -*-
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import air.compiler.util
+
+from air.dialects import func, linalg, tensor, arith, memref
+from air.dialects.air import module_builder
+from air.dialects.linalg.opdsl.lang import *
+from air.ir import *
+from air.compiler.util import run_transform
+import air.passmanager
+
+import sys
+import argparse
+
+# Default values.
+HERD_M = 4
+HERD_N = 4
+
+parser = argparse.ArgumentParser(prog="mmult_aie2.py")
+parser.add_argument(
+    "--input-file",
+    default="input.mlir",
+    type=str,
+    help="Input file containing input IR in AIR dialect",
+)
+parser.add_argument(
+    "--herd-m",
+    type=int,
+    default=HERD_M,
+    help="Number of L1 tiles along the M dimension",
+)
+parser.add_argument(
+    "--herd-n",
+    type=int,
+    default=HERD_N,
+    help="Number of L1 tiles along the N dimension",
+)
+opts = parser.parse_args()
+
+context = air.ir.Context()
+with open(opts.input_file, "r") as f:
+    air_ir_string = f.read()
+air_module = Module.parse(air_ir_string, context=context)
+
+# generate dependency information for runner
+pipeline = (
+    "builtin.module("
+    + ",".join(
+        [
+            "air-dependency",
+            "air-hoist-dma-in-accum-pattern",
+            "air-broadcast-detection",
+            "air-specialize-dma-broadcast",
+            "air-dma-to-channel",
+            "canonicalize",
+            "cse",
+            "air-dependency-canonicalize",
+            "canonicalize",
+            "cse",
+            "air-isolate-async-dma-loop-nests",
+            "canonicalize",
+            "cse",
+            "air-fuse-channels",
+            "func.func(air-fuse-alloc-dealloc)",
+            "func.func(air-shrink-memref-sizes-by-access)",
+            "air-label-scf-for-to-ping-pong",
+            "air-ping-pong-transform",
+            "canonicalize",
+            "cse",
+            "air-place-herds{num-rows="
+            + str(opts.herd_m)
+            + " num-cols="
+            + str(opts.herd_n)
+            + " row-anchor=0 col-anchor=0}",
+        ]
+    )
+    + ")"
+)
+pm = air.passmanager.PassManager.parse(pipeline, context=context)
+pm.run(air_module.operation)
+
+with open("air_ir_debug.mlir", "w") as f:
+    f.write(str(air_module))
+
+arch = {
+    "clock": 1000000000,
+    "cores": 1,
+    "datatypes": [
+        {"bytes": 1, "name": "i8"},
+        {"bytes": 2, "name": "bf16"},
+        {"bytes": 4, "name": "i32"},
+    ],
+    "devicename": "testdevice",
+    "kernels": {
+        "linalg.copy": {
+            "datatypes": {
+                "i8": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                "bf16": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                "i32": {"ops_per_core_per_cycle": 16, "efficiency": 1},
+            },
+            "name": "linalg.copy",
+        },
+        "linalg.fill": {
+            "datatypes": {
+                "i8": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                "bf16": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                "i32": {"ops_per_core_per_cycle": 16, "efficiency": 1},
+            },
+            "name": "linalg.fill",
+        },
+        "linalg.generic": {
+            "datatypes": {
+                "i8": {"macs_per_core_per_cycle": 256, "efficiency": 1},
+                "bf16": {"macs_per_core_per_cycle": 128, "efficiency": 1},
+                "i32": {"macs_per_core_per_cycle": 1, "efficiency": 1},
+            },
+            "name": "linalg.generic",
+        },
+        "linalg.matmul": {
+            "datatypes": {
+                "i8": {"macs_per_core_per_cycle": 256, "efficiency": 1},
+                "bf16": {"macs_per_core_per_cycle": 128, "efficiency": 1},
+                "i32": {"macs_per_core_per_cycle": 1, "efficiency": 1},
+            },
+            "name": "linalg.matmul",
+        },
+    },
+    "dus": {
+        "count": [4, 4],
+        "memory": {"memory_space": "L2", "bytes": 524288},
+        "ports": {
+            "outbound": {"count": 6, "bytes_per_second": 4000000000},
+            "inbound": {"count": 6, "bytes_per_second": 4000000000},
+        },
+        "tiles": {
+            "count": [1, 4],
+            "memory": {"memory_space": "L1", "bytes": 65536},
+            "ports": {
+                "outbound": {"count": 2, "bytes_per_second": 4000000000},
+                "inbound": {"count": 2, "bytes_per_second": 4000000000},
+            },
+        },
+    },
+    "noc": {
+        "outbound": {"count": 8, "bytes_per_second": 4000000000},
+        "inbound": {"count": 8, "bytes_per_second": 4000000000},
+    },
+}
+
+runner = air.compiler.util.Runner(arch, "trace.out", "core")
+trace = runner.run(air_module, "matmul_bf16")

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -1,0 +1,8 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// RUN: mkdir -p test_airrunner
+// RUN: cd test_airrunner
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run | FileCheck %s
+// CHECK: Latency:


### PR DESCRIPTION
- Changed the matrix multiplication programming example from having func.call frontend to linalg.generic frontend.