### PR TITLE
AIRToAIE: Fixup a race condition with the multi-channel DMA BD pattern

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -118,7 +118,7 @@ public:
   lookupDMAAllocation(int64_t col, int64_t row, air::MemcpyInterface &memcpyOp);
   FailureOr<std::pair<AIE::LockOp, AIE::LockOp>>
   getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
-                Operation *bufferOp);
+                Operation *bufferOp, bool lockRaceConditionFix = false);
   FailureOr<allocation_info_t>
   allocNewDmaChannel(air::MemcpyInterface &memcpyOp, AIE::TileOp tile, int chan,
                      int col, int row, std::vector<int> dma_id);
@@ -133,6 +133,7 @@ public:
   std::vector<std::tuple<Operation *, air::ChannelOp, AIE::DMAChannel,
                          AIE::LockOp, AIE::LockOp>>
       lock_allocation_list;
+  DenseMap<Value, std::pair<int, int>> passiveSideBufferUseCounters;
 };
 
 class TileDMAAllocator : public DMAAllocator {

--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -201,6 +201,11 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
           /*default=*/"false",
           "Switch to using packet flows for all data movements at shim DMAs, "
           "to enable time-multiplex sharing with control packet flows.">,
+    Option<"clUseLockRaceConditionFix", "use-lock-race-condition-fix", "bool", 
+          /*default=*/"false",
+          "Switch to enable a fix for lock race condition, which protects "
+          "against the risk of race condition, at the cost of inserting extra "
+          "dummy DMA BDs">,
   ];
   let description = [{
     This pass converts AIR dialect `herd` and `segment` operations into AIE

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -117,20 +117,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
-// CHECK:           aie.use_lock(%[[VAL_3]], Release, 0)
+// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -392,33 +392,33 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_0]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb6)
-// CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:           aie.next_bd ^bb1
-// CHECK:         ^bb2:
-// CHECK:           aie.end
-// CHECK:         ^bb3:
-// CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
-// CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_3]], Release, 1)
-// CHECK:           aie.next_bd ^bb5
-// CHECK:         ^bb5:
-// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
-// CHECK:           aie.next_bd ^bb4
-// CHECK:         ^bb6:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb7, ^bb3)
-// CHECK:         ^bb7:
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb5)
+// CHECK:         ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:           aie.use_lock(%[[VAL_5]], Acquire, 1)
 // CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
 // CHECK:           aie.use_lock(%[[VAL_5]], Release, 0)
+// CHECK:           aie.next_bd ^bb1
+// CHECK:         ^bb2:  // pred: ^bb3
+// CHECK:           aie.end
+// CHECK:         ^bb3:  // pred: ^bb5
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
+// CHECK:         ^bb4:  // 2 preds: ^bb3, ^bb4
+// CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:           aie.next_bd ^bb4
+// CHECK:         ^bb5:  // pred: ^bb0
+// CHECK:           aie.dma_start(S2MM, 1, ^bb6, ^bb3)
+// CHECK:         ^bb6:  // 2 preds: ^bb5, ^bb7
+// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:           aie.next_bd ^bb7
+// CHECK:         ^bb7:  // pred: ^bb6
+// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
+// CHECK:           aie.next_bd ^bb6
 // CHECK:         }
 
 // CHECK:    aie.core(%[[VAL_0]])  {
@@ -508,20 +508,20 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
 // CHECK:         %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {{{.*}}} : memref<16x8xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_0]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<16x8xi32, 2>, 0, 128)
-// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<16x8xi32, 2>, 0, 128)
+// CHECK:           aie.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<16x8xi32, 2>, 0, 128)
-// CHECK:           aie.use_lock(%[[VAL_3]], Release, 0)
+// CHECK:           aie.use_lock(%[[VAL_2]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<16x8xi32, 2>, 0, 128)
+// CHECK:           aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 // CHECK: @func8

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -73,20 +73,20 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: %[[VAL_12:.*]] = aie.buffer(%[[VAL_2]]) {{.*}} : memref<1024xi32, 2>
 // CHECK: %[[VAL_13:.*]] = aie.buffer(%[[VAL_2]]) {{.*}} : memref<512xi32, 2>
 // CHECK: aie.mem(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_9]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
+// CHECK:   aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
-// CHECK:   aie.use_lock(%[[VAL_10]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 // CHECK: aie.core(%[[VAL_2]]) {
@@ -98,20 +98,20 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: aie.flow(%[[VAL_3]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK: aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_3]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
-// CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
@@ -151,20 +151,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_12:.*]] = aie.buffer(%[[VAL_7]]) {{{.*}}} : memref<1024xi32, 2>
 // CHECK:         %[[VAL_13:.*]] = aie.buffer(%[[VAL_7]]) {{{.*}}} : memref<512xi32, 2>
 // CHECK:    aie.mem(%[[VAL_7]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_9]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
