### PR TITLE
Fix BF16 GEMM reference computation and add LLAMA shape validation

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16/Makefile
@@ -85,6 +85,29 @@ run3x3: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 	
+# LLAMA-3.2-1B GEMM shapes (M=128, herd 8x4, tile_m=16)
+# Q/O: 128x2048x2048, K/V: 128x2048x512, Gate/Up: 128x2048x8192, Down: 128x8192x2048
+LLAMA_TILE_M = 16
+LLAMA_TILE_N = 32
+LLAMA_TILE_K_L1 = 32
+
+compile-kernel-llama:
+	$(MAKE) -f $(srcdir)/Makefile compile-kernel TILE_M=$(LLAMA_TILE_M) TILE_N=$(LLAMA_TILE_N) TILE_K_L1=$(LLAMA_TILE_K_L1)
+
+run_llama_8x4: compile-kernel-llama
+	@echo "=== Q/O projection 128x2048x2048 ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 2048 \
+		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	@echo "=== K/V projection 128x2048x512 ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 512 \
+		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	@echo "=== Gate/Up FFN 128x2048x8192 ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 8192 \
+		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	@echo "=== Down FFN 128x8192x2048 ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 8192 --n 2048 \
+		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+
 profile: compile-kernel build-test-exe
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python ../run.py --m 1024 --k 1024 --n 1024 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -720,15 +720,14 @@ if __name__ == "__main__":
             ]
         )
 
-        # Compute reference results for sampled indices
+        # Compute reference results for sampled indices.
+        # Accumulate in F32 to match hardware behavior (AIE mmul accumulates in F32),
+        # then cast the final result to the output type.
         sampled_values = np.array(
             [
                 np.sum(
-                    (
-                        input_a[i, :].astype(OUTPUT_DATATYPE)
-                        * input_b[:, j].astype(OUTPUT_DATATYPE)
-                    ),
-                    dtype=OUTPUT_DATATYPE,
+                    input_a[i, :].astype(np.float32) * input_b[:, j].astype(np.float32),
+                    dtype=np.float32,
                 )
                 for i, j in zip(*sampled_indices)
             ],

--- a/programming_examples/matrix_multiplication/bf16/run_npu2_llama_8x4_peano.lit
+++ b/programming_examples/matrix_multiplication/bf16/run_npu2_llama_8x4_peano.lit
@@ -1,0 +1,17 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_llama_8x4_peano
+// RUN: cd test_npu2_llama_8x4_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_llama_8x4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: Q/O projection
+// CHECK: PASS!
+// CHECK: K/V projection
+// CHECK: PASS!
+// CHECK: Gate/Up FFN
+// CHECK: PASS!
+// CHECK: Down FFN
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bf16/run_npu2_llama_8x4_peano_no_direct_codegen.lit
+++ b/programming_examples/matrix_multiplication/bf16/run_npu2_llama_8x4_peano_no_direct_codegen.lit
@@ -1,0 +1,17 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_llama_8x4_peano_no_direct_codegen
+// RUN: cd test_npu2_llama_8x4_peano_no_direct_codegen
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_llama_8x4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p DIRECT_CODEGEN_FLAG= | FileCheck %s
+// CHECK: Q/O projection
+// CHECK: PASS!
+// CHECK: K/V projection
+// CHECK: PASS!
+// CHECK: Gate/Up FFN
+// CHECK: PASS!
+// CHECK: Down FFN
+// CHECK: PASS!


### PR DESCRIPTION
## Summary
  - Fix BF16 matmul reference computation to accumulate in F32 (matching AIE hardware behavior). The previous BF16 accumulation caused ~3x divergence at K>=2048, failing verification despite correct
   hardware results.
  - Add `run_llama_8x4` Makefile target for LLAMA-3.2-1B GEMM shapes (Q/O-proj 128x2048x2048, K/V-proj 128x2048x512, Gate/Up 128x2048x8192, Down 128x8192x2048) on NPU2 with 8x4 herd.
  - Add LIT tests for both direct-codegen and mm.o kernel paths.

  ## Test plan
  - [x] Baseline 512x512x512 still passes after reference fix
  - [x] All 4 LLAMA shapes pass on NPU2 hardware (direct-codegen and mm.o)
  - [x] `run_npu2_makefile_peano.lit` — PASS
  - [x] `run_npu2_makefile_peano_no_direct_codegen.lit` — PASS
  - [x] `run_npu2_llama_8x4_peano.lit` — PASS
  - [x] `run_npu2_llama_8x4_peano_no_direct_codegen.lit` — PASS