### PR TITLE
Fix air-wrap-func-with-parallel for scalar SSA chains (#1367)

### DIFF
--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1898,26 +1898,31 @@ struct WrapFuncWithParallelPattern : public OpRewritePattern<func::FuncOp> {
     auto parallelOp = scf::ParallelOp::create(rewriter, loc, lowerBounds,
                                               upperBoundsVals, steps);
 
-    // Redirect arguments properly inside the loop
+    // Create index_cast ops for induction variable type remapping.
     Block &loopBlock = parallelOp.getRegion().front();
     rewriter.setInsertionPointToStart(&loopBlock);
-    IRMapping remap;
+    SmallVector<Value> remappedIVs;
     for (unsigned i = 0; i < N; i++) {
       Value loopBlockArg = loopBlock.getArgument(i);
       if (inductionVars[i].getType() != loopBlockArg.getType())
         loopBlockArg = arith::IndexCastOp::create(
             rewriter, loc, inductionVars[i].getType(), loopBlockArg);
-      remap.map(inductionVars[i], loopBlockArg);
+      remappedIVs.push_back(loopBlockArg);
     }
 
-    // Move function body into the loop
+    // Move function body ops into the loop body instead of clone+erase.
+    // This preserves all SSA use-def chains and avoids issues with
+    // IRMapping not fully remapping scalar SSA chains between linalg ops
+    // (see https://github.com/Xilinx/mlir-air/issues/1367).
+    Operation *yield = loopBlock.getTerminator();
     for (auto op : originalFuncBodyOps) {
-      rewriter.clone(*op, remap);
+      rewriter.moveOpBefore(op, yield);
     }
 
-    // Erase original function body ops
-    for (auto o : llvm::reverse(originalFuncBodyOps))
-      rewriter.eraseOp(o);
+    // Replace induction variable uses with parallel block arguments.
+    for (unsigned i = 0; i < N; i++) {
+      rewriter.replaceAllUsesWith(inductionVars[i], remappedIVs[i]);
+    }
 
     return success();
   }

--- a/mlir/test/Conversion/ConvertToAIR/wrap_func_with_parallel.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/wrap_func_with_parallel.mlir
@@ -11,6 +11,25 @@
 // CHECK: arith.index_cast %[[ARG0]] : index to i32
 // CHECK: arith.index_cast %[[ARG1]] : index to i32
 
+// Test scalar SSA chain between linalg ops (issue #1367).
+// The pattern: linalg.generic -> linalg.reduce -> tensor.extract ->
+// scalar arith chain -> linalg.fill -> linalg.generic should be fully
+// moved into the scf.parallel body.
+
+// CHECK-LABEL: @func_scalar_ssa_chain
+// CHECK: scf.parallel {{.*}} {
+// CHECK:   linalg.generic
+// CHECK:   linalg.reduce
+// CHECK:   tensor.extract
+// CHECK:   arith.divf
+// CHECK:   arith.addf
+// CHECK:   math.rsqrt
+// CHECK:   linalg.fill
+// CHECK:   linalg.generic
+// CHECK:   scf.reduce
+
+#map_identity = affine_map<(d0) -> (d0)>
+
 func.func @func0(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: memref<*xf32>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32) {
   %cst = arith.constant 0.000000e+00 : f32
   %c64 = arith.constant 64 : index
@@ -34,5 +53,70 @@ func.func @func0(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: memref<*xf32
   %10 = arith.addi %4, %3 : index
   %reinterpret_cast_2 = memref.reinterpret_cast %arg2 to offset: [%10], sizes: [32, 32], strides: [%c64, 1] : memref<*xf32> to memref<32x32xf32, strided<[?, 1], offset: ?>>
   bufferization.materialize_in_destination %9 in writable %reinterpret_cast_2 : (tensor<32x32xf32>, memref<32x32xf32, strided<[?, 1], offset: ?>>) -> ()
+  return
+}
+
+func.func @func_scalar_ssa_chain(%arg0: memref<*xbf16>, %arg1: memref<*xbf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32) {
+  %cst_eps = arith.constant 1.000000e-05 : f32
+  %cst_N = arith.constant 6.400000e+01 : f32
+  %cst_zero = arith.constant 0.000000e+00 : f32
+  %c64 = arith.constant 64 : index
+  %c32_i32 = arith.constant 32 : i32
+  %0 = arith.muli %arg6, %c32_i32 : i32
+  %1 = arith.index_cast %0 : i32 to index
+
+  // Load input
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%1], sizes: [64], strides: [1] : memref<*xbf16> to memref<64xbf16, strided<[1], offset: ?>>
+  %alloc = memref.alloc() : memref<64xbf16>
+  memref.copy %reinterpret_cast, %alloc : memref<64xbf16, strided<[1], offset: ?>> to memref<64xbf16>
+  %input = bufferization.to_tensor %alloc restrict writable : memref<64xbf16> to tensor<64xbf16>
+
+  // Square: x * x
+  %empty_sq = tensor.empty() : tensor<64xbf16>
+  %sq = linalg.generic {indexing_maps = [#map_identity, #map_identity], iterator_types = ["parallel"]}
+    ins(%input : tensor<64xbf16>) outs(%empty_sq : tensor<64xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %mul = arith.mulf %in, %in : bf16
+    linalg.yield %mul : bf16
+  } -> tensor<64xbf16>
+
+  // Reduce: sum(x*x)
+  %init = tensor.empty() : tensor<f32>
+  %fill_init = linalg.fill ins(%cst_zero : f32) outs(%init : tensor<f32>) -> tensor<f32>
+  %reduced = linalg.reduce ins(%sq : tensor<64xbf16>) outs(%fill_init : tensor<f32>) dimensions = [0]
+    (%in: bf16, %acc: f32) {
+      %ext = arith.extf %in : bf16 to f32
+      %add = arith.addf %acc, %ext : f32
+      linalg.yield %add : f32
+    }
+
+  // Scalar SSA chain: extract -> divf -> addf -> rsqrt
+  %extracted = tensor.extract %reduced[] : tensor<f32>
+  %mean = arith.divf %extracted, %cst_N : f32
+  %with_eps = arith.addf %mean, %cst_eps : f32
+  %rstd = math.rsqrt %with_eps : f32
+
+  // Broadcast rsqrt and multiply: x * rsqrt
+  %empty_out = tensor.empty() : tensor<64xf32>
+  %fill_rstd = linalg.fill ins(%rstd : f32) outs(%empty_out : tensor<64xf32>) -> tensor<64xf32>
+  %empty_mul = tensor.empty() : tensor<64xf32>
+  %result = linalg.generic {indexing_maps = [#map_identity, #map_identity, #map_identity], iterator_types = ["parallel"]}
+    ins(%input, %fill_rstd : tensor<64xbf16>, tensor<64xf32>) outs(%empty_mul : tensor<64xf32>) {
+  ^bb0(%x: bf16, %r: f32, %out: f32):
+    %xf = arith.extf %x : bf16 to f32
+    %mul = arith.mulf %xf, %r : f32
+    linalg.yield %mul : f32
+  } -> tensor<64xf32>
+
+  // Store output
+  %reinterpret_cast_out = memref.reinterpret_cast %arg1 to offset: [%1], sizes: [64], strides: [1] : memref<*xbf16> to memref<64xbf16, strided<[1], offset: ?>>
+  %empty_trunc = tensor.empty() : tensor<64xbf16>
+  %truncated = linalg.generic {indexing_maps = [#map_identity, #map_identity], iterator_types = ["parallel"]}
+    ins(%result : tensor<64xf32>) outs(%empty_trunc : tensor<64xbf16>) {
+  ^bb0(%in: f32, %out: bf16):
+    %tr = arith.truncf %in : f32 to bf16
+    linalg.yield %tr : bf16
+  } -> tensor<64xbf16>
+  bufferization.materialize_in_destination %truncated in writable %reinterpret_cast_out : (tensor<64xbf16>, memref<64xbf16, strided<[1], offset: ?>>) -> ()
   return
 }


### PR DESCRIPTION
## Summary
- Replace clone+erase with `moveOpBefore` in `WrapFuncWithParallelPattern` to fix crash when scalar SSA chains exist between linalg ops (e.g., `tensor.extract` → `arith.divf` → `math.rsqrt` between `linalg.reduce` and `linalg.fill`)
- Add regression test with RMS-norm-like pattern exercising the scalar SSA chain scenario

## Details

The `air-wrap-func-with-parallel` pass wraps a function body inside an `scf.parallel` loop. The previous implementation used `rewriter.clone(*op, remap)` to copy ops into the parallel body, then `rewriter.eraseOp()` to delete originals. This failed with `'linalg.generic' op is being erased, but it has at least one user` when scalar ops bridged between structured linalg ops, because `IRMapping::lookupOrDefault()` can leave cloned ops referencing original values through transitive dependencies.

The fix uses `rewriter.moveOpBefore()` to move ops directly into the parallel body, preserving all SSA use-def chains. Induction variables are remapped via `rewriter.replaceAllUsesWith()` after the move. This is simpler, more robust, and avoids the `IRMapping` entirely.

Fixes #1367

## Test plan
- [x] Existing `@func0` test passes (matmul pattern)
- [x] New `@func_scalar_ssa_chain` test passes (RMS-norm pattern with `linalg.reduce` → `tensor.extract` → scalar chain → `linalg.fill` → `linalg.generic`)
- [ ] `ninja check-air-mlir` full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)