### PR TITLE
Fix eltwise_add BD exhaustion with contiguous partitioning

### DIFF
--- a/programming_examples/eltwise_add/Makefile
+++ b/programming_examples/eltwise_add/Makefile
@@ -47,14 +47,14 @@ all: run
 
 print:
 	${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG) \
-		--dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
+		--n $(N) --dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
 		--herd-x $(HERD_X) --herd-y $(HERD_Y) \
 		--tile-n $(TILE_N) $(EXTRA_PY_FLAGS) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/eltwise_add.py \
-		$(OUTPUT_FORMAT_FLAG) --dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
+		$(OUTPUT_FORMAT_FLAG) --n $(N) --dtype $(DTYPE) --vector-size $(VECTOR_SIZE) \
 		--herd-x $(HERD_X) --herd-y $(HERD_Y) --tile-n $(TILE_N) $(EXTRA_PY_FLAGS)
 
 profile: build-test-exe

--- a/programming_examples/eltwise_add/eltwise_add.py
+++ b/programming_examples/eltwise_add/eltwise_add.py
@@ -91,16 +91,16 @@ def build_module(
             l1_b_data = AllocOp(l1MemrefTy, [], [])
             l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * total_tiles):
+            chunk_size = n // total_tiles
+            for _l_ivx in range_(0, chunk_size, tile_n):
 
-                # Compute linear tile index: tx * herd_y + ty
-                # offset = loop_var + linear_tile_idx * tile_n
+                # Contiguous partitioning: each tile gets a contiguous block.
+                # offset = linear_tile_idx * chunk_size + loop_var
                 offset_map = AffineMap.get(
                     0,
                     3,
                     [
                         AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
                             AffineExpr.get_mul(
                                 AffineExpr.get_add(
                                     AffineExpr.get_mul(
@@ -109,8 +109,9 @@ def build_module(
                                     ),
                                     AffineSymbolExpr.get(2),
                                 ),
-                                AffineConstantExpr.get(tile_n),
+                                AffineConstantExpr.get(chunk_size),
                             ),
+                            AffineSymbolExpr.get(0),
                         )
                     ],
                 )


### PR DESCRIPTION
## Summary
- **Fix BD exhaustion**: Switch eltwise_add from interleaved to contiguous partitioning. The old scheme (`offset = loop_var + tile_idx * tile_n`) created strided access patterns that consumed all 4 BD wrap-and-stride dimensions, making cross-iteration BD folding impossible. At large N (e.g. 16M), each loop iteration needed a separate BD, exhausting the ~16 available BDs per shim tile. Contiguous partitioning (`offset = tile_idx * chunk_size + loop_var`) gives each tile a contiguous block, producing purely linear access that collapses into a single BD with repeat count.
- **Fix Makefile**: Pass `--n $(N)` from the `run` and `print` targets so the Make variable `N` actually takes effect (previously only the `profile` target forwarded it).

## Test plan
- [x] `N=16777216` (16M elements): previously hit "Allocator exhausted available buffer descriptor IDs", now PASS
- [x] `N=65536` (default): still PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)