-// CHECK:           aie.use_lock(%[[VAL_10]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -178,20 +178,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_7]], DMA : 0)
 // CHECK:         aie.flow(%[[VAL_7]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
-// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_3]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 
@@ -243,20 +243,20 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_23:.*]] = aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_3]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
+// CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_18]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
+// CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_19]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -273,52 +273,52 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_3]], DMA : 0, %[[VAL_2]], DMA : 1)
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 1, %[[VAL_4]], DMA : 0)
 // CHECK: aie.shim_dma(%[[VAL_4]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
+// CHECK:   aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_16]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
+// CHECK:   aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_13]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 
 // CHECK: aie.memtile_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:   aie.next_bd ^bb4
-// CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
-// CHECK: ^bb6:
-// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
-// CHECK:   aie.next_bd ^bb6
-// CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
-// CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
+// CHECK:   aie.next_bd ^bb4
+// CHECK: ^bb5:
+// CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb3)
+// CHECK: ^bb6:
+// CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:   aie.next_bd ^bb6
+// CHECK: ^bb7:
+// CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb5)
+// CHECK: ^bb8:
+// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
 

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
@@ -151,20 +151,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_9:.*]] = aie.buffer(%[[VAL_5]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_5]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_6]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_7]], Acquire, 1)
+// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.use_lock(%[[VAL_7]], Release, 0)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_7]], Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
-// CHECK:           aie.use_lock(%[[VAL_7]], Release, 0)
+// CHECK:           aie.use_lock(%[[VAL_6]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -180,20 +180,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_5]], DMA : 0, %[[VAL_2]], DMA : 0)
 
 // CHECK:    aie.shim_dma(%[[VAL_2]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 512)
-// CHECK:           aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_4]], Acquire, 1)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_4]], Release, 0)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_3]], Release, 0)
+// CHECK:           aie.use_lock(%[[VAL_3]], Acquire, 0)
+// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:           aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 // CHECK: @func3

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -61,20 +61,20 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK: %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {{.*}} : memref<1024xi32, 2>
 // CHECK: %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {{.*}} : memref<512xi32, 2>
 // CHECK: %[[VAL_8:.*]] = aie.mem(%[[VAL_0]]) {
-// CHECK:   %[[VAL_9:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   %[[VAL_9:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_3]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
+// CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   %[[VAL_10:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:   %[[VAL_10:.*]] = aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
-// CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 // CHECK: %[[VAL_11:.*]] = aie.core(%[[VAL_0]]) {
@@ -126,20 +126,20 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_7:.*]] = aie.buffer(%[[VAL_1]]) {{{.*}}} : memref<512xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_1]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_3]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
-// CHECK:           aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -204,20 +204,20 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         %[[VAL_23:.*]] = aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<1024xi32, 2>
 
 // CHECK:    aie.mem(%[[VAL_3]])  {
-// CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
-// CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
+// CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_18]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
 // CHECK:           aie.end
 // CHECK:         ^bb3:
-// CHECK:           aie.dma_start(MM2S, 0, ^bb4, ^bb2)
+// CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
-// CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
+// CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
 // CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
-// CHECK:           aie.use_lock(%[[VAL_19]], Release, 1)
+// CHECK:           aie.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
 
@@ -235,34 +235,34 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:         aie.flow(%[[VAL_2]], DMA : 1, %[[VAL_4]], DMA : 0)
 
 // CHECK: aie.memtile_dma(%[[VAL_2]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
 // CHECK:   aie.end
 // CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:   aie.next_bd ^bb4
-// CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
-// CHECK: ^bb6:
-// CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
-// CHECK:   aie.use_lock(%[[VAL_7]], Release, 1)
-// CHECK:   aie.next_bd ^bb6
-// CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
-// CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
+// CHECK:   aie.next_bd ^bb4
+// CHECK: ^bb5:
+// CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb3)
+// CHECK: ^bb6:
+// CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:   aie.next_bd ^bb6
+// CHECK: ^bb7:
+// CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb5)
+// CHECK: ^bb8:
+// CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
 // CHECK: aie.shim_dma_allocation @air_channel_5(S2MM, 0, 0)
@@ -468,24 +468,24 @@ func.func @func6(%arg5 : memref<8x8xi32>) {
 // Multi-dimensional memref copy to wraps and strides
 // CHECK: aie.device(npu1)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb5)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb5)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
 // CHECK:   aie.use_lock({{.*}}, Release, 1)
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:  // pred: ^bb5
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4, ^bb2)
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd({{.*}} : memref<8x16xi32, 1>, 0, 16, [<size = 4, stride = 16>, <size = 4, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
 // CHECK:   aie.use_lock({{.*}}, Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:  // pred: ^bb0
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
+// CHECK:   aie.dma_start(S2MM, 1, ^bb6, ^bb3)
 // CHECK: ^bb6:  // 2 preds: ^bb5, ^bb6
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
+// CHECK:   aie.dma_bd({{.*}} : memref<8x16xi32, 1>, 0, 16, [<size = 4, stride = 16>, <size = 4, stride = 1>])
 // CHECK:   aie.use_lock({{.*}}, Release, 1)
 // CHECK:   aie.next_bd ^bb6
 // CHECK: @func7
@@ -1175,14 +1175,14 @@ func.func @func16(%arg0 : memref<5xi32>, %arg1 : memref<96xi32>, %arg2 : memref<
 // Lowering complex loop structures around channel.puts/gets into BD task repeat counts (aie.memtile_dma).
 //
 // CHECK:      aie.memtile_dma
-// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK-NEXT: aie.dma_start(MM2S, 0, ^bb1, ^bb7)
 // CHECK-NEXT: ^bb1:
 // CHECK:      aie.dma_bd({{.*}}) {task_id = 0 : i32}
 // CHECK:      aie.next_bd ^bb2
 // CHECK-NEXT: ^bb2:
 // CHECK-NEXT: aie.end
 // CHECK-NEXT: ^bb3:
-// CHECK-NEXT: aie.dma_start(S2MM, 0, ^bb4, ^bb2, repeat_count = 7)
+// CHECK-NEXT: aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 7)
 // CHECK:      aie.dma_bd({{.*}}) {task_id = 1 : i32}
 // CHECK:      aie.next_bd ^bb2
 // CHECK: @func17

--- a/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
@@ -24,18 +24,18 @@
 // CHECK: %[[VAL13:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: %[[VAL14:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: aie.mem(%[[VAL1]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL8]], Release, 1)
-// CHECK:   aie.next_bd ^bb1
-// CHECK: ^bb3:  // pred: ^bb0
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4,
-// CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock(%[[VAL10]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL14]] : memref<64xi32, 2>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL9]], Release, 1)
+// CHECK:   aie.next_bd ^bb1
+// CHECK: ^bb3:  // pred: ^bb0
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4,
+// CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
+// CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL8]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 // CHECK: aie.core(%[[VAL1]]) {
@@ -60,32 +60,32 @@
 // CHECK: aie.flow(%[[VAL1]], DMA : 0, %[[VAL0]], DMA : 1)
 // CHECK: aie.flow(%[[VAL0]], DMA : 1, %[[VAL2]], DMA : 0)
 // CHECK: aie.memtile_dma(%[[VAL0]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL6]], Release, 1)
-// CHECK:   aie.next_bd ^bb1
-// CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4
-// CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL3]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
-// CHECK:   aie.next_bd ^bb4
-// CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
-// CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL5]], Release, 1)
-// CHECK:   aie.next_bd ^bb6
-// CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
-// CHECK: ^bb8:
+// CHECK:   aie.next_bd ^bb1
+// CHECK: ^bb3:
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4
+// CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL4]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL3]], Release, 1)
+// CHECK:   aie.next_bd ^bb4
+// CHECK: ^bb5:
+// CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb3)
+// CHECK: ^bb6:
+// CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL6]], Release, 1)
+// CHECK:   aie.next_bd ^bb6
+// CHECK: ^bb7:
+// CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb5)
+// CHECK: ^bb8:
+// CHECK:   aie.use_lock(%[[VAL3]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
 // CHECK: aie.shim_dma_allocation @air_channel_3(S2MM, 0, 0)
@@ -154,18 +154,18 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK: %[[VAL13:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: %[[VAL14:.*]] = aie.buffer(%[[VAL1]]) {{{.*}}} : memref<64xi32, 2>
 // CHECK: aie.mem(%[[VAL1]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL8]], Release, 1)
-// CHECK:   aie.next_bd ^bb1
-// CHECK: ^bb3:  // pred: ^bb0
-// CHECK:   aie.dma_start(MM2S, 0, ^bb4,
-// CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock(%[[VAL10]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL14]] : memref<64xi32, 2>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL9]], Release, 1)
+// CHECK:   aie.next_bd ^bb1
+// CHECK: ^bb3:  // pred: ^bb0
+// CHECK:   aie.dma_start(S2MM, 0, ^bb4,
+// CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
+// CHECK:   aie.use_lock(%[[VAL7]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL13]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL8]], Release, 1)
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
 // CHECK: aie.core(%[[VAL1]]) {
@@ -190,32 +190,32 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK: aie.flow(%[[VAL1]], DMA : 0, %[[VAL0]], DMA : 1)
 // CHECK: aie.flow(%[[VAL0]], DMA : 1, %[[VAL2]], DMA : 0)
 // CHECK: aie.memtile_dma(%[[VAL0]]) {
-// CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb7)
+// CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb7)
 // CHECK: ^bb1:
-// CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL6]], Release, 1)
-// CHECK:   aie.next_bd ^bb1
-// CHECK: ^bb3:
-// CHECK:   aie.dma_start(S2MM, 1, ^bb4
-// CHECK: ^bb4:
-// CHECK:   aie.use_lock(%[[VAL3]], AcquireGreaterEqual, 1)
-// CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
-// CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
-// CHECK:   aie.next_bd ^bb4
-// CHECK: ^bb5:
-// CHECK:   aie.dma_start(MM2S, 0, ^bb6, ^bb3)
-// CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL6]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL5]], Release, 1)
-// CHECK:   aie.next_bd ^bb6
-// CHECK: ^bb7:
-// CHECK:   aie.dma_start(MM2S, 1, ^bb8, ^bb5)
-// CHECK: ^bb8:
+// CHECK:   aie.next_bd ^bb1
+// CHECK: ^bb3:
+// CHECK:   aie.dma_start(MM2S, 1, ^bb4
+// CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL4]], AcquireGreaterEqual, 1)
 // CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
 // CHECK:   aie.use_lock(%[[VAL3]], Release, 1)
+// CHECK:   aie.next_bd ^bb4
+// CHECK: ^bb5:
+// CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb3)
+// CHECK: ^bb6:
+// CHECK:   aie.use_lock(%[[VAL5]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL11]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL6]], Release, 1)
+// CHECK:   aie.next_bd ^bb6
+// CHECK: ^bb7:
+// CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb5)
+// CHECK: ^bb8:
+// CHECK:   aie.use_lock(%[[VAL3]], AcquireGreaterEqual, 1)
+// CHECK:   aie.dma_bd(%[[VAL12]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.use_lock(%[[VAL4]], Release, 1)
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
 // CHECK: aie.shim_dma_allocation @air_channel_3(S2MM, 0, 0)

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -53,6 +53,7 @@ class XRTBackend(AirBackend):
         runtime_loop_tiling_sizes: list[int] = [4, 4],
         omit_auto_broadcast: bool = False,
         channel_multiplexing: list[str] = [],
+        use_lock_race_condition_fix: bool = False,
         trace_offset: int = 0,
         trace_size: int = 0,
         output_format: str = "xclbin",
@@ -72,6 +73,7 @@ class XRTBackend(AirBackend):
             runtime_loop_tiling_sizes: configure aircc to add extra runtime loop tiling using the experimental affine-loop-opt pass.
             omit_auto_broadcast: configure aircc to omit the detection and lowering of broadcast data movements.
             channel_multiplexing: configure aircc to perform air channel multiplexing on specified memroy spaces.
+            use_lock_race_condition_fix: configure aircc to enable a fix for lock race condition which protects against race condition.
             trace_offset: configure aircc to stream out profiling traces at outputs, starting from the specified offset.
             trace_size: configure aircc to stream out profiling traces at outputs, with specified trace data size.
             output_format: configure aircc to produce output binary in to one of the following formats: [xclbin, txn].
@@ -89,6 +91,7 @@ class XRTBackend(AirBackend):
         self.runtime_loop_tiling_sizes = runtime_loop_tiling_sizes
         self.omit_auto_broadcast = omit_auto_broadcast
         self.channel_multiplexing = channel_multiplexing
+        self.use_lock_race_condition_fix = use_lock_race_condition_fix
         self.trace_offset = trace_offset
         self.trace_size = trace_size
         self.currently_loaded = False
@@ -216,6 +219,9 @@ class XRTBackend(AirBackend):
             if len(self.channel_multiplexing) != 0:
                 aircc_options += ["--air-channel-multiplexing"]
                 aircc_options += self.channel_multiplexing
+            
+            if self.use_lock_race_condition_fix:
+                aircc_options += ["--use-lock-race-condition-fix"]
 
             if self.trace_size != 0:
                 aircc_options += ["-trace-size"]

--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -65,6 +65,7 @@ class XRTRunner:
         runtime_loop_tiling_sizes: list[int] = [4, 4],
         omit_auto_broadcast: bool = False,
         channel_multiplexing: list[str] = [],
+        use_lock_race_condition_fix: bool = False,
         trace_offset: int = 0,
         trace_size: int = 0,
         output_format: str = "xclbin",
@@ -83,6 +84,7 @@ class XRTRunner:
             runtime_loop_tiling_sizes: configure aircc to add extra runtime loop tiling using the experimental affine-loop-opt pass.
             omit_auto_broadcast: configure aircc to omit the detection and lowering of broadcast data movements.
             channel_multiplexing: configure aircc to perform air channel multiplexing on specified memroy spaces.
+            use_lock_race_condition_fix: configure aircc to enable a fix for lock race condition which protects against race condition.
             trace_offset: configure aircc to stream out profiling traces at outputs, starting from the specified offset.
             trace_size: configure aircc to stream out profiling traces at outputs, with specified trace data size.
             output_format: configure aircc to produce output binary in to one of the following formats: [xclbin, txn].
@@ -99,6 +101,7 @@ class XRTRunner:
         self.runtime_loop_tiling_sizes = runtime_loop_tiling_sizes
         self.omit_auto_broadcast = omit_auto_broadcast
         self.channel_multiplexing = channel_multiplexing
+        self.use_lock_race_condition_fix = use_lock_race_condition_fix
         self.trace_offset = trace_offset
         self.trace_size = trace_size
         self.output_format = output_format
@@ -136,6 +139,7 @@ class XRTRunner:
             runtime_loop_tiling_sizes=self.runtime_loop_tiling_sizes,
             omit_auto_broadcast=self.omit_auto_broadcast,
             channel_multiplexing=self.channel_multiplexing,
+            use_lock_race_condition_fix = self.use_lock_race_condition_fix,
             trace_offset=self.trace_offset,
             trace_size=self.trace_size,
             output_format=self.output_format,

--- a/python/air/compiler/aircc/cl_arguments.py
+++ b/python/air/compiler/aircc/cl_arguments.py
@@ -181,6 +181,13 @@ def parse_args(args=None):
         help="Adds memory spaces to which air channels shall get time-multiplexed, if operating on them",
     )
     parser.add_argument(
+        "--use-lock-race-condition-fix",
+        dest="use_lock_race_condition_fix",
+        default=False,
+        action="store_true",
+        help="Switch to enable a fix for lock race condition, which protects against the risk of race condition, at the cost of inserting extra dummy DMA BDs.",
+    )
+    parser.add_argument(
         "--output-format",
         type=str,
         choices=["xclbin", "txn"],

--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -491,6 +491,7 @@ def run(mlir_module, args=None):
         air_to_aie_pass = air_to_aie_pass + f" device={opts.device}"
         if int(opts.trace_size) > 0:
             air_to_aie_pass = air_to_aie_pass + " insert-trace-packet-flow=true"
+        air_to_aie_pass = air_to_aie_pass + f" use-lock-race-condition-fix={opts.use_lock_race_condition_fix}"
         air_to_aie_pass = air_to_aie_pass + "}"
         pass_pipeline = ",".join([air_to_aie_pass])
 

--- a/test/xrt/01_air_to_npu/gen.py
+++ b/test/xrt/01_air_to_npu/gen.py
@@ -149,5 +149,6 @@ backend = XRTBackend(
     air_loop_fusion=True,
     trace_offset=opts.trace_offset,
     trace_size=opts.trace_size,
+    use_lock_race_condition_fix=True,
 )
 backend.compile(air_module)

--- a/test/xrt/02_mul_shim_1x1/run.py
+++ b/test/xrt/02_mul_shim_1x1/run.py
@@ -96,7 +96,10 @@ def run_test(size, idtype, odtype):
     ref = (input_a * input_b).astype(odtype)
     input_c = np.ones_like(ref)
 
-    backend = xrt_backend.XRTBackend(verbose=verbose)
+    backend = xrt_backend.XRTBackend(
+        verbose=verbose,
+        use_lock_race_condition_fix=True,
+    )
 
     # run the module
     compiled_module = backend.compile(mlir_module)

--- a/test/xrt/03_mul_L1L2_1x1/run.py
+++ b/test/xrt/03_mul_L1L2_1x1/run.py
@@ -134,7 +134,10 @@ def run_test(size, idtype, odtype):
     ref = (input_a * input_b).astype(odtype)
     input_c = np.ones_like(ref)
 
-    backend = xrt_backend.XRTBackend(verbose=verbose)
+    backend = xrt_backend.XRTBackend(
+        verbose=verbose,
+        use_lock_race_condition_fix=True,
+    )
 
     # run the module
     compiled_module = backend.compile(mlir_module)

--- a/test/xrt/04_gemm_w_pack/gen.py
+++ b/test/xrt/04_gemm_w_pack/gen.py
@@ -105,5 +105,7 @@ with air.ir.Context() as ctx, Location.unknown():
     # Run compile and load
     ###############################################
 
-    backend = XRTBackend()
+    backend = XRTBackend(
+      use_lock_race_condition_fix=True,
+    )
     backend.compile(air_module)

--- a/test/xrt/06_add_shim_bf16/gen.py
+++ b/test/xrt/06_add_shim_bf16/gen.py
@@ -84,5 +84,6 @@ pm.run(module.operation)
 
 backend = XRTBackend(
     air_loop_fusion=True,
+    use_lock_race_condition_fix=True,
 )
 module_function = backend.compile(module)

--- a/test/xrt/07_extern_linalg/gen.py
+++ b/test/xrt/07_extern_linalg/gen.py
@@ -90,5 +90,6 @@ pm.run(module.operation)
 backend = XRTBackend(
     lower_linalg_to_func="kernel.o",
     omit_pingpong=True,
+    use_lock_race_condition_fix=True,
 )
 module_function = backend.compile(module)

--- a/test/xrt/08_gemm_extern_vec/gen.py
+++ b/test/xrt/08_gemm_extern_vec/gen.py
@@ -125,5 +125,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/09_gemm_extern_vec_4x4/gen.py
+++ b/test/xrt/09_gemm_extern_vec_4x4/gen.py
@@ -126,5 +126,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         air_loop_fusion=True,
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/10_gemm_peeling_extern_vec/gen.py
+++ b/test/xrt/10_gemm_peeling_extern_vec/gen.py
@@ -136,5 +136,7 @@ with air.ir.Context() as ctx, Location.unknown():
     # Run compile and load
     ###############################################
 
-    backend = XRTBackend()
+    backend = XRTBackend(
+      use_lock_race_condition_fix=True,
+    )
     backend.compile(air_module)

--- a/test/xrt/12_matmul_transform_1x4_bf16/gen.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/gen.py
@@ -137,5 +137,6 @@ backend = XRTBackend(
     air_loop_fusion=True,
     runtime_loop_tiling_sizes=[1, 1],
     lower_linalg_to_func="kernel.o",
+    use_lock_race_condition_fix=True,
 )
 backend.compile(air_module)

--- a/test/xrt/13_conv2d_i32/gen.py
+++ b/test/xrt/13_conv2d_i32/gen.py
@@ -101,7 +101,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        air_loop_fusion=True,
         runtime_loop_tiling_sizes=[1, 1],
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/14_conv2d_i8_extern_vec/gen.py
+++ b/test/xrt/14_conv2d_i8_extern_vec/gen.py
@@ -99,9 +99,9 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         lower_linalg_to_func="conv.o",
-        air_loop_fusion=True,
         trace_offset=73728,
         trace_size=262144,
         runtime_loop_tiling_sizes=[1, 1],
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
+++ b/test/xrt/15_gemm_peeling_extern_vec_4x4_bf16/gen.py
@@ -160,5 +160,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         lower_linalg_to_func="mm.o",
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
+++ b/test/xrt/16_gemm_peeling_extern_vec_4x4_bf16_packet/gen.py
@@ -160,5 +160,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
 backend = XRTBackend(
     lower_linalg_to_func="mm.o",
+    use_lock_race_condition_fix=True,
 )
 backend.compile(air_module)

--- a/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
+++ b/test/xrt/17_gemm_8x16_transform_vec_4x4/gen.py
@@ -139,5 +139,6 @@ backend = XRTBackend(
     air_loop_fusion=True,
     lower_linalg_to_func="mm.o",
     runtime_loop_tiling_sizes=[1, 1],
+    use_lock_race_condition_fix=True,
 )
 backend.compile(air_module)

--- a/test/xrt/22_conv2d_stride2_i32/gen.py
+++ b/test/xrt/22_conv2d_stride2_i32/gen.py
@@ -102,7 +102,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###############################################
 
     backend = XRTBackend(
-        air_loop_fusion=True,
         runtime_loop_tiling_sizes=[1, 1],
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/23_ctrlpkt_config/aie.py
+++ b/test/xrt/23_ctrlpkt_config/aie.py
@@ -209,7 +209,7 @@ with open("air_placed.mlir", "w") as f:
 # ## MLIR-AIR to MLIR-AIE
 # ################################################
 
-air_to_aie_pass = "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true"
+air_to_aie_pass = "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true use-lock-race-condition-fix=true"
 if opts.trace_size > 0:
     air_to_aie_pass = air_to_aie_pass + " insert-trace-packet-flow=true"
 air_to_aie_pass = air_to_aie_pass + "}"

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie.py
@@ -242,7 +242,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "canonicalize",
                 "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
+                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true use-lock-race-condition-fix=true}",
                 "canonicalize",
             ]
         )

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/aie2.py
@@ -241,7 +241,7 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "canonicalize",
                 "cse",
-                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true}",
+                "air-to-aie{row-offset=2 col-offset=0 device=npu1 emit-while-loop=true use-pkt-flow-at-shim-dma=true use-lock-race-condition-fix=true}",
                 "canonicalize",
             ]
         )

