### PR TITLE
Fix missing air-split-launch-for-padding in C++ aircc

### DIFF
--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1014,6 +1014,12 @@ static LogicalResult runAieCompilation() {
   if (debugIr)
     addCheckpoint("AIR Placement Complete", "placed.air.mlir");
 
+  // Split launch for non-tile-aligned DMA padding. No-op if no launch
+  // has the air.actual_sizes attribute (set by air-wrap-func-with-parallel).
+  if (failed(runPassPipeline("builtin.module(air-split-launch-for-padding)",
+                             placedModule.get())))
+    return failure();
+
   // --- AIR to AIE conversion ---
   std::string airToAiePipeline;
   {


### PR DESCRIPTION
## Summary
- Add the `air-split-launch-for-padding` pass to the C++ `aircc` compiler driver pipeline, between placement and AIR-to-AIE conversion
- This pass was present in the Python `aircc` ([main.py:856-860](https://github.com/Xilinx/mlir-air/blob/de32ade6/python/air/compiler/aircc/main.py#L856-L860)) but was omitted when the C++ driver was added in de32ade6
- Without this pass, workloads with non-tile-aligned M/N dimensions (using `air-wrap-func-with-parallel` with `actual-sizes`) produce incorrect results — boundary launches with `pad_after` DMA attributes are never generated
- The pass is a no-op for tile-aligned workloads (no `air.actual_sizes` attribute), so no existing tests are affected

## Test plan
- [x] Verified test 54 (`54_matmul_padding_f32_bf16_emulation`) passes end-to-end with debug IR showing `pass_043_after_air-split-launch-for-padding.mlir` correctly generated
- [x] Verified the pass splits the launch grid into 4 launches (interior, M-boundary, N-boundary, corner) with correct `pad_after` attributes
- [x] CI `check-air-mlir` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)