### PR TITLE
Add multi-tile herd and C++ profiling to RoPE LUT kernel

### DIFF
--- a/programming_examples/rope_lut/Makefile
+++ b/programming_examples/rope_lut/Makefile
@@ -12,13 +12,18 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+SEQ_LEN ?= 64
+EMBED_DIM ?= 64
+HERD_X ?= 1
+
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
+		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X) -p
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -31,11 +36,71 @@ compile-kernel:
 		exit 1; \
 	fi
 
+compile-xclbin: compile-kernel
+	mkdir -p $(BUILD_DIR)/air_project
+	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/rope_lut.py --output-format xclbin --compile-mode compile-only \
+		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X)
+
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG)
+		${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
+		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X)
+
+# C++ profiling harness (10 warmup + 20 measured iterations, microsecond precision)
+profile: compile-xclbin build-test-exe
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
+		-R $(SEQ_LEN) -D $(EMBED_DIM)
+
+# LLAMA shapes: correctness (make run) + profiling (C++ harness) for Q and K
+run_llama: compile-kernel build-test-exe
+	@echo "============================================"
+	@echo "  Prefill RoPE Q: 65536 rows x 64, herd=[8,1]"
+	@echo "============================================"
+	mkdir -p $(BUILD_DIR)/air_project
+	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		python3 ${srcdir}/rope_lut.py --output-format xclbin \
+		--seq-len 65536 --embed-dim 64 --herd-x 8
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
+		-R 65536 -D 64
+	@echo ""
+	@echo "============================================"
+	@echo "  Prefill RoPE K: 16384 rows x 64, herd=[8,1]"
+	@echo "============================================"
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		python3 ${srcdir}/rope_lut.py --output-format xclbin \
+		--seq-len 16384 --embed-dim 64 --herd-x 8
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
+		-R 16384 -D 64
+
+# Default XRT path; uses ?= so XILINX_XRT from environment (xrt/setup.sh)
+# takes precedence. Fallback needed for LIT tests where env may not propagate.
+XILINX_XRT ?= /opt/xilinx/xrt
+
+build-test-exe:
+	@GPP=$$( \
+		for bin in /usr/bin/g++-*; do \
+			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
+			if [ "$$ver" -ge 13 ] 2>/dev/null; then \
+				echo "$$ver $$bin"; \
+			fi; \
+		done | sort -nr | head -n1 | awk '{print $$2}' \
+	); \
+	if [ -z "$$GPP" ]; then \
+		echo "Error: No g++ version >= 13 found in /usr/bin."; \
+		exit 1; \
+	fi; \
+	echo "Using compiler: $$GPP"; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && $$GPP ${srcdir}/test.cpp -o test.exe -std=c++23 -Wall \
+		-I$(XILINX_XRT)/include -L$(XILINX_XRT)/lib \
+		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
+		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/rope_lut/rope_lut.py
+++ b/programming_examples/rope_lut/rope_lut.py
@@ -13,7 +13,8 @@ The cos/sin values are precomputed on the host and streamed in as a
 look-up table (LUT) with interleaved [cos, sin, cos, sin, ...] layout.
 Uses the external rope.cc kernel from mlir-aie (aie_kernels/aie2p).
 
