### PR TITLE
AIROverrideMemrefMemorySpace: operating on `ModuleOp`

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1533,7 +1533,7 @@ def DmaToChannel : Pass<"air-dma-to-channel", "ModuleOp"> {
   }];
 }
 
-def AIROverrideMemRefMemorySpace : Pass<"air-override-memref-memory-space", "func::FuncOp"> {
+def AIROverrideMemRefMemorySpace : Pass<"air-override-memref-memory-space", "ModuleOp"> {
   let summary = "Force all memrefs allocated within code region to have the specified memory space.";
   let constructor = "xilinx::air::createAIROverrideMemRefMemorySpacePass()";
   let description = [{
@@ -1544,7 +1544,7 @@ def AIROverrideMemRefMemorySpace : Pass<"air-override-memref-memory-space", "fun
            "Memory space to override to.">,
     Option<"clScope", "scope", "std::string",
             /*default=*/"\"launch\"",
-            "AIR hierarchy scope to perform the transform under. Must be one of [herd, segment, launch].">
+            "AIR hierarchy scope to perform the transform under. Must be one of [herd, segment, launch, func].">
   ];
 }
 

--- a/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
+++ b/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
@@ -64,7 +64,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "buffer-results-to-out-params",
                 "air-par-to-herd{depth=-1}",
                 "air-insert-launch-around-herd{insert-segment=false}",
-                "func.func(air-override-memref-memory-space{scope=herd memory-space=2})",
+                "air-override-memref-memory-space{scope=herd memory-space=2}",
                 "air-copy-to-dma",
                 "canonicalize",
                 "cse",

--- a/test/xrt/32_triton_matmul/run.py
+++ b/test/xrt/32_triton_matmul/run.py
@@ -62,7 +62,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "one-shot-bufferize",
                 f"func.func(air-wrap-func-with-parallel{{loop-bounds={launch_size[0]},{launch_size[1]},{launch_size[2]}}})",
                 "air-par-to-launch{depth=0 has-air-segment=true}",
-                "func.func(air-override-memref-memory-space{scope=launch memory-space=1})",
+                "air-override-memref-memory-space{scope=launch memory-space=1}",
             ]
         )
         + ")"

--- a/test/xrt/33_triton_matmul_ver2/run.py
+++ b/test/xrt/33_triton_matmul_ver2/run.py
@@ -67,7 +67,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "cse",
                 "air-par-to-herd{depth=-1}",
                 "air-insert-launch-around-herd{insert-segment=false}",
-                "func.func(air-override-memref-memory-space{scope=herd memory-space=2})",
+                "air-override-memref-memory-space{scope=herd memory-space=2}",
                 "air-copy-to-dma",
                 "canonicalize",
                 "cse",


### PR DESCRIPTION
... so that `func.func` becomes an option for scope to override memory space.