### PR TITLE
AIRTransformOp: Remove uninitialized `memref.copy`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -312,6 +312,36 @@ def FuseIntoContainingMemrefOp :
   ];
 }
 
+def RemoveUninitializedMemrefCopyOp : Op<Transform_Dialect, "air.remove_uninitialized_memref_copy",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let summary = "Remove memref.copy operations that copy from uninitialized memrefs";
+  let description = [{
+    This transform walks through a func.func operation and identifies memref.copy 
+    operations where the source is an uninitialized memref (allocated but not written to).
+    Such copy operations are erased as they copy undefined data.
+    
+    The transform detects the pattern where:
+    1. A memref is allocated with memref.alloc
+    2. A subview of that memref is created (optional)
+    3. The memref/subview is used as source in memref.copy before any write operations
+    
+    Returns a handle to the modified function.
+    
+    Example:
+    ```mlir
+    %alloc = memref.alloc() : memref<2x16x8xi32, 1>
+    %subview = memref.subview %alloc[0, 0, 0] [1, 16, 8] [1, 1, 1] : ...
+    %target = memref.alloc() : memref<1x16x8xi32, 2>
+    memref.copy %subview, %target  // <- This copy will be erased
+    ```
+  }];
+  
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$result);
+  let assemblyFormat = "$target attr-dict";
+}
+
 // Ops implemented in mlir/lib/Transform/AIRLinalgBufferize.cpp
 //
 

--- a/mlir/test/Transform/AIRTransform/AIRRemoveUninitializedMemrefCopy/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRRemoveUninitializedMemrefCopy/air_transform.mlir
@@ -1,0 +1,20 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.remove_uninitialized_memref_copy
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+        // Bufferize
+        %func_op = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %func_op_updated = transform.air.remove_uninitialized_memref_copy %func_op
+    }
+}

