### PR TITLE
Add `air.hoist_static_alloc` transform op

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.h
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.h
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir {
 class DialectRegistry;

--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -299,4 +299,76 @@ def FuseIntoContainingMemrefOp :
   ];
 }
 
+// Ops implemented in mlir/lib/Transform/AIRLinalgBufferize.cpp
+//
+
+def AIRHoistStaticAllocOp :  Op<Transform_Dialect, "air.hoist_static_alloc",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let summary = [{Hoist static allocations.}];
+  let description = [{
+    Moves certain statically-sized `memref.alloc` operations from inner blocks
+    to the entry block of the target function. This shortens and unifies buffer
+    lifetimes, which can unlock reuse and downstream optimizations.
+
+    ### Notes / limitations
+
+    * Currently targets `memref.alloc` buffers with static shapes.
+    * Uses that require exact type equality across region boundaries (e.g.,
+      `scf.yield`, `func.return`) are **not** rewritten; such allocations are skipped.
+    * Hoisting increases the buffer's lifetime; apply with care on large buffers.
+
+    ### Example
+
+    Before:
+    ```mlir
+    func.func @foo(%arg0: memref<64xi32>) {
+      scf.for %i = %c0 to %c4 step %c1 {
+        %tmp = memref.alloc() : memref<64xi32>
+        linalg.fill ins(%cst : i32) outs(%tmp : memref<64xi32>)
+        memref.dealloc %tmp : memref<64xi32>
+      }
+      return
+    }
+    ```
+
+    After:
+    ```mlir
+    func.func @foo(%arg0: memref<64xi32>) {
+      %tmp.hoisted = memref.alloc() : memref<64xi32>
+      scf.for %i = %c0 to %c4 step %c1 {
+        linalg.fill ins(%cst : i32) outs(%tmp.hoisted : memref<64xi32>)
+      }
+      memref.dealloc %tmp.hoisted : memref<64xi32>
+      return
+    }
+    ```
+
+    ### Usage (Transform dialect)
+
+    ```mlir
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb0(%f: !pdl.operation):
+      transform.air.hoist_static_alloc %f
+        : (!pdl.operation) -> ()
+    }
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::FunctionOpInterface funcOp,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // AIR_TRANSFORM_OPS

--- a/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform.mlir
@@ -1,0 +1,20 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.hoist_static_alloc
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+        // Bufferize
+        %func_op = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        transform.air.hoist_static_alloc %func_op : (!pdl.operation) -> ()
+    }
+}

--- a/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform_payload.mlir
@@ -12,14 +12,14 @@
 // CHECK: }
 // CHECK: memref.dealloc
 func.func @func0(%arg0: memref<64xi32>) {
-  %tmp.hoisted = memref.alloc() : memref<64xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %cst = arith.constant 0 : i32
   scf.for %i = %c0 to %c4 step %c1 {
-    linalg.fill ins(%cst : i32) outs(%tmp.hoisted : memref<64xi32>)
+    %tmp = memref.alloc() : memref<64xi32>
+    linalg.fill ins(%cst : i32) outs(%tmp : memref<64xi32>)
+    memref.dealloc %tmp : memref<64xi32>
   }
-  memref.dealloc %tmp.hoisted : memref<64xi32>
   return
 }

--- a/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRHoistStaticAlloc/air_transform_payload.mlir
@@ -1,0 +1,25 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' %s | FileCheck %s
+
+// CHECK: memref.alloc()
+// CHECK: scf.for
+// CHECK: }
+// CHECK: memref.dealloc
+func.func @func0(%arg0: memref<64xi32>) {
+  %tmp.hoisted = memref.alloc() : memref<64xi32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %cst = arith.constant 0 : i32
+  scf.for %i = %c0 to %c4 step %c1 {
+    linalg.fill ins(%cst : i32) outs(%tmp.hoisted : memref<64xi32>)
+  }
+  memref.dealloc %tmp.hoisted : memref<64xi32>
+  return
+}


### PR DESCRIPTION
… that hoist static `allocs` and `deallocs` before peeling, to enforce reuse of memory addresses across peeled loop iterations.

Input IR:
```
func.func @func0(%arg0: memref<64xi32>) {
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %c4 = arith.constant 4 : index
  %cst = arith.constant 0 : i32
  scf.for %i = %c0 to %c4 step %c1 {
    %tmp = memref.alloc() : memref<64xi32>
    linalg.fill ins(%cst : i32) outs(%tmp : memref<64xi32>)
    memref.dealloc %tmp : memref<64xi32>
  }
  return
}
```

Output IR:
```
  func.func @func0(%arg0: memref<64xi32>) {
    %alloc = memref.alloc() : memref<64xi32>
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c4 = arith.constant 4 : index
    %c0_i32 = arith.constant 0 : i32
    scf.for %arg1 = %c0 to %c4 step %c1 {
      linalg.fill ins(%c0_i32 : i32) outs(%alloc : memref<64xi32>)
    }
    memref.dealloc %alloc : memref<64xi32>
    return
  }
```