### PR TITLE
Add getDependentDialects to AIRWrapFuncWithParallelPass

### DIFF
--- a/mlir/lib/Conversion/ConvertToAIRPass.cpp
+++ b/mlir/lib/Conversion/ConvertToAIRPass.cpp
@@ -2206,6 +2206,11 @@ public:
       const ::xilinx::air::AIRWrapFuncWithParallelPassOptions &options)
       : AIRWrapFuncWithParallelPassBase(options) {}
 
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect>();
+    registry.insert<arith::ArithDialect>();
+  }
+
   void runOnOperation() override;
 
 private:


### PR DESCRIPTION
## Summary
- `AIRWrapFuncWithParallelPass` creates `scf::ParallelOp` (with `scf.reduce`), `arith::ConstantIndexOp`, and `arith::IndexCastOp` but did not declare `SCFDialect` or `ArithDialect` as dependent dialects.
- This causes a crash ("scf.reduce created with unregistered dialect") when the pass runs without these dialects pre-loaded by a prior pass.
- Adds `getDependentDialects` override registering both dialects, matching the pattern used by other passes in the same file (e.g., `AIRRankToLaunchPass`).

## Test plan
- [x] `ninja` build succeeds with no warnings
- [x] `ninja check-air-mlir` — all 354 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)