### PR TITLE
Add transform dialect op `LinalgToLibraryCallOp`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -54,6 +54,40 @@ def SegmentToAIEOp : Op<Transform_Dialect, "air.segment_to_aie",
   }];
 }
 
+def LinalgToLibraryCallOp : Op<Transform_Dialect, "air.linalg_to_library_call",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Convert a linalg op to a function call (library call)";
+  let description = [{
+    Replaces a linalg op with a call to a function. If the `function_name`
+    attribute is provided, it is used as the function name. Otherwise, the
+    linalg op's `library_call` attribute is used. The function is created if
+    it does not exist. If the `link_with` attribute is provided, it is used
+    to link the function call to a prebuilt object that contains the 
+    implementation of the function. If the linalg op is inside a herd, the 
+    `link_with` attribute is propagated to the herd.
+
+    Example:
+    ```
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %f : (!pdl.operation) -> !pdl.operation
+    %call = transform.air.linalg_to_library_call %matmul { function_name = "my_matmul", link_with = "extern_func.o" } : (!pdl.operation) -> !pdl.operation
+    ```
+  }];
+  let arguments = (ins PDL_Operation:$target,
+                   OptionalAttr<StrAttr>:$function_name,
+                   OptionalAttr<StrAttr>:$link_with);
+  let results = (outs PDL_Operation:$result);
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 // Ops implemented in mlir/lib/Conversion/ConvertToAIRPass.cpp
 //
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -2291,6 +2291,92 @@ DiagnosedSilenceableFailure transform::ForallWithReduceToParallelOp::apply(
   return DiagnosedSilenceableFailure::success();
 }
 
+//===----------------------------------------------------------------------===//
+// LinalgToLibraryCallOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure transform::LinalgToLibraryCallOp::applyToOne(
+    transform::TransformRewriter &rewriter, Operation *target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  using namespace mlir;
+  using namespace mlir::linalg;
+
+  auto linalgOp = dyn_cast<LinalgOp>(target);
+  if (!linalgOp)
+    return emitSilenceableError() << "expected linalg op as target";
+
+  // Get function name: from transform op attribute or linalg op attribute.
+  std::string fnName;
+  if (auto attr = getOperation()->getAttrOfType<StringAttr>("function_name")) {
+    fnName = attr.getValue().str();
+  } else {
+    fnName = linalgOp.getLibraryCallName();
+  }
+  if (fnName.empty())
+    return emitSilenceableError() << "no function name provided and linalg op "
+                                     "has no library_call attribute";
+
+  // Collect operands, handling reshape/expand/collapse.
+  auto getLibFnOperands = [](LinalgOp op) {
+    SmallVector<Value> operands;
+    for (auto operand : op->getOperands()) {
+      auto operation = operand.getDefiningOp();
+      if (operation &&
+          (isa_and_present<memref::ReshapeOp, memref::ExpandShapeOp,
+                           memref::CollapseShapeOp>(operation))) {
+        operands.push_back(operation->getOperand(0));
+        continue;
+      }
+      operands.push_back(operand);
+    }
+    return operands;
+  };
+  auto libFnOperands = getLibFnOperands(linalgOp);
+
+  // Create function if needed.
+  auto module = linalgOp->getParentOfType<ModuleOp>();
+  FlatSymbolRefAttr fnNameAttr =
+      SymbolRefAttr::get(rewriter.getContext(), fnName);
+  auto sym = module.lookupSymbol(fnNameAttr.getAttr());
+  if (!sym) {
+    auto libFnType = rewriter.getFunctionType(
+        ValueRange(ArrayRef<Value>(libFnOperands)).getTypes(), {});
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(module.getBody(),
+                               std::prev(module.getBody()->end()));
+    func::FuncOp funcOp = rewriter.create<func::FuncOp>(
+        linalgOp->getLoc(), fnNameAttr.getValue(), libFnType);
+    funcOp->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                    UnitAttr::get(linalgOp->getContext()));
+    if (auto linkWithAttr =
+            getOperation()->getAttrOfType<StringAttr>("link_with")) {
+      funcOp->setAttr("link_with", linkWithAttr);
+    } else if (auto herd = linalgOp->getParentOfType<xilinx::air::HerdOp>()) {
+      if (auto herdLinkWith = herd->getAttrOfType<StringAttr>("link_with"))
+        funcOp->setAttr("link_with", herdLinkWith);
+    }
+    funcOp.setPrivate();
+  }
+
+  // Replace linalg op with call.
+  auto callOp = rewriter.replaceOpWithNewOp<func::CallOp>(
+      linalgOp, fnNameAttr.getValue(), TypeRange(),
+      ValueRange(ArrayRef<Value>(libFnOperands)));
+
+  // If inside herd, propagate link_with.
+  if (auto herd = linalgOp->getParentOfType<xilinx::air::HerdOp>()) {
+    if (auto linkWithAttr =
+            getOperation()->getAttrOfType<StringAttr>("link_with")) {
+      rewriter.modifyOpInPlace(
+          herd, [&]() { herd->setAttr("link_with", linkWithAttr); });
+    }
+  }
+
+  results.push_back(callOp);
+  return DiagnosedSilenceableFailure::success();
+}
+
 namespace xilinx {
 namespace air {
 

--- a/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_default_name.mlir
+++ b/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_default_name.mlir
@@ -1,0 +1,21 @@
+//===- air_transform_default_name.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// Transform dialect test: fallback to library_call attribute
+// CHECK: transform.air.linalg_to_library_call
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1: !pdl.operation):
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+    // Should use the library_call attribute ("linalg_matmul_view4x4xf32_view4x4xf32_view4x4xf32")
+    %call = transform.air.linalg_to_library_call %matmul : (!pdl.operation) -> !pdl.operation
+  }
+}

