### PR TITLE
Fixup a bug in direct-codegen mode, when the `l1` and `l2` `k` tiling sizes are equal

### DIFF
--- a/programming_examples/matrix_multiplication/i16/run.py
+++ b/programming_examples/matrix_multiplication/i16/run.py
@@ -620,10 +620,6 @@ if __name__ == "__main__":
                 
                 %herd1, %herd2, %herd3 = transform.split_handle %vectorized_herds : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
                 %scf_fors = transform.structured.match ops{{["scf.for"]}} in %herd2 : (!pdl.operation) -> !pdl.operation
-                %for1, %for2, %for3, %for4 = transform.split_handle %scf_fors : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
-
-                // Apply LICM to the innermost loop to hoist invariant reads
-                transform.apply_licm to %for4 : !pdl.operation
 
                 %func1 = transform.structured.match ops{{["func.func"]}} in %arg1 : (!pdl.operation) -> !pdl.operation
                 transform.apply_patterns to %func1 {{
@@ -645,7 +641,7 @@ if __name__ == "__main__":
                 
                 // Split handles to get individual read/write operations
                 %scf_fors_1 = transform.structured.match ops{{["scf.for"]}} in %herd2_1 : (!pdl.operation) -> !pdl.operation
-                %for1_1, %for2_1, %for3_1, %for4_1 = transform.split_handle %scf_fors_1 : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+                %innermost_for, %outer_fors = transform.split_handle %scf_fors_1 {{overflow_result = 1}} : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
                 // The innermost loop has read-write pairs accessing the result buffer
                 %read0, %read1, %read2, %read3, %read4, %read5, %read6, %read7 = transform.split_handle %all_reads_in_herd2 : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
                 %write0, %write1, %write2, %write3 = transform.split_handle %all_writes_in_herd2 : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
@@ -653,23 +649,20 @@ if __name__ == "__main__":
                 %vector_contracts = transform.structured.match ops{{["vector.contract"]}} in %arg1 : (!pdl.operation) -> !pdl.operation
                 %result11 = transform.air.vector_type_cast %vector_contracts {{target_element_type = {vector_acc_type}, input_indices = [2], output_indices = [0]}}
                 
-                // Hoist read/write pair from the innermost loop (%for1_1)
-                %for1_1_updated = transform.air.hoist_loop_invariant_transfers %read2, %write0, %for1_1
-                %for1_1_updated_1 = transform.air.hoist_loop_invariant_transfers %read4, %write1, %for1_1_updated
-                %for1_1_updated_2 = transform.air.hoist_loop_invariant_transfers %read6, %write2, %for1_1_updated_1
-                %for1_1_updated_3 = transform.air.hoist_loop_invariant_transfers %read7, %write3, %for1_1_updated_2
-                %for1_1_updated_4 = transform.air.flatten_for_iter_args %for1_1_updated_3
-                %for1_1_updated_5 = transform.air.hoist_vector_transfer_pointers %for1_1_updated_4
-
+                // Hoist read/write pair from the innermost loop (%innermost_for)
+                %innermost_for_updated = transform.air.hoist_loop_invariant_transfers %read2, %write0, %innermost_for
+                %innermost_for_updated_1 = transform.air.hoist_loop_invariant_transfers %read4, %write1, %innermost_for_updated
+                %innermost_for_updated_2 = transform.air.hoist_loop_invariant_transfers %read6, %write2, %innermost_for_updated_1
+                %innermost_for_updated_3 = transform.air.hoist_loop_invariant_transfers %read7, %write3, %innermost_for_updated_2
+                %innermost_for_updated_4 = transform.air.flatten_for_iter_args %innermost_for_updated_3
+                %innermost_for_updated_5 = transform.air.hoist_vector_transfer_pointers %innermost_for_updated_4
 
                 %fors_to_hoist_ptrs = transform.structured.match ops{{["scf.for"]}} in %herd2_1 : (!pdl.operation) -> !pdl.operation
-                %for_ptr1, %for_ptr2, %for_ptr3, %for_ptr4 = transform.split_handle %fors_to_hoist_ptrs: (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
-
-
+                %innermost_for1, %outer_fors1 = transform.split_handle %fors_to_hoist_ptrs {{overflow_result = 1}}: (!pdl.operation) -> (!pdl.operation, !pdl.operation)
 
                 // Hoist the 4 extsi/trunci pairs from the innermost loop
-                %all_extsi_loop = transform.structured.match ops{{["arith.extsi"]}} in %for_ptr1 : (!pdl.operation) -> !pdl.operation
-                %all_trunci_loop = transform.structured.match ops{{["arith.trunci"]}} in %for_ptr1 : (!pdl.operation) -> !pdl.operation
+                %all_extsi_loop = transform.structured.match ops{{["arith.extsi"]}} in %innermost_for1 : (!pdl.operation) -> !pdl.operation
+                %all_trunci_loop = transform.structured.match ops{{["arith.trunci"]}} in %innermost_for1 : (!pdl.operation) -> !pdl.operation
                 
                 // Split to get individual operations
                 %extsi_i16_1, %extsi_i16_2, %extsi_i16_3, %extsi_i16_4 = transform.split_handle %all_extsi_loop : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
@@ -678,7 +671,7 @@ if __name__ == "__main__":
                 %trunci_1, %trunci_2, %trunci_3, %trunci_4 = transform.split_handle %all_trunci_loop : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
                 
                 // Hoist first pair (arg29 - index 2)
-                %for1_1_hoisted_1 = transform.air.hoist_cast_pair %extsi_i16_1, %trunci_1, %for_ptr1
+                %for1_1_hoisted_1 = transform.air.hoist_cast_pair %extsi_i16_1, %trunci_1, %innermost_for1
                 %all_extsi_loop_2 = transform.structured.match ops{{["arith.extsi"]}} in %for1_1_hoisted_1 : (!pdl.operation) -> !pdl.operation
                 %all_trunci_loop_2 = transform.structured.match ops{{["arith.trunci"]}} in %for1_1_hoisted_1 : (!pdl.operation) -> !pdl.operation
                 %extsi_i16_2_new, %e2_5, %e2_6 = transform.split_handle %all_extsi_loop_2 : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)


### PR DESCRIPTION
Update the transform dialect script to work with a varying number of for loop nests.