### PR TITLE
Fix causal masking head counter wrap threshold

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn.py
@@ -1165,9 +1165,7 @@ def build_module(
                             # Increment head counter
                             head_cur = load(counter_buf, [c2_ci])
                             head_next = arith.AddIOp(head_cur, c1_i32_ci)
-                            total_heads_i32 = ConstantOp(
-                                i32, num_head_groups * num_heads_per_unroll
-                            )
+                            total_heads_i32 = ConstantOp(i32, num_head_groups)
                             wrapped = arith.CmpIOp(
                                 arith.CmpIPredicate.sge,
                                 head_next,


### PR DESCRIPTION
## Summary

Fix the head counter wrap threshold in causal flash attention. The counter wrapped after `num_head_groups * num_heads_per_unroll` iterations instead of `num_head_groups`, causing the q_block counter to advance at half the correct rate for multi-head configs.

With NUM_HEADS=32 (num_head_groups=16), the counter wrapped after 32 instead of 16, severely corrupting the causal mask and producing output with correlation 0.086 against the reference.

Fixes #1427.

## Test plan
- [x] `make run LK=2048 LKP=64 LQ=2048 LQP=256 NUM_HEADS=32 NUM_KV_HEADS=8 EXTRA_PY_FLAGS="--causal"` — the failing config from #1427
- [x] `make run LK=2048 LKP=64 LQ=2048 LQP=256 NUM_HEADS=12 EXTRA_PY_FLAGS="--causal"`
- [x] `make run` — non-causal regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)