--- a/test/xrt/26_vecmat_i8/gen.py
+++ b/test/xrt/26_vecmat_i8/gen.py
@@ -122,6 +122,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         lower_linalg_to_func="vm.o",
-        air_loop_fusion=True,
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
+++ b/test/xrt/27_gemm_peeling_extern_vec_4x4_i32/gen.py
@@ -161,5 +161,6 @@ with air.ir.Context() as ctx, Location.unknown():
 
     backend = XRTBackend(
         runtime_loop_tiling_sizes=[2, 2],
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/28_gemm_loop_nest_bf16/gen.py
+++ b/test/xrt/28_gemm_loop_nest_bf16/gen.py
@@ -123,5 +123,6 @@ with air.ir.Context() as ctx, Location.unknown():
     backend = XRTBackend(
         omit_pingpong=True,
         lower_linalg_to_func="mm.o",
+        use_lock_race_condition_fix=True,
     )
     backend.compile(air_module)

--- a/test/xrt/30_mul_rtp_1x1/run.py
+++ b/test/xrt/30_mul_rtp_1x1/run.py
@@ -99,7 +99,11 @@ def run_test(size, idtype, odtype):
     ref = (input_a * input_b).astype(odtype)
     input_c = np.ones_like(ref)
 
-    backend = xrt_backend.XRTBackend(omit_pingpong=True, verbose=verbose)
+    backend = xrt_backend.XRTBackend(
+        omit_pingpong=True, 
+        verbose=verbose,
+        use_lock_race_condition_fix=True,
+    )
 
     # run the module
     with filelock.FileLock("/tmp/npu.lock"):

--- a/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
+++ b/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
@@ -88,6 +88,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###### Compile and test
     runner = XRTRunner(
         omit_while_true_loop=False,
+        use_lock_race_condition_fix=True,
     )
     exit(
         runner.run_test(

--- a/test/xrt/32_triton_matmul/run.py
+++ b/test/xrt/32_triton_matmul/run.py
@@ -121,6 +121,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###### Compile and test
     runner = XRTRunner(
         omit_while_true_loop=False,
+        use_lock_race_condition_fix=True,
     )
     exit(
         runner.run_test(

--- a/test/xrt/33_triton_matmul_ver2/run.py
+++ b/test/xrt/33_triton_matmul_ver2/run.py
@@ -90,6 +90,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###### Compile and test
     runner = XRTRunner(
         omit_while_true_loop=False,
+        use_lock_race_condition_fix=True,
     )
     exit(
         runner.run_test(


### PR DESCRIPTION
The previous lock allocation scheme for -air-to-aie pass possesses a risk for race condition, with the multi-in-single-out (a.k.a. join) or single-in-multi-out (a.k.a. distribute) DMA channel patterns.

TODO: MLIR IR tests.