### PR TITLE
Revert commit 0b50bbae7324f4f717bdbb3d5e6f18fabedb2047 due to leading to some test failures

### DIFF
--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -145,11 +145,12 @@ class XRTRunner:
             xclbin_input=self.xclbin_input,
         )
 
-        # run the module - slots are inputs followed by outputs
+        # run the module - slots are input/output for now, assume non-overlapping inputs/outputs
         if expected_outputs:
-            expanded_inputs = inputs + expected_outputs
+            expanded_inputs = inputs + [
+                np.zeros(o.shape, o.dtype) for o in expected_outputs
+            ]
         elif stochastic_expected_outputs:
-            # stochastic expected outputs are incomplete for initializing the output buffers; zero initialize the output buffers instead
             expanded_inputs = inputs + [
                 np.zeros(o["shape"], o["values"][0].dtype)
                 for o in stochastic_expected_outputs
@@ -157,7 +158,7 @@ class XRTRunner:
         else:
             assert (
                 False
-            ), f"Expect one of 'expected_outputs' or 'stochastic_expected_outputs' to not be empty."
+            ), f"Expect one of 'expected_outputs' and 'stochastic_expected_outputs' to not be empty."
 
         compiled_module = backend.compile(mlir_module)
         with filelock.FileLock("/tmp/npu.lock"):


### PR DESCRIPTION
"Remove an assumption in xrt runner leading to zero-initializing all output buffers; inouts are now supported (#1031)"

This reverts commit 0b50bbae7324f4f717bdbb3d5e6f18fabedb2047.