### PR TITLE
Add transform dialect op `AIRTransposeReduce`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -442,6 +442,38 @@ def ConvertMemrefCopyToLinalgCopyOp : Op<Transform_Dialect, "air.convert_memref_
   let assemblyFormat = "$target attr-dict";
 }
 
+def TransposeReduceOp : Op<Transform_Dialect, "air.transpose_reduce",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let summary = "Transpose inputs of linalg.reduce ops to make reduction dimensions innermost";
+  let description = [{
+    This transform takes a handle to linalg.reduce operations and checks if the 
+    reduction dimensions are at the innermost (last/lowest) dimensions. If any 
+    reduction dimension has non-reduction dimensions to the right, it transposes 
+    the corresponding inputs to ensure all reduction dimensions are innermost.
+    
+    For example, if a linalg.reduce operation reduces along dimension 1 in a 3D tensor
+    (shape [M, N, K] reducing along N), this transform will transpose the input to 
+    [M, K, N] so that the reduction dimension N becomes innermost.
+    
+    This optimization is beneficial for hardware accelerators that perform more 
+    efficient reductions when the reduction dimensions are contiguous and innermost.
+    
+    The transformation:
+    1. Analyzes each linalg.reduce operation's reduction dimensions
+    2. Determines if any reduction dimension has non-reduction dimensions to its right
+    3. If so, creates a transpose operation to move reduction dimensions to the end
+    4. Updates the linalg.reduce operation to work with the transposed input
+    5. Optionally transposes the output back to the original layout if needed
+    
+    Returns a handle to the transformed linalg.reduce operations.
+  }];
+  
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$result);
+  let assemblyFormat = "$target attr-dict";
+}
+
 // Ops implemented in mlir/lib/Transform/AIRLinalgBufferize.cpp
 //
 

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -2601,6 +2601,166 @@ DiagnosedSilenceableFailure transform::ConvertMemrefCopyToLinalgCopyOp::apply(
   return DiagnosedSilenceableFailure::success();
 }
 
