### PR TITLE
Add scf.if and affine.if support in dependency canonicalization

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -238,13 +238,15 @@ struct dependencyContext {
   uint64_t WaitAllOpID;
   uint64_t ForOpID;
   uint64_t ParallelOpID;
+  uint64_t IfOpID;
   uint64_t TerminatorID;
   operation_to_vertex_map op_to_v;
   operation_to_graph_map op_to_g;
 
   dependencyContext()
       : ExecuteOpID(0), DmaOpID(0), ChannelOpID(0), HierarchyOpID(0),
-        WaitAllOpID(0), ForOpID(0), ParallelOpID(0), TerminatorID(0) {}
+        WaitAllOpID(0), ForOpID(0), ParallelOpID(0), IfOpID(0),
+        TerminatorID(0) {}
 };
 
 using VertexId = dependencyGraph::VertexId;
@@ -254,10 +256,12 @@ class dependencyCanonicalizer {
   typedef std::tuple<bool, bool, bool, bool> graphGranularityProperties;
 
 public:
-  void parseCommandGraphs(func::FuncOp &toplevel, dependencyGraph &global_graph,
-                          dependencyContext &dep_ctx,
-                          std::string granularity = "herd",
-                          bool dump_dot = false, std::string dump_dir = "");
+  LogicalResult parseCommandGraphs(func::FuncOp &toplevel,
+                                   dependencyGraph &global_graph,
+                                   dependencyContext &dep_ctx,
+                                   std::string granularity = "herd",
+                                   bool dump_dot = false,
+                                   std::string dump_dir = "");
   void canonicalizeRecursive(const dependencyGraph &src, dependencyGraph &dst);
   void buildEmptyGraphStructure(const dependencyGraph &src,
                                 dependencyGraph &dst);
@@ -278,20 +282,20 @@ public:
   LogicalResult redoDepTraceIfDepOnHier(func::FuncOp func);
 
 private:
-  void addVerticesInHerd(std::vector<dependencyGraph> &herd_subgraphs,
-                         air::HerdOp herd, dependencyContext &dep_ctx,
-                         graphGranularityProperties expandHier = {true, true,
-                                                                  true, false});
-  void addVerticesInSegment(std::vector<dependencyGraph> &part_subgraphs,
-                            air::SegmentOp segment, dependencyContext &dep_ctx,
-                            graphGranularityProperties expandHier = {
-                                true, true, true, false});
-  void addVerticesInLaunch(std::vector<dependencyGraph> &launch_subgraphs,
-                           air::LaunchOp launch, dependencyContext &dep_ctx,
-                           graphGranularityProperties expandHier = {
-                               true, true, true, false});
-  VertexId addVertexFromOpImpls(Operation *op, dependencyGraph *G,
-                                dependencyContext &dep_ctx);
+  LogicalResult addVerticesInHerd(std::vector<dependencyGraph> &herd_subgraphs,
+                                  air::HerdOp herd, dependencyContext &dep_ctx,
+                                  graphGranularityProperties expandHier = {
+                                      true, true, true, false});
+  LogicalResult addVerticesInSegment(
+      std::vector<dependencyGraph> &part_subgraphs, air::SegmentOp segment,
+      dependencyContext &dep_ctx,
+      graphGranularityProperties expandHier = {true, true, true, false});
+  LogicalResult addVerticesInLaunch(
+      std::vector<dependencyGraph> &launch_subgraphs, air::LaunchOp launch,
+      dependencyContext &dep_ctx,
+      graphGranularityProperties expandHier = {true, true, true, false});
+  LogicalResult addVertexFromOpImpls(Operation *op, dependencyGraph *G,
+                                     dependencyContext &dep_ctx);
   VertexId addVertexFromOp(Operation *op, uint64_t &id, std::string event_type,
                            std::string event_name,
                            graphNodeProperties properties, dependencyGraph *G,

--- a/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
+++ b/mlir/lib/Transform/AIRDependencyCanonicalize.cpp
@@ -44,7 +44,8 @@ public:
 
       // Parse dependency graphs
       hostGraph = dependencyGraph(func, true);
-      canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx);
+      if (failed(canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx)))
+        return signalPassFailure();
 
       // Transitive reduction
       xilinx::air::dependencyGraph trHostGraph;

