### PR TITLE
Support for varying tile sizes for matrix multiplication with runner and profiler support

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16/Makefile
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+# Tile sizes
+TILE_M ?= 128
+TILE_K_L2 ?= 64
+TILE_K_L1 ?= 32
+TILE_N ?= 64
+
+# M and N tile sizes divided by 4
+TILE_M_DIV_4 := $(shell echo $$(( $(TILE_M) / 4 )))
+TILE_N_DIV_4 := $(shell echo $$(( $(TILE_N) / 4 )))
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -22,16 +32,29 @@ print:
 	${powershell} python3 ${srcdir}/run.py -p --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 --tile-k-l2 288 --tile-k-l1 48 $(DIRECT_CODEGEN_FLAG)
 
 run4x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
+		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
 
 run2x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
+		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
 
 run2x2: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
+		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
 
 run3x3: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 --tile-k-l2 288 --tile-k-l1 48 --compile-mode compile-and-run $(DIRECT_CODEGEN_FLAG)
+	
+profile: compile-kernel build-test-exe
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python ../run.py --m 512 --k 512 --n 512 \
+		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode compile-only
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M 512 -K 512 -N 512
+
+runner:
+	mkdir -p build
+	cd build && python ../run.py --m 512 --k 512 --n 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) -p > input.mlir
+	cd build && python ../mmult_aie2.py
 
 # Measure the e2e latencies across a range of problem shapes.
 sweep4x4: compile-kernel build-test-exe
@@ -51,14 +74,14 @@ compile-kernel:
 		echo "Detected PEANO_INSTALL_DIR from environment: $(PEANO_INSTALL_DIR)"; \
 		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
 			echo "Using clang++ from PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)"; \
-			$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o; \
+			$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \
 		else \
 			echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
 			exit 1; \
 		fi; \
 	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
 		echo "Using xchesscc_wrapper from PATH"; \
-		cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2 -c ${srcdir}/mm.cc -o mm.o; \
+		cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2 -c ${srcdir}/mm.cc -o mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \
 	else \
 		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
 		exit 1; \

--- a/programming_examples/matrix_multiplication/bf16/README.md
+++ b/programming_examples/matrix_multiplication/bf16/README.md
@@ -1,0 +1,12 @@
+# Matrix multiplication
+Matrix multiplication with bf16 datatype, supports variable tile sizes for m and n, and for k at L2 and L1 level.
+Use `make run4x4` to compile and run the design on the NPU.
+Use `make runner` to simulate the design on air-runner and the find the expected latency
+Use `make profile` to run the design on hardware and measure the average latency
+You can adjust the tile sizes by appending `... TILE_M=64` to the command, this can be done for "TILE_M=[]", "TILE_K_L2=[]", "TILE_K_L1=[]" and "TILE_N"
+This tile sizes can be set for `run4x4`, `runner` and `profile`. For example `make run4x4 TILE_M=64 TILE_K_L2=128 TILE_K_L1=32 TILE_N=64`.
+Any tile sizes left out are set to the default values which are shown below:
+TILE_M=128
+TILE_K_L2=64
+TILE_K_L1=32
+TILE_N=64

