### PR TITLE
Add multi-dtype passthrough and bf16 transpose examples

### DIFF
--- a/programming_examples/README.md
+++ b/programming_examples/README.md
@@ -34,11 +34,12 @@ These programming examples demonstrate how to leverage the AIR design flow with 
 | LLM Kernels | [RoPE (On-chip Sin/Cos)](rope_sincos/) | bf16 | 🟢 | 🟢 | [rope_sincos/](rope_sincos/) |
 | Attention | [Flash Attention (Dataflow)](flash_attention/dataflow_based/) | bf16 | 🟢 | 🟢 | [flash_attention/dataflow_based/](flash_attention/dataflow_based/) |
 | Attention | [Flash Attention (Kernel Fusion)](flash_attention/kernel_fusion_based/) | bf16 | ⚪ | 🟢 | [flash_attention/kernel_fusion_based/](flash_attention/kernel_fusion_based/) |
-| Data Movement | [Passthrough (DMA)](passthrough/passthrough_dma/) | u8 | 🟢 | 🟢 | [passthrough/passthrough_dma/](passthrough/passthrough_dma/) |
+| Data Movement | [Passthrough (DMA)](passthrough/passthrough_dma/) | u8, i8, i16, u16, f32, bf16 | 🟢 | 🟢 | [passthrough/passthrough_dma/](passthrough/passthrough_dma/) |
 | Data Movement | [Passthrough (Channel)](passthrough/passthrough_channel/) | u8 | 🟢 | 🟢 | [passthrough/passthrough_channel/](passthrough/passthrough_channel/) |
 | Data Movement | [Passthrough (Kernel)](passthrough/passthrough_kernel/) | u8 | 🟢 | 🟢 | [passthrough/passthrough_kernel/](passthrough/passthrough_kernel/) |
 | Data Movement | [Shim DMA 2D](shim_dma_2d/) | i32 | 🟢 | 🟢 | [shim_dma_2d/](shim_dma_2d/) |
 | Data Movement | [Data Transfer Transpose](data_transfer_transpose/) | u32 | 🟢 | 🟢 | [data_transfer_transpose/](data_transfer_transpose/) |
+| Data Movement | [Transpose (bf16)](data_transfer_transpose/dma_bf16/) | bf16 | ⚪ | 🟢 | [data_transfer_transpose/dma_bf16/](data_transfer_transpose/dma_bf16/) |
 | Data Movement | [Matrix Scalar Add](matrix_scalar_add/) | i32 | 🟢 | 🟢 | [matrix_scalar_add/](matrix_scalar_add/) |
 | Communication | [Channel Examples](channel_examples/) | i32 | 🟢 | 🟢 | [channel_examples/](channel_examples/) |
 | Communication | [Multi-Segment Examples](multi_segment/) | i32 | 🟡 | 🟡 | [multi_segment/](multi_segment/) |

--- a/programming_examples/data_transfer_transpose/dma_bf16/Makefile
+++ b/programming_examples/data_transfer_transpose/dma_bf16/Makefile
@@ -1,0 +1,38 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+OUTPUT_FORMAT ?= xclbin
+OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
+
+M ?= 64
+K ?= 32
+
+WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG
+
+all: run
+
+print:
+	${powershell} python3 ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -p -m $(M) -k $(K)
+
+compile-kernel:
+	mkdir -p $(BUILD_DIR)
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} \
+		-DDIM_M=$(M) -DDIM_N=$(K) \
+		-c ${srcdir}/transpose.cc -o $(BUILD_DIR)/transpose.o
+
+run: compile-kernel
+	mkdir -p $(BUILD_DIR)/air_project
+	cp $(BUILD_DIR)/transpose.o $(BUILD_DIR)/air_project/transpose.o
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -m $(M) -k $(K)
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/data_transfer_transpose/dma_bf16/run_makefile_peano.lit
+++ b/programming_examples/data_transfer_transpose/dma_bf16/run_makefile_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/data_transfer_transpose/dma_bf16/transpose.cc
+++ b/programming_examples/data_transfer_transpose/dma_bf16/transpose.cc
@@ -1,0 +1,29 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Simple matrix transpose kernel for bf16 (uint16_t).
+// Transposes an M x N row-major matrix to N x M row-major.
+// Uses scalar element access (not VSHUFFLE-optimized).
+
+#include <cstdint>
+
+#ifndef DIM_M
+#define DIM_M 64
+#endif
+#ifndef DIM_N
+#define DIM_N 32
+#endif
+
+using DTYPE = uint16_t;
+
+extern "C" {
+
+void transpose_bf16(DTYPE *__restrict__ in_ptr, DTYPE *__restrict__ out_ptr) {
+  for (unsigned i = 0; i < DIM_M; i++) {
+    for (unsigned j = 0; j < DIM_N; j++) {
+      out_ptr[j * DIM_M + i] = in_ptr[i * DIM_N + j];
+    }
+  }
+}
+
+} // extern "C"

