### PR TITLE
New transform dialect op: `forall_with_reduction_to_parallel`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -83,6 +83,14 @@ def air_LaunchOp : air_Op<"launch", [air_AsyncOpInterface,
         return {};
       return getKernelOperand(std::distance(args.begin(), it));
     }
+
+    /// Append the given values to kernel operands.
+    void appendKernelOperands(ValueRange operands){
+      getLaunchOperandsMutable().append(operands);
+      for (auto oper : operands){
+        getBody().addArgument(oper.getType(), getLoc());
+      }
+    }
   }];
   let hasCanonicalizer = 1;
 }
@@ -195,6 +203,14 @@ def air_SegmentOp : air_Op<"segment", [air_AsyncOpInterface,
         return {};
       return getKernelOperand(std::distance(args.begin(), it));
     }
+
+    /// Append the given values to kernel operands.
+    void appendKernelOperands(ValueRange operands){
+      getSegmentOperandsMutable().append(operands);
+      for (auto oper : operands){
+        getBody().addArgument(oper.getType(), getLoc());
+      }
+    }
   }];
   let hasCanonicalizer = 1;
 }
@@ -294,6 +310,14 @@ def air_HerdOp : air_Op<"herd", [air_AsyncOpInterface,
       if (it == args.end())
         return {};
       return getKernelOperand(std::distance(args.begin(), it));
+    }
+
+    /// Append the given values to kernel operands.
+    void appendKernelOperands(ValueRange operands){
+      getHerdOperandsMutable().append(operands);
+      for (auto oper : operands){
+        getBody().addArgument(oper.getType(), getLoc());
+      }
     }
   }];
   let hasCanonicalizer = 1;

--- a/mlir/include/air/Dialect/AIR/AIROpBase.td
+++ b/mlir/include/air/Dialect/AIR/AIROpBase.td
@@ -151,44 +151,47 @@ def air_HierarchyInterface : OpInterface<"HierarchyInterface"> {
   }];
   let cppNamespace = "xilinx::air";
   let methods = [
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the block arguments representing the iteration space indices (e.g., %x, %y for a 2D herd)",
     "ArrayRef<BlockArgument>", "getIds"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the block arguments representing the iteration space sizes (e.g., %sx, %sy for a 2D herd)",
     "ArrayRef<BlockArgument>", "getSize"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the operands that define the iteration space sizes",
     "OperandRange", "getSizeOperands"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the number of kernel operands passed to the hierarchy operation",
     "unsigned", "getNumKernelOperands"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get all block arguments representing kernel operands (arguments passed from outside)",
     "ArrayRef<BlockArgument>", "getKernelArguments"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get all operands passed as kernel arguments to the hierarchy operation",
     "OperandRange", "getKernelOperands"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the i-th kernel operand",
     "Value", "getKernelOperand", (ins "unsigned":$i)
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the i-th kernel argument (block argument corresponding to kernel operand)",
     "BlockArgument", "getKernelArgument", (ins "unsigned":$i)
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the number of dimensions in the iteration space",
     "unsigned", "getNumDims"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the unique identifier for this hierarchy operation",
     "int32_t", "getId"
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the block argument that corresponds to the given kernel operand",
     "BlockArgument", "getTiedKernelArgument", (ins "Value":$i)
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the kernel operand that corresponds to the given block argument",
     "Value", "getTiedKernelOperand", (ins "BlockArgument":$i)
     >,
-    InterfaceMethod<"description",
+    InterfaceMethod<"Get the body region of the hierarchy operation",
     "Region&", "getBody"
+    >,
+    InterfaceMethod<"Append new kernel operands to the hierarchy operation",
+    "void", "appendKernelOperands", (ins "ValueRange":$i)
     >,
   ];
 }

--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -146,6 +146,19 @@ def CopyToDmaOp : Op<Transform_Dialect, "air.copy_to_dma",
   }];
 }
 
