### PR TITLE
[CI] Improve test stability with retry, deterministic seeds, and xrt-smi diagnostics

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -157,14 +157,14 @@ jobs:
           ninja check-air-mlir
           ninja check-air-python
 
-          # E2E test set 1: peano tests
-          ninja check-air-e2e-peano
+          # E2E test set 1: peano tests (retry once on failure for flaky NPU tests)
+          ninja check-air-e2e-peano || ninja check-air-e2e-peano
 
           # E2E test set 2: chess tests
           ninja check-air-e2e-chess
 
-          # Programming examples set 1: peano tests
-          ninja check-programming-examples-peano
+          # Programming examples set 1: peano tests (retry once on failure for flaky NPU tests)
+          ninja check-programming-examples-peano || ninja check-programming-examples-peano
 
           # Programming examples set 2: chess tests
           ninja check-programming-examples-chess

--- a/programming_examples/axpy/axpy.py
+++ b/programming_examples/axpy/axpy.py
@@ -28,6 +28,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/programming_examples/cascade_reduction/cascade_reduction.py
+++ b/programming_examples/cascade_reduction/cascade_reduction.py
@@ -27,6 +27,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 NUM_TILES = 4

--- a/programming_examples/channel_examples/channel_size/channel_size.py
+++ b/programming_examples/channel_examples/channel_size/channel_size.py
@@ -3,6 +3,8 @@
 import argparse
 import numpy as np
 
+np.random.seed(42)
+
 from air.ir import *
 from air.dialects.air import *
 from air.dialects.memref import AllocOp, DeallocOp, load, store
@@ -78,7 +80,6 @@ def build_module():
             # The arguments are still the input and the output
             @segment(name="seg")
             def segment_body():
-
                 @herd(
                     name="xaddherd",
                     sizes=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH],

--- a/programming_examples/data_transfer_transpose/channel/transpose.py
+++ b/programming_examples/data_transfer_transpose/channel/transpose.py
@@ -3,6 +3,8 @@
 import argparse
 import numpy as np
 
+np.random.seed(42)
+
 from air.ir import *
 from air.dialects.air import *
 from air.dialects.memref import AllocOp, DeallocOp
@@ -29,7 +31,6 @@ def build_module(m, k, dtype):
     # We will send an image worth of data in and out
     @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
     def transpose(arg0, arg1):
-
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
             # Put data into the channel
@@ -40,7 +41,6 @@ def build_module(m, k, dtype):
 
             @segment(name="seg")
             def segment_body():
-
                 @herd(name="herd", sizes=[1, 1])
                 def herd_body(_tx, _ty, _sx, _sy):
                     # We want to store our data in L1 memory

--- a/programming_examples/data_transfer_transpose/dma/transpose.py
+++ b/programming_examples/data_transfer_transpose/dma/transpose.py
@@ -3,6 +3,8 @@
 import argparse
 import numpy as np
 
+np.random.seed(42)
+
 from air.ir import *
 from air.dialects.air import *
 from air.dialects.memref import AllocOp, DeallocOp
@@ -26,13 +28,10 @@ def build_module(m, k, dtype):
     # We will send an image worth of data in and out
     @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
     def transpose(arg0, arg1):
-
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
-
             @segment(name="seg", operands=[a, b])
             def segment_body(arg2, arg3):
-
                 @herd(name="herd", sizes=[1, 1], operands=[arg2, arg3])
                 def herd_body(_tx, _ty, _sx, _sy, a, b):
                     # We want to store our data in L1 memory

