### PR TITLE
[CI] Reduce Ryzen AI board test CI time

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -5,6 +5,7 @@ name: Build mlir-air Wheels
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       AIR_COMMIT:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -9,6 +9,7 @@ on:
       - main
   pull_request:
     types: [assigned, opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/buildAndTestNoRuntime.yml
+++ b/.github/workflows/buildAndTestNoRuntime.yml
@@ -9,6 +9,7 @@ on:
       - main
   pull_request:
     types: [assigned, opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 defaults:
@@ -53,7 +54,6 @@ jobs:
       - name: Get mlir-aie
         id: clone-mlir-aie
         run: |
-
           utils/clone-mlir-aie.sh
           source air-venv/bin/activate
           pushd mlir-aie
@@ -69,38 +69,12 @@ jobs:
 
           popd
 
-      - name: Build and Install mlir-aie
+      - name: Install mlir-aie from wheel
         run: |
           source air-venv/bin/activate
-          pushd mlir-aie
-          mkdir build
-          pushd build
-          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
-          cmake .. \
-            -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPython3_EXECUTABLE=$(which python) \
-            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_ASM_COMPILER=clang \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DLLVM_EXTERNAL_LIT=$(which lit) \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DXRT_ROOT=/opt/xilinx/xrt \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
-            -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON \
-            -DAIE_VITIS_COMPONENTS='AIE2;AIE2P' \
-            -DAIE_INCLUDE_INTEGRATION_TESTS=OFF
-          ninja install
-          popd
-          rm -rf build
-          popd
+          MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
+          pip install mlir_aie==$MLIR_AIE_VERSION \
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/
 
       # TODO: Use nightly latest llvm-aie once it is fixed
       - name: Get llvm-aie
@@ -108,15 +82,14 @@ jobs:
           source air-venv/bin/activate
           python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-19.0.0.2025071101+b3cd09d3-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 
-      # Build the repo test target in debug mode to build and test.
-      - name: Build and test mlir-air (Assert)
+      - name: Build and test mlir-air
         run: |
           source air-venv/bin/activate
 
           export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
           source /opt/xilinx/xrt/setup.sh
           WHL_MLIR_DIR=$(pwd)/mlir-aie/mlir
-          MLIR_AIE_INSTALL_DIR=$(pwd)/mlir-aie/install
+          MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
           PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie
           CMAKEMODULES_DIR=$(pwd)/mlir-aie/cmake/modulesXilinx
 
@@ -127,7 +100,7 @@ jobs:
 
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DPython3_EXECUTABLE=$(which python) \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \
@@ -153,7 +126,7 @@ jobs:
 
           pip install $PWD/../python/spensor
 
-          export LIT_OPTS="-sv --time-tests --show-unsupported --show-excluded --order random --timeout 600 -j4"
+          export LIT_OPTS="-sv --time-tests --show-unsupported --show-excluded --order random --timeout 600 -j8"
           ninja check-air-cpp
           ninja check-air-mlir
           ninja check-air-python
@@ -161,15 +134,15 @@ jobs:
           # E2E test set 1: peano tests (retry once on failure for flaky NPU tests)
           ninja check-air-e2e-peano || ninja check-air-e2e-peano
 
-          # E2E test set 2: chess tests
-          ninja check-air-e2e-chess
+          # Chess tests disabled to reduce CI time. Uncomment to re-enable:
+          # ninja check-air-e2e-chess
 
           # Programming examples set 1: peano tests (retry once on failure for flaky NPU tests)
           ninja check-programming-examples-peano || ninja check-programming-examples-peano
 
-          # Programming examples set 2: chess tests
-          ninja check-programming-examples-chess
-          
+          # Chess tests disabled to reduce CI time. Uncomment to re-enable:
+          # ninja check-programming-examples-chess
+
           # AIR-Runner test set
           ninja check-air-runner
 

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -3,6 +3,7 @@ name: Lint and Format
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
+  merge_group:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Four optimizations to the "Build and Test with AIE tools on Ryzen AI" CI workflow:

- **Install mlir-aie from released wheel** instead of building from source — replaces the cmake + ninja install step with `pip install mlir_aie`, saving build time
- **Switch Debug → RelWithDebInfo** (`-O2` with debug info and assertions) — Debug builds produce unoptimized `air-opt`/`aie-opt` binaries that make transform passes significantly slower
- **Disable chess tests** — Chess tests are the slowest component (~11-31 min per runner), dominated by `xchesscc` compilation. Peano backend provides equivalent coverage. Chess test lines are commented out (not deleted) for easy re-enabling
- **Increase test parallelism to -j8** — With chess tests removed, there is no `xchesscc` license contention, so higher LIT parallelism is safe

## Measured Results

Compared against [baseline run #22889871345](https://github.com/Xilinx/mlir-air/actions/runs/22889871345):

| Runner | Baseline | This PR | Change |
|--------|----------|---------|--------|
| **amd8845hs (NPU1)** | 42m | **9m 38s** | **-77%** |
| **amdhx370 (NPU2)** | 36m | **14m 59s** | **-58%** |

All peano test suites pass with the same test counts as baseline.

## Test plan

- [x] All remaining test suites pass on both runners (amd8845hs, amdhx370)
- [x] Same number of peano tests pass as baseline
- [x] mlir-aie wheel provides required cmake targets
- [x] All other CI workflows (Build and Test, ROCm, wheels, lint, format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)