### PR TITLE
Fix O(n^2) compilation bottlenecks in shim DMA BD and air-to-std passes

### DIFF
--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -640,11 +640,36 @@ AIRChannelInterfaceToAIRRtConversionImpl(OpBuilder builder,
   return airrtOp;
 }
 
+// Cache for channel name → first counterpart op lookups, avoiding O(n)
+// module walks per channel op during conversion.
+struct ChannelCounterpartCache {
+  llvm::DenseMap<StringAttr, air::ChannelGetOp> firstGet;
+  llvm::DenseMap<StringAttr, air::ChannelPutOp> firstPut;
+
+  void build(ModuleOp module) {
+    module.walk([&](air::ChannelGetOp get) {
+      auto name = get->getAttrOfType<FlatSymbolRefAttr>("chan_name").getAttr();
+      if (!firstGet.count(name))
+        firstGet[name] = get;
+    });
+    module.walk([&](air::ChannelPutOp put) {
+      auto name = put->getAttrOfType<FlatSymbolRefAttr>("chan_name").getAttr();
+      if (!firstPut.count(name))
+        firstPut[name] = put;
+    });
+  }
+};
+
 template <typename OpT>
 class AIRChannelGetPutToAIRRtConversion : public OpConversionPattern<OpT> {
 public:
   using OpConversionPattern<OpT>::OpConversionPattern;
   using OpAdaptor = typename OpT::Adaptor;
+
+  AIRChannelGetPutToAIRRtConversion(const TypeConverter &typeConverter,
+                                    MLIRContext *context,
+                                    ChannelCounterpartCache &cache)
+      : OpConversionPattern<OpT>(typeConverter, context), cache(cache) {}
 
   LogicalResult
   matchAndRewrite(OpT op, OpAdaptor adaptor,
@@ -656,10 +681,22 @@ public:
     if (llvm::isa<AIE::CoreOp>(op->getParentOp()))
       return failure();
 
-    auto otherOps = getTheOtherChannelOpThroughSymbol(op);
-    if (otherOps.empty())
-      return op->emitOpError("failed to find the other side of air.channel");
-    auto otherOp = otherOps[0];
+    // Use cached lookup instead of module-wide walk per op.
+    auto name = op->template getAttrOfType<FlatSymbolRefAttr>("chan_name");
+    if (!name)
+      return op->emitOpError("missing chan_name attribute");
+    air::ChannelInterface otherOp;
+    if constexpr (std::is_same_v<OpT, air::ChannelPutOp>) {
+      auto it = cache.firstGet.find(name.getAttr());
+      if (it == cache.firstGet.end())
+        return op->emitOpError("failed to find the other side of air.channel");
+      otherOp = cast<air::ChannelInterface>(it->second.getOperation());
+    } else {
+      auto it = cache.firstPut.find(name.getAttr());
+      if (it == cache.firstPut.end())
+        return op->emitOpError("failed to find the other side of air.channel");
+      otherOp = cast<air::ChannelInterface>(it->second.getOperation());
+    }
 
     auto airrtOp =
         AIRChannelInterfaceToAIRRtConversionImpl(rewriter, op, otherOp);
@@ -702,6 +739,9 @@ public:
     rewriter.eraseOp(op);
     return success();
   }
+
+private:
+  ChannelCounterpartCache &cache;
 };
 
 class L2AllocToAIRRtConversion : public ConversionPattern {
@@ -1186,10 +1226,17 @@ public:
     air_patterns.add<
         ScfYieldOpConversion, ScfIfOpConversion, ScfForOpConversion,
         ScfParOpConversion, ScfReduceReturnOpConversion, ScfReduceOpConversion,
-        AIRDmaMemcpyNdToAIRRtConversion, AIRWaitAllToAIRRtConversion,
-        AIRChannelGetPutToAIRRtConversion<air::ChannelGetOp>,
-        AIRChannelGetPutToAIRRtConversion<air::ChannelPutOp>>(converter,
-                                                              context);
+        AIRDmaMemcpyNdToAIRRtConversion, AIRWaitAllToAIRRtConversion>(converter,
+                                                                      context);
+
+    // Build channel counterpart cache to avoid O(n) module walks per channel
+    // op during conversion. Without this cache, each of the N channel ops
+    // performs a module-wide walk, resulting in O(N^2) total work.
+    ChannelCounterpartCache channelCache;
+    channelCache.build(module);
+    air_patterns.add<AIRChannelGetPutToAIRRtConversion<air::ChannelGetOp>,
+                     AIRChannelGetPutToAIRRtConversion<air::ChannelPutOp>>(
+        converter, context, channelCache);
 
     if (failed(
             applyPartialConversion(module, target, std::move(air_patterns)))) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Transforms/InliningUtils.h"
 #include "mlir/Transforms/RegionUtils.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -3342,6 +3343,26 @@ LogicalResult AIRSpecializeChannelWrapAndStrideImpl(
       cano_patterns, maxSize, maxNumDims, enableRepeatAtHighestDim);
   ExecuteOp::getCanonicalizationPatterns(cano_patterns, ctx);
   (void)applyPatternsGreedily(*region, std::move(cano_patterns));