+//===----------------------------------------------------------------------===//
+// TransposeReduceOp
+//===----------------------------------------------------------------------===//
+
+/// Check if reduction dimensions are innermost in the given linalg.reduce op
+static bool areReductionDimensionsInnermost(linalg::ReduceOp reduceOp) {
+  ArrayRef<int64_t> reductionDims = reduceOp.getDimensions();
+  if (reductionDims.empty())
+    return true;
+
+  // Get the input tensor rank
+  auto inputType = llvm::cast<ShapedType>(reduceOp.getInputs()[0].getType());
+  int64_t rank = inputType.getRank();
+
+  // Check if all reduction dimensions are at the end (innermost)
+  SmallVector<int64_t> sortedReductionDims(reductionDims.begin(),
+                                           reductionDims.end());
+  llvm::sort(sortedReductionDims);
+
+  // The reduction dimensions should be consecutive and end at rank-1
+  for (size_t i = 0; i < sortedReductionDims.size(); ++i) {
+    if (sortedReductionDims[i] !=
+        (int64_t)(rank - sortedReductionDims.size() + i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Create a transpose operation to move reduction dimensions to the end
+static Value
+createTransposeToMakeReductionInnermost(OpBuilder &builder, Location loc,
+                                        Value input,
+                                        ArrayRef<int64_t> reductionDims) {
+
+  auto inputType = llvm::cast<ShapedType>(input.getType());
+  int64_t rank = inputType.getRank();
+
+  // Create permutation: non-reduction dims first, then reduction dims
+  SmallVector<int64_t> permutation;
+  SmallVector<bool> isReductionDim(rank, false);
+
+  // Mark reduction dimensions
+  for (int64_t dim : reductionDims) {
+    isReductionDim[dim] = true;
+  }
+
+  // Add non-reduction dimensions first
+  for (int64_t i = 0; i < rank; ++i) {
+    if (!isReductionDim[i]) {
+      permutation.push_back(i);
+    }
+  }
+
+  // Add reduction dimensions at the end
+  for (int64_t dim : reductionDims) {
+    permutation.push_back(dim);
+  }
+
+  // Create the transpose operation
+  SmallVector<int64_t> transposedShape;
+  for (int64_t dim : permutation) {
+    transposedShape.push_back(inputType.getDimSize(dim));
+  }
+
+  auto transposedType =
+      RankedTensorType::get(transposedShape, inputType.getElementType());
+
+  // Create linalg.transpose operation
+  auto transposeOp = builder.create<linalg::TransposeOp>(
+      loc, input,
+      builder.create<tensor::EmptyOp>(loc, transposedShape,
+                                      inputType.getElementType()),
+      builder.getDenseI64ArrayAttr(permutation));
+
+  return transposeOp.getResult()[0];
+}
+
+/// Update reduction dimensions after transpose
+static SmallVector<int64_t>
+updateReductionDimsAfterTranspose(ArrayRef<int64_t> originalReductionDims,
+                                  int64_t rank) {
+
+  SmallVector<int64_t> newReductionDims;
+  int64_t numReductionDims = originalReductionDims.size();
+
+  // After transpose, reduction dimensions are at the end
+  for (int64_t i = 0; i < numReductionDims; ++i) {
+    newReductionDims.push_back(rank - numReductionDims + i);
+  }
+
+  return newReductionDims;
+}
+
+DiagnosedSilenceableFailure
+transform::TransposeReduceOp::apply(transform::TransformRewriter &rewriter,
+                                    transform::TransformResults &results,
+                                    transform::TransformState &state) {
+
+  SmallVector<Operation *> targets =
+      llvm::to_vector(state.getPayloadOps(getTarget()));
+
+  if (targets.empty()) {
+    results.set(llvm::cast<OpResult>(getResult()), ArrayRef<Operation *>());
+    return DiagnosedSilenceableFailure::success();
+  }
+
+  SmallVector<Operation *> transformedOps;
+
+  for (Operation *target : targets) {
+    auto reduceOp = dyn_cast<linalg::ReduceOp>(target);
+    if (!reduceOp) {
+      return emitDefiniteFailure()
+             << "target must be a linalg.reduce operation";
+    }
+
+    // Check if reduction dimensions are already innermost
+    if (areReductionDimensionsInnermost(reduceOp)) {
+      // No transformation needed
+      transformedOps.push_back(target);
+      continue;
+    }
+
+    // Get reduction dimensions and input
+    ArrayRef<int64_t> reductionDims = reduceOp.getDimensions();
+    Value input = reduceOp.getInputs()[0];
+    auto inputType = llvm::cast<ShapedType>(input.getType());
+    int64_t rank = inputType.getRank();
+
+    // Create transpose operation to move reduction dimensions to the end
+    rewriter.setInsertionPoint(reduceOp);
+    Value transposedInput = createTransposeToMakeReductionInnermost(
+        rewriter, reduceOp.getLoc(), input, reductionDims);
+
+    // Update reduction dimensions for the new layout
+    SmallVector<int64_t> newReductionDims =
+        updateReductionDimsAfterTranspose(reductionDims, rank);
+
+    // Create new reduce operation with transposed input and updated dimensions
+    auto newReduceOp = rewriter.create<linalg::ReduceOp>(
+        reduceOp.getLoc(), reduceOp.getResultTypes(),
+        ValueRange{transposedInput}, reduceOp.getInits(),
+        rewriter.getDenseI64ArrayAttr(newReductionDims));
+
+    // Copy the reduction body from the original operation
+    rewriter.cloneRegionBefore(reduceOp.getCombiner(),
+                               newReduceOp.getCombiner(),
+                               newReduceOp.getCombiner().begin());
+
+    // Replace the original operation
+    rewriter.replaceOp(reduceOp, newReduceOp.getResults());
+    transformedOps.push_back(newReduceOp);
+  }
+
+  results.set(llvm::cast<OpResult>(getResult()), transformedOps);
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===----------------------------------------------------------------------===//
+
 namespace xilinx {
 namespace air {
 

--- a/mlir/test/Transform/AIRTransform/AIRTransposeReduce/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRTransposeReduce/air_transform.mlir
@@ -1,0 +1,20 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.transpose_reduce
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+        // Find linalg.reduce operations and apply transpose optimization
+        %reduce_op = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %transformed_reduce = transform.air.transpose_reduce %reduce_op
+    }
+}

--- a/mlir/test/Transform/AIRTransform/AIRTransposeReduce/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRTransposeReduce/air_transform_payload.mlir
@@ -1,0 +1,30 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' %s | FileCheck %s
+
+// CHECK: %[[transposed:.*]] = linalg.transpose ins(%{{.*}} : tensor<8x16x32xi32>) outs(%{{.*}} : tensor<8x32x16xi32>) permutation = [0, 2, 1] 
+// CHECK: %[[reduced:.*]] = linalg.reduce ins(%[[transposed]] : tensor<8x32x16xi32>) outs(%{{.*}} : tensor<8x32xi32>) dimensions = [2] 
+
+module {
+  func.func @transpose_reduce_test(%arg0: tensor<8x16x32xi32>) -> tensor<8x32xi32> {
+    %c0_i32 = arith.constant 0 : i32
+    %init = tensor.empty() : tensor<8x32xi32>
+    %filled = linalg.fill ins(%c0_i32 : i32) outs(%init : tensor<8x32xi32>) -> tensor<8x32xi32>
+    
+    // This linalg.reduce operation reduces along dimension 1 (middle dimension)
+    // The TransposeReduceOp should transpose the input to make dimension 1 innermost
+    // Input shape: [8, 16, 32] -> should transpose to [8, 32, 16] to make reduction dim innermost
+    %reduced = linalg.reduce ins(%arg0 : tensor<8x16x32xi32>) outs(%filled : tensor<8x32xi32>) dimensions = [1] 
+      (%in: i32, %1: i32) {
+        %sum = arith.addi %in, %1 : i32
+        linalg.yield %sum : i32
+      }
+    
+    return %reduced : tensor<8x32xi32>
+  }
+}


### PR DESCRIPTION
It attempts to transpose linalg.reduce ops such that the reduction dimensions are at the innermost dimensions. This layout is preferred by our spatial accelerator's reduction intrinsics.

Context: triton-shared is currently lowering triton reduction operations with reduction dimensions forced to be dimension 0 ("outermost" dimension). This layout leads to challenges when mapping to AIEs.