### PR TITLE
Update env_setup.sh to include PEANO_INSTALL_DIR

### DIFF
--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -55,9 +55,9 @@
 5. **Environment Setup:**
    To setup your environment after building:
    ```bash
-   source utils/env_setup.sh [install_dir] $(python3 -m pip show mlir_aie | grep Location | awk '{print $2}')/mlir_aie my_install/mlir
+   source utils/env_setup.sh [install_dir] $(python3 -m pip show mlir_aie | grep Location | awk '{print $2}')/mlir_aie $(python3 -m pip show llvm-aie | grep Location | awk '{print $2}')/llvm-aie my_install/mlir
    ```
-   This command automatically detects the installation directories of the `mlir-aie` Python package, and sets up environment variables for MLIR-AIE, Python, and MLIR libraries.
+   This command automatically detects the installation directories of the `mlir-aie` and `llvm-aie` Python packages, and sets up environment variables for MLIR-AIR, MLIR-AIE, PEANO (llvm-aie compiler), Python, and MLIR libraries.
    
    **If you built with XRT support**, also run:
    ```bash
@@ -270,12 +270,21 @@ To build MLIR-AIR provide the paths to llvm, cmakeModules, and xrt (here, we ass
 
 To setup your environment after building:
 ```bash
-source utils/env_setup.sh install-xrt/ mlir-aie/install/ llvm/install/
+# If you have llvm-aie (PEANO) installed via pip:
+source utils/env_setup.sh install-xrt/ mlir-aie/install/ $(python3 -m pip show llvm-aie | grep Location | awk '{print $2}')/llvm-aie llvm/install/
+
+# Or if you built llvm-aie from source:
+source utils/env_setup.sh install-xrt/ mlir-aie/install/ /path/to/llvm-aie/install llvm/install/
 ```
 
 Note that if you are starting a new environment (e.g., by creating a new terminal sometime after building), restore your environment with:
 ```bash
-source utils/env_setup.sh install-xrt/ mlir-aie/install/ llvm/install/
+# If you have llvm-aie (PEANO) installed via pip:
+source utils/env_setup.sh install-xrt/ mlir-aie/install/ $(python3 -m pip show llvm-aie | grep Location | awk '{print $2}')/llvm-aie llvm/install/
+source sandbox/bin/activate
+
+# Or if you built llvm-aie from source:
+source utils/env_setup.sh install-xrt/ mlir-aie/install/ /path/to/llvm-aie/install llvm/install/
 source sandbox/bin/activate
 ```
 

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -7,18 +7,19 @@
 # This script sets up the environment to run the mlir-aie build tools.
 # It must be sourced, not executed.
 #
-# e.g. source env_setup.sh /scratch/mlir-air/install /scratch/mlir-aie/install /scratch/llvm/install
+# e.g. source env_setup.sh /scratch/mlir-air/install /scratch/mlir-aie/install /scratch/llvm-aie/install /scratch/llvm/install
 #
 ##===----------------------------------------------------------------------===##
 
-if [ "$#" -ne 3 ]; then
-	echo "ERROR: Needs 3 arguments for <mlir-air install dir> <mlir-aie install dir> and <llvm install dir>"
+if [ "$#" -ne 4 ]; then
+	echo "ERROR: Needs 4 arguments for <mlir-air install dir> <mlir-aie install dir> <llvm-aie install dir> and <llvm install dir>"
 	return
 fi
 
 export MLIR_AIR_INSTALL_DIR=`realpath $1`
 export MLIR_AIE_INSTALL_DIR=`realpath $2`
-export LLVM_INSTALL_DIR=`realpath $3`
+export PEANO_INSTALL_DIR=`realpath $3`
+export LLVM_INSTALL_DIR=`realpath $4`
 
 export PATH=${MLIR_AIR_INSTALL_DIR}/bin:${MLIR_AIE_INSTALL_DIR}/bin:${LLVM_INSTALL_DIR}/bin:${PATH} 
 export PYTHONPATH=${MLIR_AIR_INSTALL_DIR}/python:${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH} 


### PR DESCRIPTION
This PR updates the environment setup script to automatically configure PEANO_INSTALL_DIR.

### Changes:
- Modified `utils/env_setup.sh` to accept 4 arguments instead of 3
- Added PEANO_INSTALL_DIR (llvm-aie) as the 3rd argument
- Updated `docs/buildingRyzenLin.md` with new usage instructions
