### PR TITLE
Fix TileDMAAllocator S2MM packet-flow channel reuse

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -878,8 +878,11 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
-    // reuse the channel allocation.
-    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(col, row)) {
+    // reuse the channel allocation. Only reuse for MM2S (outbound) channels;
+    // S2MM (inbound) channels need separate allocations so the packet switch
+    // can route different packet IDs to different buffer descriptors.
+    if (isPacketFlowOp && isMM2S.value() &&
+        t.foundPacketFlowAllocInTile(col, row)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }


### PR DESCRIPTION
## Summary
- Restrict packet-flow channel reuse in `TileDMAAllocator::simpleDmaChannelAlloc` to MM2S (outbound) channels only
- Previously, S2MM (inbound) channels were also reused across packet flows on the same tile, which made it impossible for the packet switch to route different packet IDs to different buffer descriptors
- The fix adds an `isMM2S.value()` guard to the existing `isPacketFlowOp` check

## Details
When multiple `dma_packet` channels target the same destination tile, each needs its own S2MM DMA channel so the packet switch can distinguish between packets with different IDs and route them to separate buffer descriptors. The previous code unconditionally reused the first packet-flow allocation found on the tile for all subsequent packet-flow allocations, causing routing conflicts at the destination.

For MM2S (outbound) channels, reuse is correct — multiple outbound packet flows from the same tile can share a single DMA channel since they are multiplexed by the packet switch based on packet ID.

## Test plan
- [ ] Existing `check-air-mlir` tests pass (no regressions)
- [ ] Multi-destination packet-flow patterns now get separate S2MM channel allocations per destination flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)