### PR TITLE
Update mlir-aie to 7d74d1b (aievec float FMA fusion)

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=f93e513cfdbe52b011ae268289559f15c31f7176
-DATETIME=2026021204
+export HASH=7d74d1b5e855d1e98a58e1ed3233d4579cff4602
+DATETIME=2026022607
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary
- Bump mlir-aie from `f93e513` to `7d74d1b`, picking up the float FMA fusion for `arith.mulf` + `arith.addf` (mlir-aie PR #2896)
- LLVM version unchanged (`ebf5d9ef`)

## Test plan
- [ ] CI passes with updated mlir-aie wheel (`0.0.1.2026022607+7d74d1b`)
- [ ] Existing programming examples build and run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)