-Uses a single AIE tile with DMA transfers between L3 and L1 memory.
+Supports multi-tile herd (herd_x > 1) for row-parallel execution.
+Each row's RoPE is independent — no cross-row dependencies.
 """
 
 import argparse
@@ -21,6 +22,7 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air.ir import *
+from air.dialects.affine import apply as affine_apply
 from air.dialects.air import *
 from air.dialects import arith
 from air.dialects.arith import ConstantOp
@@ -34,13 +36,12 @@ range_ = for_
 
 
 @module_builder
-def build_module(seq_len, embed_dim, np_dtype_in):
+def build_module(seq_len, embed_dim, np_dtype_in, herd_x=1):
     xrt_dtype = type_mapper(np_dtype_in)
     total = seq_len * embed_dim
     assert (
         embed_dim % 16 == 0
     ), "embed_dim must be divisible by 16 (kernel vector width)"
-    index_type = IndexType.get()
 
     # L3 types
     l3DataTy = MemRefType.get([total], xrt_dtype)
@@ -58,11 +59,34 @@ def build_module(seq_len, embed_dim, np_dtype_in):
     rope_func.attributes["link_with"] = StringAttr.get("rope.o")
     rope_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
 
+    assert (
+        seq_len % herd_x == 0
+    ), f"seq_len ({seq_len}) must be divisible by herd_x ({herd_x})"
+    rows_per_tile = seq_len // herd_x
+
+    # Affine map: row_offset = (local_row + _tx * rows_per_tile) * embed_dim
+    row_offset_map = AffineMap.get(
+        0,
+        2,
+        [
+            AffineExpr.get_mul(
+                AffineExpr.get_add(
+                    AffineSymbolExpr.get(0),
+                    AffineExpr.get_mul(
+                        AffineSymbolExpr.get(1),
+                        AffineConstantExpr.get(rows_per_tile),
+                    ),
+                ),
+                AffineConstantExpr.get(embed_dim),
+            )
+        ],
+    )
+
     @FuncOp.from_py_func(l3DataTy, l3DataTy, l3DataTy)
     def rope_lut(arg0, arg1, arg2):
         # arg0 = input [total], arg1 = lut [total], arg2 = output [total]
 
-        @herd(name="herd_0", sizes=[1, 1], operands=[arg0, arg1, arg2])
+        @herd(name="herd_0", sizes=[herd_x, 1], operands=[arg0, arg1, arg2])
         def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_lut, l3_out):
             l1_in = AllocOp(l1RowTy, [], [])
             l1_lut = AllocOp(l1RowTy, [], [])
@@ -70,7 +94,9 @@ def build_module(seq_len, embed_dim, np_dtype_in):
 
             dim_i32 = ConstantOp(T.i32(), embed_dim)
 
-            for row_offset in range_(0, total, embed_dim):
+            for local_row in range_(rows_per_tile):
+                row_offset = affine_apply(row_offset_map, [local_row, _tx])
+
                 dma_memcpy_nd(
                     l1_in,
                     l3_in,
@@ -104,21 +130,47 @@ def build_module(seq_len, embed_dim, np_dtype_in):
         herd_body.attributes["link_with"] = StringAttr.get("rope.o")
 
 
+def rope_reference(input_data, lut, embed_dim):
+    """CPU F32 reference for RoPE with precomputed LUT (vectorized)."""
+    x = input_data.astype(np.float32).reshape(-1, embed_dim)
+    l = lut.astype(np.float32).reshape(-1, embed_dim)
+    x_even = x[:, 0::2]
+    x_odd = x[:, 1::2]
+    cos_v = l[:, 0::2]
+    sin_v = l[:, 1::2]
+    out = np.empty_like(x)
+    out[:, 0::2] = x_even * cos_v - x_odd * sin_v
+    out[:, 1::2] = x_even * sin_v + x_odd * cos_v
+    return out.astype(input_data.dtype)
+
+
+def generate_lut(seq_len, embed_dim, dtype=bfloat16, theta=10000.0):
+    """Generate interleaved [cos, sin, cos, sin, ...] RoPE LUT (vectorized)."""
+    i_vals = np.arange(embed_dim // 2, dtype=np.float64)
+    freqs = 1.0 / (theta ** (2.0 * i_vals / embed_dim))
+    rows = np.arange(seq_len, dtype=np.float64)
+    angles = np.outer(rows, freqs)  # (seq_len, embed_dim//2)
+    lut = np.empty((seq_len, embed_dim), dtype=np.float32)
+    lut[:, 0::2] = np.cos(angles)
+    lut[:, 1::2] = np.sin(angles)
+    return lut.astype(dtype)
+
+
 if __name__ == "__main__":
-    SEQ_LEN = 64
-    EMBED_DIM = 64
-    INPUT_DATATYPE = bfloat16
     THETA = 10000.0
 
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the RoPE (LUT-based) example",
+        description="RoPE (LUT-based) — build, run, profile",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--seq-len", type=int, default=SEQ_LEN, help="Sequence length")
+    parser.add_argument("--seq-len", type=int, default=64, help="Number of rows")
+    parser.add_argument("--embed-dim", type=int, default=64, help="Embedding dimension")
     parser.add_argument(
-        "--embed-dim", type=int, default=EMBED_DIM, help="Embedding dimension"
+        "--herd-x",
+        type=int,
+        default=1,
+        help="Number of tiles (1=single, 8=multi-tile)",
     )
     parser.add_argument(
         "--compile-mode",
@@ -136,44 +188,21 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    mlir_module = build_module(args.seq_len, args.embed_dim, INPUT_DATATYPE)
+    seq_len = args.seq_len
+    embed_dim = args.embed_dim
+    herd_x = args.herd_x
+    print(f"RoPE LUT: seq_len={seq_len}, embed_dim={embed_dim}, herd=[{herd_x},1]")
+
+    mlir_module = build_module(seq_len, embed_dim, bfloat16, herd_x=herd_x)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
-    np.random.seed(0)
-    seq_len = args.seq_len
-    embed_dim = args.embed_dim
-
-    # Generate random input
-    input_data = np.random.uniform(-4.0, 4.0, (seq_len, embed_dim)).astype(
-        INPUT_DATATYPE
-    )
-
-    # Generate LUT: interleaved [cos, sin, cos, sin, ...] per row
-    lut = np.zeros((seq_len, embed_dim), dtype=np.float32)
-    for r in range(seq_len):
-        for i in range(embed_dim // 2):
-            freq = 1.0 / (THETA ** (2.0 * i / embed_dim))
-            angle = r * freq
-            lut[r, 2 * i] = np.cos(angle)
-            lut[r, 2 * i + 1] = np.sin(angle)
-    lut = lut.astype(INPUT_DATATYPE)
-
     if args.compile_mode == "compile-and-run":
-        # Compute reference output
-        ref = np.copy(input_data).astype(np.float32)
-        input_f32 = input_data.astype(np.float32)
-        lut_f32 = lut.astype(np.float32)
-        for r in range(seq_len):
-            for i in range(embed_dim // 2):
-                cos_v = lut_f32[r, 2 * i]
-                sin_v = lut_f32[r, 2 * i + 1]
-                x0 = input_f32[r, 2 * i]
-                x1 = input_f32[r, 2 * i + 1]
-                ref[r, 2 * i] = x0 * cos_v - x1 * sin_v
-                ref[r, 2 * i + 1] = x0 * sin_v + x1 * cos_v
-        ref_flat = ref.flatten().astype(INPUT_DATATYPE)
+        np.random.seed(0)
+        input_data = np.random.uniform(-4.0, 4.0, (seq_len, embed_dim)).astype(bfloat16)
+        lut = generate_lut(seq_len, embed_dim, bfloat16, THETA)
+        y_expected = rope_reference(input_data, lut, embed_dim)
 
         runner = XRTRunner(
             verbose=args.verbose,
@@ -186,7 +215,7 @@ if __name__ == "__main__":
             runner.run_test(
                 mlir_module,
                 inputs=[input_data.flatten(), lut.flatten()],
-                expected_outputs=[ref_flat],
+                expected_outputs=[y_expected.flatten()],
                 rtol=5e-2,
                 atol=5e-2,
             )

--- a/programming_examples/rope_lut/run_llama_shape_peano.lit
+++ b/programming_examples/rope_lut/run_llama_shape_peano.lit
@@ -1,0 +1,15 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_llama_peano
+// RUN: cd test_llama_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_llama PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Prefill RoPE Q: 65536 rows x 64, herd=[8,1]
+// CHECK: PASS!
+// CHECK: Avg NPU time:
+// CHECK: Prefill RoPE K: 16384 rows x 64, herd=[8,1]
+// CHECK: PASS!
+// CHECK: Avg NPU time:

--- a/programming_examples/rope_lut/test.cpp
+++ b/programming_examples/rope_lut/test.cpp
@@ -1,0 +1,166 @@
+//===- test.cpp - RoPE LUT profiling harness --------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// C++ XRT harness for profiling the RoPE LUT kernel.
+// Times only kernel dispatch + wait (no BO sync in timer).
+//
+// Usage:
+//   ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -R <rows> -D <dim>
+//
+//===----------------------------------------------------------------------===//
+
+#include "cxxopts.hpp"
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <stdfloat>
+#include <vector>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+using DATATYPE = std::bfloat16_t;
+
+int main(int argc, const char *argv[]) {
+
+  cxxopts::Options options("RoPE LUT profiling");
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i", "path of file containing instructions",
+      cxxopts::value<std::string>())(
+      "rows,R", "Number of rows (seq_len for RoPE)",
+      cxxopts::value<int>()->default_value("64"))(
+      "dim,D", "Embedding dimension (head_dim)",
+      cxxopts::value<int>()->default_value("64"));
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+  int verbosity = vm["verbosity"].as<int>();
+
+  int rows = vm["rows"].as<int>();
+  int dim = vm["dim"].as<int>();
+  int total = rows * dim;
+
+  int DATA_SIZE = total * sizeof(DATATYPE);
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // XRT setup
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+  std::string Node = vm["kernel"].as<std::string>();
+
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 return k.get_name().rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, kernelName);
+
+  // Allocate BOs: instructions, input, lut, output
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_input =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_lut =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_output =
+      xrt::bo(device, DATA_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  // Fill input and LUT with random data
+  DATATYPE *buf_input = bo_input.map<DATATYPE *>();
+  DATATYPE *buf_lut = bo_lut.map<DATATYPE *>();
+  DATATYPE *buf_output = bo_output.map<DATATYPE *>();
+
+  for (int i = 0; i < total; i++) {
+    buf_input[i] = DATATYPE(8.0f * (float)rand() / (float)RAND_MAX - 4.0f);
+    buf_lut[i] = DATATYPE(2.0f * (float)rand() / (float)RAND_MAX - 1.0f);
+    buf_output[i] = DATATYPE(0.0f);
+  }
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_input.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_lut.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_output.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  // Profiling
+  unsigned n_warmup = 10;
+  unsigned n_iterations = 20;
+  unsigned num_iter = n_warmup + n_iterations;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+
+  // Total data moved: input + lut + output (all same size)
+  float data_bytes = 3.0f * total * sizeof(DATATYPE);
+
+  std::cout << "RoPE LUT profiling: rows=" << rows << ", dim=" << dim
+            << ", total=" << total << std::endl;
+
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+    auto start = std::chrono::high_resolution_clock::now();
+    unsigned int opcode = 3;
+    auto run =
+        kernel(opcode, bo_instr, instr_v.size(), bo_input, bo_lut, bo_output);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    bo_output.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    if (iter < n_warmup)
+      continue;
+
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+  }
+
+  float avg_us = npu_time_total / n_iterations;
+
+  std::cout << std::endl;
+  std::cout << "Avg NPU time: " << avg_us << " us" << std::endl;
+  std::cout << "Min NPU time: " << npu_time_min << " us" << std::endl;
+  std::cout << "Max NPU time: " << npu_time_max << " us" << std::endl;
+  std::cout << std::endl;
+  std::cout << "Avg bandwidth: " << std::fixed << std::setprecision(2)
+            << data_bytes / (avg_us * 1000.0f) << " GB/s" << std::endl;
+  std::cout << "Max bandwidth: " << data_bytes / (npu_time_min * 1000.0f)
+            << " GB/s" << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Add row-parallel multi-tile support (`herd_x` parameter) to the RoPE LUT kernel, distributing rows across tiles with tile-dependent offsets (same pattern as the 8-tile RMSNorm)
- Add C++ profiling harness (`test.cpp`) with 10 warmup + 20 measured iterations at microsecond precision
- Add LIT test at LLAMA-3.2-1B prefill shapes (65536x64 for Q, 16384x64 for K) verifying both correctness and profiling

Each row's RoPE is independent — no cross-row dependency, no broadcast DMA needed. The external `rope.cc` kernel is unchanged.

### Performance at LLAMA-3.2-1B prefill shapes (C++ harness)

| Shape | herd=[1,1] | herd=[8,1] | Speedup |
|-------|-----------|-----------|---------|
| Q: 65536 x 64 | 6717 us | 912 us | **7.4x** |
| K: 16384 x 64 | 1716 us | 271 us | **6.3x** |
| Q+K combined | 8433 us | 1183 us | **7.1x** |

## Test plan

- [x] `make run` PASS at default shape (64x64) with herd=[1,1]
- [x] `make run HERD_X=8` PASS at default shape with herd=[8,1]
- [x] `make run_llama` PASS at LLAMA Q+K shapes with herd=[8,1]
- [x] `make profile` C++ profiling produces consistent results
- [x] LIT test `run_llama_shape_peano.lit` PASS (correctness + profiling for both shapes)
- [x] Existing LIT test `run_makefile_peano.lit` unchanged (still tests default 64x64 herd=[1,1])

🤖 Generated with [Claude Code](https://claude.com/claude-code)