### PR TITLE
Add BF16 vectorized eltwise_add with C++ profiling harness

### DIFF
--- a/programming_examples/eltwise_add/Makefile
+++ b/programming_examples/eltwise_add/Makefile
@@ -13,14 +13,88 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# AIE target: aie2 (NPU1) or aie2p (NPU2, default)
+AIE_TARGET ?= aie2p
+
+# Device-dependent defaults
+ifeq ($(AIE_TARGET),aie2p)
+  # NPU2: BF16 vectorized, 8-column config
+  DTYPE ?= bf16
+  VECTOR_SIZE ?= 16
+  HERD_X ?= 8
+  HERD_Y ?= 1
+  TILE_N ?= 2048
+  N ?= 4194304
+else
+  # NPU1: F32 scalar, 2-tile config
+  DTYPE ?= f32
+  VECTOR_SIZE ?= 0
+  HERD_X ?= 1
+  HERD_Y ?= 2
+  TILE_N ?= 1024
+  N ?= 65536
+endif
+
+AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+
+# Auto-detect XILINX_XRT if not set
+XILINX_XRT ?= $(wildcard /opt/xilinx/xrt)
+
+# Extra Python flags (used by LIT tests to override defaults)
+EXTRA_PY_FLAGS ?=
+
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG) \
+		--dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
+		--herd-x $(HERD_X) --herd-y $(HERD_Y) \
+		--tile-n $(TILE_N) $(EXTRA_PY_FLAGS) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/eltwise_add.py \
+		$(OUTPUT_FORMAT_FLAG) --dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
+		--herd-x $(HERD_X) --herd-y $(HERD_Y) --tile-n $(TILE_N) $(EXTRA_PY_FLAGS)
+
+profile: build-test-exe
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		python3 ${srcdir}/eltwise_add.py --n $(N) --tile-n $(TILE_N) \
+		--dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
+		--herd-x $(HERD_X) --herd-y $(HERD_Y) \
+		--compile-mode compile-only --output-format xclbin
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
+		-S $(N)
+
+build-test-exe:
+	@GPP=$$( \
+		for bin in /usr/bin/g++-*; do \
+			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
+			if [ "$$ver" -ge 13 ] 2>/dev/null; then \
+				echo "$$ver $$bin"; \
+			fi; \
+		done | sort -nr | head -n1 | awk '{print $$2}' \
+	); \
+	if [ -z "$$GPP" ]; then \
+		echo "Error: No g++ version >= 13 found in /usr/bin."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(XILINX_XRT)" ]; then \
+		echo "Error: XILINX_XRT not set and /opt/xilinx/xrt not found."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(AIEOPT_DIR)" ]; then \
+		echo "Error: AIEOPT_DIR environment variable not set. Please make sure to have sourced utils/env_setup.sh."; \
+		exit 1; \
+	fi; \
+	echo "Using compiler: $$GPP"; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && $$GPP ${srcdir}/test.cpp -o test.exe -std=c++23 -Wall \
+		-I$(XILINX_XRT)/include -L$(XILINX_XRT)/lib \
+		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
+		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/eltwise_add/eltwise_add.py
+++ b/programming_examples/eltwise_add/eltwise_add.py
@@ -1,13 +1,27 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+
+"""Vectorized Element-Wise Add
+
+Implements element-wise addition on a 1D input [N]:
+  c = a + b
+
+Uses a 1xnum_tiles AIE herd with DMA transfers between L3 and L1 memory.
+Computation is vectorized using vector.transfer_read/write with
+configurable VECTOR_SIZE (default 16 for BF16, 8 for F32).
+"""
+
 import argparse
+
 from ml_dtypes import bfloat16
 
 from air.ir import *
 from air.dialects.affine import apply as affine_apply
 from air.dialects.air import *
+from air.dialects import arith
 from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
+from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
+from air.dialects.vector import transfer_read, transfer_write
 from air.dialects.func import FuncOp
 from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
@@ -21,13 +35,21 @@ range_ = for_
 
 
 @module_builder
-def build_module(n, tile_n, np_dtype_in):
+def build_module(
+    n, tile_n, np_dtype_in, vector_size=0, num_tiles=2, herd_x=1, herd_y=None
+):
     a_size = [n]
     b_size = a_size
     out_size = a_size
     xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
+
+    # Determine herd shape
+    if herd_y is None:
+        herd_y = num_tiles
+    total_tiles = herd_x * herd_y
+    assert (
+        n % (tile_n * total_tiles) == 0
+    ), f"n ({n}) must be divisible by tile_n*total_tiles ({tile_n}*{total_tiles}={tile_n*total_tiles})"
 
     # L3 MemRefTypes
     l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
