### PR TITLE
Support small irregular-shaped matmul in test 54 padding example

### DIFF
--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/run.py
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/run.py
@@ -94,10 +94,12 @@ if args.verbose:
     print(f"M_padded={M_padded}, N_padded={N_padded}")
     print(f"Launch grid: {LAUNCH_M}x{LAUNCH_N}x1")
 
-# Block-aligned allocation sizes for input buffers (same as test 54).
-INNER_BLOCK = 8
-M_alloc = math.ceil(M_actual / INNER_BLOCK) * INNER_BLOCK
-N_alloc = math.ceil(N_actual / INNER_BLOCK) * INNER_BLOCK
+# Allocation sizes: use full padded dimensions so L3→L2 DMA can read
+# entire launch tiles from zero-filled host buffers. This handles both
+# large matrices (multiple launches) and small matrices (M,N < tile size)
+# where the actual data is smaller than a single launch tile.
+M_alloc = M_padded
+N_alloc = N_padded
 
 ################################################
 # Load and transform IR

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/run_npu2_peano.lit
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/run_npu2_peano.lit
@@ -8,6 +8,6 @@
 // Inputs and outputs are f32; convert-vector-to-aievec with bf16-emulation=true
 // emulates f32 arithmetic using bf16/bfp16 operations on AIE2P.
 //
-// RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run M=500 N=500 K=784 AIE_TARGET=aie2p PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile clean BUILD_DIR=build_large
+// RUN: make -f %S/Makefile run M=500 N=500 K=784 AIE_TARGET=aie2p BUILD_DIR=build_large PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS

--- a/test/xrt/54_matmul_padding_f32_bf16_emulation/run_npu2_peano_small.lit
+++ b/test/xrt/54_matmul_padding_f32_bf16_emulation/run_npu2_peano_small.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// Small irregular-shaped F32 matmul with bf16/bfp16 emulation and memtile DMA padding.
+// Tests M and N dimensions smaller than a single herd tile (TILE_M*HERD_M=256, TILE_N*HERD_N=128).
+// The entire matrix fits within one launch tile; air-split-launch-for-padding
+// produces a corner-only partition with device-side zero padding.
+// A is stored in K×M layout (transposed); on-the-fly transpose via DMA strides.
+//
+// RUN: make -f %S/Makefile clean BUILD_DIR=build_small
+// RUN: make -f %S/Makefile run M=17 N=23 K=32 AIE_TARGET=aie2p BUILD_DIR=build_small PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS


### PR DESCRIPTION
## Summary
- Fix `M_alloc`/`N_alloc` to use `M_padded`/`N_padded` instead of `ceil(M/8)*8`, ensuring host buffers cover full launch tiles when M or N is smaller than the herd tile dimensions
- Add small-dimensions LIT test (`M=17, N=23, K=32`) exercising device-side padding for sub-tile matrices
- Use distinct `BUILD_DIR` per LIT test to prevent parallel test interference

## Test plan
- [x] `make run M=500 N=500 K=784` — original large test passes
- [x] `make run M=17 N=23 K=32` — new small irregular test passes
- [x] `make run M=8 N=8 K=32` — minimal dimensions pass
- [x] `make run M=63 N=31 K=32` — near-tile-boundary passes
- [x] `make run M=256 N=128 K=32` — tile-aligned passes
- [x] `make profile M=17 N=23 K=32` — profiling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)