### PR TITLE
Update mlir-aie to acf9d12 (AIE2P fdiv fix)

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=5f82ec48e87d0c53ec36fe5fbcb9fa4d2b452fe3
-DATETIME=2026022717
+export HASH=acf9d12f2a31446eb4bf79b750c5c34e5fc6a250
+DATETIME=2026022718
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary

Update mlir-aie dependency from `5f82ec4` to `acf9d12` to pick up the latest released wheel.

## Changes in mlir-aie acf9d12

- [aievec] Fix AIE2P fdiv to use inv+mulf instead of scalar fdiv ([#2904](https://github.com/Xilinx/mlir-aie/pull/2904))

## Test plan

- [ ] CI passes (wheel version `0.0.1.2026022718+acf9d12` resolves correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)