### PR TITLE
Switch transform.air.linalg_tile from generating scf.parallel to scf.forall

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -246,7 +246,7 @@ def LinalgTileOp : Op<Transform_Dialect, "air.linalg_tile",
                    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$interchange
                    );
   let results = (outs PDL_Operation:$tiled_linalg_op,
-                      Variadic<PDL_Operation>:$loops);
+                      PDL_Operation:$loops);
   let builders = [
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<int64_t>":$staticTileSizes,

--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -231,29 +231,25 @@ def LinalgTileOp : Op<Transform_Dialect, "air.linalg_tile",
        [DeclareOpInterfaceMethods<TransformOpInterface>,
         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let description = [{
-    Tile a linalg operation with the given sizes. Optionally apply an
-    interchange of the resulting loops. The new linalg operantion and all
-    generated loops are returned. Tiling is performed with the
-    `linalg::LinalgTilingLoopType::ParallelLoops` so that `scf.parallel`
-    loops are generated whenever possible.
+    Tile a linalg operation with the given sizes. The new linalg 
+    operantion and the generated loop are returned. Tiling is 
+    performed with the `transform::tileToForallOpImpl` so that an
+    `scf.forall` loop is generated whenever possible.
 
-    This is a variant of `transform.structured.tile`.
+    This is a variant of `transform.structured.tile_using_forall`.
   }];
 
   let arguments = (ins PDL_Operation:$target,
                    Variadic<PDL_Operation>:$dynamic_sizes,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sizes,
-                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$interchange
+                   DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$static_sizes
                    );
   let results = (outs PDL_Operation:$tiled_linalg_op,
                       PDL_Operation:$loops);
   let builders = [
     OpBuilder<(ins "Value":$target,
-                   "ArrayRef<int64_t>":$staticTileSizes,
-                   CArg<"ArrayRef<int64_t>", "{}">:$interchange)>,
+                   "ArrayRef<int64_t>":$staticTileSizes)>,
     OpBuilder<(ins "Value":$target,
-                   "ArrayRef<OpFoldResult>":$mixedTileSizes,
-                   CArg<"ArrayRef<int64_t>", "{}">:$interchange)>
+                   "ArrayRef<OpFoldResult>":$mixedTileSizes)>
   ];
 
   let hasCustomAssemblyFormat = 1;

--- a/mlir/test/Transform/AIRLinalgCodegen/air_fuse_into_containing_op.mlir
+++ b/mlir/test/Transform/AIRLinalgCodegen/air_fuse_into_containing_op.mlir
@@ -34,6 +34,6 @@ transform.sequence failures(propagate) {
   // Find the consumer and producer.
   %consumer = transform.structured.match attributes{"__consumer__"} in %arg1 : (!pdl.operation) -> !pdl.operation
   %producers = transform.structured.match attributes{"__producer__"} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %1, %loops:2 = transform.air.linalg_tile %consumer [32, 32]
-  transform.air.fuse_into_containing_op %producers into %loops#0
+  %1, %loop = transform.air.linalg_tile %consumer [32, 32]
+  transform.air.fuse_into_containing_op %producers into %loop
 }

--- a/mlir/test/Transform/AIRTransform/air_transform_ops.mlir
+++ b/mlir/test/Transform/AIRTransform/air_transform_ops.mlir
@@ -14,5 +14,5 @@
 transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  %matmul_1, %loops:2 = transform.air.linalg_tile %matmul [64, 64, 0]
+  %matmul_1, %loop = transform.air.linalg_tile %matmul [64, 64, 0]
 }

--- a/mlir/test/Transform/AIRTransform/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/air_transform_payload.mlir
@@ -7,7 +7,7 @@
 
 // RUN: air-opt -air-transform='filename=%S/air_transform_ops.mlir' %s | FileCheck %s
 
-// CHECK: scf.parallel
+// CHECK: scf.forall
 func.func @mmult(%A: memref<1024x1024xf32>, %B: memref<1024x1024xf32>, %C: memref<1024x1024xf32>) -> memref<1024x1024xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   linalg.fill ins(%cst : f32) outs(%C : memref<1024x1024xf32>)

--- a/python/air/dialects/_air_transform_ops_ext.py
+++ b/python/air/dialects/_air_transform_ops_ext.py
@@ -25,7 +25,6 @@ class LinalgTileOp(LinalgTileOp):
         sizes: Optional[
             Union[Sequence[Union[int, IntegerAttr, Operation, Value]], ArrayAttr]
         ] = None,
-        interchange: OptionalIntList = None,
         loc=None,
         ip=None
     ):
@@ -54,9 +53,6 @@ class LinalgTileOp(LinalgTileOp):
             _get_op_result_or_value(target),
             dynamic_sizes=dynamic_sizes,
             static_sizes=sizes_attr,