--- a/mlir/lib/Transform/AIRDependencyParseGraph.cpp
+++ b/mlir/lib/Transform/AIRDependencyParseGraph.cpp
@@ -38,8 +38,9 @@ public:
       // Parse dependency graphs
       std::string graphGranularity = (clShowCores) ? ("core") : ("herd");
       hostGraph = dependencyGraph(func, true);
-      canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx,
-                                       graphGranularity);
+      if (failed(canonicalizer.parseCommandGraphs(func, hostGraph, dep_ctx,
+                                                  graphGranularity)))
+        return signalPassFailure();
 
       // Dump DOT files
       std::string dumpDir = clDumpDir;

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -1483,12 +1483,10 @@ void dependencyCanonicalizer::connectAndUpdateGraphPointers(
   }
 }
 
-void dependencyCanonicalizer::parseCommandGraphs(func::FuncOp &toplevel,
-                                                 dependencyGraph &global_graph,
-                                                 dependencyContext &dep_ctx,
-                                                 std::string granularity,
-                                                 bool dump_dot,
-                                                 std::string dump_dir) {
+LogicalResult dependencyCanonicalizer::parseCommandGraphs(
+    func::FuncOp &toplevel, dependencyGraph &global_graph,
+    dependencyContext &dep_ctx, std::string granularity, bool dump_dot,
+    std::string dump_dir) {
   // Graph parsing granularity. Tuple format: <expandLaunch, expandSegment,
   // expandHerd, expandCore>
   graphGranularityProperties expandHier = {true, true, true, false};
@@ -1500,30 +1498,38 @@ void dependencyCanonicalizer::parseCommandGraphs(func::FuncOp &toplevel,
     std::get<3>(expandHier) = true;
   } else {
     toplevel->emitOpError("unknown graph parsing granularity");
-    return;
+    return failure();
   }
 
   // Create vertices for graphs
   // Build up host graph
+  LogicalResult result = success();
   toplevel.walk([&](Operation *op) {
     if (!op->getParentOfType<air::HierarchyInterface>()) {
-      addVertexFromOpImpls(op, &global_graph, dep_ctx);
+      if (failed(addVertexFromOpImpls(op, &global_graph, dep_ctx)))
+        result = failure();
       if (auto launch = dyn_cast_if_present<air::LaunchOp>(op)) {
-        addVerticesInLaunch(global_graph.subgraphs, launch, dep_ctx,
-                            expandHier);
+        if (failed(addVerticesInLaunch(global_graph.subgraphs, launch, dep_ctx,
+                                       expandHier)))
+          result = failure();
       } else if (dyn_cast_if_present<air::SegmentOp>(op) &&
                  (!op->getParentOfType<air::LaunchOp>())) {
         auto segment = dyn_cast_if_present<air::SegmentOp>(op);
-        addVerticesInSegment(global_graph.subgraphs, segment, dep_ctx,
-                             expandHier);
+        if (failed(addVerticesInSegment(global_graph.subgraphs, segment,
+                                        dep_ctx, expandHier)))
+          result = failure();
       } else if (dyn_cast_if_present<air::HerdOp>(op) &&
                  (!op->getParentOfType<air::LaunchOp>()) &&
                  (!op->getParentOfType<air::SegmentOp>())) {
         auto herd = dyn_cast_if_present<air::HerdOp>(op);
-        addVerticesInHerd(global_graph.subgraphs, herd, dep_ctx, expandHier);
+        if (failed(addVerticesInHerd(global_graph.subgraphs, herd, dep_ctx,
+                                     expandHier)))
+          result = failure();
       }
     }
   });
+  if (failed(result))
+    return failure();
 
   // Adds edges between async ops.
   parseAllDependencyEdges(global_graph, dep_ctx);
@@ -1542,12 +1548,14 @@ void dependencyCanonicalizer::parseCommandGraphs(func::FuncOp &toplevel,
   for (auto &launchGraph : global_graph.subgraphs) {
     connectAndUpdateGraphPointers(launchGraph, &global_graph);
   }
+  return success();
 }
 
-void dependencyCanonicalizer::addVerticesInHerd(
+LogicalResult dependencyCanonicalizer::addVerticesInHerd(
     std::vector<dependencyGraph> &herd_subgraphs, air::HerdOp herd,
     dependencyContext &dep_ctx, graphGranularityProperties expandHier) {
   // Build up herd graph
+  LogicalResult result = success();
   bool showCores = std::get<3>(expandHier);
   if (showCores) {
     auto hier =
@@ -1571,7 +1579,9 @@ void dependencyCanonicalizer::addVerticesInHerd(
 
       herd.walk([&](Operation *herd_childop) {
         if (!dyn_cast_if_present<air::HerdOp>(herd_childop)) {
-          addVertexFromOpImpls(herd_childop, current_herd_graph, dep_ctx);
+          if (failed(addVertexFromOpImpls(herd_childop, current_herd_graph,
+                                          dep_ctx)))
+            result = failure();
         }
       });
     }
@@ -1581,35 +1591,44 @@ void dependencyCanonicalizer::addVerticesInHerd(
 
     herd.walk([&](Operation *herd_childop) {
       if (!dyn_cast_if_present<air::HerdOp>(herd_childop)) {
-        addVertexFromOpImpls(herd_childop, current_herd_graph, dep_ctx);
+        if (failed(addVertexFromOpImpls(herd_childop, current_herd_graph,
+                                        dep_ctx)))
+          result = failure();
       }
     });
   }
+  return result;
 }
 
-void dependencyCanonicalizer::addVerticesInSegment(
+LogicalResult dependencyCanonicalizer::addVerticesInSegment(
     std::vector<dependencyGraph> &part_subgraphs, air::SegmentOp segment,
     dependencyContext &dep_ctx, graphGranularityProperties expandHier) {
   // Build up segment graph
+  LogicalResult result = success();
   part_subgraphs.push_back(dependencyGraph(segment.getOperation(), true));
   dependencyGraph *current_part_graph = &(part_subgraphs.back());
 
   segment.walk([&](Operation *part_childop) {
     if (!part_childop->getParentOfType<air::HerdOp>() &&
         !dyn_cast_if_present<air::SegmentOp>(part_childop)) {
-      addVertexFromOpImpls(part_childop, current_part_graph, dep_ctx);
+      if (failed(
+              addVertexFromOpImpls(part_childop, current_part_graph, dep_ctx)))
+        result = failure();
       if (auto herd = dyn_cast_if_present<air::HerdOp>(part_childop)) {
-        addVerticesInHerd(current_part_graph->subgraphs, herd, dep_ctx,
-                          expandHier);
+        if (failed(addVerticesInHerd(current_part_graph->subgraphs, herd,
+                                     dep_ctx, expandHier)))
+          result = failure();
       }
     }
   });
+  return result;
 }
 
-void dependencyCanonicalizer::addVerticesInLaunch(
+LogicalResult dependencyCanonicalizer::addVerticesInLaunch(
     std::vector<dependencyGraph> &launch_subgraphs, air::LaunchOp launch,
     dependencyContext &dep_ctx, graphGranularityProperties expandHier) {
   // Build up launch graph
+  LogicalResult result = success();
   launch_subgraphs.push_back(dependencyGraph(launch.getOperation(), true));
   dependencyGraph *current_launch_graph = &(launch_subgraphs.back());
 
@@ -1617,50 +1636,68 @@ void dependencyCanonicalizer::addVerticesInLaunch(
     if (!launch_childop->getParentOfType<air::SegmentOp>() &&
         !launch_childop->getParentOfType<air::HerdOp>() &&
         !dyn_cast_if_present<air::LaunchOp>(launch_childop)) {
-      addVertexFromOpImpls(launch_childop, current_launch_graph, dep_ctx);
+      if (failed(addVertexFromOpImpls(launch_childop, current_launch_graph,
+                                      dep_ctx)))
+        result = failure();
       if (auto segment = dyn_cast_if_present<air::SegmentOp>(launch_childop)) {
-        addVerticesInSegment(current_launch_graph->subgraphs, segment, dep_ctx,
-                             expandHier);
+        if (failed(addVerticesInSegment(current_launch_graph->subgraphs,
+                                        segment, dep_ctx, expandHier)))
+          result = failure();
       } else if (dyn_cast_if_present<air::HerdOp>(launch_childop) &&
                  (!launch_childop->getParentOfType<air::SegmentOp>())) {
         auto herd = dyn_cast_if_present<air::HerdOp>(launch_childop);
-        addVerticesInHerd(current_launch_graph->subgraphs, herd, dep_ctx,
-                          expandHier);
+        if (failed(addVerticesInHerd(current_launch_graph->subgraphs, herd,
+                                     dep_ctx, expandHier)))
+          result = failure();
       }
     }
   });
+  return result;
 }
 
-Graph::VertexId
+LogicalResult
 dependencyCanonicalizer::addVertexFromOpImpls(Operation *op, dependencyGraph *G,
                                               dependencyContext &dep_ctx) {
   if (auto dma_op = mlir::dyn_cast_if_present<xilinx::air::DmaMemcpyNdOp>(op)) {
-    return addVertexFromDmaOp(dma_op, G, dep_ctx);
+    addVertexFromDmaOp(dma_op, G, dep_ctx);
   } else if (auto channel_op =
                  mlir::dyn_cast_if_present<xilinx::air::ChannelInterface>(op)) {
-    return addVertexFromChannelOp(channel_op, G, dep_ctx);
+    addVertexFromChannelOp(channel_op, G, dep_ctx);
   } else if (auto execute_op =
                  dyn_cast_if_present<xilinx::air::ExecuteOp>(op)) {
-    return addVertexFromExecuteOp(execute_op, G, dep_ctx);
+    addVertexFromExecuteOp(execute_op, G, dep_ctx);
   } else if (auto wa_op = dyn_cast_if_present<xilinx::air::WaitAllOp>(op)) {
-    return addVertexFromWaitAllOp(wa_op, G, dep_ctx);
+    addVertexFromWaitAllOp(wa_op, G, dep_ctx);
   } else if (auto forop = dyn_cast_if_present<scf::ForOp>(op)) {
-    return addVertexFromOp(op, dep_ctx.ForOpID, "for_loop", "ScfForOp",
-                           graphNodeProperties("control"), G, dep_ctx);
+    addVertexFromOp(op, dep_ctx.ForOpID, "for_loop", "ScfForOp",
+                    graphNodeProperties("control"), G, dep_ctx);
   } else if (auto parallelop = dyn_cast_if_present<scf::ParallelOp>(op)) {
-    return addVertexFromOp(op, dep_ctx.ParallelOpID, "parallel_loop",
-                           "ScfParallelOp", graphNodeProperties("control"), G,
-                           dep_ctx);
+    addVertexFromOp(op, dep_ctx.ParallelOpID, "parallel_loop", "ScfParallelOp",
+                    graphNodeProperties("control"), G, dep_ctx);
+  } else if (auto ifop = dyn_cast_if_present<scf::IfOp>(op)) {
+    addVertexFromOp(op, dep_ctx.IfOpID, "if_branch", "ScfIfOp",
+                    graphNodeProperties("control"), G, dep_ctx);
+  } else if (auto affineifop = dyn_cast_if_present<affine::AffineIfOp>(op)) {
+    addVertexFromOp(op, dep_ctx.IfOpID, "if_branch", "AffineIfOp",
+                    graphNodeProperties("control"), G, dep_ctx);
   } else if (auto hier_op =
                  mlir::dyn_cast_if_present<xilinx::air::HierarchyInterface>(
                      op)) {
-    return addVertexFromHierarchyOp(hier_op, G, dep_ctx);
+    addVertexFromHierarchyOp(hier_op, G, dep_ctx);
   } else if (auto reduce_op = dyn_cast_if_present<scf::ReduceOp>(op)) {
-    return addVertexFromReduceOp(reduce_op, G, dep_ctx);
+    addVertexFromReduceOp(reduce_op, G, dep_ctx);
   } else if (op->mightHaveTrait<OpTrait::IsTerminator>()) {
-    return addVertexFromTerminatorOp(op, G, dep_ctx);
-  } else
-    return 0;
+    addVertexFromTerminatorOp(op, G, dep_ctx);
+  } else if (!isa<xilinx::air::ExecuteOp>(op->getParentOp()) &&
+             !op->getResultTypes().empty()) {
+    // Unknown op producing results outside of air.execute; signal an error
+    // only if it produces async tokens that could be used as dependencies.
+    for (auto resultType : op->getResultTypes()) {
+      if (isa<air::AsyncTokenType>(resultType))
+        return op->emitOpError("unknown op type producing async token");
+    }
+  }
+  return success();
 }
 
 // Create graph vertex from op
@@ -1855,6 +1892,16 @@ Graph::VertexId dependencyCanonicalizer::addVertexFromTerminatorOp(
       return addVertexFromOp(
           op, dep_ctx.TerminatorID, "terminator", "ScfForYieldOp",
           graphNodeProperties("control", detailed_description), G, dep_ctx);
+    } else if (getScfParentOpFromYieldOp<scf::IfOp>(op)) {
+      return addVertexFromOp(
+          op, dep_ctx.TerminatorID, "terminator", "ScfIfYieldOp",
+          graphNodeProperties("control", detailed_description), G, dep_ctx);
+    }
+  } else if (isa<affine::AffineYieldOp>(op)) {
+    if (op->getParentOfType<affine::AffineIfOp>()) {
+      return addVertexFromOp(
+          op, dep_ctx.TerminatorID, "terminator", "AffineIfYieldOp",
+          graphNodeProperties("control", detailed_description), G, dep_ctx);
     }
   }
   return 0;
@@ -1981,6 +2028,10 @@ std::string dependencyCanonicalizer::getOpTypeFromOpImpls(Operation *op) {
     return "for_loop";
   } else if (isa<scf::ParallelOp>(op)) {
     return "parallel_loop";
+  } else if (isa<scf::IfOp>(op)) {
+    return "if_branch";
+  } else if (isa<affine::AffineIfOp>(op)) {
+    return "if_branch";
   } else if (isa<xilinx::air::LaunchTerminatorOp>(op)) {
     return "hierarchy_terminator";
   } else if (isa<xilinx::air::SegmentTerminatorOp>(op)) {
@@ -1990,6 +2041,8 @@ std::string dependencyCanonicalizer::getOpTypeFromOpImpls(Operation *op) {
   } else if (isa<scf::YieldOp>(op)) {
     return "terminator";
   } else if (isa<scf::ReduceOp>(op)) {
+    return "terminator";
+  } else if (isa<affine::AffineYieldOp>(op)) {
     return "terminator";
   } else {
     if (isa<xilinx::air::ExecuteOp>(op->getParentOp())) {
@@ -2081,6 +2134,13 @@ void dependencyCanonicalizer::connectOpToItsDepListImpls(
       dep_list.push_back(operand);
     }
   }
+  // affine.yield
+  else if (auto affineyieldop =
+               dyn_cast_if_present<affine::AffineYieldOp>(op)) {
+    for (auto operand : affineyieldop->getOperands()) {
+      dep_list.push_back(operand);
+    }
+  }
   if (dep_list.size()) {
     connectOpToItsDepList(op, dep_list, g, dep_ctx);
   }
@@ -2146,6 +2206,28 @@ dependencyCanonicalizer::traceOpFromToken(Operation *op, Value dep_token) {
       output.push_back(parallelop_reduceop);
       return output;
     }
+  }
+  // Else if dependency token is from scf if (joint token from both branches)
+  else if (dep_token.getDefiningOp() &&
+           dyn_cast_if_present<scf::IfOp>(dep_token.getDefiningOp())) {
+    auto ifop = dyn_cast_if_present<scf::IfOp>(dep_token.getDefiningOp());
+    // Then block
+    auto then_terminator = ifop.thenBlock()->getTerminator();
+    for (auto operand : then_terminator->getOperands()) {
+      if (auto op = operand.getDefiningOp()) {
+        output.push_back(op);
+      }
+    }
+    // Else block
+    if (ifop.elseBlock()) {
+      auto else_terminator = ifop.elseBlock()->getTerminator();
+      for (auto operand : else_terminator->getOperands()) {
+        if (auto op = operand.getDefiningOp()) {
+          output.push_back(op);
+        }
+      }
+    }
+    return output;
   }
   // Else if dependency token is from affine if (joint token from multiple ops)
   else if (dep_token.getDefiningOp() &&

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -372,8 +372,11 @@ public:
     // Walk the launch op and create a graph using dependencyCanonicalizer
     // intepreter
     hostGraph = dependencyGraph(toplevel, true);
-    canonicalizer.parseCommandGraphs(toplevel, hostGraph, dep_ctx,
-                                     sim_granularity);
+    if (failed(canonicalizer.parseCommandGraphs(toplevel, hostGraph, dep_ctx,
+                                                sim_granularity))) {
+      toplevel->emitOpError("failed to parse dependency command graphs");
+      return;
+    }
 
     // Walk the launch graph and write process name metadata in trace
     writeTraceMetadataProcNames(hostGraph);

--- a/mlir/test/Transform/AIRDependencyCanonicalization/scf_if.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/scf_if.mlir
@@ -1,0 +1,108 @@
+//===- scf_if.mlir -------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
+
+// Test that air-dependency-canonicalize handles scf.if ops returning
+// !air.async.token inside a herd body.
+
+// CHECK-LABEL: func.func @scf_if_in_herd
+// CHECK: air.herd
+// CHECK: %[[EVENT0:.*]] = scf.if
+// CHECK: %[[EVENT1:.*]] = air.channel.get async
+// CHECK: scf.yield %[[EVENT1]]
+// CHECK: } else {
+// CHECK: %[[EVENT2:.*]] = air.channel.get async
+// CHECK: scf.yield %[[EVENT2]]
+// CHECK: }
+// CHECK: air.channel.put async [%[[EVENT0]]]
+
+// CHECK-LABEL: func.func @scf_if_in_scf_for
+// CHECK: air.herd
+// CHECK: scf.for
+// CHECK: %[[IF_RESULT:.*]] = scf.if
+// CHECK: air.channel.get async
+// CHECK: } else {
+// CHECK: air.channel.get async
+// CHECK: }
+// CHECK: air.channel.put async [%[[IF_RESULT]]]
+
+module {
+  air.channel @channel_A [1, 1, 1] {broadcast_shape = [1, 1, 4 : index]}
+  air.channel @channel_B [1, 1, 1] {broadcast_shape = [1, 1, 4 : index]}
+  air.channel @channel_out [4, 1]
+  func.func @scf_if_in_herd(%arg0: memref<1x1x2048xi32>) {
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.herd @herd_0 async  tile (%arg2, %arg3) in (%arg4=%c4, %arg5=%c1) args(%arg6=%arg0) : memref<1x1x2048xi32> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %async_token, %results = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+      } {id = 1 : i32}
+      %async_token_0, %results_1 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+      } {id = 2 : i32}
+      // scf.if selecting between channels based on tile position
+      %cond = arith.cmpi eq, %arg2, %c0 : index
+      %1 = scf.if %cond -> (!air.async.token) {
+        %2 = air.channel.get async [%async_token]  @channel_A[%c0, %c0, %arg2] (%results[] [] []) {id = 1 : i32} : (memref<64x64xbf16, 2 : i32>)
+        scf.yield %2 : !air.async.token
+      } else {
+        %2 = air.channel.get async [%async_token]  @channel_B[%c0, %c0, %arg2] (%results[] [] []) {id = 2 : i32} : (memref<64x64xbf16, 2 : i32>)
+        scf.yield %2 : !air.async.token
+      }
+      // Use the scf.if result as a dependency
+      %3 = air.channel.put async [%1]  @channel_out[%arg2, %c0] (%results_1[] [] []) {id = 3 : i32} : (memref<64x64xbf16, 2 : i32>)
+      %async_token_2 = air.execute [%3] {
+        memref.dealloc %results : memref<64x64xbf16, 2 : i32>
+      } {id = 3 : i32}
+      %async_token_3 = air.execute [%3] {
+        memref.dealloc %results_1 : memref<64x64xbf16, 2 : i32>
+      } {id = 4 : i32}
+    }
+    return
+  }
+  func.func @scf_if_in_scf_for(%arg0: memref<1x1x2048xi32>) {
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.herd @herd_1 async  tile (%arg2, %arg3) in (%arg4=%c4, %arg5=%c1) args(%arg6=%arg0) : memref<1x1x2048xi32> attributes {id = 2 : i32} {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %async_token, %results = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+      } {id = 5 : i32}
+      %async_token_0, %results_1 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+      } {id = 6 : i32}
+      %cond = arith.cmpi eq, %arg2, %c0 : index
+      // scf.for loop with scf.if inside selecting channels per iteration
+      %1 = scf.for %iv = %c0 to %c2 step %c1_0 iter_args(%dep = %async_token) -> (!air.async.token) {
+        %2 = scf.if %cond -> (!air.async.token) {
+          %3 = air.channel.get async [%dep]  @channel_A[%c0, %c0, %arg2] (%results[] [] []) {id = 4 : i32} : (memref<64x64xbf16, 2 : i32>)
+          scf.yield %3 : !air.async.token
+        } else {
+          %3 = air.channel.get async [%dep]  @channel_B[%c0, %c0, %arg2] (%results[] [] []) {id = 5 : i32} : (memref<64x64xbf16, 2 : i32>)
+          scf.yield %3 : !air.async.token
+        }
+        %4 = air.channel.put async [%2]  @channel_out[%arg2, %c0] (%results_1[] [] []) {id = 6 : i32} : (memref<64x64xbf16, 2 : i32>)
+        scf.yield %4 : !air.async.token
+      }
+      %async_token_2 = air.execute [%1] {
+        memref.dealloc %results : memref<64x64xbf16, 2 : i32>
+      } {id = 7 : i32}
+      %async_token_3 = air.execute [%1] {
+        memref.dealloc %results_1 : memref<64x64xbf16, 2 : i32>
+      } {id = 8 : i32}
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- Add `scf.if` and `affine.if` support to the dependency graph infrastructure (`addVertexFromOpImpls`, `getOpTypeFromOpImpls`, `addVertexFromTerminatorOp`, `traceOpFromToken`, `connectOpToItsDepListImpls`)
- Fix silent error propagation: `parseCommandGraphs` now returns `LogicalResult` instead of `void`, and both pass entry points call `signalPassFailure()` on error
- Add LIT test for `scf.if` in herd body and `scf.if` nested inside `scf.for`

## Test plan
- [x] New `scf_if.mlir` test with two cases: top-level `scf.if` in herd and `scf.if` inside `scf.for`
- [x] All 339 existing MLIR tests pass (same 4 pre-existing `Util/Channel` failures)
- [x] Original failing input IR processes cleanly with zero errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)