--- a/programming_examples/eltwise_add/eltwise_add.py
+++ b/programming_examples/eltwise_add/eltwise_add.py
@@ -13,6 +13,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -37,7 +41,6 @@ def build_module(n, tile_n, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def eltwise_add(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/eltwise_add_with_l2/eltwise_add.py
+++ b/programming_examples/eltwise_add_with_l2/eltwise_add.py
@@ -13,6 +13,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -57,7 +61,6 @@ def build_module(n, tile_n, np_dtype_in):
             arg1_l,
             arg2_l,
         ):
-
             @segment(name="segment_0", operands=[arg0_l, arg1_l, arg2_l])
             def segment_body(
                 arg0_s,

--- a/programming_examples/herd_dataflow/run.py
+++ b/programming_examples/herd_dataflow/run.py
@@ -9,6 +9,8 @@ This script demonstrates building and running a dataflow module using AIR and ML
 import argparse
 import numpy as np
 
+np.random.seed(42)
+
 import air
 from air.ir import *
 from air.dialects.affine import apply as affine_apply

--- a/programming_examples/leaky_relu/leaky_relu.py
+++ b/programming_examples/leaky_relu/leaky_relu.py
@@ -13,6 +13,8 @@ configurable VECTOR_SIZE (default 16).
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 
 from air.ir import *
@@ -54,7 +56,6 @@ def build_module(n, tile_n, np_dtype_in, alpha=0.01, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
     def leaky_relu(arg0, arg1):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -111,11 +111,10 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
                 config.available_features.add("ryzen_ai_npu2")
                 print("Running tests on NPU4 with command line: ", run_on_2npu)
             else:
-                print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
+                print(f"WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break
-    except:
-        print("Failed to run xrt-smi")
-        pass
+    except Exception as e:
+        print(f"Failed to run xrt-smi: {e}")
 else:
     print("xrt not found or xrt tests disabled")
     config.excludes.append("xrt")

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -19,6 +19,10 @@ from air.extras import types as extrasT
 from air.dialects.linalg.opdsl.lang import *
 import air.dialects.linalg.opdsl.lang as linalg_lang
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -156,7 +160,6 @@ def build_module(
             l3_b_data,
             l3_c_data,
         ):
-
             @segment(
                 name="matmul_seg",
                 operands=[launch_ivx, launch_ivy, l3_a_data, l3_b_data, l3_c_data],

--- a/programming_examples/matrix_multiplication/i16/run.py
+++ b/programming_examples/matrix_multiplication/i16/run.py
@@ -18,6 +18,10 @@ from air.extras import types as extrasT
 from air.dialects.linalg.opdsl.lang import *
 import air.dialects.linalg.opdsl.lang as linalg_lang
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -152,7 +156,6 @@ def build_module(
             l3_b_data,
             l3_c_data,
         ):
-
             @segment(
                 name="matmul_seg",
                 operands=[launch_ivx, launch_ivy, l3_a_data, l3_b_data, l3_c_data],

--- a/programming_examples/matrix_multiplication/i8/run.py
+++ b/programming_examples/matrix_multiplication/i8/run.py
@@ -18,6 +18,10 @@ from air.extras import types as extrasT
 from air.dialects.linalg.opdsl.lang import *
 import air.dialects.linalg.opdsl.lang as linalg_lang
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -152,7 +156,6 @@ def build_module(
             l3_b_data,
             l3_c_data,
         ):
-
             @segment(
                 name="matmul_seg",
                 operands=[launch_ivx, launch_ivy, l3_a_data, l3_b_data, l3_c_data],

--- a/programming_examples/primitives/vector_examples/vector_add/vector_add.py
+++ b/programming_examples/primitives/vector_examples/vector_add/vector_add.py
@@ -14,6 +14,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -40,7 +44,6 @@ def build_module(n, tile_n, np_dtype_in, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def vector_add(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_broadcast_scalar/vector_broadcast_scalar.py
+++ b/programming_examples/primitives/vector_examples/vector_broadcast_scalar/vector_broadcast_scalar.py
@@ -22,6 +22,10 @@ from air.dialects.math import exp
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -53,7 +57,6 @@ def build_module(m, n, tile_m, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
     def vector_broadcast_scalar(arg0, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_exp/vector_exp.py
+++ b/programming_examples/primitives/vector_examples/vector_exp/vector_exp.py
@@ -15,6 +15,10 @@ from air.dialects.math import exp
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/programming_examples/primitives/vector_examples/vector_fma/vector_fma.py
+++ b/programming_examples/primitives/vector_examples/vector_fma/vector_fma.py
@@ -15,6 +15,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/programming_examples/primitives/vector_examples/vector_max/vector_max.py
+++ b/programming_examples/primitives/vector_examples/vector_max/vector_max.py
@@ -14,6 +14,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -40,7 +44,6 @@ def build_module(n, tile_n, np_dtype_in, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def vector_max(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
+++ b/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
@@ -14,6 +14,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -45,7 +49,6 @@ def build_module(n, tile_n, np_dtype_in, arch="aie2"):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def vector_mul(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_muladd/vector_muladd.py
+++ b/programming_examples/primitives/vector_examples/vector_muladd/vector_muladd.py
@@ -15,6 +15,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/programming_examples/primitives/vector_examples/vector_reduce_add/vector_reduce_add.py
+++ b/programming_examples/primitives/vector_examples/vector_reduce_add/vector_reduce_add.py
@@ -22,6 +22,10 @@ from air.dialects.math import exp
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -52,7 +56,6 @@ def build_module(m, n, tile_m, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
     def vector_reduce_add(arg0, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_reduce_max/vector_reduce_max.py
+++ b/programming_examples/primitives/vector_examples/vector_reduce_max/vector_reduce_max.py
@@ -22,6 +22,10 @@ from air.dialects.math import exp
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -53,7 +57,6 @@ def build_module(m, n, tile_m, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
     def vector_reduce_max(arg0, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_select/vector_select.py
+++ b/programming_examples/primitives/vector_examples/vector_select/vector_select.py
@@ -14,6 +14,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -40,7 +44,6 @@ def build_module(n, tile_n, np_dtype_in, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def vector_select(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
+++ b/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
@@ -14,6 +14,10 @@ from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -40,7 +44,6 @@ def build_module(n, tile_n, np_dtype_in, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def vector_sub(arg0, arg1, arg2):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/relu/relu.py
+++ b/programming_examples/relu/relu.py
@@ -13,6 +13,8 @@ configurable VECTOR_SIZE (default 16).
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 
 from air.ir import *
@@ -54,7 +56,6 @@ def build_module(n, tile_n, np_dtype_in, vector_size=16):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
     def relu(arg0, arg1):
-
         @herd(
             name="herd_0",
             sizes=[1, num_tiles],

--- a/programming_examples/shared_l1/run.py
+++ b/programming_examples/shared_l1/run.py
@@ -22,6 +22,8 @@ Final result: output = input + 3
 import argparse
 import numpy as np
 
+np.random.seed(42)
+
 import air
 from air.ir import *
 from air.dialects.affine import apply as affine_apply

--- a/programming_examples/sine_cosine/sine_cosine.py
+++ b/programming_examples/sine_cosine/sine_cosine.py
@@ -14,6 +14,10 @@ from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 from ml_dtypes import bfloat16
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -59,7 +63,6 @@ def build_module(n, tile_n, herd_n, sin_or_cos, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
     def sine_cosine(arg0, arg1):
-
         @herd(
             name="herd_0",
             sizes=[1, herd_n],

--- a/programming_examples/softmax/softmax.py
+++ b/programming_examples/softmax/softmax.py
@@ -14,6 +14,10 @@ from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
 from ml_dtypes import bfloat16
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 
@@ -46,7 +50,6 @@ def build_module(n, tile_n, herd_n, np_dtype_in):
 
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
     def softmax(arg0, arg1):
-
         @herd(
             name="herd_0",
             sizes=[1, herd_n],

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -11,6 +11,10 @@ from air.dialects.func import FuncOp, CallOp
 from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -11,6 +11,10 @@ from air.dialects.func import FuncOp, CallOp
 from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 
+import numpy as np
+
+np.random.seed(42)
+
 range_ = for_
 
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -152,11 +152,10 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
                 config.available_features.add("ryzen_ai_npu2")
                 print("Running tests on NPU4 with command line: ", run_on_npu2)
             else:
-                print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
+                print(f"WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break
-    except:
-        print("Failed to run xrt-smi")
-        pass
+    except Exception as e:
+        print(f"Failed to run xrt-smi: {e}")
 else:
     print("xrt not found or xrt tests disabled")
     config.excludes.append("xrt")

--- a/test/xrt/01_air_to_npu/gen.py
+++ b/test/xrt/01_air_to_npu/gen.py
@@ -14,6 +14,10 @@ from air.backend.xrt_runner import XRTRunner
 from air.ir import *
 import air.passmanager
 
+import numpy as np
+
+np.random.seed(42)
+
 
 @linalg_structured_op
 def matmul_mono(

--- a/test/xrt/02_mul_shim_1x1/run.py
+++ b/test/xrt/02_mul_shim_1x1/run.py
@@ -13,6 +13,8 @@ from air.ir import *
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 import filelock
 from ml_dtypes import bfloat16
 
@@ -120,7 +122,7 @@ def run_test(size, idtype, odtype):
     compiled_module = backend.compile(mlir_module)
     with filelock.FileLock("/tmp/npu.lock"):
         mul = backend.load(compiled_module)
-        (_, _, output_c) = mul(input_a, input_b, input_c)
+        _, _, output_c = mul(input_a, input_b, input_c)
         backend.unload()
 
     print("inputA:", input_a)

--- a/test/xrt/03_mul_L1L2_1x1/run.py
+++ b/test/xrt/03_mul_L1L2_1x1/run.py
@@ -13,6 +13,8 @@ from air.ir import *
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 import filelock
 from ml_dtypes import bfloat16
 
@@ -160,7 +162,7 @@ def run_test(size, idtype, odtype):
     compiled_module = backend.compile(mlir_module)
     with filelock.FileLock("/tmp/npu.lock"):
         mul = backend.load(compiled_module)
-        (_, _, output_c) = mul(input_a, input_b, input_c)
+        _, _, output_c = mul(input_a, input_b, input_c)
         backend.unload()
 
     print("inputA:", input_a)

--- a/test/xrt/06_add_shim_bf16/run.py
+++ b/test/xrt/06_add_shim_bf16/run.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 import pyxrt as xrt
 

--- a/test/xrt/07_extern_linalg/run.py
+++ b/test/xrt/07_extern_linalg/run.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 import pyxrt as xrt
 

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 import pyxrt as xrt
 import sys

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 import pyxrt as xrt
 import sys

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+
+np.random.seed(42)
 from ml_dtypes import bfloat16
 import pyxrt as xrt
 import sys

--- a/test/xrt/30_mul_rtp_1x1/run.py
+++ b/test/xrt/30_mul_rtp_1x1/run.py
@@ -14,6 +14,8 @@ from air.ir import *
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 import filelock
 from ml_dtypes import bfloat16
 
@@ -124,7 +126,7 @@ def run_test(size, idtype, odtype):
     with filelock.FileLock("/tmp/npu.lock"):
         mul = backend.compile_and_load(mlir_module)
         print("running")
-        (_, _, output_c) = mul(input_a, input_b, input_c)
+        _, _, output_c = mul(input_a, input_b, input_c)
 
     backend.unload()
 

--- a/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
+++ b/test/xrt/31_triton_blk_ptr_eltwise_mul/run.py
@@ -10,6 +10,10 @@ from air.ir import *
 import air.passmanager
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the eltwise mul example",

--- a/test/xrt/32_triton_matmul/run.py
+++ b/test/xrt/32_triton_matmul/run.py
@@ -10,6 +10,10 @@ from air.ir import *
 import air.passmanager
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 with air.ir.Context() as ctx, Location.unknown():
 
     ################################################

--- a/test/xrt/33_triton_matmul_ver2/run.py
+++ b/test/xrt/33_triton_matmul_ver2/run.py
@@ -11,6 +11,10 @@ from air.ir import *
 import air.passmanager
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the matmul example",

--- a/test/xrt/34_cascade_vecadd/run_chess.py
+++ b/test/xrt/34_cascade_vecadd/run_chess.py
@@ -16,6 +16,10 @@ import sys
 from air.backend.xrt_runner import XRTRunner
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the cascade example",

--- a/test/xrt/34_cascade_vecadd/run_peano.py
+++ b/test/xrt/34_cascade_vecadd/run_peano.py
@@ -16,6 +16,10 @@ import sys
 from air.backend.xrt_runner import XRTRunner
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the cascade example",

--- a/test/xrt/35_herd_reduce/run.py
+++ b/test/xrt/35_herd_reduce/run.py
@@ -16,6 +16,10 @@ import sys
 from air.backend.xrt_runner import XRTRunner
 from air.backend.xrt import XRTBackend
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the cascade example",

--- a/test/xrt/37_matmul_transform_4x4_bf16/run.py
+++ b/test/xrt/37_matmul_transform_4x4_bf16/run.py
@@ -19,6 +19,8 @@ from air.backend.xrt import XRTBackend
 from ml_dtypes import bfloat16
 import numpy as np
 
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the cascade example",

--- a/test/xrt/39_triton_matmul_ver3_vectorized/run.py
+++ b/test/xrt/39_triton_matmul_ver3_vectorized/run.py
@@ -12,6 +12,10 @@ import air.passmanager
 from ml_dtypes import bfloat16
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the matmul example",

--- a/test/xrt/40_triton_vec_add/run.py
+++ b/test/xrt/40_triton_vec_add/run.py
@@ -11,6 +11,9 @@ from air.ir import *
 import air.passmanager
 from ml_dtypes import bfloat16
 import filelock
+import numpy as np
+
+np.random.seed(42)
 
 parser = argparse.ArgumentParser(
     prog="run.py",

--- a/test/xrt/41_triton_softmax/run.py
+++ b/test/xrt/41_triton_softmax/run.py
@@ -5,6 +5,8 @@
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 from air.compiler.util import run_transform

--- a/test/xrt/42_triton_softmax_bf16/run.py
+++ b/test/xrt/42_triton_softmax_bf16/run.py
@@ -5,6 +5,8 @@
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 from air.compiler.util import run_transform

--- a/test/xrt/44_triton_matmul_ver4_vector_ptr_opt/run.py
+++ b/test/xrt/44_triton_matmul_ver4_vector_ptr_opt/run.py
@@ -12,6 +12,10 @@ import air.passmanager
 from ml_dtypes import bfloat16
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the matmul example",

--- a/test/xrt/45_triton_matmul_ver4_strix_8x4/run.py
+++ b/test/xrt/45_triton_matmul_ver4_strix_8x4/run.py
@@ -12,6 +12,10 @@ import air.passmanager
 from ml_dtypes import bfloat16
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the matmul example",

--- a/test/xrt/46_triton_matmul_ver4_strix_8x4_i8_i8_i32/run.py
+++ b/test/xrt/46_triton_matmul_ver4_strix_8x4_i8_i8_i32/run.py
@@ -5,6 +5,8 @@
 
 import argparse
 import numpy as np
+
+np.random.seed(42)
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 from air.compiler.util import run_transform

--- a/test/xrt/48_triton_matmul_ver4_strix_4x4_bf16_output/run.py
+++ b/test/xrt/48_triton_matmul_ver4_strix_4x4_bf16_output/run.py
@@ -12,6 +12,10 @@ import air.passmanager
 from ml_dtypes import bfloat16
 import filelock
 
+import numpy as np
+
+np.random.seed(42)
+
 parser = argparse.ArgumentParser(
     prog="run.py",
     description="Builds, runs, and tests the matmul example",

--- a/test/xrt/49_triton_softmax_optimized_bf16_strix/run.py
+++ b/test/xrt/49_triton_softmax_optimized_bf16_strix/run.py
@@ -9,6 +9,8 @@
 import argparse
 import os
 import numpy as np
+
+np.random.seed(42)
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 from air.compiler.util import run_transform


### PR DESCRIPTION
## Summary
- Add retry logic (`|| retry`) for peano E2E and programming example test targets in CI, which have shown intermittent NPU-related failures (e.g. `40_triton_vec_add` wrong values, `silu`/`llama2_rope` exit code 255, `channel_size` MLIRError)
- Pin `np.random.seed(42)` in 54 test files across `test/xrt/` and `programming_examples/` to make test inputs deterministic and failures reproducible
- Replace bare `except:` with `except Exception as e:` in `test/lit.cfg.py` and `programming_examples/lit.cfg.py` so `xrt-smi` failures print the actual error message instead of a generic "Failed to run xrt-smi"

## Test plan
- [x] Verify CI passes on both `amd8845hs` and `amdhx370` runners
- [x] Run CI multiple times via `workflow_dispatch` to confirm reduced flaky failure rate
- [x] Verify `40_triton_vec_add`, `silu`, and `channel_size` no longer fail intermittently

🤖 Generated with [Claude Code](https://claude.com/claude-code)