### PR TITLE
Remove token generation for pure ops

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -45,7 +45,7 @@ void traceDependentInductionVar(SmallVector<Value, 1> candidate_scalar_operands,
 void traceDependentInductionVar(air::MemcpyInterface memcpyif_op,
                                 SmallVector<Value, 1> &loop_dep_history,
                                 std::vector<Operation *> &op_history);
-void traceDependentInductionVar(air::AsyncOpInterface async_op,
+void traceDependentInductionVar(Operation *op,
                                 SmallVector<Value, 1> &loop_dep_history,
                                 std::vector<Operation *> &op_history);
 void traceDependentHerdId(air::AsyncOpInterface async_op,

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -135,9 +135,6 @@ public:
         else if (isa<linalg::LinalgOp, func::CallOp, memref::DeallocOp,
                      memref::CopyOp>(op))
           createAsyncExecute(rewriter, op);
-        else if (isa<memref::CastOp, affine::AffineApplyOp, arith::AddIOp,
-                     arith::MulIOp, arith::IndexCastOp>(op))
-          createAsyncExecute(rewriter, op, op->getResult(0).getType());
         else if (auto hierarchy_op = dyn_cast<air::HierarchyInterface>(op))
           createAsyncHierarchyImpls(rewriter, hierarchy_op);
         // Create async execute region for memref.alloc
@@ -154,8 +151,7 @@ public:
         else {
           bool isCandidateExecute = false;
           for (auto operand : op->getOperands()) {
-            if (llvm::isa<BaseMemRefType>(operand.getType()) ||
-                llvm::isa<IndexType>(operand.getType())) {
+            if (llvm::isa<BaseMemRefType>(operand.getType())) {
               isCandidateExecute = true;
             }
           }

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1080,12 +1080,15 @@ scf::ForOp getScfForFromVal(Value val) {
   auto defOp = val.getDefiningOp();
   if (!defOp)
     return scf::ForOp();
+  SetVector<Value> opers;
   if (auto exec = dyn_cast<air::ExecuteOp>(defOp)) {
-    SetVector<Value> opers;
     getUsedValuesDefinedAbove(exec.getRegion(), opers);
-    for (auto oper : opers)
-      if (auto res = scf::getForInductionVarOwner(oper))
-        return res;
+  } else {
+    opers.insert(defOp->getOperands().begin(), defOp->getOperands().end());
+  }
+  for (auto oper : opers) {
+    if (auto res = scf::getForInductionVarOwner(oper))
+      return res;
   }
   return scf::ForOp();
 }

--- a/mlir/test/Transform/AIRDependency/air_channel.mlir
+++ b/mlir/test/Transform/AIRDependency/air_channel.mlir
@@ -47,7 +47,7 @@ module {
         air.channel.put @channel_2[] (%arg7[%arg16, %18] [%c64_new, %c64_new] [%c1024_new, %c1_new]) : (memref<1024x1024xbf16>)
       }
 // CHECK: %[[EVENT4:.*]] = air.wait_all async [%[[EVENT2]], %[[EVENT3]]]
-// CHECK: %[[EVENT5:.*]] = air.channel.put async [%[[EVENT6:.*]], %[[EVENT7:.*]]]{{.*}}@channel_3[]
+// CHECK: %[[EVENT5:.*]] = air.channel.put async{{.*}}@channel_3[]
       air.channel.put @channel_3[] (%arg8[%17, %18] [%c64_new, %c64_new] [%c1024_new, %c1_new]) : (memref<24576x1024xbf16>)
       
       air.segment  args(%arg9=%arg2, %arg10=%arg3, %arg11=%arg4, %arg12=%arg5, %arg13=%arg6, %arg14=%arg7) : index, index, index, index, memref<24576x1024xbf16>, memref<1024x1024xbf16> {
@@ -146,20 +146,16 @@ module {
 // CHECK: %[[VAL1:.*]] = air.channel.get async [%[[VAL0]]]
 // CHECK: %[[VAL2:.*]] = air.channel.get async [%[[VAL0]]]
 // CHECK: scf.for {{.*}}iter_args(%[[VAL3:.*]] = %{{.*}})
-// CHECK: %[[VAL4:.*]], %[[RES0:.*]] = air.execute [%[[VAL3]]]
-// CHECK: air.channel.put async [%[[VAL4]], %[[VAL3]]]
-// CHECK: %[[VAL5:.*]], %[[RES1:.*]] = air.execute [%[[VAL3]]]
-// CHECK: air.channel.put async [%[[VAL5]], %[[VAL3]]]
+// CHECK: air.channel.put async [%[[VAL3]]]
+// CHECK: air.channel.put async [%[[VAL3]]]
 // CHECK: scf.yield
 
 // CHECK: scf.for {{.*}}iter_args(%[[VAL6:.*]] = %{{.*}})
 // CHECK: %[[VAL7:.*]] = air.channel.get async [%[[VAL6]]]
 // CHECK: %[[VAL8:.*]] = air.channel.get async [%[[VAL6]]]
 // CHECK: scf.for {{.*}}iter_args(%[[VAL9:.*]] = %{{.*}})
-// CHECK: %[[VAL10:.*]], %[[RES2:.*]] = air.execute [%[[VAL9]]]
-// CHECK: air.channel.put async [%[[VAL10]], %[[VAL9]]]
-// CHECK: %[[VAL11:.*]], %[[RES3:.*]] = air.execute [%[[VAL9]]]
-// CHECK: air.channel.put async [%[[VAL11]], %[[VAL9]]]
+// CHECK: air.channel.put async [%[[VAL9]]]
+// CHECK: air.channel.put async [%[[VAL9]]]
 // CHECK: scf.yield
 
 #map = affine_map<()[s0] -> (s0 * 96)>

--- a/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_launch_dma_memcpy_nd.mlir
@@ -21,12 +21,11 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.launch @memcpy_nd async
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/air_partition_dma_memcpy_nd.mlir
@@ -21,12 +21,11 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.segment @memcpy_nd async unroll
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg3[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg3[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/dma_memcpy_nd.mlir
@@ -21,12 +21,11 @@ func.func @memcpy_nd(%arg0: memref<4096xi32>) {
   // CHECK: %[[EVENT0:.*]] = air.herd @memcpy_nd async
     %c32 = arith.constant 32 : index
     %0 = arith.muli %arg1, %c32 : index
-    // CHECK: %[[EVENT1:.*]], %[[EVENT2:.*]] = air.execute
     %1 = memref.alloc() : memref<32xi32, 2>
     // CHECK: %[[EVENT3:.*]], %[[EVENT4:.*]] = air.execute
     %c1_0 = arith.constant 1 : index
     air.dma_memcpy_nd (%1[] [] [], %arg5[%0] [%c32] [%c1_0]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
-    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT1]]{{.*}}, {{.*}}%[[EVENT3]]{{.*}}]
+    // CHECK: %[[EVENT5:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT3]]{{.*}}]
     air.dma_memcpy_nd (%arg5[%0] [%c32] [%c1_0], %1[] [] []) {id = 2 : i32} : (memref<4096xi32>, memref<32xi32, 2>)
     // CHECK: %[[EVENT6:.*]] = air.dma_memcpy_nd async [{{.*}}%[[EVENT5]]{{.*}}]
     memref.dealloc %1 : memref<32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/matmul_nd.mlir
+++ b/mlir/test/Transform/AIRDependency/matmul_nd.mlir
@@ -21,8 +21,6 @@ module attributes {torch.debug_module_name = "mmult"}  {
     linalg.fill ins(%c0_i32 : i32) outs(%0 : memref<64x64xi32>)
     // CHECK: = air.execute
     %1 = memref.cast %arg2 : memref<?x?xi32> to memref<64x64xi32>
-    // CHECK: = air.execute
-    // CHECK: air.execute_terminator
     linalg.copy ins(%0 : memref<64x64xi32>) outs(%1 : memref<64x64xi32>)
     // CHECK: = air.execute
     %2 = memref.alloc() : memref<64x64xi32, 1>
@@ -47,11 +45,7 @@ module attributes {torch.debug_module_name = "mmult"}  {
       %c64_1 = arith.constant 64 : index
       %c1_2 = arith.constant 1 : index
       %5 = arith.muli %arg3, %c32 : index
-      // CHECK: = air.execute
-      // CHECK: air.execute_terminator
       %6 = arith.muli %arg4, %c32 : index
-      // CHECK: = air.execute
-      // CHECK: air.execute_terminator
       // CHECK: = air.wait_all async
       scf.for %arg10 = %c0_0 to %c64_1 step %c32 {
         %7 = memref.alloc() : memref<32x32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/memref_reshape.mlir
+++ b/mlir/test/Transform/AIRDependency/memref_reshape.mlir
@@ -44,11 +44,7 @@ module {
       // CHECK-NOT: = air.execute
       // CHECK-NOT: air.execute_terminator
       %3 = arith.muli %arg2, %c8 : index
-      // CHECK: = air.execute
-      // CHECK: air.execute_terminator
       %4 = arith.muli %arg2, %c32_0 : index
-      // CHECK: = air.execute
-      // CHECK: air.execute_terminator
       // CHECK: = air.wait_all async
       scf.for %arg8 = %c0_0 to %c64_0 step %c32_0 {
         %5 = memref.alloc() : memref<8x4x32xi32, 2>

--- a/mlir/test/Transform/AIRDependency/parallel_herds.mlir
+++ b/mlir/test/Transform/AIRDependency/parallel_herds.mlir
@@ -10,8 +10,8 @@
 // The second herd should not depend on the first
 
 // CHECK: %[[EVENT0:.*]] = scf.for
-// CHECK: air.execute_terminator {{.*}} : index
-// CHECK: } {id = 14 : i32}
+// CHECK: scf.yield
+// CHECK-NEXT: }
 // CHECK-NOT: %[[EVENT1:.*]] = air.wait_all async [{{.*}}%[[EVENT0]]
 // CHECK: %[[EVENT2:.*]] = scf.for
 

--- a/mlir/test/Transform/AIRDependency/scf_for.mlir
+++ b/mlir/test/Transform/AIRDependency/scf_for.mlir
@@ -13,30 +13,18 @@ module {
 
   // CHECK-LABEL: func0
   // CHECK: scf.for{{.*}}iter_args(%[[ITERARG0:.*]] = %{{.*}})
-  // CHECK: %[[EXECTOK0:.*]], %[[EXECVAL0:.*]] = air.execute [%[[ITERARG0]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK1:.*]], %[[EXECVAL1:.*]] = air.execute [%[[EXECTOK0]], %[[ITERARG0]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
+  // CHECK: arith.muli
+  // CHECK: arith.addi
 
   // CHECK: scf.for{{.*}}iter_args(%[[ITERARG1:.*]] = %{{.*}})
-  // CHECK: %[[EXECTOK2:.*]], %[[EXECVAL2:.*]] = air.execute [%[[ITERARG1]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK3:.*]], %[[EXECVAL3:.*]] = air.execute [%[[EXECTOK2]], %[[ITERARG1]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK5:.*]], %[[EXECVAL5:.*]] = air.execute [%[[ITERARG1]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK7:.*]], %[[EXECVAL7:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK5]], %[[EXECTOK3]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
+  // CHECK: arith.muli
+  // CHECK: arith.addi
+  // CHECK: arith.muli
+  // CHECK: arith.addi
   // CHECK: %[[EXECTOK8:.*]], %[[EXECVAL8:.*]] = air.execute
   // CHECK-NEXT: memref.alloc
   // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]], %[[EXECTOK7]]]
+  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]]]
   // CHECK: air.dma_memcpy_nd async [%[[ITERARG1]], %[[DMA0]]]
   // CHECK: scf.yield
   // CHECK: scf.yield
@@ -76,36 +64,20 @@ module {
 
   // CHECK-LABEL: func1
   // CHECK: scf.for{{.*}}iter_args(%[[ITERARG0:.*]] = %{{.*}})
-  // CHECK: %[[EXECTOK0:.*]], %[[EXECVAL0:.*]] = air.execute [%[[ITERARG0]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK1:.*]], %[[EXECVAL1:.*]] = air.execute [%[[EXECTOK0]], %[[ITERARG0]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
+  // CHECK: arith.muli
+  // CHECK: arith.addi
 
   // CHECK: scf.for{{.*}}iter_args(%[[ITERARG1:.*]] = %{{.*}})
-  // CHECK: %[[EXECTOK2:.*]], %[[EXECVAL2:.*]] = air.execute [%[[ITERARG1]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK3:.*]], %[[EXECVAL3:.*]] = air.execute [%[[EXECTOK2]], %[[ITERARG1]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK4:.*]], %[[EXECVAL4:.*]] = air.execute [%[[ITERARG1]]]
-  // CHECK-NEXT: arith.index_cast
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK5:.*]], %[[EXECVAL5:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK4]]]
-  // CHECK-NEXT: arith.muli
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK6:.*]], %[[EXECVAL6:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK3]]]
-  // CHECK-NEXT: arith.index_cast
-  // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[EXECTOK7:.*]], %[[EXECVAL7:.*]] = air.execute [%[[ITERARG1]], %[[EXECTOK6]], %[[EXECTOK5]]]
-  // CHECK-NEXT: arith.addi
-  // CHECK-NEXT: air.execute_terminator
+  // CHECK: arith.muli
+  // CHECK: arith.addi
+  // CHECK: arith.index_cast
+  // CHECK: arith.muli
+  // CHECK: arith.index_cast
+  // CHECK: arith.addi
   // CHECK: %[[EXECTOK8:.*]], %[[EXECVAL8:.*]] = air.execute
   // CHECK-NEXT: memref.alloc
   // CHECK-NEXT: air.execute_terminator
-  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]], %[[EXECTOK7]]]
+  // CHECK: %[[DMA0:.*]] = air.dma_memcpy_nd async [%[[ITERARG1]], %[[EXECTOK8]]]
   // CHECK: air.dma_memcpy_nd async [%[[ITERARG1]], %[[DMA0]]]
   // CHECK: scf.yield
   // CHECK: scf.yield

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/prune_linalg_generic_dma.mlir
@@ -34,10 +34,8 @@ module attributes {torch.debug_module_name = "model"} {
       air.segment args(%arg9=%arg2, %arg10=%arg3, %arg11=%arg4, %arg12=%arg5, %arg13=%5, %arg14=%6) : index, index, index, index, memref<64x64xbf16, 1>, memref<64x64xbf16, 1> {
       // CHECK: %[[EVENT0:.*]], %[[VALUE0:.*]] = air.execute
       // CHECK: %[[EVENT1:.*]], %[[VALUE1:.*]] = air.execute
-      // CHECK: %[[EVENT2:.*]], %[[VALUE2:.*]] = air.execute
-      // CHECK: %[[EVENT3:.*]], %[[VALUE3:.*]] = air.execute
       // CHECK: %[[EVENT4:.*]] = air.dma_memcpy_nd async 
-      // CHECK: %[[EVENT5:.*]] = air.segment async [%[[EVENT0]], %[[EVENT1]], %[[EVENT3]], %[[EVENT4]]]
+      // CHECK: %[[EVENT5:.*]] = air.segment async [%[[EVENT1]], %[[EVENT4]]]
         %c1_1 = arith.constant 1 : index
         %c2_0 = arith.constant 2 : index
         %c64_2 = arith.constant 64 : index


### PR DESCRIPTION
The mlir operations with "pure" op interface represent operations that do not have memory side effects. We are removing any air.async_tokens generated from the pure operations, as we haven't been able to find a concrete use case for tokens generated from them.

The operations representing data movements, including air.channel.put/get/dma_memcpy_nd, memref.copy, linalg.copy, memref.load/store, and computations, including linalg.generic, will still be returning async tokens in air's async CDFG. 