### PR TITLE
Refactor AIRToAIE codebase to use memory space as Attribute

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -19,9 +19,9 @@ namespace xilinx {
 namespace air {
 
 FailureOr<bool> isTileInbound(air::MemcpyInterface memcpyOp,
-                              int tileMemSpaceAsInt);
+                              air::MemorySpace tileMemSpace);
 FailureOr<bool> isTileOutbound(air::MemcpyInterface memcpyOp,
-                               int tileMemSpaceAsInt);
+                               air::MemorySpace tileMemSpace);
 
 AIE::TileOp getPhysTileOpOrNull(AIE::DeviceOp aie_device, int col, int row);
 
@@ -102,8 +102,8 @@ struct MemcpyBundleAsFlow {
   std::vector<std::vector<Operation *>> S2MM;
   allocation_info_t MM2S_alloc;
   std::vector<Operation *> MM2S; // air::ChannelPuts
-  int MM2S_memspace_as_int;
-  int S2MM_memspace_as_int;
+  air::MemorySpace MM2S_memspace;
+  air::MemorySpace S2MM_memspace;
   int numMM2SAllocs = 0;
   int numS2MMAllocs = 0;
   std::string
@@ -121,8 +121,8 @@ class DMAAllocator {
 
 public:
   DMAAllocator() = delete;
-  DMAAllocator(AIE::DeviceOp device, int dmaMemorySpaceAsInt)
-      : device(device), DMAMemorySpaceAsInt(dmaMemorySpaceAsInt) {}
+  DMAAllocator(AIE::DeviceOp device, air::MemorySpace dmaMemorySpace)
+      : device(device), dmaMemorySpace(dmaMemorySpace) {}
 
   FailureOr<allocation_info_t>
   lookupDMAAllocation(int64_t col, int64_t row, air::MemcpyInterface &memcpyOp);
@@ -136,7 +136,7 @@ public:
 
 protected:
   AIE::DeviceOp device;
-  int DMAMemorySpaceAsInt;
+  air::MemorySpace dmaMemorySpace;
 
 public:
   std::vector<allocation_info_t> mm2s_allocs, s2mm_allocs;
@@ -150,7 +150,7 @@ class TileDMAAllocator : public DMAAllocator {
 
 public:
   TileDMAAllocator(AIE::DeviceOp device)
-      : DMAAllocator(device, (int)air::MemorySpace::L1) {}
+      : DMAAllocator(device, air::MemorySpace::L1) {}
 
   // A very simple scheme to allocate channels for dma operations:
   //  <description>
@@ -217,7 +217,7 @@ public:
   // CascadeAllocator constructor: only core-to-core (L1-level) cascade
   // connection supported.
   CascadeAllocator(AIE::DeviceOp device)
-      : device(device), DMAMemorySpaceAsInt((int)air::MemorySpace::L1) {}
+      : device(device), dmaMemorySpace(air::MemorySpace::L1) {}
   FailureOr<allocation_info_t> coreCascadeAlloc(air::MemcpyInterface &memcpyOp);
   FailureOr<allocation_info_t> allocNewCascade(air::MemcpyInterface &memcpyOp,
                                                AIE::TileOp tile);
@@ -227,7 +227,7 @@ public:
 
 protected:
   AIE::DeviceOp device;
-  int DMAMemorySpaceAsInt;
+  air::MemorySpace dmaMemorySpace;
 
 public:
   std::vector<allocation_info_t> cascade_put_allocs, cascade_get_allocs;

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -23,6 +23,33 @@ using namespace mlir;
 namespace xilinx {
 namespace air {
 
+// ===----------------------------------------------------------------------===//
+// Memory space helpers
+// ===----------------------------------------------------------------------===//
+
+// Get the memory space of a memref type as an air::MemorySpace enum.
+// If the memref has no memory space attribute, this function defaults to the
+// L3 memory space. Returns std::nullopt only if the memref has an
+// unrecognized/unsupported memory space value.
+std::optional<MemorySpace> getMemorySpace(BaseMemRefType memrefTy);
+
+// Check if a memref type belongs to a specific memory space.
+bool isL1(BaseMemRefType memrefTy);
+bool isL2(BaseMemRefType memrefTy);
+bool isL3(BaseMemRefType memrefTy);
+
+// Compare memory space hierarchy levels. Higher numeric value = more local.
+// L3(0) < L2(1) < L1(2).
+// Returns true if space 'a' is strictly more local (closer to compute) than
+// 'b'.
+bool isMoreLocal(MemorySpace a, MemorySpace b);
+
+// Return the more local of two memory spaces.
+// E.g., moreLocal(L3, L1) returns L1.
+MemorySpace moreLocal(MemorySpace a, MemorySpace b);
+
+// ===----------------------------------------------------------------------===//
+
 LogicalResult normalizeLoop(affine::AffineForOp afo);
 
 func::FuncOp getMangledFunction(ModuleOp module, std::string fnName,

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -184,7 +184,7 @@ public:
         // clone L3 get/put
         BaseMemRefType memrefTy =
             llvm::cast<BaseMemRefType>(chanOp.getMemref().getType());
-        if (memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) {
+        if (air::isL3(memrefTy)) {
           rewriter.clone(o, remap);
           continue;
         }
@@ -361,23 +361,17 @@ public:
         llvm::cast<BaseMemRefType>(op.getDstMemref().getType());
     bool isFromTile = false;
     bool isFullMemcpy = false;
-    if (src.getMemorySpaceAsInt() == (int)air::MemorySpace::L1 &&
-        dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) {
+    if (air::isL1(src) && air::isL3(dst)) {
       isFromTile = true;
-    } else if (dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L1 &&
-               src.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) {
+    } else if (air::isL1(dst) && air::isL3(src)) {
       isFromTile = false;
-    } else if (src.getMemorySpaceAsInt() == (int)air::MemorySpace::L1 &&
-               dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    } else if (air::isL1(src) && air::isL2(dst)) {
       isFromTile = true;
-    } else if (dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L1 &&
-               src.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    } else if (air::isL1(dst) && air::isL2(src)) {
       isFromTile = false;
-    } else if (src.getMemorySpaceAsInt() == (int)air::MemorySpace::L3 &&
-               dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    } else if (air::isL3(src) && air::isL2(dst)) {
       isFullMemcpy = true;
-    } else if (dst.getMemorySpaceAsInt() == (int)air::MemorySpace::L3 &&
-               src.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    } else if (air::isL3(dst) && air::isL2(src)) {
       isFromTile = true;
       isFullMemcpy = true;
     } else
@@ -489,8 +483,7 @@ AIRChannelInterfaceToAIRRtConversionImpl(OpBuilder builder,
   BaseMemRefType thisMemrefType =
       llvm::cast<BaseMemRefType>(thisOp.getMemref().getType());
 
-  bool thisOpIsInShim =
-      thisMemrefType.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L3;
+  bool thisOpIsInShim = xilinx::air::isL3(thisMemrefType);
   if (!thisOpIsInShim)
     return nullptr;
 
@@ -714,7 +707,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto alloc = cast<memref::AllocOp>(op);
     auto type = alloc.getType();
-    if (type.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    if (air::isL2(type)) {
       rewriter.replaceOpWithNewOp<airrt::AllocOp>(op, type);
       return success();
     }
@@ -732,7 +725,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto dealloc = cast<memref::DeallocOp>(op);
     auto type = llvm::cast<BaseMemRefType>(dealloc.getMemref().getType());
-    if (type.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    if (air::isL2(type)) {
       rewriter.replaceOpWithNewOp<airrt::DeallocOp>(op, SmallVector<Type>{},
                                                     op->getOperands());
       return success();
@@ -1117,13 +1110,11 @@ public:
     // DMA and HerdOp conversion
     RewritePatternSet air_patterns(context);
 
-    target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
-      return (op.getType().getMemorySpaceAsInt() != (int)air::MemorySpace::L2);
-    });
+    target.addDynamicallyLegalOp<memref::AllocOp>(
+        [&](memref::AllocOp op) { return !air::isL2(op.getType()); });
 
     target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
-      return (llvm::cast<BaseMemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() != (int)air::MemorySpace::L2);
+      return !air::isL2(llvm::cast<BaseMemRefType>(op.getMemref().getType()));
     });
 
     target.addDynamicallyLegalOp<scf::ForOp>([&](scf::ForOp op) {

--- a/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToLLVMPass.cpp
@@ -736,7 +736,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = op.getType();
-    if (op.getType().getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(op.getType()))
       return failure();
 
     auto alloc = memref::AllocOp::create(
@@ -757,7 +757,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     memref::DeallocOp::create(rewriter, op.getLoc(), adaptor.getMemref());
@@ -776,7 +776,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     rewriter.eraseOp(op);
@@ -793,7 +793,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     auto load =
@@ -813,7 +813,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     rewriter.eraseOp(op);
@@ -831,7 +831,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     auto load = affine::AffineLoadOp::create(
@@ -856,7 +856,7 @@ public:
     auto ctx = op->getContext();
 
     auto memrefTy = llvm::cast<MemRefType>(op.getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L2)
+    if (!xilinx::air::isL2(memrefTy))
       return failure();
 
     tys.push_back(IndexType::get(ctx));
@@ -908,7 +908,7 @@ public:
     auto ctx = op->getContext();
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L2)
+    if (!xilinx::air::isL2(memrefTy))
       return failure();
 
     tys.push_back(MemRefType::get(
@@ -1172,7 +1172,7 @@ public:
     converter.addConversion([&](Type type) -> std::optional<Type> {
       // convert L1 memrefs to L3
       if (auto memref = llvm::dyn_cast_if_present<MemRefType>(type))
-        if (memref.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
+        if (xilinx::air::isL1(memref))
           return mlir::MemRefType::get(memref.getShape(),
                                        memref.getElementType(),
                                        memref.getLayout(), 0);
@@ -1211,37 +1211,34 @@ public:
                            arith::ArithDialect, affine::AffineDialect,
                            scf::SCFDialect, memref::MemRefDialect>();
 
-    target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
-      return (op.getType().getMemorySpaceAsInt() == 0);
-    });
+    target.addDynamicallyLegalOp<memref::AllocOp>(
+        [&](memref::AllocOp op) { return xilinx::air::isL3(op.getType()); });
 
     target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
-      return (llvm::cast<MemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() == 0);
+      return xilinx::air::isL3(
+          llvm::cast<MemRefType>(op.getMemref().getType()));
     });
 
     target.addDynamicallyLegalOp<affine::AffineStoreOp>(
         [&](affine::AffineStoreOp op) {
-          return (llvm::cast<MemRefType>(op.getMemref().getType())
-                      .getMemorySpaceAsInt() !=
-                  (int)xilinx::air::MemorySpace::L1);
+          return !xilinx::air::isL1(
+              llvm::cast<MemRefType>(op.getMemref().getType()));
         });
 
     target.addDynamicallyLegalOp<affine::AffineLoadOp>(
         [&](affine::AffineLoadOp op) {
-          return (llvm::cast<MemRefType>(op.getMemref().getType())
-                      .getMemorySpaceAsInt() !=
-                  (int)xilinx::air::MemorySpace::L1);
+          return !xilinx::air::isL1(
+              llvm::cast<MemRefType>(op.getMemref().getType()));
         });
 
     target.addDynamicallyLegalOp<memref::StoreOp>([&](memref::StoreOp op) {
-      return (llvm::cast<MemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1);
+      return !xilinx::air::isL1(
+          llvm::cast<MemRefType>(op.getMemref().getType()));
     });
 
     target.addDynamicallyLegalOp<memref::LoadOp>([&](memref::LoadOp op) {
-      return (llvm::cast<MemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1);
+      return !xilinx::air::isL1(
+          llvm::cast<MemRefType>(op.getMemref().getType()));
     });
 
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
@@ -1251,12 +1248,12 @@ public:
     target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {
       for (auto t : op.getOperandTypes()) {
         if (auto mty = llvm::dyn_cast_if_present<MemRefType>(t))
-          if (mty.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
+          if (xilinx::air::isL1(mty))
             return false;
       }
       for (auto t : op.getResultTypes()) {
         if (auto mty = llvm::dyn_cast_if_present<MemRefType>(t))
-          if (mty.getMemorySpaceAsInt() == (int)xilinx::air::MemorySpace::L1)
+          if (xilinx::air::isL1(mty))
             return false;
       }
       return true;

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -60,7 +60,7 @@ namespace {
 // Helper function to check if a value is a memref on host memory (space 0)
 static bool isHostMemory(Value val) {
   if (auto memrefType = dyn_cast_if_present<BaseMemRefType>(val.getType()))
-    return memrefType.getMemorySpaceAsInt() == 0;
+    return xilinx::air::isL3(memrefType);
   return false;
 }
 
@@ -665,7 +665,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<BaseMemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     rewriter.eraseOp(op);
@@ -682,7 +682,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<BaseMemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1)
+    if (!xilinx::air::isL1(memrefTy))
       return failure();
 
     rewriter.eraseOp(op);
@@ -1439,15 +1439,14 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
         [&](affine::AffineStoreOp op) {
           if (op->getParentOfType<AIE::CoreOp>())
             return true;
-          return (llvm::cast<BaseMemRefType>(op.getMemref().getType())
-                      .getMemorySpaceAsInt() !=
-                  (int)xilinx::air::MemorySpace::L1);
+          return !xilinx::air::isL1(
+              llvm::cast<BaseMemRefType>(op.getMemref().getType()));
         });
     target.addDynamicallyLegalOp<memref::StoreOp>([&](memref::StoreOp op) {
       if (op->getParentOfType<AIE::CoreOp>())
         return true;
-      return (llvm::cast<BaseMemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() != (int)xilinx::air::MemorySpace::L1);
+      return !xilinx::air::isL1(
+          llvm::cast<BaseMemRefType>(op.getMemref().getType()));
     });
     target.addDynamicallyLegalOp<memref::CopyOp>([&](memref::CopyOp op) {
       auto f = op->getParentOfType<func::FuncOp>();

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -129,8 +129,10 @@ struct ShimTileAllocator {
     }
   }
 
-  AIE::TileOp getShimTile(AIE::DeviceOp aie_device, int src_memory_space,
-                          int dst_memory_space, std::string chan_name) {
+  AIE::TileOp getShimTile(AIE::DeviceOp aie_device,
+                          air::MemorySpace src_memory_space,
+                          air::MemorySpace dst_memory_space,
+                          std::string chan_name) {
     bool isMM2S = (src_memory_space < dst_memory_space);
     auto allocs = isMM2S ? &mm2s_allocs : &s2mm_allocs;
 
@@ -457,7 +459,7 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
         if (!memrefTy)
           continue;
 
-        if (memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L1) {
+        if (air::isL1(memrefTy)) {
           // fused herds sometimes have L1 memref allocation outside of herds.
           // mapping them back
           remap.map(karg, h.getKernelOperand(ki));
@@ -1225,7 +1227,7 @@ void createAIEModulesAndOutlineCores(
       auto memrefTy = llvm::dyn_cast_if_present<MemRefType>(oper.getType());
       if (!memrefTy)
         continue;
-      if (memrefTy.getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+      if (!air::isL1(memrefTy))
         continue;
       push_back_if_unique<Value>(sharedL1Memrefs, oper);
     }
@@ -1256,7 +1258,7 @@ void createAIEModulesAndOutlineCores(
       auto memrefTy = llvm::dyn_cast_if_present<MemRefType>(oper.getType());
       if (!memrefTy)
         continue;
-      if (memrefTy.getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+      if (!air::isL1(memrefTy))
         continue;
       sharedL1AllocsToHerdMap[oper.getDefiningOp()].insert(h);
     }
@@ -1744,7 +1746,7 @@ struct AllocL1BuffersPattern : public OpRewritePattern<memref::AllocOp> {
     MemRefType memrefTy = nullptr;
     memrefTy = alloc.getType();
 
-    if (memrefTy.getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+    if (!air::isL1(memrefTy))
       return failure();
 
     auto herd = tileToHerdMap[tile];
@@ -1795,7 +1797,7 @@ struct AllocL2BuffersPattern : public OpRewritePattern<memref::AllocOp> {
     MemRefType memrefTy = nullptr;
     memrefTy = alloc.getType();
 
-    if (memrefTy.getMemorySpaceAsInt() != (int)air::MemorySpace::L2)
+    if (!air::isL2(memrefTy))
       return failure();
 
     // Allocation of L2 memrefs in segment to buffer ops
@@ -1872,8 +1874,7 @@ void L2MemrefToMemTileMap(
     std::map<memref::AllocOp, AIE::TileOp> &memrefToMemTileMap) {
   std::vector<memref::AllocOp> allocs;
   m.walk([&](memref::AllocOp alloc) {
-    if (llvm::cast<MemRefType>(alloc.getMemref().getType())
-            .getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+    if (air::isL2(llvm::cast<MemRefType>(alloc.getMemref().getType()))) {
       allocs.push_back(alloc);
     }
   });
@@ -1997,8 +1998,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
       // check if this put is linked to a get from another channel
       BaseMemRefType memref =
           llvm::cast<BaseMemRefType>(channelPuts[0].getMemref().getType());
-      int mem_space = memref.getMemorySpaceAsInt();
-      if (mem_space == (int)air::MemorySpace::L2) {
+      if (air::isL2(memref)) {
         if (linksToComplete.find(channelPuts[0].getOperation()) !=
             linksToComplete.end()) {
           endOfLink = channelPuts[0].getOperation();
@@ -2016,9 +2016,9 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
       }
     } else {
       // put from L3
-      producerTile = shimTileAlloc.getShimTile(
-          device, (int)air::MemorySpace::L3, (int)air::MemorySpace::L1,
-          channel.getName().str());
+      producerTile = shimTileAlloc.getShimTile(device, air::MemorySpace::L3,
+                                               air::MemorySpace::L1,
+                                               channel.getName().str());
     }
 
     // put/get come in pairs, if one is missing then it's L3
@@ -2038,8 +2038,7 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
       // check if this get is linked to a put from another channel
       BaseMemRefType memref =
           llvm::cast<BaseMemRefType>(get.getMemref().getType());
-      int mem_space = memref.getMemorySpaceAsInt();
-      if (mem_space == (int)air::MemorySpace::L2) {
+      if (air::isL2(memref)) {
         if (linksToComplete.find(get.getOperation()) != linksToComplete.end()) {
           endOfLink = get.getOperation();
           linkFound = true;
@@ -2057,9 +2056,9 @@ struct LowerAIRChannelsPattern : public OpRewritePattern<air::ChannelOp> {
     }
     for (int i = 0; i < expectedGets - (int)channelGets.size(); i++) {
       // get from L3
-      consumerTile = shimTileAlloc.getShimTile(
-          device, (int)air::MemorySpace::L1, (int)air::MemorySpace::L3,
-          channel.getName().str());
+      consumerTile = shimTileAlloc.getShimTile(device, air::MemorySpace::L1,
+                                               air::MemorySpace::L3,
+                                               channel.getName().str());
       consumers.push_back(consumerTile);
     }
 
@@ -2150,16 +2149,16 @@ private:
   LogicalResult findChannelPutGetTile(MyOp op, Value *tile,
                                       AIE::AIEObjectFifoType *datatype) const {
     MemRefType memref = llvm::cast<MemRefType>(op.getMemref().getType());
-    int mem_space = memref.getMemorySpaceAsInt();
+    auto mem_space = air::getMemorySpace(memref);
     *datatype = AIE::AIEObjectFifoType::get(
         MemRefType::get(memref.getShape(), memref.getElementType()));
-    if (mem_space == (int)air::MemorySpace::L1) {
+    if (mem_space == air::MemorySpace::L1) {
       AIE::CoreOp core = op->template getParentOfType<AIE::CoreOp>();
       if (!core)
         return op.emitOpError("could not retrieve core for channel put/get op");
       *tile = core.getTileOp();
       return success();
-    } else if (mem_space == (int)air::MemorySpace::L2) {
+    } else if (mem_space == air::MemorySpace::L2) {
       if (bufferToMemtileMap.find(dyn_cast_if_present<AIE::BufferOp>(
               op.getMemref().getDefiningOp())) != bufferToMemtileMap.end()) {
         *tile = bufferToMemtileMap[dyn_cast_if_present<AIE::BufferOp>(
@@ -2202,8 +2201,7 @@ private:
                        AIE::ObjectFifoPort port,
                        llvm::SmallSet<Operation *, 2> &erased_allocs) const {
     BaseMemRefType memref = cast<BaseMemRefType>(op.getMemref().getType());
-    int mem_space = memref.getMemorySpaceAsInt();
-    if (mem_space == (int)air::MemorySpace::L2) {
+    if (air::isL2(memref)) {
       // add alloc to list of ops to erase
       erased_allocs.insert(op.getMemref().getDefiningOp());
       return;
@@ -2239,8 +2237,7 @@ private:
       llvm::SmallSet<Operation *, 2> &erased_deallocs) const {
     BaseMemRefType memref =
         llvm::cast<BaseMemRefType>(op.getMemref().getType());
-    int mem_space = memref.getMemorySpaceAsInt();
-    if (mem_space == (int)air::MemorySpace::L2) {
+    if (air::isL2(memref)) {
       return;
     }
     for (auto u : op.getMemref().getDefiningOp()->getUsers()) {
@@ -2604,8 +2601,7 @@ struct OpRemovalPattern : public OpConversionPattern<OpT> {
 static bool isL1ToL1CopyInCore(MemRefType srcType, MemRefType dstType,
                                Operation *op) {
   // Only handle L1-to-L1 copies (memory space 2)
-  if (srcType.getMemorySpaceAsInt() != (int)air::MemorySpace::L1 ||
-      dstType.getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+  if (!air::isL1(srcType) || !air::isL1(dstType))
     return false;
 
   // Only handle copies inside AIE cores
@@ -3013,14 +3009,12 @@ public:
     bool destIsShim = false;
     if (auto srcMemref = memcpyOp.getSrcMemref()) {
       auto memrefTy = dyn_cast_if_present<BaseMemRefType>(srcMemref.getType());
-      if (memrefTy &&
-          memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+      if (memrefTy && air::isL3(memrefTy))
         destIsShim = true;
     }
     if (auto dstMemref = memcpyOp.getDstMemref()) {
       auto memrefTy = dyn_cast_if_present<BaseMemRefType>(dstMemref.getType());
-      if (memrefTy &&
-          memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+      if (memrefTy && air::isL3(memrefTy))
         destIsShim = true;
     }
 
@@ -3188,8 +3182,7 @@ public:
         [&](air::ChannelInterface chanI) {
           auto memrefTy =
               dyn_cast_if_present<BaseMemRefType>(chanI.getMemref().getType());
-          if (!memrefTy || memrefTy.getMemorySpaceAsInt() !=
-                               static_cast<int>(air::MemorySpace::L2))
+          if (!memrefTy || !air::isL2(memrefTy))
             return mlir::WalkResult::advance();
 
           if (auto chanPut =
@@ -3343,7 +3336,7 @@ public:
           auto memrefTy = dyn_cast_if_present<MemRefType>(operand.getType());
           if (!memrefTy)
             continue;
-          if (memrefTy.getMemorySpaceAsInt() != (int)air::MemorySpace::L3)
+          if (!air::isL3(memrefTy))
             continue;
           // Skip if already handled
           if (l3MemrefsHandled.contains(operand))
@@ -3608,7 +3601,7 @@ public:
     d.walk([&](memref::AllocOp allocOp) {
       auto memref = allocOp.getMemref();
       auto memrefTy = llvm::cast<MemRefType>(memref.getType());
-      if (memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+      if (air::isL2(memrefTy)) {
         // Count the number of unique incoming and outgoing channels.
         std::vector<std::string> uniqueS2MMChannels;
         std::vector<std::string> uniqueMM2SChannels;
@@ -4078,9 +4071,9 @@ public:
             dyn_cast_if_present<BaseMemRefType>(dmaOp.getSrcMemref().getType());
         auto dstMemrefTy =
             dyn_cast_if_present<BaseMemRefType>(dmaOp.getDstMemref().getType());
-        if (srcMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+        if (air::isL3(srcMemrefTy))
           shimMemcpyMM2SOps.push_back(memcpyIf);
-        if (dstMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+        if (air::isL3(dstMemrefTy))
           shimMemcpyS2MMOps.push_back(memcpyIf);
       }
     }
@@ -4455,7 +4448,7 @@ public:
     int64_t lockAqValue = -1;
     int64_t lockRelValue = -1;
     Value alloc = nullptr;
-    auto tileInbound = isTileInbound(memcpyOpIf, (int)air::MemorySpace::L1);
+    auto tileInbound = isTileInbound(memcpyOpIf, air::MemorySpace::L1);
     if (failed(tileInbound))
       return failure();
     if (tileInbound.value()) {
@@ -4685,22 +4678,22 @@ public:
     }
     auto ndcpy = cast<air::MemcpyInterface>(memcpyOp);
 
-    if (failed(isTileInbound(ndcpy, (int)air::MemorySpace::L1)))
+    if (failed(isTileInbound(ndcpy, air::MemorySpace::L1)))
       return failure();
 
-    Value memref = isTileInbound(ndcpy, (int)air::MemorySpace::L1).value()
+    Value memref = isTileInbound(ndcpy, air::MemorySpace::L1).value()
                        ? ndcpy.getDstMemref()
                        : ndcpy.getSrcMemref();
     SmallVector<Value> sizes =
-        isTileInbound(ndcpy, (int)air::MemorySpace::L1).value()
+        isTileInbound(ndcpy, air::MemorySpace::L1).value()
             ? ndcpy.getDstSizes()
             : ndcpy.getSrcSizes();
     SmallVector<Value> offsets =
-        isTileInbound(ndcpy, (int)air::MemorySpace::L1).value()
+        isTileInbound(ndcpy, air::MemorySpace::L1).value()
             ? ndcpy.getDstOffsets()
             : ndcpy.getSrcOffsets();
     SmallVector<Value> strides =
-        isTileInbound(ndcpy, (int)air::MemorySpace::L1).value()
+        isTileInbound(ndcpy, air::MemorySpace::L1).value()
             ? ndcpy.getDstStrides()
             : ndcpy.getSrcStrides();
 
@@ -5659,8 +5652,7 @@ public:
             return;
           auto memrefTy =
               dyn_cast_if_present<BaseMemRefType>(o.getMemref().getType());
-          if (memrefTy &&
-              memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+          if (memrefTy && air::isL3(memrefTy))
             shimMemcpyIfOps.push_back(
                 dyn_cast_if_present<air::MemcpyInterface>(o.getOperation()));
         });
@@ -5671,13 +5663,11 @@ public:
             return;
           auto srcMemrefTy =
               dyn_cast_if_present<BaseMemRefType>(o.getSrcMemref().getType());
-          if (srcMemrefTy &&
-              srcMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+          if (srcMemrefTy && air::isL3(srcMemrefTy))
             shimMemcpyIfOps.push_back(o);
           auto dstMemrefTy =
               dyn_cast_if_present<BaseMemRefType>(o.getDstMemref().getType());
-          if (dstMemrefTy &&
-              dstMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+          if (dstMemrefTy && air::isL3(dstMemrefTy))
             shimMemcpyIfOps.push_back(o);
         });
         builder.setInsertionPoint(device.getBody()->getTerminator());

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -23,17 +23,15 @@ using namespace mlir;
 namespace xilinx {
 
 FailureOr<bool> air::isTileInbound(air::MemcpyInterface memcpyOp,
-                                   int tileMemSpaceAsInt) {
+                                   air::MemorySpace tileMemSpace) {
   if (memcpyOp.getSrcMemref() && memcpyOp.getDstMemref()) {
-    int src_memory_space =
-        llvm::cast<BaseMemRefType>(memcpyOp.getSrcMemref().getType())
-            .getMemorySpaceAsInt();
-    int dst_memory_space =
-        llvm::cast<BaseMemRefType>(memcpyOp.getDstMemref().getType())
-            .getMemorySpaceAsInt();
-    if (src_memory_space == tileMemSpaceAsInt)
+    auto src_memory_space = air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(memcpyOp.getSrcMemref().getType()));
+    auto dst_memory_space = air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(memcpyOp.getDstMemref().getType()));
+    if (src_memory_space && *src_memory_space == tileMemSpace)
       return false;
-    else if (dst_memory_space == tileMemSpaceAsInt)
+    else if (dst_memory_space && *dst_memory_space == tileMemSpace)
       return true;
     memcpyOp->emitOpError(
         "neither src nor dst use the tile's memory space, indicating a "
@@ -45,8 +43,8 @@ FailureOr<bool> air::isTileInbound(air::MemcpyInterface memcpyOp,
     return false;
 }
 FailureOr<bool> air::isTileOutbound(air::MemcpyInterface memcpyOp,
-                                    int tileMemSpaceAsInt) {
-  auto isTileInbRes = isTileInbound(memcpyOp, tileMemSpaceAsInt);
+                                    air::MemorySpace tileMemSpace) {
+  auto isTileInbRes = isTileInbound(memcpyOp, tileMemSpace);
   if (failed(isTileInbRes))
     return failure();
   return !(*isTileInbRes);
@@ -611,7 +609,7 @@ FailureOr<air::allocation_info_t>
 air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
                                        air::MemcpyInterface &memcpyOp) {
 
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -773,7 +771,7 @@ FailureOr<air::allocation_info_t> air::DMAAllocator::allocNewDmaChannel(
     return memcpyOp.emitOpError("failed to get the AIE tile. This indicates a "
                                 "potential error in the compilation flow.");
   }
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -821,7 +819,7 @@ void air::DMAAllocator::sortMemcpyOps(std::vector<Operation *> dma_memcpy_ops) {
 FailureOr<air::allocation_info_t>
 air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                                              int col, int row, int chan = -1) {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -870,11 +868,11 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
 FailureOr<AIE::BufferOp>
 air::TileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
                                  air::MemcpyInterface &memcpyOp) {
-  if (failed(isTileInbound(memcpyOp, DMAMemorySpaceAsInt)))
+  auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
+  if (failed(isInbound))
     return failure();
-  Value buffer = isTileInbound(memcpyOp, DMAMemorySpaceAsInt).value()
-                     ? (memcpyOp.getDstMemref())
-                     : (memcpyOp.getSrcMemref());
+  Value buffer =
+      isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
   auto bufferOp = getUnderlyingBufferOp(buffer);
   if (!bufferOp)
     return failure();
@@ -884,7 +882,7 @@ air::TileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
 // ShimDMAAllocator impl.
 
 air::ShimDMAAllocator::ShimDMAAllocator(AIE::DeviceOp device)
-    : air::DMAAllocator(device, (int)air::MemorySpace::L3) {
+    : air::DMAAllocator(device, air::MemorySpace::L3) {
   const auto &aie_target = device.getTargetModel();
   shim_dma_channels = 2;
   for (int i = 0, e = aie_target.columns(); i < e; i++) {
@@ -897,7 +895,7 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
     air::MemcpyInterface &memcpyOp, int col, int row,
     std::vector<Operation *> &dma_ops,
     std::string colAllocConstraint = "same_column") {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -963,7 +961,7 @@ FailureOr<air::allocation_info_t>
 air::ShimDMAAllocator::allocNewDmaChannel(air::MemcpyInterface &memcpyOp,
                                           air::allocation_info_t existing_alloc,
                                           std::vector<Operation *> &dma_ops) {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -993,7 +991,7 @@ air::ShimDMAAllocator::allocNewDmaChannel(air::MemcpyInterface &memcpyOp,
 FailureOr<AIE::ExternalBufferOp>
 air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
                                  air::MemcpyInterface &memcpyOp) {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   // Allocate external buffers
@@ -1001,9 +999,8 @@ air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
       (isMM2S.value()) ? (memcpyOp.getSrcMemref()) : (memcpyOp.getDstMemref());
   MemRefType memrefTy = llvm::cast<MemRefType>(memref.getType());
   // External buffers have memory space L3
-  mlir::IntegerType i32Ty = mlir::IntegerType::get(memcpyOp->getContext(), 32);
   mlir::Attribute memSpaceAttr =
-      mlir::IntegerAttr::get(i32Ty, DMAMemorySpaceAsInt);
+      air::MemorySpaceAttr::get(memcpyOp->getContext(), dmaMemorySpace);
   memrefTy = MemRefType::get(memrefTy.getShape(), memrefTy.getElementType(),
                              AffineMap(), memSpaceAttr);
   AIE::ExternalBufferOp bufferOp = allocateExternalBufferOp(
@@ -1055,7 +1052,7 @@ air::ShimDMAAllocator::foundFlowReuseOpportunity(
 namespace xilinx {
 
 air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
-    : air::DMAAllocator(device, (int)air::MemorySpace::L2) {
+    : air::DMAAllocator(device, air::MemorySpace::L2) {
   const auto &aie_target = device.getTargetModel();
   for (int i = 0, e = aie_target.columns(); i < e; i++) {
     memtile_dma_columns.push_back(i);
@@ -1065,7 +1062,7 @@ air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
 FailureOr<air::allocation_info_t>
 air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                                                 int chan = -1) {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -1117,7 +1114,7 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
 FailureOr<air::allocation_info_t>
 air::MemTileDMAAllocator::simpleDmaChannelAlloc(
     air::MemcpyInterface &memcpyOp, air::allocation_info_t &existing_alloc) {
-  auto isMM2S = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
@@ -1181,11 +1178,11 @@ air::MemTileDMAAllocator::foundFlowReuseOpportunity(
 FailureOr<AIE::BufferOp>
 air::MemTileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
                                     air::MemcpyInterface &memcpyOp) {
-  if (failed(isTileInbound(memcpyOp, DMAMemorySpaceAsInt)))
+  auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
+  if (failed(isInbound))
     return failure();
-  Value buffer = isTileInbound(memcpyOp, DMAMemorySpaceAsInt).value()
-                     ? (memcpyOp.getDstMemref())
-                     : (memcpyOp.getSrcMemref());
+  Value buffer =
+      isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
   auto bufferOp = getUnderlyingBufferOp(buffer);
   if (!bufferOp)
     return failure();
@@ -1198,7 +1195,7 @@ air::MemTileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
 FailureOr<air::allocation_info_t>
 air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
   // Determine if the operation is a cascade put (outbound)
-  auto isCascadePut = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isCascadePut = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isCascadePut))
     return failure();
 
@@ -1237,7 +1234,7 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
   }
 
   // Determine if this is a cascade put or get
-  auto isCascadePut = isTileOutbound(memcpyOp, DMAMemorySpaceAsInt);
+  auto isCascadePut = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isCascadePut))
     return failure();
   auto allocs =
@@ -1275,13 +1272,13 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 FailureOr<AIE::BufferOp>
 air::CascadeAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
                                  air::MemcpyInterface &memcpyOp) {
-  if (failed(isTileInbound(memcpyOp, DMAMemorySpaceAsInt)))
+  auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
+  if (failed(isInbound))
     return failure();
 
   // Select source or destination buffer depending on inbound/outbound
-  Value buffer = isTileInbound(memcpyOp, DMAMemorySpaceAsInt).value()
-                     ? (memcpyOp.getDstMemref())
-                     : (memcpyOp.getSrcMemref());
+  Value buffer =
+      isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
 
   // Resolve the actual underlying buffer op
   auto bufferOp = getUnderlyingBufferOp(buffer);
@@ -1296,13 +1293,15 @@ LogicalResult
 air::MemcpyBundleAsFlow::pushBackMemcpyOpToBundle(air::DmaMemcpyNdOp memcpyOp) {
   // air::DmaMemcpyNdOp is a complete memcpy with both src and dst
   S2MM[0].push_back(memcpyOp.getOperation());
-  S2MM_memspace_as_int =
-      llvm::cast<BaseMemRefType>(memcpyOp.getDstMemref().getType())
-          .getMemorySpaceAsInt();
+  auto dstMS = air::getMemorySpace(
+      llvm::cast<BaseMemRefType>(memcpyOp.getDstMemref().getType()));
+  auto srcMS = air::getMemorySpace(
+      llvm::cast<BaseMemRefType>(memcpyOp.getSrcMemref().getType()));
+  if (!dstMS || !srcMS)
+    return memcpyOp->emitOpError("unrecognized memory space on memref");
+  S2MM_memspace = *dstMS;
   MM2S.push_back(memcpyOp.getOperation());
-  MM2S_memspace_as_int =
-      llvm::cast<BaseMemRefType>(memcpyOp.getSrcMemref().getType())
-          .getMemorySpaceAsInt();
+  MM2S_memspace = *srcMS;
   memcpyResourceType = "dma_stream";
   return success();
 }
@@ -1335,9 +1334,11 @@ air::MemcpyBundleAsFlow::pushBackMemcpyOpToBundle(air::ChannelGetOp memcpyOp) {
   }
   air_flow_op = chan.getOperation();
   S2MM[alloc_id].push_back(memcpyOp.getOperation());
-  S2MM_memspace_as_int =
-      llvm::cast<BaseMemRefType>(memcpyOp.getMemref().getType())
-          .getMemorySpaceAsInt();
+  auto getMS = air::getMemorySpace(
+      llvm::cast<BaseMemRefType>(memcpyOp.getMemref().getType()));
+  if (!getMS)
+    return memcpyOp->emitOpError("unrecognized memory space on memref");
+  S2MM_memspace = *getMS;
   memcpyResourceType = chan.getChannelType().str();
   return success();
 }
@@ -1347,9 +1348,11 @@ air::MemcpyBundleAsFlow::pushBackMemcpyOpToBundle(air::ChannelPutOp memcpyOp) {
   auto chan = air::getChannelDeclarationThroughSymbol(memcpyOp);
   air_flow_op = chan.getOperation();
   MM2S.push_back(memcpyOp.getOperation());
-  MM2S_memspace_as_int =
-      llvm::cast<BaseMemRefType>(memcpyOp.getMemref().getType())
-          .getMemorySpaceAsInt();
+  auto putMS = air::getMemorySpace(
+      llvm::cast<BaseMemRefType>(memcpyOp.getMemref().getType()));
+  if (!putMS)
+    return memcpyOp->emitOpError("unrecognized memory space on memref");
+  MM2S_memspace = *putMS;
   memcpyResourceType = chan.getChannelType().str();
   return success();
 }
@@ -1410,7 +1413,7 @@ LogicalResult air::simpleDMAChannelAllocation(
     TileDMAAllocator &tile_dma_alloc,
     air::CascadeAllocator &core_cascade_alloc) {
   for (auto &f : memcpy_flows) {
-    if (f.MM2S_memspace_as_int == (int)air::MemorySpace::L1) {
+    if (f.MM2S_memspace == air::MemorySpace::L1) {
       for (auto o : f.MM2S) {
         auto memcpyOpIf = cast<air::MemcpyInterface>(o);
         auto core = memcpyOpIf->getParentOfType<AIE::CoreOp>();
@@ -1440,7 +1443,7 @@ LogicalResult air::simpleDMAChannelAllocation(
           return failure();
       }
     }
-    if (f.S2MM_memspace_as_int == (int)air::MemorySpace::L1) {
+    if (f.S2MM_memspace == air::MemorySpace::L1) {
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.S2MM[i]) {
           auto memcpyOpIf = cast<air::MemcpyInterface>(o);
@@ -1474,7 +1477,7 @@ LogicalResult air::simpleDMAChannelAllocation(
     }
   }
   for (auto &f : memcpy_flows) {
-    if (f.MM2S_memspace_as_int == (int)air::MemorySpace::L2) {
+    if (f.MM2S_memspace == air::MemorySpace::L2) {
       for (auto o : f.MM2S) {
         auto memcpyOpIf = cast<air::MemcpyInterface>(o);
         // Report error if the data movement lowers to neither dma stream
@@ -1489,7 +1492,7 @@ LogicalResult air::simpleDMAChannelAllocation(
         f.MM2S_alloc = alloc_res.value();
       }
     }
-    if (f.S2MM_memspace_as_int == (int)air::MemorySpace::L2) {
+    if (f.S2MM_memspace == air::MemorySpace::L2) {
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.S2MM[i]) {
           auto memcpyOpIf = cast<air::MemcpyInterface>(o);
@@ -1509,7 +1512,7 @@ LogicalResult air::simpleDMAChannelAllocation(
     }
   }
   for (auto &f : memcpy_flows) {
-    if (f.MM2S_memspace_as_int == (int)air::MemorySpace::L3) {
+    if (f.MM2S_memspace == air::MemorySpace::L3) {
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.MM2S) {
           auto memcpyOpIf = cast<air::MemcpyInterface>(o);
@@ -1532,7 +1535,7 @@ LogicalResult air::simpleDMAChannelAllocation(
         }
       }
     }
-    if (f.S2MM_memspace_as_int == (int)air::MemorySpace::L3) {
+    if (f.S2MM_memspace == air::MemorySpace::L3) {
       // L3 shim tiles assumed to not be target for broadcast
       if (f.S2MM.size() > 1) {
         return f.S2MM.front().front()->emitOpError(
@@ -1590,7 +1593,7 @@ bool air::groupingMemcpysByLoop(
   std::map<AIE::CoreOp, std::vector<scf::ForOp>> for_loops_log_mm2s,
       for_loops_log_s2mm;
   for (auto &f : memcpy_flows) {
-    if (f.MM2S_memspace_as_int == (int)air::MemorySpace::L1) {
+    if (f.MM2S_memspace == air::MemorySpace::L1) {
       for (auto o : f.MM2S) {
         auto core = o->getParentOfType<AIE::CoreOp>();
         f.flow_op_group = foundInVector<scf::ForOp>(
@@ -1600,7 +1603,7 @@ bool air::groupingMemcpysByLoop(
         }
       }
     }
-    if (f.S2MM_memspace_as_int == (int)air::MemorySpace::L1) {
+    if (f.S2MM_memspace == air::MemorySpace::L1) {
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.S2MM[i]) {
           auto core = o->getParentOfType<AIE::CoreOp>();

--- a/mlir/lib/Conversion/AIRToAsyncPass.cpp
+++ b/mlir/lib/Conversion/AIRToAsyncPass.cpp
@@ -358,7 +358,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = op.getType();
-    if (op.getType().getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+    if (air::isL3(op.getType()))
       return failure();
 
     auto alloc = memref::AllocOp::create(
@@ -382,7 +382,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto memrefTy = llvm::cast<MemRefType>(op.getMemref().getType());
-    if (memrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+    if (air::isL3(memrefTy))
       return failure();
 
     memref::DeallocOp::create(rewriter, op.getLoc(), adaptor.getMemref());
@@ -783,7 +783,7 @@ public:
       if (auto t = llvm::dyn_cast_if_present<air::AsyncTokenType>(type))
         return async::TokenType::get(context);
       if (auto t = llvm::dyn_cast_if_present<MemRefType>(type))
-        if (t.getMemorySpaceAsInt() != 0)
+        if (!air::isL3(t))
           return MemRefType::get(t.getShape(), t.getElementType(),
                                  t.getLayout(), 0);
       return type;
@@ -859,7 +859,7 @@ public:
         if (llvm::isa<air::AsyncTokenType>(t))
           return true;
         if (auto mt = llvm::dyn_cast_if_present<MemRefType>(t))
-          return mt.getMemorySpaceAsInt() != 0;
+          return !air::isL3(mt);
         return false;
       };
       return (!llvm::any_of(op->getResultTypes(), isIllegal) &&
@@ -885,13 +885,11 @@ public:
       return true;
     });
 
-    target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
-      return (op.getType().getMemorySpaceAsInt() == 0);
-    });
+    target.addDynamicallyLegalOp<memref::AllocOp>(
+        [&](memref::AllocOp op) { return air::isL3(op.getType()); });
 
     target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
-      return (llvm::cast<MemRefType>(op.getMemref().getType())
-                  .getMemorySpaceAsInt() == 0);
+      return air::isL3(llvm::cast<MemRefType>(op.getMemref().getType()));
     });
 
     RewritePatternSet typeConversionPatterns(context);

--- a/mlir/lib/Conversion/AIRToROCDLPass.cpp
+++ b/mlir/lib/Conversion/AIRToROCDLPass.cpp
@@ -7,6 +7,7 @@
 #include "air/Conversion/AIRToROCDLPass.h"
 #include "air/Conversion/GPUPassDetail.h"
 #include "air/Dialect/AIR/AIRDialect.h"
+#include "air/Util/Util.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
@@ -571,7 +572,7 @@ struct ConvertAIRToROCDLPass
     launchOp.walk([&](memref::AllocOp allocOp) {
       // workgroup
       MemRefType memRefType = allocOp.getType();
-      if (memRefType.getMemorySpaceAsInt() == 1) {
+      if (air::isL2(memRefType)) {
         mlir::Type elementType = memRefType.getElementType();
         llvm::ArrayRef<int64_t> shape = memRefType.getShape();
 
@@ -583,7 +584,7 @@ struct ConvertAIRToROCDLPass
         auto wg = launchOp.addWorkgroupAttribution(newType, loc);
         allocOp.replaceAllUsesWith(wg); // Replace row with globalRow
         allocOp.erase();
-      } else if (memRefType.getMemorySpaceAsInt() == 2) {
+      } else if (air::isL1(memRefType)) {
         mlir::Type elementType = memRefType.getElementType();
         llvm::ArrayRef<int64_t> shape = memRefType.getShape();
 

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -203,8 +203,7 @@ matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
   if (!src_type)
     return failure();
 
-  if ((src_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) &&
-      (dst_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3))
+  if (air::isL3(src_type) && air::isL3(dst_type))
     return failure();
 
   if (!(src_type.hasStaticShape() || dst_type.hasStaticShape()))
@@ -1342,7 +1341,7 @@ struct CopyToDmaPass : public air::impl::CopyToDmaBase<CopyToDmaPass> {
           llvm::dyn_cast_if_present<MemRefType>(co.getSource().getType());
       auto dst_type =
           llvm::dyn_cast_if_present<MemRefType>(co.getTarget().getType());
-      return src_type.getMemorySpaceAsInt() == dst_type.getMemorySpaceAsInt();
+      return air::getMemorySpace(src_type) == air::getMemorySpace(dst_type);
     });
 
     DmaMemcpyOpID = 0;
@@ -1417,11 +1416,9 @@ static void getHerdNames(ModuleOp module) {
                 continue;
               if (!isa<MemRefType>(operJ.getType()))
                 continue;
-              if (llvm::cast<MemRefType>(operI.getType())
-                      .getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+              if (!air::isL1(llvm::cast<MemRefType>(operI.getType())))
                 continue;
-              if (llvm::cast<MemRefType>(operJ.getType())
-                      .getMemorySpaceAsInt() != (int)air::MemorySpace::L1)
+              if (!air::isL1(llvm::cast<MemRefType>(operJ.getType())))
                 continue;
               if (operI != operJ)
                 continue;
@@ -1563,15 +1560,11 @@ struct ParallelToHerdPass
       Value L1Memref = nullptr;
       Value L2Memref = nullptr;
       bool SrcIsL1 = false;
-      if ((srcMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L1) &&
-          (dstMemrefTy.getMemorySpaceAsInt() == (int)air::MemorySpace::L2)) {
+      if (air::isL1(srcMemrefTy) && air::isL2(dstMemrefTy)) {
         L1Memref = op.getSrcMemref();
         L2Memref = op.getDstMemref();
         SrcIsL1 = true;
-      } else if ((srcMemrefTy.getMemorySpaceAsInt() ==
-                  (int)air::MemorySpace::L2) &&
-                 (dstMemrefTy.getMemorySpaceAsInt() ==
-                  (int)air::MemorySpace::L1)) {
+      } else if (air::isL2(srcMemrefTy) && air::isL1(dstMemrefTy)) {
         L1Memref = op.getDstMemref();
         L2Memref = op.getSrcMemref();
         SrcIsL1 = false;
@@ -2245,9 +2238,9 @@ LogicalResult forallWithReduceToParallelLoop(RewriterBase &rewriter,
       Type expectedOutputType = linalgReduceOp.getDpsInits()[i].getType();
       if (auto tensorType =
               dyn_cast_if_present<RankedTensorType>(expectedOutputType)) {
-        auto newInitMemrefTy =
-            MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
-                            AffineMap(), (int)xilinx::air::MemorySpace::L1);
+        auto newInitMemrefTy = MemRefType::get(
+            tensorType.getShape(), tensorType.getElementType(), AffineMap(),
+            static_cast<unsigned>(xilinx::air::MemorySpace::L1));
         Value bufferInitVal = bufferization::ToBufferOp::create(
             rewriter, loc, newInitMemrefTy, linalgReduceOp.getDpsInits()[i]);
         modifiedInitVals.push_back(bufferInitVal);

--- a/mlir/lib/Conversion/GPUKernelOutlinePass.cpp
+++ b/mlir/lib/Conversion/GPUKernelOutlinePass.cpp
@@ -7,6 +7,7 @@
 #include "air/Conversion/GPUKernelOutlinePass.h"
 #include "air/Conversion/GPUPassDetail.h"
 #include "air/Dialect/AIR/AIRDialect.h"
+#include "air/Util/Util.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
@@ -584,7 +585,7 @@ struct ConvertGPUKernelOutlinePass
     launchOp.walk([&](memref::AllocOp allocOp) {
       // workgroup
       MemRefType memRefType = allocOp.getType();
-      if (memRefType.getMemorySpaceAsInt() == 1) {
+      if (air::isL2(memRefType)) {
         mlir::Type elementType = memRefType.getElementType();
         llvm::ArrayRef<int64_t> shape = memRefType.getShape();
 
@@ -596,7 +597,7 @@ struct ConvertGPUKernelOutlinePass
         auto wg = launchOp.addWorkgroupAttribution(newType, loc);
         allocOp.replaceAllUsesWith(wg); // Replace row with globalRow
         allocOp.erase();
-      } else if (memRefType.getMemorySpaceAsInt() == 2) {
+      } else if (air::isL1(memRefType)) {
         mlir::Type elementType = memRefType.getElementType();
         llvm::ArrayRef<int64_t> shape = memRefType.getShape();
 

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -29,6 +29,7 @@
 using namespace mlir;
 
 #include "air/Dialect/AIR/AIRDialect.cpp.inc"
+#include "air/Dialect/AIR/AIREnums.cpp.inc"
 
 namespace xilinx {
 
@@ -1053,22 +1054,36 @@ unsigned air::SegmentOp::getNumDims() {
 }
 
 /// Utility function to verify that all memref.alloc operations within a region
-/// have a memory space greater than or equal to the specified minimum.
+/// have a memory space at least as local as the specified minimum.
+/// For example, minMemorySpace=L2 means allocations must be L2 or L1;
+/// minMemorySpace=L1 means allocations must be L1.
 /// Returns failure if any alloc violates the constraint.
 template <typename OpT>
-static LogicalResult verifyAllocMemorySpace(OpT op, unsigned minMemorySpace,
+static LogicalResult verifyAllocMemorySpace(OpT op,
+                                            air::MemorySpace minMemorySpace,
                                             StringRef opName) {
+  auto minVal = static_cast<uint32_t>(minMemorySpace);
   WalkResult result =
       op.getBody().walk([&](memref::AllocOp allocOp) -> WalkResult {
         auto memrefType = allocOp.getType();
-        // Get memory space (defaults to 0 if not specified)
         unsigned memorySpace = memrefType.getMemorySpaceAsInt();
 
-        if (memorySpace < minMemorySpace) {
-          allocOp.emitOpError()
-              << "memref.alloc inside " << opName
-              << " must have memory space >= " << minMemorySpace
-              << ", but found memory space " << memorySpace;
+        // Verify that the memory space is at least as local as the minimum.
+        // Higher numeric value = more local (L1=2 > L2=1 > L3=0).
+        if (memorySpace < minVal) {
+          if (auto actualEnum = air::symbolizeMemorySpace(memorySpace)) {
+            allocOp.emitOpError() << "memref.alloc inside " << opName
+                                  << " must have memory space >= "
+                                  << stringifyMemorySpace(minMemorySpace)
+                                  << ", but found memory space "
+                                  << stringifyMemorySpace(*actualEnum);
+          } else {
+            allocOp.emitOpError()
+                << "memref.alloc inside " << opName
+                << " must have memory space >= "
+                << stringifyMemorySpace(minMemorySpace)
+                << ", but found numeric memory space " << memorySpace;
+          }
           return WalkResult::interrupt();
         }
         return WalkResult::advance();
@@ -1109,8 +1124,9 @@ static Value getDirectlyAccessedMemref(Operation *op) {
 /// can only access their local L1 memory directly; non-local memory must be
 /// staged via DMA. This checks low-level load/store and vector transfer ops
 /// but not higher-level ops (linalg, memref.copy) that are lowered later.
-static LogicalResult verifyComputeMemoryAccess(air::HerdOp op,
-                                               unsigned minMemorySpace) {
+static LogicalResult
+verifyComputeMemoryAccess(air::HerdOp op, air::MemorySpace minMemorySpace) {
+  auto minVal = static_cast<uint32_t>(minMemorySpace);
   WalkResult result = op.getBody().walk([&](Operation *innerOp) -> WalkResult {
     Value memref = getDirectlyAccessedMemref(innerOp);
     if (!memref)
@@ -1119,13 +1135,17 @@ static LogicalResult verifyComputeMemoryAccess(air::HerdOp op,
     if (!memrefType)
       return WalkResult::advance();
     unsigned memorySpace = memrefType.getMemorySpaceAsInt();
-    if (memorySpace < minMemorySpace) {
+    if (memorySpace < minVal) {
+      auto msStr = air::symbolizeMemorySpace(memorySpace)
+                       ? std::string(stringifyMemorySpace(
+                             *air::symbolizeMemorySpace(memorySpace)))
+                       : std::to_string(memorySpace);
       innerOp->emitOpError()
-          << "inside 'air.herd' accesses memref with memory_space "
-          << memorySpace
-          << "; AIE core tiles can only access L1 (memory_space >= "
-          << minMemorySpace
-          << ") directly. Use air.dma_memcpy_nd to stage data first.";
+          << "inside 'air.herd' accesses memref with memory_space " << msStr
+          << "; AIE core tiles can only access "
+          << stringifyMemorySpace(minMemorySpace)
+          << " or more local memory directly. "
+             "Use air.dma_memcpy_nd to stage data first.";
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
@@ -1135,7 +1155,7 @@ static LogicalResult verifyComputeMemoryAccess(air::HerdOp op,
 }
 
 LogicalResult air::SegmentOp::verify() {
-  return verifyAllocMemorySpace(*this, /*minMemorySpace=*/1, "air.segment");
+  return verifyAllocMemorySpace(*this, air::MemorySpace::L2, "air.segment");
 }
 
 //
@@ -1414,9 +1434,9 @@ uint64_t air::HerdOp::getNumRows() {
 }
 
 LogicalResult air::HerdOp::verify() {
-  if (failed(verifyAllocMemorySpace(*this, /*minMemorySpace=*/2, "air.herd")))
+  if (failed(verifyAllocMemorySpace(*this, air::MemorySpace::L1, "air.herd")))
     return failure();
-  return verifyComputeMemoryAccess(*this, /*minMemorySpace=*/2);
+  return verifyComputeMemoryAccess(*this, air::MemorySpace::L1);
 }
 
 //

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -9,6 +9,7 @@
 #include "air/Transform/AIRDependencyScheduleOpt.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Dependency.h"
+#include "air/Util/Util.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
@@ -1463,13 +1464,10 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
         if (!alloc_op)
           continue;
         auto memref_type = llvm::cast<MemRefType>(alloc_op.getType());
-        int memorySpace = memref_type.getMemorySpaceAsInt();
 
         // Check if this alloc's memory space matches the omit criteria
-        if ((omitMemorySpace == "L1" &&
-             memorySpace == (int)air::MemorySpace::L1) ||
-            (omitMemorySpace == "L2" &&
-             memorySpace == (int)air::MemorySpace::L2)) {
+        if ((omitMemorySpace == "L1" && air::isL1(memref_type)) ||
+            (omitMemorySpace == "L2" && air::isL2(memref_type))) {
           shouldSkip = true;
           break;
         }
@@ -2672,18 +2670,13 @@ public:
   // Trace dma ops' dependency to loop induction variables
   void getDmaOpLoopDependency(func::FuncOp f) {
     f.walk([&](air::DmaMemcpyNdOp dma_op) {
-      int src_memspace = -1;
-      int dst_memspace = -1;
+      bool isL1Memcpy = false;
       if (dma_op.getSrcMemref())
-        src_memspace =
-            llvm::cast<BaseMemRefType>(dma_op.getSrcMemref().getType())
-                .getMemorySpaceAsInt();
+        isL1Memcpy |= air::isL1(
+            llvm::cast<BaseMemRefType>(dma_op.getSrcMemref().getType()));
       if (dma_op.getDstMemref())
-        dst_memspace =
-            llvm::cast<BaseMemRefType>(dma_op.getDstMemref().getType())
-                .getMemorySpaceAsInt();
-      bool isL1Memcpy = (src_memspace == (int)air::MemorySpace::L1) ||
-                        (dst_memspace == (int)air::MemorySpace::L1);
+        isL1Memcpy |= air::isL1(
+            llvm::cast<BaseMemRefType>(dma_op.getDstMemref().getType()));
       if (dma_op->getParentOfType<xilinx::air::HerdOp>() && isL1Memcpy) {
         // Start recursively tracing for loop induction variables
         dma_op_history.push_back(dma_op);
@@ -3617,18 +3610,15 @@ public:
     if (clAggressiveMode.empty())
       return;
     for (unsigned i = 0; i < clAggressiveMode.size(); ++i) {
-      if (clAggressiveMode[i] == "L1")
-        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L1);
-      else if (clAggressiveMode[i] == "L2")
-        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L2);
-      else if (clAggressiveMode[i] == "L3")
-        targetMemorySpaces.push_back((unsigned)air::MemorySpace::L3);
+      auto ms = air::symbolizeMemorySpace(clAggressiveMode[i]);
+      if (ms)
+        targetMemorySpaces.push_back(*ms);
       LLVM_DEBUG(llvm::outs() << "clAggressiveMode[" << i
                               << "] = " << clAggressiveMode[i] << "\n");
     }
   }
 
-  SmallVector<unsigned> targetMemorySpaces;
+  SmallVector<air::MemorySpace> targetMemorySpaces;
 
 private:
   // Get a vector of channel ops which can be fused using a new for loop.
@@ -3819,17 +3809,15 @@ private:
                                  std::vector<air::ChannelGetOp> &gets) {
     for (auto put : puts) {
       BaseMemRefType ty = llvm::cast<BaseMemRefType>(put.getMemref().getType());
-      if (llvm::any_of(targetMemorySpaces, [&](unsigned memSpace) {
-            return memSpace == ty.getMemorySpaceAsInt();
-          })) {
+      auto ms = air::getMemorySpace(ty);
+      if (ms && llvm::is_contained(targetMemorySpaces, *ms)) {
         return true;
       }
     }
     for (auto get : gets) {
       BaseMemRefType ty = llvm::cast<BaseMemRefType>(get.getMemref().getType());
-      if (llvm::any_of(targetMemorySpaces, [&](unsigned memSpace) {
-            return memSpace == ty.getMemorySpaceAsInt();
-          })) {
+      auto ms = air::getMemorySpace(ty);
+      if (ms && llvm::is_contained(targetMemorySpaces, *ms)) {
         return true;
       }
     }
@@ -3961,14 +3949,14 @@ private:
   // share the same channel.
   bool memrefsAreAffinitiveToSameChannel(Value a, Value b) {
     // Extract the memory space (e.g., L1, L2, L3) from the memref types.
-    int aMemorySpace =
-        llvm::cast<BaseMemRefType>(a.getType()).getMemorySpaceAsInt();
-    int bMemorySpace =
-        llvm::cast<BaseMemRefType>(b.getType()).getMemorySpaceAsInt();
+    auto aMemorySpace =
+        air::getMemorySpace(llvm::cast<BaseMemRefType>(a.getType()));
+    auto bMemorySpace =
+        air::getMemorySpace(llvm::cast<BaseMemRefType>(b.getType()));
     // If both memrefs are in L3 (DDR), they are considered affinitive to all
     // shim DMA channels.
-    if (aMemorySpace == (int)air::MemorySpace::L3 &&
-        bMemorySpace == (int)air::MemorySpace::L3)
+    if (aMemorySpace == air::MemorySpace::L3 &&
+        bMemorySpace == air::MemorySpace::L3)
       return true;
     // For non-L3 cases, memrefs are only guaranteed to share a channel if they
     // are the same. First, check if both values are proper MemRefType values.

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -8,6 +8,7 @@
 #include "air/Transform/AIRDmaToChannel.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Dependency.h"
+#include "air/Util/Util.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -324,7 +325,8 @@ createChannelOp(OpBuilder builder, ModuleOp module, std::string cname,
 }
 
 static void replaceAIRDmaWithAIRChannelPairs(
-    OpBuilder &builder, unsigned innerMemorySpace, air::DmaMemcpyNdOp op,
+    OpBuilder &builder, air::MemorySpace innerMemorySpace,
+    air::DmaMemcpyNdOp op,
     SmallVector<air::ChannelInterface, 1> &internalGetPutVector,
     SmallVector<air::ChannelInterface, 1> &externalGetPutVector) {
   auto loc = op->getLoc();
@@ -427,7 +429,7 @@ static void replaceAIRDmaWithAIRChannelPairs(
   if (auto op_token = op.getAsyncToken()) {
     tys.push_back(air::AsyncTokenType::get(ctx));
   }
-  if (dst_type.getMemorySpaceAsInt() == innerMemorySpace) {
+  if (air::getMemorySpace(dst_type) == innerMemorySpace) {
     auto internal = air::ChannelGetOp::create(
         builder, loc, tys, internalDeps, FlatSymbolRefAttr::get(ctx, cname),
         channel_idx_internal, dst, dst_offsets, dst_sizes, dst_strides);
@@ -441,7 +443,7 @@ static void replaceAIRDmaWithAIRChannelPairs(
         dyn_cast_if_present<air::ChannelInterface>(external.getOperation());
   }
 
-  if (src_type.getMemorySpaceAsInt() == innerMemorySpace) {
+  if (air::getMemorySpace(src_type) == innerMemorySpace) {
     auto internal = air::ChannelPutOp::create(
         builder, loc, tys, internalDeps, FlatSymbolRefAttr::get(ctx, cname),
         channel_idx_internal, src, src_offsets, src_sizes, src_strides);
@@ -496,12 +498,11 @@ bool isInMatchingHierarchy(air::ChannelInterface getput) {
   if (!getput->getParentOfType<air::HierarchyInterface>())
     return true;
   if (isa<air::HerdOp>(getput->getParentOfType<air::HierarchyInterface>()) &&
-      (memrefType.getMemorySpaceAsInt() == (int)air::MemorySpace::L1))
+      air::isL1(memrefType))
     return true;
   else if (isa<air::SegmentOp>(
                getput->getParentOfType<air::HierarchyInterface>()) &&
-           (memrefType.getMemorySpaceAsInt() == (int)air::MemorySpace::L2 ||
-            memrefType.getMemorySpaceAsInt() == (int)air::MemorySpace::L1))
+           (air::isL2(memrefType) || air::isL1(memrefType)))
     return true;
   else if (isa<air::LaunchOp>(
                getput->getParentOfType<air::HierarchyInterface>())) {
@@ -553,25 +554,24 @@ class AIRDmaToAIRChannelConversion
     if (!src_type)
       return failure();
 
-    if ((src_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3) &&
-        (dst_type.getMemorySpaceAsInt() == (int)air::MemorySpace::L3))
+    if (air::isL3(src_type) && air::isL3(dst_type))
       return failure();
 
     if (!(src_type.hasStaticShape() || dst_type.hasStaticShape()))
       return failure();
 
     air::HierarchyInterface hier_op = nullptr;
-    unsigned int innerMemorySpace = 0;
+    air::MemorySpace innerMemorySpace = air::MemorySpace::L3;
     auto herd = op->getParentOfType<air::HerdOp>();
     auto segment = op->getParentOfType<air::SegmentOp>();
     if (herd) {
       hier_op =
           dyn_cast_if_present<air::HierarchyInterface>(herd.getOperation());
-      innerMemorySpace = (int)air::MemorySpace::L1;
+      innerMemorySpace = air::MemorySpace::L1;
     } else if (segment) {
       hier_op =
           dyn_cast_if_present<air::HierarchyInterface>(segment.getOperation());
-      innerMemorySpace = (int)air::MemorySpace::L2;
+      innerMemorySpace = air::MemorySpace::L2;
     } else
       return failure();
 
@@ -882,11 +882,11 @@ static LogicalResult AIRDemoteMemrefToAIRHierarchy(
     OpBuilder &builder) {
 
   air::HierarchyInterface hier_op = pair.first;
-  unsigned int hierMemorySpace = 0;
+  air::MemorySpace hierMemorySpace = air::MemorySpace::L3;
   if (isa<air::HerdOp>(hier_op.getOperation())) {
-    hierMemorySpace = (int)air::MemorySpace::L1;
+    hierMemorySpace = air::MemorySpace::L1;
   } else if (isa<air::SegmentOp>(hier_op.getOperation())) {
-    hierMemorySpace = (int)air::MemorySpace::L2;
+    hierMemorySpace = air::MemorySpace::L2;
   } else
     return failure();
 
@@ -902,9 +902,12 @@ static LogicalResult AIRDemoteMemrefToAIRHierarchy(
       auto memref_type =
           llvm::dyn_cast_if_present<BaseMemRefType>(memref.getType());
 
-      if (memref_type.getMemorySpaceAsInt() == hierMemorySpace)
+      auto allocMemSpace = air::getMemorySpace(memref_type);
+      if (!allocMemSpace)
+        continue; // Unrecognized memory space, skip
+      if (*allocMemSpace == hierMemorySpace)
         continue; // Alloc op is already under correct hierarchy
-      else if (memref_type.getMemorySpaceAsInt() > hierMemorySpace)
+      else if (air::isMoreLocal(*allocMemSpace, hierMemorySpace))
         continue; // This pass is currently not able to promote in memory tier
 
       // Get dealloc
@@ -993,27 +996,30 @@ class AIRDemoteDmaToAIRHierarchyConversion
     auto herd = op->getParentOfType<air::HerdOp>();
     auto segment = op->getParentOfType<air::SegmentOp>();
 
-    if (src_type.getMemorySpaceAsInt() == dst_type.getMemorySpaceAsInt())
+    if (air::getMemorySpace(src_type) == air::getMemorySpace(dst_type))
       return failure(); // Src and dst under same memory space
 
     air::HierarchyInterface hier_op = nullptr;
-    unsigned int innerMemorySpace = 0;
+    air::MemorySpace innerMemorySpace = air::MemorySpace::L3;
     if (herd) {
       hier_op =
           dyn_cast_if_present<air::HierarchyInterface>(herd.getOperation());
-      innerMemorySpace = (int)air::MemorySpace::L1;
+      innerMemorySpace = air::MemorySpace::L1;
     } else if (segment) {
       hier_op =
           dyn_cast_if_present<air::HierarchyInterface>(segment.getOperation());
-      innerMemorySpace = (int)air::MemorySpace::L2;
+      innerMemorySpace = air::MemorySpace::L2;
     } else
       return failure();
 
-    auto memcpyInnerMemorySpace = std::max(src_type.getMemorySpaceAsInt(),
-                                           dst_type.getMemorySpaceAsInt());
+    auto srcMS = air::getMemorySpace(src_type);
+    auto dstMS = air::getMemorySpace(dst_type);
+    if (!srcMS || !dstMS)
+      return failure();
+    auto memcpyInnerMemorySpace = air::moreLocal(*srcMS, *dstMS);
     if (memcpyInnerMemorySpace == innerMemorySpace)
       return failure(); // Dma op is already under correct hierarchy
-    else if (memcpyInnerMemorySpace > innerMemorySpace)
+    else if (air::isMoreLocal(memcpyInnerMemorySpace, innerMemorySpace))
       return failure(); // This pass is currently not able to promote in memory
                         // tier
 
@@ -1196,13 +1202,13 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
       f.walk([&](memref::AllocOp alloc) {
         auto memref_type =
             dyn_cast_if_present<BaseMemRefType>(alloc.getMemref().getType());
-        int hierMemorySpace = (int)air::MemorySpace::L3;
+        air::MemorySpace hierMemorySpace = air::MemorySpace::L3;
         air::HierarchyInterface hier_op =
             alloc->getParentOfType<air::HierarchyInterface>();
         if (hier_op && isa<air::HerdOp>(hier_op.getOperation()))
-          hierMemorySpace = (int)air::MemorySpace::L1;
+          hierMemorySpace = air::MemorySpace::L1;
         else if (hier_op && isa<air::SegmentOp>(hier_op.getOperation()))
-          hierMemorySpace = (int)air::MemorySpace::L2;
+          hierMemorySpace = air::MemorySpace::L2;
         else
           return;
         // If async, then log the execute op around alloc
@@ -1210,7 +1216,9 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
             alloc->getParentOfType<air::ExecuteOp>()
                 ? alloc->getParentOfType<air::ExecuteOp>().getOperation()
                 : alloc.getOperation();
-        if (memref_type.getMemorySpaceAsInt() < (unsigned)hierMemorySpace) {
+        auto allocMemSpace = air::getMemorySpace(memref_type);
+        if (allocMemSpace &&
+            air::isMoreLocal(hierMemorySpace, *allocMemSpace)) {
           hier_to_allocs[hier_op].push_back(alloc_op);
         }
       });
@@ -1235,8 +1243,7 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
           auto dst_type = llvm::dyn_cast_if_present<BaseMemRefType>(
               dma.getDstMemref().getType());
           if (dma->getParentOfType<air::HerdOp>()) {
-            if (src_type.getMemorySpaceAsInt() < (int)air::MemorySpace::L1 &&
-                dst_type.getMemorySpaceAsInt() < (int)air::MemorySpace::L1)
+            if (!air::isL1(src_type) && !air::isL1(dst_type))
               return false;
           }
           return true;

--- a/mlir/lib/Transform/AIRHerdPlacementPass.cpp
+++ b/mlir/lib/Transform/AIRHerdPlacementPass.cpp
@@ -327,9 +327,8 @@ private:
         if (!memrefType)
           continue;
 
-        // Check if memory space is 2 (L1)
-        auto memorySpace = memrefType.getMemorySpaceAsInt();
-        if (memorySpace == 2) {
+        // Check if memory space is L1
+        if (air::isL1(memrefType)) {
           memrefToHerds[arg].insert(herdName);
           LLVM_DEBUG(llvm::dbgs() << "Found L1 memref accessed by herd "
                                   << herdName << "\n");

--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -1019,7 +1019,7 @@ allocBufferCallBack(OpBuilder &b, memref::SubViewOp subView,
   MemRefType viewType = subView.getType();
   MemRefType allocType = MemRefType::get(
       viewType.getShape(), viewType.getElementType(), AffineMap(),
-      b.getI32IntegerAttr((int)air::MemorySpace::L1));
+      air::MemorySpaceAttr::get(b.getContext(), air::MemorySpace::L1));
   Value buffer = b.createOrFold<memref::AllocOp>(subView.getLoc(), allocType);
   return buffer;
 }
@@ -1141,8 +1141,9 @@ FailureOr<linalg::TiledLinalgOp> static pipelineReduceLinalgOp(
       auto ty = llvm::cast<MemRefType>(tiledOperands[resultIdx].getType());
       auto alloc = memref::AllocOp::create(
           b, loc,
-          MemRefType::get(ty.getShape(), ty.getElementType(), AffineMap(),
-                          b.getI32IntegerAttr((int)air::MemorySpace::L1)));
+          MemRefType::get(
+              ty.getShape(), ty.getElementType(), AffineMap(),
+              air::MemorySpaceAttr::get(b.getContext(), air::MemorySpace::L1)));
       tiledOperands[resultIdx] = alloc.getResult();
       SmallVector<Value> src_offsets;
       SmallVector<Value> src_sizes;
@@ -2172,13 +2173,8 @@ transform::LinalgPromoteOp::apply(transform::TransformRewriter &rewriter,
   };
   promotionOptions.setCopyInOutFns(copyCallBack, copyCallBack);
 
-  auto memorySpace = xilinx::air::MemorySpace::L1;
-  if (getMemorySpace() == "L1")
-    memorySpace = xilinx::air::MemorySpace::L1;
-  else if (getMemorySpace() == "L2")
-    memorySpace = xilinx::air::MemorySpace::L2;
-  else if (getMemorySpace() == "L3")
-    memorySpace = xilinx::air::MemorySpace::L3;
+  auto memorySpace = xilinx::air::symbolizeMemorySpace(getMemorySpace())
+                         .value_or(xilinx::air::MemorySpace::L1);
 
   SetVector<Operation *> transformed;
   int64_t operandOffset = 0;

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1539,9 +1539,8 @@ FailureOr<Value> tileChannelOpByFactor(
   Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
   // Create and apply affine map onto the split channel ops.
   SmallVector<Value> tokens;
-  int memorySpace =
-      dyn_cast_if_present<BaseMemRefType>(originalChanOp.getMemref().getType())
-          .getMemorySpaceAsInt();
+  auto memorySpace = air::getMemorySpace(dyn_cast_if_present<BaseMemRefType>(
+      originalChanOp.getMemref().getType()));
   for (int i = 0; i < factor; i++) {
     // Get affine map and split size from splitInfo.
     auto &[splitInfoDimOnOffsets, splitInfoAffineMap, splitInfoSplitOffset,
@@ -1687,8 +1686,7 @@ FailureOr<Value> tileChannelOpByFactor(
     // Strategy: add one dimension to wrap-and-stride list. Rationale: (1) the
     // stride factor should apply on existing size, (2) original offset must
     // continue with the original stride.
-    if (splitInfoSplitStrideFactor &&
-        memorySpace == (int)air::MemorySpace::L3) {
+    if (splitInfoSplitStrideFactor && memorySpace == air::MemorySpace::L3) {
       newStrides.insert(newStrides.begin() + splitDimOnOffsets,
                         newStrides[splitDimOnOffsets]);
       newStrides[splitDimOnOffsets + 1] = arith::ConstantIndexOp::create(
@@ -2060,8 +2058,7 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
   SmallVector<memref::AllocOp> allocOps;
   func.walk([&](memref::AllocOp allocOp) {
     if (allocOp->getParentOfType<air::SegmentOp>() &&
-        llvm::cast<MemRefType>(allocOp.getMemref().getType())
-                .getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+        air::isL2(llvm::cast<MemRefType>(allocOp.getMemref().getType()))) {
       allocOps.push_back(allocOp);
     }
   });
@@ -2321,8 +2318,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
   func.walk([&](memref::AllocOp allocOp) {
     auto parentSeg = allocOp->getParentOfType<air::SegmentOp>();
     if (parentSeg && segmentsNeedingSplit.contains(parentSeg) &&
-        llvm::cast<MemRefType>(allocOp.getMemref().getType())
-                .getMemorySpaceAsInt() == (int)air::MemorySpace::L2) {
+        air::isL2(llvm::cast<MemRefType>(allocOp.getMemref().getType()))) {
       allocOps.push_back(allocOp);
     }
   });
@@ -2748,13 +2744,17 @@ struct OverrideMemorySpacePattern : public OpRewritePattern<memref::AllocOp> {
         dyn_cast_if_present<MemRefType>(alloc.getMemref().getType());
     if (!memrefTy)
       return failure();
-    if ((int)memrefTy.getMemorySpaceAsInt() == clMemorySpace)
+    auto targetMS =
+        air::symbolizeMemorySpace(static_cast<uint32_t>(clMemorySpace));
+    if (!targetMS)
+      return failure();
+    if (air::getMemorySpace(memrefTy) == *targetMS)
       return failure();
 
-    auto newMemrefType =
-        MemRefType::get(memrefTy.getShape(), memrefTy.getElementType(),
-                        memrefTy.getLayout().getAffineMap(),
-                        rewriter.getI32IntegerAttr(clMemorySpace));
+    auto newMemrefType = MemRefType::get(
+        memrefTy.getShape(), memrefTy.getElementType(),
+        memrefTy.getLayout().getAffineMap(),
+        air::MemorySpaceAttr::get(rewriter.getContext(), *targetMS));
 
     rewriter.replaceOpWithNewOp<memref::AllocOp>(alloc, newMemrefType);
 
@@ -2787,7 +2787,7 @@ struct correctViewLikeOpIOMemorySpacesInScope : public OpRewritePattern<OpTy> {
         auto destTy = dyn_cast_if_present<MemRefType>(res.getType());
         if (!destTy)
           return;
-        if (srcTy.getMemorySpaceAsInt() == destTy.getMemorySpaceAsInt())
+        if (air::getMemorySpace(srcTy) == air::getMemorySpace(destTy))
           continue;
         viewLikeOpsToRes[viewLike].push_back(res);
       }
@@ -2961,7 +2961,8 @@ DiagnosedSilenceableFailure transform::OverrideMemRefMemorySpaceOp::apply(
         auto destTy = dyn_cast_if_present<MemRefType>(res.getType());
         if (!destTy)
           continue;
-        if (srcTy.getMemorySpaceAsInt() != destTy.getMemorySpaceAsInt()) {
+        if (xilinx::air::getMemorySpace(srcTy) !=
+            xilinx::air::getMemorySpace(destTy)) {
           needsUpdate = true;
           break;
         }
@@ -2973,7 +2974,8 @@ DiagnosedSilenceableFailure transform::OverrideMemRefMemorySpaceOp::apply(
           auto destTy = dyn_cast_if_present<MemRefType>(res.getType());
           if (!destTy)
             continue;
-          if (srcTy.getMemorySpaceAsInt() == destTy.getMemorySpaceAsInt())
+          if (xilinx::air::getMemorySpace(srcTy) ==
+              xilinx::air::getMemorySpace(destTy))
             continue;
           MemRefType::Builder builder(destTy);
           builder.setMemorySpace(srcTy.getMemorySpace());

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -815,27 +815,15 @@ std::string to_string(std::vector<unsigned> vec) {
 std::string to_string(dependencyNodeEntry &c) { return air::to_string(c.op); }
 
 std::string lookUpMemorySpaceFromInt(unsigned memory_space) {
-  std::string output = "";
-  if (memory_space == 0) {
-    output += "L3";
-  } else if (memory_space == 1) {
-    output += "L2";
-  } else if (memory_space == 2) {
-    output += "L1";
-  }
-  return output;
+  if (auto ms = symbolizeMemorySpace(memory_space))
+    return std::string(stringifyMemorySpace(*ms));
+  return "";
 }
 
 unsigned lookUpMemorySpaceIntFromString(std::string memory_space) {
-  unsigned output = 0;
-  if (memory_space == "L3") {
-    output = 0;
-  } else if (memory_space == "L2") {
-    output = 1;
-  } else if (memory_space == "L1") {
-    output = 2;
-  }
-  return output;
+  if (auto ms = symbolizeMemorySpace(llvm::StringRef(memory_space)))
+    return static_cast<unsigned>(*ms);
+  return 0;
 }
 
 template <typename T>

--- a/mlir/lib/Util/Runner/Resource.cpp
+++ b/mlir/lib/Util/Runner/Resource.cpp
@@ -193,7 +193,10 @@ public:
   }
 
   memory(std::string ms, double b) {
-    this->set_memory_space(lookUpMemorySpaceIntFromString(ms));
+    if (auto memSpace = symbolizeMemorySpace(llvm::StringRef(ms)))
+      this->set_memory_space(static_cast<unsigned>(*memSpace));
+    else
+      this->set_memory_space(0);
     this->set_bytes(b);
     this->reset_reservation();
     this->reset_usage();

--- a/mlir/lib/Util/Runner/ResourceHierarchy.cpp
+++ b/mlir/lib/Util/Runner/ResourceHierarchy.cpp
@@ -369,12 +369,15 @@ public:
 
   double getDataRateFromMemorySpace(unsigned memory_space,
                                     std::string port_direction) {
-    if (lookUpMemorySpaceFromInt(memory_space) == "L3") {
+    auto ms = symbolizeMemorySpace(memory_space);
+    if (!ms)
+      return 0;
+    if (*ms == air::MemorySpace::L3) {
       if (this->ports.count(port_direction))
         return this->ports[port_direction][0]->data_rate;
       else
         return 0;
-    } else if (lookUpMemorySpaceFromInt(memory_space) == "L2") {
+    } else if (*ms == air::MemorySpace::L2) {
       if (this->dus.size()) {
         if (this->dus[0]->ports.count(port_direction))
           return this->dus[0]->ports[port_direction][0]->data_rate;
@@ -382,7 +385,7 @@ public:
           return 0;
       } else
         return 0;
-    } else if (lookUpMemorySpaceFromInt(memory_space) == "L1") {
+    } else if (*ms == air::MemorySpace::L1) {
       if (this->dus.size()) {
         if (this->dus[0]->tiles.size()) {
           if (this->dus[0]->tiles[0]->ports.count(port_direction))

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -35,6 +35,39 @@ using namespace mlir;
 
 namespace xilinx {
 
+// ===----------------------------------------------------------------------===//
+// Memory space helpers
+// ===----------------------------------------------------------------------===//
+
+std::optional<air::MemorySpace> air::getMemorySpace(BaseMemRefType memrefTy) {
+  return symbolizeMemorySpace(memrefTy.getMemorySpaceAsInt());
+}
+
+bool air::isL1(BaseMemRefType memrefTy) {
+  return memrefTy.getMemorySpaceAsInt() ==
+         static_cast<unsigned>(MemorySpace::L1);
+}
+
+bool air::isL2(BaseMemRefType memrefTy) {
+  return memrefTy.getMemorySpaceAsInt() ==
+         static_cast<unsigned>(MemorySpace::L2);
+}
+
+bool air::isL3(BaseMemRefType memrefTy) {
+  return memrefTy.getMemorySpaceAsInt() ==
+         static_cast<unsigned>(MemorySpace::L3);
+}
+
+bool air::isMoreLocal(air::MemorySpace a, air::MemorySpace b) {
+  return static_cast<uint32_t>(a) > static_cast<uint32_t>(b);
+}
+
+air::MemorySpace air::moreLocal(air::MemorySpace a, air::MemorySpace b) {
+  return static_cast<uint32_t>(a) > static_cast<uint32_t>(b) ? a : b;
+}
+
+// ===----------------------------------------------------------------------===//
+
 const StringLiteral air::LinalgTransforms::kLinalgTransformMarker =
     "__internal_linalg_transform__";
 
@@ -348,21 +381,13 @@ std::string air::getMemorySpaceAsString(Value memref) {
     memref.getDefiningOp()->emitOpError("value returned is not a memref");
     return "";
   }
-  auto memory_space_as_int =
-      llvm::dyn_cast_if_present<BaseMemRefType>(memref.getType())
-          .getMemorySpaceAsInt();
-  std::string memorySpaceStr = "";
-  if (memory_space_as_int == (int)air::MemorySpace::L1) {
-    memorySpaceStr = "L1";
-  } else if (memory_space_as_int == (int)air::MemorySpace::L2) {
-    memorySpaceStr = "L2";
-  } else if (memory_space_as_int == (int)air::MemorySpace::L3) {
-    memorySpaceStr = "L3";
-  } else {
+  auto ms = getMemorySpace(llvm::cast<BaseMemRefType>(memref.getType()));
+  if (!ms) {
     memref.getDefiningOp()->emitOpError(
         "value returned has an unexpected memory space");
+    return "";
   }
-  return memorySpaceStr;
+  return std::string(stringifyMemorySpace(*ms));
 }
 
 // Returns the first affine if op in block; nullptr otherwise
@@ -2061,7 +2086,7 @@ struct BufferMemrefToFuncArgsPattern : public OpRewritePattern<func::FuncOp> {
             dyn_cast_if_present<BaseMemRefType>(res.getType());
         if (!resType)
           continue;
-        if (resType.getMemorySpaceAsInt() == (int)air::MemorySpace::L3)
+        if (air::isL3(resType))
           memrefs.insert(res);
       }
     }

--- a/mlir/test/Dialect/AIR/air_herd_compute_memspace.mlir
+++ b/mlir/test/Dialect/AIR/air_herd_compute_memspace.mlir
@@ -74,7 +74,7 @@ func.func @herd_l2_load_rejected() {
   %l2_alloc = memref.alloc() : memref<32xi32, 1 : i32>
   air.herd tile (%x, %y) in (%sx=%c1, %sy=%c1) args(%buf=%l2_alloc) : memref<32xi32, 1 : i32> {
     %c0 = arith.constant 0 : index
-    // expected-error @+1 {{'memref.load' op inside 'air.herd' accesses memref with memory_space 1; AIE core tiles can only access L1 (memory_space >= 2) directly. Use air.dma_memcpy_nd to stage data first.}}
+    // expected-error @+1 {{'memref.load' op inside 'air.herd' accesses memref with memory_space L2; AIE core tiles can only access L1 or more local memory directly. Use air.dma_memcpy_nd to stage data first.}}
     %v = memref.load %buf[%c0] : memref<32xi32, 1 : i32>
     air.herd_terminator
   }
@@ -91,7 +91,7 @@ func.func @herd_l3_store_rejected() {
   air.herd tile (%x, %y) in (%sx=%c1, %sy=%c1) args(%buf=%l3_alloc) : memref<32xi32> {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 42 : i32
-    // expected-error @+1 {{'memref.store' op inside 'air.herd' accesses memref with memory_space 0; AIE core tiles can only access L1 (memory_space >= 2) directly. Use air.dma_memcpy_nd to stage data first.}}
+    // expected-error @+1 {{'memref.store' op inside 'air.herd' accesses memref with memory_space L3; AIE core tiles can only access L1 or more local memory directly. Use air.dma_memcpy_nd to stage data first.}}
     memref.store %cst, %buf[%c0] : memref<32xi32>
     air.herd_terminator
   }
@@ -108,7 +108,7 @@ func.func @herd_l3_transfer_read_rejected() {
   air.herd tile (%x, %y) in (%sx=%c1, %sy=%c1) args(%buf=%l3_alloc) : memref<32xf32> {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.0 : f32
-    // expected-error @+1 {{'vector.transfer_read' op inside 'air.herd' accesses memref with memory_space 0; AIE core tiles can only access L1 (memory_space >= 2) directly. Use air.dma_memcpy_nd to stage data first.}}
+    // expected-error @+1 {{'vector.transfer_read' op inside 'air.herd' accesses memref with memory_space L3; AIE core tiles can only access L1 or more local memory directly. Use air.dma_memcpy_nd to stage data first.}}
     %v = vector.transfer_read %buf[%c0], %cst : memref<32xf32>, vector<16xf32>
     air.herd_terminator
   }


### PR DESCRIPTION
## Summary
- Replace ~150 integer-based memory space comparisons across 21 files with type-safe `air::MemorySpace` enum and helper functions (`isL1`/`isL2`/`isL3`, `getMemorySpace`, `isMoreLocal`, `moreLocal`)
- Change core scheduling infrastructure (`isTileInbound`/`isTileOutbound`, `DMAAllocator`, `CascadeAllocator`, `MemcpyBundleAsFlow`) from `int` parameters to `air::MemorySpace` enum
- Eliminate all magic number comparisons (`== 0`, `== 1`, `== 2`) and `(int)air::MemorySpace::XX` casts
- Use `MemorySpaceAttr::get()` and `symbolizeMemorySpace()` from TableGen-generated code

Closes #969

## Test plan
- [x] `ninja check-air-mlir` — 322 passed, 7 expected failures
- [x] `ninja check-air-cpp` — 1/1 passed
- [x] `ninja check-air-python` — 7/7 passed
- [ ] CI linting and formatting checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)