--- a/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
+++ b/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""bf16 matrix transpose using an external kernel.
+
+Transposes an [M, K] bf16 matrix to [K, M] using a C++ kernel compiled
+with Peano. The kernel performs scalar element-by-element transpose.
+
+DMA stride-based transpose is not possible for sub-32-bit types on AIE
+because the inner-most DMA stride must be 1 for <32b data widths.
+Instead, we DMA the matrix into L1 contiguously and let the kernel
+perform the transpose.
+"""
+
+import argparse
+import numpy as np
+from ml_dtypes import bfloat16
+
+np.random.seed(42)
+
+from air.ir import *
+from air.dialects.air import *
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.func import FuncOp
+from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt import XRTBackend
+
+INOUT_DATATYPE = bfloat16
+
+
+@module_builder
+def build_module(m, k):
+    xrt_dtype = type_mapper(INOUT_DATATYPE)
+
+    memrefTyIn = MemRefType.get(shape=[m * k], element_type=xrt_dtype)
+    memrefTyOut = MemRefType.get(shape=[k * m], element_type=xrt_dtype)
+
+    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l1_type = MemRefType.get(
+        shape=[m * k],
+        element_type=xrt_dtype,
+        memory_space=mem_space,
+    )
+
+    transpose_func = external_func("transpose_bf16", inputs=[l1_type, l1_type])
+
+    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
+    def transpose(arg0, arg1):
+        @launch(operands=[arg0, arg1])
+        def launch_body(a, b):
+            @segment(name="seg", operands=[a, b])
+            def segment_body(arg2, arg3):
+                @herd(
+                    name="herd",
+                    sizes=[1, 1],
+                    operands=[arg2, arg3],
+                    link_with="transpose.o",
+                )
+                def herd_body(_tx, _ty, _sx, _sy, a, b):
+                    l1_in = AllocOp(l1_type, [], [])
+                    l1_out = AllocOp(l1_type, [], [])
+
+                    dma_memcpy_nd(l1_in, a)
+
+                    call(
+                        transpose_func,
+                        inputs=[l1_in, l1_out],
+                        input_types=[l1_type, l1_type],
+                    )
+
+                    dma_memcpy_nd(b, l1_out)
+
+                    DeallocOp(l1_in)
+                    DeallocOp(l1_out)
+
+
+if __name__ == "__main__":
+    M = 64
+    K = 32
+
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Builds, runs, and tests the bf16 transpose example",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("-m", type=int, default=M, help="Matrix rows")
+    parser.add_argument("-k", type=int, default=K, help="Matrix columns")
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-only", "compile-and-run"],
+        dest="compile_mode",
+        default="compile-and-run",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="xclbin",
+        dest="output_format",
+    )
+    args = parser.parse_args()
+
+    mlir_module = build_module(args.m, args.k)
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    input_matrix = np.random.uniform(-1.0, 1.0, (args.m, args.k)).astype(INOUT_DATATYPE)
+    expected_output = np.transpose(input_matrix)
+
+    if args.compile_mode == "compile-and-run":
+        runner = XRTRunner(
+            verbose=args.verbose,
+            output_format=args.output_format,
+            instance_name="transpose",
+        )
+        exit(
+            runner.run_test(
+                mlir_module,
+                inputs=[input_matrix.reshape(-1)],
+                expected_outputs=[expected_output.reshape(-1)],
+            )
+        )
+    elif args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            output_format=args.output_format,
+        )
+        module_function = backend.compile(mlir_module)
+        backend.unload()

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -190,7 +190,7 @@ EXAMPLES = [
         "category": "Data Movement",
         "name": "Passthrough (DMA)",
         "path": "passthrough/passthrough_dma",
-        "datatypes": "u8",
+        "datatypes": "u8, i8, i16, u16, f32, bf16",
     },
     {
         "category": "Data Movement",
@@ -215,6 +215,12 @@ EXAMPLES = [
         "name": "Data Transfer Transpose",
         "path": "data_transfer_transpose",
         "datatypes": "u32",
+    },
+    {
+        "category": "Data Movement",
+        "name": "Transpose (bf16)",
+        "path": "data_transfer_transpose/dma_bf16",
+        "datatypes": "bf16",
     },
     {
         "category": "Data Movement",

--- a/programming_examples/passthrough/passthrough_dma/Makefile
+++ b/programming_examples/passthrough/passthrough_dma/Makefile
@@ -13,14 +13,18 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# Data type: uint8 (default) or bfloat16
+DTYPE ?= uint8
+DTYPE_FLAG = --dtype $(DTYPE)
+
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
+++ b/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 import argparse
 import numpy as np
+from ml_dtypes import bfloat16
 
 from air.ir import *
 from air.dialects.air import *
@@ -12,13 +13,21 @@ from air.backend.xrt_runner import XRTRunner, type_mapper
 
 range_ = for_
 
-INOUT_DATATYPE = np.uint8
+dtype_map = {
+    "uint8": np.uint8,
+    "int8": np.int8,
+    "int16": np.int16,
+    "uint16": np.uint16,
+    "float32": np.float32,
+    "bfloat16": bfloat16,
+}
+DEFAULT_DTYPE = "uint8"
 
 
 @module_builder
-def build_module(vector_size, num_subvectors):
+def build_module(vector_size, num_subvectors, np_dtype):
     assert vector_size % num_subvectors == 0
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    xrt_dtype = type_mapper(np_dtype)
 
     # Type and method of input/output
     memrefTyInOut = T.memref(vector_size, xrt_dtype)
@@ -121,15 +130,23 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "-t",
+        "--dtype",
+        default=DEFAULT_DTYPE,
+        choices=dtype_map.keys(),
+        help="The data type to use (default: uint8)",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module(args.vector_size, args.subvector_size)
+    np_dtype = dtype_map[args.dtype]
+    mlir_module = build_module(args.vector_size, args.subvector_size, np_dtype)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
-    input_a = np.arange(args.vector_size, dtype=INOUT_DATATYPE)
-    output_b = np.arange(args.vector_size, dtype=INOUT_DATATYPE)
+    input_a = np.arange(args.vector_size, dtype=np_dtype)
+    output_b = np.arange(args.vector_size, dtype=np_dtype)
 
     runner = XRTRunner(
         verbose=args.verbose, output_format=args.output_format, instance_name="copy"

--- a/programming_examples/passthrough/passthrough_dma/run_makefile_peano_bf16.lit
+++ b/programming_examples/passthrough/passthrough_dma/run_makefile_peano_bf16.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DTYPE=bfloat16 | FileCheck %s
+// CHECK: PASS!


### PR DESCRIPTION
## Summary
- Extend **passthrough_dma** with `--dtype` flag supporting 6 data types: `uint8`, `int8`, `int16`, `uint16`, `float32`, `bfloat16`
- Add `run_makefile_peano_bf16.lit` test for bf16 passthrough
- Add **bf16 transpose** example (`data_transfer_transpose/dma_bf16/`): uses external C++ kernel for transpose since DMA stride-based transpose is not possible for sub-32-bit types on AIE (inner-most dim stride must be 1)
- Update dashboard with new entries
- Regenerate `programming_examples/README.md`

## Test plan
- [x] Passthrough: all 6 dtypes pass on NPU2 (exact match)
- [x] Transpose bf16 (64x32): `make run` passes on NPU2 (exact match)
- [x] Dashboard shows correct status for all entries
- [x] CI builds and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)