### PR TITLE
Fix air-override-memref-memory-space to propagate types through AIR block args (#1384)

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2819,6 +2819,29 @@ void AIROverrideMemRefMemorySpacePass::runOnOperation() {
   RewritePatternSet patterns(context);
   patterns.add<OverrideMemorySpacePattern>(context, clScope, clMemorySpace);
   (void)applyPatternsGreedily(moduleOp, std::move(patterns));
+
+  // After alloc types change, propagate types through AIR hierarchy block
+  // arguments. When an alloc outside a herd/segment/launch changes type,
+  // the hierarchy op's operand updates but the body block argument retains
+  // the old type (issue #1384).
+  auto updateBlockArgTypes = [](auto hierarchyOp) {
+    auto kernelOperands = hierarchyOp.getKernelOperands();
+    auto kernelArgs = hierarchyOp.getKernelArguments();
+    for (unsigned i = 0; i < kernelArgs.size(); i++) {
+      if (kernelArgs[i].getType() != kernelOperands[i].getType()) {
+        // Get a mutable reference via the block directly.
+        auto &block = hierarchyOp.getBody().front();
+        block.getArgument(kernelArgs[i].getArgNumber())
+            .setType(kernelOperands[i].getType());
+      }
+    }
+  };
+  // Propagate types from outermost to innermost hierarchy ops so that
+  // updated alloc types are visible when updating inner block arguments.
+  moduleOp.walk([&](air::LaunchOp op) { updateBlockArgTypes(op); });
+  moduleOp.walk([&](air::SegmentOp op) { updateBlockArgTypes(op); });
+  moduleOp.walk([&](air::HerdOp op) { updateBlockArgTypes(op); });
+
   RewritePatternSet fixResTypePatterns(context);
   if (clScope == "herd") {
     fixResTypePatterns.add<correctViewLikeOpIOMemorySpacesInScope<air::HerdOp>>(

--- a/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
@@ -130,4 +130,30 @@ module {
     }
     return
   }
+
+  // Test that subview source type is updated when herd arg type changes
+  // due to segment-level alloc override (issue #1384).
+
+  // SEGMENT-LABEL: func.func @func_subview_type_propagation
+  // SEGMENT: air.segment
+  // SEGMENT:   memref.alloc() : memref<64xbf16, 1 : i32>
+  // SEGMENT:   air.herd
+  // SEGMENT:     memref.subview %{{.*}}[0] [32] [1] : memref<64xbf16, 1 : i32> to memref<32xbf16, strided<[1]>, 1 : i32>
+
+  func.func @func_subview_type_propagation() {
+    air.launch () in () {
+      air.segment @seg {
+        %c1 = arith.constant 1 : index
+        %buf = memref.alloc() : memref<64xbf16, 3>
+        air.herd @herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%h0=%buf) : memref<64xbf16, 3> {
+          %local = memref.alloc() : memref<32xbf16, 3>
+          %sv = memref.subview %h0[0] [32] [1] : memref<64xbf16, 3> to memref<32xbf16, strided<[1]>, 3>
+          memref.copy %sv, %local : memref<32xbf16, strided<[1]>, 3> to memref<32xbf16, 3>
+          memref.dealloc %local : memref<32xbf16, 3>
+        }
+        memref.dealloc %buf : memref<64xbf16, 3>
+      }
+    }
+    return
+  }
 }


### PR DESCRIPTION
## Summary
- Propagate changed alloc types through AIR hierarchy block arguments (herd/segment/launch) after the alloc override pattern runs
- Add regression test with `memref.subview` inside herd that depends on a segment-level alloc

## Problem
When `air-override-memref-memory-space` changes an alloc outside a herd (e.g., at segment scope), the herd's operand type updates automatically via SSA replacement, but the herd's body block argument type is NOT updated. This causes `memref.subview` and other ops using the block argument to have a type mismatch — the SSA value has the new memory space but ops retain the old type annotation. This leads to segfaults in aircc.

## Fix
After the alloc override pattern runs (and before the view-like type fix pattern), walk all `air::HerdOp`, `air::SegmentOp`, and `air::LaunchOp` ops and update each kernel block argument's type to match its corresponding operand type via `arg.setType(oper.getType())`.

Fixes #1384

## Test plan
- [x] New `@func_subview_type_propagation` test: segment alloc passed to herd, subview inside herd — both types update correctly with `scope=segment memory-space=1`
- [x] All existing tests preserved
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)