### PR TITLE
Fix packet_flow_id off-by-one in shim DMA alloc store-back

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3784,7 +3784,7 @@ public:
           shimFlowOpToFlowIdMap.insert(f.air_flow_op);
           auto it = llvm::find(shimFlowOpToFlowIdMap, f.air_flow_op);
           int flowID = std::distance(shimFlowOpToFlowIdMap.begin(), it);
-          getPacketFlowOp(
+          auto pktFlowOp = getPacketFlowOp(
               aie_device, f.MM2S_alloc.getDmaTile(), AIE::WireBundle::DMA,
               (uint32_t)f.MM2S_alloc.dma_channel.channel,
               f.S2MM_alloc[i].getDmaTile(), AIE::WireBundle::DMA,
@@ -3792,12 +3792,15 @@ public:
           // Update global shim flow ID following the local packet assignment.
           globalShimFlowID = std::max(globalShimFlowID, flowID);
           // Store flow ID in matching MM2S shim alloc for labeling phase.
+          // Use the packet flow op's actual ID, not the mutated flowID
+          // (createPacketFlowOp post-increments flowID by reference).
+          int storedFlowID = pktFlowOp ? pktFlowOp.getID() : flowID;
           for (auto &sa : shim_dma_alloc.mm2s_allocs) {
             if (sa.getDmaTile() == f.MM2S_alloc.getDmaTile() &&
                 sa.dma_channel == f.MM2S_alloc.dma_channel &&
                 sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
                 sa.dma_id == f.MM2S_alloc.dma_id) {
-              sa.packet_flow_id = flowID;
+              sa.packet_flow_id = storedFlowID;
               break;
             }
           }
@@ -3808,7 +3811,7 @@ public:
             shimFlowOpToFlowIdMap.insert(f.air_flow_op);
             auto it = llvm::find(shimFlowOpToFlowIdMap, f.air_flow_op);
             int flowID = std::distance(shimFlowOpToFlowIdMap.begin(), it);
-            getPacketFlowOp(
+            auto pktFlowOp = getPacketFlowOp(
                 aie_device, f.MM2S_alloc.getDmaTile(), AIE::WireBundle::DMA,
                 (uint32_t)f.MM2S_alloc.dma_channel.channel,
                 f.S2MM_alloc[i].getDmaTile(), AIE::WireBundle::DMA,
@@ -3816,12 +3819,15 @@ public:
             // Update global shim flow ID following the local packet assignment.
             globalShimFlowID = std::max(globalShimFlowID, flowID);
             // Store flow ID in matching MM2S shim alloc for labeling phase.
+            // Use the packet flow op's actual ID, not the mutated flowID
+            // (createPacketFlowOp post-increments flowID by reference).
+            int storedFlowID = pktFlowOp ? pktFlowOp.getID() : flowID;
             for (auto &sa : shim_dma_alloc.mm2s_allocs) {
               if (sa.getDmaTile() == f.MM2S_alloc.getDmaTile() &&
                   sa.dma_channel == f.MM2S_alloc.dma_channel &&
                   sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
                   sa.dma_id == f.MM2S_alloc.dma_id) {
-                sa.packet_flow_id = flowID;
+                sa.packet_flow_id = storedFlowID;
                 break;
               }
             }


### PR DESCRIPTION
## Summary
- Fix off-by-one error in `packet_flow_id` stored in shim DMA allocations during packet flow creation
- `createPacketFlowOp` post-increments `flowID` by reference (`flowID++` at AIRToAIEPass.cpp:2950), so after `getPacketFlowOp` returns, the caller's `flowID` variable holds `actualID + 1`
- The store-back code used this mutated value, causing every BD's stored packet flow ID to be off by +1
- Fix: capture the returned `PacketFlowOp` and use `pktFlowOp.getID()` for the store-back
- Applied to both the `use_packet_flow_at_shim_dmas` and `dma_packet` code paths

## Details
The bug is latent on current main (masked by the fallback source-only lookup in `labelMemcpyOpsWithPacketFlow`), but becomes a hardware deadlock when combined with #1525 (ShimDMA packet-flow channel reuse). With shared shim DMA channels, the off-by-one causes:
- pkt_id 0 is never assigned to any BD (skipped)
- The last two BDs per shim tile get duplicate packet IDs
- Packet routing mismatches cause hardware timeouts

## Test plan
- [x] Existing `check-air-mlir` tests pass (no regression)
- [x] `shared_shim_channel_packet_ids.mlir` test produces correct pkt_id=0 and pkt_id=1
- [x] Hardware-verified with dual-herd packet-switch example (with #1525) on NPU2