### PR TITLE
Fix airrt-to-npu to handle HerdLoadOp in multi-launch identification

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -991,7 +991,7 @@ bool isLaunchBoundaryLoop(affine::AffineForOp forOp) {
 // Identify launch regions within a function.
 // Launch regions are delimited by affine.for %arg = 0 to 1 loops
 // with "affine_opt_label" attribute, and contain airrt.segment_load
-// operations that link to device ops.
+// or airrt.herd_load operations that link to device ops.
 SmallVector<LaunchRegion> identifyLaunchRegions(func::FuncOp funcOp,
                                                 ModuleOp module) {
   SmallVector<LaunchRegion> regions;
@@ -1001,9 +1001,15 @@ SmallVector<LaunchRegion> identifyLaunchRegions(func::FuncOp funcOp,
     if (!isLaunchBoundaryLoop(forOp))
       return;
 
-    // Look for airrt.segment_load inside this loop
-    forOp.walk([&](airrt::SegmentLoadOp segLoadOp) {
-      StringRef deviceName = segLoadOp.getSymName();
+    // Look for airrt.segment_load or airrt.herd_load inside this loop
+    forOp.walk([&](Operation *op) {
+      StringRef deviceName;
+      if (auto segLoad = dyn_cast<airrt::SegmentLoadOp>(op))
+        deviceName = segLoad.getSymName();
+      else if (auto herdLoad = dyn_cast<airrt::HerdLoadOp>(op))
+        deviceName = herdLoad.getSymName();
+      else
+        return;
       AIE::DeviceOp device = getDeviceByName(module, deviceName);
       if (device) {
         regions.push_back({forOp, deviceName, device});
@@ -1545,7 +1551,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
 
     for (auto funcOp : funcOps) {
       // Identify launch regions (affine.for with affine_opt_label containing
-      // segment_load)
+      // segment_load/herd_load)
       SmallVector<LaunchRegion> regions = identifyLaunchRegions(funcOp, module);
 
       if (regions.empty()) {

--- a/mlir/test/Conversion/AIRRtToNpu/multi_device_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/multi_device_split.mlir
@@ -80,3 +80,80 @@ module {
     return
   }
 }
+
+// -----
+
+// Test: Mixed segment_load and herd_load in multi-launch.
+// When one launch uses airrt.segment_load and another uses airrt.herd_load
+// (bare herd, no segment wrapper), both should be identified as launch regions.
+
+// CHECK-LABEL: aie.device(npu1_1col) @seg_device
+// CHECK:   aie.shim_dma_allocation @air_channel_in_seg
+// CHECK:   aie.shim_dma_allocation @air_channel_out_seg
+// CHECK:   aie.runtime_sequence @seg_device_sequence(%[[ARG0:.*]]: memref<512xi32>)
+// CHECK:     aiex.dma_configure_task_for @air_channel_in_seg
+// CHECK:     aiex.dma_start_task
+// CHECK:     aiex.dma_configure_task_for @air_channel_out_seg
+// CHECK:     aiex.dma_start_task
+
+// CHECK: aie.device(npu1_1col) @herd_device
+// CHECK:   aie.shim_dma_allocation @air_channel_in_herd
+// CHECK:   aie.shim_dma_allocation @air_channel_out_herd
+// CHECK:   aie.runtime_sequence @herd_device_sequence(%{{.*}}: memref<512xi32>)
+// CHECK:     aiex.dma_configure_task_for @air_channel_in_herd
+// CHECK:     aiex.dma_start_task
+// CHECK:     aiex.dma_configure_task_for @air_channel_out_herd
+// CHECK:     aiex.dma_start_task
+
+// CHECK: aie.device(npu1_1col)
+// CHECK:   aie.runtime_sequence @mixed_seg_herd(%[[MAIN_ARG0:.*]]: memref<512xi32>)
+// CHECK:     aiex.configure @seg_device
+// CHECK:       aiex.run @seg_device_sequence(%[[MAIN_ARG0]]) : (memref<512xi32>)
+// CHECK:     aiex.configure @herd_device
+// CHECK:       aiex.run @herd_device_sequence(%[[MAIN_ARG0]]) : (memref<512xi32>)
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @air_channel_in_seg(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @air_channel_out_seg(%tile_0_0, S2MM, 0)
+  } {sym_name = "seg_device"}
+
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @air_channel_in_herd(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @air_channel_out_herd(%tile_0_0, S2MM, 0)
+  } {sym_name = "herd_device"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "herd_device"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_device"}
+    }
+  }
+
+  func.func @mixed_seg_herd(%arg0: memref<512xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+
+    // First launch region - uses airrt.segment_load
+    affine.for %arg1 = 0 to 1 {
+      %0 = airrt.dma_memcpy_nd(%c1_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @air_channel_in_seg} : (i32, i64, i64, memref<512xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      %1 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @air_channel_out_seg} : (i32, i64, i64, memref<512xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      airrt.wait_all %0, %1
+      %p = airrt.segment_load "seg_device" : i64
+    } {affine_opt_label = "tiling"}
+
+    // Second launch region - uses airrt.herd_load (bare herd, no segment)
+    affine.for %arg1 = 0 to 1 {
+      %0 = airrt.dma_memcpy_nd(%c1_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @air_channel_in_herd} : (i32, i64, i64, memref<512xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      %1 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c512_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @air_channel_out_herd} : (i32, i64, i64, memref<512xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      airrt.wait_all %0, %1
+      %h = airrt.herd_load "herd_device" () {segment_name = "herd_device"} : () -> i64
+    } {affine_opt_label = "tiling"}
+
+    return
+  }
+}


### PR DESCRIPTION
## Summary

- Fix `identifyLaunchRegions()` in `AIRRtToNpuPass.cpp` to also walk `airrt::HerdLoadOp`, not just `airrt::SegmentLoadOp`
- Previously, bare-herd launches (no `air.segment` wrapper) were silently dropped in multi-launch ELF modules, causing `"failed to legalize operation 'airrt.dma_memcpy_nd'"` errors
- Add LIT test for mixed `segment_load`/`herd_load` multi-launch scenario

Fixes #1483

## Test plan

- [x] `lit -sv mlir/test/Conversion/AIRRtToNpu/multi_device_split.mlir` — new test passes
- [x] `lit -sv mlir/test/Conversion/AIRRtToNpu/` — all 9 tests pass
- [x] `ninja check-air-mlir` — 350 passed, 7 expectedly failed, 2 unsupported (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)