+def ForallWithReduceToParallelOp : Op<Transform_Dialect, "air.forall_with_reduce_to_parallel",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let summary = "Converts a pattern of scf.forall and linalg.reduce to scf.parallel";
+  let description = [{
+    .
+  }];
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs Variadic<PDL_Operation>:$transformed);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+}
+
 // Ops implemented in mlir/lib/Transform/AIRLinalgCodegen.cpp
 //
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -893,6 +893,24 @@ FailureOr<hierTy> ScfParToAIRHierarchyConversionImpl(
     replaceAllUsesInRegionWith(v, kernel_args[arg_idx++], hierOp.getRegion());
   if (op != parOp)
     rewriter.eraseOp(op);
+
+  // Final step: Ensure IsolatedFromAbove trait compliance by checking for any
+  // remaining external dependencies that may have been introduced during
+  // region transformations (e.g., by ScfReduceToAffineIf)
+  SmallVector<Value, 4> remainingExternalDeps;
+  getUsedArgsDefinedAbove(hierOp.getRegion(), remainingExternalDeps);
+
+  // Add any newly discovered external dependencies as kernel operands
+  hierOp.appendKernelOperands(remainingExternalDeps);
+
+  // Remap the external dependencies to their corresponding kernel arguments
+  // to satisfy the IsolatedFromAbove trait requirement
+  for (auto externalDep : remainingExternalDeps) {
+    replaceAllUsesInRegionWith(externalDep,
+                               hierOp.getTiedKernelArgument(externalDep),
+                               hierOp.getBody());
+  }
+
   return hierOp;
 }
 
