### PR TITLE
Update mlir-aie to 5f82ec4

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=8f2205886f4b6f76c16c3a33393a9a13b9f9fc18
-DATETIME=2026022619
+export HASH=5f82ec48e87d0c53ec36fe5fbcb9fa4d2b452fe3
+DATETIME=2026022717
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary
- Bump mlir-aie from `8f22058` to `5f82ec4` (2026-02-27 wheel)

## mlir-aie commits included
- `16766ab` Add aiesim and host compilation support to C++ aiecc (#2890)
- `2e7c91b` Fix layernorm CI stability: remove dead srand, widen tolerance (#2897)
- `8f22058` [aievec] Add scalar compound shift+clamp+truncate to SRS pattern (#2894)
- `84138ec` Add tile type for tile classification (#2885)
- `1b17072` [aievec] Extend vector.fma to 32-lane bf16 with splitting (#2901)
- `3f79d49` [aievec] Fix null pointer crash in hasSigmoidComputationChain (#2902)
- `5f82ec4` [aievec] Allow f32 mulf→addf to convert independently of FMA (#2903)

## Test plan
- [ ] CI passes with new wheel version
- [ ] `bash utils/clone-mlir-aie.sh --get-wheel-version` outputs `0.0.1.2026022717+5f82ec4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)