### PR TITLE
Add transform dialect op `FuseExtfLinalgOp`

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRTransformOps.td
+++ b/mlir/include/air/Dialect/AIR/AIRTransformOps.td
@@ -474,6 +474,57 @@ def TransposeReduceOp : Op<Transform_Dialect, "air.transpose_reduce",
   let assemblyFormat = "$target attr-dict";
 }
 
+def FuseExtfLinalgOp : Op<Transform_Dialect, "air.fuse_extf_linalg",
+    [FunctionalStyleTransformOpTrait, DeclareOpInterfaceMethods<TransformOpInterface>,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Fuse a linalg operation containing only arith.extf with its consumer";
+  let description = [{
+    This transform fuses two linalg operations where:
+    1. The first operation contains only an arith.extf operation in its body (apart from terminator)
+    2. The second operation directly consumes the result of the first operation
+    
+    The fusion is performed by:
+    1. Removing the arith.extf from the first operation
+    2. Updating the input type in the second operation to use the original (narrower) type
+    3. Adding arith.extf operations as needed to maintain type consistency
+    4. Erasing the first operation
+    
+    This optimization folds the arithmetic extensions into the linalg ops, and enables the use of
+    native native intrinsics on narrower datatypes, such as AMD AIEs.
+    
+    Example:
+    ```mlir
+    // Before fusion:
+    %0 = linalg.generic {
+      ^bb0(%arg0: f16):
+        %1 = arith.extf %arg0 : f16 to f32
+        linalg.yield %1 : f32
+    } ins(%input : tensor<16xf16>) outs(%temp : tensor<16xf32>)
+    
+    %result = linalg.generic {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %2 = arith.addf %arg0, %arg1 : f32
+        linalg.yield %2 : f32
+    } ins(%0, %other : tensor<16xf32>, tensor<16xf32>) outs(%output : tensor<16xf32>)
+    
+    // After fusion:
+    %result = linalg.generic {
+      ^bb0(%arg0: f16, %arg1: f32):
+        %1 = arith.extf %arg0 : f16 to f32
+        %2 = arith.addf %1, %arg1 : f32
+        linalg.yield %2 : f32
+    } ins(%input, %other : tensor<16xf16>, tensor<16xf32>) outs(%output : tensor<16xf32>)
+    ```
+    
+    Returns a handle to the fused operation (the second operation after modification).
+  }];
+  
+  let arguments = (ins PDL_Operation:$first_op,
+                       PDL_Operation:$second_op);
+  let results = (outs PDL_Operation:$fused_op);
+  let assemblyFormat = "$first_op `,` $second_op attr-dict";
+}
+
 def AIRHerdVectorizeOp : Op<Transform_Dialect, "air.herd_vectorize",
     [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
      TransformOpInterface, TransformEachOpTrait]> {

--- a/mlir/test/Transform/AIRTransform/AIRFuseExtfLinalg/air_transform.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRFuseExtfLinalg/air_transform.mlir
@@ -1,0 +1,37 @@
+//===- air_transform.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s | FileCheck %s
+
+// CHECK: transform.air.fuse_extf_linalg
+
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  // Test case 1: Basic fusion of extf with elementwise add
+  %func1 = transform.structured.match ops{["func.func"]} attributes{sym_name = "fuse_extf_with_add"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %ops1 = transform.structured.match ops{["linalg.generic"]} in %func1 : (!pdl.operation) -> !pdl.operation
+  %extf_op1, %consumer_op1 = transform.split_handle %ops1 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fused1 = transform.air.fuse_extf_linalg %extf_op1, %consumer_op1
+
+  // Test case 2: Fusion with multiple inputs where extf result is not the first input
+  %func2 = transform.structured.match ops{["func.func"]} attributes{sym_name = "fuse_extf_with_mul_second_input"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %ops2 = transform.structured.match ops{["linalg.generic"]} in %func2 : (!pdl.operation) -> !pdl.operation
+  %extf_op2, %consumer_op2 = transform.split_handle %ops2 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fused2 = transform.air.fuse_extf_linalg %extf_op2, %consumer_op2
+
+  // Test case 3: 2D tensor fusion
+  %func3 = transform.structured.match ops{["func.func"]} attributes{sym_name = "fuse_extf_2d_tensor"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %ops3 = transform.structured.match ops{["linalg.generic"]} in %func3 : (!pdl.operation) -> !pdl.operation
+  %extf_op3, %consumer_op3 = transform.split_handle %ops3 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fused3 = transform.air.fuse_extf_linalg %extf_op3, %consumer_op3
+
+  // Test case 4: Different precision extension (bf16 to f32)
+  %func4 = transform.structured.match ops{["func.func"]} attributes{sym_name = "fuse_extf_bf16_to_f32"} in %arg1 : (!pdl.operation) -> !pdl.operation
+  %ops4 = transform.structured.match ops{["linalg.generic"]} in %func4 : (!pdl.operation) -> !pdl.operation
+  %extf_op4, %consumer_op4 = transform.split_handle %ops4 : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fused4 = transform.air.fuse_extf_linalg %extf_op4, %consumer_op4
+}

--- a/mlir/test/Transform/AIRTransform/AIRFuseExtfLinalg/air_transform_payload.mlir
+++ b/mlir/test/Transform/AIRTransform/AIRFuseExtfLinalg/air_transform_payload.mlir
@@ -1,0 +1,221 @@
+//===- air_transform_payload.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-transform='filename=%S/air_transform.mlir' -verify-diagnostics %s | FileCheck %s
+
+// Test case 1: Basic fusion of extf with elementwise add
+// CHECK-LABEL: @fuse_extf_with_add
+func.func @fuse_extf_with_add(%input: tensor<16xf16>, %other: tensor<16xf32>) -> tensor<16xf32> {
+  %empty1 = tensor.empty() : tensor<16xf32>
+  %empty2 = tensor.empty() : tensor<16xf32>
+  
+  // First op: contains only arith.extf
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<16xf16>) outs(%empty1 : tensor<16xf32>) {
+  ^bb0(%arg0: f16, %arg1: f32):
+    %0 = arith.extf %arg0 : f16 to f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // Second op: consumes the result of first op
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%extf_result, %other : tensor<16xf32>, tensor<16xf32>) outs(%empty2 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.addf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // CHECK: linalg.generic {{.*}} ins(%{{.*}}, %{{.*}} : tensor<16xf16>, tensor<16xf32>)
+  // CHECK: ^bb0(%{{.*}}: f16, %{{.*}}: f32, %{{.*}}: f32):
+  // CHECK:   %{{.*}} = arith.extf %{{.*}} : f16 to f32
+  // CHECK:   %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
+  // CHECK:   linalg.yield %{{.*}} : f32
+  
+  return %result : tensor<16xf32>
+}
+
+// Test case 2: Fusion with multiple inputs where extf result is not the first input
+// CHECK-LABEL: @fuse_extf_with_mul_second_input
+func.func @fuse_extf_with_mul_second_input(%input: tensor<8xf16>, %other: tensor<8xf32>) -> tensor<8xf32> {
+  %empty1 = tensor.empty() : tensor<8xf32>
+  %empty2 = tensor.empty() : tensor<8xf32>
+  
+  // First op: contains only arith.extf
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<8xf16>) outs(%empty1 : tensor<8xf32>) {
+  ^bb0(%arg0: f16, %arg1: f32):
+    %0 = arith.extf %arg0 : f16 to f32
+    linalg.yield %0 : f32
+  } -> tensor<8xf32>
+  
+  // Second op: extf_result is the second input
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%other, %extf_result : tensor<8xf32>, tensor<8xf32>) outs(%empty2 : tensor<8xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.mulf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<8xf32>
+  
+  // CHECK: linalg.generic {{.*}} ins(%{{.*}}, %{{.*}} : tensor<8xf32>, tensor<8xf16>)
+  // CHECK: ^bb0(%{{.*}}: f32, %{{.*}}: f16, %{{.*}}: f32):
+  // CHECK:   %{{.*}} = arith.extf %{{.*}} : f16 to f32
+  // CHECK:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f32
+  // CHECK:   linalg.yield %{{.*}} : f32
+  
+  return %result : tensor<8xf32>
+}
+
+// Test case 3: 2D tensor fusion
+// CHECK-LABEL: @fuse_extf_2d_tensor
+func.func @fuse_extf_2d_tensor(%input: tensor<4x8xf16>, %other: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %empty1 = tensor.empty() : tensor<4x8xf32>
+  %empty2 = tensor.empty() : tensor<4x8xf32>
+  
+  // First op: 2D extf operation
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%input : tensor<4x8xf16>) outs(%empty1 : tensor<4x8xf32>) {
+  ^bb0(%arg0: f16, %arg1: f32):
+    %0 = arith.extf %arg0 : f16 to f32
+    linalg.yield %0 : f32
+  } -> tensor<4x8xf32>
+  
+  // Second op: 2D elementwise operation
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%extf_result, %other : tensor<4x8xf32>, tensor<4x8xf32>) outs(%empty2 : tensor<4x8xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.subf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<4x8xf32>
+  
+  // CHECK: linalg.generic {{.*}} ins(%{{.*}}, %{{.*}} : tensor<4x8xf16>, tensor<4x8xf32>)
+  // CHECK: ^bb0(%{{.*}}: f16, %{{.*}}: f32, %{{.*}}: f32):
+  // CHECK:   %{{.*}} = arith.extf %{{.*}} : f16 to f32
+  // CHECK:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : f32
+  // CHECK:   linalg.yield %{{.*}} : f32
+  
+  return %result : tensor<4x8xf32>
+}
+
+// Test case 4: Different precision extension (bf16 to f32)
+// CHECK-LABEL: @fuse_extf_bf16_to_f32
+func.func @fuse_extf_bf16_to_f32(%input: tensor<16xbf16>, %other: tensor<16xf32>) -> tensor<16xf32> {
+  %empty1 = tensor.empty() : tensor<16xf32>
+  %empty2 = tensor.empty() : tensor<16xf32>
+  
+  // First op: bf16 to f32 extension
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<16xbf16>) outs(%empty1 : tensor<16xf32>) {
+  ^bb0(%arg0: bf16, %arg1: f32):
+    %0 = arith.extf %arg0 : bf16 to f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // Second op: max operation
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%extf_result, %other : tensor<16xf32>, tensor<16xf32>) outs(%empty2 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.maximumf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // CHECK: linalg.generic {{.*}} ins(%{{.*}}, %{{.*}} : tensor<16xbf16>, tensor<16xf32>)
+  // CHECK: ^bb0(%{{.*}}: bf16, %{{.*}}: f32, %{{.*}}: f32):
+  // CHECK:   %{{.*}} = arith.extf %{{.*}} : bf16 to f32
+  // CHECK:   %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} : f32
+  // CHECK:   linalg.yield %{{.*}} : f32
+  
+  return %result : tensor<16xf32>
+}
+
+// Test case 5: Negative test - first op contains more than just extf (should not fuse)
+// CHECK-LABEL: @no_fuse_extf_with_extra_ops
+func.func @no_fuse_extf_with_extra_ops(%input: tensor<16xf16>, %other: tensor<16xf32>) -> tensor<16xf32> {
+  %empty1 = tensor.empty() : tensor<16xf32>
+  %empty2 = tensor.empty() : tensor<16xf32>
+  %cst = arith.constant 1.0 : f32
+  
+  // First op: contains extf AND additional operation (should not be fusable)
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<16xf16>) outs(%empty1 : tensor<16xf32>) {
+  ^bb0(%arg0: f16, %arg1: f32):
+    %0 = arith.extf %arg0 : f16 to f32
+    %1 = arith.addf %0, %cst : f32
+    linalg.yield %1 : f32
+  } -> tensor<16xf32>
+  
+  // Second op: would consume the result
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%extf_result, %other : tensor<16xf32>, tensor<16xf32>) outs(%empty2 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.mulf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%{{.*}} : tensor<16xf16>)
+  // CHECK: arith.extf
+  // CHECK: arith.addf
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%{{.*}}, %{{.*}} : tensor<16xf32>, tensor<16xf32>)
+  
+  return %result : tensor<16xf32>
+}
+
+// Test case 6: Negative test - operations are not directly connected (should not fuse)
+// CHECK-LABEL: @no_fuse_not_directly_connected
+func.func @no_fuse_not_directly_connected(%input: tensor<16xf16>, %other: tensor<16xf32>) -> tensor<16xf32> {
+  %empty1 = tensor.empty() : tensor<16xf32>
+  %empty2 = tensor.empty() : tensor<16xf32>
+  
+  // First op: contains only extf
+  %extf_result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%input : tensor<16xf16>) outs(%empty1 : tensor<16xf32>) {
+  ^bb0(%arg0: f16, %arg1: f32):
+    %0 = arith.extf %arg0 : f16 to f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // Second op: does NOT use extf_result (uses %other twice instead)
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%other, %other : tensor<16xf32>, tensor<16xf32>) outs(%empty2 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %0 = arith.addf %arg0, %arg1 : f32
+    linalg.yield %0 : f32
+  } -> tensor<16xf32>
+  
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%{{.*}} : tensor<16xf16>)
+  // CHECK: arith.extf
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%{{.*}}, %{{.*}} : tensor<16xf32>, tensor<16xf32>)
+  
+  return %result : tensor<16xf32>
+}


### PR DESCRIPTION
Adapted from `fuse_into_containing_ops` and `linalg_fuse_elementwise_ops`, but works with non-elementwise consumers too.

[IR examples](https://github.com/Xilinx/mlir-air/blob/42b855bc7f341c385b33bc1f23a1e9642154b55b/mlir/test/Transform/AIRTransform/AIRFuseExtfLinalg/air_transform_payload.mlir)