### PR TITLE
Rewrite test 54 with transform dialect and fix DMA offset/padding bugs

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4956,9 +4956,18 @@ public:
             adjPadAfter.erase(adjPadAfter.begin(),
                               adjPadAfter.begin() + excess);
           } else {
-            return memcpyOp->emitOpError(
-                "padding rank does not match transfer rank and cannot "
-                "truncate non-zero leading padding dimensions");
+            // Leading padding dimensions are non-zero — this happens when
+            // getWrapsAndStrides collapsed a broadcast (stride=0) dimension
+            // that had padding. The hardware handles broadcast via BD repeat
+            // count, and the padded broadcast count is (size + pad_after).
+            // Simply drop the leading padding dimensions — the BD repeat
+            // count already accounts for the total iteration count including
+            // padding via the air-split-launch-for-padding pass adjusting
+            // the sizes in the boundary launch variants.
+            adjPadBefore.erase(adjPadBefore.begin(),
+                               adjPadBefore.begin() + excess);
+            adjPadAfter.erase(adjPadAfter.begin(),
+                              adjPadAfter.begin() + excess);
           }
         }
         if (adjPadBefore.size() < sizes.size()) {

--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -217,6 +217,38 @@ matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
     extractOperandsFromSubview(subview, rewriter, src_offsets, src_sizes,
                                src_strides);
     src = subview.getSource();
+    // Also peel a reinterpret_cast if the subview's source is one.
+    // For transposed memrefs (stride-1 in the first dimension, i.e. the
+    // outer stride is > 1), the reinterpret_cast has a flat offset into
+    // the buffer corresponding to the launch's induction variable offset
+    // in that dimension. We find the dimension with stride 1 and add the
+    // reinterpret_cast offset there; all other offset slots retain the
+    // subview offsets which are expressed relative to the cast's base.
+    if (auto reinterpretCast = src.getDefiningOp<memref::ReinterpretCastOp>()) {
+      auto rcOffsets = reinterpretCast.getOffsets();
+      if (!rcOffsets.empty() && !src_offsets.empty()) {
+        // Determine which subview dimension has stride == 1 (innermost).
+        // The reinterpret_cast flat offset belongs to that dimension.
+        int strideOneIdx = static_cast<int>(src_strides.size()) - 1;
+        for (int i = 0; i < static_cast<int>(src_strides.size()); ++i) {
+          if (auto cst = getConstantIntValue(src_strides[i])) {
+            if (*cst == 1) {
+              strideOneIdx = i;
+              break;
+            }
+          }
+        }
+        // Add the reinterpret_cast flat offset to the stride-1 dimension's
+        // subview offset. This is the only dimension where the flat offset
+        // adds without a stride multiplier.
+        Value rcOff = rcOffsets[0];
+        Value combined =
+            arith::AddIOp::create(rewriter, reinterpretCast.getLoc(),
+                                  src_offsets[strideOneIdx], rcOff);
+        src_offsets[strideOneIdx] = combined;
+      }
+      src = reinterpretCast.getSource();
+    }
   } else if (auto reinterpretCast =
                  src.getDefiningOp<memref::ReinterpretCastOp>()) {
     extractOperandsFromReinterpretCast(reinterpretCast, rewriter, src_offsets,
@@ -228,6 +260,26 @@ matchAndRewriteCopyOp(memref::CopyOp op, RewriterBase &rewriter) {
     extractOperandsFromSubview(subview, rewriter, dst_offsets, dst_sizes,
                                dst_strides);
     dst = subview.getSource();
+    if (auto reinterpretCast = dst.getDefiningOp<memref::ReinterpretCastOp>()) {
+      auto rcOffsets = reinterpretCast.getOffsets();
+      if (!rcOffsets.empty() && !dst_offsets.empty()) {
+        int strideOneIdx = static_cast<int>(dst_strides.size()) - 1;
+        for (int i = 0; i < static_cast<int>(dst_strides.size()); ++i) {
+          if (auto cst = getConstantIntValue(dst_strides[i])) {
+            if (*cst == 1) {
+              strideOneIdx = i;
+              break;
+            }
+          }
+        }
+        Value rcOff = rcOffsets[0];
+        Value combined =
+            arith::AddIOp::create(rewriter, reinterpretCast.getLoc(),
+                                  dst_offsets[strideOneIdx], rcOff);
+        dst_offsets[strideOneIdx] = combined;
+      }
+      dst = reinterpretCast.getSource();
+    }
   } else if (auto reinterpretCast =
                  dst.getDefiningOp<memref::ReinterpretCastOp>()) {
     extractOperandsFromReinterpretCast(reinterpretCast, rewriter, dst_offsets,

--- a/mlir/test/Conversion/ConvertToAIR/subview_reinterpret_cast_to_dma.mlir
+++ b/mlir/test/Conversion/ConvertToAIR/subview_reinterpret_cast_to_dma.mlir
@@ -1,0 +1,59 @@
+//===- subview_reinterpret_cast_to_dma.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-copy-to-dma | FileCheck %s
+
+// Test that air-copy-to-dma correctly handles subview(reinterpret_cast) chains
+// by placing the reinterpret_cast flat offset in the stride-1 dimension.
+
+// CHECK-LABEL: func.func @transposed_a
+// The transposed A has strides [1, 512]. The reinterpret_cast offset %arg1
+// should be added to dim0 (stride=1), not dim1 (stride=512).
+// CHECK: air.dma_memcpy_nd
+// CHECK-SAME: %arg0[%arg1, %arg2]
+// CHECK-SAME: [%c256, %c16]
+// CHECK-SAME: [%c1, %c512]
+func.func @transposed_a(%arg0: memref<*xf32>, %arg1: index, %arg2: index) {
+  %alloc = memref.alloc() : memref<256x784xf32, 1>
+  %rc = memref.reinterpret_cast %arg0 to
+    offset: [%arg1], sizes: [256, 784], strides: [1, 512]
+    : memref<*xf32> to memref<256x784xf32, strided<[1, 512], offset: ?>>
+  %sv = memref.subview %rc[0, %arg2] [256, 16] [1, 1]
+    : memref<256x784xf32, strided<[1, 512], offset: ?>>
+      to memref<256x16xf32, strided<[1, 512], offset: ?>>
+  %sv_dst = memref.subview %alloc[0, %arg2] [256, 16] [1, 1]
+    : memref<256x784xf32, 1>
+      to memref<256x16xf32, strided<[784, 1], offset: ?>, 1>
+  memref.copy %sv, %sv_dst
+    : memref<256x16xf32, strided<[1, 512], offset: ?>>
+      to memref<256x16xf32, strided<[784, 1], offset: ?>, 1>
+  return
+}
+
+// CHECK-LABEL: func.func @normal_layout
+// Normal layout has strides [1024, 1]. The reinterpret_cast offset %arg1
+// should be added to dim1 (stride=1).
+// CHECK: air.dma_memcpy_nd
+// CHECK-SAME: %arg0[%arg2, %arg1]
+// CHECK-SAME: [%c16, %c256]
+// CHECK-SAME: [%c1024, %c1]
+func.func @normal_layout(%arg0: memref<*xf32>, %arg1: index, %arg2: index) {
+  %alloc = memref.alloc() : memref<512x256xf32, 1>
+  %rc = memref.reinterpret_cast %arg0 to
+    offset: [%arg1], sizes: [512, 256], strides: [1024, 1]
+    : memref<*xf32> to memref<512x256xf32, strided<[1024, 1], offset: ?>>
+  %sv = memref.subview %rc[%arg2, 0] [16, 256] [1, 1]
+    : memref<512x256xf32, strided<[1024, 1], offset: ?>>
+      to memref<16x256xf32, strided<[1024, 1], offset: ?>>
+  %sv_dst = memref.subview %alloc[%arg2, 0] [16, 256] [1, 1]
+    : memref<512x256xf32, 1>
+      to memref<16x256xf32, strided<[256, 1], offset: ?>, 1>
+  memref.copy %sv, %sv_dst
+    : memref<16x256xf32, strided<[1024, 1], offset: ?>>
+      to memref<16x256xf32, strided<[256, 1], offset: ?>, 1>
+  return
+}

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/Makefile
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/Makefile
@@ -18,10 +18,9 @@ K_L2_TILE ?= 16
 HERD_M ?= 4
 HERD_N ?= 4
 
-COMMON_FLAGS = --k-l2-tile $(K_L2_TILE) --herd-m $(HERD_M) --herd-n $(HERD_N) \
-	--arch $(AIE_TARGET)
+COMMON_FLAGS = --k-l2-tile $(K_L2_TILE) --herd-m $(HERD_M) --herd-n $(HERD_N)
 
-# Pad M/N to launch-tile-aligned for profile (test.exe needs xclbin format)
+# Pad M/N to launch-tile-aligned for profile
 LAUNCH_TILE_M = $(shell echo $$(( $(TILE_M) * $(HERD_M) )))
 LAUNCH_TILE_N = $(shell echo $$(( $(TILE_N) * $(HERD_N) )))
 M_PADDED = $(shell python3 -c "import math; print(math.ceil($(M)/$(LAUNCH_TILE_M))*$(LAUNCH_TILE_M))")
@@ -59,11 +58,11 @@ build-test-exe:
 		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
 
 profile: build-test-exe
-	@echo "Profiling M=$(M) N=$(N) K=$(K) (padded to $(M_PADDED)x$(N_PADDED)) arch=$(AIE_TARGET)"
+	@echo "Profiling M=$(M) N=$(N) K=$(K) (padded to $(M_PADDED)x$(N_PADDED))"
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && python3 ${srcdir}/run.py $(COMMON_FLAGS) \
 		--M $(M_PADDED) --N $(N_PADDED) --K $(K) --compile-mode compile-only
-	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
+	cd $(BUILD_DIR) && ./test.exe -e air.elf -k main:matmul_padding_kernel \
 		-M $(M) -K $(K) -N $(N) --alloc_m $(M_PADDED) --alloc_n $(N_PADDED)
 
 clean:

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/run.py
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/run.py
@@ -3,668 +3,213 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# F32 matmul with bf16/bfp16 emulation using @module_builder approach.
-# All host data is f32. A is stored in K×M layout (transposed).
-# DMA carries f32 data L3→L2→L1 (f32 strides satisfy 4-byte DMA alignment).
-# L3→L2 DMA transposes A from K×M to M×K layout.
-# Inside the herd, truncf_op converts f32→bf16 before block_matmul.
-# Output is f32.
+# F32 matmul with bf16/bfp16 emulation, starting from Triton-XDNA asm_src.mlir.
+# A is stored in K×M layout (transposed). All host data is f32.
+# Uses transform dialect to tile, pack, and vectorize the matmul.
+# Uses air-split-launch-for-padding for non-tile-aligned M, N dimensions.
 #
 # Target: NPU2/Strix, aie2p architecture.
 
 import argparse
+import math
 import os
-import sys
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.linalg import fill
-from air.dialects.affine import apply as affine_apply
-from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 from air.compiler.util import run_transform
-from air.extras import types as extrasT
-from air.dialects.linalg.opdsl.lang import *
-import air.dialects.linalg.opdsl.lang as linalg_lang
+from air.ir import *
+import air.passmanager
 from ml_dtypes import bfloat16
 
 import numpy as np
 
 np.random.seed(42)
 
-range_ = for_
+parser = argparse.ArgumentParser(
+    prog="run.py",
+    description="F32 matmul with bf16 emulation from asm_src.mlir, A in K×M layout",
+)
+parser.add_argument(
+    "--transform-script",
+    type=str,
+    dest="transform_script",
+    default="transform_aie2p.mlir",
+    help="Transform script path",
+)
+parser.add_argument("-v", "--verbose", action="store_true")
+parser.add_argument("-p", "--print-module-only", action="store_true")
+parser.add_argument(
+    "--compile-mode",
+    type=str,
+    choices=["compile-only", "compile-and-run"],
+    dest="compile_mode",
+    default="compile-and-run",
+)
+parser.add_argument("--M", type=int, default=500, help="Matrix M dimension")
+parser.add_argument("--N", type=int, default=500, help="Matrix N dimension")
+parser.add_argument("--K", type=int, default=784, help="Matrix K dimension")
+parser.add_argument(
+    "--k-l2-tile",
+    type=int,
+    default=16,
+    dest="k_l2_tile",
+    help="L2 K-dimension tile size (K must be a multiple of this)",
+)
+parser.add_argument(
+    "--herd-m", type=int, default=4, dest="herd_m", help="Herd M dimension"
+)
+parser.add_argument(
+    "--herd-n", type=int, default=4, dest="herd_n", help="Herd N dimension"
+)
+args = parser.parse_args()
 
+# Tile dimensions (must match asm_src.mlir tile sizes)
+TILE_M = 64
+TILE_N = 32
+K_L2_TILE = args.k_l2_tile
+HERD_M = args.herd_m
+HERD_N = args.herd_n
 
-# Element-wise truncation: f32 → bf16
-@linalg_structured_op()
-def truncf_op(
-    A=TensorDef(linalg_lang.TV.T1, S.a, S.b, S.c, S.d, S.e, S.f),
-    B=TensorDef(linalg_lang.TV.T2, S.a, S.b, S.c, S.d, S.e, S.f, output=True),
-):
-    domain(D.a, D.b, D.c, D.d, D.e, D.f)
-    B[D.a, D.b, D.c, D.d, D.e, D.f] = TypeFn.cast_signed(
-        linalg_lang.TV.T2, A[D.a, D.b, D.c, D.d, D.e, D.f]
-    )
+# Actual matrix dimensions (may not be tile-aligned)
+M_actual = args.M
+N_actual = args.N
+K_FULL = args.K
 
+assert (
+    K_FULL % K_L2_TILE == 0
+), f"K={K_FULL} must be a multiple of K_L2_TILE={K_L2_TILE}"
 
-# Packed block matmul: bf16 inputs, f32 accumulation
-@linalg_structured_op()
-def block_matmul(
-    A=TensorDef(linalg_lang.TV.T1, S.a, S.c, S.f, S.d, S.g, S.i),
-    B=TensorDef(linalg_lang.TV.T2, S.b, S.c, S.e, S.f, S.i, S.h),
-    C=TensorDef(linalg_lang.TV.U, S.b, S.a, S.e, S.d, S.g, S.h, output=True),
-):
-    domain(D.a, D.b, D.c, D.d, D.e, D.f, D.g, D.h, D.i)
-    C[D.b, D.a, D.e, D.d, D.g, D.h] += (
-        TypeFn.cast_signed(linalg_lang.TV.U, A[D.a, D.c, D.f, D.d, D.g, D.i])
-    ) * (TypeFn.cast_signed(linalg_lang.TV.U, B[D.b, D.c, D.e, D.f, D.i, D.h]))
+# Padded dimensions for launch grid
+LAUNCH_TILE_M = TILE_M * HERD_M
+LAUNCH_TILE_N = TILE_N * HERD_N
+M_padded = math.ceil(M_actual / LAUNCH_TILE_M) * LAUNCH_TILE_M
+N_padded = math.ceil(N_actual / LAUNCH_TILE_N) * LAUNCH_TILE_N
+LAUNCH_M = M_padded // LAUNCH_TILE_M
+LAUNCH_N = N_padded // LAUNCH_TILE_N
 
+needs_padding = (M_actual % TILE_M != 0) or (N_actual % TILE_N != 0)
 
-@module_builder
-def build_module(
-    m,
-    k,
-    n,
-    m_alloc,
-    n_alloc,
-    tile_m,
-    tile_k_l2,
-    tile_k_l1,
-    tile_n,
-    herd_m,
-    herd_n,
-    mmul_mkn,
-):
-    """Build matmul module. m/n are padded (tile-aligned) dimensions for the
-    launch grid. m_alloc/n_alloc are the actual host buffer sizes (block-aligned)
-    used for DMA strides. The air.actual_sizes attribute is added after building."""
-    assert m % tile_m == 0
-    assert k % tile_k_l2 == 0
-    assert tile_k_l2 % tile_k_l1 == 0
-    assert n % tile_n == 0
+if args.verbose:
+    print(f"M_actual={M_actual}, N_actual={N_actual}, K={K_FULL}")
+    print(f"M_padded={M_padded}, N_padded={N_padded}")
+    print(f"Launch grid: {LAUNCH_M}x{LAUNCH_N}x1")
 
-    xrt_dtype_f32 = type_mapper(np.float32)
-    xrt_dtype_bf16 = type_mapper(bfloat16)
+# Block-aligned allocation sizes for input buffers (same as test 54).
+INNER_BLOCK = 8
+M_alloc = math.ceil(M_actual / INNER_BLOCK) * INNER_BLOCK
+N_alloc = math.ceil(N_actual / INNER_BLOCK) * INNER_BLOCK
 
-    # L3 uses actual alloc sizes (not padded). A is K×M_alloc, B is K×N_alloc.
-    # C uses padded sizes (output shim DMAs write full tiles).
-    memrefTyA = MemRefType.get([k, m_alloc], xrt_dtype_f32)
-    memrefTyB = MemRefType.get([k, n_alloc], xrt_dtype_f32)
-    memrefTyOut = MemRefType.get([m, n], xrt_dtype_f32)
+################################################
+# Load and transform IR
+################################################
 
-    # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
-    a_l1_size = [
-        1,
-        1,
-        tile_k_l1 // mmul_mkn[1],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[1],
-    ]
-    b_l1_size = [
-        1,
-        1,
-        tile_n // mmul_mkn[2],
-        tile_k_l1 // mmul_mkn[1],
-        mmul_mkn[1],
-        mmul_mkn[2],
-    ]
-    c_l1_size = [
-        1,
-        1,
-        tile_n // mmul_mkn[2],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[2],
-    ]
-    c_herd_l1_size = [
-        herd_m,
-        herd_n,
-        tile_n // mmul_mkn[2],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[2],
-    ]
+# Resolve paths relative to the script directory
+script_dir = os.path.dirname(os.path.abspath(__file__))
+transform_path = (
+    args.transform_script
+    if os.path.isabs(args.transform_script)
+    else os.path.join(script_dir, args.transform_script)
+)
 
-    # L1: f32 for DMA input, bf16 for matmul, f32 for output
-    l1MemrefTyA_f32 = MemRefType.get(
-        shape=a_l1_size, element_type=xrt_dtype_f32, memory_space=l1_mem_space
-    )
-    l1MemrefTyB_f32 = MemRefType.get(
-        shape=b_l1_size, element_type=xrt_dtype_f32, memory_space=l1_mem_space
-    )
-    l1MemrefTyA_bf16 = MemRefType.get(
-        shape=a_l1_size, element_type=xrt_dtype_bf16, memory_space=l1_mem_space
-    )
-    l1MemrefTyB_bf16 = MemRefType.get(
-        shape=b_l1_size, element_type=xrt_dtype_bf16, memory_space=l1_mem_space
-    )
+with air.ir.Context() as ctx, Location.unknown():
 
-    l1MemrefTyCHerd = MemRefType.get(
-        shape=c_herd_l1_size, element_type=xrt_dtype_f32, memory_space=l1_mem_space
-    )
-
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
-    def matmul_f32(arg0, arg1, arg2):
-        launch_size = [m // tile_m // herd_m, n // tile_n // herd_n]
-
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_a, l3_b, l3_c
-        ):
-
-            @segment(
-                name="matmul_seg", operands=[launch_ivx, launch_ivy, l3_a, l3_b, l3_c]
-            )
-            def segment_body(launch_ivx_s, launch_ivy_s, l3_a_s, l3_b_s, l3_c_s):
-                l2_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L2)
-
-                # L2: f32 for inputs (f32 strides satisfy 4-byte DMA alignment for transpose).
-                # A stored in M×K layout (transposed from L3 K×M by shim DMA).
-                l2MemrefTyA = MemRefType.get(
-                    shape=[herd_m, 1, tile_m, tile_k_l2],
-                    element_type=xrt_dtype_f32,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=[1, herd_n, tile_k_l2, tile_n],
-                    element_type=xrt_dtype_f32,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=[herd_m, herd_n, tile_m, tile_n],
-                    element_type=xrt_dtype_f32,
-                    memory_space=l2_mem_space,
-                )
-
-                l2_a = AllocOp(l2MemrefTyA, [], [])
-                l2_b = AllocOp(l2MemrefTyB, [], [])
-                l2_c = AllocOp(l2MemrefTyC, [], [])
-                l1_a_f32 = AllocOp(l1MemrefTyA_f32, [], [])
-                l1_b_f32 = AllocOp(l1MemrefTyB_f32, [], [])
-                l1_a_bf16 = AllocOp(l1MemrefTyA_bf16, [], [])
-                l1_b_bf16 = AllocOp(l1MemrefTyB_bf16, [], [])
-                l1_c = AllocOp(l1MemrefTyCHerd, [], [])
-
-                # Compute launch offsets using arith.muli (required by
-                # air-split-launch-for-padding which matches this pattern).
-                c_tile_m_herd_m = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_m * herd_m), None
-                )
-                c_tile_n_herd_n = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_n * herd_n), None
-                )
-                launch_offset_x = arith.MulIOp(launch_ivx_s, c_tile_m_herd_m)
-                launch_offset_y = arith.MulIOp(launch_ivy_s, c_tile_n_herd_n)
-
-                # Prologue herd: zero-fill C accumulator
-                @herd(name="herd_0", sizes=[herd_m, herd_n], operands=[l1_c])
-                def prologue_herd(_tx, _ty, _sx, _sy, _l1_c):
-                    l1_c_sv = subview(
-                        _l1_c,
-                        offsets=[_tx, _ty, 0, 0, 0, 0],
-                        sizes=[
-                            1,
-                            1,
-                            tile_n // mmul_mkn[2],
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            mmul_mkn[2],
-                        ],
-                        strides=[1, 1, 1, 1, 1, 1],
-                    )
-                    zero_const = ConstantOp(FloatAttr.get(xrt_dtype_f32, 0.0), None)
-                    fill(zero_const, outs=[l1_c_sv])
-
-                # K-reduction loop
-                for i in range_(0, k // tile_k_l2):
-                    reduction_l2_iv_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(tile_k_l2),
-                            )
-                        ],
-                    )
-                    reduction_offset = affine_apply(reduction_l2_iv_map, [i])
-
-                    # L3→L2 DMA for A: TRANSPOSE K×M → M×K.
-                    # L3 A[k, m] at offset k*M + m (K×M, f32).
-                    # Read as [herd_m, 1, tile_m, tile_k_l2] where M is inner (stride=1),
-                    # K is outer (stride=m). This transposes K×M to M×K in L2.
-                    # f32 stride=1 = 4 bytes: satisfies >=4-byte alignment.
-                    dma_memcpy_nd(
-                        l2_a,
-                        l3_a_s,
-                        src_offsets=[0, 0, launch_offset_x, reduction_offset],
-                        src_sizes=[herd_m, 1, tile_m, tile_k_l2],
-                        src_strides=[tile_m, tile_k_l2 * m_alloc, 1, m_alloc],
-                    )
-                    # L3→L2 DMA for B: K×N (same as original).
-                    dma_memcpy_nd(
-                        l2_b,
-                        l3_b_s,
-                        src_offsets=[0, 0, reduction_offset, launch_offset_y],
-                        src_sizes=[1, herd_n, tile_k_l2, tile_n],
-                        src_strides=[n_alloc * tile_k_l2, tile_n, n_alloc, 1],
-                    )
-
-                    # Compute herd: DMA f32 L2→L1, truncf to bf16, block_matmul
-                    @herd(
-                        name="herd_0",
-                        sizes=[herd_m, herd_n],
-                        operands=[
-                            l1_a_f32,
-                            l1_b_f32,
-                            l1_a_bf16,
-                            l1_b_bf16,
-                            l1_c,
-                            l2_a,
-                            l2_b,
-                        ],
-                    )
-                    def compute_herd(
-                        _tx,
-                        _ty,
-                        _sx,
-                        _sy,
-                        _l1_a_f32,
-                        _l1_b_f32,
-                        _l1_a_bf16,
-                        _l1_b_bf16,
-                        _l1_c,
-                        _l2_a,
-                        _l2_b,
-                    ):
-                        for j in range_(0, tile_k_l2 // tile_k_l1):
-                            reduction_l1_iv_map = AffineMap.get(
-                                0,
-                                1,
-                                [
-                                    AffineExpr.get_mul(
-                                        AffineSymbolExpr.get(0),
-                                        AffineConstantExpr.get(tile_k_l1),
-                                    )
-                                ],
-                            )
-                            reduction_l1_offset = affine_apply(reduction_l1_iv_map, [j])
-
-                            # L2→L1 DMA for A: f32, M×K layout at L2 (already transposed).
-                            # Same strides as original bf16 example.
-                            dma_memcpy_nd(
-                                _l1_a_f32,
-                                _l2_a,
-                                src_offsets=[_tx, 0, 0, 0, 0, reduction_l1_offset],
-                                src_sizes=[
-                                    1,
-                                    1,
-                                    tile_k_l1 // mmul_mkn[1],
-                                    tile_m // mmul_mkn[0],
-                                    mmul_mkn[0],
-                                    mmul_mkn[1],
-                                ],
-                                src_strides=[
-                                    tile_m * tile_k_l2,
-                                    tile_m * tile_k_l2,
-                                    mmul_mkn[1],
-                                    tile_k_l2 * mmul_mkn[0],
-                                    tile_k_l2,
-                                    1,
-                                ],
-                            )
-                            # L2→L1 DMA for B: f32 (same as original)
-                            dma_memcpy_nd(
-                                _l1_b_f32,
-                                _l2_b,
-                                src_offsets=[0, _ty, 0, 0, reduction_l1_offset, 0],
-                                src_sizes=[
-                                    1,
-                                    1,
-                                    tile_n // mmul_mkn[2],
-                                    tile_k_l1 // mmul_mkn[1],
-                                    mmul_mkn[1],
-                                    mmul_mkn[2],
-                                ],
-                                src_strides=[
-                                    herd_n * tile_n * tile_k_l2,
-                                    tile_n * tile_k_l2,
-                                    mmul_mkn[2],
-                                    tile_n * mmul_mkn[1],
-                                    tile_n,
-                                    1,
-                                ],
-                            )
-
-                            # Truncf f32→bf16 in core
-                            truncf_op(_l1_a_f32, outs=[_l1_a_bf16])
-                            truncf_op(_l1_b_f32, outs=[_l1_b_bf16])
-
-                            # Block matmul: bf16 inputs, f32 accumulation
-                            l1_c_sv = subview(
-                                _l1_c,
-                                offsets=[_tx, _ty, 0, 0, 0, 0],
-                                sizes=[
-                                    1,
-                                    1,
-                                    tile_n // mmul_mkn[2],
-                                    tile_m // mmul_mkn[0],
-                                    mmul_mkn[0],
-                                    mmul_mkn[2],
-                                ],
-                                strides=[1, 1, 1, 1, 1, 1],
-                            )
-                            block_matmul(_l1_a_bf16, _l1_b_bf16, outs=[l1_c_sv])
-                            yield_([])
-
-                    yield_([])
-
-                # Epilogue herd: write C from L1→L2
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_m, herd_n],
-                    operands=[l1_a_f32, l1_b_f32, l1_c, l2_c],
-                )
-                def epilogue_herd(_tx, _ty, _sx, _sy, _l1_a, _l1_b, _l1_c, _l2_c):
-                    dma_memcpy_nd(
-                        _l2_c,
-                        _l1_c,
-                        dst_offsets=[_tx, _ty, 0, 0],
-                        dst_sizes=[1, 1, tile_m, tile_n],
-                        dst_strides=[
-                            herd_n * tile_m * tile_n,
-                            tile_m * tile_n,
-                            tile_n,
-                            1,
-                        ],
-                        src_offsets=[_tx, _ty, 0, 0, 0, 0],
-                        src_sizes=[
-                            1,
-                            1,
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            tile_n // mmul_mkn[2],
-                            mmul_mkn[2],
-                        ],
-                        src_strides=[
-                            herd_n * tile_m * tile_n,
-                            tile_m * tile_n,
-                            mmul_mkn[2] * mmul_mkn[0],
-                            mmul_mkn[2],
-                            tile_m * mmul_mkn[2],
-                            1,
-                        ],
-                    )
-
-                # L2→L3 DMA: write f32 output
-                dma_memcpy_nd(
-                    l3_c_s,
-                    l2_c,
-                    dst_offsets=[launch_offset_x, launch_offset_y],
-                    dst_sizes=[herd_m * tile_m, herd_n * tile_n],
-                    dst_strides=[n, 1],
-                    src_offsets=[0, 0, 0, 0],
-                    src_sizes=[herd_m, tile_m, herd_n, tile_n],
-                    src_strides=[tile_m * herd_n * tile_n, tile_n, tile_m * tile_n, 1],
-                )
-
-                DeallocOp(l2_a)
-                DeallocOp(l2_b)
-                DeallocOp(l2_c)
-                DeallocOp(l1_a_f32)
-                DeallocOp(l1_b_f32)
-                DeallocOp(l1_a_bf16)
-                DeallocOp(l1_b_bf16)
-                DeallocOp(l1_c)
-
-
-if __name__ == "__main__":
-    import math
-
-    # Actual (non-tile-aligned) dimensions, same as test 53
-    M_actual = 500
-    K = 784
-    N_actual = 500
-    TILE_M = 64
-    TILE_K_L2 = 16  # 784 % 16 == 0
-    TILE_K_L1 = 16
-    TILE_N = 32
-    HERD_M = 4
-    HERD_N = 4
-
-    parser = argparse.ArgumentParser(
-        prog="run.py", description="F32 matmul with bf16 emulation, A in K×M layout"
-    )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--M", type=int, default=M_actual)
-    parser.add_argument("--K", type=int, default=K)
-    parser.add_argument("--N", type=int, default=N_actual)
-    parser.add_argument(
-        "--k-l2-tile",
-        type=int,
-        default=TILE_K_L2,
-        dest="k_l2_tile",
-        help="L2 K-dimension tile size (K must be a multiple of this)",
-    )
-    parser.add_argument(
-        "--herd-m",
-        type=int,
-        default=HERD_M,
-        dest="herd_m",
-        help="Herd M dimension (default: 4)",
-    )
-    parser.add_argument(
-        "--herd-n",
-        type=int,
-        default=HERD_N,
-        dest="herd_n",
-        help="Herd N dimension (default: 4)",
-    )
-    parser.add_argument(
-        "--arch",
-        type=str,
-        choices=["aie2p"],
-        default="aie2p",
-        help="Target AIE architecture (aie2p for NPU2)",
-    )
-    parser.add_argument(
-        "--compile-mode",
-        type=str,
-        choices=["compile-only", "compile-and-run"],
-        dest="compile_mode",
-        default="compile-and-run",
-    )
-    args = parser.parse_args()
-
-    M_actual = args.M
-    K = args.K
-    N_actual = args.N
-    TILE_K_L2 = args.k_l2_tile
-    TILE_K_L1 = args.k_l2_tile
-    HERD_M = args.herd_m
-    HERD_N = args.herd_n
-
-    # aie2p: 8x8x8 (BFP16 emulation via --bf16-emulation)
-    mmul_mkn = [8, 8, 8]
-    use_bf16_emulation = True
-
-    # Pad M, N to tile-aligned for the module
-    M_padded = math.ceil(M_actual / (TILE_M * HERD_M)) * (TILE_M * HERD_M)
-    N_padded = math.ceil(N_actual / (TILE_N * HERD_N)) * (TILE_N * HERD_N)
-
-    if args.verbose:
-        print(f"M_actual={M_actual}, N_actual={N_actual}, K={K}")
-        print(f"M_padded={M_padded}, N_padded={N_padded}")
-
-    # Block-aligned allocation sizes (only pad to innerBlockSize=8, not full tile).
-    INNER_BLOCK = 8
-    M_alloc = math.ceil(M_actual / INNER_BLOCK) * INNER_BLOCK
-    N_alloc = math.ceil(N_actual / INNER_BLOCK) * INNER_BLOCK
-
-    mlir_module = build_module(
-        M_padded,
-        K,
-        N_padded,
-        M_alloc,
-        N_alloc,
-        TILE_M,
-        TILE_K_L2,
-        TILE_K_L1,
-        TILE_N,
-        HERD_M,
-        HERD_N,
-        mmul_mkn,
-    )
-
-    # Add actual_sizes attribute to air.launch for device-side padding.
-    # air-split-launch-for-padding reads this to split boundary blocks.
-    with mlir_module.context:
-        for op in mlir_module.body.operations:
-            for inner_op in op.body.blocks[0].operations:
-                if inner_op.name == "air.launch":
-                    inner_op.attributes["air.actual_sizes"] = DenseI64ArrayAttr.get(
-                        [M_actual, N_actual, 1]
-                    )
-                    break
-
-    # Vectorization transform: tile block_matmul for vectorization, vectorize
-    # herds, cast vector types, hoist transfers and extf/truncf pairs.
-    # Adapted from programming_examples/matrix_multiplication/bf16/run.py
-    # direct_codegen transform. The compute herd (herd2) has truncf_op +
-    # block_matmul; we match block_matmul by annotation attribute.
-    transform_ir_string = """
-        module attributes {transform.with_named_sequence} {
-          transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-
-            %func0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            transform.apply_patterns to %func0 {
-                transform.apply_patterns.linalg.tiling_canonicalization
-                transform.apply_patterns.scf.for_loop_canonicalization
-                transform.apply_patterns.canonicalization
-            } : !transform.any_op
-            %func_fold_1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %func_folded_1 = transform.air.fold_unit_extent_dims %func_fold_1 : (!transform.any_op) -> !transform.any_op
-
-            // Match 2 truncf_ops + 1 block_matmul
-            %all_generics = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %truncf_a_g, %truncf_b_g, %matmul = transform.split_handle %all_generics : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-
-            // Tile truncf_ops to [1,1,0,0] → vector<8x8> for aievec
-            %tiled_truncf_a, %truncf_a_loops:2 =
-              transform.structured.tile_using_for %truncf_a_g tile_sizes [1, 1, 0, 0]
-              : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-            %tiled_truncf_b, %truncf_b_loops:2 =
-              transform.structured.tile_using_for %truncf_b_g tile_sizes [1, 1, 0, 0]
-              : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-
-            // Tile block_matmul for vectorization [2,2,1,0,0,0] then unroll
-
-            %inner_most_matmul, %vec_loops:3 =
-              transform.structured.tile_using_for %matmul tile_sizes [2, 2, 1, 0, 0, 0]
-              : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
-            %inner_most_matmul_to_unroll, %vec_loops_to_unroll:2 =
-              transform.structured.tile_using_for %inner_most_matmul tile_sizes [1, 1, 0, 0, 0, 0]
-              : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-            transform.loop.unroll %vec_loops_to_unroll#1 {factor = 2} : !transform.any_op
-            transform.loop.unroll %vec_loops_to_unroll#0 {factor = 2} : !transform.any_op
-
-            %linalg_fills = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %inner_most_fills, %vec_fill_loops:2 =
-              transform.structured.tile_using_for %linalg_fills tile_sizes [0, 0, 1, 1]
-              : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-
-            // Vectorize all herds
-            %herds = transform.structured.match ops{["air.herd"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %vectorized_herds = transform.air.herd_vectorize %herds : (!transform.any_op) -> !transform.any_op
-
-            %herd1, %herd2, %herd3 = transform.split_handle %vectorized_herds : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-
-            %func1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            transform.apply_patterns to %func1 {
-                transform.apply_patterns.linalg.tiling_canonicalization
-                transform.apply_patterns.scf.for_loop_canonicalization
-                transform.apply_patterns.canonicalization
-                transform.apply_patterns.memref.fold_memref_alias_ops
-            } : !transform.any_op
-            %func_fold_2 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %func_folded_2 = transform.air.fold_unit_extent_dims %func_fold_2 : (!transform.any_op) -> !transform.any_op
-
-            %func1_rematch = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %func1_optimized = transform.air.eliminate_redundant_vector_transfers %func1_rematch : (!transform.any_op) -> !transform.any_op
-
-            // Re-vectorize after cleanup, then hoist transfers
-            %herds_1 = transform.structured.match ops{["air.herd"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %vectorized_herds_1 = transform.air.herd_vectorize %herds_1 : (!transform.any_op) -> !transform.any_op
-            %herd1_1, %herd2_1, %herd3_1 = transform.split_handle %vectorized_herds_1 : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-
-            %scf_fors_1 = transform.structured.match ops{["scf.for"]} in %herd2_1 : (!transform.any_op) -> !transform.any_op
-            %innermost_for, %outer_fors = transform.split_handle %scf_fors_1 {overflow_result = 1} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-
-            // Cast vector.contract accumulator types (bf16→f32 for matmul)
-            %vector_contracts = transform.structured.match ops{["vector.contract"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %result11 = transform.air.vector_type_cast %vector_contracts {target_element_type = f32, input_indices = [2], output_indices = [0]} : (!transform.any_op) -> !transform.any_op
-
-            %innermost_for_updated_3 = transform.air.hoist_loop_invariant_transfers %herd2_1, %innermost_for : (!transform.any_op, !transform.any_op) -> !transform.any_op
-            %innermost_for_updated_4 = transform.air.flatten_for_iter_args %innermost_for_updated_3 : (!transform.any_op) -> !transform.any_op
-            %innermost_for_updated_5 = transform.air.hoist_vector_transfer_pointers %innermost_for_updated_4 : (!transform.any_op) -> !transform.any_op
-
-            // Hoist extf/truncf pairs from the innermost loop.
-            // The compute herd has truncf_op (f32→bf16) + block_matmul (bf16→f32 cast).
-            // After vectorization, there are 4 extf and 4 truncf from the matmul contracts,
-            // plus additional truncf from truncf_op. We hoist the 4 matmul pairs.
-            %fors_to_hoist = transform.structured.match ops{["scf.for"]} in %herd2_1 : (!transform.any_op) -> !transform.any_op
-            %innermost_for1, %outer_fors1 = transform.split_handle %fors_to_hoist {overflow_result = 1}: (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-            %all_extf = transform.structured.match ops{["arith.extf"]} in %innermost_for1 : (!transform.any_op) -> !transform.any_op
-            %all_truncf = transform.structured.match ops{["arith.truncf"]} in %innermost_for1 : (!transform.any_op) -> !transform.any_op
-
-            // Skip extf/truncf hoisting for now — the truncf_op adds extra
-            // cast ops that change the count. The matmul will still vectorize
-            // correctly; hoisting is a performance optimization.
-
-            %func2 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            transform.apply_patterns to %func2 {
-                transform.apply_patterns.linalg.tiling_canonicalization
-                transform.apply_patterns.scf.for_loop_canonicalization
-                transform.apply_patterns.canonicalization
-                transform.apply_patterns.memref.fold_memref_alias_ops
-            } : !transform.any_op
-            %func_fold_3 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-            %func_folded_3 = transform.air.fold_unit_extent_dims %func_fold_3 : (!transform.any_op) -> !transform.any_op
-          transform.yield
-        }
-        }
+    # Generate full-K matmul IR for the FULL LAUNCH TILE (HERD_M*TILE_M × HERD_N*TILE_N).
+    # This matches test 53's pattern where the string IR represents the full herd's work.
+    # The transform splits it into multi-core via forall.
+    # A is K×M (transposed, strides [1, M_alloc]); B is K×N (strides [N_alloc, 1]).
+    LT_M = LAUNCH_TILE_M  # 256
+    LT_N = LAUNCH_TILE_N  # 128
+    air_tiled_ir_string = f"""
+    module {{
+      func.func @matmul_padding_kernel(%arg0: memref<*xf32> {{tt.divisibility = 16 : i32}}, %arg1: memref<*xf32> {{tt.divisibility = 16 : i32}}, %arg2: memref<*xf32> {{tt.divisibility = 16 : i32}}, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32) {{
+        %cst = arith.constant 0.000000e+00 : f32
+        %c{K_FULL} = arith.constant {K_FULL} : index
+        %c_m_alloc = arith.constant {M_alloc} : index
+        %c_n_alloc = arith.constant {N_alloc} : index
+        %c_n_padded = arith.constant {N_padded} : index
+        %c{LT_M}_i32 = arith.constant {LT_M} : i32
+        %c{LT_N}_i32 = arith.constant {LT_N} : i32
+        %0 = arith.muli %arg6, %c{LT_M}_i32 : i32
+        %1 = arith.index_cast %0 : i32 to index
+        %2 = arith.muli %arg7, %c{LT_N}_i32 : i32
+        %3 = arith.index_cast %2 : i32 to index
+        %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%1], sizes: [{LT_M}, {K_FULL}], strides: [1, {M_alloc}] : memref<*xf32> to memref<{LT_M}x{K_FULL}xf32, strided<[1, {M_alloc}], offset: ?>>
+        %alloc = memref.alloc() : memref<{LT_M}x{K_FULL}xf32>
+        memref.copy %reinterpret_cast, %alloc : memref<{LT_M}x{K_FULL}xf32, strided<[1, {M_alloc}], offset: ?>> to memref<{LT_M}x{K_FULL}xf32>
+        %5 = bufferization.to_tensor %alloc restrict writable : memref<{LT_M}x{K_FULL}xf32> to tensor<{LT_M}x{K_FULL}xf32>
+        %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [%3], sizes: [{K_FULL}, {LT_N}], strides: [{N_alloc}, 1] : memref<*xf32> to memref<{K_FULL}x{LT_N}xf32, strided<[{N_alloc}, 1], offset: ?>>
+        %alloc_1 = memref.alloc() : memref<{K_FULL}x{LT_N}xf32>
+        memref.copy %reinterpret_cast_0, %alloc_1 : memref<{K_FULL}x{LT_N}xf32, strided<[{N_alloc}, 1], offset: ?>> to memref<{K_FULL}x{LT_N}xf32>
+        %6 = bufferization.to_tensor %alloc_1 restrict writable : memref<{K_FULL}x{LT_N}xf32> to tensor<{K_FULL}x{LT_N}xf32>
+        %7 = tensor.empty() : tensor<{LT_M}x{LT_N}xf32>
+        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<{LT_M}x{LT_N}xf32>) -> tensor<{LT_M}x{LT_N}xf32>
+        %9 = linalg.matmul ins(%5, %6 : tensor<{LT_M}x{K_FULL}xf32>, tensor<{K_FULL}x{LT_N}xf32>) outs(%8 : tensor<{LT_M}x{LT_N}xf32>) -> tensor<{LT_M}x{LT_N}xf32>
+        %10 = arith.muli %1, %c_n_padded : index
+        %11 = arith.addi %10, %3 : index
+        %reinterpret_cast_2 = memref.reinterpret_cast %arg2 to offset: [%11], sizes: [{LT_M}, {LT_N}], strides: [{N_padded}, 1] : memref<*xf32> to memref<{LT_M}x{LT_N}xf32, strided<[{N_padded}, 1], offset: ?>>
+        bufferization.materialize_in_destination %9 in writable %reinterpret_cast_2 : (tensor<{LT_M}x{LT_N}xf32>, memref<{LT_M}x{LT_N}xf32, strided<[{N_padded}, 1], offset: ?>>) -> ()
+        return
+      }}
+    }}
     """
+    air_module = Module.parse(air_tiled_ir_string)
+
+    # Pre-transform: override memory spaces to L2
+    pipeline = (
+        "builtin.module(air-override-memref-memory-space{scope=func memory-space=1})"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    # Apply transform script
+    with open(transform_path, "r") as f:
+        transform_ir_string = f.read()
+    transform_ir = Module.parse(transform_ir_string, context=air_module.context)
+    run_transform(transform_ir, air_module)
+
     if args.print_module_only:
-        print(mlir_module)
+        print(air_module)
         exit(0)
 
-    transform_ir = Module.parse(transform_ir_string, context=mlir_module.context)
-    run_transform(transform_ir, mlir_module)
+    # Wrap with parallel + convert to AIR hierarchy
+    pipeline = (
+        "builtin.module("
+        + ",".join(
+            [
+                f"func.func(air-wrap-func-with-parallel{{loop-bounds={LAUNCH_M},{LAUNCH_N},1 actual-sizes={M_actual},{N_actual},1}})",
+                "air-par-to-launch{depth=0 has-air-segment=true}",
+                "canonicalize",
+                "cse",
+            ]
+        )
+        + ")"
+    )
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
 
     if args.verbose:
-        # Count extf/truncf in the vectorized module
-        module_str = str(mlir_module)
-        print(
-            f"After vectorization: {module_str.count('arith.extf')} extf, {module_str.count('arith.truncf')} truncf, {module_str.count('vector.contract')} contracts"
-        )
+        # Dump IR before air-copy-to-dma for debugging
+        with open("before_copy_to_dma.mlir", "w") as f:
+            f.write(str(air_module))
+
+    pipeline = "builtin.module(air-copy-to-dma)"
+    pm = air.passmanager.PassManager.parse(pipeline)
+    pm.run(air_module.operation)
+
+    if args.verbose:
+        print("Running module:")
+        print(air_module)
+
+    ###############################################
+    # Compile and run
+    ###############################################
 
     # Host data: f32. A is K×M_alloc (transposed, block-aligned actual size).
     # B is K×N_alloc. Zero-padded beyond M_actual/N_actual.
-    # Device-side padding (air-split-launch-for-padding) handles boundary tiles.
-    #
-    # Use random inputs scaled by 4 (matching IRON methodology from PR #1440).
-    input_a = np.zeros((K, M_alloc), dtype=np.float32)
-    input_a[:, :M_actual] = (np.random.rand(K, M_actual) * 4).astype(np.float32)
-    input_b = np.zeros((K, N_alloc), dtype=np.float32)
-    input_b[:, :N_actual] = (np.random.rand(K, N_actual) * 4).astype(np.float32)
+    input_a = np.zeros((K_FULL, M_alloc), dtype=np.float32)
+    input_a[:, :M_actual] = (np.random.rand(K_FULL, M_actual) * 4).astype(np.float32)
+    input_b = np.zeros((K_FULL, N_alloc), dtype=np.float32)
+    input_b[:, :N_actual] = (np.random.rand(K_FULL, N_actual) * 4).astype(np.float32)
 
     if args.compile_mode == "compile-and-run":
         num_samples = 100
@@ -676,7 +221,6 @@ if __name__ == "__main__":
         )
 
         # Add deterministic boundary-tile samples to catch padding errors.
-        # These sample the last few rows/cols of each boundary herd.
         boundary_m = list(
             set(
                 [
@@ -699,8 +243,7 @@ if __name__ == "__main__":
         sampled_indices = np.hstack([sampled_indices, boundary_indices])
 
         # Golden: truncate f32 inputs to bf16 (matching hardware truncf_op),
-        # then compute dot product with f32 accumulation. This eliminates the
-        # f32-vs-bf16 rounding bias that inflated the tolerance (PR #1440).
+        # then compute dot product with f32 accumulation.
         input_a_bf16 = input_a.astype(bfloat16)
         input_b_bf16 = input_b.astype(bfloat16)
         sampled_values = np.array(
@@ -721,35 +264,28 @@ if __name__ == "__main__":
             "values": sampled_values,
         }
 
-        needs_padding = (M_actual % TILE_M != 0) or (N_actual % TILE_N != 0)
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
-            output_format="elf" if needs_padding else "xclbin",
-            instance_name="matmul_f32",
-            bf16_emulation=use_bf16_emulation,
+            output_format="elf",
+            instance_name="matmul_padding_kernel",
+            bf16_emulation=True,
+            debug_ir=True,
         )
-        # With bf16-truncated golden, remaining error is from BFP16 block
-        # floating point quantization (shared exponent per 8-element block
-        # vs element-wise bf16 in golden). conv_even rounding is emitted
-        # by AIECoreToStandard (crRnd=12). The f32-to-bf16 in-core truncation
-        # adds rounding noise beyond the bf16-input case.
         exit(
             runner.run_test(
-                mlir_module,
+                air_module,
                 inputs=[input_a, input_b],
                 stochastic_expected_outputs=[sampled_data],
                 rtol=0.1,
-                max_mismatch_percentage=10,
             )
         )
     elif args.compile_mode == "compile-only":
-        needs_padding = (M_actual % TILE_M != 0) or (N_actual % TILE_N != 0)
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
-            output_format="elf" if needs_padding else "xclbin",
-            bf16_emulation=use_bf16_emulation,
+            output_format="elf",
+            bf16_emulation=True,
         )
-        module_function = backend.compile(mlir_module)
+        module_function = backend.compile(air_module)
         backend.unload()

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/test.cpp
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/test.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026, Advanced Micro Devices, Inc.
 //
-// Profiling harness for f32 matmul with bf16 emulation.
+// Profiling harness for f32 matmul with bf16 emulation (ELF format).
 // A is K×M (transposed), B is K×N, C is M×N (all f32).
 //
 //===----------------------------------------------------------------------===//
@@ -12,11 +12,11 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
-#include <fstream>
-#include <iomanip>
 #include <iostream>
-#include <sstream>
+#include <limits>
+#include <string>
 #include <vector>
 
 #include "test_utils.h"
@@ -25,20 +25,23 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+// Experimental headers for elf format support
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+
 using A_DATATYPE = float;
 using B_DATATYPE = float;
 using C_DATATYPE = float;
 
 void add_default_options(cxxopts::Options &options) {
   options.add_options()("help,h", "produce help message")(
-      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
-      "kernel,k", "the kernel name in the XCLBIN",
+      "elf,e", "the input elf path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name (format: <kernel>:<instance>)",
       cxxopts::value<std::string>())("verbosity,v",
                                      "the verbosity of the output",
                                      cxxopts::value<int>()->default_value("0"))(
-      "instr,i", "path of file containing instructions",
-      cxxopts::value<std::string>())("size_m,M", "Actual matrix M (for GFLOPS)",
-                                     cxxopts::value<int>())(
+      "size_m,M", "Actual matrix M (for GFLOPS)", cxxopts::value<int>())(
       "size_n,N", "Actual matrix N (for GFLOPS)", cxxopts::value<int>())(
       "size_k,K", "Matrix K dimension",
       cxxopts::value<int>())("alloc_m", "M buffer alloc size (default: M)",
@@ -49,16 +52,25 @@ void add_default_options(cxxopts::Options &options) {
 
 int main(int argc, const char *argv[]) {
   cxxopts::Options options("Allowed options");
-  cxxopts::ParseResult vm;
   add_default_options(options);
-  test_utils::parse_options(argc, argv, options, vm);
-  int verbosity = vm["verbosity"].as<int>();
+  auto vm = options.parse(argc, argv);
 
+  if (vm.count("help")) {
+    std::cout << options.help() << std::endl;
+    return 1;
+  }
+
+  if (!vm.count("elf") || !vm.count("kernel") || !vm.count("size_m") ||
+      !vm.count("size_n") || !vm.count("size_k")) {
+    std::cerr << "Error: Required options missing (-e, -k, -M, -N, -K)\n\n";
+    std::cerr << options.help() << std::endl;
+    return 1;
+  }
+
+  int verbosity = vm["verbosity"].as<int>();
   int M = vm["size_m"].as<int>();
   int K = vm["size_k"].as<int>();
   int N = vm["size_n"].as<int>();
-  // Buffer alloc sizes (padded to tile-aligned for hardware).
-  // M/N are the actual dimensions used for GFLOPS calculation.
   int M_buf = vm["alloc_m"].as<int>();
   int N_buf = vm["alloc_n"].as<int>();
   if (M_buf <= 0)
@@ -67,68 +79,49 @@ int main(int argc, const char *argv[]) {
     N_buf = N;
 
   // A is K×M_buf (transposed layout), B is K×N_buf, C is M_buf×N_buf
-  int A_VOLUME = K * M_buf;
-  int B_VOLUME = K * N_buf;
-  int C_VOLUME = M_buf * N_buf;
+  size_t A_VOLUME = (size_t)K * M_buf;
+  size_t B_VOLUME = (size_t)K * N_buf;
+  size_t C_VOLUME = (size_t)M_buf * N_buf;
 
-  int A_SIZE = A_VOLUME * sizeof(A_DATATYPE);
-  int B_SIZE = B_VOLUME * sizeof(B_DATATYPE);
-  int C_SIZE = C_VOLUME * sizeof(C_DATATYPE);
+  size_t A_SIZE = A_VOLUME * sizeof(A_DATATYPE);
+  size_t B_SIZE = B_VOLUME * sizeof(B_DATATYPE);
+  size_t C_SIZE = C_VOLUME * sizeof(C_DATATYPE);
 
   srand(time(NULL));
 
-  std::vector<uint32_t> instr_v =
-      test_utils::load_instr_binary(vm["instr"].as<std::string>());
-
-  if (verbosity >= 1)
-    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
-
+  // Set up XRT with ELF
   unsigned int device_index = 0;
   auto device = xrt::device(device_index);
 
+  std::string elfPath = vm["elf"].as<std::string>();
   if (verbosity >= 1)
-    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
-  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+    std::cout << "Loading elf: " << elfPath << "\n";
 
-  std::string Node = vm["kernel"].as<std::string>();
-  auto xkernels = xclbin.get_kernels();
-  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
-                               [Node, verbosity](xrt::xclbin::kernel &k) {
-                                 auto name = k.get_name();
-                                 if (verbosity >= 1)
-                                   std::cout << "Name: " << name << std::endl;
-                                 return name.rfind(Node, 0) == 0;
-                               });
-  auto kernelName = xkernel.get_name();
+  xrt::elf ctx_elf{elfPath};
+  xrt::hw_context context = xrt::hw_context(device, ctx_elf);
 
-  device.register_xclbin(xclbin);
-  xrt::hw_context context(device, xclbin.get_uuid());
-  auto kernel = xrt::kernel(context, kernelName);
+  std::string kernelName = vm["kernel"].as<std::string>();
+  if (verbosity >= 1)
+    std::cout << "Kernel name: " << kernelName << "\n";
 
-  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
-                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
-  auto bo_a =
-      xrt::bo(device, A_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-  auto bo_b =
-      xrt::bo(device, B_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
-  auto bo_c =
-      xrt::bo(device, C_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+  auto kernel = xrt::ext::kernel(context, kernelName);
+
+  // Create buffer objects using xrt::ext::bo
+  xrt::bo bo_a = xrt::ext::bo{device, A_SIZE};
+  xrt::bo bo_b = xrt::ext::bo{device, B_SIZE};
+  xrt::bo bo_c = xrt::ext::bo{device, C_SIZE};
 
   A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
-  for (int i = 0; i < A_VOLUME; i++)
+  for (size_t i = 0; i < A_VOLUME; i++)
     bufA[i] = 4.0f * (float)rand() / (float)RAND_MAX;
 
   B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
-  for (int i = 0; i < B_VOLUME; i++)
+  for (size_t i = 0; i < B_VOLUME; i++)
     bufB[i] = 4.0f * (float)rand() / (float)RAND_MAX;
 
   C_DATATYPE *bufC = bo_c.map<C_DATATYPE *>();
   memset(bufC, 0, C_SIZE);
 
-  void *bufInstr = bo_instr.map<void *>();
-  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
-
-  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
@@ -137,7 +130,7 @@ int main(int argc, const char *argv[]) {
   unsigned n_warmup_iterations = 10;
   unsigned num_iter = n_iterations + n_warmup_iterations;
   float npu_time_total = 0;
-  float npu_time_min = 9999999;
+  float npu_time_min = std::numeric_limits<float>::max();
   float npu_time_max = 0;
 
   float macs = 2.0f * float(M) * float(K) * float(N);
@@ -146,10 +139,14 @@ int main(int argc, const char *argv[]) {
     if (verbosity >= 1)
       std::cout << "Running Kernel.\n";
 
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo_a);
+    run.set_arg(1, bo_b);
+    run.set_arg(2, bo_c);
+
     auto start = std::chrono::high_resolution_clock::now();
-    unsigned int opcode = 3;
-    auto run = kernel(opcode, bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
-    run.wait();
+    run.start();
+    run.wait2();
     auto stop = std::chrono::high_resolution_clock::now();
     bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
 

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/transform_aie2p.mlir
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/transform_aie2p.mlir
@@ -1,0 +1,282 @@
+// Transform Script for F32 Matmul with BF16 Emulation
+//
+// Starting IR: Full-K matmul (no K-loop), all f32, generated from asm_src params.
+//   - func @matmul_padding_kernel(memref<*xf32>*3, i32*6)
+//   - linalg.matmul(64xK @ Kx32 → 64x32), f32 accumulation
+//   - A in K×M layout (strides [1, M_alloc]), B in K×N (strides [N_alloc, 1])
+//
+// Follows test 53's transform pattern: tile copies, pack [8,8,8], tile K,
+// tile forall for multi-core, vectorize, hoist.
+//
+// Target: 4×8 AIE core array (Strix/NPU2), BFP16 emulation
+// Tile sizes: M=64, N=32, K_L2=16, pack [8,8,8]
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+
+    //==========================================================================
+    // PHASE 1: TILE L3→L2 MEMORY COPIES
+    //==========================================================================
+
+        %func10 = transform.structured.match ops{["func.func"]} in %arg1  : (!transform.any_op) -> !transform.any_op
+        %func10_updated = transform.air.convert_memref_copy_to_linalg_copy %func10 : (!transform.any_op) -> !transform.any_op
+        %copies = transform.structured.match ops{["linalg.copy"]} in %arg1  : (!transform.any_op) -> !transform.any_op
+        %copy1, %copy2 = transform.split_handle %copies : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        // Tile A copy: 64×K → 64×16 tiles (K_L2_TILE=16)
+        %tiled_copy1, %tile_copy_loop1 =
+          transform.structured.tile_using_for %copy1 tile_sizes [0, 16]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %tile_copy_loop1 "copy_a_loop" : !transform.any_op
+        // Tile B copy: K×32 → 16×32 tiles
+        %tiled_copy2, %tile_copy_loop2 =
+          transform.structured.tile_using_for %copy2 tile_sizes [16]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %tile_copy_loop2 "copy_b_loop" : !transform.any_op
+
+    //==========================================================================
+    // PHASE 2: PROMOTE OUTPUT TO L2
+    // No truncf fusion needed (output is f32).
+    //==========================================================================
+
+        %result_l2 = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %result_l2_buffer, %result_t2_new = transform.structured.bufferize_to_allocation %result_l2
+            {memory_space = 1, bufferize_destination_only, mempcy = "linalg.copy", emit_dealloc} : !transform.any_op
+
+    //==========================================================================
+    // PHASE 3: PACK MATMUL FOR VECTORIZED COMPUTATION
+    // Pack sizes [8, 8, 8] for M, N, K dimensions.
+    //==========================================================================
+
+        %matmul_to_pack = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %packed = transform.structured.pack %matmul_to_pack packed_sizes = [8, 8, 8]
+          : (!transform.any_op) -> (!transform.any_op)
+
+        %pack_producer_a = transform.get_producer_of_operand %packed[0]
+          : (!transform.any_op) -> (!transform.any_op)
+        %packed_a, %pack_a, %empty_unpack_a =
+          transform.structured.pack_transpose %pack_producer_a with_compute_op(%packed)
+          outer_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+          -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+        %pack_producer_b = transform.get_producer_of_operand %packed_a[1]
+          : (!transform.any_op) -> (!transform.any_op)
+        %packed_b, %pack_b, %empty_unpack_b =
+          transform.structured.pack_transpose %pack_producer_b with_compute_op(%packed_a)
+          outer_perm = [1, 0] inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+          -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+        %unpack = transform.get_consumers_of_result %packed_b[0]
+          : (!transform.any_op) -> (!transform.any_op)
+        %packed_c, %pack_c, %unpack_c =
+          transform.structured.pack_transpose %unpack with_compute_op(%packed_b)
+          outer_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+          -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+        %output_l1_pack_op_source_buffer, %output_l1_pack_op_new = transform.structured.bufferize_to_allocation %pack_c
+            {memory_space = 2, bufferize_destination_only, memcpy_op = "linalg.copy", emit_dealloc} : !transform.any_op
+
+        // Annotate the packed matmul so we can find it after K-tiling
+        transform.annotate %packed_c "packed_matmul" : !transform.any_op
+
+    //==========================================================================
+    // PHASE 4: TILE K REDUCTION AND FUSE PACK OPERATIONS
+    // K/8 packed K-dim. Tile by 2 (= 16 raw K elements = K_L2_TILE).
+    //==========================================================================
+
+        %tiled_reduction, %outer_for_loop =
+          transform.structured.tile_using_for %packed_c tile_sizes [0, 0, 2]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %outer_for_loop "k_reduction_loop" : !transform.any_op
+
+        %fused_lhs_l1_pack, %2 = transform.structured.fuse_into_containing_op %pack_a into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+        %fused_rhs_l1_pack, %3 = transform.structured.fuse_into_containing_op %pack_b into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    //==========================================================================
+    // PHASE 5: TILE FOR MULTI-CORE PARALLELISM
+    // Packed C dims after pack [8,8,8] + outer_perm [1,0]:
+    //   [N/8, M/8, K/8] = [16, 32, K/8] → tile [8, 4, 0] → forall(2, 8)
+    //   par_to_herd maps to herd(8, 2) → collapse to 4×4
+    //==========================================================================
+
+        %matmul_1 = transform.structured.match ops{["linalg.generic"]} attributes{packed_matmul} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %tiled_matmul_1, %inner_forall =
+          transform.structured.tile_using_forall %matmul_1 tile_sizes [8, 4, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %inner_forall "compute_forall" : !transform.any_op
+        transform.annotate %tiled_matmul_1 "matmul_compute" : !transform.any_op
+
+        %fused_lhs_l1_pack2, %6 = transform.structured.fuse_into_containing_op %fused_lhs_l1_pack into %inner_forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+        %fused_rhs_l1_pack2, %7 = transform.structured.fuse_into_containing_op %fused_rhs_l1_pack into %inner_forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+        %func_2 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.apply_patterns to %func_2 {
+            transform.apply_patterns.linalg.tiling_canonicalization
+            transform.apply_patterns.scf.for_loop_canonicalization
+            transform.apply_patterns.canonicalization
+        } : !transform.any_op
+        transform.apply_cse to %func_2 : !transform.any_op
+
+    //==========================================================================
+    // PHASE 6: PROMOTE INPUTS TO L1 AND TILE PROLOGUE/EPILOGUE
+    //==========================================================================
+
+        %buffer_a, %new_a = transform.structured.bufferize_to_allocation %fused_lhs_l1_pack2
+          {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+        %buffer_b, %new_b = transform.structured.bufferize_to_allocation %fused_rhs_l1_pack2
+          {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Prologue: fill → generalize → interchange → tile_using_forall
+    // After packing, fill is on packed 4D tensor [N/8, M/8, 8, 8] = [16, 32, 8, 8].
+    // Interchange [1,0,2,3] swaps N/M dims → [32, 16, 8, 8].
+    // Tile [8, 4] → forall(4, 4) matching herd.
+        %fill_op = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %generic_fill_op = transform.structured.generalize %fill_op
+            : (!transform.any_op) -> !transform.any_op
+        transform.annotate %generic_fill_op "init_fill" : !transform.any_op
+        %interchanged_fill_op = transform.structured.interchange %generic_fill_op
+          iterator_interchange = [1, 0, 2, 3]
+          : (!transform.any_op) -> !transform.any_op
+        %prologue_tiled_fill, %prologue_forall =
+          transform.structured.tile_using_forall %interchanged_fill_op tile_sizes [8, 4]
+            : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %prologue_forall "prologue_forall" : !transform.any_op
+
+    // Epilogue: unpack → tile_using_forall [64, 32] for 4×4 herd
+        %unpack_op = transform.structured.match ops{["linalg.unpack"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %epilogue_tiled_unpack, %epilogue_forall =
+          transform.structured.tile_using_forall %unpack_op tile_sizes [64, 32]
+            : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+        transform.annotate %epilogue_forall "epilogue_forall" : !transform.any_op
+
+        %func_3 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.apply_patterns to %func_3 {
+            transform.apply_patterns.linalg.tiling_canonicalization
+            transform.apply_patterns.scf.for_loop_canonicalization
+            transform.apply_patterns.canonicalization
+        } : !transform.any_op
+        transform.apply_cse to %func_3 : !transform.any_op
+
+    //==========================================================================
+    // PHASE 7: BUFFERIZATION AND MEMORY OPTIMIZATION
+    //==========================================================================
+
+        %func_op = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %func_bufferized = transform.bufferization.one_shot_bufferize %func_op : (!transform.any_op) -> !transform.any_op
+
+        %func6 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.apply_patterns to %func6 {
+            transform.apply_patterns.linalg.tiling_canonicalization
+            transform.apply_patterns.scf.for_loop_canonicalization
+            transform.apply_patterns.canonicalization
+        } : !transform.any_op
+        transform.apply_cse to %func6 : !transform.any_op
+        transform.apply_patterns to %func6 {
+            transform.apply_patterns.canonicalization
+        } : !transform.any_op
+        %func_op_updated = transform.air.remove_uninitialized_copy %func6 : (!transform.any_op) -> !transform.any_op
+        %func_op_updated_1 = transform.air.eliminate_cascade_memcpy %func_op_updated : (!transform.any_op) -> !transform.any_op
+
+    //==========================================================================
+    // PHASE 8: FUSE LOOPS FOR L2 PINGPONG BUFFERING
+    //==========================================================================
+
+        %for_loop_copy_1 = transform.structured.match ops{["scf.for"]} attributes{copy_a_loop} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %for_loop_copy_2 = transform.structured.match ops{["scf.for"]} attributes{copy_b_loop} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %main_for_loop = transform.structured.match ops{["scf.for"]} attributes{k_reduction_loop} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %main_for_loop_norm = transform.air.normalize_for_bounds %main_for_loop : (!transform.any_op) -> !transform.any_op
+        transform.apply_cse to %func_op_updated_1 : !transform.any_op
+        %fused_for_loop_2 = transform.loop.fuse_sibling %for_loop_copy_2 into %main_for_loop_norm
+          : (!transform.any_op, !transform.any_op) -> !transform.any_op
+        %fused_for_loop_1 = transform.loop.fuse_sibling %for_loop_copy_1 into %fused_for_loop_2
+          : (!transform.any_op, !transform.any_op) -> !transform.any_op
+
+    //==========================================================================
+    // PHASE 9: TILE FOR VECTORIZATION
+    //==========================================================================
+
+        %generic1 = transform.structured.match ops{["linalg.generic"]} attributes{init_fill} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %generic2 = transform.structured.match ops{["linalg.generic"]} attributes{matmul_compute} in %arg1 : (!transform.any_op) -> !transform.any_op
+        // Per-core packed matmul: [4, 8, K/8, 8, 8, 8].
+        // Tile for vectorization: [2, 2, 1, 0, 0, 0] then unroll.
+        %inner_most_generics, %vec_loops:3 =
+          transform.structured.tile_using_for %generic2 tile_sizes [2, 2, 1, 0, 0, 0]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+
+        %inner_most_matmul_to_unroll, %vec_loops_to_unroll:2 =
+          transform.structured.tile_using_for %inner_most_generics tile_sizes [1, 1, 0, 0, 0, 0]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+        transform.loop.unroll %vec_loops_to_unroll#1 {factor = 2} : !transform.any_op
+        transform.loop.unroll %vec_loops_to_unroll#0 {factor = 2} : !transform.any_op
+
+        %inner_most_fills, %vec_fill_loops:2 =
+          transform.structured.tile_using_for %generic1 tile_sizes [1, 1, 0, 0]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    //==========================================================================
+    // PHASE 10: CONVERT TO AIE HERDS AND VECTORIZE
+    //==========================================================================
+
+        %forall1 = transform.structured.match ops{["scf.forall"]} attributes{prologue_forall} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %forall2 = transform.structured.match ops{["scf.forall"]} attributes{compute_forall} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %forall3 = transform.structured.match ops{["scf.forall"]} attributes{epilogue_forall} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %parallel1 = transform.loop.forall_to_parallel %forall1  : (!transform.any_op) -> !transform.any_op
+        %herd1 = transform.air.par_to_herd %parallel1 : (!transform.any_op) -> !transform.any_op
+        transform.annotate %herd1 "prologue_herd" : !transform.any_op
+        %parallel2 = transform.loop.forall_to_parallel %forall2  : (!transform.any_op) -> !transform.any_op
+        %herd2 = transform.air.par_to_herd %parallel2 : (!transform.any_op) -> !transform.any_op
+        transform.annotate %herd2 "compute_herd" : !transform.any_op
+        %parallel3 = transform.loop.forall_to_parallel %forall3  : (!transform.any_op) -> !transform.any_op
+        %herd3 = transform.air.par_to_herd %parallel3 : (!transform.any_op) -> !transform.any_op
+        transform.annotate %herd3 "epilogue_herd" : !transform.any_op
+
+        %herds = transform.structured.match ops{["air.herd"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %vectorized_herds = transform.air.herd_vectorize %herds : (!transform.any_op) -> !transform.any_op
+
+        %func7 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.apply_patterns to %func7 {
+            transform.apply_patterns.linalg.tiling_canonicalization
+            transform.apply_patterns.scf.for_loop_canonicalization
+            transform.apply_patterns.canonicalization
+            transform.apply_patterns.memref.fold_memref_alias_ops
+        } : !transform.any_op
+        %func_fold_1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %func_folded_1 = transform.air.fold_unit_extent_dims %func_fold_1 : (!transform.any_op) -> !transform.any_op
+
+        %func7_rematch = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %func1_optimized = transform.air.eliminate_redundant_vector_transfers %func7_rematch : (!transform.any_op) -> !transform.any_op
+
+    //==========================================================================
+    // PHASE 11: HOIST LOOP-INVARIANT VECTOR TRANSFERS
+    //==========================================================================
+
+        %herd2_1 = transform.structured.match ops{["air.herd"]} attributes{compute_herd} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %scf_fors_1 = transform.structured.match ops{["scf.for"]} in %herd2_1 : (!transform.any_op) -> !transform.any_op
+        %innermost_for, %outer_fors = transform.split_handle %scf_fors_1 {overflow_result = 1} : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+        // Cast vector.contract input types: inputs 0,1 to bf16, accumulator 2 and output to f32
+        %vector_contracts = transform.structured.match ops{["vector.contract"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %result11 = transform.air.vector_type_cast %vector_contracts {target_element_type = f32, input_indices = [2], output_indices = [0]} : (!transform.any_op) -> !transform.any_op
+        %vector_contracts_2 = transform.structured.match ops{["vector.contract"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %result11b = transform.air.vector_type_cast %vector_contracts_2 {target_element_type = bf16, input_indices = [0, 1], output_indices = []} : (!transform.any_op) -> !transform.any_op
+
+        %innermost_for_updated_3 = transform.air.hoist_loop_invariant_transfers %herd2_1, %innermost_for : (!transform.any_op, !transform.any_op) -> !transform.any_op
+
+    //==========================================================================
+    // PHASE 12: FINAL LOOP OPTIMIZATIONS
+    //==========================================================================
+
+        %innermost_for_updated_4 = transform.air.flatten_for_iter_args %innermost_for_updated_3 : (!transform.any_op) -> !transform.any_op
+        %innermost_for_updated_5 = transform.air.hoist_vector_transfer_pointers %innermost_for_updated_4 : (!transform.any_op) -> !transform.any_op
+
+        %func9 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        transform.apply_patterns to %func9 {
+            transform.apply_patterns.linalg.tiling_canonicalization
+            transform.apply_patterns.scf.for_loop_canonicalization
+            transform.apply_patterns.canonicalization
+            transform.apply_patterns.memref.fold_memref_alias_ops
+        } : !transform.any_op
+        %func_fold_2 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+        %func_folded_2 = transform.air.fold_unit_extent_dims %func_fold_2 : (!transform.any_op) -> !transform.any_op
+
+    transform.yield
+  }
+}


### PR DESCRIPTION
## Summary
- Rewrite test 54 (`54_matmul_padding_f32_bf16_emulation`) from `@module_builder` Python API to transform dialect script, matching the pattern used by test 53 and other Triton-based tests
- Fix a bug in `air-copy-to-dma` where `subview(reinterpret_cast)` chains lost the reinterpret_cast offset, causing incorrect DMA addressing for transposed memrefs with multi-launch grids
- Fix padding rank mismatch in `air-to-aie` when `getWrapsAndStrides` collapses broadcast dimensions with non-zero padding

## Changes

### Test 54 rewrite
- `run.py`: Generates tensor-level IR with `linalg.matmul` (f32, K×M transposed A), applies 12-phase transform script, wraps with `air-wrap-func-with-parallel` + `air-copy-to-dma`
- `transform_aie2p.mlir`: New 12-phase transform (copy tiling → L2 promotion → pack [8,8,8] → K-reduction → multi-core forall → L1 promotion → prologue/epilogue → bufferization → loop fusion → vectorization → herd conversion → vector type cast + hoist)
- `asm_src.mlir`: Triton-XDNA reference IR (f32 inputs)
- `test.cpp`: Updated for ELF-based XRT API (`xrt::elf`, `xrt::ext::kernel`)
- `Makefile`: Updated for ELF profile flow

### Compiler fixes
- `ConvertToAIRPass.cpp`: Chain through `subview(reinterpret_cast)` in `matchAndRewriteCopyOp` — add reinterpret_cast offset to first subview offset dimension
- `AIRToAIEPass.cpp`: When padding rank exceeds sizes rank due to collapsed broadcast dims, drop leading non-zero padding dimensions instead of erroring

## Test plan
- [x] `make run` with M=500, N=500, K=768: PASS (rtol=0.1)
- [x] `make run` with M=512, N=512, K=768: PASS
- [x] `make run` with M=256, N=128, K=768: PASS
- [x] `make profile`: 113 avg / 115 peak GFLOPS on NPU2

🤖 Generated with [Claude Code](https://claude.com/claude-code)