### PR TITLE
Improve softmax shim dma stream efficiency by disabling the runtime loop tiling

### DIFF
--- a/test/xrt/42_triton_softmax_bf16/run.py
+++ b/test/xrt/42_triton_softmax_bf16/run.py
@@ -194,7 +194,7 @@ with air.ir.Context() as ctx, Location.unknown():
     ###### Compile and test
     runner = XRTRunner(
         omit_while_true_loop=False,
-        runtime_loop_tiling_sizes=[],
+        runtime_loop_tiling_sizes=[],  # disable loop tiling to improve shim DMA stream efficiency / avoid BD count limiting
     )
     exit(
         runner.run_test(


### PR DESCRIPTION
Default values for `runtime_loop_tiling_sizes` are [4, 4], which conservatively enforces shim dma bd count to within controlled range. Setting `runtime_loop_tiling_sizes=[]` disables this feature.