### PR TITLE
Enable `8x8x8` `bfp16`-emulated `bf16` matmul on strix for aie_api

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16/Makefile
@@ -105,7 +105,7 @@ compile-kernel:
 		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
 			if [ "$(AIE_TARGET)" = "aie2p" ]; then \
 				echo "Using clang++ from PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) with target $(AIE_TARGET) and mm_aie2p.cc"; \
-				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm_aie2p.cc -o $(BUILD_DIR)/mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm_aie2p.cc -o $(BUILD_DIR)/mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4) -DDIM_N_DIV_8=$(TILE_N_DIV_8) -DDIM_M_DIV_8=$(TILE_M_DIV_8) -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16; \
 			else \
 				echo "Using clang++ from PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) with target $(AIE_TARGET) and mm.cc"; \
 				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \
@@ -117,7 +117,7 @@ compile-kernel:
 	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
 		if [ "$(AIE_TARGET)" = "aie2p" ]; then \
 			echo "Using xchesscc_wrapper from PATH with target $(AIE_TARGET) and mm_aie2p.cc"; \
-			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm_aie2p.cc -o mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm_aie2p.cc -o mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4) -DDIM_N_DIV_8=$(TILE_N_DIV_8) -DDIM_M_DIV_8=$(TILE_M_DIV_8) -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16; \
 		else \
 			echo "Using xchesscc_wrapper from PATH with target $(AIE_TARGET) and mm.cc"; \
 			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm.cc -o mm.o -DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) -DDIM_N_DIV_4=$(TILE_N_DIV_4) -DDIM_M_DIV_4=$(TILE_M_DIV_4); \

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -61,12 +61,12 @@ def build_module(
     xrt_dtype_out = type_mapper(np_dtype_out)
 
     # Architecture-specific matrix multiplication dimensions
-    # aie2p with direct codegen uses 8x8x8, otherwise uses 4x8x4
-    # aie2 always uses 4x8x4
-    if arch == "aie2p" and direct_codegen:
-        mmul_mkn = [8, 8, 8]  # For aie2p with BFP16 emulation (direct codegen)
+    # aie2p uses 8x8x8 (using -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16 if without direct-codegen, i.e. aie_api)
+    # aie2 uses 4x8x4
+    if arch == "aie2p":
+        mmul_mkn = [8, 8, 8]  # For aie2p
     else:
-        mmul_mkn = [4, 8, 4]  # For aie2 or aie2p without direct codegen
+        mmul_mkn = [4, 8, 4]  # For aie2
 
     # L3 MemRefTypes
     memrefTyA = MemRefType.get(a_size, xrt_dtype_in)


### PR DESCRIPTION
The previous generic matmul `aie_api` kernel, where the first k-loop iteration is peeled out, triggers a numerical error with bfp16 emulation method.