--- a/programming_examples/matrix_multiplication/bf16/mmult_aie2.py
+++ b/programming_examples/matrix_multiplication/bf16/mmult_aie2.py
@@ -1,0 +1,168 @@
+# mmult_aie2.py -*- Python -*-
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import air.compiler.util
+
+from air.dialects import func, linalg, tensor, arith, memref
+from air.dialects.air import module_builder
+from air.dialects.linalg.opdsl.lang import *
+from air.ir import *
+from air.compiler.util import run_transform
+import air.passmanager
+
+import sys
+import argparse
+import re
+
+# Default values.
+HERD_M = 4
+HERD_N = 4
+
+def mmult_runner(air_ir_string: str, herd_m: int = HERD_M, herd_n: int = HERD_N):
+    context = air.ir.Context()
+    air_module = Module.parse(air_ir_string, context=context)
+
+    # generate dependency information for runner
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                "air-dependency",
+                "air-hoist-dma-in-accum-pattern",
+                "air-broadcast-detection",
+                "air-specialize-dma-broadcast",
+                "air-dma-to-channel",
+                "canonicalize",
+                "cse",
+                "air-dependency-canonicalize",
+                "canonicalize",
+                "cse",
+                "air-isolate-async-dma-loop-nests",
+                "canonicalize",
+                "cse",
+                "air-fuse-channels",
+                "func.func(air-fuse-alloc-dealloc)",
+                "func.func(air-shrink-memref-sizes-by-access)",
+                "air-label-scf-for-to-ping-pong",
+                "air-ping-pong-transform",
+                "canonicalize",
+                "cse",
+                "air-place-herds{num-rows="
+                + str(herd_m)
+                + " num-cols="
+                + str(herd_n)
+                + " row-anchor=0 col-anchor=0}",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline, context=context)
+    pm.run(air_module.operation)
+
+    with open("air_ir_debug.mlir", "w") as f:
+        f.write(str(air_module))
+
+    arch = {
+        "clock": 1000000000,
+        "cores": 1,
+        "datatypes": [
+            {"bytes": 1, "name": "i8"},
+            {"bytes": 2, "name": "bf16"},
+            {"bytes": 4, "name": "i32"},
+        ],
+        "devicename": "testdevice",
+        "kernels": {
+            "linalg.copy": {
+                "datatypes": {
+                    "i8": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                    "bf16": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                    "i32": {"ops_per_core_per_cycle": 16, "efficiency": 1},
+                },
+                "name": "linalg.copy",
+            },
+            "linalg.fill": {
+                "datatypes": {
+                    "i8": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                    "bf16": {"ops_per_core_per_cycle": 32, "efficiency": 1},
+                    "i32": {"ops_per_core_per_cycle": 16, "efficiency": 1},
+                },
+                "name": "linalg.fill",
+            },
+            "linalg.generic": {
+                "datatypes": {
+                    "i8": {"macs_per_core_per_cycle": 256, "efficiency": 1},
+                    "bf16": {"macs_per_core_per_cycle": 128, "efficiency": 1},
+                    "i32": {"macs_per_core_per_cycle": 1, "efficiency": 1},
+                },
+                "name": "linalg.generic",
+            },
+            "linalg.matmul": {
+                "datatypes": {
+                    "i8": {"macs_per_core_per_cycle": 256, "efficiency": 1},
+                    "bf16": {"macs_per_core_per_cycle": 128, "efficiency": 1},
+                    "i32": {"macs_per_core_per_cycle": 1, "efficiency": 1},
+                },
+                "name": "linalg.matmul",
+            },
+        },
+        "dus": {
+            "count": [4, 4],
+            "memory": {"memory_space": "L2", "bytes": 524288},
+            "ports": {
+                "outbound": {"count": 6, "bytes_per_second": 4000000000},
+                "inbound": {"count": 6, "bytes_per_second": 4000000000},
+            },
+            "tiles": {
+                "count": [1, 4],
+                "memory": {"memory_space": "L1", "bytes": 65536},
+                "ports": {
+                    "outbound": {"count": 2, "bytes_per_second": 4000000000},
+                    "inbound": {"count": 2, "bytes_per_second": 4000000000},
+                },
+            },
+        },
+        "noc": {
+            "outbound": {"count": 8, "bytes_per_second": 4000000000},
+            "inbound": {"count": 8, "bytes_per_second": 4000000000},
+        },
+    }
+
+    runner = air.compiler.util.Runner(arch, None, "core")
+    trace = runner.run(air_module, "matmul_bf16")
+
+    latency = (re.findall("\\d+\\.\\d+", trace))
+    if len(latency) == 0:
+        return 0.0
+    else:
+        latency = latency[len(latency)-1]
+        return float(latency)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="mmult_aie2.py")
+    parser.add_argument(
+        "--input-file",
+        default="input.mlir",
+        type=str,
+        help="Input file containing input IR in AIR dialect",
+    )
+    parser.add_argument(
+        "--herd-m",
+        type=int,
+        default=HERD_M,
+        help="Number of L1 tiles along the M dimension",
+    )
+    parser.add_argument(
+        "--herd-n",
+        type=int,
+        default=HERD_N,
+        help="Number of L1 tiles along the N dimension",
+    )
+    opts = parser.parse_args()
+
+    with open(opts.input_file, "r") as f:
+        air_ir_string = f.read()
+
+    latency = mmult_runner(air_ir_string=air_ir_string)
+    print("Lat:", latency)

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -460,9 +460,9 @@ if __name__ == "__main__":
     M = 512
     K = 512
     N = 512
-    TILE_M = 64
+    TILE_M = 128
     TILE_K_L2 = 128
-    TILE_K_L1 = 64
+    TILE_K_L1 = 32
     TILE_N = 64
     HERD_M = 4
     HERD_N = 4


### PR DESCRIPTION
- Adjusted mm.cc so that linalg fill function has correct name for tile sizes
- Updated makefile so that tile sizes are passed into kernel compile
- Added support for simulating design with air-runner
- Added variable tile size support for running on hardware, profilingon hardware, and with air-runner
- Updated default L1 tile sizes to values which have slightly better performance
- Added a bried readme