### PR TITLE
Disable expensive checks in runAIRTransform to fix segfault with transform.include

### DIFF
--- a/mlir/lib/Transform/AIRTransformInterpreter.cpp
+++ b/mlir/lib/Transform/AIRTransformInterpreter.cpp
@@ -104,12 +104,17 @@ static transform::NamedSequenceOp findEntryPoint(ModuleOp transformModule) {
 
 LogicalResult xilinx::air::runAIRTransform(ModuleOp transformModule,
                                            ModuleOp payloadModule) {
+  // Expensive checks are disabled because the handle invalidation tracker
+  // segfaults with transform.include: it accesses erased payload operations
+  // via dangling pointers when validating handles across region scopes.
+  // See https://github.com/Xilinx/mlir-air/issues/1464.
+  transform::TransformOptions options;
+  options.enableExpensiveChecks(false);
+
   // Try named_sequence entry point first (modern transform dialect style).
   if (auto namedSeq = findEntryPoint(transformModule)) {
-    return transform::applyTransforms(
-        payloadModule, namedSeq, {},
-        transform::TransformOptions().enableExpensiveChecks(true),
-        /*enforceToplevelTransformOp=*/false);
+    return transform::applyTransforms(payloadModule, namedSeq, {}, options,
+                                      /*enforceToplevelTransformOp=*/false);
   }
 
   // Fallback: iterate top-level TransformOpInterface ops (legacy style).
@@ -117,10 +122,7 @@ LogicalResult xilinx::air::runAIRTransform(ModuleOp transformModule,
        transformModule.getBody()->getOps<transform::TransformOpInterface>()) {
     if (isa<transform::NamedSequenceOp>(op))
       continue;
-    if (failed(transform::applyTransforms(
-            payloadModule, op, {},
-            transform::TransformOptions().enableExpensiveChecks(
-                /*enableExpensiveChecks=*/true))))
+    if (failed(transform::applyTransforms(payloadModule, op, {}, options)))
       return failure();
   }
   return success();


### PR DESCRIPTION
## Summary
- Disable `enableExpensiveChecks` in `runAIRTransform` to fix a segfault when transform modules use `transform.include` with named sequences that modify payload IR

The handle invalidation tracker (`TransformState::recordOpHandleInvalidationOne`) accesses erased payload operations via `Operation::isProperAncestor()` on dangling pointers. This is a use-after-free that crashes non-deterministically. The expensive checks are a debug/verification feature documented as "only necessary for error reporting in case of transform dialect misuse with dangling handles" and are not required for correctness.

## Test plan
- [x] Build succeeds (ninja)
- [x] All 341 MLIR regression tests pass (`lit -sv mlir/test/`)
- [x] All 21 ConvertToAIR transform tests pass (exercises `air-transform` pass)

Fixes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)