@@ -2049,6 +2067,226 @@ transform::CopyToDmaOp::applyToOne(transform::TransformRewriter &rewriter,
   if (failed(res))
     return emitDefaultDefiniteFailure(op);
   results.push_back(*res);
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===----------------------------------------------------------------------===//
+// ForallWithReduceToParallel
+//===----------------------------------------------------------------------===//
+
+LogicalResult forallWithReduceToParallelLoop(RewriterBase &rewriter,
+                                             scf::ForallOp forallOp,
+                                             scf::ParallelOp *result) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(forallOp);
+
+  Location loc = forallOp.getLoc();
+
+  // Convert mixed bounds and steps to SSA values.
+  SmallVector<Value> lbs = forallOp.getLowerBound(rewriter);
+  SmallVector<Value> ubs = forallOp.getUpperBound(rewriter);
+  SmallVector<Value> steps = forallOp.getStep(rewriter);
+
+  // Get shared_outs to use as init_vals for scf.parallel
+  ValueRange sharedOuts = forallOp.getOutputs();
+
+  // Find the linalg.reduce operation that uses the forall result
+  linalg::ReduceOp linalgReduceOp = nullptr;
+  for (auto user : forallOp->getUsers()) {
+    auto reduceOp = dyn_cast<linalg::ReduceOp>(user);
+    if (!reduceOp)
+      continue;
+    // Check if this reduce uses the forall result as input
+    if (llvm::any_of(reduceOp.getInputs(), [&](Value input) {
+          return llvm::any_of(forallOp->getResults(), [&](Value forallRes) {
+            return input == forallRes;
+          });
+        })) {
+      linalgReduceOp = reduceOp;
+      break;
+    }
+  }
+
+  // Check if we need to modify shared_outs shape to match reduction
+  // requirements
+  SmallVector<Value> modifiedInitVals;
+  if (linalgReduceOp && !sharedOuts.empty()) {
+    for (unsigned i = 0; i < forallOp.getRank(); i++) {
+      Type expectedOutputType = linalgReduceOp.getDpsInits()[i].getType();
+      if (auto tensorType = dyn_cast<RankedTensorType>(expectedOutputType)) {
+        auto newInitMemrefTy =
+            MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
+                            AffineMap(), (int)xilinx::air::MemorySpace::L1);
+        Value bufferInitVal = bufferization::ToBufferOp::create(
+            rewriter, loc, newInitMemrefTy, linalgReduceOp.getDpsInits()[i]);
+        modifiedInitVals.push_back(bufferInitVal);
+      } else {
+        modifiedInitVals.push_back(linalgReduceOp.getDpsInits()[i]);
+      }
+    }
+  }
+
+  // Create scf.parallel op with modified init_vals
+  auto parallelOp =
+      rewriter.create<scf::ParallelOp>(loc, lbs, ubs, steps, modifiedInitVals);
+
+  // Clone the forall body into the parallel body, but skip the terminator
+  Block &forallBody = forallOp.getRegion().front();
+  Block &parallelBody = parallelOp.getRegion().front();
+  rewriter.setInsertionPointToStart(&parallelBody);
+
+  // Create mapping from forall block args to parallel block args
+  IRMapping mapping;
+  // Map induction variables
+  for (auto [forallIV, parallelIV] :
+       llvm::zip(forallOp.getInductionVars(), parallelOp.getInductionVars())) {
+    mapping.map(forallIV, parallelIV);
+  }
+  // Map shared_outs block arguments to parallel init_vals
+  auto forallSharedOutArgs = forallOp.getRegionOutArgs();
+  for (auto forallSharedOutArg : forallSharedOutArgs)
+    mapping.map(forallSharedOutArg,
+                forallOp.getTiedOpOperand(forallSharedOutArg)->get());
+
+  // Clone operations from forall body to parallel body (except terminator)
+  for (auto &op : forallBody.without_terminator()) {
+    rewriter.clone(op, mapping);
+  }
+
+  // Process the forall terminator to create scf.reduce operations
+  auto forallTerminator = cast<scf::InParallelOp>(forallBody.getTerminator());
+
+  // Collect all the values to be reduced
+  SmallVector<Value> reduceValues;
+  for (const auto &[i, yieldingOp] :
+       llvm::enumerate(forallTerminator.getYieldingOps())) {
+    if (auto insertOp = dyn_cast<tensor::ParallelInsertSliceOp>(yieldingOp)) {
+      Value sourceValue = mapping.lookupOrDefault(insertOp.getSource());
+      Value sourceBufferValue = bufferization::ToBufferOp::create(
+          rewriter, insertOp.getLoc(), modifiedInitVals[i].getType(),
+          sourceValue, /*read_only=*/true);
+      reduceValues.push_back(sourceBufferValue);
+    }
+  }
+
+  // Create a single scf.reduce operation with all values
+  if (!reduceValues.empty()) {
+    auto reduceOp = rewriter.create<scf::ReduceOp>(loc, reduceValues);
+
+    // For each reduction value, populate the corresponding reduction region
+    for (auto [i, reduceValue] : llvm::enumerate(reduceValues)) {
+      Region &reduceRegion = reduceOp.getReductions()[i];
+      Block &reduceBlock = reduceRegion.front(); // Use the existing empty block
+
+      // The scf.reduce operation automatically creates the block arguments
+      // We should not add them manually - they are already there
+
+      rewriter.setInsertionPointToStart(&reduceBlock);
+
+      // If we found a linalg.reduce, create appropriate tensor-level reduction
+      if (linalgReduceOp) {
+        // Check what kind of reduction operation this is
+        Block &linalgReduceBody = linalgReduceOp.getCombiner().front();
+
+        // Look for the reduction operation in the linalg.reduce body
+        Operation *reductionOp = nullptr;
+        for (auto &op : linalgReduceBody.without_terminator()) {
+          if (isa<arith::AddIOp, arith::MulIOp, arith::MaxSIOp, arith::MinSIOp>(
+                  &op)) {
+            reductionOp = &op;
+            break;
+          }
+        }
+
+        if (reductionOp && isa<arith::AddIOp>(reductionOp)) {
+          // For addition reduction, use linalg.add
+          rewriter.create<linalg::AddOp>(
+              loc,
+              ValueRange{reduceBlock.getArgument(0),
+                         reduceBlock.getArgument(1)},
+              ValueRange{reduceBlock.getArgument(0)});
+          rewriter.create<scf::ReduceReturnOp>(loc, reduceBlock.getArgument(0));
+        } else if (reductionOp && isa<arith::MulIOp>(reductionOp)) {
+          // For multiplication reduction, use linalg.mul
+          auto mulOp = rewriter.create<linalg::MulOp>(
+              loc,
+              ValueRange{reduceBlock.getArgument(0),
+                         reduceBlock.getArgument(1)},
+              ValueRange{reduceBlock.getArgument(0)});
+          rewriter.create<scf::ReduceReturnOp>(loc, reduceBlock.getArgument(0));
+        } else {
+          return rewriter.notifyMatchFailure(
+              linalgReduceOp,
+              "unsupported reduction type. Currently supports add and mul.");
+        }
+      } else {
+        // Default reduction: just return the first argument (no actual
+        // reduction)
+        rewriter.create<scf::ReduceReturnOp>(loc, reduceBlock.getArgument(0));
+      }
+    }
+  }
+
+  // If the mapping attribute is present, propagate to the new parallelOp.
+  if (forallOp.getMapping())
+    parallelOp->setAttr("mapping", *forallOp.getMapping());
+
+  // Replace users of linalg.reduce with scf.parallel result
+  if (linalgReduceOp) {
+    rewriter.setInsertionPointAfter(parallelOp);
+    // The scf.parallel should have the same number of results as the
+    // linalg.reduce
+    for (auto [linalgResult, parallelResult] :
+         llvm::zip(linalgReduceOp->getResults(), parallelOp->getResults())) {
+      Value parallelResultTensor = bufferization::ToTensorOp::create(
+          rewriter, loc, linalgResult.getType(), parallelResult,
+          /*restrict=*/true, /*writable=*/true);
+      linalgResult.replaceAllUsesWith(parallelResultTensor);
+    }
+    // Erase the linalg.reduce operation
+    rewriter.eraseOp(linalgReduceOp);
+  }
+
+  // Erase the scf.forall op.
+  rewriter.eraseOp(forallOp);
+
+  if (result)
+    *result = parallelOp;
+
+  return success();
+}
+
+DiagnosedSilenceableFailure transform::ForallWithReduceToParallelOp::apply(
+    transform::TransformRewriter &rewriter,
+    transform::TransformResults &results, transform::TransformState &state) {
+  auto payload = state.getPayloadOps(getTarget());
+  if (!llvm::hasSingleElement(payload))
+    return emitSilenceableError() << "expected a single payload op";
+
+  auto target = dyn_cast<scf::ForallOp>(*payload.begin());
+  if (!target) {
+    DiagnosedSilenceableFailure diag =
+        emitSilenceableError() << "expected the payload to be scf.forall";
+    diag.attachNote((*payload.begin())->getLoc()) << "payload op";
+    return diag;
+  }
+
+  if (getNumResults() != 1) {
+    DiagnosedSilenceableFailure diag = emitSilenceableError()
+                                       << "op expects one result, given "
+                                       << getNumResults();
+    diag.attachNote(target.getLoc()) << "payload op";
+    return diag;
+  }
+
+  scf::ParallelOp opResult;
+  if (failed(forallWithReduceToParallelLoop(rewriter, target, &opResult))) {
+    DiagnosedSilenceableFailure diag =
+        emitSilenceableError() << "failed to convert forall into parallel";
+    return diag;
+  }
+
+  results.set(cast<OpResult>(getTransformed()[0]), {opResult});
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/mlir/test/Transform/AIRTransform/AIRScfForallWithReduceToPar/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRScfForallWithReduceToPar/air_transform.mlir
@@ -1,0 +1,20 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.forall_with_reduce_to_parallel
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+        // Bufferize
+        %forall_op = transform.structured.match ops{["scf.forall"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %inner_parallel = transform.air.forall_with_reduce_to_parallel %forall_op : (!pdl.operation) -> (!pdl.operation)
+    }
+}

--- a/mlir/test/Transform/AIRTransform/AIRScfForallWithReduceToPar/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRScfForallWithReduceToPar/air_transform_payload.mlir
@@ -1,0 +1,43 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' %s | FileCheck %s
+
+// CHECK: %[[init_buf:.*]] = bufferization.to_buffer
+// CHECK: scf.parallel (%{{.*}}) = (%c0{{.*}}) to (%c4{{.*}}) step (%c1{{.*}}) init (%[[init_buf]]) -> memref<32xi32, 2>
+// CHECK: scf.reduce
+// CHECK: linalg.add
+// CHECK: scf.reduce.return
+#map = affine_map<()[s0] -> (s0 * 32)>
+module {
+  func.func @forward(%arg0: memref<512x64xi32>, %arg1: index) -> memref<32xi32> {
+    %c0_i32 = arith.constant 0 : i32
+    %alloc = memref.alloc() : memref<64xi32, 1>
+    %0 = bufferization.to_tensor %alloc restrict writable : memref<64xi32, 1> to tensor<64xi32>
+    %1 = affine.apply #map()[%arg1]
+    %extracted_slice = tensor.extract_slice %0[%1] [32] [1] : tensor<64xi32> to tensor<32xi32>
+    %2 = bufferization.alloc_tensor() : tensor<32xi32>
+    %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<32xi32>) -> tensor<32xi32>
+    %4 = tensor.empty() : tensor<32x4xi32>
+    %5 = scf.forall (%arg2) in (4) shared_outs(%arg3 = %4) -> (tensor<32x4xi32>) {
+      %extracted_slice_0 = tensor.extract_slice %arg3[0, %arg2] [32, 1] [1, 1] : tensor<32x4xi32> to tensor<32x1xi32>
+      %8 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_0 : tensor<32x1xi32>) -> tensor<32x1xi32>
+      %extracted_slice_1 = tensor.extract_slice %8[0, 0] [32, 1] [1, 1] : tensor<32x1xi32> to tensor<32xi32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %extracted_slice_1 into %arg3[0, %arg2] [32, 1] [1, 1] : tensor<32xi32> into tensor<32x4xi32>
+      }
+    }
+    %reduced = linalg.reduce ins(%5 : tensor<32x4xi32>) outs(%3 : tensor<32xi32>) dimensions = [1] 
+      (%in: i32, %init: i32) {
+        %8 = arith.addi %in, %init : i32
+        linalg.yield %8 : i32
+      }
+    %6 = linalg.copy ins(%reduced : tensor<32xi32>) outs(%extracted_slice : tensor<32xi32>) -> tensor<32xi32>
+    %7 = bufferization.to_buffer %6 : tensor<32xi32> to memref<32xi32>
+    return %7 : memref<32xi32>
+  }
+}


