### PR TITLE
Fix shared buffer validation for flash attention tile size mismatch

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn.py
@@ -59,7 +59,10 @@ def build_module(
     assert (
         lk % (lkp * num_cascade_stages) == 0
     ), f"lk ({lk}) must be divisible by lkp * num_cascade_stages ({lkp * num_cascade_stages})"
-    enable_shared_buffers = lkp == dk
+    # Shared buffers: Q and K reuse the same L2 buffer (sized lkp×dk).
+    # Only valid when tile_size_q <= lkp so Q tile fits in the K buffer.
+    tile_size_q_check = lqp // num_q_tiles
+    enable_shared_buffers = lkp == dk and tile_size_q_check <= lkp
     if causal:
         assert lq == lk, f"Causal masking requires lq == lk, got lq={lq}, lk={lk}"
         assert lkp == dk, (
@@ -1388,7 +1391,7 @@ if __name__ == "__main__":
         else:
             lazy_attn_output[h] = (Gp_acc / sp_acc).astype(OUTPUT_DATATYPE)
 
-    enable_shared_buffers_main = lkp == dk
+    enable_shared_buffers_main = lkp == dk and lqp // 4 <= lkp
     # Causal requires enable_shared_buffers (lkp==dk), which already sets
     # omit_while_true_loop=False. The while-true loop lets the core maintain
     # a local counter across launch iterations without PDI reset.


### PR DESCRIPTION
## Summary
When `tile_size_q > lkp`, the shared L2 buffer (sized `lkp×dk` for K data) cannot hold Q tile data (sized `tile_size_q×dk`). This caused a BD out-of-bounds error during compilation for configs like `LQP=512` with `LKP=64` (`tile_size_q=128 > lkp=64`).

Fix: disable `enable_shared_buffers` when `tile_size_q > lkp`. Q gets its own independently-sized L2 buffer.

Partially addresses #1420 (Issue 3: pass pipeline failures for large tiles).

## Test plan
- [ ] `make run LK=2048 LKP=64 LQ=2048 LQP=512 NUM_HEADS=2` — should no longer crash with BD out-of-bounds (now fails with resource allocation, which is a separate L1 memory issue)
- [ ] `make run` — default non-causal regression
- [ ] `make run LK=2048 LKP=64 LQ=2048 LQP=256 NUM_HEADS=2 EXTRA_PY_FLAGS="--causal"` — causal regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)