### PR TITLE
Fix air-to-aie shim DMA linkage with segment unroll scf.if/affine.if

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1417,8 +1417,10 @@ struct SpecializeAffineIfPattern : public OpRewritePattern<affine::AffineIfOp> {
   LogicalResult matchAndRewrite(affine::AffineIfOp op,
                                 PatternRewriter &rewriter) const override {
 
-    auto core = op->getParentOfType<AIE::CoreOp>();
-    if (!core)
+    // Allow specialization inside both AIE cores and at the segment level
+    // within a device (for segment-unrolled affine.if ops on unroll indices).
+    if (!op->getParentOfType<AIE::CoreOp>() &&
+        !op->getParentOfType<AIE::DeviceOp>())
       return failure();
 
     bool in_set = false;
@@ -1483,8 +1485,10 @@ struct SpecializeScfIfPattern : public OpRewritePattern<scf::IfOp> {
   LogicalResult matchAndRewrite(scf::IfOp op,
                                 PatternRewriter &rewriter) const override {
 
-    auto core = op->getParentOfType<AIE::CoreOp>();
-    if (!core)
+    // Allow specialization inside both AIE cores and at the segment level
+    // within a device (for segment-unrolled scf.if ops on unroll indices).
+    if (!op->getParentOfType<AIE::CoreOp>() &&
+        !op->getParentOfType<AIE::DeviceOp>())
       return failure();
 
     // Try to resolve the condition to a constant boolean.
@@ -1501,7 +1505,12 @@ struct SpecializeScfIfPattern : public OpRewritePattern<scf::IfOp> {
       auto lhsConst = mlir::getConstantIntValue(cmpOp.getLhs());
       auto rhsConst = mlir::getConstantIntValue(cmpOp.getRhs());
       if (lhsConst && rhsConst) {
-        unsigned bitWidth = cmpOp.getLhs().getType().getIntOrFloatBitWidth();
+        // Use 64-bit APInt for index types (which have no fixed bit width),
+        // and the actual bit width for integer types.
+        unsigned bitWidth =
+            isa<IndexType>(cmpOp.getLhs().getType())
+                ? 64
+                : cmpOp.getLhs().getType().getIntOrFloatBitWidth();
         APInt lhs(bitWidth, *lhsConst, /*isSigned=*/true);
         APInt rhs(bitWidth, *rhsConst, /*isSigned=*/true);
         condValue = arith::applyCmpPredicate(cmpOp.getPredicate(), lhs, rhs);
@@ -4070,11 +4079,16 @@ public:
 
   // Create shim DMA allocation ops and annotate the corresponding memcpy
   // operations with symbolic metadata.
+  // When skipUnlinked is true, shim-side memcpy ops that don't match any
+  // allocation are silently skipped instead of producing an error. This is
+  // used for segment-unrolled designs where each device processes its own
+  // allocations independently, so ops belonging to other devices are expected
+  // to be unlinked.
   LogicalResult createShimDMAAllocationOps(
       OpBuilder builder, MLIRContext *ctx,
       std::vector<air::MemcpyInterface> shimSideMemcpyIfOps,
       air::ShimDMAAllocator &shimDmaAllocs,
-      std::map<int, int> chanRenumberReverseMap) {
+      std::map<int, int> chanRenumberReverseMap, bool skipUnlinked = false) {
     std::vector<air::MemcpyInterface> shimMemcpyS2MMOps, shimMemcpyMM2SOps;
 
     // Separate memcpy ops into S2MM and MM2S based on direction.
@@ -4101,14 +4115,14 @@ public:
     // Create shim-side S2MM DMA allocs and annotate corresponding ops.
     if (failed(createShimDMAAllocationOpsImpl(
             builder, ctx, shimMemcpyS2MMOps, shimDmaAllocs.s2mm_allocs,
-            AIE::DMAChannelDir::S2MM, chanRenumberReverseMap))) {
+            AIE::DMAChannelDir::S2MM, chanRenumberReverseMap, skipUnlinked))) {
       return failure();
     }
 
     // Create shim-side MM2S DMA allocs and annotate corresponding ops.
     if (failed(createShimDMAAllocationOpsImpl(
             builder, ctx, shimMemcpyMM2SOps, shimDmaAllocs.mm2s_allocs,
-            AIE::DMAChannelDir::MM2S, chanRenumberReverseMap))) {
+            AIE::DMAChannelDir::MM2S, chanRenumberReverseMap, skipUnlinked))) {
       return failure();
     }
     return success();
@@ -4141,7 +4155,7 @@ public:
       OpBuilder builder, MLIRContext *ctx,
       std::vector<air::MemcpyInterface> shimSideMemcpyIfOps,
       std::vector<air::allocation_info_t> allocs, AIE::DMAChannelDir dir,
-      std::map<int, int> chanRenumberReverseMap) {
+      std::map<int, int> chanRenumberReverseMap, bool skipUnlinked = false) {
 
     // Helper function getting dma_name from the air::MemcpyInterface op.
     auto getDmaNameFromMemcpyIfOp = [](air::MemcpyInterface memcpyIfOp) {
@@ -4190,21 +4204,29 @@ public:
     }
 
     // Capture errors when any shim memcpy op fails to link to shim allocation.
-    auto unlinkedMemcpyIfOp = llvm::find_if(
-        shimSideMemcpyIfOps, [&](air::MemcpyInterface memcpyIfOp) {
-          std::string dma_name = getDmaNameFromMemcpyIfOp(memcpyIfOp);
-          return !shimChanSymbolToAlloc.count(dma_name);
-        });
-    if (unlinkedMemcpyIfOp != shimSideMemcpyIfOps.end()) {
-      unlinkedMemcpyIfOp->emitOpError(
-          "failed to link to any shim dma allocation.");
-      return failure();
+    // When skipUnlinked is true (segment-unrolled per-device processing),
+    // unlinked ops belong to other devices and are silently skipped.
+    if (!skipUnlinked) {
+      auto unlinkedMemcpyIfOp = llvm::find_if(
+          shimSideMemcpyIfOps, [&](air::MemcpyInterface memcpyIfOp) {
+            std::string dma_name = getDmaNameFromMemcpyIfOp(memcpyIfOp);
+            return !shimChanSymbolToAlloc.count(dma_name);
+          });
+      if (unlinkedMemcpyIfOp != shimSideMemcpyIfOps.end()) {
+        unlinkedMemcpyIfOp->emitOpError(
+            "failed to link to any shim dma allocation.");
+        return failure();
+      }
     }
 
     // Create shim dma allocation ops.
     for (auto memcpyIfOp : shimSideMemcpyIfOps) {
       std::string dma_name = getDmaNameFromMemcpyIfOp(memcpyIfOp);
-      int t_idx = 0;
+      // Start index from the existing metadataArray size so that per-device
+      // calls produce globally sequential indices across devices.
+      ArrayAttr existingMeta =
+          memcpyIfOp->getAttrOfType<ArrayAttr>("metadataArray");
+      int t_idx = existingMeta ? existingMeta.size() : 0;
       for (air::allocation_info_t &t : shimChanSymbolToAlloc[dma_name]) {
         auto deviceOp = t.getDmaTile()->getParentOfType<AIE::DeviceOp>();
         // Create shim allocation symbol name shim_name_attr.
@@ -4219,7 +4241,7 @@ public:
                 deviceOp->getAttrOfType<IntegerAttr>("segment_unroll_y")) {
           shim_name += "_" + std::to_string(unrollYAttr.getInt());
         }
-        if (shimChanSymbolToAlloc[dma_name].size() > 1)
+        if (shimChanSymbolToAlloc[dma_name].size() > 1 || t_idx > 0)
           shim_name += "_" + std::to_string(t_idx);
         StringAttr shim_name_attr = builder.getStringAttr(shim_name);
 
@@ -5768,16 +5790,6 @@ public:
     createAIEModulesAndOutlineCores(module, aie_devices, tileToHerdMap,
                                     options);
 
-    // Deferred shim DMA metadata: for segment-unrolled devices, collect all
-    // allocations across devices and build metadataArrays in a single call.
-    // This produces correctly-ordered entries without relying on the post-hoc
-    // name-parsing sort.
-    std::vector<air::allocation_info_t> combinedS2MMAllocs, combinedMM2SAllocs;
-    air::LaunchOp deferredLaunch = nullptr;
-    std::map<int, int> deferredChanRenumberMap;
-    func::FuncOp deferredFunc = nullptr;
-    MLIRContext *deferredCtx = nullptr;
-
     std::set<AIE::DeviceOp> seen;
     for (auto &p : aie_devices) {
       auto device = std::get<0>(p);
@@ -5937,55 +5949,42 @@ public:
       if (isa<AIE::AIE2TargetModel>(device.getTargetModel()) && !clUseObjFifo) {
         bool isSegmentUnrolled = device->hasAttr("segment_unroll_x") ||
                                  device->hasAttr("segment_unroll_y");
-        if (isSegmentUnrolled) {
-          // Defer: collect allocations from all segment-unrolled devices
-          // so metadataArrays can be built in one pass with all entries.
-          combinedS2MMAllocs.insert(combinedS2MMAllocs.end(),
-                                    shimDmaAlloc.s2mm_allocs.begin(),
-                                    shimDmaAlloc.s2mm_allocs.end());
-          combinedMM2SAllocs.insert(combinedMM2SAllocs.end(),
-                                    shimDmaAlloc.mm2s_allocs.begin(),
-                                    shimDmaAlloc.mm2s_allocs.end());
-          if (!deferredLaunch) {
-            deferredLaunch = targetLaunch;
-            deferredChanRenumberMap = chan_renumber_reverse_map;
-            deferredFunc = h->getParentOfType<func::FuncOp>();
-            deferredCtx = ctx;
-          }
-        } else {
-          // Non-unrolled: process immediately as before.
-          auto func = h->getParentOfType<func::FuncOp>();
-          std::vector<air::MemcpyInterface> shimMemcpyIfOps;
-          func.walk([&](air::ChannelInterface o) {
-            auto parentLaunch = o->getParentOfType<air::LaunchOp>();
-            if (parentLaunch && parentLaunch != targetLaunch)
-              return;
-            auto memrefTy =
-                dyn_cast_if_present<BaseMemRefType>(o.getMemref().getType());
-            if (memrefTy && air::isL3(memrefTy))
-              shimMemcpyIfOps.push_back(
-                  dyn_cast_if_present<air::MemcpyInterface>(o.getOperation()));
-          });
-          func.walk([&](air::DmaMemcpyNdOp o) {
-            auto parentLaunch = o->getParentOfType<air::LaunchOp>();
-            if (parentLaunch && parentLaunch != targetLaunch)
-              return;
-            auto srcMemrefTy =
-                dyn_cast_if_present<BaseMemRefType>(o.getSrcMemref().getType());
-            if (srcMemrefTy && air::isL3(srcMemrefTy))
-              shimMemcpyIfOps.push_back(o);
-            auto dstMemrefTy =
-                dyn_cast_if_present<BaseMemRefType>(o.getDstMemref().getType());
-            if (dstMemrefTy && air::isL3(dstMemrefTy))
-              shimMemcpyIfOps.push_back(o);
-          });
-          builder.setInsertionPoint(device.getBody()->getTerminator());
-          if (failed(createShimDMAAllocationOps(builder, ctx, shimMemcpyIfOps,
-                                                shimDmaAlloc,
-                                                chan_renumber_reverse_map))) {
-            signalPassFailure();
+        // Process shim DMA metadata per-device. For segment-unrolled designs,
+        // each device processes its own allocations independently. Shim-side
+        // ops belonging to other devices are silently skipped (skipUnlinked).
+        auto func = h->getParentOfType<func::FuncOp>();
+        std::vector<air::MemcpyInterface> shimMemcpyIfOps;
+        func.walk([&](air::ChannelInterface o) {
+          auto parentLaunch = o->getParentOfType<air::LaunchOp>();
+          if (parentLaunch && parentLaunch != targetLaunch)
             return;
-          }
+          auto memrefTy =
+              dyn_cast_if_present<BaseMemRefType>(o.getMemref().getType());
+          if (memrefTy && air::isL3(memrefTy))
+            shimMemcpyIfOps.push_back(
+                dyn_cast_if_present<air::MemcpyInterface>(o.getOperation()));
+        });
+        func.walk([&](air::DmaMemcpyNdOp o) {
+          auto parentLaunch = o->getParentOfType<air::LaunchOp>();
+          if (parentLaunch && parentLaunch != targetLaunch)
+            return;
+          auto srcMemrefTy =
+              dyn_cast_if_present<BaseMemRefType>(o.getSrcMemref().getType());
+          if (srcMemrefTy && air::isL3(srcMemrefTy))
+            shimMemcpyIfOps.push_back(o);
+          auto dstMemrefTy =
+              dyn_cast_if_present<BaseMemRefType>(o.getDstMemref().getType());
+          if (dstMemrefTy && air::isL3(dstMemrefTy))
+            shimMemcpyIfOps.push_back(o);
+        });
+        builder.setInsertionPoint(device.getBody()->getTerminator());
+        if (failed(createShimDMAAllocationOps(builder, ctx, shimMemcpyIfOps,
+                                              shimDmaAlloc,
+                                              chan_renumber_reverse_map,
+                                              /*skipUnlinked=*/
+                                              isSegmentUnrolled))) {
+          signalPassFailure();
+          return;
         }
       }
 
@@ -6026,56 +6025,6 @@ public:
       // Clean up dead memref.get_global/memref.global left by outlineAIECores
       // after DMA/channel lowering consumed their users.
       removeDeadGlobalOps(device);
-    }
-
-    // Deferred shim DMA metadata: process all segment-unrolled devices'
-    // allocations in a single call so metadataArrays are built with all
-    // entries present, producing correctly-ordered arrays.
-    if (deferredFunc &&
-        (!combinedS2MMAllocs.empty() || !combinedMM2SAllocs.empty())) {
-      std::vector<air::MemcpyInterface> shimMemcpyIfOps;
-      deferredFunc.walk([&](air::ChannelInterface o) {
-        auto parentLaunch = o->getParentOfType<air::LaunchOp>();
-        if (parentLaunch && parentLaunch != deferredLaunch)
-          return;
-        auto memrefTy =
-            dyn_cast_if_present<BaseMemRefType>(o.getMemref().getType());
-        if (memrefTy && air::isL3(memrefTy))
-          shimMemcpyIfOps.push_back(
-              dyn_cast_if_present<air::MemcpyInterface>(o.getOperation()));
-      });
-      deferredFunc.walk([&](air::DmaMemcpyNdOp o) {
-        auto parentLaunch = o->getParentOfType<air::LaunchOp>();
-        if (parentLaunch && parentLaunch != deferredLaunch)
-          return;
-        auto srcMemrefTy =
-            dyn_cast_if_present<BaseMemRefType>(o.getSrcMemref().getType());
-        if (srcMemrefTy && air::isL3(srcMemrefTy))
-          shimMemcpyIfOps.push_back(o);
-        auto dstMemrefTy =
-            dyn_cast_if_present<BaseMemRefType>(o.getDstMemref().getType());
-        if (dstMemrefTy && air::isL3(dstMemrefTy))
-          shimMemcpyIfOps.push_back(o);
-      });
-      // Use a temporary allocator wrapper to pass combined allocations.
-      // The builder insertion point is set per-allocation inside
-      // createShimDMAAllocationOpsImpl (each op is created in its own
-      // DeviceOp).
-      air::ShimDMAAllocator combinedAlloc(
-          combinedS2MMAllocs.empty() ? combinedMM2SAllocs.front()
-                                           .getDmaTile()
-                                           ->getParentOfType<AIE::DeviceOp>()
-                                     : combinedS2MMAllocs.front()
-                                           .getDmaTile()
-                                           ->getParentOfType<AIE::DeviceOp>());
-      combinedAlloc.s2mm_allocs = std::move(combinedS2MMAllocs);
-      combinedAlloc.mm2s_allocs = std::move(combinedMM2SAllocs);
-      if (failed(createShimDMAAllocationOps(builder, deferredCtx,
-                                            shimMemcpyIfOps, combinedAlloc,
-                                            deferredChanRenumberMap))) {
-        signalPassFailure();
-        return;
-      }
     }
   }
 

--- a/mlir/test/Conversion/AIRToAIE/air_segment_unroll_to_multi_device.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_segment_unroll_to_multi_device.mlir
@@ -136,3 +136,84 @@ module {
     return
   }
 }
+
+// -----
+
+// Test that segment-level scf.if on the unroll index is correctly specialized
+// inside the device. When the segment body contains scf.if checking the unroll
+// index to select different L2 channels, the specialize patterns must resolve
+// these conditionals inside the device (not just inside aie.core).
+// Without this fix, the scf.if remains unresolved, causing both branches'
+// channel ops to exist in both devices, leading to orphaned channels and
+// shim DMA linkage failures.
+
+// FULL-LABEL: aie.device{{.*}}@segment_scfif_0_0
+// Device 0: scf.if should be resolved to true (unroll_x=0),
+// so only @chan_a should remain, @chan_b removed as orphaned.
+// FULL:         air.channel @chan_a
+// FULL-NOT:     air.channel @chan_b
+// FULL:       segment_unroll_x = 0
+
+// FULL-LABEL: aie.device{{.*}}@segment_scfif_1_0
+// Device 1: scf.if should be resolved to false (unroll_x=1),
+// so only @chan_b should remain, @chan_a removed as orphaned.
+// FULL:         air.channel @chan_b
+// FULL-NOT:     air.channel @chan_a
+// FULL:       segment_unroll_x = 1
+
+module {
+  air.channel @chan_a [1, 1]
+  air.channel @chan_b [1, 1]
+
+  func.func @test_segment_level_scf_if(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %0 = air.launch async () in () args(%in0=%arg0, %in1=%arg1) : memref<64xi32>, memref<64xi32> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c32 = arith.constant 32 : index
+
+      // L3 puts for two different channels
+      %put_a = air.channel.put async @chan_a[%c0, %c0] (%in0[%c0] [%c32] [%c1]) {id = 1 : i32} : (memref<64xi32>)
+      %put_b = air.channel.put async @chan_b[%c0, %c0] (%in1[%c0] [%c32] [%c1]) {id = 2 : i32} : (memref<64xi32>)
+
+      %segment = air.segment @segment_scfif async unroll(%ux, %uy) in (%sx=%c2, %sy=%c1)
+          attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 2 : i64, y_size = 2 : i64} {
+        %c0_seg = arith.constant 0 : index
+        %c1_seg = arith.constant 1 : index
+
+        // Segment-level scf.if on unroll index: selects which L2 buffer
+        // to allocate and which channel to get from.
+        // Device 0 (ux=0): takes then branch -> gets from @chan_a
+        // Device 1 (ux=1): takes else branch -> gets from @chan_b
+        %cond = arith.cmpi eq, %ux, %c0_seg : index
+        %async_token, %buf = air.execute -> (memref<32xi32, 1 : i32>) {
+          %alloc = memref.alloc() : memref<32xi32, 1 : i32>
+          air.execute_terminator %alloc : memref<32xi32, 1 : i32>
+        }
+        %3 = scf.if %cond -> (!air.async.token) {
+          %get = air.channel.get async [%async_token] @chan_a[%c0_seg, %c0_seg] (%buf[] [] []) {id = 3 : i32} : (memref<32xi32, 1 : i32>)
+          scf.yield %get : !air.async.token
+        } else {
+          %get = air.channel.get async [%async_token] @chan_b[%c0_seg, %c0_seg] (%buf[] [] []) {id = 4 : i32} : (memref<32xi32, 1 : i32>)
+          scf.yield %get : !air.async.token
+        }
+
+        %herd = air.herd @herd_scfif async tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg)
+            args(%hbuf=%buf) : memref<32xi32, 1 : i32>
+            attributes {id = 3 : i32} {
+          %async_token_h, %lbuf = air.execute -> (memref<32xi32, 2>) {
+            %alloc = memref.alloc() : memref<32xi32, 2>
+            air.execute_terminator %alloc : memref<32xi32, 2>
+          }
+          %dealloc = air.execute [%async_token_h] {
+            memref.dealloc %lbuf : memref<32xi32, 2>
+          }
+        }
+        %async_token_d = air.execute [%3] {
+          memref.dealloc %buf : memref<32xi32, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/segment_unroll_metadata_ordering.mlir
+++ b/mlir/test/Conversion/AIRToAIE/segment_unroll_metadata_ordering.mlir
@@ -21,7 +21,7 @@
 
 // Check that both devices are created with correct allocations:
 // CHECK-LABEL: aie.device{{.*}}@segment_meta_0_0
-// CHECK:       aie.shim_dma_allocation @air_out_chan_0_0_0
+// CHECK:       aie.shim_dma_allocation @air_out_chan_0_0
 // CHECK:       segment_unroll_x = 0
 
 // CHECK-LABEL: aie.device{{.*}}@segment_meta_1_0
@@ -29,13 +29,14 @@
 // CHECK:       segment_unroll_x = 1
 
 // Check metadataArray ordering on the launch-body channel gets.
-// With segment unroll, entries should include allocations from both devices.
-// The metadataArray must be ordered to match getIteratorFromMDVector.
+// With per-device processing, each device independently adds its allocation
+// to the metadataArray. Entries accumulate in device iteration order.
+// Device 1's index continues from device 0's count (index=1).
 // CHECK: air.channel.get @out_chan[%c0]
-// CHECK-SAME: metadataArray = [{base = "air_out_chan_0_0_0"
+// CHECK-SAME: metadataArray = [{base = "air_out_chan_0_0"
 // CHECK-SAME:                   {base = "air_out_chan_1_0_1"
 // CHECK: air.channel.get @out_chan[%c1]
-// CHECK-SAME: metadataArray = [{base = "air_out_chan_0_0_0"
+// CHECK-SAME: metadataArray = [{base = "air_out_chan_0_0"
 // CHECK-SAME:                   {base = "air_out_chan_1_0_1"
 
 module {


### PR DESCRIPTION
## Summary

- Fix `SpecializeAffineIfPattern` and `SpecializeScfIfPattern` to resolve conditionals inside `AIE::DeviceOp` scope (not just `AIE::CoreOp`), so segment-level `scf.if`/`affine.if` on the unroll index are specialized after cloning into devices
- Replace deferred shim DMA metadata processing with per-device processing — each device independently processes its own shim allocations, skipping ops belonging to other devices via a new `skipUnlinked` parameter
- Add test for segment-level `scf.if` on unroll index wrapping channel ops

## Test plan

- [x] `lit -sv mlir/test/Conversion/AIRToAIE/` — all 55 tests pass
- [x] `air-opt workspace/air-to-aie/input.mlir -air-to-aie='device=npu2'` — previously failing attention kernel with 2-head segment unroll now passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)