### PR TITLE
Add transform dialect op `AIRHerdVectorize`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -474,6 +474,54 @@ def TransposeReduceOp : Op<Transform_Dialect, "air.transpose_reduce",
   let assemblyFormat = "$target attr-dict";
 }
 
+def AIRHerdVectorizeOp : Op<Transform_Dialect, "air.herd_vectorize",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Vectorize operations inside air.herd operations";
+  let description = [{
+    This transform takes a handle to air.herd operations and vectorizes the operations
+    inside their bodies using the same logic as the AIRHerdVectorizePass. It walks the
+    body of each herd operation and applies vectorization patterns to linalg operations
+    and other vectorizable operations.
+    
+    The transform supports the same options as the AIRHerdVectorizePass:
+    - vectorize_nd_extract: Controls whether to vectorize tensor.extract when the input tensor is rank >= 2
+    - flatten_1d_depthwise_conv: Controls whether to "flatten" the channel dimension when vectorizing 1D depthwise convolutions
+    - disable_transfer_permutation_map_lowering_patterns: Disables vector transfer permutation map lowering patterns
+    - disable_multi_reduction_to_contract_patterns: Disables multi-reduction to contract patterns
+    - vectorize_padding: Enables vectorization of padding operations
+    
+    Example:
+    ```mlir
+    %herd = transform.structured.match ops{["air.herd"]} in %f : (!pdl.operation) -> !pdl.operation
+    %vectorized = transform.air.herd_vectorize %herd {
+      vectorize_nd_extract = false,
+      flatten_1d_depthwise_conv = false,
+      vectorize_padding = true
+    } : (!pdl.operation) -> !pdl.operation
+    ```
+    
+    Returns a handle to the transformed air.herd operations.
+  }];
+  
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<BoolAttr, "false">:$vectorize_nd_extract,
+                   DefaultValuedAttr<BoolAttr, "false">:$flatten_1d_depthwise_conv,
+                   DefaultValuedAttr<BoolAttr, "false">:$disable_transfer_permutation_map_lowering_patterns,
+                   DefaultValuedAttr<BoolAttr, "false">:$disable_multi_reduction_to_contract_patterns,
+                   DefaultValuedAttr<BoolAttr, "false">:$vectorize_padding);
+  let results = (outs PDL_Operation:$result);
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 // Ops implemented in mlir/lib/Transform/AIRLinalgBufferize.cpp
 //
 

--- a/mlir/test/Transform/AIRTransform/AIRHerdVectorize/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRHerdVectorize/air_transform.mlir
@@ -1,0 +1,20 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.herd_vectorize
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+    transform.sequence %arg0 : !pdl.operation failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+        // Find air.herd operations and apply vectorization
+        %herd_op = transform.structured.match ops{["air.herd"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %vectorized_herd = transform.air.herd_vectorize %herd_op
+    }
+}

--- a/mlir/test/Transform/AIRTransform/AIRHerdVectorize/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRHerdVectorize/air_transform_payload.mlir
@@ -1,0 +1,34 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' %s | FileCheck %s
+
+// CHECK: vector.transfer_read
+// CHECK: vector.transfer_read
+// CHECK: arith.addf
+// CHECK: vector.transfer_write
+
+module {
+  func.func @test_herd_vectorize(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    air.herd @herd_0 tile (%tx, %ty) in (%size_x = %c2, %size_y = %c2) args(%a0=%arg0, %a1=%arg1, %a2=%arg2) : memref<32x32xf32>, memref<32x32xf32>, memref<32x32xf32> {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : index
+      %subview_a0 = memref.subview %a0[%tx, %ty] [16, 16] [1, 1] : memref<32x32xf32> to memref<16x16xf32, strided<[32, 1], offset: ?>>
+      %subview_a1 = memref.subview %a1[%tx, %ty] [16, 16] [1, 1] : memref<32x32xf32> to memref<16x16xf32, strided<[32, 1], offset: ?>>
+      %subview_a2 = memref.subview %a2[%tx, %ty] [16, 16] [1, 1] : memref<32x32xf32> to memref<16x16xf32, strided<[32, 1], offset: ?>>
+      
+      // This linalg.add should be vectorized by our transform op
+      linalg.add ins(%subview_a0, %subview_a1 : memref<16x16xf32, strided<[32, 1], offset: ?>>, memref<16x16xf32, strided<[32, 1], offset: ?>>) 
+                 outs(%subview_a2 : memref<16x16xf32, strided<[32, 1], offset: ?>>)
+      
+      air.herd_terminator
+    }
+    return
+  }
+}

