### PR TITLE
Add an xrt requirement for the air-runner test

### DIFF
--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -1,6 +1,7 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
+// REQUIRES: xrt
 // RUN: mkdir -p test_airrunner
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean


### PR DESCRIPTION
...due to input IR being generated from an implementation under programming_examples, which depends on xrt.

Should fix the current failure in [Build and Test with AIE tools](https://github.com/Xilinx/mlir-air/actions/workflows/buildAndTestAieTools.yml) workflow, e.g. https://github.com/Xilinx/mlir-air/actions/runs/15746373976/job/44383312311.