### PR TITLE
Extends bufferization methods in `bufferization` dialect, with extra light-weight cleanups, to enable AIR tiling

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -299,4 +299,84 @@ def FuseIntoContainingMemrefOp :
   ];
 }
 
+// Ops implemented in mlir/lib/Transform/AIRLinalgBufferize.cpp
+//
+
+def AIRDuplicateAndEliminateEmptyTensorsOp
+    : Op<Transform_Dialect, "air.duplicate_and_eliminate_empty_tensors",
+        [DeclareOpInterfaceMethods<TransformOpInterface>,
+         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let description = [{
+    This transform op duplicates all multi-use `tensor.empty` operations
+    within the target payload operation and then eliminates them via the
+    One-Shot Bufferization "empty tensor elimination" step.
+
+    The transform performs the following actions in sequence:
+
+    1. **Duplicate**: For each `tensor.empty` with more than one use, clones
+       the operation so that each use has a distinct producer.
+    2. **Destination Style Conversion**: Applies Linalg conversion patterns
+       to rewrite eligible operations into destination-passing style.
+    3. **Bufferization Analysis**: Runs One-Shot Bufferization analysis with
+       target-specific options to prepare for empty tensor elimination.
+    4. **Elimination**: Replaces `tensor.empty` with buffer-backed allocations
+       or forwards them to existing buffers, based on the analysis.
+
+    This transform modifies the payload IR but does not change the transform
+    IR except for reading the `target` handle.
+
+    The `target` must be a handle to one or more operations containing
+    `tensor.empty` producers that are eligible for bufferization.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` type($target)";
+}
+
+def AIRBufferizeOp
+    : Op<Transform_Dialect, "air.bufferize",
+        [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+         DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    Bufferizes the payload IR rooted at `target` using One-Shot Bufferization
+    with AIR defaults, then performs a light cleanup.
+
+    Specifically, this transform:
+    - Runs One-Shot Bufferization on the target operation with AIR options
+      (e.g., custom `allocationFn`/`memCpyFn`, disabled parallel-region checks).
+      By default, allocations are created with `memref.alloc` and copies are
+      emitted as `linalg.generic` elementwise copies to enable tiling/vectorization.
+    - Applies canonical cleanups to erase unused operands and results that may
+      appear after destination-passing rewrites.
+
+    The transform **modifies the payload IR** but only **reads** the transform
+    handle. On failure, emits a diagnostic attached to the target.
+
+    **Operands**
+    - `target` — A handle to the operation(s) to bufferize.
+
+    **Results**
+    - `result` — A handle to the same operation(s) after bufferization.
+
+    This op is functional-style: the result type matches the handle type and
+    the printer/parser use a functional signature:
+      `air.bufferize %t : (!pdl.operation) -> !pdl.operation`
+  }];
+
+  let arguments = (
+      ins PDL_Operation:$target
+  );
+
+  let results = (outs PDL_Operation:$result);
+
+  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
+}
+
 #endif // AIR_TRANSFORM_OPS

--- a/mlir/lib/Transform/AIRLinalgBufferize.cpp
+++ b/mlir/lib/Transform/AIRLinalgBufferize.cpp
@@ -7,11 +7,15 @@
 
 #include "air/Transform/AIRLinalgBufferize.h"
 #include "air/Dialect/AIR/AIRDialect.h"
+#include "air/Dialect/AIR/AIRTransformOps.h"
 #include "air/Util/Util.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
+#include "mlir/Dialect/Bufferization/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "air-linalg-bufferize"
@@ -135,8 +139,221 @@ public:
 private:
 };
 
+// Configure One-Shot Bufferization from bufferization dialect.
+// Ref:
+// https://github.com/iree-org/iree/blob/2a123d7b764dc8cc8d89b7591a00f646ab0ade38/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp#L145
+static bufferization::OneShotBufferizationOptions getBufferizationOptions() {
+  bufferization::OneShotBufferizationOptions options;
+  options.opFilter.denyOperation<arith::ConstantOp>();
+  options.opFilter.denyOperation<bufferization::ToBufferOp>();
+  options.unknownTypeConverterFn =
+      [](TensorType tensorType, Attribute memorySpace,
+         const bufferization::BufferizationOptions &options) {
+        if (tensorType.hasStaticShape()) {
+          return bufferization::getMemRefTypeWithStaticIdentityLayout(
+              tensorType, memorySpace);
+        }
+        return bufferization::getMemRefTypeWithFullyDynamicLayout(tensorType,
+                                                                  memorySpace);
+      };
+
+  return options;
+}
+
+// Duplicate a `tensor.empty` if it has multiple uses so each use can be
+// rewritten independently by downstream passes (e.g., dest-style, CSE).
+// Returns success if all duplicates are created and wired to users.
+LogicalResult duplicateTensorEmptyOps(OpBuilder &b, tensor::EmptyOp emptyOp) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(emptyOp);
+
+  // Snapshot uses because we'll mutate operands below.
+  SmallVector<OpOperand *> uses = llvm::map_to_vector(
+      emptyOp->getUses(), [](OpOperand &use) { return &use; });
+
+  // Keep the first use attached to the original op; clone for the rest.
+  for (auto use : llvm::make_range(std::next(uses.begin()), uses.end())) {
+    auto newOp = cast<tensor::EmptyOp>(b.clone(*emptyOp.getOperation()));
+    Operation *user = use->getOwner();
+    user->setOperand(use->getOperandNumber(), newOp);
+  }
+  return success();
+}
+
+// End-to-end helper that:
+//   1) Duplicates multi-use `tensor.empty` ops,
+//   2) Converts eligible Linalg ops to destination style,
+//   3) Runs one-shot bufferization analysis,
+//   4) Eliminates `tensor.empty` producers where possible.
+//
+// This is intended to be invoked on a target `Operation *op` that owns the IR
+// region(s) to clean up.
+LogicalResult AIRDuplicateAndEliminateEmptyTensors(RewriterBase &rewriter,
+                                                   Operation *op) {
+  MLIRContext *context = rewriter.getContext();
+
+  // Step 1: duplicate multi-use `tensor.empty` so each user can get a distinct
+  // producer (enables better folding and bufferization).
+  SmallVector<tensor::EmptyOp> emptyOps;
+  op->walk([&](tensor::EmptyOp emptyOp) { emptyOps.push_back(emptyOp); });
+  if (llvm::any_of(emptyOps, [&](tensor::EmptyOp emptyOp) {
+        return failed(duplicateTensorEmptyOps(rewriter, emptyOp));
+      })) {
+    return op->emitError("Failed to duplicate empty tensors");
+  }
+
+  // Step 2: run "convert to destination style" patterns. This rewrites ops to
+  // take explicit output buffers, which makes later bufferization more precise.
+  {
+    RewritePatternSet patterns(context);
+    linalg::populateConvertToDestinationStylePatterns(patterns);
+    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
+      return op->emitOpError(
+          "Failed in conversion to destination style patterns");
+    }
+  }
+
+  // Step 3: configure and run one-shot bufferization analysis on `op`.
+  auto bufferizationOptions = getBufferizationOptions();
+  bufferization::OneShotAnalysisState state(op, bufferizationOptions);
+  if (failed(analyzeOp(op, state)))
+    return op->emitOpError("Failed in anaylzing op");
+
+  // Step 4: eliminate `tensor.empty` by forwarding to in-place buffers or by
+  // replacing with buffer-backed allocations where justified by the analysis.
+  if (failed(bufferization::eliminateEmptyTensors(rewriter, op, state)))
+    return op->emitOpError("Failed to eliminate empty tensors");
+
+  return success();
+}
+
+// Create a linalg::GenericOp version of an n-D copy that can further tile,
+// lower to loops or vectorize, unlike the current implementation of
+// memref::CopyOp.
+// Ref:
+// https://github.com/iree-org/iree/blob/2a123d7b764dc8cc8d89b7591a00f646ab0ade38/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp#L980
+Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
+                              ArrayRef<NamedAttribute> attributes = {}) {
+  auto memrefTypeFrom = llvm::dyn_cast<MemRefType>(from.getType());
+  auto memrefTypeTo = llvm::dyn_cast<MemRefType>(to.getType());
+  if (!memrefTypeFrom || !memrefTypeTo ||
+      memrefTypeFrom.getRank() != memrefTypeTo.getRank()) {
+    mlir::emitError(
+        loc, "unable to generate copy op within bufferization from type ")
+        << memrefTypeFrom << " to " << memrefTypeTo;
+    return nullptr;
+  }
+  AffineMap id =
+      AffineMap::getMultiDimIdentityMap(memrefTypeTo.getRank(), b.getContext());
+  SmallVector<utils::IteratorType> iteratorTypes(memrefTypeTo.getRank(),
+                                                 utils::IteratorType::parallel);
+  return b.create<linalg::GenericOp>(
+      loc,
+      /*inputs=*/from,
+      /*outputs=*/to,
+      /*indexingMaps=*/llvm::ArrayRef({id, id}),
+      /*iteratorTypes=*/iteratorTypes,
+      [](OpBuilder &b, Location loc, ValueRange args) {
+        b.create<linalg::YieldOp>(loc, args.front());
+      },
+      attributes);
+}
+
 } // namespace air
 } // namespace xilinx
+
+//===----------------------------------------------------------------------===//
+// AIRBufferizeOp
+//===----------------------------------------------------------------------===//
+
+// Default allocation callback: materialize a memref::AllocOp of the requested
+// type/sizes. The `alignment` is ignored by this default (many backends do).
+static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
+                                            MemRefType allocationType,
+                                            ValueRange dynamicSizes,
+                                            unsigned int alignment) {
+  return builder.create<memref::AllocOp>(loc, allocationType, dynamicSizes)
+      .getResult();
+}
+
+// Default memcpy callback: emit an n-D linalg.generic copy instead of
+// memref.copy so that downstream tiling/vectorization passes have room to act.
+static LogicalResult defaultMemCpyFn(OpBuilder &builder, Location loc,
+                                     Value from, Value to) {
+  Operation *copyOp = createLinalgCopyOp(builder, loc, from, to);
+  return success(static_cast<bool>(copyOp));
+}
+
+void transform::AIRBufferizeOp::build(OpBuilder &builder,
+                                      OperationState &result, Value target) {
+  result.addOperands(target);
+  MLIRContext *ctx = builder.getContext();
+  result.addTypes(pdl::OperationType::get(ctx));
+}
+
+DiagnosedSilenceableFailure
+transform::AIRBufferizeOp::apply(transform::TransformRewriter &rewriter,
+                                 transform::TransformResults &results,
+                                 transform::TransformState &state) {
+  auto payload = state.getPayloadOps(getTarget());
+  Operation *target = *payload.begin();
+  ErrorCheckingTrackingListener listener(state, *this);
+
+  // Configure one-shot bufferization for AIR.
+  bufferization::OneShotBufferizationOptions options =
+      xilinx::air::getBufferizationOptions();
+  options.allocationFn = defaultAllocationFn;
+  options.memCpyFn = defaultMemCpyFn;
+  options.checkParallelRegions = false;
+  bufferization::BufferizationState bufferizationState;
+  if (failed(bufferization::runOneShotBufferize(target, options,
+                                                bufferizationState))) {
+    return mlir::emitDefiniteFailure(target, "bufferization failed");
+  }
+
+  // Post-bufferization cleanup: Drop dead operands/results introduced by
+  // dest-style rewrites.
+  {
+    RewritePatternSet patterns(getContext());
+    linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
+    GreedyRewriteConfig config;
+    config.setListener(&listener);
+    LogicalResult result =
+        applyOpPatternsGreedily(target, std::move(patterns), config);
+    if (failed(result)) {
+      return mlir::emitDefiniteFailure(target,
+                                       "greedy pattern application failed");
+    }
+    if (listener.failed())
+      return listener.checkAndResetError();
+  }
+
+  results.set(getOperation()->getOpResult(0), {target});
+  return listener.checkAndResetError();
+}
+
+//===----------------------------------------------------------------------===//
+// AIRDuplicateAndEliminateEmptyTensorsOp
+//===----------------------------------------------------------------------===//
+
+void transform::AIRDuplicateAndEliminateEmptyTensorsOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  onlyReadsHandle(getTargetMutable(), effects);
+  modifiesPayload(effects);
+}
+
+DiagnosedSilenceableFailure
+transform::AIRDuplicateAndEliminateEmptyTensorsOp::apply(
+    transform::TransformRewriter &rewriter, TransformResults &transformResults,
+    TransformState &state) {
+  for (Operation *target : state.getPayloadOps(getTarget())) {
+    if (failed(xilinx::air::AIRDuplicateAndEliminateEmptyTensors(rewriter,
+                                                                 target)))
+      return mlir::emitSilenceableFailure(target->getLoc())
+             << "empty tensor elimination failed";
+  }
+  return DiagnosedSilenceableFailure::success();
+}
 
 namespace xilinx {
 namespace air {


### PR DESCRIPTION
New transform dialect ops:
- AIRDuplicateAndEliminateEmptyTensorsOp: duplicates all multi-use `tensor.empty` operations within the target payload operation and then eliminates them via the One-Shot Bufferization "empty tensor elimination" step.
- AIRBufferizeOp: Bufferizes the payload IR rooted at `target` using One-Shot Bufferization with AIR defaults, then performs a light cleanup.