### PR TITLE
Fix Python backend POSIX assumptions for Windows compatibility

### DIFF
--- a/python/air/backend/cpu_backend.py
+++ b/python/air/backend/cpu_backend.py
@@ -11,17 +11,19 @@ import air.ir
 import air.passmanager
 
 import os
+import sys
 
 # override the default library paths for the mlir extras refbackend
-os.environ["ASYNC_RUNTIME_LIB_PATH"] = (
-    f"{install_path()}/python/air/_mlir_libs/libmlir_async_runtime.so"
-)
-os.environ["C_RUNNER_UTILS_LIB_PATH"] = (
-    f"{install_path()}/python/air/_mlir_libs/libmlir_c_runner_utils.so"
-)
-os.environ["RUNNER_UTILS_LIB_PATH"] = (
-    f"{install_path()}/python/air/_mlir_libs/libmlir_runner_utils.so"
-)
+if sys.platform != "win32":
+    os.environ["ASYNC_RUNTIME_LIB_PATH"] = (
+        f"{install_path()}/python/air/_mlir_libs/libmlir_async_runtime.so"
+    )
+    os.environ["C_RUNNER_UTILS_LIB_PATH"] = (
+        f"{install_path()}/python/air/_mlir_libs/libmlir_c_runner_utils.so"
+    )
+    os.environ["RUNNER_UTILS_LIB_PATH"] = (
+        f"{install_path()}/python/air/_mlir_libs/libmlir_runner_utils.so"
+    )
 from aie.extras.runtime.refbackend import LLVMJITBackend
 import aie.ir as aieir
 
@@ -31,13 +33,15 @@ import air.compiler.util
 
 import ctypes
 
-ctypes.CDLL(
-    f"{install_path()}/runtime_lib/x86_64/aircpu/libaircpu.so", mode=ctypes.RTLD_GLOBAL
-)
-ctypes.CDLL(
-    f"{install_path()}/python/air/_mlir_libs/libmlir_async_runtime.so",
-    mode=ctypes.RTLD_GLOBAL,
-)
+if sys.platform != "win32":
+    ctypes.CDLL(
+        f"{install_path()}/runtime_lib/x86_64/aircpu/libaircpu.so",
+        mode=ctypes.RTLD_GLOBAL,
+    )
+    ctypes.CDLL(
+        f"{install_path()}/python/air/_mlir_libs/libmlir_async_runtime.so",
+        mode=ctypes.RTLD_GLOBAL,
+    )
 
 __all__ = ["AirCpuBackend", "DEFAULT_PIPELINE"]
 

--- a/python/air/backend/linalg_on_tensors.py
+++ b/python/air/backend/linalg_on_tensors.py
@@ -27,27 +27,31 @@ import shutil
 import subprocess
 
 import ctypes
+import sys
 from pathlib import Path
 from typing import List
 
-# First need to load the libhsa-runtime64.so.1 so we can load libairhost_shared
-try:
-    ctypes.CDLL(f"{rocm_path}/../../libhsa-runtime64.so.1", mode=ctypes.RTLD_GLOBAL)
-except Exception as e:
-    print("[WARNING] We were not able to load .so for libhsa-runtime64.so.1")
-    print(e)
-    pass
+# Runtime libraries (libhsa-runtime64, libairhost_shared) use POSIX APIs
+# (dlopen, mmap, ioctl) and are not available on Windows.
+if sys.platform != "win32":
+    # First need to load the libhsa-runtime64.so.1 so we can load libairhost_shared
+    try:
+        ctypes.CDLL(f"{rocm_path}/../../libhsa-runtime64.so.1", mode=ctypes.RTLD_GLOBAL)
+    except Exception as e:
+        print("[WARNING] We were not able to load .so for libhsa-runtime64.so.1")
+        print(e)
+        pass
 
-# After loading libhsa-runtime64.so we can load the AIR runtime functions
-try:
-    ctypes.CDLL(
-        f"{install_path()}/runtime_lib/x86_64/airhost/libairhost_shared.so",
-        mode=ctypes.RTLD_GLOBAL,
-    )
-except Exception as e:
-    print("[WARNING] We were not able to load .so for libairhost_shared.so")
-    print(e)
-    pass
+    # After loading libhsa-runtime64.so we can load the AIR runtime functions
+    try:
+        ctypes.CDLL(
+            f"{install_path()}/runtime_lib/x86_64/airhost/libairhost_shared.so",
+            mode=ctypes.RTLD_GLOBAL,
+        )
+    except Exception as e:
+        print("[WARNING] We were not able to load .so for libairhost_shared.so")
+        print(e)
+        pass
 try:
     import air._mlir_libs._airRt as airrt
 except Exception as e:

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -168,7 +168,7 @@ class XRTBackend(AirBackend):
             # Try to auto-detect device via xrt-smi
             target_device = "npu1"  # Default fallback
             try:
-                xrtsmi = "/opt/xilinx/xrt/bin/xrt-smi"
+                xrtsmi = shutil.which("xrt-smi") or "/opt/xilinx/xrt/bin/xrt-smi"
                 result = subprocess.run(
                     [xrtsmi, "examine"],
                     stdout=subprocess.PIPE,

--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import os
+import tempfile
+
 import numpy as np
 from .xrt import XRTBackend
 from air.dialects.air import *
@@ -255,7 +258,7 @@ class XRTRunner:
         expanded_inputs = inputs + output_placeholders
 
         compiled_module = backend.compile(mlir_module)
-        with filelock.FileLock("/tmp/npu.lock"):
+        with filelock.FileLock(os.path.join(tempfile.gettempdir(), "npu.lock")):
             module_function = backend.load(compiled_module)
             actual_outputs = module_function(*expanded_inputs)
 


### PR DESCRIPTION
## Summary
- Guard Linux-only runtime library loading (`airhost`, `aircpu`, `libhsa-runtime64`) behind `sys.platform != "win32"` checks so importing these modules does not crash on Windows
- Replace hardcoded `/tmp/npu.lock` with `os.path.join(tempfile.gettempdir(), "npu.lock")` for cross-platform file locking
- Use `shutil.which("xrt-smi")` for XRT tool discovery instead of hardcoded `/opt/xilinx/xrt/bin/xrt-smi`

Part of Windows support effort (RFC #1433).

## Test plan
- [ ] Verify `ninja check-air-python` passes on Linux (no regressions — guards only skip on `win32`)
- [ ] Verify Windows CI (`buildAndTestWindows.yml`) passes
- [ ] Smoke test: `python -c "from air.backend.xrt_runner import XRTRunner"` on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)