### PR DESCRIPTION
Input IR:
```
    %4 = tensor.empty() : tensor<32x4xi32>
    %5 = scf.forall (%arg2) in (4) shared_outs(%arg3 = %4) -> (tensor<32x4xi32>) {
      %extracted_slice_0 = tensor.extract_slice %arg3[0, %arg2] [32, 1] [1, 1] : tensor<32x4xi32> to tensor<32x1xi32>
      %8 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_0 : tensor<32x1xi32>) -> tensor<32x1xi32>
      %extracted_slice_1 = tensor.extract_slice %8[0, 0] [32, 1] [1, 1] : tensor<32x1xi32> to tensor<32xi32>
      scf.forall.in_parallel {
        tensor.parallel_insert_slice %extracted_slice_1 into %arg3[0, %arg2] [32, 1] [1, 1] : tensor<32xi32> into tensor<32x4xi32>
      }
    }
    %reduced = linalg.reduce ins(%5 : tensor<32x4xi32>) outs(%3 : tensor<32xi32>) dimensions = [1] 
      (%in: i32, %init: i32) {
        %8 = arith.addi %in, %init : i32
        linalg.yield %8 : i32
      }
```

Output IR:
```
        %alloc_6 = memref.alloc() : memref<32xi32, 2>
        %2 = scf.parallel (%arg4) = (%c0) to (%c4) step (%c1) init (%alloc_6) -> memref<32xi32, 2> {
          ...
          %cast = memref.cast %subview_10 : memref<32xi32, strided<[1]>, 2> to memref<32xi32, 2>
          scf.reduce(%cast : memref<32xi32, 2>) {
          ^bb0(%arg5: memref<32xi32, 2>, %arg6: memref<32xi32, 2>):
            linalg.add ins(%arg5, %arg6 : memref<32xi32, 2>, memref<32xi32, 2>) outs(%arg5 : memref<32xi32, 2>)
            scf.reduce.return %arg5 : memref<32xi32, 2>
          }
        }
```