### PR TITLE
Add dual-herd packet-switched shim DMA programming example

### DIFF
--- a/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
@@ -1,0 +1,26 @@
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Determine build dir based on whether PEANO_INSTALL_DIR is set
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+# Output format: xclbin (default) or elf
+OUTPUT_FORMAT ?= elf
+OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
+
+all: run
+
+print:
+	${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG) -p
+
+run:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG)
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
@@ -27,10 +27,22 @@ run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG)
 
+PROFILE_ARGS = $(OUTPUT_FORMAT_FLAG) --tile-size $(TILE_SIZE) --warmup $(WARMUP) --iterations $(ITERATIONS)
+
 profile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG) \
-		--tile-size $(TILE_SIZE) --warmup $(WARMUP) --iterations $(ITERATIONS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
+
+compare:
+	mkdir -p $(BUILD_DIR)
+	@echo "=== Single-herd add ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_herd_add.py $(PROFILE_ARGS)
+	@echo ""
+	@echo "=== Single-herd mul ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_herd_mul.py $(PROFILE_ARGS)
+	@echo ""
+	@echo "=== Dual-herd (fused) ==="
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
@@ -13,6 +13,11 @@ endif
 OUTPUT_FORMAT ?= elf
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# Profile parameters
+TILE_SIZE ?= 4096
+WARMUP ?= 5
+ITERATIONS ?= 100
+
 all: run
 
 print:
@@ -21,6 +26,11 @@ print:
 run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG)
