### PR TITLE
Fix lit test build directory isolation for channel_examples

### DIFF
--- a/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_chess.lit
+++ b/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_chess.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, valid_xchess_license
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, valid_xchess_license
+//
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano_elf.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast/single_herd/run_makefile_chess.lit
+++ b/programming_examples/channel_examples/broadcast/single_herd/run_makefile_chess.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, valid_xchess_license
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, valid_xchess_license
+//
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast/single_herd/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/broadcast/single_herd/run_makefile_peano.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast/single_herd/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/broadcast/single_herd/run_makefile_peano_elf.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
+// SPDX-License-Identifier: MIT
 //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast_selective_capture/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/broadcast_selective_capture/run_makefile_peano.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/broadcast_selective_capture/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/broadcast_selective_capture/run_makefile_peano_elf.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
+// SPDX-License-Identifier: MIT
 //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/channel_3d_segment_unroll/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/channel_3d_segment_unroll/run_makefile_peano.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/channel_3d_segment_unroll/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/channel_3d_segment_unroll/run_makefile_peano_elf.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
+// SPDX-License-Identifier: MIT
 //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/channel_size/run_makefile_chess.lit
+++ b/programming_examples/channel_examples/channel_size/run_makefile_chess.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, valid_xchess_license
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, valid_xchess_license
+//
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/channel_size/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/channel_size/run_makefile_peano.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/channel_size/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/channel_size/run_makefile_peano_elf.lit
@@ -1,8 +1,10 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
+// SPDX-License-Identifier: MIT
 //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_chess.lit
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_chess.lit
@@ -1,9 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, valid_xchess_license
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run | FileCheck %s
- // CHECK: PASS!
- // XFAIL: *
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, valid_xchess_license
+//
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+// XFAIL: *

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_peano.lit
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_peano.lit
@@ -1,9 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
- // XFAIL: *
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai, peano
+//
+// RUN: mkdir -p test_peano
+// RUN: cd test_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!
+// XFAIL: *

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/run_makefile_peano_elf.lit
@@ -1,9 +1,11 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
- // SPDX-License-Identifier: MIT
- //
- // REQUIRES: ryzen_ai_npu2, peano
- //
- // RUN: make -f %S/Makefile clean
- // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
- // CHECK: PASS!
- // XFAIL: *
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!
+// XFAIL: *


### PR DESCRIPTION
## Summary
- 16 `.lit` test files across 6 `channel_examples` directories were running `make clean`/`make run` directly in the source directory using a shared `build_peano` dir, causing conflicts when multiple test variants (peano, peano_elf, chess) target the same example
- Added `mkdir -p test_<variant>` / `cd test_<variant>` isolation to each lit test, matching the pattern used by all other programming_examples (e.g., `worker_to_worker`, `segment_unroll`, `hierarchical`)
- Fixed directories: `broadcast/multi_herd`, `broadcast/single_herd`, `broadcast_selective_capture`, `channel_3d_segment_unroll`, `channel_size`, `herd_to_herd/multi_segment`

## Test plan
- [ ] Verify `ninja check-air-e2e-peano` passes on NPU1 runner
- [ ] Verify `ninja check-air-e2e-peano` passes on NPU2 runner
- [ ] Confirm no `make clean` conflicts when both peano and peano_elf tests run for the same example

🤖 Generated with [Claude Code](https://claude.com/claude-code)