### PR TITLE
Fix air-override-memref-memory-space to exclude all deeper AIR scopes (#1379)

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2718,11 +2718,14 @@ struct OverrideMemorySpacePattern : public OpRewritePattern<memref::AllocOp> {
         return failure();
     } else if (clScope == "launch") {
       parent = alloc->getParentOfType<air::LaunchOp>();
-      if (alloc->getParentOfType<air::SegmentOp>())
+      if (alloc->getParentOfType<air::SegmentOp>() ||
+          alloc->getParentOfType<air::HerdOp>())
         return failure();
     } else if (clScope == "func") {
       parent = alloc->getParentOfType<func::FuncOp>();
-      if (alloc->getParentOfType<air::LaunchOp>())
+      if (alloc->getParentOfType<air::LaunchOp>() ||
+          alloc->getParentOfType<air::SegmentOp>() ||
+          alloc->getParentOfType<air::HerdOp>())
         return failure();
     } else
       return alloc->emitOpError(

--- a/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
@@ -8,6 +8,7 @@
 // RUN: air-opt %s -air-override-memref-memory-space="scope=herd memory-space=2" | FileCheck %s
 // RUN: air-opt %s -air-override-memref-memory-space="scope=launch memory-space=2" | FileCheck %s --check-prefix=LAUNCH
 // RUN: air-opt %s -air-override-memref-memory-space="scope=segment memory-space=1" | FileCheck %s --check-prefix=SEGMENT
+// RUN: air-opt %s -air-override-memref-memory-space="scope=func memory-space=1" | FileCheck %s --check-prefix=FUNC
 
 module {
 
@@ -104,6 +105,28 @@ module {
           memref.copy %h1, %herd_buf : memref<32xf32, 3> to memref<32xf32, 3>
         }
       }
+    }
+    return
+  }
+
+  // Test scope=func with herd directly inside func (no launch/segment).
+  // scope=func should NOT override the herd alloc (issue #1379 follow-up).
+
+  // FUNC-LABEL: func.func @func_herd_no_launch
+  // scope=func changes func-level alloc from 3 to 1, herd alloc stays at 3
+  // FUNC: memref.alloc() : memref<64xf32, 1 : i32>
+  // FUNC: air.herd
+  // FUNC:   memref.alloc() : memref<32xf32, 3>
+
+  func.func @func_herd_no_launch(%arg0: memref<32xf32, 3>) {
+    %c1 = arith.constant 1 : index
+    // Alloc at func level (outside herd) — starts at memory_space 3
+    %func_buf = memref.alloc() : memref<64xf32, 3>
+    memref.dealloc %func_buf : memref<64xf32, 3>
+    air.herd @herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%h0=%arg0) : memref<32xf32, 3> {
+      // Alloc at herd level — should NOT be changed by scope=func
+      %herd_buf = memref.alloc() : memref<32xf32, 3>
+      memref.copy %h0, %herd_buf : memref<32xf32, 3> to memref<32xf32, 3>
     }
     return
   }


### PR DESCRIPTION
## Summary
Follow-up to #1381. Fix exclusive scope matching to check for ALL deeper AIR scopes, not just the immediate next level.

## Problem
PR #1381 only checked one level down:
- `scope=func` excluded `LaunchOp` but NOT `SegmentOp` or `HerdOp`
- `scope=launch` excluded `SegmentOp` but NOT `HerdOp`

When a herd exists directly inside a func (before `air-par-to-launch` creates the launch/segment wrappers), `scope=func` still matched herd-internal allocs.

## Fix
- `scope=func`: exclude `LaunchOp` OR `SegmentOp` OR `HerdOp`
- `scope=launch`: exclude `SegmentOp` OR `HerdOp`
- `scope=segment`: exclude `HerdOp` (unchanged)
- `scope=herd`: no exclusion (unchanged)

## Test
New `@func_herd_no_launch` test: herd directly inside func with `scope=func memory-space=1` — func-level alloc changes, herd-level alloc is untouched.

Fixes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)