### PR TITLE
Enable xrt test 40 on aie2p by switching on the `use_lock_race_condition_fix` mode

### DIFF
--- a/test/xrt/40_triton_vec_add/run.py
+++ b/test/xrt/40_triton_vec_add/run.py
@@ -69,7 +69,6 @@ with air.ir.Context() as ctx, Location.unknown():
             [
                 "air-resolve-tensor-opoperand-conflicts",
                 "air-override-memref-memory-space{scope=func memory-space=1}",
-                "linalg-fuse-elementwise-ops",
             ]
         )
         + ")"
@@ -119,19 +118,18 @@ with air.ir.Context() as ctx, Location.unknown():
         M,
     ).astype(
         input_type
-    )  # Shape [M, K]
+    )  # Shape [M]
     B = np.random.rand(
         M,
     ).astype(
         input_type
-    )  # Shape [K, N]
-    C = np.add(A, B).astype(output_type)  # Shape [M, N]
+    )  # Shape [M]
+    C = np.add(A, B).astype(output_type)  # Shape [M]
 
     ###### Compile and test
     runner = XRTRunner(
         omit_while_true_loop=False,
-        air_loop_fusion=True,
-        verbose=True,
+        use_lock_race_condition_fix=True,
     )
     exit(
         runner.run_test(

--- a/test/xrt/40_triton_vec_add/run_npu2_peano.lit
+++ b/test/xrt/40_triton_vec_add/run_npu2_peano.lit
@@ -1,0 +1,8 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+// RUN: mkdir -p test_npu2_peano
+// RUN: cd test_npu2_peano
+// RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: %python %S/run.py --transform-script %S/transform.mlir


### PR DESCRIPTION
- Identified that the vector-add example was failing previously due to the lock race condition (core kernel is too small and too fast); switching on use_lock_race_condition_fix fixes the issue.
- Alternative fix is to increase the workload per core, so that the race condition happens less often.