### PR TITLE
Add apt-get update before package installs in CI

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Install packages
         run: |
+          sudo apt-get update
           sudo apt-get install -y ninja-build clang lld
 
       - name: Install libboost

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install packages
-        run: sudo apt-get install -y libboost-all-dev clang lld && sudo apt-get clean
+        run: sudo apt-get update && sudo apt-get install -y libboost-all-dev clang lld && sudo apt-get clean
 
       - name: Install Ninja
         uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -46,7 +46,9 @@ jobs:
           fi
 
       - name: Install packages
-        run: sudo apt-get install -y ninja-build clang lld
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build clang lld
       
       - name: Install Ninja
         uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268


### PR DESCRIPTION
## Summary
- Add `sudo apt-get update` before `sudo apt-get install` in three CI workflows (`buildAndTest.yml`, `buildAndTestNoRuntime.yml`, `generateDocs.yml`)
- Fixes persistent 404 errors when GitHub Actions runner's cached apt index references package versions that have been rotated out on Ubuntu mirrors (e.g., `gcc-12` `12.3.0-1ubuntu1~22.04.2` → newer)
- The `lintAndFormat.yml` workflow already had `apt-get update`; the other three did not

## Test plan
- [ ] CI "Build and Test with ROCm runtime" job passes the "Install packages" step without 404 errors
- [ ] CI "Build and Test (no runtime)" job continues to pass
- [ ] CI "Generate Docs" job continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)