### PR TITLE
Use scope=launch for air-isolate-async-dma-loop-nests in aircc

### DIFF
--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-isolate-async-dma-loop-nests="scope=func" --split-input-file | FileCheck %s
+// RUN: air-opt %s -air-isolate-async-dma-loop-nests="scope=launch" --split-input-file | FileCheck %s --check-prefix=LAUNCH
 
 // Isolate scf for loops containing dma ops into perfectly nested loop.
 
@@ -1405,6 +1406,47 @@ module {
         scf.yield %3 : !air.async.token
       }
       scf.yield %2 : !air.async.token
+    }
+    return
+  }
+}
+
+// -----
+
+// Loops with channel.put ops to different channels directly inside air.launch
+// (outside air.segment) should be split into separate perfectly nested loops.
+
+// LAUNCH-LABEL: func_launch_level_dma_loop_split
+// LAUNCH: air.launch
+// LAUNCH: scf.for
+// LAUNCH:   air.channel.put{{.*}}@A_chan
+// LAUNCH-NOT: air.channel.put{{.*}}@B_chan
+// LAUNCH:   scf.yield
+// LAUNCH: scf.for
+// LAUNCH:   air.channel.put{{.*}}@B_chan
+// LAUNCH-NOT: air.channel.put{{.*}}@A_chan
+// LAUNCH:   scf.yield
+
+module {
+  air.channel @A_chan []
+  air.channel @B_chan []
+  func.func @func_launch_level_dma_loop_split(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
+    %c2 = arith.constant 2 : index
+    %0 = air.launch async (%arg4, %arg5) in (%arg6=%c2, %arg7=%c2) args(%arg8=%arg0, %arg9=%arg1) : memref<512x512xbf16>, memref<512x512xbf16> attributes {id = 1 : i32} {
+      %c512 = arith.constant 512 : index
+      %c64 = arith.constant 64 : index
+      %c256 = arith.constant 256 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %c0 = arith.constant 0 : index
+      %1 = air.wait_all async
+      %2 = scf.for %arg12 = %c0 to %c8 step %c1 iter_args(%arg13 = %1) -> (!air.async.token) {
+        %3 = air.channel.put async [%arg13] @A_chan[] (%arg8[%c0, %c0] [%c256, %c64] [%c512, %c1]) {id = 1 : i32} : (memref<512x512xbf16>)
+        %4 = air.channel.put async [%arg13] @B_chan[] (%arg9[%c0, %c0] [%c64, %c256] [%c512, %c1]) {id = 2 : i32} : (memref<512x512xbf16>)
+        %5 = air.wait_all async [%3, %4]
+        scf.yield %5 : !air.async.token
+      }
+      air.launch_terminator
     }
     return
   }

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -800,7 +800,7 @@ static std::string buildOptimizationPipeline() {
 
   os << ",air-dma-to-channel,canonicalize,cse";
   os << ",air-dependency-canonicalize,canonicalize,cse";
-  os << ",air-isolate-async-dma-loop-nests,canonicalize,cse";
+  os << ",air-isolate-async-dma-loop-nests{scope=launch},canonicalize,cse";
 
   // Channel multiplexing
   if (!channelMultiplexing.empty()) {
@@ -820,7 +820,7 @@ static std::string buildOptimizationPipeline() {
   // L2 splitting (skip for npu_1col)
   if (deviceName.getValue().find("npu_1col") == std::string::npos) {
     os << ",func.func(air-split-l2-memref),canonicalize,cse";
-    os << ",air-isolate-async-dma-loop-nests,canonicalize,cse";
+    os << ",air-isolate-async-dma-loop-nests{scope=launch},canonicalize,cse";
   }
 
   // Loop fusion or alloc/dealloc optimization


### PR DESCRIPTION
## Summary
- Changes both `air-isolate-async-dma-loop-nests` invocations in the aircc pipeline from default `scope=segment` to `scope=launch`, so the pass also splits DMA loops directly inside `air.launch` (not only those inside `air.segment`).
- `scope=launch` is a superset of `scope=segment` — the region walk already finds all nested `scf.for` ops including those inside `air.segment`, so existing behavior is preserved.
- Adds a test case (`func_launch_level_dma_loop_split`) verifying that two `channel.put` ops to different channels in a loop inside `air.launch` get correctly split into separate perfectly nested loops.

## Test plan
- [x] `ninja check-air-mlir` — all 356 tests pass, no regressions
- [x] Manual verification with `air-opt --air-isolate-async-dma-loop-nests="scope=launch"` on representative IR

🤖 Generated with [Claude Code](https://claude.com/claude-code)