-            interchange=(
-                _get_dense_int64_array_attr(interchange) if interchange else None
-            ),
             loc=loc,
             ip=ip,
         )

--- a/python/air/dialects/_air_transform_ops_ext.py
+++ b/python/air/dialects/_air_transform_ops_ext.py
@@ -48,10 +48,9 @@ class LinalgTileOp(LinalgTileOp):
                     dynamic_sizes.append(_get_op_result_or_value(size))
             sizes_attr = DenseI64ArrayAttr.get(static_sizes)
 
-        num_loops = sum(v if v == 0 else 1 for v in self.__extract_values(sizes_attr))
         super().__init__(
             pdl_operation_type,
-            [pdl_operation_type] * num_loops,
+            [pdl_operation_type],
             _get_op_result_or_value(target),
             dynamic_sizes=dynamic_sizes,
             static_sizes=sizes_attr,

--- a/python/air/dialects/_air_transform_ops_ext.py
+++ b/python/air/dialects/_air_transform_ops_ext.py
@@ -29,7 +29,6 @@ class LinalgTileOp(LinalgTileOp):
         ip=None
     ):
         pdl_operation_type = pdl.OperationType.get()
-        i64_type = IntegerType.get_signless(64)
 
         if sizes is None:
             sizes = []
@@ -49,15 +48,10 @@ class LinalgTileOp(LinalgTileOp):
 
         super().__init__(
             pdl_operation_type,
-            [pdl_operation_type],
+            pdl_operation_type,
             _get_op_result_or_value(target),
             dynamic_sizes=dynamic_sizes,
             static_sizes=sizes_attr,
             loc=loc,
             ip=ip,
         )
-
-    def __extract_values(self, attr: Optional[DenseI64ArrayAttr]) -> List[int]:
-        if not attr:
-            return []
-        return [element for element in attr]

