### PR TITLE
Fix dependency canonicalize dominance violation with scf.if

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -2483,16 +2483,15 @@ void dependencyCanonicalizer::fillAIRDepListUsingGraphTR(
       } else if (auto async_src_op =
                      dyn_cast_if_present<xilinx::air::AsyncOpInterface>(
                          src_op)) {
-        // Elevate src token if src op is in affine if
-        while (auto parent_affine_if_op =
-                   dyn_cast_if_present<affine::AffineIfOp>(
-                       src_op->getParentOp())) {
+        // Elevate src token if src op is in affine.if or scf.if
+        while (isa_and_present<affine::AffineIfOp, scf::IfOp>(
+            src_op->getParentOp())) {
           DominanceInfo domInfo(src_op);
           if (domInfo.properlyDominates(src_op, async_op)) {
             // SSA dominance check passed. Jump to adding dependency edge.
             break;
           }
-          src_op = parent_affine_if_op.getOperation();
+          src_op = src_op->getParentOp();
         }
         if (src_op->isAncestor(async_op))
           continue; // Avoid depending on its ancestor.

--- a/mlir/test/Transform/AIRDependencyCanonicalization/scf_if.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/scf_if.mlir
@@ -7,101 +7,85 @@
 
 // RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
 
-// Test that air-dependency-canonicalize handles scf.if ops returning
-// !air.async.token inside a herd body.
+// Test that air-dependency-canonicalize properly elevates tokens from ops
+// inside scf.if branches when wiring dependencies to ops at the enclosing
+// scf.for body level. Without the fix, the second channel.get would get
+// a dependency on the channel.put INSIDE the scf.if branch (violating
+// SSA dominance) instead of on the scf.if result.
 
-// CHECK-LABEL: func.func @scf_if_in_herd
-// CHECK: air.herd
-// CHECK: %[[EVENT0:.*]] = scf.if
-// CHECK: %[[EVENT1:.*]] = air.channel.get async
-// CHECK: scf.yield %[[EVENT1]]
-// CHECK: } else {
-// CHECK: %[[EVENT2:.*]] = air.channel.get async
-// CHECK: scf.yield %[[EVENT2]]
-// CHECK: }
-// CHECK: air.channel.put async [%[[EVENT0]]]
-
-// CHECK-LABEL: func.func @scf_if_in_scf_for
-// CHECK: air.herd
+// CHECK-LABEL: func.func @scf_if_token_elevation
+// CHECK: air.segment
 // CHECK: scf.for
-// CHECK: %[[IF_RESULT:.*]] = scf.if
-// CHECK: air.channel.get async
-// CHECK: } else {
-// CHECK: air.channel.get async
-// CHECK: }
-// CHECK: air.channel.put async [%[[IF_RESULT]]]
+// CHECK:   air.channel.get async
+// CHECK:   %[[IF_RESULT:.*]] = scf.if
+// CHECK:     air.channel.put async
+// CHECK:   } else {
+// CHECK:     air.channel.put async
+// CHECK:   }
+// The second channel.get must depend on the scf.if result, NOT on a
+// channel.put defined inside the scf.if branch.
+// CHECK:   air.channel.get async [{{.*}}%[[IF_RESULT]]{{.*}}]
 
 module {
-  air.channel @channel_A [1, 1, 1] {broadcast_shape = [1, 1, 4 : index]}
-  air.channel @channel_B [1, 1, 1] {broadcast_shape = [1, 1, 4 : index]}
-  air.channel @channel_out [4, 1]
-  func.func @scf_if_in_herd(%arg0: memref<1x1x2048xi32>) {
-    %c4 = arith.constant 4 : index
+  air.channel @chan_in [2]
+  air.channel @chan_out_0 [1, 1, 1]
+  air.channel @chan_out_1 [1, 1, 1]
+  func.func @scf_if_token_elevation(%arg0: memref<64x64xbf16>, %arg1: memref<64x64xbf16>, %arg2: memref<64x64xbf16>) {
     %c1 = arith.constant 1 : index
-    %0 = air.herd @herd_0 async  tile (%arg2, %arg3) in (%arg4=%c4, %arg5=%c1) args(%arg6=%arg0) : memref<1x1x2048xi32> attributes {id = 1 : i32} {
+    %0 = air.launch async (%arg3) in (%arg4=%c1) args(%arg5=%arg0, %arg6=%arg1, %arg7=%arg2) : memref<64x64xbf16>, memref<64x64xbf16>, memref<64x64xbf16> {
       %c0 = arith.constant 0 : index
-      %async_token, %results = air.execute -> (memref<64x64xbf16, 2 : i32>) {
-        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
-        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
-      } {id = 1 : i32}
-      %async_token_0, %results_1 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
-        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
-        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
-      } {id = 2 : i32}
-      // scf.if selecting between channels based on tile position
-      %cond = arith.cmpi eq, %arg2, %c0 : index
-      %1 = scf.if %cond -> (!air.async.token) {
-        %2 = air.channel.get async [%async_token]  @channel_A[%c0, %c0, %arg2] (%results[] [] []) {id = 1 : i32} : (memref<64x64xbf16, 2 : i32>)
-        scf.yield %2 : !air.async.token
-      } else {
-        %2 = air.channel.get async [%async_token]  @channel_B[%c0, %c0, %arg2] (%results[] [] []) {id = 2 : i32} : (memref<64x64xbf16, 2 : i32>)
-        scf.yield %2 : !air.async.token
-      }
-      // Use the scf.if result as a dependency
-      %3 = air.channel.put async [%1]  @channel_out[%arg2, %c0] (%results_1[] [] []) {id = 3 : i32} : (memref<64x64xbf16, 2 : i32>)
-      %async_token_2 = air.execute [%3] {
-        memref.dealloc %results : memref<64x64xbf16, 2 : i32>
-      } {id = 3 : i32}
-      %async_token_3 = air.execute [%3] {
-        memref.dealloc %results_1 : memref<64x64xbf16, 2 : i32>
-      } {id = 4 : i32}
-    }
-    return
-  }
-  func.func @scf_if_in_scf_for(%arg0: memref<1x1x2048xi32>) {
-    %c4 = arith.constant 4 : index
-    %c1 = arith.constant 1 : index
-    %0 = air.herd @herd_1 async  tile (%arg2, %arg3) in (%arg4=%c4, %arg5=%c1) args(%arg6=%arg0) : memref<1x1x2048xi32> attributes {id = 2 : i32} {
-      %c0 = arith.constant 0 : index
-      %c1_0 = arith.constant 1 : index
       %c2 = arith.constant 2 : index
-      %async_token, %results = air.execute -> (memref<64x64xbf16, 2 : i32>) {
-        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
-        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
-      } {id = 5 : i32}
-      %async_token_0, %results_1 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
-        %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
-        air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
-      } {id = 6 : i32}
-      %cond = arith.cmpi eq, %arg2, %c0 : index
-      // scf.for loop with scf.if inside selecting channels per iteration
-      %1 = scf.for %iv = %c0 to %c2 step %c1_0 iter_args(%dep = %async_token) -> (!air.async.token) {
-        %2 = scf.if %cond -> (!air.async.token) {
-          %3 = air.channel.get async [%dep]  @channel_A[%c0, %c0, %arg2] (%results[] [] []) {id = 4 : i32} : (memref<64x64xbf16, 2 : i32>)
-          scf.yield %3 : !air.async.token
-        } else {
-          %3 = air.channel.get async [%dep]  @channel_B[%c0, %c0, %arg2] (%results[] [] []) {id = 5 : i32} : (memref<64x64xbf16, 2 : i32>)
-          scf.yield %3 : !air.async.token
+      %c64 = arith.constant 64 : index
+      %c1_0 = arith.constant 1 : index
+      // Matching channel.put for chan_in (feed data into segment)
+      air.channel.put  @chan_in[%c0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c1_0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c1_0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c1_0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      air.channel.put  @chan_in[%c1_0] (%arg5[] [] []) : (memref<64x64xbf16>)
+      // Matching channel.get for chan_out_0 and chan_out_1
+      air.channel.get  @chan_out_0[%c0, %c0, %c0] (%arg6[] [] []) : (memref<64x64xbf16>)
+      air.channel.get  @chan_out_0[%c0, %c0, %c0] (%arg6[] [] []) : (memref<64x64xbf16>)
+      air.channel.get  @chan_out_1[%c0, %c0, %c0] (%arg7[] [] []) : (memref<64x64xbf16>)
+      air.channel.get  @chan_out_1[%c0, %c0, %c0] (%arg7[] [] []) : (memref<64x64xbf16>)
+      %1 = air.segment @seg async  unroll(%arg8) in (%arg9=%c2) {
+        %async_token, %results = air.execute -> (memref<64x64xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x64xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x64xbf16, 1 : i32>
+        } {id = 1 : i32}
+        %c0_1 = arith.constant 0 : index
+        %c1_1 = arith.constant 1 : index
+        %c2_2 = arith.constant 2 : index
+        %c8 = arith.constant 8 : index
+        %c512 = arith.constant 512 : index
+        %c64_3 = arith.constant 64 : index
+        %2 = scf.for %iv = %c0_1 to %c2_2 step %c1_1 iter_args(%dep = %async_token) -> (!air.async.token) {
+          %3 = air.channel.get async [%dep]  @chan_in[%arg8] (%results[] [] []) {id = 2 : i32} : (memref<64x64xbf16, 1 : i32>)
+          %cond = arith.cmpi eq, %arg8, %c0_1 : index
+          %4 = scf.if %cond -> (!air.async.token) {
+            %7 = air.channel.put async [%3]  @chan_out_0[%c0_1, %c0_1, %c0_1] (%results[%c0_1, %c0_1, %c0_1, %c0_1] [%c8, %c8, %c8, %c8] [%c8, %c512, %c64_3, %c1_1]) {id = 3 : i32} : (memref<64x64xbf16, 1 : i32>)
+            scf.yield %7 : !air.async.token
+          } else {
+            %7 = air.channel.put async [%3]  @chan_out_1[%c0_1, %c0_1, %c0_1] (%results[%c0_1, %c0_1, %c0_1, %c0_1] [%c8, %c8, %c8, %c8] [%c8, %c512, %c64_3, %c1_1]) {id = 4 : i32} : (memref<64x64xbf16, 1 : i32>)
+            scf.yield %7 : !air.async.token
+          }
+          %5 = air.channel.get async [%dep, %4]  @chan_in[%arg8] (%results[] [] []) {id = 5 : i32} : (memref<64x64xbf16, 1 : i32>)
+          %6 = scf.if %cond -> (!air.async.token) {
+            %7 = air.channel.put async [%5]  @chan_out_0[%c0_1, %c0_1, %c0_1] (%results[%c0_1, %c0_1, %c0_1, %c0_1] [%c8, %c8, %c8, %c8] [%c8, %c512, %c64_3, %c1_1]) {id = 6 : i32} : (memref<64x64xbf16, 1 : i32>)
+            scf.yield %7 : !air.async.token
+          } else {
+            %7 = air.channel.put async [%5]  @chan_out_1[%c0_1, %c0_1, %c0_1] (%results[%c0_1, %c0_1, %c0_1, %c0_1] [%c8, %c8, %c8, %c8] [%c8, %c512, %c64_3, %c1_1]) {id = 7 : i32} : (memref<64x64xbf16, 1 : i32>)
+            scf.yield %7 : !air.async.token
+          }
+          scf.yield %6 : !air.async.token
         }
-        %4 = air.channel.put async [%2]  @channel_out[%arg2, %c0] (%results_1[] [] []) {id = 6 : i32} : (memref<64x64xbf16, 2 : i32>)
-        scf.yield %4 : !air.async.token
+        %async_token_4 = air.execute [%2] {
+          memref.dealloc %results : memref<64x64xbf16, 1 : i32>
+        } {id = 8 : i32}
       }
-      %async_token_2 = air.execute [%1] {
-        memref.dealloc %results : memref<64x64xbf16, 2 : i32>
-      } {id = 7 : i32}
-      %async_token_3 = air.execute [%1] {
-        memref.dealloc %results_1 : memref<64x64xbf16, 2 : i32>
-      } {id = 8 : i32}
     }
     return
   }


### PR DESCRIPTION
## Summary
- Fix SSA dominance violation in `air-dependency-canonicalize` when async token sources are nested inside `scf.if` branches
- The `fillAIRDepListUsingGraphTR` function elevated tokens from `affine.if` but not `scf.if`, causing a channel.get at the `scf.for` body level to depend on a channel.put defined inside an `scf.if` branch (child region)
- This pattern is produced by `air-specialize-dma-broadcast` for segment-unrolled channel specialization
- Replace the broken `scf_if.mlir` test (which had unpaired channel ops) with a proper regression test

## Test plan
- [x] Verified the original failing pipeline (`air-dependency-canonicalize` on attention IR with segment unroll) now passes
- [x] Verified the new regression test fails without the fix and passes with it
- [x] `ninja check-air-mlir` passes (341 tests, same as baseline; 4 pre-existing `Util/Channel/` failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)