--- a/mlir/test/Transform/AIRTransform/AIRRemoveUninitializedMemrefCopy/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRRemoveUninitializedMemrefCopy/air_transform_payload.mlir
@@ -1,0 +1,174 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' %s | FileCheck %s
+
+// Test basic uninitialized memref copy removal
+// CHECK-LABEL: @test_basic_uninitialized_copy
+// CHECK: %[[ALLOC_6:.*]] = memref.alloc() : memref<2x16x8xi32, 1>
+// CHECK: %[[SUBVIEW_11:.*]] = memref.subview %[[ALLOC_6]][0, 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_12:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK-NOT: memref.copy %[[SUBVIEW_11]], %[[ALLOC_12]]
+// CHECK: linalg.fill ins(%{{.*}} : i32) outs(%[[ALLOC_12]] : memref<1x16x8xi32, 2>)
+func.func @test_basic_uninitialized_copy() {
+  %c0_i32 = arith.constant 0 : i32
+  %alloc_6 = memref.alloc() : memref<2x16x8xi32, 1>
+  %subview_11 = memref.subview %alloc_6[0, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, 1> to memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1>
+  %alloc_12 = memref.alloc() : memref<1x16x8xi32, 2>
+  memref.copy %subview_11, %alloc_12 : memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1> to memref<1x16x8xi32, 2>
+  linalg.fill ins(%c0_i32 : i32) outs(%alloc_12 : memref<1x16x8xi32, 2>)
+  return
+}
+
+// -----
+
+// Test that initialized memref copy is NOT removed
+// CHECK-LABEL: @test_initialized_copy_not_removed
+// CHECK: %[[ALLOC_6:.*]] = memref.alloc() : memref<2x16x8xi32, 1>
+// CHECK: linalg.fill ins(%{{.*}} : i32) outs(%[[ALLOC_6]] : memref<2x16x8xi32, 1>)
+// CHECK: %[[SUBVIEW_11:.*]] = memref.subview %[[ALLOC_6]][0, 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_12:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK: memref.copy %[[SUBVIEW_11]], %[[ALLOC_12]]
+func.func @test_initialized_copy_not_removed() {
+  %c0_i32 = arith.constant 0 : i32
+  %alloc_6 = memref.alloc() : memref<2x16x8xi32, 1>
+  linalg.fill ins(%c0_i32 : i32) outs(%alloc_6 : memref<2x16x8xi32, 1>)
+  %subview_11 = memref.subview %alloc_6[0, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, 1> to memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1>
+  %alloc_12 = memref.alloc() : memref<1x16x8xi32, 2>
+  memref.copy %subview_11, %alloc_12 : memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1> to memref<1x16x8xi32, 2>
+  return
+}
+
+// -----
+
+// Test copy with write between alloc and copy (should NOT be removed)
+// CHECK-LABEL: @test_copy_with_intermediate_write
+// CHECK: %[[ALLOC_6:.*]] = memref.alloc() : memref<2x16x8xi32, 1>
+// CHECK: memref.store %{{.*}}, %[[ALLOC_6]]
+// CHECK: %[[SUBVIEW_11:.*]] = memref.subview %[[ALLOC_6]][0, 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_12:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK: memref.copy %[[SUBVIEW_11]], %[[ALLOC_12]]
+func.func @test_copy_with_intermediate_write() {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %alloc_6 = memref.alloc() : memref<2x16x8xi32, 1>
+  memref.store %c0_i32, %alloc_6[%c0, %c0, %c0] : memref<2x16x8xi32, 1>
+  %subview_11 = memref.subview %alloc_6[0, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, 1> to memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1>
+  %alloc_12 = memref.alloc() : memref<1x16x8xi32, 2>
+  memref.copy %subview_11, %alloc_12 : memref<1x16x8xi32, strided<[128, 8, 1], offset: 0>, 1> to memref<1x16x8xi32, 2>
+  return
+}
+
+// -----
+
+// Test nested scf.forall with uninitialized copy
+// CHECK-LABEL: @test_nested_scf_forall
+// CHECK: scf.forall (%[[ARG3:.*]]) in (2) {
+// CHECK: %[[ALLOC_6:.*]] = memref.alloc() : memref<2x16x8xi32, 1>
+// CHECK: %[[SUBVIEW_11:.*]] = memref.subview %[[ALLOC_6]][%[[ARG3]], 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_12:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK-NOT: memref.copy %[[SUBVIEW_11]], %[[ALLOC_12]]
+// CHECK: linalg.fill ins(%{{.*}} : i32) outs(%[[ALLOC_12]] : memref<1x16x8xi32, 2>)
+func.func @test_nested_scf_forall() {
+  %c0_i32 = arith.constant 0 : i32
+  scf.forall (%arg3) in (2) {
+    %alloc_6 = memref.alloc() : memref<2x16x8xi32, 1>
+    %subview_11 = memref.subview %alloc_6[%arg3, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, 1> to memref<1x16x8xi32, strided<[128, 8, 1], offset: ?>, 1>
+    %alloc_12 = memref.alloc() : memref<1x16x8xi32, 2>
+    memref.copy %subview_11, %alloc_12 : memref<1x16x8xi32, strided<[128, 8, 1], offset: ?>, 1> to memref<1x16x8xi32, 2>
+    linalg.fill ins(%c0_i32 : i32) outs(%alloc_12 : memref<1x16x8xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// Test copy from function argument (should NOT be removed)
+// CHECK-LABEL: @test_copy_from_function_arg
+// CHECK: memref.copy %[[ARG0:.*]], %[[ALLOC:.*]]
+func.func @test_copy_from_function_arg(%arg0: memref<16x8xi32>) {
+  %alloc = memref.alloc() : memref<16x8xi32, 2>
+  memref.copy %arg0, %alloc : memref<16x8xi32> to memref<16x8xi32, 2>
+  return
+}
+
+// -----
+
+// Test complex pattern from the original example
+// CHECK-LABEL: @test_complex_pattern
+// CHECK: %[[ALLOC_2:.*]] = memref.alloc() : memref<2x16x128x128xi32, 1>
+// CHECK: %[[ALLOC_6:.*]] = memref.alloc() : memref<2x16x8xi32, 1>
+// CHECK: scf.forall (%[[ARG3:.*]]) in (2) {
+// CHECK: %[[SUBVIEW_10:.*]] = memref.subview %[[ALLOC_2]][%[[ARG3]], 0, 0, 0] [1, 16, 128, 128] [1, 1, 1, 1]
+// CHECK: %[[SUBVIEW_11:.*]] = memref.subview %[[ALLOC_6]][%[[ARG3]], 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_12:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK-NOT: memref.copy %[[SUBVIEW_11]], %[[ALLOC_12]]
+// CHECK: linalg.fill ins(%{{.*}} : i32) outs(%[[ALLOC_12]] : memref<1x16x8xi32, 2>)
+func.func @test_complex_pattern() {
+  %c0_i32 = arith.constant 0 : i32
+  %alloc_2 = memref.alloc() : memref<2x16x128x128xi32, 1>
+  %alloc_6 = memref.alloc() : memref<2x16x8xi32, 1>
+  scf.forall (%arg3) in (2) {
+    %subview_10 = memref.subview %alloc_2[%arg3, 0, 0, 0] [1, 16, 128, 128] [1, 1, 1, 1] : memref<2x16x128x128xi32, 1> to memref<1x16x128x128xi32, strided<[262144, 16384, 128, 1], offset: ?>, 1>
+    %subview_11 = memref.subview %alloc_6[%arg3, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, 1> to memref<1x16x8xi32, strided<[128, 8, 1], offset: ?>, 1>
+    %alloc_12 = memref.alloc() : memref<1x16x8xi32, 2>
+    memref.copy %subview_11, %alloc_12 : memref<1x16x8xi32, strided<[128, 8, 1], offset: ?>, 1> to memref<1x16x8xi32, 2>
+    linalg.fill ins(%c0_i32 : i32) outs(%alloc_12 : memref<1x16x8xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// Test multiple levels of subviews
+// CHECK-LABEL: @test_multiple_subview_levels
+// CHECK: %[[ALLOC_BASE:.*]] = memref.alloc() : memref<4x32x16xi32, 1>
+// CHECK: %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_BASE]][0, 0, 0] [2, 16, 8] [1, 1, 1]
+// CHECK: %[[SUBVIEW_2:.*]] = memref.subview %[[SUBVIEW_1]][0, 0, 0] [1, 16, 8] [1, 1, 1]
+// CHECK: %[[ALLOC_DST:.*]] = memref.alloc() : memref<1x16x8xi32, 2>
+// CHECK-NOT: memref.copy %[[SUBVIEW_2]], %[[ALLOC_DST]]
+func.func @test_multiple_subview_levels() {
+  %alloc_base = memref.alloc() : memref<4x32x16xi32, 1>
+  %subview_1 = memref.subview %alloc_base[0, 0, 0] [2, 16, 8] [1, 1, 1] : memref<4x32x16xi32, 1> to memref<2x16x8xi32, strided<[512, 16, 1]>, 1>
+  %subview_2 = memref.subview %subview_1[0, 0, 0] [1, 16, 8] [1, 1, 1] : memref<2x16x8xi32, strided<[512, 16, 1]>, 1> to memref<1x16x8xi32, strided<[512, 16, 1]>, 1>
+  %alloc_dst = memref.alloc() : memref<1x16x8xi32, 2>
+  memref.copy %subview_2, %alloc_dst : memref<1x16x8xi32, strided<[512, 16, 1]>, 1> to memref<1x16x8xi32, 2>
+  return
+}
+
+// -----
+
+// Test multiple uninitialized copies removal
+// CHECK-LABEL: @test_multiple_uninitialized_copies
+// CHECK: %[[ALLOC_1:.*]] = memref.alloc() : memref<16x128xi32, 1>
+// CHECK: %[[ALLOC_2:.*]] = memref.alloc() : memref<2x16x128x128xi32, 1>
+// CHECK: %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_1]][0, 0] [4, 128] [1, 1]
+// CHECK: %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_2]][0, 0, 0, 0] [1, 4, 128, 128] [1, 1, 1, 1]
+// CHECK: %[[ALLOC_DST_1:.*]] = memref.alloc() : memref<4x128xi32, 2>
+// CHECK: %[[ALLOC_DST_2:.*]] = memref.alloc() : memref<1x4x128x128xi32, 2>
+// CHECK-NOT: memref.copy %[[SUBVIEW_1]], %[[ALLOC_DST_1]]
+// CHECK-NOT: memref.copy %[[SUBVIEW_2]], %[[ALLOC_DST_2]]
+// CHECK: linalg.generic
+func.func @test_multiple_uninitialized_copies() {
+  %alloc_1 = memref.alloc() : memref<16x128xi32, 1>
+  %alloc_2 = memref.alloc() : memref<2x16x128x128xi32, 1>
+  
+  %subview_1 = memref.subview %alloc_1[0, 0] [4, 128] [1, 1] : memref<16x128xi32, 1> to memref<4x128xi32, strided<[128, 1]>, 1>
+  %subview_2 = memref.subview %alloc_2[0, 0, 0, 0] [1, 4, 128, 128] [1, 1, 1, 1] : memref<2x16x128x128xi32, 1> to memref<1x4x128x128xi32, strided<[262144, 16384, 128, 1]>, 1>
+  
+  %alloc_dst_1 = memref.alloc() : memref<4x128xi32, 2>
+  %alloc_dst_2 = memref.alloc() : memref<1x4x128x128xi32, 2>
+  
+  memref.copy %subview_1, %alloc_dst_1 : memref<4x128xi32, strided<[128, 1]>, 1> to memref<4x128xi32, 2>
+  memref.copy %subview_2, %alloc_dst_2 : memref<1x4x128x128xi32, strided<[262144, 16384, 128, 1]>, 1> to memref<1x4x128x128xi32, 2>
+  
+  linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, d0, d1, 0)>], iterator_types = ["parallel", "parallel"]} ins(%alloc_dst_1 : memref<4x128xi32, 2>) outs(%alloc_dst_2 : memref<1x4x128x128xi32, 2>) {
+  ^bb0(%in: i32, %out: i32):
+    linalg.yield %in : i32
+  }
+  return
+}

--- a/test/xrt/37_matmul_transform_4x4_bf16/transform.mlir
+++ b/test/xrt/37_matmul_transform_4x4_bf16/transform.mlir
@@ -194,6 +194,7 @@ transform.with_pdl_patterns {
         transform.apply_patterns to %func6 {
             transform.apply_patterns.canonicalization
         } : !pdl.operation
+        %func_op_updated = transform.air.remove_uninitialized_memref_copy %func6
 
         // Tile linalg.generics for vectorization
         %linalg_generics = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation


### PR DESCRIPTION
[IR example](https://github.com/Xilinx/mlir-air/blob/8439de8838cddfeb81c69a659c62b763eaba3b93/mlir/test/Transform/AIRTransform/AIRRemoveUninitializedMemrefCopy/air_transform_payload.mlir)