### PR TITLE
Fix RTP buffer index mismatch in AIRToAIE and AIRRtToNpu

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -609,6 +609,7 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
         }
 
         if (rtpBufferExists) {
+          unsigned rtp_slot = 0;
           for (int i = 0, e = op.getNumOperands(); i < e; i++) {
             Value oper = adaptor.getOperands()[i];
             if (!llvm::isa<IntegerType, IndexType, FloatType>(oper.getType()))
@@ -616,10 +617,12 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
 
             auto constOp =
                 dyn_cast_if_present<arith::ConstantOp>(oper.getDefiningOp());
-            if (!constOp)
-              continue;
-            uint32_t v = cast<IntegerAttr>(constOp.getValue()).getInt();
-            AIEX::NpuWriteRTPOp::create(rewriter, op.getLoc(), name, i, v);
+            if (constOp) {
+              uint32_t v = cast<IntegerAttr>(constOp.getValue()).getInt();
+              AIEX::NpuWriteRTPOp::create(rewriter, op.getLoc(), name, rtp_slot,
+                                          v);
+            }
+            rtp_slot++;
           }
         }
         // FIXME: this should depend on the metadata to enable and to get the id

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -398,6 +398,7 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
                                herd_lock, lockAction, lockValue);
       }
 
+      unsigned rtp_slot = 0;
       for (unsigned ki = 0, ke = h.getNumKernelOperands(); ki < ke; ki++) {
         BlockArgument karg = h.getKernelArgument(ki);
 
@@ -418,7 +419,7 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
 
           // load from rtp buffer
           SmallVector<Value> offsets{
-              arith::ConstantIndexOp::create(core_builder, hloc, ki)};
+              arith::ConstantIndexOp::create(core_builder, hloc, rtp_slot)};
           auto load = memref::LoadOp::create(core_builder, hloc,
                                              IntegerType::get(ctx, 32),
                                              rtp_buffer, offsets);
@@ -453,7 +454,8 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
           if (rtp)
             remap.map(karg, rtp);
           else
-            h.emitWarning("Unsupported runtime parmeter int or float type");
+            h.emitWarning("Unsupported runtime parameter int or float type");
+          rtp_slot++;
         }
 
         auto memrefTy = llvm::dyn_cast_if_present<MemRefType>(karg.getType());

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_rtp.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_rtp.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-to-aie | FileCheck %s
+// RUN: air-opt %s --split-input-file -air-to-aie | FileCheck %s
 
 func.func @herd1(%arg0: i32, %arg1: i32, %arg2: i32) {
   // CHECK-LABEL: aie.device
@@ -46,3 +46,30 @@ func.func @herd1(%arg0: i32, %arg1: i32, %arg2: i32) {
   return
 }
 
+// -----
+
+// Test that L1 memref operands before scalar operands don't inflate RTP
+// indices. The two scalar args should get RTP slots 0 and 1, not 2 and 3.
+
+func.func @herd_rtp_with_memref_before_scalar(%arg0: i32, %arg1: i32) {
+  // CHECK-LABEL: aie.device
+  // CHECK: %[[TILE:.*]] = aie.tile(1, 1)
+  // CHECK: %[[RTP:.*]] = aie.buffer(%[[TILE]]) {{{.*}}sym_name = "__air_herd_rtp_1_1"{{.*}}} : memref<2xi32>
+  // CHECK: aie.core(%[[TILE]])
+  // CHECK: memref.load %[[RTP]][%c0] : memref<2xi32>
+  // CHECK: memref.load %[[RTP]][%c1] : memref<2xi32>
+  %cst1 = arith.constant 1 : index
+  %cst12 = arith.constant 12 : i32
+  %cst34 = arith.constant 34 : i32
+  %buf0 = memref.alloc() : memref<16xi32, 2>
+  %buf1 = memref.alloc() : memref<16xi32, 2>
+  air.herd @herd2 tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) args(%m0 = %buf0, %m1 = %buf1, %a = %cst12, %b = %cst34) : memref<16xi32, 2>, memref<16xi32, 2>, i32, i32 {
+    %zero = arith.constant 0 : index
+    %0 = memref.load %m0[%zero] : memref<16xi32, 2>
+    %1 = arith.addi %0, %a : i32
+    %2 = arith.addi %1, %b : i32
+    memref.store %2, %m1[%zero] : memref<16xi32, 2>
+    air.herd_terminator
+  }
+  return
+}


### PR DESCRIPTION
## Summary

- Fix out-of-bounds RTP buffer access when scalar herd operands appear after memref or hierarchy-ID operands
- Introduce `rtp_slot` counter in `AIRToAIEPass` (`memref.load` index) and `AIRRtToNpuPass` (`NpuWriteRTPOp` index) that only increments for actual RTP slots consumed
- Add regression test with L1 memref operands before scalar operands

## Test plan

- [x] `ninja check-air-mlir` — all 354 tests pass
- [x] New test `air_herd_to_aie_rtp.mlir` verifies RTP buffer is `memref<2xi32>` and loads use indices `%c0`/`%c1` (not `%c2`/`%c3`)

Fixes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)