### PR TITLE
Fix Windows wheel .pyd files incorrectly tagged as cp314

### DIFF
--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -175,6 +175,7 @@ class CMakeBuild(build_ext):
             cmake_generator,
             f"-DCMAKE_INSTALL_PREFIX={_cmake_path(install_dir)}",
             f"-DPython3_EXECUTABLE={_cmake_path(sys.executable)}",
+            f"-DPython_EXECUTABLE={_cmake_path(sys.executable)}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
             f"-DLLVM_DIR={_cmake_path(MLIR_INSTALL_ABS_PATH)}/lib/cmake/llvm",
             f"-DMLIR_DIR={_cmake_path(MLIR_INSTALL_ABS_PATH)}/lib/cmake/mlir",


### PR DESCRIPTION
## Summary
- Fixes Windows wheels containing `.cp314-win_amd64.pyd` files regardless of the target Python version (3.10, 3.11, 3.12)
- Root cause: `setup.py` set `-DPython3_EXECUTABLE` but not `-DPython_EXECUTABLE`, allowing CMake's `find_package(Python)` (used by nanobind) to resolve to the system-installed Python 3.14 on the `windows-2022` CI runner
- Adding `-DPython_EXECUTABLE` ensures both `find_package(Python3)` and `find_package(Python)` resolve to the same interpreter

## Test plan
- [ ] Trigger `buildAIRWheels.yml` workflow
- [ ] Download resulting Windows wheels for each Python version
- [ ] Verify `.pyd` files inside each wheel match the wheel's Python version tag (e.g., cp312 wheel contains `.cp312-win_amd64.pyd`)

Reported in: https://github.com/amd/Triton-XDNA/pull/35#issuecomment-4185225966

🤖 Generated with [Claude Code](https://claude.com/claude-code)