### PR TITLE
AIRCC: Add `scf-convert-forall-to-parallel` after `air.hierarchy` mapping

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -453,6 +453,7 @@ def run(mlir_module, args=None):
             [
                 "air-insert-launch-around-herd{insert-segment=true}",
                 "func.func(air-lower-herd-parallel)",
+                "scf-forall-to-parallel",
             ]
             + (
                 get_air_optimization_pass(


### PR DESCRIPTION
... to materialize parallelism in places other than air hierarchy constructs, e.g. parallel data movements.