### PR TITLE
Add air.rank Python API and pipeline integration

### DIFF
--- a/python/air/compiler/aircc/main.py
+++ b/python/air/compiler/aircc/main.py
@@ -813,6 +813,7 @@ extern "C" {
         air_placed = opts.tmpdir + "/placed." + air_mlir_filename
         pass_pipeline = ",".join(
             [
+                "air-rank-to-launch",
                 "air-insert-launch-around-herd{insert-segment=true}",
                 "func.func(air-lower-herd-parallel)",
                 "scf-forall-to-parallel",

--- a/python/air/dialects/_air_ops_ext.py
+++ b/python/air/dialects/_air_ops_ext.py
@@ -130,6 +130,34 @@ class Herd(HerdOp):
         self.regions[0].blocks.append(*operand_types)
 
 
+class Rank(RankOp):
+    """Specialization for RankOp class."""
+
+    def __init__(
+        self,
+        name=None,
+        sizes=[],
+        async_token=None,
+        async_dependencies=[],
+        operands=[],
+        universe=None,
+        attributes={},
+        loc=None,
+        ip=None,
+    ):
+        sizes = list(map(pyint_to_index, sizes))
+        super().__init__(
+            async_token=async_token,
+            async_dependencies=async_dependencies,
+            universe=universe,
+            sizes=sizes,
+            rank_operands=operands,
+            sym_name=name,
+        )
+        operand_types = [s.type for s in sizes] * 2 + get_region_operand_types(operands)
+        self.regions[0].blocks.append(*operand_types)
+
+
 class Channel(ChannelOp):
     def __init__(
         self,
@@ -318,6 +346,7 @@ def module_builder(module_function):
 herd = region_op(Herd, terminator=lambda *_args: HerdTerminatorOp())
 launch = region_op(Launch, terminator=lambda *_args: LaunchTerminatorOp())
 segment = region_op(Segment, terminator=lambda *_args: SegmentTerminatorOp())
+rank = region_op(Rank, terminator=lambda *_args: RankTerminatorOp())
 
 
 def external_func(name, inputs, outputs=None, visibility="private"):

--- a/python/test/dialect/air_ops.py
+++ b/python/test/dialect/air_ops.py
@@ -64,6 +64,19 @@ def herdOp():
         HerdTerminatorOp()
 
 
+# CHECK-LABEL: TEST: rankOp
+# CHECK: %[[C2:.*]] = arith.constant 2 : index
+# CHECK: air.rank @pyRank (%{{.*}}) in (%{{.*}}=%[[C2]]) {
+# CHECK:   %{{.*}} = arith.constant 1 : index
+@constructAndPrintInFunc
+def rankOp():
+    R = Rank("pyRank", [2])
+    with InsertionPoint(R.body.blocks[0]):
+        idx_ty = IndexType.get()
+        ConstantOp(idx_ty, IntegerAttr.get(idx_ty, 1))
+        RankTerminatorOp()
+
+
 # CHECK-LABEL: TEST: waitallOp
 # CHECK: %0 = air.wait_all async
 # CHECK: air.wait_all [%0]

--- a/python/test/dialect/test_region.py
+++ b/python/test/dialect/test_region.py
@@ -35,3 +35,22 @@ def test_herd():
             def herd_body(x, y, sx, sy):
                 AddIOp(x, y)
                 AddIOp(sx, sy)
+
+
+# CHECK-LABEL: TEST: test_rank
+# CHECK: air.rank @r (%[[RX:.*]]) in (%[[RSX:.*]]=%{{.*}})
+# CHECK:   air.launch
+# CHECK:     air.segment @seg
+# CHECK:       air.herd @hrd
+@constructAndPrintInFunc
+@module_builder
+def test_rank():
+    @rank(name="r", sizes=[2])
+    def rank_body(rx, sx):
+        @launch
+        def launch_body():
+            @segment(name="seg")
+            def segment_body():
+                @herd(name="hrd", sizes=[2, 2])
+                def herd_body(x, y, sx, sy):
+                    AddIOp(x, y)


### PR DESCRIPTION
## Summary
- Add `Rank` builder class and `@rank` decorator to `_air_ops_ext.py`, following the same pattern as `Launch`/`Segment`/`Herd`
- Insert `air-rank-to-launch` pass into `aircc.py` pipeline (before `air-insert-launch-around-herd`), enabling automatic serialization of `air.rank` ops during compilation
- Add Python builder and decorator tests verifying the full 4-level hierarchy (`rank > launch > segment > herd`)

Follows up on #1479 (Phase 1: dialect and C++ implementation). Part of #1414.

## Test plan
- [x] `check-air-python`: 8/8 passed
- [x] `check-air-mlir`: 349 passed, 0 failures
- [x] CI: Build and Test
- [x] CI: clang-tidy

🤖 Generated with [Claude Code](https://claude.com/claude-code)