### PR TITLE
AIRToAIE: Fixup packet id allocator at shim tiles

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -92,6 +92,9 @@ std::vector<ChannelGetOp> getTheOtherChannelOpThroughSymbol(ChannelPutOp put);
 std::vector<ChannelPutOp> getTheOtherChannelOpThroughSymbol(ChannelGetOp get);
 std::vector<air::ChannelInterface>
 getTheOtherChannelOpThroughSymbol(air::ChannelInterface op);
+// Get integer index to metadataArray, from channel bundle indices.
+std::optional<int>
+getIndexToMetadataArrayFromChannelIndices(air::ChannelInterface op);
 void getSizesFromIntegerSet(MLIRContext *ctx, IntegerSet int_set,
                             SmallVector<int, 2> &lbs_int,
                             SmallVector<int, 2> &ubs_int);

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -505,6 +505,34 @@ air::getTheOtherChannelOpThroughSymbol(air::ChannelInterface op) {
     return std::vector<air::ChannelInterface>();
 }
 
+// Get integer index to metadataArray, from channel bundle indices.
+std::optional<int>
+air::getIndexToMetadataArrayFromChannelIndices(air::ChannelInterface op) {
+  std::optional<int> res = std::nullopt;
+  std::vector<unsigned> indicesUint =
+      air::convertVecOfConstIndexToVecOfUInt(op.getIndices());
+  auto channelBundleSize =
+      air::getChannelDeclarationThroughSymbol(op).getSize();
+
+  auto arrayAttrToUIntVector =
+      [](mlir::ArrayAttr attr) -> std::vector<unsigned int> {
+    std::vector<unsigned int> vec;
+    for (mlir::Attribute a : attr) {
+      if (auto intAttr = dyn_cast<mlir::IntegerAttr>(a))
+        vec.push_back(static_cast<unsigned int>(intAttr.getInt()));
+      else
+        llvm::errs() << "Warning: Non-integer attribute in ArrayAttr\n";
+    }
+    return vec;
+  };
+
+  std::vector<unsigned int> uIntVec = arrayAttrToUIntVector(channelBundleSize);
+  if (uIntVec.empty())
+    return res;
+  res = air::getIteratorFromMDVector(uIntVec, indicesUint);
+  return res;
+}
+
 // Get sizes from integerset
 void air::getSizesFromIntegerSet(MLIRContext *ctx, IntegerSet int_set,
                                  SmallVector<int, 2> &lbs_int,

--- a/mlir/test/Conversion/AIRToAIE/shim_packet_flow_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_packet_flow_npu.mlir
@@ -1,4 +1,4 @@
-//===- air_to_npu_spatial_add_one.mlir -------------------------*- MLIR -*-===//
+//===- shim_packet_flow_npu.mlir -------------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2021-2022, Xilinx Inc. All rights reserved.
 // Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/matrix_multiplication.h
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/matrix_multiplication.h
@@ -20,19 +20,6 @@
 namespace matmul_common {
 
 // --------------------------------------------------------------------------
-// Command Line Argument Handling
-// --------------------------------------------------------------------------
-
-void add_default_options(cxxopts::Options &options) {
-  options.add_options()("help,h", "produce help message")(
-      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
-      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
-      cxxopts::value<std::string>())("verbosity,v",
-                                     "the verbosity of the output",
-                                     cxxopts::value<int>()->default_value("0"));
-}
-
-// --------------------------------------------------------------------------
 // Matrix / Float / Math
 // --------------------------------------------------------------------------
 

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
@@ -5,17 +5,17 @@
 // RUN: mkdir -p test_npu1_chess
 // RUN: cd test_npu1_chess
 // UN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
+// UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
+// UN: %python aiecc.py --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
+// UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
+// UN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: mv ctrlpkt_dma_seq.bin aie1_ctrlpkt_dma_seq.bin
+// UN: mv ctrlpkt.bin aie1_ctrlpkt.bin
 // UN: %python %S/aie2.py
-// UN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// UN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
-// UN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-// UN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// UN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
-// UN: %python %S/aie2.py
-// UN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
-// UN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
-// UN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
-// UN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
+// UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
+// UN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: mv ctrlpkt_dma_seq.bin aie2_ctrlpkt_dma_seq.bin
+// UN: mv ctrlpkt.bin aie2_ctrlpkt.bin
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE
+// UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -6,17 +6,17 @@
 // RUN: cd test_npu1_peano
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // RUN: %python %S/aie.py
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// RUN: mv ctrlpkt_dma_seq.bin aie1_ctrlpkt_dma_seq.bin
+// RUN: mv ctrlpkt.bin aie1_ctrlpkt.bin
 // RUN: %python %S/aie2.py
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-xclbin --no-compile-host --generate-ctrl-pkt-overlay --xclbin-name=base.xclbin %S/base.mlir
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie_run_seq.bin aie.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
-// RUN: %python %S/aie2.py
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --generate-ctrl-pkt-overlay --npu-insts-name=aie2_run_seq.bin aie2.mlir
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt.bin
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2.mlir.prj/ctrlpkt.mlir -o aie2_ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure aie2_ctrlpkt_dma_seq.mlir -o aie2_ctrlpkt_dma_seq.bin
+// RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// RUN: mv ctrlpkt_dma_seq.bin aie2_ctrlpkt_dma_seq.bin
+// RUN: mv ctrlpkt.bin aie2_ctrlpkt.bin
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
-// UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE
+// RUN: %run_on_npu1% ./test.exe


### PR DESCRIPTION
Update the packet id allocation method to support the metadataArray format.