### PR TITLE
Reduce `using namespace` in global scope

### DIFF
--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -45,9 +45,9 @@
 #define DEBUG_TYPE "air-lowering-pass"
 
 using namespace mlir;
-using namespace xilinx;
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRLaunchConversion : public ConversionPattern {
 public:
@@ -1390,7 +1390,8 @@ private:
   }
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
@@ -29,9 +29,9 @@
 #define DEBUG_TYPE "airrt-to-llvm-pass"
 
 using namespace mlir;
-using namespace xilinx;
 
-namespace {
+namespace xilinx {
+
 #define GEN_PASS_DEF_AIRRTTOLLVM
 #include "air/Conversion/Passes.h.inc"
 
@@ -1316,7 +1316,7 @@ public:
 private:
 };
 
-} // namespace
+} // namespace xilinx
 
 namespace xilinx {
 namespace airrt {

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -34,9 +34,9 @@
 #define DEBUG_TYPE "airrt-to-npu-pass"
 
 using namespace mlir;
-using namespace xilinx;
 
-namespace {
+namespace xilinx {
+
 #define GEN_PASS_DECL_AIRRTTONPU
 #define GEN_PASS_DEF_AIRRTTONPU
 #include "air/Conversion/Passes.h.inc"
@@ -1353,7 +1353,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
   }
 };
 
-} // namespace
+} // namespace xilinx
 
 namespace xilinx {
 namespace airrt {

--- a/mlir/lib/Conversion/AIRToAsyncPass.cpp
+++ b/mlir/lib/Conversion/AIRToAsyncPass.cpp
@@ -40,11 +40,9 @@
 #define DEBUG_TYPE "air-to-cpu"
 
 using namespace mlir;
-using namespace mlir::arith;
-using namespace xilinx;
-using namespace xilinx::air;
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRHerdOpConversion : public ConversionPattern {
 public:
@@ -812,7 +810,8 @@ public:
   }
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Dialect/AIRRt/IR/AIRRtDialect.cpp
+++ b/mlir/lib/Dialect/AIRRt/IR/AIRRtDialect.cpp
@@ -15,9 +15,10 @@
 #include "air/Dialect/AIRRt/AIRRtOps.h"
 
 using namespace mlir;
-using namespace xilinx::airrt;
 
 #include "air/Dialect/AIRRt/AIRRtOpsDialect.cpp.inc"
+
+namespace xilinx::airrt {
 
 void AIRRtDialect::initialize() {
   addTypes<EventType>();
@@ -108,3 +109,5 @@ void DeallocOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                             MLIRContext *context) {
   patterns.add(FoldDealloc);
 }
+
+} // namespace xilinx::airrt

--- a/mlir/lib/Dialect/AIRRt/IR/AIRRtOps.cpp
+++ b/mlir/lib/Dialect/AIRRt/IR/AIRRtOps.cpp
@@ -15,7 +15,6 @@
 #include "air/Dialect/AIRRt/AIRRtOps.h"
 
 using namespace mlir;
-using namespace xilinx::airrt;
 
 namespace xilinx {
 namespace airrt {

--- a/mlir/lib/Targets/AIRHerdToJSON.cpp
+++ b/mlir/lib/Targets/AIRHerdToJSON.cpp
@@ -41,10 +41,9 @@
 #define DEBUG_TYPE "air-herds-to-json"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class Herd {
 
@@ -148,7 +147,8 @@ mlir::LogicalResult AIRHerdsToJSONTranslate(mlir::ModuleOp module,
 
 }; // end class
 
-} // end namespace
+} // end namespace air
+} // end namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Targets/AIRTargets.cpp
+++ b/mlir/lib/Targets/AIRTargets.cpp
@@ -38,7 +38,6 @@
 #include "llvm/Support/TargetSelect.h"
 
 using namespace mlir;
-using namespace xilinx;
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRAutomaticTilingPass.cpp
+++ b/mlir/lib/Transform/AIRAutomaticTilingPass.cpp
@@ -41,11 +41,9 @@
 #define DEBUG_TYPE "air-automatic-tiling"
 
 using namespace mlir;
-using namespace mlir::affine;
-using namespace xilinx;
-using namespace xilinx::air;
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRAutomaticTilingPass
     : public xilinx::air::impl::AIRAutomaticTilingBase<AIRAutomaticTilingPass> {
@@ -318,8 +316,6 @@ void AIRAutomaticTilingPass::tileLoopsManually(
 
     auto stringAttr = band[0]->getAttrOfType<StringAttr>(
         AIRAutomaticTilingPass::affineOptAttrName);
-    // StringRef originalLabel = band[0]->getAttrOfType<StringRef>(
-    //   AIRAutomaticTilingPass::affineOptAttrName);
     if (stringAttr) {
       StringAttr postLabel =
           clPostLabel.empty()
@@ -331,7 +327,8 @@ void AIRAutomaticTilingPass::tileLoopsManually(
   }
 }
 
-} // anonymous namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -44,12 +44,10 @@
 #include <vector>
 
 using namespace mlir;
-using namespace xilinx;
-using namespace air;
-
 #define DEBUG_TYPE "air-dependency"
 
-namespace {
+namespace xilinx {
+namespace air {
 
 // Remove an op if it has no users, else return failure.
 // This is a temporary measure, while the issue
@@ -84,7 +82,7 @@ struct executeNode {
   unsigned operationId;
 };
 
-using ExecuteGraph = air::TypedDirectedAdjacencyMap<::executeNode>;
+using ExecuteGraph = air::TypedDirectedAdjacencyMap<air::executeNode>;
 
 typedef std::map<ExecuteGraph::VertexId, ExecuteGraph::VertexId> vertex_map;
 typedef std::map<unsigned, ExecuteGraph::VertexId> operation_id_to_vertex_map;
@@ -1788,7 +1786,8 @@ private:
   }
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -11,12 +11,11 @@
 #include "air/Util/Dependency.h"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 #define DEBUG_TYPE "air-dependency-canonicalize"
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRDependencyCanonicalize
     : public xilinx::air::impl::AIRDependencyCanonicalizeBase<
@@ -61,7 +60,8 @@ private:
   xilinx::air::dependencyContext dep_ctx;
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRDependencyParseGraph.cpp
+++ b/mlir/lib/Transform/AIRDependencyParseGraph.cpp
@@ -10,12 +10,11 @@
 #include "air/Util/Dependency.h"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 #define DEBUG_TYPE "air-dependency-parse-graph"
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRDependencyParseGraph
     : public xilinx::air::impl::AIRDependencyParseGraphBase<
@@ -42,7 +41,6 @@ public:
                                        graphGranularity);
       // Purge id attribute
       func.walk([&](Operation *op) { op->removeAttr("id"); });
-
     }
   }
 
@@ -53,7 +51,8 @@ private:
       g_to_tr; // Map between graph g and graph tr (post-tr graph)
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -52,12 +52,11 @@
 #include <vector>
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 #define DEBUG_TYPE "air-dependency-schedule-opt"
 
-namespace {
+namespace xilinx {
+namespace air {
 
 //===----------------------------------------------------------------------===//
 // Utility methods for op hoisting
@@ -6365,7 +6364,8 @@ public:
 private:
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -25,7 +25,6 @@ using namespace mlir;
 #define DEBUG_TYPE "dma-to-channel"
 
 namespace xilinx {
-namespace air {
 
 static void generateYieldAndOrReduceToScfLoop(OpBuilder builder,
                                               MLIRContext *ctx,
@@ -534,7 +533,6 @@ bool isValidExternalChannelOp(air::ChannelInterface getput) {
   return true;
 }
 
-} // namespace air
 } // namespace xilinx
 
 namespace xilinx {

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -21,9 +21,11 @@
 #include "mlir/Transforms/RegionUtils.h"
 
 using namespace mlir;
-using namespace xilinx;
 
 #define DEBUG_TYPE "dma-to-channel"
+
+namespace xilinx {
+namespace air {
 
 static void generateYieldAndOrReduceToScfLoop(OpBuilder builder,
                                               MLIRContext *ctx,
@@ -532,7 +534,12 @@ bool isValidExternalChannelOp(air::ChannelInterface getput) {
   return true;
 }
 
-namespace {
+} // namespace air
+} // namespace xilinx
+
+namespace xilinx {
+namespace air {
+
 class AIRDmaToAIRChannelConversion
     : public OpRewritePattern<air::DmaMemcpyNdOp> {
   using OpRewritePattern<air::DmaMemcpyNdOp>::OpRewritePattern;
@@ -807,8 +814,6 @@ class AIRHoistExternalAIRChannelPattern : public OpRewritePattern<AIRHierOpTy> {
   }
 };
 
-} // namespace
-
 template <class T>
 static Value insertArgToHierOpImpl(OpBuilder &builder, T op,
                                    SmallVector<Value> vec) {
@@ -963,7 +968,6 @@ static LogicalResult AIRDemoteMemrefToAIRHierarchy(
   return success();
 }
 
-namespace {
 class AIRDemoteDmaToAIRHierarchyConversion
     : public OpRewritePattern<air::DmaMemcpyNdOp> {
   using OpRewritePattern<air::DmaMemcpyNdOp>::OpRewritePattern;
@@ -1413,7 +1417,8 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
   }
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRHerdAssignPass.cpp
+++ b/mlir/lib/Transform/AIRHerdAssignPass.cpp
@@ -31,11 +31,11 @@
 #define DEBUG_TYPE "air-herd-assign"
 
 using namespace mlir;
-using namespace xilinx::air;
 
 static llvm::cl::OptionCategory clOptionsCategory(DEBUG_TYPE " options");
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class AIRHerdAssignPass
     : public xilinx::air::impl::AIRHerdAssignBase<AIRHerdAssignPass> {
@@ -126,7 +126,8 @@ public:
 private:
 };
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRHerdPlacementPass.cpp
+++ b/mlir/lib/Transform/AIRHerdPlacementPass.cpp
@@ -33,12 +33,11 @@
 #include <vector>
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 #define DEBUG_TYPE "air-place-herds"
 
-namespace {
+namespace xilinx {
+namespace air {
 
 class Herd {
 
@@ -330,7 +329,8 @@ private:
 
 }; // end AIRHerdPlacementPass
 
-} // end namespace
+} // end namespace air
+} // end namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRLinalgOpStats.cpp
+++ b/mlir/lib/Transform/AIRLinalgOpStats.cpp
@@ -20,8 +20,6 @@
 #define DEBUG_TYPE "air-linalg-op-stats"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 class AIRLinalgOpStats
     : public xilinx::air::impl::AIRLinalgOpStatsBase<AIRLinalgOpStats> {

--- a/mlir/lib/Transform/AIRLoopMergingPass.cpp
+++ b/mlir/lib/Transform/AIRLoopMergingPass.cpp
@@ -39,9 +39,6 @@
 #define DEBUG_TYPE "air-loop-merging"
 
 using namespace mlir;
-using namespace mlir::affine;
-using namespace xilinx;
-using namespace xilinx::air;
 
 namespace {
 

--- a/mlir/lib/Transform/AIRLoopPermutationPass.cpp
+++ b/mlir/lib/Transform/AIRLoopPermutationPass.cpp
@@ -10,11 +10,11 @@
 // Refers to include/mlir/Transform/LoopUtils.h
 // ===---------------------------------------------------------------------===//
 //
-// This pass performs a loop nest reordering according to the input mapping. 
-// The i-th loop will be moved from position i -> permMap[i] where the counting 
-// of i starts at the outermost loop. The pass transforms only perfect loop 
-// nests. The specified ordering starts from 0, and should be of the same 
-// length as the loop nest size. Each number is required to appear once in 
+// This pass performs a loop nest reordering according to the input mapping.
+// The i-th loop will be moved from position i -> permMap[i] where the counting
+// of i starts at the outermost loop. The pass transforms only perfect loop
+// nests. The specified ordering starts from 0, and should be of the same
+// length as the loop nest size. Each number is required to appear once in
 // the input mapping.
 //
 // ===---------------------------------------------------------------------===//
@@ -42,9 +42,6 @@
 #define DEBUG_TYPE "air-loop-permutation"
 
 using namespace mlir;
-using namespace mlir::affine;
-using namespace xilinx;
-using namespace xilinx::air;
 
 namespace {
 
@@ -55,10 +52,10 @@ public:
   AIRLoopPermutationPass() = default;
   AIRLoopPermutationPass(const AIRLoopPermutationPass &pass){};
 
-
   void runOnOperation() override;
 
   static const char *affineOptAttrName;
+
 private:
 };
 
@@ -67,17 +64,17 @@ const char *AIRLoopPermutationPass::affineOptAttrName = "affine_opt_label";
 void AIRLoopPermutationPass::runOnOperation() {
 
   auto func = getOperation();
-  
+
   // Bands of loops to tile
   std::vector<SmallVector<affine::AffineForOp, 6>> bands;
   xilinx::air::getTileableBands(
       func, bands, AIRLoopPermutationPass::affineOptAttrName, clLabel);
 
-  for (auto band: bands) {
+  for (auto band : bands) {
     // Save and erase the previous label
     auto stringAttr = band[0]->getAttrOfType<StringAttr>(
-      AIRLoopPermutationPass::affineOptAttrName);
-    
+        AIRLoopPermutationPass::affineOptAttrName);
+
     unsigned newOutermost = permuteLoops(band, loopOrder);
 
     if (stringAttr) {
@@ -85,8 +82,8 @@ void AIRLoopPermutationPass::runOnOperation() {
           clPostLabel.empty()
               ? stringAttr
               : StringAttr::get(clPostLabel, stringAttr.getType());
-      band[newOutermost]->setAttr(
-          AIRLoopPermutationPass::affineOptAttrName, postLabel);
+      band[newOutermost]->setAttr(AIRLoopPermutationPass::affineOptAttrName,
+                                  postLabel);
     }
     (void)band[0]->removeAttr(AIRLoopPermutationPass::affineOptAttrName);
   }

--- a/mlir/lib/Transform/AIRLowerLinalgTensors.cpp
+++ b/mlir/lib/Transform/AIRLowerLinalgTensors.cpp
@@ -28,8 +28,6 @@
 #define DEBUG_TYPE "air-lower-linalg-tensors"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::air;
 
 // Remove tensor_load followed by buffer_cast
 struct RemoveBufferCastPattern
@@ -142,7 +140,7 @@ void AIRLowerLinalgTensors::runOnOperation() {
   MLIRContext &context = getContext();
 
   ConversionTarget target(context);
-  target.addLegalDialect<AIE::AIEDialect, affine::AffineDialect,
+  target.addLegalDialect<xilinx::AIE::AIEDialect, affine::AffineDialect,
                          math::MathDialect, memref::MemRefDialect,
                          func::FuncDialect, arith::ArithDialect>();
   target.addIllegalOp<tensor::EmptyOp, tensor::ExtractSliceOp,

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -43,9 +43,8 @@
 #define DEBUG_TYPE "air-misc-passes"
 
 using namespace mlir;
-using namespace xilinx;
 
-namespace {
+namespace xilinx {
 
 class AIRExamplePass : public air::impl::AIRExamplePassBase<AIRExamplePass> {
 
@@ -2117,7 +2116,7 @@ void AIROverrideMemRefMemorySpacePass::runOnOperation() {
   (void)applyPatternsGreedily(funcOp, std::move(fixResTypePatterns));
 }
 
-} // anonymous namespace
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRRegularizeLoopPass.cpp
+++ b/mlir/lib/Transform/AIRRegularizeLoopPass.cpp
@@ -50,9 +50,6 @@
 #define DEBUG_TYPE "air-regularize-loop"
 
 using namespace mlir;
-using namespace mlir::affine;
-using namespace xilinx;
-using namespace xilinx::air;
 
 namespace {
 

--- a/mlir/lib/Transform/AIRTilingUtils.cpp
+++ b/mlir/lib/Transform/AIRTilingUtils.cpp
@@ -14,7 +14,6 @@
 #define DEBUG_TYPE "air-tiling-utils"
 
 using namespace mlir;
-using namespace mlir::affine;
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/AIRTransformInterpreter.cpp
+++ b/mlir/lib/Transform/AIRTransformInterpreter.cpp
@@ -20,7 +20,6 @@
 #define DEBUG_TYPE "air-transform-interpreter"
 
 using namespace mlir;
-using namespace xilinx;
 
 /// Utility to parse the content of a `transformFileName` mlir file containing
 /// a transform dialect specification.
@@ -63,7 +62,7 @@ public:
   AIRTransformInterpreterPass(const AIRTransformInterpreterPass &pass){};
 
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
-    registry.insert<air::airDialect, transform::TransformDialect>();
+    registry.insert<xilinx::air::airDialect, transform::TransformDialect>();
   }
 
   void runOnOperation() override {

--- a/mlir/lib/Transform/AffineLoopOptPass.cpp
+++ b/mlir/lib/Transform/AffineLoopOptPass.cpp
@@ -10,6 +10,7 @@
 
 #include "air/Transform/AffineLoopOptPass.h"
 #include "air/Util/Outliner.h"
+#include "air/Util/Util.h"
 
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
@@ -31,23 +32,9 @@
 #define DEBUG_TYPE "affine-loop-opt"
 
 using namespace mlir;
-using namespace xilinx::air;
 
-namespace {
-
-/// Returns the largest number that perfectly divides `num` that is less than or
-/// equal to max
-int findLargestFactor(int num, int max) {
-  if (num < max) {
-    return num;
-  }
-  for (int i = max; i > 0; i--) {
-    if (num % i == 0) {
-      return i;
-    }
-  }
-  return 1;
-}
+namespace xilinx {
+namespace air {
 
 class AffineLoopOptPass
     : public xilinx::air::impl::AffineLoopOptPassBase<AffineLoopOptPass> {
@@ -181,7 +168,7 @@ void AffineLoopOptPass::tileLoops(
           band[i].getStepAsInt();
       // Make sure the tile size divides the untiled size and is less than or
       // equal to the desired tile size.
-      actualTileSizes[i] = findLargestFactor(untiledSize, actualTileSizes[i]);
+      actualTileSizes[i] = air::findLargestFactor(untiledSize, actualTileSizes[i]);
     }
 
     if (failed(tilePerfectlyNested(band, actualTileSizes, &tiledNest)))
@@ -272,7 +259,8 @@ void AffineLoopOptPass::getTileableBands(
       }
 }
 
-} // namespace
+} // namespace air
+} // namespace xilinx
 
 namespace xilinx {
 namespace air {

--- a/mlir/lib/Transform/ReturnEliminationPass.cpp
+++ b/mlir/lib/Transform/ReturnEliminationPass.cpp
@@ -16,13 +16,12 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Pass/Pass.h"
 
-#include <vector>
 #include <set>
+#include <vector>
 
 #define DEBUG_TYPE "return-elimination"
 
 using namespace mlir;
-using namespace xilinx::air;
 
 namespace {
 
@@ -51,7 +50,7 @@ public:
         tys.push_back(t);
 
       auto newFnTy = FunctionType::get(op->getContext(), tys, {});
-      std::string newFnName = callOp.getCallee().str()+"_out";
+      std::string newFnName = callOp.getCallee().str() + "_out";
 
       if (!module.lookupSymbol<func::FuncOp>(newFnName)) {
         auto fn = func::FuncOp::create(op->getLoc(), newFnName, newFnTy);
@@ -60,7 +59,7 @@ public:
       }
 
       std::vector<Value> newCallArgs{callOp.arg_operand_begin(),
-                                      callOp.arg_operand_end()};
+                                     callOp.arg_operand_end()};
 
       for (auto v : callOp.getResults()) {
         if (!llvm::isa<MemRefType>(v.getType()))
@@ -77,7 +76,8 @@ public:
           op->getLoc(), newFnName, ArrayRef<Type>{}, newCallArgs);
       erasedOps.insert(op);
       auto fn = module.lookupSymbol<func::FuncOp>(callOp.getCallee());
-      if (fn && fn.use_empty()) erasedOps.insert(fn);
+      if (fn && fn.use_empty())
+        erasedOps.insert(fn);
     } else if (isa<memref::AllocOp>(op)) {
       Value v = op->getResult(0);
       if (valueMap.count(v)) {
@@ -88,9 +88,9 @@ public:
     // else if ( isa<xilinx::air::AllocOp>(op) ) {
     // }
     else {
-      //getModule().dump();
-      //op->dump();
-      //llvm_unreachable("unhandled operation type");
+      // getModule().dump();
+      // op->dump();
+      // llvm_unreachable("unhandled operation type");
     }
 
     for (Value v : op->getOperands()) {
@@ -101,7 +101,6 @@ public:
       if (v.getDefiningOp())
         runOn(v.getDefiningOp());
     }
-
   }
 
   void runOnOperation() override {
@@ -132,7 +131,8 @@ public:
       for (auto ty : funcTy.getResults())
         newFuncInputTys.push_back(ty);
 
-      FunctionType newFuncTy = FunctionType::get(module.getContext(), newFuncInputTys, {});
+      FunctionType newFuncTy =
+          FunctionType::get(module.getContext(), newFuncInputTys, {});
       graph.setType(newFuncTy);
 
       Operation *retOp = retOps.front();
@@ -156,7 +156,7 @@ public:
           runOn(v.getDefiningOp());
       }
 
-      for (auto oi=BB.rbegin(),oe=BB.rend(); oi!=oe; ++oi) {
+      for (auto oi = BB.rbegin(), oe = BB.rend(); oi != oe; ++oi) {
         Operation *o = &*oi;
         for (Value v : o->getResults()) {
           if (llvm::isa<MemRefType>(v.getType())) {
@@ -172,9 +172,9 @@ public:
   }
 
 private:
-  llvm::DenseMap<Value,Value> valueMap;
-  std::set<Operation*> visitedOps;
-  std::set<Operation*> erasedOps;
+  llvm::DenseMap<Value, Value> valueMap;
+  std::set<Operation *> visitedOps;
+  std::set<Operation *> erasedOps;
 };
 
 } // namespace
@@ -188,4 +188,3 @@ std::unique_ptr<mlir::Pass> createReturnEliminationPass() {
 
 } // namespace air
 } // namespace xilinx
-

--- a/mlir/lib/Util/CostModel.cpp
+++ b/mlir/lib/Util/CostModel.cpp
@@ -30,7 +30,6 @@ using namespace mlir;
 namespace xilinx {
 namespace air {
 
-
 static uint64_t getTensorVolume(const ShapedType ty) {
 
   if (!ty.hasRank())
@@ -39,7 +38,7 @@ static uint64_t getTensorVolume(const ShapedType ty) {
   uint64_t volume = 1;
   for (auto &d : ty.getShape())
     volume *= d;
-  return volume * (ty.getElementTypeBitWidth()/8);
+  return volume * (ty.getElementTypeBitWidth() / 8);
 }
 
 static uint64_t getTensorVolume(const Type ty) {
@@ -50,9 +49,7 @@ static uint64_t getTensorVolume(const Type ty) {
   }
 }
 
-
-void
-CostModel::getLinalgOpCounts(OpCountMap &map, linalg::LinalgOp op) {
+void CostModel::getLinalgOpCounts(OpCountMap &map, linalg::LinalgOp op) {
   OpBuilder b(op);
   auto loc = op.getLoc();
 
@@ -118,9 +115,7 @@ CostModel::getLinalgOpCounts(OpCountMap &map, linalg::LinalgOp op) {
   return;
 }
 
-void
-CostModel::getScfForOpCounts(CostModel::OpCountMap &map, scf::ForOp op)
-{
+void CostModel::getScfForOpCounts(CostModel::OpCountMap &map, scf::ForOp op) {
   // everything must be a constant
   auto step = op.getStep();
   if (!step.getDefiningOp<arith::ConstantIndexOp>())
@@ -135,8 +130,10 @@ CostModel::getScfForOpCounts(CostModel::OpCountMap &map, scf::ForOp op)
     return;
 
   auto stepI64 = cast<arith::ConstantIndexOp>(step.getDefiningOp()).value();
-  auto lowerBoundI64 = cast<arith::ConstantIndexOp>(lowerBound.getDefiningOp()).value();
-  auto upperBoundI64 = cast<arith::ConstantIndexOp>(upperBound.getDefiningOp()).value();
+  auto lowerBoundI64 =
+      cast<arith::ConstantIndexOp>(lowerBound.getDefiningOp()).value();
+  auto upperBoundI64 =
+      cast<arith::ConstantIndexOp>(upperBound.getDefiningOp()).value();
 
   auto iters = (upperBoundI64 - lowerBoundI64) / stepI64;
 
@@ -152,27 +149,21 @@ CostModel::getScfForOpCounts(CostModel::OpCountMap &map, scf::ForOp op)
   return;
 }
 
-CostModel::OpCountMap
-CostModel::getOpCounts(Operation* op)
-{
+CostModel::OpCountMap CostModel::getOpCounts(Operation *op) {
   OpCountMap map;
   map.name = op->getName().getStringRef().str();
-  llvm::TypeSwitch<Operation*>(op)
-      .Case<linalg::LinalgOp>([&](linalg::LinalgOp o){
-        getLinalgOpCounts(map, o);
-      })
-      .Case<scf::ForOp>([&](scf::ForOp o){
-        getScfForOpCounts(map, o);
-      })
-      .Default([&](Operation *op){
-        return map;//map.insert({"unknown", 1});
+  llvm::TypeSwitch<Operation *>(op)
+      .Case<linalg::LinalgOp>(
+          [&](linalg::LinalgOp o) { getLinalgOpCounts(map, o); })
+      .Case<scf::ForOp>([&](scf::ForOp o) { getScfForOpCounts(map, o); })
+      .Default([&](Operation *op) {
+        return map; // map.insert({"unknown", 1});
       });
   return map;
 }
 
-void
-CostModel::opCountToJSON(OpCountMap &opCounts,
-                         llvm::json::Object &parent) {
+void CostModel::opCountToJSON(OpCountMap &opCounts,
+                              llvm::json::Object &parent) {
   llvm::json::Object layerStatsJSON;
   for (auto p : opCounts.map) {
     auto name = p.first;
@@ -186,8 +177,7 @@ CostModel::opCountToJSON(OpCountMap &opCounts,
       llvm::json::Value(std::move(layerStatsJSON));
 }
 
-std::string
-CostModel::opCountsToJSON(ModuleOp module) {
+std::string CostModel::opCountsToJSON(ModuleOp module) {
   llvm::json::Object top;
 
   module.walk([&](func::FuncOp fop) {

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -30,7 +30,8 @@
 #define DEBUG_TYPE "air-util"
 
 using namespace mlir;
-using namespace xilinx;
+
+namespace xilinx {
 
 const StringLiteral air::LinalgTransforms::kLinalgTransformMarker =
     "__internal_linalg_transform__";
@@ -2079,3 +2080,5 @@ air::consructComposedAffineApplyOpFromArithMulI(OpBuilder &builder,
       builder, mulOp.getLoc(), map,
       getAsOpFoldResult({mulOp.getLhs(), mulOp.getRhs()}));
 }
+
+} // namespace xilinx


### PR DESCRIPTION
Limit `using namespace xilinx/air` in global scope, to reduce the stress on clang++/g++ parser.