### PR TITLE
Bump mlir-aie to 9ad95d3

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           git clone https://github.com/Xilinx/cmakeModules.git
 
-      # Build the repo test target in debug mode to build and test.
+      # Build the repo test target in release mode to build and test.
       - name: Build and test mlir-air (Assert)
         run: |
           source air-venv/bin/activate
@@ -126,7 +126,7 @@ jobs:
 
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DPython3_EXECUTABLE=$(which python) \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           git clone https://github.com/Xilinx/cmakeModules.git
 
-      # Build the repo test target in release mode to build and test.
+      # Build the repo test target in debug mode to build and test.
       - name: Build and test mlir-air (Assert)
         run: |
           source air-venv/bin/activate
@@ -126,7 +126,7 @@ jobs:
 
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DPython3_EXECUTABLE=$(which python) \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \

--- a/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_channel_get_put.mlir
@@ -313,7 +313,7 @@ module {
 // CHECK: airrt.dma_memcpy_nd{{.*}}{metadata = @air_channel_1_3}
 
 module {
-  aie.device(npu1_4col) {
+  aie.device(npu1) {
     aie.shim_dma_allocation @air_channel_1_0(S2MM, 0, 0)
     memref.global "public" @air_channel_1_0 : memref<4x2xf32, 2 : i32>
     aie.shim_dma_allocation @air_channel_1_1(S2MM, 1, 0)

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -520,7 +520,7 @@ module {
 
 #map = affine_map<(d0)[] -> (d0 * 128)>
 module {
-  aie.device(npu1_4col) {
+  aie.device(npu1) {
     aie.shim_dma_allocation @airMemcpyId10(MM2S, 1, 0)
     memref.global "public" @airMemcpyId10 : memref<1x2x64x64xbf16, 1 : i32>
   } {sym_name = "matmul_bf16_large_dispatch_0_matmul_308x2432x9728_bf16_0"}

--- a/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
@@ -9,7 +9,7 @@
 // RUN: air-opt -airrt-to-npu --split-input-file %s | FileCheck %s
 
 
-// CHECK-LABEL: aie.device(npu1_4col)
+// CHECK-LABEL: aie.device(npu1)
 // CHECK: aie.shim_dma_allocation @airMemcpyId29(S2MM, 0, 0)
 // CHECK: memref.global "public" @airMemcpyId29 : memref<128x128xf32, 1>
 // CHECK: aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
@@ -130,7 +130,7 @@
 // CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId29}
 
 module {
-  aie.device(npu1_4col) {
+  aie.device(npu1) {
     aie.shim_dma_allocation @airMemcpyId29(S2MM, 0, 0)
     memref.global "public" @airMemcpyId29 : memref<128x128xf32, 1>
     aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
@@ -12,7 +12,7 @@
 //Test correctness of generated offsets, wraps and strides
 //
 //
-// CHECK-LABEL: aie.device(npu1_4col)
+// CHECK-LABEL: aie.device(npu1)
 // CHECK: aie.shim_dma_allocation @airMemcpyId19(S2MM, 0, 0)
 // CHECK: memref.global "public" @airMemcpyId19 : memref<128x128xf32, 1>
 // CHECK: aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
@@ -87,7 +87,7 @@
 // CHECK: aiex.npu.dma_wait {symbol = @airMemcpyId19}
 
 module {
-  aie.device(npu1_4col) {
+  aie.device(npu1) {
     aie.shim_dma_allocation @airMemcpyId19(S2MM, 0, 0)
     memref.global "public" @airMemcpyId19 : memref<128x128xf32, 1>
     aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)

--- a/mlir/test/Conversion/AIRRtToNpu/generate_trace_write32.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/generate_trace_write32.mlir
@@ -7,7 +7,7 @@
 
 // RUN: air-opt %s -airrt-to-npu='trace-offset=65536 trace-size=65536' | FileCheck %s
 module {
-  aie.device(npu1_4col) {
+  aie.device(npu1) {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu1_4col" --split-input-file | FileCheck %s
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu1" --split-input-file | FileCheck %s
 
-// CHECK-LABEL:   aie.device(npu1_4col) {
+// CHECK-LABEL:   aie.device(npu1) {
 // CHECK:  %[[VAL_0:.*]] = aie.tile(0, 2)
 // CHECK:  %[[VAL_1:.*]] = aie.tile(0, 0)
 // CHECK:  %[[VAL_2:.*]] = aie.lock(%[[VAL_0]], 1) {init = 1 : i32}
@@ -51,7 +51,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 
 // -----
 
-// CHECK-LABEL:   aie.device(npu1_4col) {
+// CHECK-LABEL:   aie.device(npu1) {
 // CHECK: %[[VAL_0:.*]] = aie.tile(0, 2)
 // CHECK: %[[VAL_1:.*]] = aie.tile(0, 0)
 // CHECK: %[[VAL_2:.*]] = aie.lock(%[[VAL_0]], 3) {init = 1 : i32}
@@ -115,7 +115,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // -----
 
 // air.channel to aie.locks.
-// CHECK-LABEL:   aie.device(npu1_4col) {
+// CHECK-LABEL:   aie.device(npu1) {
 // CHECK:         %[[VAL_0:.*]] = aie.tile(0, 0)
 // CHECK:         %[[VAL_1:.*]] = aie.tile(0, 2)
 // CHECK:         %[[VAL_2:.*]] = aie.lock(%[[VAL_1]], 3) {init = 1 : i32}
@@ -187,7 +187,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // -----
 
 // air.channel to aie.locks.
-// CHECK-LABEL:   aie.device(npu1_4col) {
+// CHECK-LABEL:   aie.device(npu1) {
 // CHECK:         %[[VAL_2:.*]] = aie.tile(0, 1)
 // CHECK:         %[[VAL_3:.*]] = aie.tile(0, 2)
 // CHECK:         %[[VAL_4:.*]] = aie.tile(0, 0)
@@ -396,7 +396,7 @@ func.func @func5(%arg0 : memref<1024xi32>) -> () {
 // -----
 
 // L3 to L1 parallel shim dmas
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CHECK: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CHECK: %[[tile_0_3:.*]] = aie.tile(0, 3)
@@ -466,7 +466,7 @@ func.func @func6(%arg5 : memref<8x8xi32>) {
 // -----
 
 // Multi-dimensional memref copy to wraps and strides
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -522,7 +522,7 @@ func.func @func7(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // -----
 
 // Multi-dimensional memref copy to wraps and strides, with offsets having more dims than memref type.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -559,7 +559,7 @@ func.func @func8(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // -----
 
 // 1D scf.parallel iteration space support.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
@@ -621,7 +621,7 @@ func.func @func9(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // -----
 
 // Tile / memtile DMA repeat count support.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2>, 0, 8192)
@@ -683,7 +683,7 @@ func.func @func10(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // -----
 
 // Bf16 datatype support.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2>, 0, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
@@ -747,7 +747,7 @@ func.func @func11(%arg0: memref<128xbf16>, %arg1: memref<128xbf16>) {
 // -----
 
 // 4x4 herd support.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CHECK: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CHECK: %[[tile_2_0:.*]] = aie.tile(2, 0)
@@ -953,7 +953,7 @@ module {
 // -----
 
 // Wrap-and-stride list canonicalization during herd outlining.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tile_2_0:.*]] = aie.tile(0, 0)
 // CHECK: %[[tile_2_1:.*]] = aie.tile(0, 1)
 // CHECK: %[[tile_2_3:.*]] = aie.tile(0, 2)
@@ -1032,7 +1032,7 @@ module {
 // -----
 
 // Unrolled bundle of channels from shim accessing directly to herd.
-// CHECK: aie.device(npu1_4col)
+// CHECK: aie.device(npu1)
 // CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CHECK: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CHECK: %[[tile_0_2:.*]] = aie.tile(0, 2)

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks_npu.mlir
@@ -5,9 +5,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-to-aie="row-offset=2 col-offset=0 device=npu1_4col" -canonicalize -cse %s | FileCheck %s
+// RUN: air-opt -air-fuse-channels="aggressive-mode=L1,L2,L3" -air-to-aie="row-offset=2 col-offset=0 device=npu1" -canonicalize -cse %s | FileCheck %s
 
-// CHECK-LABEL:   aie.device(npu1_4col) {
+// CHECK-LABEL:   aie.device(npu1) {
 // CHECK:   %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CHECK:   %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CHECK:   %[[tile_0_1:.*]] = aie.tile(0, 1)

--- a/mlir/test/Conversion/AIRToAIE/emit_lock.mlir
+++ b/mlir/test/Conversion/AIRToAIE/emit_lock.mlir
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-to-aie='emit-herd-lock=true' -split-input-file | FileCheck %s
-// RUN: air-opt %s -air-to-aie='emit-herd-lock=false device=npu1_4col row-offset=2' -split-input-file | FileCheck %s --check-prefix=NPU1
+// RUN: air-opt %s -air-to-aie='emit-herd-lock=false device=npu1 row-offset=2' -split-input-file | FileCheck %s --check-prefix=NPU1
 
 // CHECK-LABEL: aie.device(xcvc1902)
 // CHECK:  %[[VAL_0:.*]] = aie.tile
@@ -20,7 +20,7 @@
 // CHECK:    aie.use_lock(%[[VAL_2]], Release, 0)
 // CHECK:    aie.end
 
-// NPU1-LABEL: aie.device(npu1_4col)
+// NPU1-LABEL: aie.device(npu1)
 // NPU1:  %[[VAL_0:.*]] = aie.tile
 // NPU1:  %[[VAL_3:.*]] = aie.core(%[[VAL_0]]) {
 // NPU1:    cf.br ^bb1
@@ -57,7 +57,7 @@ module {
 // CHECK:    aie.use_lock(%[[HERD_LOCK]], Release, 0)
 // CHECK:    aie.end
 
-// NPU1-LABEL: aie.device(npu1_4col)
+// NPU1-LABEL: aie.device(npu1)
 // NPU1:  %[[VAL_0:.*]] = aie.tile(1, 2)
 // NPU1:  %[[LOCK_0:.*]] = aie.lock(%[[VAL_0]],
 // NPU1:  %[[LOCK_1:.*]] = aie.lock(%[[VAL_0]],
@@ -107,7 +107,7 @@ module {
 // CHECK-DAG:    aie.use_lock(%[[HERD_LOCK]], Release, 0)
 // CHECK:    aie.end
 
-// NPU1-LABEL: aie.device(npu1_4col)
+// NPU1-LABEL: aie.device(npu1)
 // NPU1:  %[[VAL_0:.*]] = aie.tile(1, 2)
 // NPU1:  %[[LOCK_0:.*]] = aie.lock(%[[VAL_0]],
 // NPU1:  %[[LOCK_1:.*]] = aie.lock(%[[VAL_0]],
@@ -161,7 +161,7 @@ module {
 // CHECK:    aie.use_lock(%[[HERD_LOCK]], Release, 0)
 // CHECK:    aie.end
 
-// NPU1-LABEL: aie.device(npu1_4col)
+// NPU1-LABEL: aie.device(npu1)
 // NPU1:  %[[VAL_0:.*]] = aie.tile(1, 2)
 // NPU1:  %[[LOCK_0:.*]] = aie.lock(%[[VAL_0]],
 // NPU1:  %[[LOCK_1:.*]] = aie.lock(%[[VAL_0]],
@@ -229,7 +229,7 @@ module {
 // CHECK:    aie.use_lock(%[[HERD_LOCK]], Release, 0)
 // CHECK:    aie.end
 
-// NPU1-LABEL: aie.device(npu1_4col)
+// NPU1-LABEL: aie.device(npu1)
 // NPU1:  %[[VAL_0:.*]] = aie.tile(1, 2)
 // NPU1:  %[[LOCK_0:.*]] = aie.lock(%[[VAL_0]],
 // NPU1:  %[[LOCK_1:.*]] = aie.lock(%[[VAL_0]],

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-opt-memtile-dma-bds="device=npu1_4col" -split-input-file | FileCheck %s
+// RUN: air-opt %s -air-opt-memtile-dma-bds="device=npu1" -split-input-file | FileCheck %s
 
 // RUN: not air-opt %s 2>&1 -air-opt-memtile-dma-bds="device=xcvc1902" -split-input-file | FileCheck %s --check-prefix=AIE1
 

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds.mlir
@@ -5,8 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1_4col" | FileCheck %s
-// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1_4col shim-dma-tile-sizes=2,2" | FileCheck %s --check-prefix=NPUTILED
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1" | FileCheck %s
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1 shim-dma-tile-sizes=2,2" | FileCheck %s --check-prefix=NPUTILED
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=xcvc1902" | FileCheck %s --check-prefix=AIE1
 
 // Optimize logical air.channel.put/get op into efficient shim dma block descriptor (BD).

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -126,7 +126,7 @@ class XRTBackend(AirBackend):
             )
 
         # Try to get xrt.
-        target_device = "npu1_4col"
+        target_device = "npu1"
         try:
             import subprocess
             import re
@@ -153,7 +153,7 @@ class XRTBackend(AirBackend):
                 if self.verbose:
                     print(f"\tmodel: '{model}'")
                 if model in ["npu1", "Phoenix"]:
-                    target_device = "npu1_4col"
+                    target_device = "npu1"
                 elif model in ["npu4", "Strix"]:
                     target_device = "npu2_4col"
                 else:

--- a/test/xrt/05_extern_func/run_npu1_chess.lit
+++ b/test/xrt/05_extern_func/run_npu1_chess.lit
@@ -5,6 +5,6 @@
 // RUN: mkdir -p test_npu1_chess
 // RUN: cd test_npu1_chess
 // RUN: xchesscc_wrapper aie2 -c %S/chess/beefmaker_kernel.cc
-// RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1_4col row-offset=2 col-offset=0" -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
+// RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu1_peano.lit
+++ b/test/xrt/05_extern_func/run_npu1_peano.lit
@@ -6,6 +6,6 @@
 // RUN: cd test_npu1_peano
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
-// RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1_4col row-offset=2 col-offset=0" -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
+// RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
 // RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --aie-generate-xclbin --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/23_ctrlpkt_config/aie.py
+++ b/test/xrt/23_ctrlpkt_config/aie.py
@@ -163,7 +163,7 @@ pipeline = (
             "air-ping-pong-transform",
             "canonicalize",
             "cse",
-            "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
+            "func.func(air-opt-memtile-dma-bds{device=npu1})",
             "canonicalize",
             "cse",
         ]
@@ -209,7 +209,7 @@ with open("air_placed.mlir", "w") as f:
 # ## MLIR-AIR to MLIR-AIE
 # ################################################
 
-air_to_aie_pass = "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true use-pkt-flow-at-shim-dma=true"
+air_to_aie_pass = "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true"
 if opts.trace_size > 0:
     air_to_aie_pass = air_to_aie_pass + " insert-trace-packet-flow=true"
 air_to_aie_pass = air_to_aie_pass + "}"
@@ -236,7 +236,7 @@ pipeline = (
     "builtin.module("
     + ",".join(
         [
-            "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
+            "func.func(air-opt-shim-dma-bds{device=npu1})",
             "air-to-std",
             "airrt-to-npu{"
             + f"trace-offset={opts.trace_offset} trace-size={opts.trace_size}"

--- a/test/xrt/23_ctrlpkt_config/base.mlir
+++ b/test/xrt/23_ctrlpkt_config/base.mlir
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 module {
-  aie.device(npu1_4col){
+  aie.device(npu1){
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)

--- a/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
@@ -5,10 +5,9 @@
 // RUN: mkdir -p test_npu1_chess
 // RUN: cd test_npu1_chess
 // RUN: %python %S/aie.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2
+// RUN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+// RUN: mkdir -p test_npu1_peano
+// RUN: cd test_npu1_peano
+// RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
+// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
@@ -4,11 +4,11 @@
 // REQUIRES: ryzen_ai_npu1, peano
 // RUN: mkdir -p test_npu1_peano
 // RUN: cd test_npu1_peano
+// RUN: %python %S/aie.py
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2
+// RUN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
@@ -199,7 +199,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
+                "func.func(air-opt-memtile-dma-bds{device=npu1})",
                 "canonicalize",
                 "cse",
             ]
@@ -242,7 +242,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "canonicalize",
                 "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
+                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
                 "canonicalize",
             ]
         )
@@ -259,7 +259,7 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
+                "func.func(air-opt-shim-dma-bds{device=npu1})",
                 "air-to-std",
                 "canonicalize",
                 "symbol-dce",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
@@ -198,7 +198,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-ping-pong-transform",
                 "canonicalize",
                 "cse",
-                "func.func(air-opt-memtile-dma-bds{device=npu1_4col})",
+                "func.func(air-opt-memtile-dma-bds{device=npu1})",
                 "canonicalize",
                 "cse",
             ]
@@ -241,7 +241,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "canonicalize",
                 "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1_4col emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
+                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
                 "canonicalize",
             ]
         )
@@ -258,7 +258,7 @@ with air.ir.Context() as ctx, Location.unknown():
         "builtin.module("
         + ",".join(
             [
-                "func.func(air-opt-shim-dma-bds{device=npu1_4col})",
+                "func.func(air-opt-shim-dma-bds{device=npu1})",
                 "air-to-std",
                 "canonicalize",
                 "symbol-dce",

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/base.mlir
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/base.mlir
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 module {
-  aie.device(npu1_4col){
+  aie.device(npu1){
     %tile_0_0 = aie.tile(0, 0)
     %tile_1_0 = aie.tile(1, 0)
     %tile_2_0 = aie.tile(2, 0)

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
@@ -4,18 +4,18 @@
 // REQUIRES: ryzen_ai_npu1, valid_xchess_license
 // RUN: mkdir -p test_npu1_chess
 // RUN: cd test_npu1_chess
-// RUN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
-// RUN: %python %S/aie.py
-// RUN: %python %S/aie2.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
-// RUN: %python %S/aie2.py
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
-// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// UN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
+// UN: %python %S/aie.py
+// UN: %python %S/aie2.py
+// UN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
+// UN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
+// UN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
+// UN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
+// UN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// UN: %python %S/aie2.py
+// UN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
+// UN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
+// UN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
+// UN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
+// UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -1,0 +1,22 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+// RUN: mkdir -p test_npu1_peano
+// RUN: cd test_npu1_peano
+// RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
+// RUN: %python %S/aie.py
+// RUN: %python %S/aie2.py
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
+// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: %python %S/aie2.py
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
+// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
+// RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -19,4 +19,4 @@
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE
+// RUN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -19,4 +19,4 @@
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// RUN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE
+// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=626fe482d86ef0c065c95542dff656f26fc4fc98
-DATETIME=2025060204
+export HASH=9ad95d3ac16702c18f019d6ebbaf256dadfe1f83
+DATETIME=2025063004
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
This patch in mlir-aie brings in changes needed to support the up-to-date peano versions: https://github.com/Xilinx/mlir-aie/pull/2417