### PR TITLE
Auto-detect packet switching need in air-dma-to-channel

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1595,6 +1595,13 @@ def DmaToChannel : Pass<"air-dma-to-channel", "ModuleOp"> {
     }
     ```
   }];
+  let options = [
+    Option<"clShimDmaChannelsPerCol", "shim-dma-channels-per-col", "int",
+           /*default=*/"2",
+           "Number of physical DMA channels per direction per shim tile "
+           "column. Used by auto-packet-switching detection to determine "
+           "when channel count exceeds physical capacity.">,
+  ];
 }
 
 def AIROverrideMemRefMemorySpace : Pass<"air-override-memref-memory-space", "ModuleOp"> {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5920,6 +5920,7 @@ public:
                                     options);
 
     std::set<AIE::DeviceOp> seen;
+    DenseSet<func::FuncOp> shimUnrolledFuncs;
     for (auto &p : aie_devices) {
       auto device = std::get<0>(p);
       air::HerdOp h = std::get<1>(p);
@@ -6087,7 +6088,10 @@ public:
         // level) so each tile gets a discrete channel put/get. This is needed
         // when air-dma-to-channel wraps channel ops in scf.parallel; without
         // unrolling, all tiles share one channel op and get the same packet ID.
-        {
+        // Guard with shimUnrolledFuncs to avoid redundant rewrites when
+        // multiple devices share the same parent func.
+        if (!shimUnrolledFuncs.contains(func)) {
+          shimUnrolledFuncs.insert(func);
           RewritePatternSet shimUnrollPatterns(ctx);
           air::populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
               shimUnrollPatterns);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6082,6 +6082,18 @@ public:
         // each device processes its own allocations independently. Shim-side
         // ops belonging to other devices are silently skipped (skipUnlinked).
         auto func = h->getParentOfType<func::FuncOp>();
+
+        // Unroll scf.parallel loops around shim-side channel ops (at func
+        // level) so each tile gets a discrete channel put/get. This is needed
+        // when air-dma-to-channel wraps channel ops in scf.parallel; without
+        // unrolling, all tiles share one channel op and get the same packet ID.
+        {
+          RewritePatternSet shimUnrollPatterns(ctx);
+          air::populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
+              shimUnrollPatterns);
+          (void)applyPatternsGreedily(func, std::move(shimUnrollPatterns));
+        }
+
         std::vector<air::MemcpyInterface> shimMemcpyIfOps;
         func.walk([&](air::ChannelInterface o) {
           auto parentLaunch = o->getParentOfType<air::LaunchOp>();

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6091,7 +6091,13 @@ public:
           RewritePatternSet shimUnrollPatterns(ctx);
           air::populateAIRunrollAIRChannelPutGetInScfParallelPatterns(
               shimUnrollPatterns);
-          (void)applyPatternsGreedily(func, std::move(shimUnrollPatterns));
+          if (failed(
+                  applyPatternsGreedily(func, std::move(shimUnrollPatterns)))) {
+            func->emitOpError(
+                "failed to unroll scf.parallel around shim channel ops");
+            signalPassFailure();
+            return;
+          }
         }
 
         std::vector<air::MemcpyInterface> shimMemcpyIfOps;

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1556,28 +1556,16 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
 
     // Auto-detect channels that need packet switching. When a segment has
     // multiple herds, each herd's L3-to-L1 channels share shim DMA resources.
-    // If the total number of L3-bound input (or output) channels across all
-    // herds exceeds the total physical shim DMA channel capacity
-    // (channels-per-col * herd-width), mark those channels as dma_packet to
-    // enable time-multiplexed sharing via packet IDs.
+    // Each logical channel is replicated on every shim column (not distributed
+    // across columns), so the per-column channel pressure equals the total
+    // number of L3-bound channels in a given direction. If this exceeds the
+    // physical shim DMA channel limit per column, mark those channels as
+    // dma_packet to enable time-multiplexed sharing via packet IDs.
     module.walk([&](air::SegmentOp seg) {
       // Collect all herds in this segment.
       SmallVector<air::HerdOp> herds;
       seg.walk([&](air::HerdOp h) { herds.push_back(h); });
       if (herds.size() <= 1)
-        return;
-
-      // Determine the maximum herd width (number of columns) across herds.
-      // This approximates the number of shim tile columns available.
-      int64_t herdWidth = 0;
-      for (auto h : herds) {
-        auto sizes = h.getSizeOperands();
-        if (!sizes.empty()) {
-          if (auto cst = sizes[0].getDefiningOp<arith::ConstantIndexOp>())
-            herdWidth = std::max(herdWidth, (int64_t)cst.value());
-        }
-      }
-      if (herdWidth == 0)
         return;
 
       // Count L3-bound input/output channels per direction. Only channels
@@ -1643,11 +1631,10 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
           outputChannels.push_back(chanOp);
       }
 
-      // Total shim DMA capacity = channels_per_col * number_of_columns.
-      // If the channel count in a direction exceeds this capacity, upgrade
-      // all channels in that direction to dma_packet.
+      // Per-column shim DMA limit. Each channel is replicated on every
+      // column, so the per-column count equals the total channel count.
+      // If it exceeds the physical limit, upgrade to dma_packet.
       int64_t shimChannelsPerCol = clShimDmaChannelsPerCol;
-      int64_t totalCapacity = shimChannelsPerCol * herdWidth;
 
       auto upgradeToPacket = [&](SmallVector<air::ChannelOp> &channels) {
         for (auto chanOp : channels) {
@@ -1655,9 +1642,9 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
         }
       };
 
-      if ((int64_t)inputChannels.size() > totalCapacity)
+      if ((int64_t)inputChannels.size() > shimChannelsPerCol)
         upgradeToPacket(inputChannels);
-      if ((int64_t)outputChannels.size() > totalCapacity)
+      if ((int64_t)outputChannels.size() > shimChannelsPerCol)
         upgradeToPacket(outputChannels);
     });
   }

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1557,9 +1557,9 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
     // Auto-detect channels that need packet switching. When a segment has
     // multiple herds, each herd's L3-to-L1 channels share shim DMA resources.
     // If the total number of L3-bound input (or output) channels across all
-    // herds exceeds the physical shim DMA channel limit (2 per direction per
-    // column), mark excess channels as dma_packet to enable time-multiplexed
-    // sharing via packet IDs.
+    // herds exceeds the total physical shim DMA channel capacity
+    // (channels-per-col * herd-width), mark those channels as dma_packet to
+    // enable time-multiplexed sharing via packet IDs.
     module.walk([&](air::SegmentOp seg) {
       // Collect all herds in this segment.
       SmallVector<air::HerdOp> herds;
@@ -1567,14 +1567,8 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
       if (herds.size() <= 1)
         return;
 
-      // For each direction (L3->L1 = "input", L1->L3 = "output"), count
-      // how many unique channels each column needs. A channel is L3-bound
-      // if it has a put or get at launch level (outside the segment).
-      // Group channels by the herd column they target.
-      //
-      // Simplified heuristic: if the total number of L3-to-L1 input channels
-      // across all herds > 2 * herd_width (where herd_width is the number of
-      // columns), then mark input channels as dma_packet. Same for outputs.
+      // Determine the maximum herd width (number of columns) across herds.
+      // This approximates the number of shim tile columns available.
       int64_t herdWidth = 0;
       for (auto h : herds) {
         auto sizes = h.getSizeOperands();
@@ -1587,8 +1581,8 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
         return;
 
       // Count L3-bound input/output channels per direction.
-      // Input = channel.put at launch level, channel.get inside herd.
-      // Output = channel.get at launch level, channel.put inside herd.
+      // Input = channel.get inside herd (L3->L1 direction).
+      // Output = channel.put inside herd (L1->L3 direction).
       SmallVector<air::ChannelOp> inputChannels, outputChannels;
       for (auto &op : module.getBody()->getOperations()) {
         auto chanOp = dyn_cast<air::ChannelOp>(op);
@@ -1596,15 +1590,19 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
           continue;
         // Check if this channel has a put/get inside one of the herds.
         bool hasHerdSideOp = false;
-        bool isInput = false; // true = L3->L1 (put at launch, get in herd)
+        bool isInput = false;
         auto channelName = chanOp.getSymName();
-        seg.walk([&](air::ChannelInterface ci) {
+        seg.walk([&](air::ChannelInterface ci) -> WalkResult {
+          if (hasHerdSideOp)
+            return WalkResult::interrupt();
           if (ci.getChanName() != channelName)
-            return;
+            return WalkResult::advance();
           if (ci->getParentOfType<air::HerdOp>()) {
             hasHerdSideOp = true;
             isInput = isa<air::ChannelGetOp>(ci.getOperation());
+            return WalkResult::interrupt();
           }
+          return WalkResult::advance();
         });
         if (!hasHerdSideOp)
           continue;
@@ -1614,12 +1612,11 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
           outputChannels.push_back(chanOp);
       }
 
-      // Physical limit: 2 MM2S and 2 S2MM channels per shim tile. After
-      // segment unrolling, each channel bundle index maps to a shim column.
-      // The per-column channel count equals the number of unique channels
-      // targeting herds on that column. If this exceeds the physical limit,
-      // mark all channels in that direction as dma_packet.
-      int64_t shimChannelsPerCol = 2;
+      // Total shim DMA capacity = channels_per_col * number_of_columns.
+      // If the channel count in a direction exceeds this capacity, upgrade
+      // all channels in that direction to dma_packet.
+      int64_t shimChannelsPerCol = clShimDmaChannelsPerCol;
+      int64_t totalCapacity = shimChannelsPerCol * herdWidth;
 
       auto upgradeToPacket = [&](SmallVector<air::ChannelOp> &channels) {
         for (auto chanOp : channels) {
@@ -1627,9 +1624,9 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
         }
       };
 
-      if ((int64_t)inputChannels.size() > shimChannelsPerCol)
+      if ((int64_t)inputChannels.size() > totalCapacity)
         upgradeToPacket(inputChannels);
-      if ((int64_t)outputChannels.size() > shimChannelsPerCol)
+      if ((int64_t)outputChannels.size() > totalCapacity)
         upgradeToPacket(outputChannels);
     });
   }

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1580,35 +1580,66 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
       if (herdWidth == 0)
         return;
 
-      // Count L3-bound input/output channels per direction.
-      // Input = channel.get inside herd (L3->L1 direction).
-      // Output = channel.put inside herd (L1->L3 direction).
+      // Count L3-bound input/output channels per direction. Only channels
+      // that have one endpoint inside a herd AND the other endpoint at launch
+      // level operating on an L3 memref are shim-bound.
+      // Input = channel.get inside herd + channel.put at launch on L3 memref.
+      // Output = channel.put inside herd + channel.get at launch on L3 memref.
       SmallVector<air::ChannelOp> inputChannels, outputChannels;
       for (auto &op : module.getBody()->getOperations()) {
         auto chanOp = dyn_cast<air::ChannelOp>(op);
         if (!chanOp)
           continue;
-        // Check if this channel has a put/get inside one of the herds.
-        bool hasHerdSideOp = false;
-        bool isInput = false;
         auto channelName = chanOp.getSymName();
+
+        // Check herd-side endpoint in this segment.
+        bool hasHerdSideGet = false;
+        bool hasHerdSidePut = false;
         seg.walk([&](air::ChannelInterface ci) -> WalkResult {
-          if (hasHerdSideOp)
+          if (hasHerdSideGet || hasHerdSidePut)
             return WalkResult::interrupt();
           if (ci.getChanName() != channelName)
             return WalkResult::advance();
           if (ci->getParentOfType<air::HerdOp>()) {
-            hasHerdSideOp = true;
-            isInput = isa<air::ChannelGetOp>(ci.getOperation());
+            if (isa<air::ChannelGetOp>(ci.getOperation()))
+              hasHerdSideGet = true;
+            else
+              hasHerdSidePut = true;
             return WalkResult::interrupt();
           }
           return WalkResult::advance();
         });
-        if (!hasHerdSideOp)
+        if (!hasHerdSideGet && !hasHerdSidePut)
           continue;
-        if (isInput)
+
+        // Verify the launch-side endpoint operates on an L3 memref.
+        bool hasLaunchSideL3Put = false;
+        bool hasLaunchSideL3Get = false;
+        module.walk([&](air::ChannelInterface ci) -> WalkResult {
+          if (hasLaunchSideL3Put || hasLaunchSideL3Get)
+            return WalkResult::interrupt();
+          if (ci.getChanName() != channelName)
+            return WalkResult::advance();
+          // Must be at launch level, not inside herd or segment.
+          if (ci->getParentOfType<air::HerdOp>() ||
+              ci->getParentOfType<air::SegmentOp>())
+            return WalkResult::advance();
+          auto memrefTy =
+              dyn_cast_if_present<BaseMemRefType>(ci.getMemref().getType());
+          if (!memrefTy || !air::isL3(memrefTy))
+            return WalkResult::advance();
+          if (isa<air::ChannelPutOp>(ci.getOperation()))
+            hasLaunchSideL3Put = true;
+          else
+            hasLaunchSideL3Get = true;
+          return WalkResult::interrupt();
+        });
+
+        // Input: get in herd + put at launch on L3 (L3->L1).
+        // Output: put in herd + get at launch on L3 (L1->L3).
+        if (hasHerdSideGet && hasLaunchSideL3Put)
           inputChannels.push_back(chanOp);
-        else
+        else if (hasHerdSidePut && hasLaunchSideL3Get)
           outputChannels.push_back(chanOp);
       }
 

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1553,6 +1553,85 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
         op->removeAttr("hoist");
       });
     }
+
+    // Auto-detect channels that need packet switching. When a segment has
+    // multiple herds, each herd's L3-to-L1 channels share shim DMA resources.
+    // If the total number of L3-bound input (or output) channels across all
+    // herds exceeds the physical shim DMA channel limit (2 per direction per
+    // column), mark excess channels as dma_packet to enable time-multiplexed
+    // sharing via packet IDs.
+    module.walk([&](air::SegmentOp seg) {
+      // Collect all herds in this segment.
+      SmallVector<air::HerdOp> herds;
+      seg.walk([&](air::HerdOp h) { herds.push_back(h); });
+      if (herds.size() <= 1)
+        return;
+
+      // For each direction (L3->L1 = "input", L1->L3 = "output"), count
+      // how many unique channels each column needs. A channel is L3-bound
+      // if it has a put or get at launch level (outside the segment).
+      // Group channels by the herd column they target.
+      //
+      // Simplified heuristic: if the total number of L3-to-L1 input channels
+      // across all herds > 2 * herd_width (where herd_width is the number of
+      // columns), then mark input channels as dma_packet. Same for outputs.
+      int64_t herdWidth = 0;
+      for (auto h : herds) {
+        auto sizes = h.getSizeOperands();
+        if (!sizes.empty()) {
+          if (auto cst = sizes[0].getDefiningOp<arith::ConstantIndexOp>())
+            herdWidth = std::max(herdWidth, (int64_t)cst.value());
+        }
+      }
+      if (herdWidth == 0)
+        return;
+
+      // Count L3-bound input/output channels per direction.
+      // Input = channel.put at launch level, channel.get inside herd.
+      // Output = channel.get at launch level, channel.put inside herd.
+      SmallVector<air::ChannelOp> inputChannels, outputChannels;
+      for (auto &op : module.getBody()->getOperations()) {
+        auto chanOp = dyn_cast<air::ChannelOp>(op);
+        if (!chanOp)
+          continue;
+        // Check if this channel has a put/get inside one of the herds.
+        bool hasHerdSideOp = false;
+        bool isInput = false; // true = L3->L1 (put at launch, get in herd)
+        auto channelName = chanOp.getSymName();
+        seg.walk([&](air::ChannelInterface ci) {
+          if (ci.getChanName() != channelName)
+            return;
+          if (ci->getParentOfType<air::HerdOp>()) {
+            hasHerdSideOp = true;
+            isInput = isa<air::ChannelGetOp>(ci.getOperation());
+          }
+        });
+        if (!hasHerdSideOp)
+          continue;
+        if (isInput)
+          inputChannels.push_back(chanOp);
+        else
+          outputChannels.push_back(chanOp);
+      }
+
+      // Physical limit: 2 MM2S and 2 S2MM channels per shim tile. After
+      // segment unrolling, each channel bundle index maps to a shim column.
+      // The per-column channel count equals the number of unique channels
+      // targeting herds on that column. If this exceeds the physical limit,
+      // mark all channels in that direction as dma_packet.
+      int64_t shimChannelsPerCol = 2;
+
+      auto upgradeToPacket = [&](SmallVector<air::ChannelOp> &channels) {
+        for (auto chanOp : channels) {
+          chanOp.setChannelType(StringAttr::get(context, "dma_packet"));
+        }
+      };
+
+      if ((int64_t)inputChannels.size() > shimChannelsPerCol)
+        upgradeToPacket(inputChannels);
+      if ((int64_t)outputChannels.size() > shimChannelsPerCol)
+        upgradeToPacket(outputChannels);
+    });
   }
 
   void updateDependencyOnFunction(func::FuncOp f) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/dma_to_channel_auto_packet.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/dma_to_channel_auto_packet.mlir
@@ -1,0 +1,71 @@
+//===- dma_to_channel_auto_packet.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Test that air-dma-to-channel auto-detects when packet switching is needed
+// for multi-herd designs. When a segment has multiple herds and the total
+// L3-to-L1 input channels exceed 2 per column, the pass should mark them
+// as dma_packet.
+
+// RUN: air-opt %s -air-dma-to-channel | FileCheck %s
+
+// Two herds with 2 inputs each = 4 input channels > 2 per-column limit.
+// CHECK-COUNT-4: air.channel {{.*}} {channel_type = "dma_packet"}
+
+// Two output channels stay as default (2 outputs <= 2 per-column limit).
+// The default channel_type is "dma_stream" which is not printed when it
+// matches the default.
+
+module {
+  func.func @dual_herd(%arg0: memref<1024xbf16>, %arg1: memref<1024xbf16>,
+                        %arg2: memref<1024xbf16>, %arg3: memref<1024xbf16>,
+                        %arg4: memref<1024xbf16>, %arg5: memref<1024xbf16>) {
+    air.launch () in () args(%a0=%arg0, %b0=%arg1, %a1=%arg2, %b1=%arg3,
+                              %co=%arg4, %cm=%arg5)
+        : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
+          memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+      air.segment @seg args(%sa0=%a0, %sb0=%b0, %sa1=%a1, %sb1=%b1,
+                             %sco=%co, %scm=%cm)
+          : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
+            memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+        %c1 = arith.constant 1 : index
+        air.herd @add_herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1)
+            args(%ha=%sa0, %hb=%sb0, %hc=%sco)
+            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_b = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_b : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+        air.herd @mul_herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1)
+            args(%ha=%sa1, %hb=%sb1, %hc=%scm)
+            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_b = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_b : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_auto_packet.mlir
+++ b/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_auto_packet.mlir
@@ -6,23 +6,20 @@
 //===----------------------------------------------------------------------===//
 
 // Test that air-dma-to-channel auto-detects when packet switching is needed
-// for multi-herd designs. When a segment has multiple herds and the total
-// L3-to-L1 input channels exceed 2 per column, the pass should mark them
-// as dma_packet.
+// for multi-herd designs. Two 1x1 herds with 2 inputs each = 4 input channels.
+// Capacity = 2 channels/col * 1 col = 2. Since 4 > 2, input channels are
+// upgraded to dma_packet. Output channels (2 total) do not exceed capacity.
 
 // RUN: air-opt %s -air-dma-to-channel | FileCheck %s
 
-// Two herds with 2 inputs each = 4 input channels > 2 per-column limit.
 // CHECK-COUNT-4: air.channel {{.*}} {channel_type = "dma_packet"}
-
-// Two output channels stay as default (2 outputs <= 2 per-column limit).
-// The default channel_type is "dma_stream" which is not printed when it
-// matches the default.
+// CHECK-NOT: channel_type = "dma_packet"
 
 module {
-  func.func @dual_herd(%arg0: memref<1024xbf16>, %arg1: memref<1024xbf16>,
-                        %arg2: memref<1024xbf16>, %arg3: memref<1024xbf16>,
-                        %arg4: memref<1024xbf16>, %arg5: memref<1024xbf16>) {
+  func.func @dual_herd_overflow(%arg0: memref<1024xbf16>,
+      %arg1: memref<1024xbf16>, %arg2: memref<1024xbf16>,
+      %arg3: memref<1024xbf16>, %arg4: memref<1024xbf16>,
+      %arg5: memref<1024xbf16>) {
     air.launch () in () args(%a0=%arg0, %b0=%arg1, %a1=%arg2, %b1=%arg3,
                               %co=%arg4, %cm=%arg5)
         : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,

--- a/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_auto_packet.mlir
+++ b/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_auto_packet.mlir
@@ -7,8 +7,8 @@
 
 // Test that air-dma-to-channel auto-detects when packet switching is needed
 // for multi-herd designs. Two 1x1 herds with 2 inputs each = 4 input channels.
-// Capacity = 2 channels/col * 1 col = 2. Since 4 > 2, input channels are
-// upgraded to dma_packet. Output channels (2 total) do not exceed capacity.
+// Per-column shim DMA limit = 2. Since 4 > 2, input channels are upgraded to
+// dma_packet. Output channels (2 total) do not exceed the per-column limit.
 
 // RUN: air-opt %s -air-dma-to-channel | FileCheck %s
 

--- a/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_no_auto_packet.mlir
+++ b/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_no_auto_packet.mlir
@@ -58,64 +58,7 @@ module {
 
 // -----
 
-// Test 2: Two 2x1 herds with 2 inputs each = 4 input channels.
-// Capacity = 2 channels/col * 2 cols = 4. 4 <= 4 => no upgrade.
-module {
-  func.func @dual_herd_multi_col(%arg0: memref<1024xbf16>,
-      %arg1: memref<1024xbf16>, %arg2: memref<1024xbf16>,
-      %arg3: memref<1024xbf16>, %arg4: memref<1024xbf16>,
-      %arg5: memref<1024xbf16>) {
-    air.launch () in () args(%a0=%arg0, %b0=%arg1, %a1=%arg2, %b1=%arg3,
-                              %co=%arg4, %cm=%arg5)
-        : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
-          memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
-      air.segment @seg args(%sa0=%a0, %sb0=%b0, %sa1=%a1, %sb1=%b1,
-                             %sco=%co, %scm=%cm)
-          : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
-            memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
-        %c2 = arith.constant 2 : index
-        %c1 = arith.constant 1 : index
-        air.herd @add_herd tile (%tx, %ty) in (%sx=%c2, %sy=%c1)
-            args(%ha=%sa0, %hb=%sb0, %hc=%sco)
-            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
-          %buf_a = memref.alloc() : memref<1024xbf16, 2>
-          %buf_b = memref.alloc() : memref<1024xbf16, 2>
-          %buf_c = memref.alloc() : memref<1024xbf16, 2>
-          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
-              (memref<1024xbf16, 2>, memref<1024xbf16>)
-          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
-              (memref<1024xbf16, 2>, memref<1024xbf16>)
-          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
-              (memref<1024xbf16>, memref<1024xbf16, 2>)
-          memref.dealloc %buf_a : memref<1024xbf16, 2>
-          memref.dealloc %buf_b : memref<1024xbf16, 2>
-          memref.dealloc %buf_c : memref<1024xbf16, 2>
-        }
-        air.herd @mul_herd tile (%tx, %ty) in (%sx=%c2, %sy=%c1)
-            args(%ha=%sa1, %hb=%sb1, %hc=%scm)
-            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
-          %buf_a = memref.alloc() : memref<1024xbf16, 2>
-          %buf_b = memref.alloc() : memref<1024xbf16, 2>
-          %buf_c = memref.alloc() : memref<1024xbf16, 2>
-          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
-              (memref<1024xbf16, 2>, memref<1024xbf16>)
-          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
-              (memref<1024xbf16, 2>, memref<1024xbf16>)
-          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
-              (memref<1024xbf16>, memref<1024xbf16, 2>)
-          memref.dealloc %buf_a : memref<1024xbf16, 2>
-          memref.dealloc %buf_b : memref<1024xbf16, 2>
-          memref.dealloc %buf_c : memref<1024xbf16, 2>
-        }
-      }
-    }
-    return
-  }
-}
-
-// -----
-
-// Test 3: Single-herd segment with 3 inputs. Single herd => early return,
+// Test 2: Single-herd segment with 3 inputs. Single herd => early return,
 // no auto-detection applied regardless of channel count.
 module {
   func.func @single_herd(%arg0: memref<1024xbf16>,

--- a/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_no_auto_packet.mlir
+++ b/mlir/test/Transform/AIRDmaToChannel/dma_to_channel_no_auto_packet.mlir
@@ -1,0 +1,156 @@
+//===- dma_to_channel_no_auto_packet.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Negative tests for auto-packet-switching detection in air-dma-to-channel.
+// In all cases below, no channels should be upgraded to dma_packet.
+
+// RUN: air-opt %s -air-dma-to-channel -split-input-file | FileCheck %s
+
+// None of these cases should produce dma_packet channels.
+// CHECK-NOT: channel_type = "dma_packet"
+
+// Test 1: Two 1x1 herds with 1 input each = 2 input channels.
+// Capacity = 2 channels/col * 1 col = 2. 2 <= 2 => no upgrade.
+module {
+  func.func @dual_herd_at_limit(%arg0: memref<1024xbf16>,
+      %arg1: memref<1024xbf16>,
+      %arg2: memref<1024xbf16>, %arg3: memref<1024xbf16>) {
+    air.launch () in () args(%a0=%arg0, %a1=%arg1, %co=%arg2, %cm=%arg3)
+        : memref<1024xbf16>, memref<1024xbf16>,
+          memref<1024xbf16>, memref<1024xbf16> {
+      air.segment @seg args(%sa0=%a0, %sa1=%a1, %sco=%co, %scm=%cm)
+          : memref<1024xbf16>, memref<1024xbf16>,
+            memref<1024xbf16>, memref<1024xbf16> {
+        %c1 = arith.constant 1 : index
+        air.herd @add_herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1)
+            args(%ha=%sa0, %hc=%sco)
+            : memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+        air.herd @mul_herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1)
+            args(%ha=%sa1, %hc=%scm)
+            : memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Test 2: Two 2x1 herds with 2 inputs each = 4 input channels.
+// Capacity = 2 channels/col * 2 cols = 4. 4 <= 4 => no upgrade.
+module {
+  func.func @dual_herd_multi_col(%arg0: memref<1024xbf16>,
+      %arg1: memref<1024xbf16>, %arg2: memref<1024xbf16>,
+      %arg3: memref<1024xbf16>, %arg4: memref<1024xbf16>,
+      %arg5: memref<1024xbf16>) {
+    air.launch () in () args(%a0=%arg0, %b0=%arg1, %a1=%arg2, %b1=%arg3,
+                              %co=%arg4, %cm=%arg5)
+        : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
+          memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+      air.segment @seg args(%sa0=%a0, %sb0=%b0, %sa1=%a1, %sb1=%b1,
+                             %sco=%co, %scm=%cm)
+          : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16>,
+            memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        air.herd @add_herd tile (%tx, %ty) in (%sx=%c2, %sy=%c1)
+            args(%ha=%sa0, %hb=%sb0, %hc=%sco)
+            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_b = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_b : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+        air.herd @mul_herd tile (%tx, %ty) in (%sx=%c2, %sy=%c1)
+            args(%ha=%sa1, %hb=%sb1, %hc=%scm)
+            : memref<1024xbf16>, memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_b = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_b : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Test 3: Single-herd segment with 3 inputs. Single herd => early return,
+// no auto-detection applied regardless of channel count.
+module {
+  func.func @single_herd(%arg0: memref<1024xbf16>,
+      %arg1: memref<1024xbf16>, %arg2: memref<1024xbf16>,
+      %arg3: memref<1024xbf16>) {
+    air.launch () in () args(%a0=%arg0, %b0=%arg1, %d0=%arg2, %co=%arg3)
+        : memref<1024xbf16>, memref<1024xbf16>,
+          memref<1024xbf16>, memref<1024xbf16> {
+      air.segment @seg args(%sa0=%a0, %sb0=%b0, %sd0=%d0, %sco=%co)
+          : memref<1024xbf16>, memref<1024xbf16>,
+            memref<1024xbf16>, memref<1024xbf16> {
+        %c1 = arith.constant 1 : index
+        air.herd @only_herd tile (%tx, %ty) in (%sx=%c1, %sy=%c1)
+            args(%ha=%sa0, %hb=%sb0, %hd=%sd0, %hc=%sco)
+            : memref<1024xbf16>, memref<1024xbf16>,
+              memref<1024xbf16>, memref<1024xbf16> {
+          %buf_a = memref.alloc() : memref<1024xbf16, 2>
+          %buf_b = memref.alloc() : memref<1024xbf16, 2>
+          %buf_d = memref.alloc() : memref<1024xbf16, 2>
+          %buf_c = memref.alloc() : memref<1024xbf16, 2>
+          air.dma_memcpy_nd (%buf_a[] [] [], %ha[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_b[] [] [], %hb[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%buf_d[] [] [], %hd[] [] []) :
+              (memref<1024xbf16, 2>, memref<1024xbf16>)
+          air.dma_memcpy_nd (%hc[] [] [], %buf_c[] [] []) :
+              (memref<1024xbf16>, memref<1024xbf16, 2>)
+          memref.dealloc %buf_a : memref<1024xbf16, 2>
+          memref.dealloc %buf_b : memref<1024xbf16, 2>
+          memref.dealloc %buf_d : memref<1024xbf16, 2>
+          memref.dealloc %buf_c : memref<1024xbf16, 2>
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- Auto-detect when packet switching is needed for multi-herd designs in the air-dma-to-channel pass
- When a segment has multiple herds and the per-column L3-bound channel count exceeds 2 (the physical shim DMA limit), input channels are auto-upgraded to channel_type=dma_packet
- Also unrolls scf.parallel around shim-side channel ops in air-to-aie so each tile gets a discrete channel put with correct packet ID

## Details
Two changes:
1. **AIRDmaToChannel.cpp**: Post-processing after channel creation counts per-column channel pressure. If input channels exceed 2 per column across herds, they are marked as dma_packet.
2. **AIRToAIEPass.cpp**: Runs scf.parallel unrolling on the parent function scope before shim-side channel op collection. Without this, DMA-generated channel puts stay wrapped in scf.parallel and all tiles get the same packet ID.

## Dependencies
- #1525 (ShimDMA packet-flow channel reuse) must be merged first

## Test plan
- [x] check-air-mlir passes (360 tests, no regressions)
- [x] New LIT test dma_to_channel_auto_packet.mlir verifies 4 input channels get dma_packet
- [x] Hardware-verified on NPU2 with dma_memcpy_nd dual-herd example (PASS)