--- a/python/test/compiler/run_transform.py
+++ b/python/test/compiler/run_transform.py
@@ -58,7 +58,11 @@ def gemm_module():
         transform.sequence %arg0 : !pdl.operation failures(propagate) {
         ^bb1(%arg1: !pdl.operation):
             %matmul = transform.structured.match ops{["linalg.generic"]} in %arg1  : (!pdl.operation) -> !pdl.operation
-            %matmul_1, %loops:3 = transform.air.linalg_tile %matmul [64, 64, 64]
+            %matmul_1, %forall = transform.air.linalg_tile %matmul [64, 64, 0]
+            %parallal = transform.loop.forall_to_parallel %forall  : (!pdl.operation) -> !pdl.operation
+            %matmul_2 = transform.structured.match ops{["linalg.generic"]} in %parallal  : (!pdl.operation) -> !pdl.operation
+            %matmul_3, %forall_1 = transform.air.linalg_tile %matmul_2 [0, 0, 64]
+            %scffor = transform.loop.forall_to_for %forall_1  : (!pdl.operation) -> !pdl.operation
         }
     }
     """

--- a/test/airrunner/matmul/mmult_aie2.py
+++ b/test/airrunner/matmul/mmult_aie2.py
@@ -123,13 +123,13 @@ transform.with_pdl_patterns {{
     ^bb1(%arg1: !pdl.operation):
         %fill = transform.structured.match ops{{["linalg.fill"]}} in %arg1  : (!pdl.operation) -> !pdl.operation
         %matmul = transform.structured.match ops{{["linalg.generic"]}} in %arg1  : (!pdl.operation) -> !pdl.operation
-        %matmul_1, %loops:2 = transform.air.linalg_tile %matmul [{opts.tile_l2_m}, {opts.tile_l2_n}, 0]
-        %fill_1 = transform.air.fuse_into_containing_op %fill into %loops#1
+        %matmul_1, %loop = transform.air.linalg_tile %matmul [{opts.tile_l2_m}, {opts.tile_l2_n}, 0]
+        %fill_1 = transform.air.fuse_into_containing_op %fill into %loop
         transform.air.linalg_promote %fill_1 {{"operands_to_promote"=[1], "memory_space"="L2"}}
         transform.air.linalg_promote %matmul_1 {{"operands_to_promote"=[2], "memory_space"="L2"}}
         transform.air.linalg_promote %matmul_1 {{"operands_to_promote"=[0,1], "memory_space"="L2"}}
-        %matmul_2, %loops_2:2 = transform.air.linalg_tile %matmul_1 [{opts.tile_l1_m}, {opts.tile_l1_n}, 0]
-        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loops_2#1
+        %matmul_2, %loop_2 = transform.air.linalg_tile %matmul_1 [{opts.tile_l1_m}, {opts.tile_l1_n}, 0]
+        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loop_2
         transform.air.linalg_promote %fill_2 {{"operands_to_promote"=[1], "memory_space"="L1"}}
         transform.air.linalg_promote %matmul_2 {{"operands_to_promote"=[2], "memory_space"="L1"}}
         %matmul_3, %reduction_loop = transform.air.linalg_tile %matmul_2 [0, 0, {opts.tile_l1_k}]
@@ -146,8 +146,8 @@ pipeline = (
     + ",".join(
         [
             "buffer-results-to-out-params",
-            "air-par-to-herd{depth=-1}",
-            "air-par-to-launch{has-air-segment=true}",
+            "air-par-to-launch{depth=0 has-air-segment=true}",
+            "air-par-to-herd{depth=0}",
             "scf-forall-to-for",
             "air-copy-to-dma",
             "canonicalize",

--- a/test/xrt/01_air_to_npu/gen.py
+++ b/test/xrt/01_air_to_npu/gen.py
@@ -79,13 +79,13 @@ transform.with_pdl_patterns {
     ^bb1(%arg1: !pdl.operation):
         %fill = transform.structured.match ops{["linalg.fill"]} in %arg1  : (!pdl.operation) -> !pdl.operation
         %matmul = transform.structured.match ops{["linalg.generic"]} in %arg1  : (!pdl.operation) -> !pdl.operation
-        %matmul_1, %loops:2 = transform.air.linalg_tile %matmul [64, 64, 0]
-        %fill_1 = transform.air.fuse_into_containing_op %fill into %loops#1
+        %matmul_1, %loop = transform.air.linalg_tile %matmul [64, 64, 0]
+        %fill_1 = transform.air.fuse_into_containing_op %fill into %loop
         transform.air.linalg_promote %fill_1 {"operands_to_promote"=[1], "memory_space"="L2"}
         transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[2], "memory_space"="L2"}
         transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[0,1], "memory_space"="L2"}
-        %matmul_2, %loops_2:2 = transform.air.linalg_tile %matmul_1 [32, 32, 0]
-        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loops_2#1
+        %matmul_2, %loop_2 = transform.air.linalg_tile %matmul_1 [32, 32, 0]
+        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loop_2
         transform.air.linalg_promote %fill_2 {"operands_to_promote"=[1], "memory_space"="L1"}
         transform.air.linalg_promote %matmul_2 {"operands_to_promote"=[2], "memory_space"="L1"}
         %matmul_3, %reduction_loop = transform.air.linalg_tile %matmul_2 [0, 0, 32]
@@ -108,8 +108,8 @@ pipeline = (
     + ",".join(
         [
             "buffer-results-to-out-params",
-            "air-par-to-herd{depth=-1}",
-            "air-par-to-launch{has-air-segment=true}",
+            "air-par-to-launch{depth=0 has-air-segment=true}",
+            "air-par-to-herd{depth=0}",
             "scf-forall-to-for",
             "air-copy-to-dma",
             "canonicalize",

--- a/test/xrt/06_add_shim_bf16/gen.py
+++ b/test/xrt/06_add_shim_bf16/gen.py
@@ -40,10 +40,12 @@ transform.with_pdl_patterns {
     transform.sequence %arg0 : !pdl.operation failures(propagate) {
     ^bb1(%arg1: !pdl.operation):
     %l0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    %l1, %herd_tile_loops = transform.air.linalg_tile %l0 [0,128]
-    %l3, %inner_tile_loops:2 = transform.air.linalg_tile %l1 [32,32]
+    %l1, %herd_tile_loop = transform.air.linalg_tile %l0 [0,128]
+    %l3, %inner_tile_loop = transform.air.linalg_tile %l1 [32,32]
     transform.air.linalg_promote %l3 {"operands_to_promote"=[0,1,2], "memory_space"="L1"}
-    %herd = transform.air.par_to_herd %herd_tile_loops
+    %inner_tile_par = transform.loop.forall_to_parallel %inner_tile_loop  : (!pdl.operation) -> !pdl.operation
+    %herd_tile_par = transform.loop.forall_to_parallel %herd_tile_loop  : (!pdl.operation) -> !pdl.operation
+    %herd = transform.air.par_to_herd %herd_tile_par
     %copies = transform.pdl_match @match_copy in %arg0 : (!pdl.operation) -> !pdl.operation
     %h = transform.air.copy_to_dma %copies
     }

--- a/test/xrt/12_matmul_transform_1x4_bf16/gen.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/gen.py
@@ -90,7 +90,7 @@ transform.with_pdl_patterns {
         %ps = transform.merge_handles %fill_0, %matmul_0 : !pdl.operation
         transform.air.linalg_promote %ps {"operands_to_promote"=[1,4], "group_size"=2, "memory_space"="L1"}
 
-        %matmul_1, %loops:3 = transform.air.linalg_tile %matmul_0 [16, 16, 16]
+        %matmul_1, %loop = transform.air.linalg_tile %matmul_0 [16, 16, 16]
 
         transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[0,1], "memory_space"="L1"}
 
@@ -116,8 +116,8 @@ pipeline = (
     + ",".join(
         [
             "air-copy-to-dma",
-            "air-par-to-herd{depth=-1}",
-            "air-par-to-launch{has-air-segment=1}",
+            "air-par-to-launch{depth=0 has-air-segment=true}",
+            "air-par-to-herd{depth=0}",
             "scf-forall-to-for",
             "canonicalize",
             "cse",

--- a/test/xrt/23_ctrlpkt_config/aie.py
+++ b/test/xrt/23_ctrlpkt_config/aie.py
@@ -80,13 +80,13 @@ transform.with_pdl_patterns {
     ^bb1(%arg1: !pdl.operation):
         %fill = transform.structured.match ops{["linalg.fill"]} in %arg1  : (!pdl.operation) -> !pdl.operation
         %matmul = transform.structured.match ops{["linalg.generic"]} in %arg1  : (!pdl.operation) -> !pdl.operation
-        %matmul_1, %loops:2 = transform.air.linalg_tile %matmul [64, 64, 0]
-        %fill_1 = transform.air.fuse_into_containing_op %fill into %loops#1
+        %matmul_1, %loop = transform.air.linalg_tile %matmul [64, 64, 0]
+        %fill_1 = transform.air.fuse_into_containing_op %fill into %loop
         transform.air.linalg_promote %fill_1 {"operands_to_promote"=[1], "memory_space"="L2"}
         transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[2], "memory_space"="L2"}
         transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[0,1], "memory_space"="L2"}
-        %matmul_2, %loops_2:2 = transform.air.linalg_tile %matmul_1 [32, 32, 0]
-        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loops_2#1
+        %matmul_2, %loop_2 = transform.air.linalg_tile %matmul_1 [32, 32, 0]
+        %fill_2 = transform.air.fuse_into_containing_op %fill_1 into %loop_2
         transform.air.linalg_promote %fill_2 {"operands_to_promote"=[1], "memory_space"="L1"}
         transform.air.linalg_promote %matmul_2 {"operands_to_promote"=[2], "memory_space"="L1"}
         %matmul_3, %reduction_loop = transform.air.linalg_tile %matmul_2 [0, 0, 32]
@@ -109,8 +109,8 @@ pipeline = (
     + ",".join(
         [
             "buffer-results-to-out-params",
-            "air-par-to-herd{depth=-1}",
-            "air-par-to-launch{has-air-segment=true}",
+            "air-par-to-launch{depth=0 has-air-segment=true}",
+            "air-par-to-herd{depth=0}",
             "scf-forall-to-for",
             "air-copy-to-dma",
             "canonicalize",

--- a/test/xrt/32_triton_matmul/run.py
+++ b/test/xrt/32_triton_matmul/run.py
@@ -81,12 +81,13 @@ with air.ir.Context() as ctx, Location.unknown():
         ^bb1(%arg1: !pdl.operation):
             %fill = transform.structured.match ops{["linalg.fill"]} in %arg1  : (!pdl.operation) -> !pdl.operation
             %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg1  : (!pdl.operation) -> !pdl.operation
-            %matmul_1, %loops:2 = transform.air.linalg_tile %matmul [32, 32, 0]
-            %fill_1 = transform.air.fuse_into_containing_op %fill into %loops#1
+            %matmul_1, %loop = transform.air.linalg_tile %matmul [32, 32, 0]
+            %fill_1 = transform.air.fuse_into_containing_op %fill into %loop
             transform.air.linalg_promote %fill_1 {"operands_to_promote"=[1], "memory_space"="L1"}
             transform.air.linalg_promote %matmul_1 {"operands_to_promote"=[2], "memory_space"="L1"}
             %matmul_2, %reduction_loop = transform.air.linalg_tile %matmul_1 [0, 0, 32]
             transform.air.linalg_promote %matmul_2 {"operands_to_promote"=[0,1], "memory_space"="L1"}
+            %scffor = transform.loop.forall_to_for %reduction_loop  : (!pdl.operation) -> !pdl.operation
         }
     }
     """


### PR DESCRIPTION
… to adapt to upstream transform dialect changes.

https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredtile_using_forall-transformtileusingforallop

`transform.structured.tile` is deprecated and replaced with `transform.structured.tile_using_forall`.