### PR TITLE
AIRChannel: `channel_type` attribute to specify channel lowering to stream/packet-flow/cascade mechanism

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -377,21 +377,49 @@ def air_WaitAllOp: air_Op<"wait_all", [air_AsyncOpInterface]> {
 
 def air_ChannelOp : air_Op<"channel", [Symbol]>,
     Arguments<(ins SymbolNameAttr:$sym_name,
-                   DefaultValuedAttr<I64ArrayAttr, "{}">:$size)> {
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$size,
+                   DefaultValuedAttr<StrAttr, "\"dma_stream\"">:$channel_type)> {
   let assemblyFormat = [{
     $sym_name $size attr-dict
   }];
   let summary = "Channel for data movement.";
   let description = [{
-    Operation to represent a channel as a point-to-point connection between two memrefs. The array
-    following the channel name symbol represents the channel sizes. If each channel is broadcasting
-    to multiple destinations, then the optional 'broadcast_shape' attribute annotates the output 
-    sizes after broadcasting.
+    Operation to represent a communication channel as a point-to-point connection between two memrefs.
+    The array following the channel name symbol represents the channel's dimensional sizes. Default
+    size, with empty size array, is 1. The data movement mechanism that the channel uses is controlled 
+    by the `channel_type` attribute.
+
+    ### Channel Types
+    The `channel_type` attribute is a string that determines the mechanism used for data movement:
+    - **"dma_stream"** (default):  
+      Use DMA engines to send and receive data, with routing performed over a streaming interconnect.
+    - **"dma_packet"**:  
+      Use DMA engines to send and receive data, with routing performed over a packet-switched network.
+    - **"cascade"**:  
+      Use processor cores to send and receive data via cascade connections between adjacent tiles.
+
+    ### Broadcasting
+    If a channel broadcasts to multiple destinations, the optional `broadcast_shape` attribute  
+    annotates the output sizes after broadcasting. Broadcasting follows NumPy's broadcasting rules.
 
     Example:
 
     ```mlir
-    air.channel @channel_0 [1, 1] {broadcast_shape = [1, 4]}
+    // An array of 4 x 4 streaming DMA channels
+    air.channel @channel_0 [4, 4] {channel_type = "dma_stream"}
+
+    // A streaming DMA channel broadcasting to 4 destinations
+    air.channel @channel_1 [1, 1] {broadcast_shape = [1, 4], channel_type = "dma_stream"}
+
+    // An array of 1 x 4 streaming DMA channels broadcasting to 4 x 4 destinations.
+    // Broadcasting follows NumPy's rules.
+    air.channel @channel_2 [1, 4] {broadcast_shape = [4, 4], channel_type = "dma_stream"}
+
+    // A packet-switched DMA channel
+    air.channel @channel_3 [] {channel_type = "dma_packet"}
+
+    // A cascade channel using core-to-core cascade connections
+    air.channel @channel_4 [] {channel_type = "cascade"}
     ```
   }];
   let extraClassDeclaration = [{
@@ -445,7 +473,37 @@ def air_ChannelPutOp : air_Op<"channel.put", [air_AsyncOpInterface,
     Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Push for air channels.";
   let description = [{
-    Experimental operation to represent copying data from a memref to a channel.
+    The `air.channel.put` operation represents a **push** (send) operation that copies data from a 
+    source memref into a specified channel.
+
+    This operation models one-way data movement into a channel endpoint, enabling asynchronous 
+    communication between producer and consumer operations. It is typically paired with 
+    `air.channel.get` operations on the receiving side.
+
+    ### Semantics
+    - The source data is specified by the `src` memref, along with its associated 
+      `src_offsets`, `src_sizes`, and `src_strides` which describe the subview being transferred.
+    - The channel being targeted is identified by the symbol referenced by `chan_name`.
+    - The channel must have been declared earlier via an `air.channel` operation.
+    - The operation may be asynchronous: if an async token is produced, it can be used to 
+      synchronize with subsequent dependent operations.
+    - The specific channel it operates on, when `chan_name` references an array of channels, is
+      identified by `indices`.
+
+    ### Interfaces
+    - Implements `air_AsyncOpInterface`, allowing it to participate in async dependency chains.
+    - Implements `air_MemcpyInterface`, enabling it to behave like a DMA/memcpy operation.
+    - Implements `air_ChannelInterface`, allowing inspection of channel properties.
+
+    ### Example
+
+    ```mlir
+    // Send a 4x4 tile from %src into channel @chan_0
+    air.channel.put @chan_0(%src[%c0, %c0][%c4, %c4][%c1, %c1]) : (memref<16x16xf32>)
+    
+    // Asynchronous put with dependency on %t0
+    %t1 = air.channel.put async [%t0] @chan_1(%src[%c8, %c0][%c4, %c4][%c1, %c1]) : (memref<16x16xf32>)
+    ```
   }];
   let assemblyFormat = [{
     custom<AsyncDependencies>(type($async_token), $async_dependencies)
@@ -487,7 +545,37 @@ def air_ChannelGetOp : air_Op<"channel.get", [air_AsyncOpInterface,
     Results<(outs Optional<air_AsyncToken>:$async_token)> {
   let summary = "Get for air channels.";
   let description = [{
-    Experimental operation to represent copying from a channel to a memref.
+    The `air.channel.get` operation represents a **pull** (receive) operation that copies data from a 
+    specified channel into a destination memref.
+
+    This operation models one-way data movement from a channel endpoint into memory, enabling 
+    asynchronous communication where data previously sent by a corresponding 
+    `air.channel.put` becomes available to the consumer.
+
+    ### Semantics
+    - The destination buffer is specified by the `dst` memref, along with its associated 
+      `dst_offsets`, `dst_sizes`, and `dst_strides` which describe the subview being written to.
+    - The channel being read is identified by the symbol referenced by `chan_name`.
+    - The channel must have been declared earlier via an `air.channel` operation.
+    - The operation may be asynchronous: if an async token is produced, it can be used to 
+      synchronize with subsequent dependent operations.
+    - The specific channel it operates on, when `chan_name` references an array of channels, is
+      identified by `indices`.
+
+    ### Interfaces
+    - Implements `air_AsyncOpInterface`, enabling participation in async dependency chains.
+    - Implements `air_MemcpyInterface`, allowing it to behave like a DMA/memcpy operation.
+    - Implements `air_ChannelInterface`, allowing inspection of channel properties.
+
+    ### Example
+
+    ```mlir
+    // Receive a 4x4 tile into %dst from channel @chan_0
+    air.channel.get @chan_0(%dst[%c0, %c0][%c4, %c4][%c1, %c1]) : (memref<16x16xf32>)
+    
+    // Asynchronous get with dependency on %t1
+    %t2 = air.channel.get async [%t1] @chan_1(%dst[%c8, %c0][%c4, %c4][%c1, %c1]) : (memref<16x16xf32>)
+    ```
   }];
   let assemblyFormat = [{
     custom<AsyncDependencies>(type($async_token), $async_dependencies)

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1418,7 +1418,8 @@ struct SpecializeChannelBundlePattern
       chan_to_chan_map[cname] = channel.getName().str();
       SmallVector<int64_t, 2> channel_sizes = {1, 1};
       auto new_chan = rewriter.create<air::ChannelOp>(
-          channel->getLoc(), cname, rewriter.getI64ArrayAttr(channel_sizes));
+          channel->getLoc(), cname, rewriter.getI64ArrayAttr(channel_sizes),
+          rewriter.getStringAttr("dma_stream"));
       if (channel->hasAttr("broadcast_shape")) {
         auto broadcast_shape = specializeBroadcastShape(rewriter, channel);
         new_chan->setAttr("broadcast_shape",

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2366,7 +2366,8 @@ public:
     // Update channel declaration
     sizes[chanDim] *= factor;
     builder.create<air::ChannelOp>(op->getLoc(), chan_op.getSymName().str(),
-                                   builder.getI64ArrayAttr(sizes));
+                                   builder.getI64ArrayAttr(sizes),
+                                   builder.getStringAttr("dma_stream"));
 
     // Add scf.parallel to unroll channel puts and gets
     auto puts = air::getChannelPutOpThroughSymbol(chan_op);

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -320,7 +320,8 @@ createChannelOpWithBCast(OpBuilder builder, ModuleOp module, std::string cname,
   builder.setInsertionPoint(o);
 
   auto channel_op = builder.create<air::ChannelOp>(
-      loc, cname, builder.getI64ArrayAttr(bcast_sizes));
+      loc, cname, builder.getI64ArrayAttr(bcast_sizes),
+      builder.getStringAttr("dma_stream"));
 
   builder.restoreInsertionPoint(insertionCheckpoint);
 

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -1027,8 +1027,8 @@ FailureOr<linalg::TiledLinalgOp> static pipelineReduceLinalgOp(
       auto module = op->getParentOfType<ModuleOp>();
       auto cname = createChannelName(module);
       b.setInsertionPointToStart(module.getBody());
-      auto channel_op =
-          b.create<air::ChannelOp>(loc, cname, b.getI64ArrayAttr({1}));
+      auto channel_op = b.create<air::ChannelOp>(
+          loc, cname, b.getI64ArrayAttr({1}), b.getStringAttr("dma_stream"));
       b.setInsertionPoint(stageBlock->getTerminator());
       SmallVector<Value> src_offsets;
       SmallVector<Value> src_sizes;

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1757,7 +1757,8 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
       } else {
         SmallVector<int64_t, 2> channel_sizes = {targetColTilingFactor, 1};
         new_chan = rewriter.create<air::ChannelOp>(
-            loc, cname, rewriter.getI64ArrayAttr(channel_sizes));
+            loc, cname, rewriter.getI64ArrayAttr(channel_sizes),
+            rewriter.getStringAttr("dma_stream"));
       }
 
       // Perform tiling on these channel put/get ops which are using the memref.

--- a/mlir/test/Dialect/AIR/air_channel.mlir
+++ b/mlir/test/Dialect/AIR/air_channel.mlir
@@ -12,7 +12,7 @@
 // CHECK: func.func @channel
 // CHECK: %[[V1:.*]] = air.channel.put async [{{.*}}] @channel_1[{{.*}}, {{.*}}]
 // CHECK: %[[V2:.*]] = air.channel.get async [{{.*}}] @channel_1[{{.*}}, {{.*}}]
-air.channel @channel_1 [2,2]
+air.channel @channel_1 [2,2] {channel_type = "dma_stream"}
 func.func @channel() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -35,7 +35,7 @@ func.func @channel() {
 // CHECK: func.func @fork
 // CHECK: %[[V1:.*]] = air.channel.put async [{{.*}}] @bcast[] ({{.*}}[{{.*}},{{.*}}]
 // CHECK: air.channel.get @bcast[{{.*}}, {{.*}}] ({{.*}}[] [] []) 
-air.channel @bcast [2,1]
+air.channel @bcast [2,1] {channel_type = "dma_stream"}
 func.func @fork() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -55,7 +55,7 @@ func.func @fork() {
 // CHECK: func.func @distribute
 // CHECK: air.channel.put @merge[{{.*}}, {{.*}}] ({{.*}}[
 // CHECK: %[[V2:.*]] = air.channel.get async [{{.*}}] @merge[]
-air.channel @merge[2,2]
+air.channel @merge[2,2] {channel_type = "dma_stream"}
 func.func @distribute() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -73,3 +73,67 @@ func.func @distribute() {
   }
   return 
 } 
+
+// CHECK: air.channel @packet_flow [2, 2] {channel_type = "dma_packet"}
+// CHECK: func.func @packet_flow_func
+// CHECK: %[[V1:.*]] = air.channel.put async [{{.*}}] @packet_flow[{{.*}}, {{.*}}]
+// CHECK: %[[V2:.*]] = air.channel.get async [{{.*}}] @packet_flow[{{.*}}, {{.*}}]
+air.channel @packet_flow[2,2] {channel_type = "dma_packet"}
+func.func @packet_flow_func() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %0 = memref.alloc() : memref<64x64xbf16, 1>
+  %1 = memref.alloc() : memref<32x32xbf16, 2>
+  scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+    %2 = air.wait_all async
+    %3 = air.channel.put async [%2] @packet_flow[%arg0, %arg1] (%0[%c0, %c0] [%c32, %c32] [%c64, %c1]) : (memref<64x64xbf16, 1>)
+  }
+  scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+    %4 = air.wait_all async
+    %5 = air.channel.get async [%4] @packet_flow[%arg0, %arg1] (%1[] [] []) : (memref<32x32xbf16, 2>)
+  }
+  return 
+} 
+
+// CHECK: air.channel @cascade [3] {channel_type = "cascade"}
+// CHECK: func.func @cascade_func
+// CHECK: affine.if
+// CHECK: air.channel.put  @cascade[%{{.*}}]
+// CHECK: else
+// CHECK: affine.if
+// CHECK: air.channel.get  @cascade[%{{.*}}]
+// CHECK: air.channel.put  @cascade[%{{.*}}]
+// CHECK: else
+// CHECK: air.channel.get  @cascade[%{{.*}}]
+#set = affine_set<()[s0] : (s0 == 0)>
+#set1 = affine_set<()[s0] : (s0 - 1 >= 0, -s0 + 2 >= 0)>
+air.channel @cascade [3] {channel_type = "cascade"}
+func.func @cascade_func() {
+  %c4 = arith.constant 4 : index
+  %c1_0 = arith.constant 1 : index
+  air.herd @herd_0  tile (%arg8, %arg9) in (%arg10=%c1_0, %arg11=%c4) {
+    %c1_i32 = arith.constant 1 : i32
+    %alloc = memref.alloc() : memref<1x1x2048xi32, 2 : i32>
+    affine.if #set()[%arg9] {
+      %alloc_1 = memref.alloc() : memref<1x1x2048xi32, 2 : i32>
+      air.channel.put  @cascade[%arg9] (%alloc[] [] []) : (memref<1x1x2048xi32, 2 : i32>)
+    } else {
+      affine.if #set1()[%arg9] {
+        %alloc_1 = memref.alloc() : memref<1x1x2048xi32, 2 : i32>
+        %c1_1 = arith.constant 1 : index
+        %iv_sub1 = arith.subi %arg9, %c1_1 : index
+        air.channel.get  @cascade[%iv_sub1] (%alloc_1[] [] []) : (memref<1x1x2048xi32, 2 : i32>)
+        air.channel.put  @cascade[%arg9] (%alloc[] [] []) : (memref<1x1x2048xi32, 2 : i32>)
+      } else {
+        %alloc_1 = memref.alloc() : memref<1x1x2048xi32, 2 : i32>
+        %c1_1 = arith.constant 1 : index
+        %iv_sub1 = arith.subi %arg9, %c1_1 : index
+        air.channel.get  @cascade[%iv_sub1] (%alloc_1[] [] []) : (memref<1x1x2048xi32, 2 : i32>)
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
This PR introduces the `channel_types` attribute to `air.channel`.

The `channel_type` attribute is a string that determines the mechanism used for data movement:
- **"dma_stream"** (default):  
  Use DMA engines to send and receive data, with routing performed over a streaming interconnect.
- **"dma_packet"**:  
  Use DMA engines to send and receive data, with routing performed over a packet-switched network.
- **"cascade"**:  
  Use processor cores to send and receive data via cascade connections between adjacent tiles.
  
Example:

```mlir
// An array of 4 x 4 streaming DMA channels
air.channel @channel_0 [4, 4] {channel_type = "dma_stream"}

// A streaming DMA channel broadcasting to 4 destinations
air.channel @channel_1 [1, 1] {broadcast_shape = [1, 4], channel_type = "dma_stream"}

// An array of 1 x 4 streaming DMA channels broadcasting to 4 x 4 destinations.
// Broadcasting follows NumPy's rules.
air.channel @channel_2 [1, 4] {broadcast_shape = [4, 4], channel_type = "dma_stream"}

// A packet-switched DMA channel
air.channel @channel_3 [] {channel_type = "dma_packet"}

// A cascade channel using core-to-core cascade connections
air.channel @channel_4 [] {channel_type = "cascade"}
```