### PR TITLE
Preserve channel_type in air-split-l2-memref pass

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2533,7 +2533,7 @@ public:
     sizes[chanDim] *= factor;
     air::ChannelOp::create(builder, op->getLoc(), chan_op.getSymName().str(),
                            builder.getI64ArrayAttr(sizes),
-                           builder.getStringAttr("dma_stream"));
+                           chan_op.getChannelType());
 
     // Add scf.parallel to unroll channel puts and gets
     auto puts = air::getChannelPutOpThroughSymbol(chan_op);

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2622,7 +2622,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         }
         new_chan = air::ChannelOp::create(
             rewriter, loc, cname, rewriter.getI64ArrayAttr(channel_sizes),
-            rewriter.getStringAttr("dma_stream"));
+            origChanOp.getChannelTypeAttr());
       }
 
       // Perform tiling on these channel put/get ops which are using the memref.

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2622,7 +2622,7 @@ void AIRSplitL2MemrefForBufferConstraintPass::runOnOperation() {
         }
         new_chan = air::ChannelOp::create(
             rewriter, loc, cname, rewriter.getI64ArrayAttr(channel_sizes),
-            origChanOp.getChannelTypeAttr());
+            origChanOp.getChannelType());
       }
 
       // Perform tiling on these channel put/get ops which are using the memref.

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
@@ -2412,3 +2412,86 @@ module {
     return
   }
 }
+
+// -----
+
+// Verify that channel_type attribute is preserved after L2 memref splitting.
+// The split pass creates new channel declarations; non-default channel_type
+// (e.g., "dma_packet") must be carried over from the original channel.
+
+// CHECK: air.channel @channel_1 [1, 1] {channel_type = "dma_packet"}
+// CHECK: air.channel @channel_0 [4, 4] {channel_type = "dma_packet"}
+// CHECK: air.channel @channel_2 [4, 1] {channel_type = "dma_packet"}
+// CHECK-LABEL: func.func @test_preserve_channel_type
+
+#map = affine_map<()[s0] -> (s0 * 256)>
+#map1 = affine_map<()[s0] -> (s0 * 64)>
+air.channel @channel_1 [1, 1] {channel_type = "dma_packet"}
+air.channel @channel_0 [4, 4] {channel_type = "dma_packet"}
+func.func @test_preserve_channel_type(%arg0: memref<512x1024xbf16>, %arg1: memref<1024x512xbf16>, %arg2: memref<512x512xbf16>) {
+  %c2 = arith.constant 2 : index
+  %0 = air.launch async (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) args(%arg7=%arg2) : memref<512x512xbf16> attributes {id = 1 : i32} {
+    %c512 = arith.constant 512 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %async_token, %results = air.execute -> (index) {
+      %3 = affine.apply #map()[%arg3]
+      air.execute_terminator %3 : index
+    }
+    %async_token_0, %results_1 = air.execute -> (index) {
+      %3 = affine.apply #map()[%arg4]
+      air.execute_terminator %3 : index
+    }
+    %1 = air.channel.get async [%async_token, %async_token_0]  @channel_1[] (%arg7[%results, %results_1] [%c256, %c256] [%c512, %c1]) {id = 3 : i32} : (memref<512x512xbf16>)
+    %2 = air.segment @segment_0 async  {
+      %c64 = arith.constant 64 : index
+      %c1_2 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      %c0 = arith.constant 0 : index
+      %c256_3 = arith.constant 256 : index
+      %3 = air.wait_all async
+      %4 = air.wait_all async
+      %async_token_4, %results_5 = air.execute -> (memref<256x256xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<256x256xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<256x256xbf16, 1 : i32>
+      }
+      %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c4, %c4) step (%c1_2, %c1_2) init (%async_token_4) -> !air.async.token {
+        %async_token_7, %results_8 = air.execute -> (index) {
+          %9 = affine.apply #map1()[%arg8]
+          air.execute_terminator %9 : index
+        }
+        %async_token_9, %results_10 = air.execute -> (index) {
+          %9 = affine.apply #map1()[%arg9]
+          air.execute_terminator %9 : index
+        }
+        %8 = air.channel.get async [%async_token_4, %async_token_9, %async_token_7]  @channel_0[%arg8, %arg9] (%results_5[%results_8, %results_10] [%c64, %c64] [%c256_3, %c1_2]) {id = 24 : i32} : (memref<256x256xbf16, 1 : i32>)
+        scf.reduce(%8 : !air.async.token) {
+        ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+          %9 = air.wait_all async [%arg10, %arg11]
+          scf.reduce.return %9 : !air.async.token
+        }
+      }
+      %6 = air.herd @herd_0 async [%async_token_4]  tile (%arg8, %arg9) in (%arg10=%c4, %arg11=%c4) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c64_7 = arith.constant 64 : index
+        %c256_8 = arith.constant 256 : index
+        %c4_9 = arith.constant 4 : index
+        %c16 = arith.constant 16 : index
+        %c1_10 = arith.constant 1 : index
+        %c0_11 = arith.constant 0 : index
+        %async_token_12, %results_13 = air.execute -> (memref<16x16x4x4xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<16x16x4x4xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<16x16x4x4xbf16, 2 : i32>
+        }
+        %8 = air.channel.put async [%async_token_12]  @channel_0[%arg8, %arg9] (%results_13[%c0_11, %c0_11, %c0_11] [%c64_7, %c16, %c4_9] [%c4_9, %c256_8, %c1_10]) {id = 41 : i32} : (memref<16x16x4x4xbf16, 2 : i32>)
+        %async_token_14 = air.execute [%8] {
+          memref.dealloc %results_13 : memref<16x16x4x4xbf16, 2 : i32>
+        }
+      }
+      %7 = air.channel.put async [%3, %4, %6]  @channel_1[] (%results_5[] [] []) {id = 42 : i32} : (memref<256x256xbf16, 1 : i32>)
+      %async_token_6 = air.execute [%7] {
+        memref.dealloc %results_5 : memref<256x256xbf16, 1 : i32>
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary
- Fix `AIRSplitL2MemrefForBufferConstraintPass` hardcoding `"dma_stream"` as the channel type when creating replacement channel declarations
- Channels with other types (e.g., `"dma_packet"`) were silently losing their `channel_type` attribute after L2 memref splitting
- Use `origChanOp.getChannelTypeAttr()` to preserve the original channel's type attribute

## Test plan
- [x] Verify existing `check-air-mlir` tests pass (no regressions since `"dma_stream"` channels are unaffected)
- [x] Verify that channels with `channel_type = "dma_packet"` retain their type after the split-L2-memref pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)