### PR TITLE
Fix 3D channel broadcast specialization in air-specialize-dma-broadcast

### DIFF
--- a/mlir/include/air/Transform/PassDetail.h
+++ b/mlir/include/air/Transform/PassDetail.h
@@ -9,7 +9,10 @@
 #ifndef AIR_TRANSFORM_PASSDETAIL_H_
 #define AIR_TRANSFORM_PASSDETAIL_H_
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1186,10 +1186,15 @@ def AIRSpecializeDmaBroadcast : Pass<"air-specialize-dma-broadcast", "ModuleOp">
   let summary = "Specialize dma operations for broadcast pattern";
   let constructor = "xilinx::air::createAIRSpecializeDmaBroadcast()";
   let description = [{
-    Specializes `air.dma_memcpy_nd` operations for broadcast patterns within a 
-    computation. This specialization involves transforming data movement operations 
+    Specializes `air.dma_memcpy_nd` operations for broadcast patterns within a
+    computation. This specialization involves transforming data movement operations
     into more optimized versions that are aware of the broadcast semantics.
   }];
+  let dependentDialects = [
+    "affine::AffineDialect",
+    "arith::ArithDialect",
+    "scf::SCFDialect"
+  ];
 }
 
 def AIRLinalgNamePass : Pass<"air-linalg-name", "ModuleOp"> {

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -282,51 +282,160 @@ public:
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPoint(get);
 
+      // Check if the get has enough indices for the specialized dimension.
+      if (get.getIndices().size() <= (size_t)specializeDim)
+        return get->emitOpError(
+            "air.channel.get has fewer indices than the specialized "
+            "dimension requires");
+      auto idxVal = get.getIndices()[specializeDim];
+      auto idxOpt = getConstantIntValue(idxVal);
+
+      // Case 1: Static index — directly rewrite to the specialized channel.
+      if (idxOpt && *idxOpt >= 0 && *idxOpt < numSegments) {
+        int64_t idx = *idxOpt;
+        get.setChanName(specializedChannels[idx].getSymName());
+        get->setOperand(get.getAsyncDependencies().size() + specializeDim,
+                        getValueOrCreateConstantIndexOp(
+                            rewriter, loc, rewriter.getIndexAttr(0)));
+        continue;
+      }
+
+      // Collect herd IDs.
       SmallVector<Value, 4> herdIds;
       for (BlockArgument arg : herd.getIds())
         herdIds.push_back(Value(arg));
-      // Helper lambda to create and yield a ChannelGetOp
-      auto createAndYieldChannelGet = [&](int idx) -> Value {
-        auto newGet = air::ChannelGetOp::create(
-            rewriter, loc, get.getResultTypes(), get.getAsyncDependencies(),
-            rewriter.getStringAttr(specializedChannels[idx].getSymName()),
-            get.getIndices(), get.getMemref(), get.getOffsets(), get.getSizes(),
-            get.getStrides(),
-            /*pad_before=*/nullptr, /*pad_after=*/nullptr);
-        air::copyPaddingAttributes(get, newGet);
-        affine::AffineYieldOp::create(rewriter, loc, newGet.getAsyncToken());
-        return newGet.getAsyncToken();
-      };
 
-      for (int64_t i = 0; i < numSegments; ++i) {
-        SmallVector<AffineExpr, 4> exprs;
-        SmallVector<bool, 4> eqFlags;
-        makeBroadcastAffineSetConstraints(herdIds.size(), specializeDim, i,
-                                          herd.getNumCols(), ctx, exprs,
-                                          eqFlags);
-        auto intSet = IntegerSet::get(0, herdIds.size(), exprs, eqFlags);
-        SmallVector<Value, 4> setArgs = herdIds;
-        if (i == 0) {
-          auto aif = affine::AffineIfOp::create(
-              rewriter, loc, get.getResultTypes(), intSet, setArgs, true);
-          rewriter.setInsertionPointToStart(aif.getThenBlock());
-          createAndYieldChannelGet(i);
-          rewriter.replaceAllUsesWith(get.getAsyncToken(), aif.getResult(0));
-          rewriter.setInsertionPointToStart(aif.getElseBlock());
-        } else if (i < numSegments - 1) {
-          auto aif = affine::AffineIfOp::create(
-              rewriter, loc, get.getResultTypes(), intSet, setArgs, true);
-          rewriter.setInsertionPointToStart(aif.getThenBlock());
-          createAndYieldChannelGet(i);
-          rewriter.setInsertionPointAfter(aif);
-          SmallVector<Value, 1> parentBlockYieldToken{aif.getResult(0)};
-          affine::AffineYieldOp::create(rewriter, loc, parentBlockYieldToken);
-          rewriter.setInsertionPointToStart(aif.getElseBlock());
-        } else {
-          createAndYieldChannelGet(i);
+      // Find which herd dimension (if any) this channel index corresponds to.
+      int64_t herdDimIdx = -1;
+      for (size_t d = 0; d < herdIds.size(); ++d) {
+        if (idxVal == herdIds[d]) {
+          herdDimIdx = d;
+          break;
         }
       }
-      rewriter.eraseOp(get);
+
+      bool isAsync = !get.getResultTypes().empty();
+
+      if (herdDimIdx >= 0) {
+        // Case 2: Herd ID dimension — use affine.if dispatch.
+        // Build specialized indices with the specialized dim set to 0.
+        SmallVector<Value, 4> specializedIndices(get.getIndices().begin(),
+                                                 get.getIndices().end());
+        specializedIndices[specializeDim] = getValueOrCreateConstantIndexOp(
+            rewriter, loc, rewriter.getIndexAttr(0));
+        auto createChannelGet = [&](int idx) {
+          auto newGet = air::ChannelGetOp::create(
+              rewriter, loc, get.getResultTypes(), get.getAsyncDependencies(),
+              rewriter.getStringAttr(specializedChannels[idx].getSymName()),
+              specializedIndices, get.getMemref(), get.getOffsets(),
+              get.getSizes(), get.getStrides(),
+              /*pad_before=*/nullptr, /*pad_after=*/nullptr);
+          air::copyPaddingAttributes(get, newGet);
+          if (isAsync)
+            affine::AffineYieldOp::create(rewriter, loc,
+                                          newGet.getAsyncToken());
+          return newGet;
+        };
+
+        for (int64_t i = 0; i < numSegments; ++i) {
+          SmallVector<AffineExpr, 4> exprs;
+          SmallVector<bool, 4> eqFlags;
+          makeBroadcastAffineSetConstraints(herdIds.size(), herdDimIdx, i,
+                                            herd.getNumCols(), ctx, exprs,
+                                            eqFlags);
+          auto intSet = IntegerSet::get(0, herdIds.size(), exprs, eqFlags);
+          SmallVector<Value, 4> setArgs = herdIds;
+          if (i == 0) {
+            auto aif = affine::AffineIfOp::create(
+                rewriter, loc, get.getResultTypes(), intSet, setArgs, true);
+            rewriter.setInsertionPointToStart(aif.getThenBlock());
+            createChannelGet(i);
+            if (isAsync)
+              rewriter.replaceAllUsesWith(get.getAsyncToken(),
+                                          aif.getResult(0));
+            rewriter.setInsertionPointToStart(aif.getElseBlock());
+          } else if (i < numSegments - 1) {
+            auto aif = affine::AffineIfOp::create(
+                rewriter, loc, get.getResultTypes(), intSet, setArgs, true);
+            rewriter.setInsertionPointToStart(aif.getThenBlock());
+            createChannelGet(i);
+            if (isAsync) {
+              rewriter.setInsertionPointAfter(aif);
+              SmallVector<Value, 1> parentBlockYieldToken{aif.getResult(0)};
+              affine::AffineYieldOp::create(rewriter, loc,
+                                            parentBlockYieldToken);
+            }
+            rewriter.setInsertionPointToStart(aif.getElseBlock());
+          } else {
+            createChannelGet(i);
+          }
+        }
+        rewriter.eraseOp(get);
+      } else {
+        // Case 3: Non-herd dimension (e.g. segment unroll index) — use scf.if
+        // dispatch, mirroring the put-side logic.
+        auto zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+        Value result;
+        for (int64_t i = numSegments - 1; i >= 0; --i) {
+          SmallVector<Value> newIndices(get.getIndices().begin(),
+                                        get.getIndices().end());
+          newIndices[specializeDim] = zeroIdx;
+          if (i == numSegments - 1) {
+            // Default case (last segment).
+            auto newGet = air::ChannelGetOp::create(
+                rewriter, loc, get.getResultTypes(), get.getAsyncDependencies(),
+                rewriter.getStringAttr(specializedChannels[i].getSymName()),
+                newIndices, get.getMemref(), get.getOffsets(), get.getSizes(),
+                get.getStrides(),
+                /*pad_before=*/nullptr, /*pad_after=*/nullptr);
+            air::copyPaddingAttributes(get, newGet);
+            newGet->setAttrs(get->getDiscardableAttrDictionary());
+            if (isAsync) {
+              result = newGet.getAsyncToken();
+            } else {
+              // Synchronous: no result to thread through.
+              result = nullptr;
+            }
+          } else {
+            auto cmpVal = arith::ConstantIndexOp::create(rewriter, loc, i);
+            auto cond = arith::CmpIOp::create(
+                rewriter, loc, arith::CmpIPredicate::eq, idxVal, cmpVal);
+            auto ifOp = scf::IfOp::create(rewriter, loc, get.getResultTypes(),
+                                          cond, /*withElse=*/true);
+            rewriter.setInsertionPointToStart(ifOp.thenBlock());
+            auto newGet = air::ChannelGetOp::create(
+                rewriter, loc, get.getResultTypes(), get.getAsyncDependencies(),
+                rewriter.getStringAttr(specializedChannels[i].getSymName()),
+                newIndices, get.getMemref(), get.getOffsets(), get.getSizes(),
+                get.getStrides(),
+                /*pad_before=*/nullptr, /*pad_after=*/nullptr);
+            air::copyPaddingAttributes(get, newGet);
+            newGet->setAttrs(get->getDiscardableAttrDictionary());
+            if (isAsync)
+              scf::YieldOp::create(rewriter, loc, newGet->getResults());
+            else
+              scf::YieldOp::create(rewriter, loc);
+            rewriter.setInsertionPointToStart(ifOp.elseBlock());
+            if (isAsync) {
+              result.getDefiningOp()->moveBefore(ifOp.elseBlock(),
+                                                 ifOp.elseBlock()->begin());
+              scf::YieldOp::create(rewriter, loc, ValueRange{result});
+            } else {
+              // Move the previous default get into the else block.
+              if (auto *defOp = result.getDefiningOp())
+                defOp->moveBefore(ifOp.elseBlock(), ifOp.elseBlock()->begin());
+              scf::YieldOp::create(rewriter, loc);
+            }
+            rewriter.setInsertionPoint(get);
+            if (isAsync)
+              result = ifOp.getResult(0);
+          }
+        }
+        if (isAsync)
+          rewriter.replaceOp(get, result);
+        else
+          rewriter.eraseOp(get);
+      }
     }
     return success();
   }

--- a/mlir/test/Transform/AIRMiscPasses/air_specialize_channel_broadcast_3d.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_specialize_channel_broadcast_3d.mlir
@@ -1,0 +1,87 @@
+//===- air_specialize_channel_broadcast_3d.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-specialize-dma-broadcast | FileCheck %s
+
+// Test 3D channel indices: channel with segment unroll index as extra leading
+// dimension. The segment index is NOT a herd ID, so it must dispatch via scf.if
+// rather than affine.if. The herd y-dimension dispatches via affine.if.
+
+// CHECK-DAG: [[$SET0:#set[0-9]*]] = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 3 >= 0, s1 == 0)>
+// CHECK-DAG: [[$SET1:#set[0-9]*]] = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 3 >= 0, s1 - 1 == 0)>
+// CHECK-DAG: [[$SET2:#set[0-9]*]] = affine_set<()[s0, s1] : (s0 >= 0, -s0 + 3 >= 0, s1 - 2 == 0)>
+
+// Specialized channels: 2 segment iterations x 4 herd y positions = 8 channels.
+// Each has broadcast_shape [1, 4, 1] — dim 1 (herd x) still broadcasts to 4.
+// CHECK-DAG: air.channel @ch3d_0_0 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_0_1 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_0_2 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_0_3 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_1_0 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_1_1 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_1_2 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+// CHECK-DAG: air.channel @ch3d_1_3 [1, 1, 1] {broadcast_shape = [1, 4 : index, 1]}
+
+// Puts: segment index dispatched via scf.if, herd y index is constant per put.
+// CHECK-LABEL: func.func @segment_unroll_3d_broadcast
+// CHECK: arith.cmpi eq
+// CHECK: scf.if
+// CHECK: air.channel.put async{{.*}}@ch3d_0_0
+// CHECK: } else {
+// CHECK: air.channel.put async{{.*}}@ch3d_1_0
+// CHECK: arith.cmpi eq
+// CHECK: scf.if
+// CHECK: air.channel.put async{{.*}}@ch3d_0_1
+// CHECK: } else {
+// CHECK: air.channel.put async{{.*}}@ch3d_1_1
+
+// Gets: segment index dispatched via scf.if, herd y via affine.if.
+// CHECK: air.herd @herd_0
+// CHECK: arith.cmpi eq
+// CHECK: scf.if
+// CHECK: affine.if [[$SET0]]
+// CHECK: air.channel.get async{{.*}}@ch3d_0_0
+// CHECK: } else {
+// CHECK: affine.if [[$SET1]]
+// CHECK: air.channel.get async{{.*}}@ch3d_0_1
+// CHECK: } else {
+// CHECK: affine.if [[$SET2]]
+// CHECK: air.channel.get async{{.*}}@ch3d_0_2
+// CHECK: } else {
+// CHECK: air.channel.get async{{.*}}@ch3d_0_3
+// CHECK: } else {
+// CHECK: affine.if [[$SET0]]
+// CHECK: air.channel.get async{{.*}}@ch3d_1_0
+// CHECK: } else {
+// CHECK: affine.if [[$SET1]]
+// CHECK: air.channel.get async{{.*}}@ch3d_1_1
+
+module {
+  air.channel @ch3d [2, 1, 4] {broadcast_shape = [2 : index, 4 : index, 4 : index]}
+  func.func @segment_unroll_3d_broadcast(%arg0: memref<128xbf16>, %arg1: memref<64xbf16, 2 : i32>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%a0, %a1) in (%a2=%c1, %a3=%c1) args(%la0=%arg0, %la1=%arg1) : memref<128xbf16>, memref<64xbf16, 2 : i32> attributes {id = 1 : i32} {
+      %c2 = arith.constant 2 : index
+      %c1_0 = arith.constant 1 : index
+      %1 = air.segment @seg async unroll(%arg12, %arg13) in (%arg14=%c2, %arg15=%c1_0) args(%sa0=%la0, %sa1=%la1) : memref<128xbf16>, memref<64xbf16, 2 : i32> attributes {id = 2 : i32} {
+        %c0 = arith.constant 0 : index
+        %c1_s = arith.constant 1 : index
+        %c2_s = arith.constant 2 : index
+        %c3_s = arith.constant 3 : index
+        %c4 = arith.constant 4 : index
+        %t0 = air.channel.put async @ch3d[%arg12, %c0, %c0] (%sa0[] [] []) {id = 1 : i32} : (memref<128xbf16>)
+        %t1 = air.channel.put async @ch3d[%arg12, %c0, %c1_s] (%sa0[] [] []) {id = 2 : i32} : (memref<128xbf16>)
+        %t2 = air.channel.put async @ch3d[%arg12, %c0, %c2_s] (%sa0[] [] []) {id = 3 : i32} : (memref<128xbf16>)
+        %t3 = air.channel.put async @ch3d[%arg12, %c0, %c3_s] (%sa0[] [] []) {id = 4 : i32} : (memref<128xbf16>)
+        %2 = air.herd @herd_0 async tile (%arg16, %arg17) in (%arg18=%c4, %arg19=%c4) args(%buf=%sa1, %seg_idx=%arg12) : memref<64xbf16, 2 : i32>, index attributes {id = 3 : i32} {
+          %3 = air.channel.get async @ch3d[%seg_idx, %arg16, %arg17] (%buf[] [] []) {id = 5 : i32} : (memref<64xbf16, 2 : i32>)
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- Fix `SpecializeChannelBroadcastPattern` to correctly handle channels with more index dimensions than herd tile coordinates (e.g., 3D channel indices `[segment_idx, herd_x, herd_y]` with a 2D herd)
- The get-side dispatch now handles three cases: constant index (direct rewrite), herd ID dimension (affine.if with correct dimension mapping), and non-herd dimension like segment unroll index (scf.if dispatch mirroring the put-side logic)
- Add missing dependent dialect registrations (Affine, Arith, SCF) for the pass

## Test plan
- [ ] Existing `air_specialize_channel_broadcast.mlir` test passes (2D case regression check)
- [ ] New `air_specialize_channel_broadcast_3d.mlir` test verifies 3D channel with segment unroll produces correct scf.if + affine.if dispatch
- [ ] Full `check-air-mlir` suite passes (343/343)

🤖 Generated with [Claude Code](https://claude.com/claude-code)