+
+  // Remove duplicate async token dependencies created by loop unrolling.
+  // Without this, the downstream canonicalize pass spends O(n^2) time
+  // scanning the expanded IR to remove these duplicates.
+  region->walk([](Operation *op) {
+    auto asyncOp = dyn_cast<air::AsyncOpInterface>(op);
+    if (!asyncOp)
+      return;
+    auto deps = asyncOp.getAsyncDependencies();
+    if (deps.empty())
+      return;
+    llvm::SmallDenseSet<Value> seen;
+    SmallVector<unsigned> toRemove;
+    for (unsigned i = 0; i < deps.size(); i++) {
+      if (!seen.insert(deps[i]).second)
+        toRemove.push_back(i);
+    }
+    for (auto it = toRemove.rbegin(); it != toRemove.rend(); ++it)
+      asyncOp.eraseAsyncDependency(*it);
+  });
 
   return success();
 }

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -930,7 +930,7 @@ void preserveAsyncDependenciesAfterUnroll(Block &parentBlock) {
         if (!domInfo.properlyDominates(op, asyncUser))
           continue;
 
-        asyncUser.addAsyncDependency(air::getAsyncTokenFromOp(op));
+        air::addAsyncDependencyIfNew(asyncUser, air::getAsyncTokenFromOp(op));
       }
     }
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for_and_hoist_alloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/unroll_scf_for_and_hoist_alloc.mlir
@@ -18,10 +18,9 @@
 // CHECK: {unrolled_iteration = 0 : i32}
 // CHECK: %[[EVENT2:.*]] = scf.for {{.*}} iter_args(%[[EVENT1:.*]] =
 // CHECK: %[[EVENT3:.*]] = air.wait_all async [{{.*}}%[[EVENT1]]{{.*}}]{{.*}}{unrolled_iteration = 0 : i32}
-// CHECK: %[[EVENT4:.*]] = air.wait_all async [{{.*}}%[[EVENT3]]{{.*}}]
-// CHECK: %[[EVENT5:.*]] = air.wait_all async [{{.*}}%[[EVENT4]]{{.*}}]{{.*}}{unrolled_iteration = 1 : i32}
-// CHECK: %[[EVENT6:.*]] = air.wait_all async [{{.*}}%[[EVENT5]]{{.*}}]
-// CHECK: scf.yield %[[EVENT6]]
+// CHECK: %[[EVENT4:.*]] = air.wait_all async [{{.*}}%[[EVENT3]]{{.*}}]{{.*}}{unrolled_iteration = 1 : i32}
+// CHECK: %[[EVENT5:.*]] = air.wait_all async [{{.*}}%[[EVENT3]]{{.*}}, {{.*}}%[[EVENT4]]{{.*}}]
+// CHECK: scf.yield %[[EVENT5]]
 // CHECK: %[[EVENT7:.*]] = air.execute [{{.*}}%[[EVENT2]]{{.*}}]
 // CHECK: memref.dealloc
 // CHECK: {unrolled_iteration = 0 : i32}


### PR DESCRIPTION
## Summary
- Deduplicate async token dependencies after loop unrolling in `preserveAsyncDependenciesAfterUnroll` by using `addAsyncDependencyIfNew`, plus an O(n) dedup walk at end of `AIRSpecializeChannelWrapAndStrideImpl`
- Cache channel counterpart lookups in `AIRChannelGetPutToAIRRtConversion` (air-to-std) to avoid O(n) module walks per channel op

## Motivation
Flash attention compilation with large sequence lengths is bottlenecked by two O(n^2) patterns:

1. `air-opt-shim-dma-bds` produces duplicate async tokens during loop unrolling, forcing the downstream `canonicalize` to spend O(n^2) time deduplicating on large IR
2. `air-to-std` calls `getTheOtherChannelOpThroughSymbol` per channel op (module-wide walk), making conversion O(n^2) in the number of channel ops

## Results (flash attention LQ=LK=8192, 12 heads, dk=dv=64)
| Pass | Before | After |
|------|--------|-------|
| `air-to-std` | 148s | **0.9s** |

## Test plan
- [ ] `ninja check-air-mlir` — no regressions (same 4 pre-existing Util/Channel failures)