### PR TITLE
Add NumPy broadcasting rule validation to air.channel verifier

### DIFF
--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -2625,6 +2625,31 @@ LogicalResult air::ChannelOp::verify() {
     auto broadcast_shape = getBroadcastShape();
     if (bundle_size.size() != broadcast_shape.size())
       return emitOpError("bundle rank should match broadcast_shape rank");
+
+    // Validate NumPy-style broadcasting rules for each dimension.
+    for (unsigned i = 0; i < bundle_size.size(); i++) {
+      auto sizeAttr = dyn_cast_if_present<IntegerAttr>(bundle_size[i]);
+      if (!sizeAttr)
+        return emitOpError() << "expected integer attribute for size[" << i
+                             << "], but found " << bundle_size[i];
+      auto bcastAttr = dyn_cast_if_present<IntegerAttr>(broadcast_shape[i]);
+      if (!bcastAttr)
+        return emitOpError()
+               << "expected integer attribute for broadcast_shape[" << i
+               << "], but found " << broadcast_shape[i];
+      int64_t sizeVal = sizeAttr.getInt();
+      int64_t bcastVal = bcastAttr.getInt();
+      if (bcastVal < sizeVal)
+        return emitOpError() << "broadcast_shape[" << i << "] (" << bcastVal
+                             << ") must be >= size[" << i << "] (" << sizeVal
+                             << "): broadcasting cannot shrink a dimension";
+      if (sizeVal != bcastVal && sizeVal != 1)
+        return emitOpError()
+               << "size[" << i << "] (" << sizeVal
+               << ") is not compatible with broadcast_shape[" << i << "] ("
+               << bcastVal << "): size must be 1 or equal to broadcast_shape "
+               << "(NumPy broadcasting rules)";
+    }
   }
   return success();
 }

--- a/mlir/test/Dialect/AIR/air_channel_invalid.mlir
+++ b/mlir/test/Dialect/AIR/air_channel_invalid.mlir
@@ -1,0 +1,53 @@
+//===- air_channel_invalid.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt --split-input-file --verify-diagnostics %s
+
+// -----
+
+// Test: rank mismatch between size and broadcast_shape.
+// expected-error @+1 {{'air.channel' op bundle rank should match broadcast_shape rank}}
+air.channel @rank_mismatch [2, 2] {broadcast_shape = [4, 4, 4]}
+
+// -----
+
+// Test: broadcast_shape smaller than size (shrinking is invalid).
+// expected-error @+1 {{'air.channel' op broadcast_shape[0] (1) must be >= size[0] (2): broadcasting cannot shrink a dimension}}
+air.channel @shrink [2, 2] {broadcast_shape = [1, 2]}
+
+// -----
+
+// Test: size is not 1 and not equal to broadcast_shape (NumPy rule violation).
+// expected-error @+1 {{'air.channel' op size[0] (2) is not compatible with broadcast_shape[0] (8): size must be 1 or equal to broadcast_shape (NumPy broadcasting rules)}}
+air.channel @bad_broadcast [2, 2] {broadcast_shape = [8, 2]}
+
+// -----
+
+// Test: violation in second dimension.
+// expected-error @+1 {{'air.channel' op size[1] (3) is not compatible with broadcast_shape[1] (4): size must be 1 or equal to broadcast_shape (NumPy broadcasting rules)}}
+air.channel @bad_dim1 [1, 3] {broadcast_shape = [1, 4]}
+
+// -----
+
+// Test: 3D channel with broadcasting violation.
+// expected-error @+1 {{'air.channel' op size[2] (3) is not compatible with broadcast_shape[2] (4): size must be 1 or equal to broadcast_shape (NumPy broadcasting rules)}}
+air.channel @bad_3d [2, 1, 3] {broadcast_shape = [2, 4, 4]}
+
+// -----
+
+// Test: valid broadcasting (positive test - should pass with no errors).
+air.channel @valid_broadcast [1, 4] {broadcast_shape = [4, 4]}
+
+// -----
+
+// Test: valid 3D broadcasting (positive test).
+air.channel @valid_3d [2, 1, 4] {broadcast_shape = [2, 4, 4]}
+
+// -----
+
+// Test: valid all-ones size broadcasting (positive test).
+air.channel @valid_all_ones [1, 1] {broadcast_shape = [4, 4]}


### PR DESCRIPTION
## Summary
- Adds per-dimension NumPy broadcasting validation to `air.channel` verifier: each `size[i]` must equal `broadcast_shape[i]` or be exactly 1
- Rejects ambiguous configurations like `size=[2,2]` with `broadcast_shape=[8,2]` where the broadcast intent is unclear
- Adds `air_channel_invalid.mlir` with negative and positive verifier tests

## Test plan
- [x] `ninja -C build check-air-mlir` passes (353 tests, 0 failures verified locally)
- [x] New test `mlir/test/Dialect/AIR/air_channel_invalid.mlir` covers rank mismatch, shrink, and NumPy rule violations (2D/3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)