### PR TITLE
Add traceDeps for HierarchyInterface in air-dependency

### DIFF
--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -286,6 +286,10 @@ public:
               channel_op;
         } else if (auto hier_op =
                        dyn_cast_if_present<air::HierarchyInterface>(op)) {
+          traceDeps<air::HierarchyInterface>(sink_op_memref_reads, hier_op,
+                                             "RAW");
+          traceDeps<air::HierarchyInterface>(sink_op_memref_writes, hier_op,
+                                             "WAW/WAR");
           opIdToOpMap[std::make_pair("hierarchy", hier_op.getId())] = hier_op;
         }
       });

--- a/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
+++ b/mlir/test/Transform/AIRDependency/air_hierarchy.mlir
@@ -48,4 +48,26 @@ module  {
     }
     return
   }
+  // Sequential herds sharing the same buffer: second herd must depend on first.
+  // traceDeps for HierarchyInterface creates RAW dependency between herds.
+  func.func @sequential_herds_same_buffer() {
+    %c1 = arith.constant 1 : index
+    air.launch (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) {
+    // CHECK: air.launch async
+      air.segment {
+        %c1_0 = arith.constant 1 : index
+        %buf = memref.alloc() : memref<256xi32, 2>
+        // CHECK: %[[ALLOC:.*]], %[[BUF:.*]] = air.execute
+        air.herd tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%a=%buf) : memref<256xi32, 2> {
+        // CHECK: %[[HERD1:.*]] = air.herd async [{{.*}}%[[ALLOC]]{{.*}}]
+        }
+        air.herd tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%a=%buf) : memref<256xi32, 2> {
+        // CHECK: %[[HERD2:.*]] = air.herd async [{{.*}}%[[HERD1]]{{.*}}]
+        }
+        memref.dealloc %buf : memref<256xi32, 2>
+        // CHECK: air.execute [{{.*}}%[[HERD2]]{{.*}}]
+      }
+    }
+    return
+  }
 }


### PR DESCRIPTION
## Summary
- Add `traceDeps<air::HierarchyInterface>` calls for RAW and WAW/WAR in the 2nd traversal of `air-dependency`
- Without this, `HierarchyInterface` ops (herds/segments) are added to `opIdToOpMap` but don't get dependency edges from prior writers to their operand buffers

## Motivation
In multi-phase designs where sequential herds share the same L2 buffer operand, the second herd needs a dependency on the first to ensure correct ordering. Without `traceDeps`, the second herd has no async dependency on the first, which can cause incorrect scheduling.

## Test plan
- [x] Added regression test in `air_hierarchy.mlir` (`sequential_herds_same_buffer`)
- [x] All 364 `check-air-mlir` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)