+
+profile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG) \
+		--tile-size $(TILE_SIZE) --warmup $(WARMUP) --iterations $(ITERATIONS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Dual-herd example with packet-switched shim DMA channels.
+#
+# Two 8x1 herds coexist on the same NPU2 device:
+#   - add_herd: element-wise add (C_add = A0 + B0)
+#   - mul_herd: element-wise mul (C_mul = A1 * B1)
+#
+# All four L3-to-L1 input channels use channel_type="dma_packet" so that
+# the shim DMA MM2S ports are time-multiplexed via packet-switched routing.
+# Without packet switching, 4 channels x 8 tiles = 32 circuit-switched flows
+# would exceed the 16 available shim MM2S channels on NPU2. With dma_packet,
+# the ShimDMAAllocator reuses channels on the same shim tile via packet IDs.
+
+import argparse
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import *
+from air.dialects.air import *
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.func import FuncOp
+from air.backend.xrt_runner import XRTRunner, type_mapper
+import air.dialects.linalg.opdsl.lang as linalg_lang
+
+TILE_SIZE = 1024
+HERD_SIZE = 8
+TOTAL_SIZE = TILE_SIZE * HERD_SIZE  # 8192
+
+INOUT_DATATYPE = bfloat16
+
+
+# elemwise_binary is deprecated from upstream; define as custom linalg op.
+@linalg_lang.linalg_structured_op
+def elemwise_binary(
+    lhs=linalg_lang.TensorDef(linalg_lang.TV.T1),
+    rhs=linalg_lang.TensorDef(linalg_lang.TV.T2),
+    O=linalg_lang.TensorDef(linalg_lang.U, output=True),
+    fun=linalg_lang.BinaryFnAttrDef(default=linalg_lang.BinaryFn.add),
+    cast=linalg_lang.TypeFnAttrDef(default=linalg_lang.TypeFn.cast_signed),
+):
+    O[None] = fun(cast(linalg_lang.U, lhs[None]), cast(linalg_lang.U, rhs[None]))
+
+
+@module_builder
+def build_module():
+    xrt_dtype = type_mapper(INOUT_DATATYPE)
+
+    # L3 memref types
+    l3_type = MemRefType.get([TOTAL_SIZE], xrt_dtype)
+
+    # L1 tile memref types
+    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l1_type = MemRefType.get(
+        shape=[TILE_SIZE],
+        element_type=xrt_dtype,
+        memory_space=mem_space_l1,
+    )
+
+    # --- Input channels: packet-switched for shim DMA sharing ---
+    chan_a0 = Channel("A0_to_L1", size=[HERD_SIZE, 1])
+    chan_a0.attributes["channel_type"] = StringAttr.get("dma_packet")
+    chan_b0 = Channel("B0_to_L1", size=[HERD_SIZE, 1])
+    chan_b0.attributes["channel_type"] = StringAttr.get("dma_packet")
+    chan_a1 = Channel("A1_to_L1", size=[HERD_SIZE, 1])
+    chan_a1.attributes["channel_type"] = StringAttr.get("dma_packet")
+    chan_b1 = Channel("B1_to_L1", size=[HERD_SIZE, 1])
+    chan_b1.attributes["channel_type"] = StringAttr.get("dma_packet")
+
+    # --- Output channels: circuit-switched (default dma_stream) ---
+    Channel("Add_out", size=[HERD_SIZE, 1])
+    Channel("Mul_out", size=[HERD_SIZE, 1])
+
+    @FuncOp.from_py_func(l3_type, l3_type, l3_type, l3_type, l3_type, l3_type)
+    def dual_herd_elemwise(a0, b0, a1, b1, c_add, c_mul):
+
+        @launch(operands=[a0, b0, a1, b1, c_add, c_mul])
+        def launch_body(a0_, b0_, a1_, b1_, c_add_, c_mul_):
+
+            # L3 -> L1 puts for all four inputs (packet-switched)
+            for tile_idx in range(HERD_SIZE):
+                offset = tile_idx * TILE_SIZE
+                ChannelPut(
+                    "A0_to_L1",
+                    a0_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+                ChannelPut(
+                    "B0_to_L1",
+                    b0_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+                ChannelPut(
+                    "A1_to_L1",
+                    a1_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+                ChannelPut(
+                    "B1_to_L1",
+                    b1_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+
+            # L1 -> L3 gets for outputs (circuit-switched)
+            for tile_idx in range(HERD_SIZE):
+                offset = tile_idx * TILE_SIZE
+                ChannelGet(
+                    "Add_out",
+                    c_add_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+                ChannelGet(
+                    "Mul_out",
+                    c_mul_,
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                    indices=[tile_idx, 0],
+                )
+
+            @segment(name="seg")
+            def segment_body():
+
+                # --- Herd 0: element-wise add ---
+                @herd(name="add_herd", sizes=[HERD_SIZE, 1])
+                def add_herd_body(tx, ty, sx, sy):
+                    tile_a = AllocOp(l1_type, [], [])
+                    tile_b = AllocOp(l1_type, [], [])
+                    tile_c = AllocOp(l1_type, [], [])
+
+                    ChannelGet("A0_to_L1", tile_a, indices=[tx, 0])
+                    ChannelGet("B0_to_L1", tile_b, indices=[tx, 0])
+
+                    elemwise_binary(
+                        tile_a,
+                        tile_b,
+                        outs=[tile_c],
+                        fun=linalg_lang.BinaryFn.add,
+                        cast=linalg_lang.TypeFn.cast_signed,
+                    )
+
+                    ChannelPut("Add_out", tile_c, indices=[tx, 0])
+
+                    DeallocOp(tile_a)
+                    DeallocOp(tile_b)
+                    DeallocOp(tile_c)
+
+                # --- Herd 1: element-wise mul ---
+                @herd(name="mul_herd", sizes=[HERD_SIZE, 1])
+                def mul_herd_body(tx, ty, sx, sy):
+                    tile_a = AllocOp(l1_type, [], [])
+                    tile_b = AllocOp(l1_type, [], [])
+                    tile_c = AllocOp(l1_type, [], [])
+
+                    ChannelGet("A1_to_L1", tile_a, indices=[tx, 0])
+                    ChannelGet("B1_to_L1", tile_b, indices=[tx, 0])
+
+                    elemwise_binary(
+                        tile_a,
+                        tile_b,
+                        outs=[tile_c],
+                        fun=linalg_lang.BinaryFn.mul,
+                        cast=linalg_lang.TypeFn.cast_signed,
+                    )
+
+                    ChannelPut("Mul_out", tile_c, indices=[tx, 0])
+
+                    DeallocOp(tile_a)
+                    DeallocOp(tile_b)
+                    DeallocOp(tile_c)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="dual_herd_packet_switch.py",
+        description="Dual 8x1 herd elemwise add/mul with packet-switched shim DMA",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="elf",
+        dest="output_format",
+    )
+    args = parser.parse_args()
+
+    mlir_module = build_module()
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    # Golden reference computation using small integers (exact in bf16)
+    np.random.seed(42)
+    a0 = np.random.randint(-8, 9, size=TOTAL_SIZE).astype(bfloat16)
+    b0 = np.random.randint(-8, 9, size=TOTAL_SIZE).astype(bfloat16)
+    a1 = np.random.randint(-4, 5, size=TOTAL_SIZE).astype(bfloat16)
+    b1 = np.random.randint(-4, 5, size=TOTAL_SIZE).astype(bfloat16)
+
+    c_add_ref = (a0.astype(np.float32) + b0.astype(np.float32)).astype(bfloat16)
+    c_mul_ref = (a1.astype(np.float32) * b1.astype(np.float32)).astype(bfloat16)
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        output_format=args.output_format,
+        instance_name="dual_herd_elemwise",
+    )
+    exit(
+        runner.run_test(
+            mlir_module,
+            inputs=[a0, b0, a1, b1],
+            expected_outputs=[c_add_ref, c_mul_ref],
+        )
+    )

--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -14,6 +14,7 @@
 # the ShimDMAAllocator reuses channels on the same shim tile via packet IDs.
 
 import argparse
+import time
 import numpy as np
 from ml_dtypes import bfloat16
 
@@ -22,12 +23,10 @@ from air.dialects.air import *
 from air.dialects.memref import AllocOp, DeallocOp
 from air.dialects.func import FuncOp
 from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt import XRTBackend
 import air.dialects.linalg.opdsl.lang as linalg_lang
 
-TILE_SIZE = 1024
 HERD_SIZE = 8
-TOTAL_SIZE = TILE_SIZE * HERD_SIZE  # 8192
-
 INOUT_DATATYPE = bfloat16
 
 
@@ -43,143 +42,148 @@ def elemwise_binary(
     O[None] = fun(cast(linalg_lang.U, lhs[None]), cast(linalg_lang.U, rhs[None]))
 
 
-@module_builder
-def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+def build_module(tile_size):
+    total_size = tile_size * HERD_SIZE
 
-    # L3 memref types
-    l3_type = MemRefType.get([TOTAL_SIZE], xrt_dtype)
+    @module_builder
+    def build():
+        xrt_dtype = type_mapper(INOUT_DATATYPE)
 
-    # L1 tile memref types
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1_type = MemRefType.get(
-        shape=[TILE_SIZE],
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+        # L3 memref types
+        l3_type = MemRefType.get([total_size], xrt_dtype)
 
-    # --- Input channels: packet-switched for shim DMA sharing ---
-    channel("A0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-    channel("B0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-    channel("A1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-    channel("B1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+        # L1 tile memref types
+        mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l1_type = MemRefType.get(
+            shape=[tile_size],
+            element_type=xrt_dtype,
+            memory_space=mem_space_l1,
+        )
 
-    # --- Output channels: circuit-switched (default dma_stream) ---
-    Channel("Add_out", size=[HERD_SIZE, 1])
-    Channel("Mul_out", size=[HERD_SIZE, 1])
+        # --- Input channels: packet-switched for shim DMA sharing ---
+        channel("A0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+        channel("B0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+        channel("A1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+        channel("B1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
 
-    @FuncOp.from_py_func(l3_type, l3_type, l3_type, l3_type, l3_type, l3_type)
-    def dual_herd_elemwise(a0, b0, a1, b1, c_add, c_mul):
+        # --- Output channels: circuit-switched (default dma_stream) ---
+        Channel("Add_out", size=[HERD_SIZE, 1])
+        Channel("Mul_out", size=[HERD_SIZE, 1])
 
-        @launch(operands=[a0, b0, a1, b1, c_add, c_mul])
-        def launch_body(a0_, b0_, a1_, b1_, c_add_, c_mul_):
+        @FuncOp.from_py_func(l3_type, l3_type, l3_type, l3_type, l3_type, l3_type)
+        def dual_herd_elemwise(a0, b0, a1, b1, c_add, c_mul):
 
-            # L3 -> L1 puts for all four inputs (packet-switched)
-            for tile_idx in range(HERD_SIZE):
-                offset = tile_idx * TILE_SIZE
-                ChannelPut(
-                    "A0_to_L1",
-                    a0_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
-                ChannelPut(
-                    "B0_to_L1",
-                    b0_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
-                ChannelPut(
-                    "A1_to_L1",
-                    a1_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
-                ChannelPut(
-                    "B1_to_L1",
-                    b1_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
+            @launch(operands=[a0, b0, a1, b1, c_add, c_mul])
+            def launch_body(a0_, b0_, a1_, b1_, c_add_, c_mul_):
 
-            # L1 -> L3 gets for outputs (circuit-switched)
-            for tile_idx in range(HERD_SIZE):
-                offset = tile_idx * TILE_SIZE
-                ChannelGet(
-                    "Add_out",
-                    c_add_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
-                ChannelGet(
-                    "Mul_out",
-                    c_mul_,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                    indices=[tile_idx, 0],
-                )
-
-            @segment(name="seg")
-            def segment_body():
-
-                # --- Herd 0: element-wise add ---
-                @herd(name="add_herd", sizes=[HERD_SIZE, 1])
-                def add_herd_body(tx, ty, sx, sy):
-                    tile_a = AllocOp(l1_type, [], [])
-                    tile_b = AllocOp(l1_type, [], [])
-                    tile_c = AllocOp(l1_type, [], [])
-
-                    ChannelGet("A0_to_L1", tile_a, indices=[tx, 0])
-                    ChannelGet("B0_to_L1", tile_b, indices=[tx, 0])
-
-                    elemwise_binary(
-                        tile_a,
-                        tile_b,
-                        outs=[tile_c],
-                        fun=linalg_lang.BinaryFn.add,
-                        cast=linalg_lang.TypeFn.cast_signed,
+                # L3 -> L1 puts for all four inputs (packet-switched)
+                for tile_idx in range(HERD_SIZE):
+                    offset = tile_idx * tile_size
+                    ChannelPut(
+                        "A0_to_L1",
+                        a0_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
+                    )
+                    ChannelPut(
+                        "B0_to_L1",
+                        b0_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
+                    )
+                    ChannelPut(
+                        "A1_to_L1",
+                        a1_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
+                    )
+                    ChannelPut(
+                        "B1_to_L1",
+                        b1_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
                     )
 
-                    ChannelPut("Add_out", tile_c, indices=[tx, 0])
-
-                    DeallocOp(tile_a)
-                    DeallocOp(tile_b)
-                    DeallocOp(tile_c)
-
-                # --- Herd 1: element-wise mul ---
-                @herd(name="mul_herd", sizes=[HERD_SIZE, 1])
-                def mul_herd_body(tx, ty, sx, sy):
-                    tile_a = AllocOp(l1_type, [], [])
-                    tile_b = AllocOp(l1_type, [], [])
-                    tile_c = AllocOp(l1_type, [], [])
-
-                    ChannelGet("A1_to_L1", tile_a, indices=[tx, 0])
-                    ChannelGet("B1_to_L1", tile_b, indices=[tx, 0])
-
-                    elemwise_binary(
-                        tile_a,
-                        tile_b,
-                        outs=[tile_c],
-                        fun=linalg_lang.BinaryFn.mul,
-                        cast=linalg_lang.TypeFn.cast_signed,
+                # L1 -> L3 gets for outputs (circuit-switched)
+                for tile_idx in range(HERD_SIZE):
+                    offset = tile_idx * tile_size
+                    ChannelGet(
+                        "Add_out",
+                        c_add_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
+                    )
+                    ChannelGet(
+                        "Mul_out",
+                        c_mul_,
+                        offsets=[offset],
+                        sizes=[tile_size],
+                        strides=[1],
+                        indices=[tile_idx, 0],
                     )
 
-                    ChannelPut("Mul_out", tile_c, indices=[tx, 0])
+                @segment(name="seg")
+                def segment_body():
 
-                    DeallocOp(tile_a)
-                    DeallocOp(tile_b)
-                    DeallocOp(tile_c)
+                    # --- Herd 0: element-wise add ---
+                    @herd(name="add_herd", sizes=[HERD_SIZE, 1])
+                    def add_herd_body(tx, ty, sx, sy):
+                        tile_a = AllocOp(l1_type, [], [])
+                        tile_b = AllocOp(l1_type, [], [])
+                        tile_c = AllocOp(l1_type, [], [])
+
+                        ChannelGet("A0_to_L1", tile_a, indices=[tx, 0])
+                        ChannelGet("B0_to_L1", tile_b, indices=[tx, 0])
+
+                        elemwise_binary(
+                            tile_a,
+                            tile_b,
+                            outs=[tile_c],
+                            fun=linalg_lang.BinaryFn.add,
+                            cast=linalg_lang.TypeFn.cast_signed,
+                        )
+
+                        ChannelPut("Add_out", tile_c, indices=[tx, 0])
+
+                        DeallocOp(tile_a)
+                        DeallocOp(tile_b)
+                        DeallocOp(tile_c)
+
+                    # --- Herd 1: element-wise mul ---
+                    @herd(name="mul_herd", sizes=[HERD_SIZE, 1])
+                    def mul_herd_body(tx, ty, sx, sy):
+                        tile_a = AllocOp(l1_type, [], [])
+                        tile_b = AllocOp(l1_type, [], [])
+                        tile_c = AllocOp(l1_type, [], [])
+
+                        ChannelGet("A1_to_L1", tile_a, indices=[tx, 0])
+                        ChannelGet("B1_to_L1", tile_b, indices=[tx, 0])
+
+                        elemwise_binary(
+                            tile_a,
+                            tile_b,
+                            outs=[tile_c],
+                            fun=linalg_lang.BinaryFn.mul,
+                            cast=linalg_lang.TypeFn.cast_signed,
+                        )
+
+                        ChannelPut("Mul_out", tile_c, indices=[tx, 0])
+
+                        DeallocOp(tile_a)
+                        DeallocOp(tile_b)
+                        DeallocOp(tile_c)
+
+    return build()
 
 
 if __name__ == "__main__":
@@ -197,32 +201,117 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: elf)",
     )
+    parser.add_argument(
+        "--tile-size",
+        type=int,
+        default=1024,
+        help="Elements per tile per herd (default: 1024)",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=0,
+        help="Number of warmup iterations before measurement (default: 0)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of measurement iterations (default: 1)",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    tile_size = args.tile_size
+    total_size = tile_size * HERD_SIZE
+
+    mlir_module = build_module(tile_size)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
     # Golden reference computation using small integers (exact in bf16)
     np.random.seed(42)
-    a0 = np.random.randint(-8, 9, size=TOTAL_SIZE).astype(bfloat16)
-    b0 = np.random.randint(-8, 9, size=TOTAL_SIZE).astype(bfloat16)
-    a1 = np.random.randint(-4, 5, size=TOTAL_SIZE).astype(bfloat16)
-    b1 = np.random.randint(-4, 5, size=TOTAL_SIZE).astype(bfloat16)
+    a0 = np.random.randint(-8, 9, size=total_size).astype(bfloat16)
+    b0 = np.random.randint(-8, 9, size=total_size).astype(bfloat16)
+    a1 = np.random.randint(-4, 5, size=total_size).astype(bfloat16)
+    b1 = np.random.randint(-4, 5, size=total_size).astype(bfloat16)
 
     c_add_ref = (a0.astype(np.float32) + b0.astype(np.float32)).astype(bfloat16)
     c_mul_ref = (a1.astype(np.float32) * b1.astype(np.float32)).astype(bfloat16)
 
-    runner = XRTRunner(
-        verbose=args.verbose,
-        output_format=args.output_format,
-        instance_name="dual_herd_elemwise",
-    )
-    exit(
-        runner.run_test(
-            mlir_module,
-            inputs=[a0, b0, a1, b1],
-            expected_outputs=[c_add_ref, c_mul_ref],
+    if args.iterations > 1 or args.warmup > 0:
+        # Profiling mode: compile once, run many times
+        import filelock, tempfile
+
+        backend = XRTBackend(
+            verbose=args.verbose,
+            output_format=args.output_format,
+            instance_name="dual_herd_elemwise",
         )
-    )
+
+        compiled_module = backend.compile(mlir_module)
+
+        with filelock.FileLock(tempfile.gettempdir() + "/npu.lock"):
+            module_function = backend.load(compiled_module)
+
+            c_add_out = np.zeros(total_size, dtype=bfloat16)
+            c_mul_out = np.zeros(total_size, dtype=bfloat16)
+
+            # Warmup
+            for _ in range(args.warmup):
+                module_function(a0, b0, a1, b1, c_add_out, c_mul_out)
+
+            # Measurement
+            times = []
+            for _ in range(args.iterations):
+                t0 = time.perf_counter()
+                module_function(a0, b0, a1, b1, c_add_out, c_mul_out)
+                t1 = time.perf_counter()
+                times.append(t1 - t0)
+
+            # Verify last run
+            results = module_function(a0, b0, a1, b1, c_add_out, c_mul_out)
+            c_add_actual = results[4]
+            c_mul_actual = results[5]
+
+        backend.unload()
+
+        if not np.array_equal(c_add_actual, c_add_ref):
+            print("FAIL: add_herd output mismatch")
+            exit(1)
+        if not np.array_equal(c_mul_actual, c_mul_ref):
+            print("FAIL: mul_herd output mismatch")
+            exit(1)
+
+        # Stats
+        # Data moved: 4 inputs + 2 outputs, each total_size * 2 bytes (bf16)
+        data_bytes = 6 * total_size * 2
+        times_us = [t * 1e6 for t in times]
+        avg_us = np.mean(times_us)
+        min_us = np.min(times_us)
+        max_us = np.max(times_us)
+        avg_gbps = data_bytes / (np.mean(times) * 1e9)
+        peak_gbps = data_bytes / (min(times) * 1e9)
+
+        print(f"PASS!")
+        print(f"Problem size: {total_size} elements x 6 buffers = {data_bytes} bytes")
+        print(f"Iterations:   {args.iterations} (warmup: {args.warmup})")
+        print(f"Avg time:     {avg_us:.1f} us")
+        print(f"Min time:     {min_us:.1f} us")
+        print(f"Max time:     {max_us:.1f} us")
+        print(f"Avg BW:       {avg_gbps:.2f} GB/s")
+        print(f"Peak BW:      {peak_gbps:.2f} GB/s")
+    else:
+        # Single-run correctness mode
+        runner = XRTRunner(
+            verbose=args.verbose,
+            output_format=args.output_format,
+            instance_name="dual_herd_elemwise",
+        )
+        exit(
+            runner.run_test(
+                mlir_module,
+                inputs=[a0, b0, a1, b1],
+                expected_outputs=[c_add_ref, c_mul_ref],
+            )
+        )

--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -1,17 +1,18 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# Dual-herd example with packet-switched shim DMA channels.
+# Dual-herd example demonstrating automatic packet-switched shim DMA sharing.
 #
 # Two 8x1 herds coexist on the same NPU2 device:
 #   - add_herd: element-wise add (C_add = A0 + B0)
 #   - mul_herd: element-wise mul (C_mul = A1 * B1)
 #
-# All four L3-to-L1 input channels use channel_type="dma_packet" so that
-# the shim DMA MM2S ports are time-multiplexed via packet-switched routing.
-# Without packet switching, 4 channels x 8 tiles = 32 circuit-switched flows
-# would exceed the 16 available shim MM2S channels on NPU2. With dma_packet,
-# the ShimDMAAllocator reuses channels on the same shim tile via packet IDs.
+# Data movement is expressed via air.dma_memcpy_nd (no explicit channels).
+# The compiler automatically:
+#   1. Converts DMAs to channels (air-dma-to-channel)
+#   2. Detects that 4 input channels exceed the 2-per-column shim DMA limit
+#   3. Upgrades input channels to channel_type="dma_packet" for packet-switched
+#      time-multiplexing of shim DMA MM2S ports
 
 import argparse
 import time
@@ -20,6 +21,7 @@ from ml_dtypes import bfloat16
 
 from air.ir import *
 from air.dialects.air import *
+from air.dialects import arith
 from air.dialects.memref import AllocOp, DeallocOp
 from air.dialects.func import FuncOp
 from air.backend.xrt_runner import XRTRunner, type_mapper
@@ -60,15 +62,8 @@ def build_module(tile_size):
             memory_space=mem_space_l1,
         )
 
-        # --- Input channels: packet-switched for shim DMA sharing ---
-        channel("A0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-        channel("B0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-        channel("A1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-        channel("B1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
-
-        # --- Output channels: circuit-switched (default dma_stream) ---
-        Channel("Add_out", size=[HERD_SIZE, 1])
-        Channel("Mul_out", size=[HERD_SIZE, 1])
+        # No explicit channel declarations — air-dma-to-channel will infer
+        # them from the dma_memcpy_nd ops inside the herds.
 
         @FuncOp.from_py_func(l3_type, l3_type, l3_type, l3_type, l3_type, l3_type)
         def dual_herd_elemwise(a0, b0, a1, b1, c_add, c_mul):
@@ -76,74 +71,39 @@ def build_module(tile_size):
             @launch(operands=[a0, b0, a1, b1, c_add, c_mul])
             def launch_body(a0_, b0_, a1_, b1_, c_add_, c_mul_):
 
-                # L3 -> L1 puts for all four inputs (packet-switched)
-                for tile_idx in range(HERD_SIZE):
-                    offset = tile_idx * tile_size
-                    ChannelPut(
-                        "A0_to_L1",
-                        a0_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-                    ChannelPut(
-                        "B0_to_L1",
-                        b0_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-                    ChannelPut(
-                        "A1_to_L1",
-                        a1_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-                    ChannelPut(
-                        "B1_to_L1",
-                        b1_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-
-                # L1 -> L3 gets for outputs (circuit-switched)
-                for tile_idx in range(HERD_SIZE):
-                    offset = tile_idx * tile_size
-                    ChannelGet(
-                        "Add_out",
-                        c_add_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-                    ChannelGet(
-                        "Mul_out",
-                        c_mul_,
-                        offsets=[offset],
-                        sizes=[tile_size],
-                        strides=[1],
-                        indices=[tile_idx, 0],
-                    )
-
-                @segment(name="seg")
-                def segment_body():
+                @segment(name="seg", operands=[a0_, b0_, a1_, b1_, c_add_, c_mul_])
+                def segment_body(a0_s, b0_s, a1_s, b1_s, c_add_s, c_mul_s):
 
                     # --- Herd 0: element-wise add ---
-                    @herd(name="add_herd", sizes=[HERD_SIZE, 1])
-                    def add_herd_body(tx, ty, sx, sy):
+                    @herd(
+                        name="add_herd",
+                        sizes=[HERD_SIZE, 1],
+                        operands=[a0_s, b0_s, c_add_s],
+                    )
+                    def add_herd_body(tx, ty, sx, sy, a0_h, b0_h, c_add_h):
                         tile_a = AllocOp(l1_type, [], [])
                         tile_b = AllocOp(l1_type, [], [])
                         tile_c = AllocOp(l1_type, [], [])
 
-                        ChannelGet("A0_to_L1", tile_a, indices=[tx, 0])
-                        ChannelGet("B0_to_L1", tile_b, indices=[tx, 0])
+                        # L3 -> L1 via dma_memcpy_nd
+                        dma_memcpy_nd(
+                            tile_a,
+                            a0_h,
+                            src_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            src_sizes=[tile_size],
+                            src_strides=[1],
+                        )
+                        dma_memcpy_nd(
+                            tile_b,
+                            b0_h,
+                            src_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            src_sizes=[tile_size],
+                            src_strides=[1],
+                        )
 
                         elemwise_binary(
                             tile_a,
@@ -153,21 +113,50 @@ def build_module(tile_size):
                             cast=linalg_lang.TypeFn.cast_signed,
                         )
 
-                        ChannelPut("Add_out", tile_c, indices=[tx, 0])
+                        # L1 -> L3 via dma_memcpy_nd
+                        dma_memcpy_nd(
+                            c_add_h,
+                            tile_c,
+                            dst_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            dst_sizes=[tile_size],
+                            dst_strides=[1],
+                        )
 
                         DeallocOp(tile_a)
                         DeallocOp(tile_b)
                         DeallocOp(tile_c)
 
                     # --- Herd 1: element-wise mul ---
-                    @herd(name="mul_herd", sizes=[HERD_SIZE, 1])
-                    def mul_herd_body(tx, ty, sx, sy):
+                    @herd(
+                        name="mul_herd",
+                        sizes=[HERD_SIZE, 1],
+                        operands=[a1_s, b1_s, c_mul_s],
+                    )
+                    def mul_herd_body(tx, ty, sx, sy, a1_h, b1_h, c_mul_h):
                         tile_a = AllocOp(l1_type, [], [])
                         tile_b = AllocOp(l1_type, [], [])
                         tile_c = AllocOp(l1_type, [], [])
 
-                        ChannelGet("A1_to_L1", tile_a, indices=[tx, 0])
-                        ChannelGet("B1_to_L1", tile_b, indices=[tx, 0])
+                        dma_memcpy_nd(
+                            tile_a,
+                            a1_h,
+                            src_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            src_sizes=[tile_size],
+                            src_strides=[1],
+                        )
+                        dma_memcpy_nd(
+                            tile_b,
+                            b1_h,
+                            src_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            src_sizes=[tile_size],
+                            src_strides=[1],
+                        )
 
                         elemwise_binary(
                             tile_a,
@@ -177,7 +166,15 @@ def build_module(tile_size):
                             cast=linalg_lang.TypeFn.cast_signed,
                         )
 
-                        ChannelPut("Mul_out", tile_c, indices=[tx, 0])
+                        dma_memcpy_nd(
+                            c_mul_h,
+                            tile_c,
+                            dst_offsets=[
+                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
+                            ],
+                            dst_sizes=[tile_size],
+                            dst_strides=[1],
+                        )
 
                         DeallocOp(tile_a)
                         DeallocOp(tile_b)

--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -59,14 +59,10 @@ def build_module():
     )
 
     # --- Input channels: packet-switched for shim DMA sharing ---
-    chan_a0 = Channel("A0_to_L1", size=[HERD_SIZE, 1])
-    chan_a0.attributes["channel_type"] = StringAttr.get("dma_packet")
-    chan_b0 = Channel("B0_to_L1", size=[HERD_SIZE, 1])
-    chan_b0.attributes["channel_type"] = StringAttr.get("dma_packet")
-    chan_a1 = Channel("A1_to_L1", size=[HERD_SIZE, 1])
-    chan_a1.attributes["channel_type"] = StringAttr.get("dma_packet")
-    chan_b1 = Channel("B1_to_L1", size=[HERD_SIZE, 1])
-    chan_b1.attributes["channel_type"] = StringAttr.get("dma_packet")
+    channel("A0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+    channel("B0_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+    channel("A1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
+    channel("B1_to_L1", size=[HERD_SIZE, 1], channel_type="dma_packet")
 
     # --- Output channels: circuit-switched (default dma_stream) ---
     Channel("Add_out", size=[HERD_SIZE, 1])
@@ -199,6 +195,7 @@ if __name__ == "__main__":
         choices=["xclbin", "elf"],
         default="elf",
         dest="output_format",
+        help="Output format for the compiled binary (default: elf)",
     )
     args = parser.parse_args()
 

--- a/programming_examples/channel_examples/dual_herd_packet_switch/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/run_makefile_peano_elf.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -278,6 +278,12 @@ EXAMPLES = [
     },
     {
         "category": "Communication",
+        "name": "Dual-Herd Packet Switch",
+        "path": "channel_examples/dual_herd_packet_switch",
+        "datatypes": "bf16",
+    },
+    {
+        "category": "Communication",
         "name": "Multi-Segment Examples",
         "path": "multi_segment",
         "datatypes": "i32",


### PR DESCRIPTION
## Summary
- Adds a new programming example (`programming_examples/channel_examples/dual_herd_packet_switch/`) demonstrating two 8x1 herds coexisting on NPU2 with packet-switched shim DMA channel sharing.
- **add_herd** (8x1): element-wise add (`C_add = A0 + B0`, bf16); **mul_herd** (8x1): element-wise mul (`C_mul = A1 * B1`, bf16).
- Four L3-to-L1 input channels use `channel_type="dma_packet"` so that 32 L3→L1 flows are time-multiplexed across the 16 available shim MM2S channels via packet IDs. Output channels use standard circuit-switched routing.

## Dependencies
This example requires the following compiler fixes to compile and run correctly:
- #1523 — TileDMAAllocator S2MM restriction
- #1525 — ShimDMAAllocator packet-flow sharing
- #1524 — Packet ID assignment fix

## Test plan
- [x] Verify `python3 dual_herd_packet_switch.py --print-module-only` generates valid MLIR
- [x] Verify compilation succeeds with `aircc` on NPU2 (after dependency PRs are merged)
- [x] Verify hardware execution produces correct results (elemwise add and mul match golden reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)