### PR TITLE
Improve code stability by only registering the results of `memref.alloc` or `memref.assume_alignment` as input memrefs

### DIFF
--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1914,7 +1914,7 @@ struct BufferMemrefToFuncArgsPattern : public OpRewritePattern<func::FuncOp> {
     SmallVector<Type, 6> memrefTypes;
     llvm::SetVector<Value> memrefs;
     for (auto &op : funcOp.getFunctionBody().getOps()) {
-      if (mlir::isPure(&op))
+      if (!isa<memref::AllocOp, memref::AssumeAlignmentOp>(op))
         continue;
       for (auto res : op.getResults()) {
         BaseMemRefType resType = dyn_cast<BaseMemRefType>(res.getType());

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1914,7 +1914,7 @@ struct BufferMemrefToFuncArgsPattern : public OpRewritePattern<func::FuncOp> {
     SmallVector<Type, 6> memrefTypes;
     llvm::SetVector<Value> memrefs;
     for (auto &op : funcOp.getFunctionBody().getOps()) {
-      if (isa<CastOpInterface, UnrealizedConversionCastOp>(op))
+      if (mlir::isPure(&op))
         continue;
       for (auto res : op.getResults()) {
         BaseMemRefType resType = dyn_cast<BaseMemRefType>(res.getType());


### PR DESCRIPTION
... instead of filtering out a list of op types.