### PR TITLE
Fix flaky CI by deduplicating .lit test build directory names

### DIFF
--- a/programming_examples/passthrough/passthrough_dma/run_makefile_peano_bf16.lit
+++ b/programming_examples/passthrough/passthrough_dma/run_makefile_peano_bf16.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: mkdir -p test_peano
-// RUN: cd test_peano
+// RUN: mkdir -p test_peano_bf16
+// RUN: cd test_peano_bf16
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DTYPE=bfloat16 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_add/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_add/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_exp/run_npu2_makefile_peano_vec32.lit
+++ b/programming_examples/primitives/vector_examples/vector_exp/run_npu2_makefile_peano_vec32.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano
-// RUN: cd test_peano
+// RUN: mkdir -p test_peano_vec32
+// RUN: cd test_peano_vec32
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_exp/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_exp/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_elf
-// RUN: cd test_peano_elf
+// RUN: mkdir -p test_peano_vec32_elf
+// RUN: cd test_peano_vec32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_fma/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_fma/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_max/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_max/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_muladd/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_muladd/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v1_peano_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v1_peano_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v1
-// RUN: cd test_peano_v1
+// RUN: mkdir -p test_peano_v1_elf
+// RUN: cd test_peano_v1_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run-v1 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v2_peano_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v2_peano_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v2
-// RUN: cd test_peano_v2
+// RUN: mkdir -p test_peano_v2_elf
+// RUN: cd test_peano_v2_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run-v2 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v3_peano_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_rsqrt/run_npu2_makefile_v3_peano_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v3
-// RUN: cd test_peano_v3
+// RUN: mkdir -p test_peano_v3_elf
+// RUN: cd test_peano_v3_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run-v3 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_select/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_select/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_sub/run_npu2_makefile_peano_vec32_elf.lit
+++ b/programming_examples/primitives/vector_examples/vector_sub/run_npu2_makefile_peano_vec32_elf.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano_v32
-// RUN: cd test_peano_v32
+// RUN: mkdir -p test_peano_v32_elf
+// RUN: cd test_peano_v32_elf
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/primitives/vector_examples/vector_tanh/run_npu2_makefile_peano_vec32.lit
+++ b/programming_examples/primitives/vector_examples/vector_tanh/run_npu2_makefile_peano_vec32.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_peano
-// RUN: cd test_peano
+// RUN: mkdir -p test_peano_vec32
+// RUN: cd test_peano_vec32
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p VECTOR_SIZE=32 | FileCheck %s
 // CHECK: PASS!


### PR DESCRIPTION
## Summary
- Multiple `.lit` test files within the same directory were creating build directories with identical names (e.g., both `run_npu2_makefile_v2_peano.lit` and `run_npu2_makefile_v2_peano_elf.lit` used `test_peano_v2`), causing race conditions when LIT runs tests in parallel on CI
- Renamed colliding build directories by appending `_elf`, `_vec32`, `_vec32_elf`, or `_bf16` suffixes to make them unique
- Only fixed collisions where both `.lit` files have the same `REQUIRES` line (i.e., would actually run on the same CI runner)
- 13 `.lit` files changed across 10 directories: vector_rsqrt, vector_exp, vector_tanh, vector_add, vector_fma, vector_max, vector_muladd, vector_select, vector_sub, and passthrough_dma

## Test plan
- [x] Verify no remaining same-REQUIRES build directory collisions exist
- [ ] CI tests pass without flaky failures from directory conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)