### PR TITLE
Fix air-dependency to handle tensor-mode linalg ops with results (#1369)

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -132,9 +132,13 @@ public:
           createAsyncDMA(rewriter, op);
         else if (isa<air::ChannelInterface>(op))
           createAsyncChannel(rewriter, op);
-        else if (isa<linalg::LinalgOp, func::CallOp, memref::DeallocOp>(op))
-          createAsyncExecute(rewriter, op);
-        else if (isa<memref::CopyOp>(op)) {
+        else if (isa<linalg::LinalgOp, func::CallOp, memref::DeallocOp>(op)) {
+          if (op->getNumResults())
+            createAsyncExecute(rewriter, op,
+                               op->getResults().front().getType());
+          else
+            createAsyncExecute(rewriter, op);
+        } else if (isa<memref::CopyOp>(op)) {
           // Skip wrapping memref.copy in air.execute when inside scf.if,
           // as the resulting async token would not dominate uses outside
           // the enclosing loop. L1-to-L1 copies are synchronous and don't

--- a/mlir/test/Transform/AIRDependency/tensor_linalg_generic.mlir
+++ b/mlir/test/Transform/AIRDependency/tensor_linalg_generic.mlir
@@ -1,0 +1,43 @@
+//===- tensor_linalg_generic.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+// Test that air-dependency correctly handles tensor-mode linalg.generic ops
+// whose tensor results are consumed by bufferization.materialize_in_destination.
+// The linalg.generic should be wrapped in an air.execute that forwards the
+// tensor result (issue #1369).
+
+// CHECK-LABEL: @tensor_linalg_materialize
+// CHECK: %[[TOKEN:.*]], %[[RESULT:.*]] = air.execute
+// CHECK:   %[[GENERIC:.*]] = linalg.generic
+// CHECK:   air.execute_terminator %[[GENERIC]]
+// CHECK: air.execute
+// CHECK:   bufferization.materialize_in_destination %[[RESULT]]
+
+#map = affine_map<(d0) -> (d0)>
+
+module {
+  func.func @tensor_linalg_materialize(%arg0: memref<64xf32>) {
+    %c1 = arith.constant 1 : index
+    air.herd @herd_0 tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%out=%arg0) : memref<64xf32> {
+      %cst = arith.constant 2.000000e+00 : f32
+      %alloc = memref.alloc() : memref<64xf32, 2>
+      %input = bufferization.to_tensor %alloc restrict writable : memref<64xf32, 2> to tensor<64xf32>
+      %empty = tensor.empty() : tensor<64xf32>
+      %result = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+        ins(%input : tensor<64xf32>) outs(%empty : tensor<64xf32>) {
+      ^bb0(%in: f32, %o: f32):
+        %mul = arith.mulf %in, %cst : f32
+        linalg.yield %mul : f32
+      } -> tensor<64xf32>
+      bufferization.materialize_in_destination %result in writable %out : (tensor<64xf32>, memref<64xf32>) -> ()
+      memref.dealloc %alloc : memref<64xf32, 2>
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- Fix `createAsyncExecute` dispatch in `air-dependency` pass to check `op->getNumResults()` for `linalg::LinalgOp` and `func::CallOp` before choosing the no-result vs result-forwarding variant
- Add regression test with tensor-mode `linalg.generic` whose result is consumed by `bufferization.materialize_in_destination`

## Details

The dispatch for `linalg::LinalgOp`, `func::CallOp`, and `memref::DeallocOp` at `AIRDependency.cpp:135` unconditionally called the no-result variant of `createAsyncExecute`. This is correct for bufferized linalg ops (memref mode, 0 results) but wrong for tensor-mode linalg ops that produce tensor results. The no-result variant clones the op into `air.execute` but never calls `replaceAllUsesWith`, so when it tries to erase the original, downstream ops like `bufferization.materialize_in_destination` still reference the original tensor result.

The fix checks `op->getNumResults()` to choose the correct variant, mirroring the existing pattern at lines 189-194 (the generic "unknown op" path).

Fixes #1369

## Test plan
- [x] New `tensor_linalg_generic.mlir` test passes (tensor-mode linalg + materialize_in_destination)
- [x] All 22 existing `AIRDependency` tests pass (1 pre-existing failure: `air_channel.mlir`)
- [ ] `ninja check-air-mlir` full test suite
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)