### PR TITLE
Fix BD repeat dim double-counting when size-1 dim creates 3D layout

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -439,8 +439,10 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
         transferLen /= size;
         continue;
       }
-      // Include dimension if size > 1, or if it's the innermost dimension
-      if (size > 1 || i == 3) {
+      // Include dimension if size > 1, if it's the innermost dimension,
+      // or if the 4th dim is in use and this is a middle dim (retain size-1
+      // dims to preserve the 4-entry layout needed for iteration_stride).
+      if (size > 1 || i == 3 || (use4thDimInBd && i > 0)) {
         auto dimLayout = AIE::BDDimLayoutAttr::get(ctx, size, stride);
         dimLayouts.push_back(dimLayout);
       }

--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -962,3 +962,46 @@ module {
     }
   }
 }
+
+// -----
+
+// 4D BD pattern with size-1 gap: sizes=[4, 1, 128, 64] strides=[65536, 64, 512, 1].
+// The size-1 dim must be retained when use4thDimInBd is true, so that the 4th BD
+// dimension provides iteration_stride to the hardware. Without the fix, the size-1
+// dim is skipped, collapsing to 3 entries where the repeat dim appears in both
+// repeat_count AND dimLayouts, causing validator rejection (4*128*64 != 8192).
+// The fix retains size-1 middle dims when use4thDimInBd is true.
+
+// CHECK-LABEL: aie.runtime_sequence @bd_repeat_dim_size1_gap
+// CHECK-SAME: %[[ARG0:.*]]: memref<512x512xbf16>
+// CHECK-NEXT: aiex.dma_configure_task_for @airMemcpyId5 {
+// CHECK:        aie.dma_bd(%[[ARG0]] : memref<512x512xbf16>, 64, 8192, [<size = 4, stride = 65536>, <size = 1, stride = 64>, <size = 128, stride = 512>, <size = 64, stride = 1>])
+// CHECK: } {repeat_count = 3 : i32}
+// CHECK: aiex.dma_start_task
+module {
+  aie.device(npu1_1col) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId5(%shim_noc_tile_0_0, MM2S, 0)
+    func.func @bd_repeat_dim_size1_gap(%arg0: memref<512x512xbf16>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c4_i64 = arith.constant 4 : i64
+      %c64_i64 = arith.constant 64 : i64
+      %c128_i64 = arith.constant 128 : i64
+      %c512_i64 = arith.constant 512 : i64
+      %c65536_i64 = arith.constant 65536 : i64
+      %c5_i32 = arith.constant 5 : i32
+      // sizes=[4, 1, 128, 64] strides=[65536, 64, 512, 1]
+      // use4thDimInBd=true (strides[0]=65536 != 0), repeat_count=3
+      // dim 0: size=4 stride=65536 -> iteration dim (4th BD dim)
+      // dim 1: size=1 stride=64 -> retained (degenerate, preserves 4D layout)
+      // dim 2: size=128 stride=512 -> BD dim
+      // dim 3: size=64 stride=1 -> BD dim (innermost)
+      // transferLen = 1*128*64 = 8192
+      // Without fix: dim 1 skipped -> 3 entries -> validator: 4*128*64=32768 != 8192 FAIL
+      // With fix: dim 1 retained -> 4 entries -> validator checks lowest 3: 1*128*64=8192 PASS
+      airrt.dma_memcpy_nd(%c5_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c64_i64], [%c4_i64, %c1_i64, %c128_i64, %c64_i64], [%c65536_i64, %c64_i64, %c512_i64, %c1_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<512x512xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64])
+      return
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix `DmaToNpuPattern` in `AIRRtToNpuPass.cpp` to retain size-1 middle dimensions in `dimLayouts` when `use4thDimInBd` is true
- This preserves the 4-entry BD layout so that the outermost dimension correctly maps to `iteration_stride` in the hardware, and the mlir-aie validator only checks the lowest 3 dims against `transferLen`

## Motivation
When `air-opt-shim-dma-bds` folds K-loop iterations into a 4D BD pattern like `sizes=[4, 1, 128, 64]`, the size-1 dim (dim 1) was previously skipped in `dimLayouts`, collapsing to 3 entries. This caused two problems:

1. **Validator rejection**: The outermost dim (size=4) appeared in both `repeat_count=3` AND `dimLayouts[0]`. The mlir-aie validator checks all 3 dims against `transferLen`: `4 * 128 * 64 = 32768 != 8192 = len` → failure.
2. **Lost iteration_stride**: If dim 0 were removed from `dimLayouts` to fix the validator, the `iteration_stride` (65536) would be lost since `DMAConfigureTaskForOp` has no `iteration_stride` field — it can only come from the BD's 4th dimension.

## Fix
Retain size-1 middle dims when `use4thDimInBd` is true by adding `(use4thDimInBd && i > 0)` to the dimension inclusion condition. The degenerate `<size = 1, stride = 64>` entry occupies a BD slot (hardware no-op) but keeps `dimLayouts` at 4 entries:
- Validator checks only the lowest 3 dims: `1 * 128 * 64 = 8192 == 8192 = len` ✓
- 4th dim preserves `iteration_stride = 65536` for correct address advancement between repeats ✓

## Test plan
- [x] Added regression test in `airrt_to_npu.mlir` (`bd_repeat_dim_size1_gap`)
- [x] All 364 `check-air-mlir` tests pass (including existing `repeat_count=37` test with 4D BDs)
- [x] Verified on NPU2 hardware with fused SwiGLU (4×4 herd, bf16 matmul)

🤖 Generated with [Claude Code](https://claude.com/claude-code)