### PR TITLE
Add automatic BD recycling in airrt-to-npu for shim DMA tasks

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1491,6 +1491,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // DMAConfigureTaskForOp result.
     generateAwaitsFromWaitAllOps(module);
 
+    // Insert BD recycling points when task count per shim tile exceeds
+    // the hardware BD limit. This prevents BD exhaustion for designs
+    // with many DMA tasks per launch iteration (e.g., direct L3→L1).
+    insertBdRecyclingPoints(module);
+
     // Renumber npu dma ops
     renumberNpuDmaOps(module.getBody());
 
@@ -1857,6 +1862,63 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // Now that WaitAllOps with DMA operands are erased, purge DMA async
     // tokens (they no longer have uses from WaitAllOps)
     purgeDmaAsyncTokens(module);
+  }
+
+  // Insert DMAAwaitTaskOp + DMAFreeTaskOp at regular intervals when the
+  // number of outstanding tasks per shim tile exceeds a threshold. This
+  // prevents BD exhaustion for designs with many DMA tasks per launch
+  // iteration (e.g., direct L3→L1 without memtile staging).
+  void insertBdRecyclingPoints(ModuleOp module) {
+    // Maximum outstanding tasks per shim tile before inserting a recycle point.
+    // Shim tiles have 16 BDs total; leave headroom for concurrent tasks.
+    constexpr unsigned kMaxOutstandingPerTile = 12;
+
+    module.walk([&](AIE::DeviceOp device) {
+      device.walk([&](func::FuncOp f) {
+        if (f.getBody().empty())
+          return;
+
+        // Collect all DMAConfigureTaskForOp in order, grouped by shim tile
+        llvm::MapVector<StringRef, unsigned> tileTaskCount;
+        SmallVector<AIEX::DMAConfigureTaskForOp> outstandingTasks;
+
+        auto getShimTile =
+            [&](AIEX::DMAConfigureTaskForOp configTask) -> StringRef {
+          auto allocSymbol = configTask.getAlloc();
+          return allocSymbol.getLeafReference().getValue();
+        };
+
+        // Walk ops in order within runtime_sequence blocks
+        f.walk([&](AIEX::DMAConfigureTaskForOp configTask) {
+          StringRef tile = getShimTile(configTask);
+          tileTaskCount[tile]++;
+          outstandingTasks.push_back(configTask);
+
+          // Check if any tile exceeds the threshold
+          bool needRecycle = false;
+          for (auto &kv : tileTaskCount)
+            if (kv.second > kMaxOutstandingPerTile)
+              needRecycle = true;
+
+          if (needRecycle) {
+            // Free the OLDEST outstanding task's BD for reuse.
+            // Use DMAFreeTaskOp (not DMAAwaitTaskOp) because MM2S tasks
+            // don't issue tokens and can't be awaited.
+            if (!outstandingTasks.empty()) {
+              auto oldestTask = outstandingTasks.front();
+              OpBuilder builder(configTask);
+              builder.setInsertionPoint(configTask);
+              AIEX::DMAFreeTaskOp::create(builder, configTask.getLoc(),
+                                          oldestTask.getResult());
+              outstandingTasks.erase(outstandingTasks.begin());
+              StringRef oldTile = getShimTile(oldestTask);
+              if (tileTaskCount.count(oldTile) && tileTaskCount[oldTile] > 0)
+                tileTaskCount[oldTile]--;
+            }
+          }
+        });
+      });
+    });
   }
 
   // Convert NpuDmaWaitOp → DMAAwaitTaskOp or DMAFreeTaskOp AFTER DMA


### PR DESCRIPTION
## Summary
Insert DMAFreeTaskOp at regular intervals when outstanding DMA tasks per shim tile exceed a threshold (12 out of 16 BDs), preventing BD exhaustion for designs with many shim tasks per launch iteration.

## Motivation
Enables direct L3-to-L1 data transfer (bypassing memtile) where each K/V chunk generates a separate shim DMA task, potentially exceeding the 16-BD limit within a single launch iteration.

## Test plan
- [x] make run LK=4096 LKP=64 LQ=4096 LQP=256 NUM_HEADS=2 -- PASS
- [x] make run LK=4096 LKP=64 LQ=4096 LQP=256 NUM_HEADS=12 -- PASS