--- a/test/xrt/39_triton_matmul_ver3_vectorized/run.py
+++ b/test/xrt/39_triton_matmul_ver3_vectorized/run.py
@@ -102,9 +102,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-par-to-launch{depth=0 has-air-segment=true}",
                 "canonicalize",
                 "cse",
-                "air-par-to-herd{depth=-1}",
                 "air-copy-to-dma",
-                "func.func(air-herd-vectorize)",
             ]
         )
         + ")"

--- a/test/xrt/39_triton_matmul_ver3_vectorized/transform.mlir
+++ b/test/xrt/39_triton_matmul_ver3_vectorized/transform.mlir
@@ -163,6 +163,20 @@ transform.with_pdl_patterns {
         %linalg_fills = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!pdl.operation) -> !pdl.operation
         %inner_most_fills, %vec_fill_loops:2 =
           transform.structured.tile_using_for %linalg_fills tile_sizes [1, 1]
-          : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)         
+          : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)   
+
+    // Step 19: AIR Constructs Mapping
+    // Purpose: Convert high-level parallel constructs to AIE-specific operations for hardware execution.
+    // Convert parallel loops to AIE herd operations for multi-core execution
+        %forall_as_herd = transform.structured.match ops{["scf.forall"]} in %arg1 : (!pdl.operation) -> !pdl.operation
+        %parallel = transform.loop.forall_to_parallel %forall_as_herd  : (!pdl.operation) -> !pdl.operation
+        %herd = transform.air.par_to_herd %parallel
+
+    // Convert memory copies to DMA operations for efficient data movement
+        %copies_in_herd = transform.structured.match ops{["memref.copy", "linalg.copy"]} in %herd : (!pdl.operation) -> !pdl.operation
+        %dmas_from_copies = transform.air.copy_to_dma %copies_in_herd
+        
+    // Apply vectorization to optimize for AIE vector units
+        %vectorized_herd = transform.air.herd_vectorize %herd
     }
 }

--- a/test/xrt/40_triton_vec_add/run.py
+++ b/test/xrt/40_triton_vec_add/run.py
@@ -99,9 +99,7 @@ with air.ir.Context() as ctx, Location.unknown():
                 "air-par-to-launch{depth=0 has-air-segment=true}",
                 "canonicalize",
                 "cse",
-                "air-par-to-herd{depth=-1}",
                 "air-copy-to-dma",
-                "func.func(air-herd-vectorize)",
                 "canonicalize",
                 "cse",
             ]

--- a/test/xrt/41_triton_softmax/run.py
+++ b/test/xrt/41_triton_softmax/run.py
@@ -159,7 +159,6 @@ with air.ir.Context() as ctx, Location.unknown():
         + ",".join(
             [
                 f"func.func(air-wrap-func-with-parallel{{loop-bounds={launch_size[0]},{launch_size[1]},1}})",
-                "air-par-to-herd{depth=-1}",
                 "air-par-to-launch{depth=-1 has-air-segment=true}",
                 "air-copy-to-dma",
                 "canonicalize",

--- a/test/xrt/41_triton_softmax/transform.mlir
+++ b/test/xrt/41_triton_softmax/transform.mlir
@@ -224,8 +224,5 @@ transform.with_pdl_patterns {
         // Convert memory copies to DMA operations for efficient data movement
         %copies_in_herd = transform.structured.match ops{["memref.copy", "linalg.copy"]} in %herd : (!pdl.operation) -> !pdl.operation
         %dmas_from_copies = transform.air.copy_to_dma %copies_in_herd
-        
-        // Apply vectorization to optimize for AIE vector units
-        %vectorized_herd = transform.air.herd_vectorize %herd
     }
 }


### PR DESCRIPTION
Adapted from the mlir pass `AIRHerdVectorizePass`, applied to individual `air.herd` ops.