@@ -39,11 +61,21 @@ def build_module(n, tile_n, np_dtype_in):
         memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
     )
 
+    # Vectorization setup
+    vectorize = vector_size > 0
+    if vectorize:
+        assert (
+            tile_n % vector_size == 0
+        ), f"tile_n ({tile_n}) must be divisible by vector_size ({vector_size})"
+        vecTy = VectorType.get([vector_size], xrt_dtype_in)
+        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+        index_type = IndexType.get()
+
     @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
     def eltwise_add(arg0, arg1, arg2):
         @herd(
             name="herd_0",
-            sizes=[1, num_tiles],
+            sizes=[herd_x, herd_y],
             operands=[arg0, arg1, arg2],
         )
         def herd_body(
@@ -59,22 +91,30 @@ def build_module(n, tile_n, np_dtype_in):
             l1_b_data = AllocOp(l1MemrefTy, [], [])
             l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+            for _l_ivx in range_(0, n, tile_n * total_tiles):
 
+                # Compute linear tile index: tx * herd_y + ty
+                # offset = loop_var + linear_tile_idx * tile_n
                 offset_map = AffineMap.get(
                     0,
-                    2,
+                    3,
                     [
                         AffineExpr.get_add(
                             AffineSymbolExpr.get(0),
                             AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
+                                AffineExpr.get_add(
+                                    AffineExpr.get_mul(
+                                        AffineSymbolExpr.get(1),
+                                        AffineConstantExpr.get(herd_y),
+                                    ),
+                                    AffineSymbolExpr.get(2),
+                                ),
                                 AffineConstantExpr.get(tile_n),
                             ),
                         )
                     ],
                 )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                offset = affine_apply(offset_map, [_l_ivx, _tx, _ty])
 
                 dma_memcpy_nd(
                     l1_a_data,
@@ -94,12 +134,36 @@ def build_module(n, tile_n, np_dtype_in):
                     src_sizes=[tile_n],
                     src_strides=[1],
                 )
-                for i in range_(tile_n):
-                    val_a = load(l1_a_data, [i])
-                    val_b = load(l1_b_data, [i])
-                    val_out = arith.addf(val_a, val_b)
-                    store(val_out, l1_out_data, [i])
-                    yield_([])
+
+                if vectorize:
+                    # Vectorized compute loop
+                    c0 = ConstantOp(index_type, 0)
+                    cVecSize = ConstantOp(index_type, vector_size)
+                    cTileN = ConstantOp(index_type, tile_n)
+                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
+
+                    for j in range_(c0, cTileN, cVecSize):
+                        sub_a = subview(l1_a_data.result, [j], [vector_size], [1])
+                        sub_b = subview(l1_b_data.result, [j], [vector_size], [1])
+                        sub_c = subview(l1_out_data.result, [j], [vector_size], [1])
+                        v_a = transfer_read(
+                            vecTy, sub_a, [c0], identity_map, cst0, [True]
+                        )
+                        v_b = transfer_read(
+                            vecTy, sub_b, [c0], identity_map, cst0, [True]
+                        )
+                        v_c = arith.AddFOp(v_a, v_b)
+                        transfer_write(None, v_c, sub_c, [c0], identity_map, [True])
+                        yield_([])
+                else:
+                    # Scalar compute loop (original)
+                    for i in range_(tile_n):
+                        val_a = load(l1_a_data, [i])
+                        val_b = load(l1_b_data, [i])
+                        val_out = arith.addf(val_a, val_b)
+                        store(val_out, l1_out_data, [i])
+                        yield_([])
+
                 dma_memcpy_nd(
                     _l3_c,
                     l1_out_data,
@@ -117,14 +181,17 @@ def build_module(n, tile_n, np_dtype_in):
 
 
 if __name__ == "__main__":
-    # Default values.
+    # Default values — optimized BF16 vectorized config for NPU2.
+    # For NPU1 (F32 scalar): --dtype f32 --vector-size 0 --herd-x 1 --herd-y 2
     N = 65536
     TILE_N = 1024
-    INPUT_DATATYPE = np.float32
+    INPUT_DATATYPE = bfloat16
+    VECTOR_SIZE = 16
+    NUM_TILES = 2
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the eltwise_add example",
     )
     parser.add_argument(
         "-v",
@@ -144,6 +211,37 @@ if __name__ == "__main__":
     )
     parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
     parser.add_argument(
+        "--vector-size",
+        type=int,
+        default=VECTOR_SIZE,
+        help="Vector width (0 for scalar, 16 for BF16, 8 for F32)",
+    )
+    parser.add_argument(
+        "--num-tiles",
+        type=int,
+        default=NUM_TILES,
+        help="Number of herd tiles (parallel cores), used as herd_y when herd-x/herd-y not set",
+    )
+    parser.add_argument(
+        "--herd-x",
+        type=int,
+        default=1,
+        help="Herd x dimension (default: 1)",
+    )
+    parser.add_argument(
+        "--herd-y",
+        type=int,
+        default=None,
+        help="Herd y dimension (default: num-tiles)",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["bf16", "f32"],
+        default="bf16",
+        help="Data type (default: bf16)",
+    )
+    parser.add_argument(
         "--compile-mode",
         type=str,
         choices=["compile-only", "compile-and-run"],
@@ -161,19 +259,26 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    if args.dtype == "bf16":
+        INPUT_DATATYPE = bfloat16
+    else:
+        INPUT_DATATYPE = np.float32
+
     mlir_module = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
+        vector_size=args.vector_size,
+        num_tiles=args.num_tiles,
+        herd_x=args.herd_x,
+        herd_y=args.herd_y,
     )
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
-    input_a = np.arange(0, args.n, dtype=np.int64).reshape(args.n)
-    input_a = input_a.astype(INPUT_DATATYPE)
-    input_b = np.arange(0, args.n, dtype=np.int64).reshape(args.n)
-    input_b = input_b.astype(INPUT_DATATYPE)
+    input_a = np.random.uniform(0, 4, args.n).astype(INPUT_DATATYPE)
+    input_b = np.random.uniform(0, 4, args.n).astype(INPUT_DATATYPE)
 
     if args.compile_mode == "compile-and-run":
 
