### PR TITLE
Bump mlir-aie to e368f3e (latest main)

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=c019e6391b03ba8fb6e13e53bb7a56a0e6c26032
-DATETIME=2026032417
+export HASH=e368f3e730f0dc891559df1ff41cdddf40f9e836
+DATETIME=2026040605
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary
- Update pinned mlir-aie commit from `c019e63` (Mar 24) to `e368f3e` (Apr 3)
- No LLVM or mlir-python-extras version change needed (both remain the same)

## Notable mlir-aie changes included
- Insert trace flows pass (#2962)
- Introduce placement pass (#2900)
- Declarative trace IRON API (#2988)
- Runtime and tensor improvements (#3008)
- Fix Buffer resolution in `inline_ops` and resnet RTP pattern (#3011, #3017)

## Test plan
- [x] `ninja check-air-mlir` — 355 passed
- [x] `ninja check-air-cpp` — 1/1 passed
- [x] `ninja check-air-python` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)