--- a/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_explicit_name.mlir
+++ b/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_explicit_name.mlir
@@ -1,0 +1,21 @@
+//===- air_transform_explicit_name.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// Transform dialect test: explicit function_name
+// CHECK: transform.air.linalg_to_library_call
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1: !pdl.operation):
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+    // Should use "my_explicit_func" as the function name
+    %call = transform.air.linalg_to_library_call %matmul { function_name = "my_explicit_func" } : (!pdl.operation) -> !pdl.operation
+  }
+}

--- a/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_link_with.mlir
+++ b/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_link_with.mlir
@@ -1,0 +1,21 @@
+//===- air_transform_link_with.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// Transform dialect test: link_with attribute
+// CHECK: transform.air.linalg_to_library_call
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 : !pdl.operation failures(propagate) {
+  ^bb1(%arg1: !pdl.operation):
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+    // Should use "my_linked_func" as the function name and "extern_func.o" as link_with
+    %call = transform.air.linalg_to_library_call %matmul { function_name = "my_linked_func", link_with = "extern_func.o" } : (!pdl.operation) -> !pdl.operation
+  }
+}

--- a/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/LinalgToLibraryCall/air_transform_payload.mlir
@@ -1,0 +1,21 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform_default_name.mlir' %s | FileCheck %s
+// RUN: air-opt -air-transform='filename=%S/air_transform_explicit_name.mlir' %s | FileCheck %s  --check-prefix=EXPLICITNAME
+// RUN: air-opt -air-transform='filename=%S/air_transform_link_with.mlir' %s | FileCheck %s  --check-prefix=LINKWITH
+
+// CHECK: call @linalg_matmul_view4x4xf32_view4x4xf32_view4x4xf32(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>) -> ()
+// EXPLICITNAME: call @my_explicit_func(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>) -> ()
+// LINKWITH: func.func private @my_linked_func(memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>) attributes {link_with = "extern_func.o", llvm.emit_c_interface}
+// LINKWITH: call @my_linked_func(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>) -> ()
+module {
+  func.func @main(%A: memref<4x4xf32>, %B: memref<4x4xf32>, %C: memref<4x4xf32>) {
+    linalg.matmul ins(%A, %B : memref<4x4xf32>, memref<4x4xf32>) outs(%C : memref<4x4xf32>)
+    return
+  }
+}


### PR DESCRIPTION
- Adapted from `air-linalg-to-func`, applied to individual `linalg` ops.