### PR TITLE
Fix memory space attribute comparison in linalg_promote

### DIFF
--- a/mlir/lib/Transform/AIRLinalgCodegen.cpp
+++ b/mlir/lib/Transform/AIRLinalgCodegen.cpp
@@ -2253,8 +2253,10 @@ transform::LinalgPromoteOp::apply(transform::TransformRewriter &rewriter,
       if (!operandType)
         continue;
 
-      // Skip if already in the target memory space.
-      if (operandType.getMemorySpace() == targetMemSpaceAttr)
+      // Skip if already in the target memory space. Compare integer
+      // values to handle format mismatch (2 vs 2:i32).
+      if (operandType.getMemorySpaceAsInt() ==
+          static_cast<unsigned>(memorySpace))
         continue;
 
       // Reuse an existing promoted buffer if the same Value was already


### PR DESCRIPTION
## Summary
Fix `linalg_promote` manual promotion (from #1407) skipping operands that are already in the target memory space when the memory space attribute format differs (`2` vs `2 : i32`).

## Problem
`operandType.getMemorySpace() == targetMemSpaceAttr` compares MLIR attributes directly. Memory space `2` (plain IntegerAttr from `bufferize_to_allocation`) and `2 : i32` (IntegerAttr with i32 type from `linalg_promote`) compare as NOT equal, causing redundant L1→L1 copies.

## Fix
Use `getMemorySpaceAsInt()` for integer value comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)