### PR TITLE
Fix air-override-memref-memory-space to skip non-default allocs

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1573,7 +1573,9 @@ def AIROverrideMemRefMemorySpace : Pass<"air-override-memref-memory-space", "Mod
   let summary = "Force all memrefs allocated within code region to have the specified memory space.";
   let constructor = "xilinx::air::createAIROverrideMemRefMemorySpacePass()";
   let description = [{
-    Experimental pass. Force all memrefs allocated within a specified code region to have the specified memory space.
+    Experimental pass. Force all memrefs allocated within a specified code region
+    to have the specified memory space. Allocs that already have an explicitly set
+    non-default memory space (i.e., not L3/0) are preserved and not overridden.
   }];
   let options = [
     Option<"clMemorySpace", "memory-space", "unsigned", /*default=*/"0",

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2810,9 +2810,11 @@ struct OverrideMemorySpacePattern : public OpRewritePattern<memref::AllocOp> {
       return failure();
     if (air::getMemorySpace(memrefTy) == *targetMS)
       return failure();
-    // Skip allocs that already have a non-default memory space (e.g., L1=2
-    // when target is L2=1). Only override allocs with default memory space (L3=0).
-    if (air::getMemorySpace(memrefTy) != air::MemorySpace::L3)
+    // Skip allocs that already have a recognized non-default memory space
+    // (e.g., L1=2 when target is L2=1). Only override allocs with default
+    // memory space (L3=0) or unrecognized raw integer memory spaces.
+    auto currentMS = air::getMemorySpace(memrefTy);
+    if (currentMS && *currentMS != air::MemorySpace::L3)
       return failure();
 
     auto newMemrefType = MemRefType::get(

--- a/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_override_memref_memory_space.mlir
@@ -156,4 +156,52 @@ module {
     }
     return
   }
+
+  // Test that allocs with explicit non-default memory space are preserved
+  // while unset memory space allocs are overridden (PR #1436).
+  // Uses memory_space=3 (raw int) for "unassigned" allocs to satisfy verifier,
+  // and memory_space=2 (L1) / memory_space=1 (L2) for "already set" allocs.
+
+  // CHECK-LABEL: func.func @func_skip_existing_memspace
+  // scope=herd, target=L1(2): unassigned herd alloc overridden, L1 alloc preserved
+  // CHECK: air.herd
+  // CHECK:   memref.alloc() : memref<32xf32, 2 : i32>
+  // CHECK:   memref.alloc() : memref<32xf32, 2 : i32>
+
+  // SEGMENT-LABEL: func.func @func_skip_existing_memspace
+  // scope=segment, target=L2(1): unassigned segment alloc overridden,
+  // L2 segment alloc preserved, herd allocs unchanged by scope exclusion
+  // SEGMENT: air.segment
+  // SEGMENT:   memref.alloc() : memref<64xf32, 1 : i32>
+  // SEGMENT:   memref.alloc() : memref<64xf32, 1 : i32>
+  // SEGMENT:   air.herd
+  // SEGMENT:     memref.alloc() : memref<32xf32, 3>
+  // SEGMENT:     memref.alloc() : memref<32xf32, 2 : i32>
+
+  func.func @func_skip_existing_memspace(%arg0: memref<*xf32>) {
+    air.launch () in () args(%a0=%arg0) : memref<*xf32> {
+      air.segment @seg args(%s0=%a0) : memref<*xf32> {
+        %c1 = arith.constant 1 : index
+        %c64 = arith.constant 64 : index
+        %rc64 = memref.reinterpret_cast %s0 to offset: [0], sizes: [64], strides: [1] : memref<*xf32> to memref<64xf32, strided<[1], offset: ?>>
+        // Unassigned (memory_space=3) alloc at segment level - should be overridden
+        %seg_default = memref.alloc() : memref<64xf32, 3>
+        memref.copy %rc64, %seg_default : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32, 3>
+        // Explicit L2 (memory_space=1) alloc at segment level - should be preserved
+        %seg_l2 = memref.alloc() : memref<64xf32, 1 : i32>
+        memref.copy %rc64, %seg_l2 : memref<64xf32, strided<[1], offset: ?>> to memref<64xf32, 1 : i32>
+        air.herd @herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%h0=%s0) : memref<*xf32> {
+          %c32 = arith.constant 32 : index
+          %rc32 = memref.reinterpret_cast %h0 to offset: [0], sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+          // Unassigned (memory_space=3) alloc at herd level - should be overridden by scope=herd
+          %herd_default = memref.alloc() : memref<32xf32, 3>
+          memref.copy %rc32, %herd_default : memref<32xf32, strided<[1], offset: ?>> to memref<32xf32, 3>
+          // Explicit L1 (memory_space=2) alloc at herd level - should be preserved
+          %herd_l1 = memref.alloc() : memref<32xf32, 2 : i32>
+          memref.copy %rc32, %herd_l1 : memref<32xf32, strided<[1], offset: ?>> to memref<32xf32, 2 : i32>
+        }
+      }
+    }
+    return
+  }
 }


### PR DESCRIPTION
## Summary
- Fix `OverrideMemorySpacePattern` in `AIRMiscPasses.cpp` to skip allocs that already have a non-default memory space (e.g., L1=2)
- Prevents the pass from overwriting explicitly-set L1 allocs when re-run after bufferization
- Required for `@module_builder` patterns that create L1 allocs with explicit memory space

## Test plan
- [x] Verify test/xrt/54 compilation (uses L1 allocs with explicit memory space)
- [x] No regression on existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)