@@ -205,12 +310,14 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="eltwise_add",
         )
+        # BF16 has ~0.8% relative precision; use looser tolerance
+        rtol = 0.01 if INPUT_DATATYPE == bfloat16 else 1e-3
         exit(
             runner.run_test(
                 mlir_module,
                 inputs=[input_a, input_b],
                 stochastic_expected_outputs=[sampled_data],
-                rtol=1e-3,
+                rtol=rtol,
             )
         )
 

--- a/programming_examples/eltwise_add/run_makefile_chess.lit
+++ b/programming_examples/eltwise_add/run_makefile_chess.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run | FileCheck %s
+// RUN: make -f %S/Makefile run AIE_TARGET=aie2 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/eltwise_add/run_makefile_peano.lit
+++ b/programming_examples/eltwise_add/run_makefile_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run AIE_TARGET=aie2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/eltwise_add/run_makefile_peano_npu2.lit
+++ b/programming_examples/eltwise_add/run_makefile_peano_npu2.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_npu2
+// RUN: cd test_peano_npu2
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck --check-prefix=PROFILE %s
+// CHECK: PASS!
+// PROFILE: PASS

--- a/programming_examples/eltwise_add/test.cpp
+++ b/programming_examples/eltwise_add/test.cpp
@@ -1,0 +1,229 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "cxxopts.hpp"
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdfloat>
+#include <vector>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+using DATATYPE = std::bfloat16_t;
+
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>())("size,S", "Total number of elements",
+                                     cxxopts::value<int>());
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  cxxopts::Options options("Allowed options");
+  cxxopts::ParseResult vm;
+  add_default_options(options);
+  test_utils::parse_options(argc, argv, options, vm);
+  int verbosity = vm["verbosity"].as<int>();
+
+  int SIZE = vm["size"].as<int>();
+  int DATA_SIZE = SIZE * sizeof(DATATYPE);
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node, verbosity](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 if (verbosity >= 1) {
+                                   std::cout << "Name: " << name << std::endl;
+                                 }
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_a =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_b =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_c =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  // Fill input buffers with random data
+  DATATYPE *bufA = bo_a.map<DATATYPE *>();
+  std::vector<DATATYPE> AVec(SIZE);
+  for (int i = 0; i < SIZE; i++) {
+    AVec[i] = DATATYPE(4.0f * rand() / RAND_MAX);
+  }
+  memcpy(bufA, AVec.data(), AVec.size() * sizeof(DATATYPE));
+
+  DATATYPE *bufB = bo_b.map<DATATYPE *>();
+  std::vector<DATATYPE> BVec(SIZE);
+  for (int i = 0; i < SIZE; i++) {
+    BVec[i] = DATATYPE(4.0f * rand() / RAND_MAX);
+  }
+  memcpy(bufB, BVec.data(), BVec.size() * sizeof(DATATYPE));
+
+  DATATYPE *bufC = bo_c.map<DATATYPE *>();
+  std::vector<DATATYPE> CVec(SIZE, 0);
+  memcpy(bufC, CVec.data(), CVec.size() * sizeof(DATATYPE));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iterations = 20;
+  unsigned n_warmup_iterations = 10;
+  unsigned num_iter = n_iterations + n_warmup_iterations;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+
+  // Bandwidth: 2 reads + 1 write = 3 * SIZE * sizeof(DATATYPE) bytes
+  float total_bytes = 3.0f * SIZE * sizeof(DATATYPE);
+  bool verified = false;
+
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+
+    if (verbosity >= 1) {
+      std::cout << "Running Kernel.\n";
+    }
+    auto start = std::chrono::high_resolution_clock::now();
+    unsigned int opcode = 3;
+    auto run = kernel(opcode, bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+    bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    if (iter < n_warmup_iterations) {
+      /* Warmup iterations do not count towards average runtime. */
+      continue;
+    }
+
+    // Verify correctness on first measurement iteration
+    if (!verified) {
+      memcpy(CVec.data(), bufC, CVec.size() * sizeof(DATATYPE));
+      int errors = 0;
+      for (int i = 0; i < SIZE; i++) {
+        float expected = float(AVec[i]) + float(BVec[i]);
+        float got = float(CVec[i]);
+        float tol = std::max(0.05f, 0.01f * std::abs(expected));
+        if (std::abs(got - expected) > tol) {
+          if (errors < 10) {
+            std::cout << "Error at index " << i << ": got " << got
+                      << ", expected " << expected << std::endl;
+          }
+          errors++;
+        }
+      }
+      if (errors > 0) {
+        std::cout << "FAIL: " << errors << " / " << SIZE
+                  << " elements incorrect." << std::endl;
+      } else {
+        std::cout << "PASS: All " << SIZE << " elements correct." << std::endl;
+      }
+      verified = true;
+    }
+
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+  }
+
+  std::cout << std::endl
+            << "Problem size: " << SIZE << " elements ("
+            << (SIZE * sizeof(DATATYPE)) / 1024 << " KB per buffer)"
+            << std::endl;
+
+  std::cout << std::endl
+            << "Avg NPU eltwise_add time: " << npu_time_total / n_iterations
+            << "us." << std::endl;
+  std::cout << "Avg bandwidth: "
+            << total_bytes / (1000.0f * npu_time_total / n_iterations)
+            << " GB/s" << std::endl;
+
+  std::cout << std::endl
+            << "Min NPU eltwise_add time: " << npu_time_min << "us."
+            << std::endl;
+  std::cout << "Max bandwidth: " << total_bytes / (1000.0f * npu_time_min)
+            << " GB/s" << std::endl;
+
+  std::cout << std::endl
+            << "Max NPU eltwise_add time: " << npu_time_max << "us."
+            << std::endl;
+  std::cout << "Min bandwidth: " << total_bytes / (1000.0f * npu_time_max)
+            << " GB/s" << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Upgrade `eltwise_add` from F32 scalar to BF16 16-wide vectorized with configurable 2D herd
- Optimal `[8,1]` herd config achieves **415µs / 60.6 GB/s** on 4M elements (NPU2), matching IRON reference
- Add C++ XRT profiling harness (`test.cpp`) with `make profile` target
- Device-aware Makefile: `AIE_TARGET=aie2p` (NPU2, default) uses BF16/vec16/[8,1]; `AIE_TARGET=aie2` (NPU1) uses F32/scalar/[1,2]
- Existing NPU1 LIT tests pass via `AIE_TARGET=aie2`; new NPU2 LIT test validates both `make run` and `make profile`

## Performance (n=4,194,304 BF16 elements, NPU2)

| Version | Herd | Latency | Bandwidth | vs IRON |
|---------|------|---------|-----------|---------|
| Old (F32 scalar) | [1,2] | 214,619 µs | 0.23 GB/s | 497× slower |
| **New (BF16 vec16)** | **[8,1]** | **415 µs** | **60.6 GB/s** | **0.96× (4% faster)** |
| IRON reference | 8 cols | 432 µs | 57.6 GB/s | 1.0× |

## Test plan
- [x] `make run` — BF16 vec16 [8,1] (NPU2 default): PASS
- [x] `make run AIE_TARGET=aie2` — F32 scalar [1,2] (NPU1): PASS
- [x] `make profile` — C++ harness, 4M elements: PASS (all elements correct)
- [x] `lit -v run_makefile_peano.lit` — NPU1 LIT: PASS
- [x] `lit -v run_makefile_peano_elf.lit` — NPU2 ELF LIT: PASS
- [x] `lit -v run_makefile_peano_npu2.lit` — NPU2 run + profile LIT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)