### PR TITLE
Replace an error message with a warning

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1863,7 +1863,7 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     if (!splitDim) {
       allocOp->emitWarning(
           "memref splitting analysis failed to get the split dimension.");
-      return failure();
+      continue;
     }
 
     // Methods to get root offset/size/stride from air.channel's operands, where


### PR DESCRIPTION
This termination doesn't indicate broken compilation. The pass has already been refactored such that it just skips this memref and analyze the rest of the memrefs.