### PR TITLE
Fix convergence and legality issues in air-par-to-launch (#1387)

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1833,9 +1833,10 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       if (!runtimeSeq)
         continue;
       auto resetRef = FlatSymbolRefAttr::get(module.getContext(), resetName);
-      runtimeSeq.walk([&](AIEX::NpuLoadPdiOp op) {
+      auto &origNameRef = origName;
+      runtimeSeq.walk([&origNameRef, &resetRef](AIEX::NpuLoadPdiOp op) {
         if (auto ref = op.getDeviceRefAttr()) {
-          if (ref.getValue() == origName)
+          if (ref.getValue() == origNameRef)
             op.setDeviceRefAttr(resetRef);
         }
       });

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -1608,11 +1608,9 @@ struct ParallelToLaunchPass
     ConversionTarget target(*context);
 
     target.addLegalDialect<LLVM::LLVMDialect, func::FuncDialect,
-                           air::airDialect, arith::ArithDialect>();
-
-    target.addLegalOp<affine::AffineApplyOp, affine::AffineForOp,
-                      affine::AffineLoadOp, affine::AffineStoreOp,
-                      affine::AffineYieldOp, scf::YieldOp>();
+                           air::airDialect, arith::ArithDialect, ub::UBDialect,
+                           affine::AffineDialect, memref::MemRefDialect,
+                           scf::SCFDialect, linalg::LinalgDialect>();
 
     target.addDynamicallyLegalOp<scf::ParallelOp>(
         [&](scf::ParallelOp p) { return !filteredOps.contains(p); });
@@ -1704,11 +1702,9 @@ struct ParallelToSegmentPass
     ConversionTarget target(*context);
 
     target.addLegalDialect<LLVM::LLVMDialect, func::FuncDialect,
-                           air::airDialect, arith::ArithDialect>();
-
-    target.addLegalOp<affine::AffineApplyOp, affine::AffineForOp,
-                      affine::AffineLoadOp, affine::AffineStoreOp,
-                      affine::AffineYieldOp, scf::YieldOp>();
+                           air::airDialect, arith::ArithDialect, ub::UBDialect,
+                           affine::AffineDialect, memref::MemRefDialect,
+                           scf::SCFDialect, linalg::LinalgDialect>();
 
     target.addDynamicallyLegalOp<scf::ParallelOp>(
         [&](scf::ParallelOp p) { return !filteredOps.contains(p); });

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2789,6 +2789,8 @@ struct correctViewLikeOpIOMemorySpacesInScope : public OpRewritePattern<OpTy> {
         rewriter.modifyOpInPlace(viewLike, [&]() { res.setType(builder); });
       }
     }
+    if (viewLikeOpsToRes.empty())
+      return failure();
     return success();
   }
 };

--- a/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_launch_and_segment.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/scf_parallel_to_launch_and_segment.mlir
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt -air-par-to-launch='has-air-segment=true' %s -cse | FileCheck %s
+// RUN: air-opt -air-par-to-launch='has-air-segment=true' %s | FileCheck %s --check-prefix=HERD
 // CHECK-LABEL: func.func @f0
 // CHECK: %[[C0:.*]] = arith.constant 2 : index
 // CHECK: air.launch (%[[V0:.*]], %[[V1:.*]]) in (%[[V2:.*]]=%[[C0]], %[[V3:.*]]=%[[C0]])
@@ -68,5 +69,30 @@ func.func @f3()  {
   }
   memref.dealloc %alloc_0 : memref<1x1x64x128xbf16, 1 : i32>
   memref.dealloc %alloc : memref<1x1x16x8x8x4xbf16, 2 : i32>
+  return
+}
+
+// Test that air-par-to-launch completes when air.herd block arg types
+// have memory space annotations matching their operand types (issue #1387).
+// HERD-LABEL: func.func @f4
+// HERD: air.launch
+// HERD:   air.segment @f4_0
+// HERD:     air.herd @herd
+// HERD:       memref.subview %{{.*}}[0] [32] [1] : memref<64xbf16, 1 : i32> to memref<32xbf16, strided<[1]>, 1 : i32>
+func.func @f4()  {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %alloc = memref.alloc() : memref<64xbf16, 1 : i32>
+  scf.parallel (%x) = (%c0) to (%c2) step (%c1) {
+    air.herd @herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%h0=%alloc) : memref<64xbf16, 1 : i32> {
+      %local = memref.alloc() : memref<32xbf16, 2 : i32>
+      %sv = memref.subview %h0[0] [32] [1] : memref<64xbf16, 1 : i32> to memref<32xbf16, strided<[1]>, 1 : i32>
+      memref.copy %sv, %local : memref<32xbf16, strided<[1]>, 1 : i32> to memref<32xbf16, 2 : i32>
+      memref.dealloc %local : memref<32xbf16, 2 : i32>
+      air.herd_terminator
+    }
+  }
+  memref.dealloc %alloc : memref<64xbf16, 1 : i32>
   return
 }


### PR DESCRIPTION
## Summary
- Fix `correctViewLikeOpIOMemorySpacesInScope` to return `failure()` when no view-like ops have mismatched memory spaces, preventing unnecessary re-application in the greedy rewrite driver
- Add missing dialect legality declarations (`memref`, `scf`, `affine`, `linalg`, `ub`) to `ParallelToLaunchPass` and `ParallelToSegmentPass`, matching the existing `ParallelToHerdPass`
- Fix pre-existing C++17 structured binding capture build error in `AIRRtToNpuPass`
- Add regression test for `air-par-to-launch` with `air.herd` containing memory-space-annotated block args

Fixes #1387

## Test plan
- [x] New test `@f4` in `scf_parallel_to_launch_and_segment.mlir`: `air-par-to-launch` with `air.herd` whose block args have `memref<64xbf16, 1 : i32>` type (matching operand)
- [x] All 310 existing MLIR tests pass (`ninja check-air-mlir`)
- [x] `air_override_memref_memory_space.mlir` tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)