### PR TITLE
Add symmetric heap runtime for multi-GPU peer access

### DIFF
--- a/runtime_lib/airgpu/CMakeLists.txt
+++ b/runtime_lib/airgpu/CMakeLists.txt
@@ -15,6 +15,8 @@ if(EXISTS "${ROCM_PATH}/include/hip/hip_runtime.h")
     gpu_runtime.cpp
     gpu_test_utils.cpp
     vmem_allocator.cpp
+    symmetric_heap.cpp
+    fd_passing.cpp
   )
 
   set_property(TARGET airgpu PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/runtime_lib/airgpu/Makefile
+++ b/runtime_lib/airgpu/Makefile
@@ -9,7 +9,7 @@ INCLUDES  = -I$(ROCM_PATH)/include -I.
 LDFLAGS   = -shared -L$(ROCM_PATH)/lib -lamdhip64
 
 TARGET    = libairgpu.so
-SOURCES   = gpu_runtime.cpp gpu_test_utils.cpp vmem_allocator.cpp
+SOURCES   = gpu_runtime.cpp gpu_test_utils.cpp vmem_allocator.cpp symmetric_heap.cpp fd_passing.cpp
 OBJECTS   = $(SOURCES:.cpp=.o)
 
 .PHONY: all clean test
@@ -23,7 +23,7 @@ $(TARGET): $(OBJECTS)
 	$(HIPCC) $(CXXFLAGS) $(INCLUDES) -c -o $@ $<
 
 clean:
-	rm -f $(OBJECTS) $(TARGET) test_vmem
+	rm -f $(OBJECTS) $(TARGET) test_vmem test_symmetric_heap
 
 # Quick smoke test: allocate and free via VMem
 test: $(TARGET)
@@ -31,3 +31,12 @@ test: $(TARGET)
 	$(HIPCC) $(CXXFLAGS) $(INCLUDES) -o test_vmem ../../test/gpu/test_vmem.cpp -L. -lairgpu -Wl,-rpath,.
 	./test_vmem
 	@echo "=== PASSED ==="
+
+# Symmetric heap test (multi-process)
+test_symmetric_heap: $(TARGET)
+	$(HIPCC) $(CXXFLAGS) $(INCLUDES) -o test_symmetric_heap ../../test/gpu/test_symmetric_heap.cpp -L. -lairgpu -Wl,-rpath,.
+
+test-symmetric: test_symmetric_heap
+	@echo "=== Symmetric heap test ==="
+	bash ../../test/gpu/run_symmetric_heap_test.sh
+	@echo "=== DONE ==="

--- a/runtime_lib/airgpu/Makefile
+++ b/runtime_lib/airgpu/Makefile
@@ -4,7 +4,7 @@
 ROCM_PATH ?= /opt/rocm
 HIPCC     := $(ROCM_PATH)/bin/hipcc
 
-CXXFLAGS  = -std=c++17 -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
+CXXFLAGS  = -std=c++17 -fPIC -O2 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-return-type-c-linkage
 INCLUDES  = -I$(ROCM_PATH)/include -I.
 LDFLAGS   = -shared -L$(ROCM_PATH)/lib -lamdhip64
 

--- a/runtime_lib/airgpu/fd_passing.cpp
+++ b/runtime_lib/airgpu/fd_passing.cpp
@@ -12,9 +12,13 @@
 #include <unistd.h>
 
 static std::string sockPath(int rank) {
+  const char *job_id = std::getenv("AIRGPU_JOB_ID");
   char buf[108];
-  snprintf(buf, sizeof(buf), "/tmp/airgpu_%d_%d.sock",
-           static_cast<int>(getuid()), rank);
+  if (job_id && job_id[0] != '\0')
+    snprintf(buf, sizeof(buf), "/tmp/airgpu_%s_%d.sock", job_id, rank);
+  else
+    snprintf(buf, sizeof(buf), "/tmp/airgpu_%d_%d.sock",
+             static_cast<int>(getuid()), rank);
   return std::string(buf);
 }
 
@@ -85,7 +89,9 @@ int sendAll(int sock_fd, const void *buf, size_t len) {
   const char *p = static_cast<const char *>(buf);
   while (len > 0) {
     ssize_t n = send(sock_fd, p, len, 0);
-    if (n <= 0) {
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
       perror("airgpu: sendAll");
       return -1;
     }
@@ -99,8 +105,14 @@ int recvAll(int sock_fd, void *buf, size_t len) {
   char *p = static_cast<char *>(buf);
   while (len > 0) {
     ssize_t n = recv(sock_fd, p, len, 0);
-    if (n <= 0) {
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
       perror("airgpu: recvAll");
+      return -1;
+    }
+    if (n == 0) {
+      fprintf(stderr, "airgpu: recvAll: peer disconnected\n");
       return -1;
     }
     p += n;

--- a/runtime_lib/airgpu/fd_passing.cpp
+++ b/runtime_lib/airgpu/fd_passing.cpp
@@ -71,8 +71,7 @@ int recvFd(int sock_fd) {
   }
 
   struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
-  if (cmsg && cmsg->cmsg_level == SOL_SOCKET &&
-      cmsg->cmsg_type == SCM_RIGHTS) {
+  if (cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
     int fd;
     memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
     return fd;
@@ -129,8 +128,8 @@ std::map<int, int> setupFdMesh(int rank, int world_size) {
   addr.sun_family = AF_UNIX;
   strncpy(addr.sun_path, my_path.c_str(), sizeof(addr.sun_path) - 1);
 
-  if (bind(listener, reinterpret_cast<struct sockaddr *>(&addr),
-           sizeof(addr)) < 0) {
+  if (bind(listener, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) <
+      0) {
     perror("airgpu: bind");
     abort();
   }
@@ -164,9 +163,8 @@ std::map<int, int> setupFdMesh(int rank, int world_size) {
       usleep(10000); // 10ms
     }
     if (!connected) {
-      fprintf(stderr,
-              "airgpu: rank %d timed out connecting to rank %d at %s\n", rank,
-              peer, peer_path.c_str());
+      fprintf(stderr, "airgpu: rank %d timed out connecting to rank %d at %s\n",
+              rank, peer, peer_path.c_str());
       abort();
     }
 

--- a/runtime_lib/airgpu/fd_passing.cpp
+++ b/runtime_lib/airgpu/fd_passing.cpp
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "fd_passing.h"
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static std::string sockPath(int rank) {
+  char buf[108];
+  snprintf(buf, sizeof(buf), "/tmp/airgpu_%d_%d.sock",
+           static_cast<int>(getuid()), rank);
+  return std::string(buf);
+}
+
+int sendFd(int sock_fd, int fd_to_send) {
+  char dummy = '\0';
+  struct iovec iov = {};
+  iov.iov_base = &dummy;
+  iov.iov_len = 1;
+
+  union {
+    struct cmsghdr hdr;
+    char buf[CMSG_SPACE(sizeof(int))];
+  } cmsg_buf = {};
+
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.buf;
+  msg.msg_controllen = sizeof(cmsg_buf.buf);
+
+  struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+  memcpy(CMSG_DATA(cmsg), &fd_to_send, sizeof(int));
+
+  if (sendmsg(sock_fd, &msg, 0) < 0) {
+    perror("airgpu: sendFd");
+    return -1;
+  }
+  return 0;
+}
+
+int recvFd(int sock_fd) {
+  char dummy;
+  struct iovec iov = {};
+  iov.iov_base = &dummy;
+  iov.iov_len = 1;
+
+  union {
+    struct cmsghdr hdr;
+    char buf[CMSG_SPACE(sizeof(int))];
+  } cmsg_buf = {};
+
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.buf;
+  msg.msg_controllen = sizeof(cmsg_buf.buf);
+
+  if (recvmsg(sock_fd, &msg, 0) < 0) {
+    perror("airgpu: recvFd");
+    return -1;
+  }
+
+  struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+  if (cmsg && cmsg->cmsg_level == SOL_SOCKET &&
+      cmsg->cmsg_type == SCM_RIGHTS) {
+    int fd;
+    memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
+    return fd;
+  }
+
+  fprintf(stderr, "airgpu: recvFd: no SCM_RIGHTS in message\n");
+  return -1;
+}
+
+int sendAll(int sock_fd, const void *buf, size_t len) {
+  const char *p = static_cast<const char *>(buf);
+  while (len > 0) {
+    ssize_t n = send(sock_fd, p, len, 0);
+    if (n <= 0) {
+      perror("airgpu: sendAll");
+      return -1;
+    }
+    p += n;
+    len -= n;
+  }
+  return 0;
+}
+
+int recvAll(int sock_fd, void *buf, size_t len) {
+  char *p = static_cast<char *>(buf);
+  while (len > 0) {
+    ssize_t n = recv(sock_fd, p, len, 0);
+    if (n <= 0) {
+      perror("airgpu: recvAll");
+      return -1;
+    }
+    p += n;
+    len -= n;
+  }
+  return 0;
+}
+
+std::map<int, int> setupFdMesh(int rank, int world_size) {
+  std::map<int, int> conns;
+  if (world_size <= 1)
+    return conns;
+
+  // Create listener
+  std::string my_path = sockPath(rank);
+  unlink(my_path.c_str());
+
+  int listener = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (listener < 0) {
+    perror("airgpu: socket");
+    abort();
+  }
+
+  struct sockaddr_un addr = {};
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, my_path.c_str(), sizeof(addr.sun_path) - 1);
+
+  if (bind(listener, reinterpret_cast<struct sockaddr *>(&addr),
+           sizeof(addr)) < 0) {
+    perror("airgpu: bind");
+    abort();
+  }
+  if (listen(listener, world_size) < 0) {
+    perror("airgpu: listen");
+    abort();
+  }
+
+  // Connect to all lower ranks
+  for (int peer = 0; peer < rank; peer++) {
+    int s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (s < 0) {
+      perror("airgpu: socket");
+      abort();
+    }
+
+    std::string peer_path = sockPath(peer);
+    struct sockaddr_un peer_addr = {};
+    peer_addr.sun_family = AF_UNIX;
+    strncpy(peer_addr.sun_path, peer_path.c_str(),
+            sizeof(peer_addr.sun_path) - 1);
+
+    // Retry with timeout — peer may not have bound yet
+    int connected = 0;
+    for (int attempt = 0; attempt < 1000; attempt++) {
+      if (connect(s, reinterpret_cast<struct sockaddr *>(&peer_addr),
+                  sizeof(peer_addr)) == 0) {
+        connected = 1;
+        break;
+      }
+      usleep(10000); // 10ms
+    }
+    if (!connected) {
+      fprintf(stderr,
+              "airgpu: rank %d timed out connecting to rank %d at %s\n", rank,
+              peer, peer_path.c_str());
+      abort();
+    }
+
+    // Identify ourselves
+    uint32_t my_rank = static_cast<uint32_t>(rank);
+    sendAll(s, &my_rank, sizeof(my_rank));
+    conns[peer] = s;
+  }
+
+  // Accept connections from higher ranks
+  for (int i = rank + 1; i < world_size; i++) {
+    int client = accept(listener, nullptr, nullptr);
+    if (client < 0) {
+      perror("airgpu: accept");
+      abort();
+    }
+    uint32_t peer_rank = 0;
+    recvAll(client, &peer_rank, sizeof(peer_rank));
+    conns[static_cast<int>(peer_rank)] = client;
+  }
+
+  close(listener);
+  unlink(my_path.c_str());
+
+  fprintf(stderr, "airgpu: rank %d fd mesh established with %zu peers\n", rank,
+          conns.size());
+  return conns;
+}
+
+void teardownFdMesh(std::map<int, int> &mesh) {
+  for (auto &[peer, fd] : mesh)
+    close(fd);
+  mesh.clear();
+}

--- a/runtime_lib/airgpu/fd_passing.h
+++ b/runtime_lib/airgpu/fd_passing.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Unix domain socket mesh for cross-process file descriptor exchange.
+// Uses SCM_RIGHTS ancillary messages to pass DMA-BUF fds between ranks.
+
+#pragma once
+
+#include <map>
+
+// Send one file descriptor over a connected AF_UNIX socket.
+// Returns 0 on success, -1 on error (with perror printed).
+int sendFd(int sock_fd, int fd_to_send);
+
+// Receive one file descriptor from a connected AF_UNIX socket.
+// Returns the received fd (>= 0) on success, -1 on error.
+int recvFd(int sock_fd);
+
+// Send exactly `len` bytes over a socket. Returns 0 on success.
+int sendAll(int sock_fd, const void *buf, size_t len);
+
+// Receive exactly `len` bytes from a socket. Returns 0 on success.
+int recvAll(int sock_fd, void *buf, size_t len);
+
+// Build a full mesh of persistent AF_UNIX connections between all ranks.
+// Socket paths are deterministic: /tmp/airgpu_<uid>_<rank>.sock
+// Lower ranks connect to higher ranks; higher ranks accept.
+// Returns map: peer_rank -> connected socket fd.
+std::map<int, int> setupFdMesh(int rank, int world_size);
+
+// Close all sockets in a mesh returned by setupFdMesh.
+void teardownFdMesh(std::map<int, int> &mesh);

--- a/runtime_lib/airgpu/fd_passing.h
+++ b/runtime_lib/airgpu/fd_passing.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <map>
 
 // Send one file descriptor over a connected AF_UNIX socket.

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -44,8 +44,12 @@ struct StridedMemRefType {
 static VMemAllocator *g_allocator = nullptr;
 static SymmetricHeap *g_symmetric_heap = nullptr;
 
-__attribute__((constructor)) static void airgpu_runtime_init() {
-  g_allocator = new VMemAllocator();
+// Lazy-init the standalone allocator (only when mgpuMemAlloc is called
+// without a symmetric heap).  Avoids pinning device 0 at library load time.
+static VMemAllocator *getDefaultAllocator() {
+  if (!g_allocator)
+    g_allocator = new VMemAllocator();
+  return g_allocator;
 }
 
 __attribute__((destructor)) static void airgpu_runtime_shutdown() {
@@ -147,12 +151,12 @@ extern "C" void mgpuEventRecord(hipEvent_t event, hipStream_t stream) {
 
 extern "C" void *mgpuMemAlloc(uint64_t sizeBytes, hipStream_t /*stream*/,
                               bool /*isHostShared*/) {
-  return g_allocator->allocate(static_cast<size_t>(sizeBytes));
+  return getDefaultAllocator()->allocate(static_cast<size_t>(sizeBytes));
 }
 
 extern "C" void mgpuMemFree(void *ptr, hipStream_t /*stream*/) {
   if (ptr)
-    g_allocator->free(ptr);
+    getDefaultAllocator()->free(ptr);
 }
 
 // ===========================================================================

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <hip/hip_runtime.h>
+#include <mutex>
 
 #define HIP_REPORT_IF_ERROR(expr)                                              \
   {                                                                            \
@@ -46,9 +47,10 @@ static SymmetricHeap *g_symmetric_heap = nullptr;
 
 // Lazy-init the standalone allocator (only when mgpuMemAlloc is called
 // without a symmetric heap).  Avoids pinning device 0 at library load time.
+static std::once_flag g_allocator_flag;
 static VMemAllocator *getDefaultAllocator() {
-  if (!g_allocator)
-    g_allocator = new VMemAllocator();
+  std::call_once(g_allocator_flag,
+                 [] { g_allocator = new VMemAllocator(); });
   return g_allocator;
 }
 

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -10,6 +10,7 @@
 //       --shared-libs=libairgpu.so \
 //       final.mlir
 
+#include "symmetric_heap.h"
 #include "vmem_allocator.h"
 #include <cstdint>
 #include <cstdio>
@@ -41,12 +42,15 @@ struct StridedMemRefType {
 // ---------------------------------------------------------------------------
 
 static VMemAllocator *g_allocator = nullptr;
+static SymmetricHeap *g_symmetric_heap = nullptr;
 
 __attribute__((constructor)) static void airgpu_runtime_init() {
   g_allocator = new VMemAllocator();
 }
 
 __attribute__((destructor)) static void airgpu_runtime_shutdown() {
+  delete g_symmetric_heap;
+  g_symmetric_heap = nullptr;
   delete g_allocator;
   g_allocator = nullptr;
 }
@@ -234,4 +238,68 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   result.sizes[0] = size;
   result.strides[0] = stride;
   return result;
+}
+
+// ===========================================================================
+// Symmetric Heap — multi-GPU memory sharing
+// ===========================================================================
+
+extern "C" void mgpuSymmetricHeapInit(uint64_t heap_size) {
+  if (g_symmetric_heap) {
+    fprintf(stderr, "airgpu: symmetric heap already initialized\n");
+    return;
+  }
+  g_symmetric_heap = new SymmetricHeap(static_cast<size_t>(heap_size));
+}
+
+extern "C" void mgpuSymmetricHeapDestroy() {
+  delete g_symmetric_heap;
+  g_symmetric_heap = nullptr;
+}
+
+extern "C" int32_t mgpuGetRank() {
+  if (!g_symmetric_heap)
+    return 0;
+  return g_symmetric_heap->getRank();
+}
+
+extern "C" int32_t mgpuGetWorldSize() {
+  if (!g_symmetric_heap)
+    return 1;
+  return g_symmetric_heap->getWorldSize();
+}
+
+extern "C" void *mgpuSymmetricAlloc(uint64_t sizeBytes,
+                                    hipStream_t /*stream*/) {
+  if (!g_symmetric_heap) {
+    fprintf(stderr, "airgpu: symmetric heap not initialized\n");
+    abort();
+  }
+  return g_symmetric_heap->allocate(static_cast<size_t>(sizeBytes));
+}
+
+extern "C" void mgpuSymmetricFree(void *ptr, hipStream_t /*stream*/) {
+  if (g_symmetric_heap && ptr)
+    g_symmetric_heap->free(ptr);
+}
+
+extern "C" void *mgpuGetHeapBase(int32_t rank) {
+  if (!g_symmetric_heap)
+    return nullptr;
+  return g_symmetric_heap->getHeapBase(rank);
+}
+
+extern "C" void **mgpuGetHeapBases() {
+  if (!g_symmetric_heap)
+    return nullptr;
+  return g_symmetric_heap->getHeapBases();
+}
+
+extern "C" void mgpuBarrier() {
+  if (g_symmetric_heap)
+    g_symmetric_heap->barrier();
+}
+
+extern "C" void mgpuSetDevice(int32_t device_id) {
+  HIP_REPORT_IF_ERROR(hipSetDevice(device_id));
 }

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -151,17 +151,11 @@ extern "C" void mgpuEventRecord(hipEvent_t event, hipStream_t stream) {
 
 extern "C" void *mgpuMemAlloc(uint64_t sizeBytes, hipStream_t /*stream*/,
                               bool /*isHostShared*/) {
-  if (g_symmetric_heap)
-    return g_symmetric_heap->allocate(static_cast<size_t>(sizeBytes));
   return getDefaultAllocator()->allocate(static_cast<size_t>(sizeBytes));
 }
 
 extern "C" void mgpuMemFree(void *ptr, hipStream_t /*stream*/) {
-  if (!ptr)
-    return;
-  if (g_symmetric_heap)
-    g_symmetric_heap->free(ptr);
-  else
+  if (ptr)
     getDefaultAllocator()->free(ptr);
 }
 

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -151,11 +151,17 @@ extern "C" void mgpuEventRecord(hipEvent_t event, hipStream_t stream) {
 
 extern "C" void *mgpuMemAlloc(uint64_t sizeBytes, hipStream_t /*stream*/,
                               bool /*isHostShared*/) {
+  if (g_symmetric_heap)
+    return g_symmetric_heap->allocate(static_cast<size_t>(sizeBytes));
   return getDefaultAllocator()->allocate(static_cast<size_t>(sizeBytes));
 }
 
 extern "C" void mgpuMemFree(void *ptr, hipStream_t /*stream*/) {
-  if (ptr)
+  if (!ptr)
+    return;
+  if (g_symmetric_heap)
+    g_symmetric_heap->free(ptr);
+  else
     getDefaultAllocator()->free(ptr);
 }
 

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -49,8 +49,7 @@ static SymmetricHeap *g_symmetric_heap = nullptr;
 // without a symmetric heap).  Avoids pinning device 0 at library load time.
 static std::once_flag g_allocator_flag;
 static VMemAllocator *getDefaultAllocator() {
-  std::call_once(g_allocator_flag,
-                 [] { g_allocator = new VMemAllocator(); });
+  std::call_once(g_allocator_flag, [] { g_allocator = new VMemAllocator(); });
   return g_allocator;
 }
 

--- a/runtime_lib/airgpu/symmetric_heap.cpp
+++ b/runtime_lib/airgpu/symmetric_heap.cpp
@@ -72,20 +72,33 @@ SymmetricHeap::SymmetricHeap(size_t heap_size) {
 
 SymmetricHeap::~SymmetricHeap() {
   // Synchronize before cleanup
-  hipDeviceSynchronize();
+  hipError_t sync_err = hipDeviceSynchronize();
+  if (sync_err != hipSuccess)
+    fprintf(stderr, "airgpu: hipDeviceSynchronize failed: %s\n",
+            hipGetErrorString(sync_err));
 
   // Unmap and release all peer imports
   for (auto &[peer, mappings] : peer_mappings_) {
     for (auto &m : mappings) {
-      hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(m.va), m.size);
-      hipMemRelease(m.handle);
+      hipError_t err =
+          hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(m.va), m.size);
+      if (err != hipSuccess)
+        fprintf(stderr, "airgpu: hipMemUnmap(%p) failed: %s\n", m.va,
+                hipGetErrorString(err));
+      err = hipMemRelease(m.handle);
+      if (err != hipSuccess)
+        fprintf(stderr, "airgpu: hipMemRelease failed: %s\n",
+                hipGetErrorString(err));
     }
   }
 
   // Free peer VA reservations
   for (auto &[peer, va] : peer_va_bases_) {
-    hipMemAddressFree(reinterpret_cast<hipDeviceptr_t>(va),
-                      allocator_->getHeapSize());
+    hipError_t err = hipMemAddressFree(reinterpret_cast<hipDeviceptr_t>(va),
+                                       allocator_->getHeapSize());
+    if (err != hipSuccess)
+      fprintf(stderr, "airgpu: hipMemAddressFree(%p) failed: %s\n", va,
+              hipGetErrorString(err));
   }
 
   // Teardown socket mesh

--- a/runtime_lib/airgpu/symmetric_heap.cpp
+++ b/runtime_lib/airgpu/symmetric_heap.cpp
@@ -43,11 +43,12 @@ SymmetricHeap::SymmetricHeap(size_t heap_size) {
   // Set GPU for this rank
   HIP_CHECK(hipSetDevice(device_id_));
 
+  heap_size_ = heap_size;
+
   // Create local VMem allocator and pre-map the full heap.
   // This maps the entire heap as one physical chunk so peers can import it.
   allocator_ = new VMemAllocator(heap_size);
   allocator_->allocate(heap_size);
-  allocator_->resetOffset();
 
   // Initialize heap_bases — local rank gets its own VA base
   heap_bases_.resize(world_size_, nullptr);
@@ -97,12 +98,22 @@ SymmetricHeap::~SymmetricHeap() {
 }
 
 void *SymmetricHeap::allocate(size_t size_bytes) {
-  void *ptr = allocator_->allocate(size_bytes);
-  if (!ptr) {
-    fprintf(stderr, "airgpu: symmetric heap out of memory (requested %zu)\n",
-            size_bytes);
+  // Simple bump allocator within the pre-mapped heap.
+  // No new hipMemCreate/hipMemMap — the full heap is already mapped.
+  size_t granularity = allocator_->getGranularity();
+  size_t aligned = (size_bytes + granularity - 1) & ~(granularity - 1);
+  size_t offset = (alloc_offset_ + granularity - 1) & ~(granularity - 1);
+
+  if (offset + aligned > heap_size_) {
+    fprintf(stderr,
+            "airgpu: symmetric heap out of memory "
+            "(requested %zu, used %zu, total %zu)\n",
+            size_bytes, offset, heap_size_);
     abort();
   }
+
+  void *ptr = static_cast<char *>(allocator_->getVaBase()) + offset;
+  alloc_offset_ = offset + aligned;
   return ptr;
 }
 

--- a/runtime_lib/airgpu/symmetric_heap.cpp
+++ b/runtime_lib/airgpu/symmetric_heap.cpp
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "symmetric_heap.h"
+#include "fd_passing.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t err_ = (expr);                                                  \
+    if (err_ != hipSuccess) {                                                  \
+      fprintf(stderr, "airgpu: %s failed: %s (%d)\n", #expr,                  \
+              hipGetErrorString(err_), static_cast<int>(err_));                \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+static int envInt(const char *name, int fallback) {
+  const char *val = std::getenv(name);
+  if (!val)
+    return fallback;
+  return atoi(val);
+}
+
+SymmetricHeap::SymmetricHeap(size_t heap_size) {
+  // Read rank info from environment
+  rank_ = envInt("RANK", -1);
+  world_size_ = envInt("WORLD_SIZE", -1);
+  device_id_ = envInt("LOCAL_RANK", rank_);
+
+  if (rank_ < 0 || world_size_ < 1) {
+    fprintf(stderr,
+            "airgpu: RANK and WORLD_SIZE environment variables required\n");
+    abort();
+  }
+
+  fprintf(stderr, "airgpu: rank %d/%d initializing symmetric heap (%zu MB)\n",
+          rank_, world_size_, heap_size >> 20);
+
+  // Set GPU for this rank
+  HIP_CHECK(hipSetDevice(device_id_));
+
+  // Create local VMem allocator and pre-map the full heap.
+  // This maps the entire heap as one physical chunk so peers can import it.
+  allocator_ = new VMemAllocator(heap_size);
+  allocator_->allocate(heap_size);
+  allocator_->resetOffset();
+
+  // Initialize heap_bases — local rank gets its own VA base
+  heap_bases_.resize(world_size_, nullptr);
+  heap_bases_[rank_] = allocator_->getVaBase();
+
+  if (world_size_ > 1) {
+    // Set up socket mesh for fd passing
+    fd_mesh_ = setupFdMesh(rank_, world_size_);
+
+    // Establish peer access (exchange fds, import, map)
+    establishPeerAccess();
+  }
+
+  // Print heap bases for debugging
+  for (int r = 0; r < world_size_; r++) {
+    fprintf(stderr, "airgpu: rank %d: heap_bases[%d] = %p\n", rank_, r,
+            heap_bases_[r]);
+  }
+}
+
+SymmetricHeap::~SymmetricHeap() {
+  // Synchronize before cleanup
+  hipDeviceSynchronize();
+
+  // Unmap and release all peer imports
+  for (auto &[peer, mappings] : peer_mappings_) {
+    for (auto &m : mappings) {
+      hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(m.va), m.size);
+      hipMemRelease(m.handle);
+    }
+  }
+
+  // Free peer VA reservations
+  for (auto &[peer, va] : peer_va_bases_) {
+    hipMemAddressFree(reinterpret_cast<hipDeviceptr_t>(va),
+                      allocator_->getHeapSize());
+  }
+
+  // Teardown socket mesh
+  teardownFdMesh(fd_mesh_);
+
+  // Delete local allocator
+  delete allocator_;
+  allocator_ = nullptr;
+
+  fprintf(stderr, "airgpu: rank %d symmetric heap destroyed\n", rank_);
+}
+
+void *SymmetricHeap::allocate(size_t size_bytes) {
+  void *ptr = allocator_->allocate(size_bytes);
+  if (!ptr) {
+    fprintf(stderr, "airgpu: symmetric heap out of memory (requested %zu)\n",
+            size_bytes);
+    abort();
+  }
+  return ptr;
+}
+
+void SymmetricHeap::free(void *ptr) { allocator_->free(ptr); }
+
+void *SymmetricHeap::getHeapBase(int rank) const {
+  if (rank < 0 || rank >= world_size_)
+    return nullptr;
+  return heap_bases_[rank];
+}
+
+void **SymmetricHeap::getHeapBases() { return heap_bases_.data(); }
+
+void SymmetricHeap::barrier() {
+  if (world_size_ <= 1)
+    return;
+
+  // Simple O(N) barrier over socket mesh.
+  // Protocol: for each pair, the lower rank sends first and the higher rank
+  // receives first. This avoids deadlock.
+  char token = 0;
+  for (auto &[peer, sock] : fd_mesh_) {
+    if (rank_ < peer) {
+      sendAll(sock, &token, 1);
+      recvAll(sock, &token, 1);
+    } else {
+      recvAll(sock, &token, 1);
+      sendAll(sock, &token, 1);
+    }
+  }
+}
+
+void SymmetricHeap::establishPeerAccess() {
+  // Step 1: Exchange base addresses via sockets
+  // Higher rank sends first to avoid deadlock
+  uintptr_t my_base = reinterpret_cast<uintptr_t>(allocator_->getVaBase());
+
+  for (auto &[peer, sock] : fd_mesh_) {
+    uintptr_t peer_base = 0;
+    if (peer < rank_) {
+      // Send first, then recv
+      sendAll(sock, &my_base, sizeof(my_base));
+      recvAll(sock, &peer_base, sizeof(peer_base));
+    } else {
+      // Recv first, then send
+      recvAll(sock, &peer_base, sizeof(peer_base));
+      sendAll(sock, &my_base, sizeof(my_base));
+    }
+    // Store the peer's original base for reference (not the mapped VA yet)
+    (void)peer_base;
+  }
+
+  barrier();
+
+  // Step 2: Export local allocation handles and exchange with peers
+  const auto &records = allocator_->getAllocRecords();
+  size_t heap_size = allocator_->getHeapSize();
+  size_t granularity = allocator_->getGranularity();
+
+  // Build local access descriptor for this device
+  hipMemAccessDesc access_desc = {};
+  access_desc.location.type = hipMemLocationTypeDevice;
+  access_desc.location.id = device_id_;
+  access_desc.flags = hipMemAccessFlagsProtReadWrite;
+
+  for (auto &[peer, sock] : fd_mesh_) {
+    // Reserve a SEPARATE VA range for this peer's heap
+    // (critical for gfx950 — imported handles can't share VA with local ones)
+    hipDeviceptr_t peer_va = 0;
+    HIP_CHECK(
+        hipMemAddressReserve(&peer_va, heap_size, granularity, 0, 0));
+    peer_va_bases_[peer] = reinterpret_cast<void *>(peer_va);
+
+    // Exchange allocation count
+    uint32_t my_count = static_cast<uint32_t>(records.size());
+    uint32_t peer_count = 0;
+
+    if (peer < rank_) {
+      sendAll(sock, &my_count, sizeof(my_count));
+      recvAll(sock, &peer_count, sizeof(peer_count));
+    } else {
+      recvAll(sock, &peer_count, sizeof(peer_count));
+      sendAll(sock, &my_count, sizeof(my_count));
+    }
+
+    // Exchange each allocation's metadata and fd
+    // Send: (offset, size, fd) for each local record
+    // Recv: (offset, size, fd) for each peer record
+    for (uint32_t i = 0; i < std::max(my_count, peer_count); i++) {
+      if (peer < rank_) {
+        // Send local record, then recv peer record
+        if (i < my_count) {
+          uint64_t offset = reinterpret_cast<uintptr_t>(records[i].va_ptr) -
+                            reinterpret_cast<uintptr_t>(allocator_->getVaBase());
+          uint64_t size = records[i].size;
+          sendAll(sock, &offset, sizeof(offset));
+          sendAll(sock, &size, sizeof(size));
+
+          int fd = -1;
+          HIP_CHECK(hipMemExportToShareableHandle(
+              &fd, records[i].handle,
+              hipMemHandleTypePosixFileDescriptor, 0));
+          sendFd(sock, fd);
+          close(fd);
+        }
+        if (i < peer_count) {
+          uint64_t offset = 0, size = 0;
+          recvAll(sock, &offset, sizeof(offset));
+          recvAll(sock, &size, sizeof(size));
+          int peer_fd = recvFd(sock);
+
+          // Import the peer's handle
+          hipMemGenericAllocationHandle_t imported = {};
+          HIP_CHECK(hipMemImportFromShareableHandle(
+              &imported, reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
+              hipMemHandleTypePosixFileDescriptor));
+          close(peer_fd);
+
+          // Map into the peer's VA reservation
+          hipDeviceptr_t target = static_cast<hipDeviceptr_t>(
+              static_cast<char *>(peer_va) + offset);
+          HIP_CHECK(hipMemMap(target, size, 0, imported, 0));
+          HIP_CHECK(hipMemSetAccess(target, size, &access_desc, 1));
+
+          peer_mappings_[peer].push_back(
+              {imported, reinterpret_cast<void *>(target), size});
+        }
+      } else {
+        // Recv peer record first, then send local
+        if (i < peer_count) {
+          uint64_t offset = 0, size = 0;
+          recvAll(sock, &offset, sizeof(offset));
+          recvAll(sock, &size, sizeof(size));
+          int peer_fd = recvFd(sock);
+
+          hipMemGenericAllocationHandle_t imported = {};
+          HIP_CHECK(hipMemImportFromShareableHandle(
+              &imported, reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
+              hipMemHandleTypePosixFileDescriptor));
+          close(peer_fd);
+
+          hipDeviceptr_t target = static_cast<hipDeviceptr_t>(
+              static_cast<char *>(peer_va) + offset);
+          HIP_CHECK(hipMemMap(target, size, 0, imported, 0));
+          HIP_CHECK(hipMemSetAccess(target, size, &access_desc, 1));
+
+          peer_mappings_[peer].push_back(
+              {imported, reinterpret_cast<void *>(target), size});
+        }
+        if (i < my_count) {
+          uint64_t offset = reinterpret_cast<uintptr_t>(records[i].va_ptr) -
+                            reinterpret_cast<uintptr_t>(allocator_->getVaBase());
+          uint64_t size = records[i].size;
+          sendAll(sock, &offset, sizeof(offset));
+          sendAll(sock, &size, sizeof(size));
+
+          int fd = -1;
+          HIP_CHECK(hipMemExportToShareableHandle(
+              &fd, records[i].handle,
+              hipMemHandleTypePosixFileDescriptor, 0));
+          sendFd(sock, fd);
+          close(fd);
+        }
+      }
+    }
+
+    heap_bases_[peer] = reinterpret_cast<void *>(peer_va);
+  }
+
+  barrier();
+  fprintf(stderr, "airgpu: rank %d peer access established\n", rank_);
+}

--- a/runtime_lib/airgpu/symmetric_heap.cpp
+++ b/runtime_lib/airgpu/symmetric_heap.cpp
@@ -12,7 +12,7 @@
   do {                                                                         \
     hipError_t err_ = (expr);                                                  \
     if (err_ != hipSuccess) {                                                  \
-      fprintf(stderr, "airgpu: %s failed: %s (%d)\n", #expr,                  \
+      fprintf(stderr, "airgpu: %s failed: %s (%d)\n", #expr,                   \
               hipGetErrorString(err_), static_cast<int>(err_));                \
       abort();                                                                 \
     }                                                                          \
@@ -183,8 +183,7 @@ void SymmetricHeap::establishPeerAccess() {
     // Reserve a SEPARATE VA range for this peer's heap
     // (critical for gfx950 — imported handles can't share VA with local ones)
     hipDeviceptr_t peer_va = 0;
-    HIP_CHECK(
-        hipMemAddressReserve(&peer_va, heap_size, granularity, 0, 0));
+    HIP_CHECK(hipMemAddressReserve(&peer_va, heap_size, granularity, 0, 0));
     peer_va_bases_[peer] = reinterpret_cast<void *>(peer_va);
 
     // Exchange allocation count
@@ -206,16 +205,16 @@ void SymmetricHeap::establishPeerAccess() {
       if (peer < rank_) {
         // Send local record, then recv peer record
         if (i < my_count) {
-          uint64_t offset = reinterpret_cast<uintptr_t>(records[i].va_ptr) -
-                            reinterpret_cast<uintptr_t>(allocator_->getVaBase());
+          uint64_t offset =
+              reinterpret_cast<uintptr_t>(records[i].va_ptr) -
+              reinterpret_cast<uintptr_t>(allocator_->getVaBase());
           uint64_t size = records[i].size;
           sendAll(sock, &offset, sizeof(offset));
           sendAll(sock, &size, sizeof(size));
 
           int fd = -1;
           HIP_CHECK(hipMemExportToShareableHandle(
-              &fd, records[i].handle,
-              hipMemHandleTypePosixFileDescriptor, 0));
+              &fd, records[i].handle, hipMemHandleTypePosixFileDescriptor, 0));
           sendFd(sock, fd);
           close(fd);
         }
@@ -228,7 +227,8 @@ void SymmetricHeap::establishPeerAccess() {
           // Import the peer's handle
           hipMemGenericAllocationHandle_t imported = {};
           HIP_CHECK(hipMemImportFromShareableHandle(
-              &imported, reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
+              &imported,
+              reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
               hipMemHandleTypePosixFileDescriptor));
           close(peer_fd);
 
@@ -251,7 +251,8 @@ void SymmetricHeap::establishPeerAccess() {
 
           hipMemGenericAllocationHandle_t imported = {};
           HIP_CHECK(hipMemImportFromShareableHandle(
-              &imported, reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
+              &imported,
+              reinterpret_cast<void *>(static_cast<intptr_t>(peer_fd)),
               hipMemHandleTypePosixFileDescriptor));
           close(peer_fd);
 
@@ -264,16 +265,16 @@ void SymmetricHeap::establishPeerAccess() {
               {imported, reinterpret_cast<void *>(target), size});
         }
         if (i < my_count) {
-          uint64_t offset = reinterpret_cast<uintptr_t>(records[i].va_ptr) -
-                            reinterpret_cast<uintptr_t>(allocator_->getVaBase());
+          uint64_t offset =
+              reinterpret_cast<uintptr_t>(records[i].va_ptr) -
+              reinterpret_cast<uintptr_t>(allocator_->getVaBase());
           uint64_t size = records[i].size;
           sendAll(sock, &offset, sizeof(offset));
           sendAll(sock, &size, sizeof(size));
 
           int fd = -1;
           HIP_CHECK(hipMemExportToShareableHandle(
-              &fd, records[i].handle,
-              hipMemHandleTypePosixFileDescriptor, 0));
+              &fd, records[i].handle, hipMemHandleTypePosixFileDescriptor, 0));
           sendFd(sock, fd);
           close(fd);
         }

--- a/runtime_lib/airgpu/symmetric_heap.cpp
+++ b/runtime_lib/airgpu/symmetric_heap.cpp
@@ -3,6 +3,7 @@
 
 #include "symmetric_heap.h"
 #include "fd_passing.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -117,7 +118,10 @@ void *SymmetricHeap::allocate(size_t size_bytes) {
   return ptr;
 }
 
-void SymmetricHeap::free(void *ptr) { allocator_->free(ptr); }
+void SymmetricHeap::free(void * /*ptr*/) {
+  // Bump allocator — individual frees are a no-op.
+  // The full heap is released when SymmetricHeap is destroyed.
+}
 
 void *SymmetricHeap::getHeapBase(int rank) const {
   if (rank < 0 || rank >= world_size_)
@@ -137,11 +141,17 @@ void SymmetricHeap::barrier() {
   char token = 0;
   for (auto &[peer, sock] : fd_mesh_) {
     if (rank_ < peer) {
-      sendAll(sock, &token, 1);
-      recvAll(sock, &token, 1);
+      if (sendAll(sock, &token, 1) < 0 || recvAll(sock, &token, 1) < 0) {
+        fprintf(stderr, "airgpu: barrier failed (rank=%d, peer=%d)\n", rank_,
+                peer);
+        abort();
+      }
     } else {
-      recvAll(sock, &token, 1);
-      sendAll(sock, &token, 1);
+      if (recvAll(sock, &token, 1) < 0 || sendAll(sock, &token, 1) < 0) {
+        fprintf(stderr, "airgpu: barrier failed (rank=%d, peer=%d)\n", rank_,
+                peer);
+        abort();
+      }
     }
   }
 }

--- a/runtime_lib/airgpu/symmetric_heap.h
+++ b/runtime_lib/airgpu/symmetric_heap.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Symmetric heap for multi-process multi-GPU memory sharing.
+// All peer access is established at init time.
+
+#pragma once
+
+#include "vmem_allocator.h"
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+// Tracks one imported peer mapping (for cleanup).
+struct PeerMapping {
+  hipMemGenericAllocationHandle_t handle;
+  void *va;
+  size_t size;
+};
+
+class SymmetricHeap {
+public:
+  // Collective constructor — all ranks must call with the same heap_size.
+  // Reads RANK, WORLD_SIZE, LOCAL_RANK from environment.
+  explicit SymmetricHeap(size_t heap_size);
+  ~SymmetricHeap();
+
+  // Allocate on the local symmetric heap.
+  void *allocate(size_t size_bytes);
+
+  // Free a symmetric heap allocation.
+  void free(void *ptr);
+
+  // Get the base VA for a specific rank's heap (as visible from this process).
+  void *getHeapBase(int rank) const;
+
+  // Get array of all heap bases (length = world_size).
+  void **getHeapBases();
+
+  int getRank() const { return rank_; }
+  int getWorldSize() const { return world_size_; }
+  int getDeviceId() const { return device_id_; }
+
+  // Host-side barrier: all ranks synchronize via socket mesh.
+  void barrier();
+
+  SymmetricHeap(const SymmetricHeap &) = delete;
+  SymmetricHeap &operator=(const SymmetricHeap &) = delete;
+
+private:
+  int rank_;
+  int world_size_;
+  int device_id_;
+
+  VMemAllocator *allocator_;
+
+  // Socket mesh for fd passing (peer_rank -> socket fd)
+  std::map<int, int> fd_mesh_;
+
+  // heap_bases_[r] = VA base of rank r's heap as visible from THIS process
+  std::vector<void *> heap_bases_;
+
+  // Per-peer: imported mappings for cleanup
+  std::map<int, std::vector<PeerMapping>> peer_mappings_;
+
+  // Per-peer: separate VA reservation base
+  std::map<int, void *> peer_va_bases_;
+
+  // Set up peer access for all ranks.
+  void establishPeerAccess();
+};

--- a/runtime_lib/airgpu/symmetric_heap.h
+++ b/runtime_lib/airgpu/symmetric_heap.h
@@ -54,6 +54,8 @@ private:
   int device_id_;
 
   VMemAllocator *allocator_;
+  size_t heap_size_;
+  size_t alloc_offset_ = 0; // bump pointer within pre-mapped heap
 
   // Socket mesh for fd passing (peer_rank -> socket fd)
   std::map<int, int> fd_mesh_;

--- a/runtime_lib/airgpu/vmem_allocator.cpp
+++ b/runtime_lib/airgpu/vmem_allocator.cpp
@@ -37,6 +37,7 @@ VMemAllocator::VMemAllocator(size_t heap_size) {
   prop.type = hipMemAllocationTypePinned;
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device_id_;
+  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
 
   size_t gran = 0;
   HIP_CHECK(hipMemGetAllocationGranularity(&gran, &prop,
@@ -51,7 +52,7 @@ VMemAllocator::VMemAllocator(size_t heap_size) {
   HIP_CHECK(hipMemAddressReserve(&va, heap_size_, granularity_, 0, 0));
   va_base_ = reinterpret_cast<void *>(va);
 
-  // Build access descriptors for ALL GPUs (future-ready for symmetric heap)
+  // Build access descriptors for ALL GPUs (enables cross-GPU access via XGMI)
   access_descs_.resize(num_devices_);
   for (int i = 0; i < num_devices_; i++) {
     access_descs_[i].location.type = hipMemLocationTypeDevice;
@@ -117,6 +118,7 @@ void *VMemAllocator::allocate(size_t size_bytes) {
   prop.type = hipMemAllocationTypePinned;
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device_id_;
+  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
 
   hipMemGenericAllocationHandle_t handle;
   HIP_CHECK(hipMemCreate(&handle, aligned_size, &prop, 0));

--- a/runtime_lib/airgpu/vmem_allocator.cpp
+++ b/runtime_lib/airgpu/vmem_allocator.cpp
@@ -148,7 +148,14 @@ void VMemAllocator::free(void *ptr) {
     return;
   }
 
-  hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(it->va_ptr), it->size);
-  hipMemRelease(it->handle);
+  hipError_t e1 =
+      hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(it->va_ptr), it->size);
+  if (e1 != hipSuccess)
+    fprintf(stderr, "airgpu: hipMemUnmap(%p) failed: %s\n", it->va_ptr,
+            hipGetErrorString(e1));
+  hipError_t e2 = hipMemRelease(it->handle);
+  if (e2 != hipSuccess)
+    fprintf(stderr, "airgpu: hipMemRelease failed: %s\n",
+            hipGetErrorString(e2));
   alloc_records_.erase(it);
 }

--- a/runtime_lib/airgpu/vmem_allocator.h
+++ b/runtime_lib/airgpu/vmem_allocator.h
@@ -45,9 +45,6 @@ public:
     return alloc_records_;
   }
 
-  // Reset the bump pointer to 0 (used after pre-mapping the full heap).
-  void resetOffset() { current_offset_ = 0; }
-
   VMemAllocator(const VMemAllocator &) = delete;
   VMemAllocator &operator=(const VMemAllocator &) = delete;
 

--- a/runtime_lib/airgpu/vmem_allocator.h
+++ b/runtime_lib/airgpu/vmem_allocator.h
@@ -40,6 +40,14 @@ public:
   int getDeviceId() const { return device_id_; }
   int getNumDevices() const { return num_devices_; }
 
+  // Get all allocation records (for symmetric heap export).
+  const std::vector<AllocRecord> &getAllocRecords() const {
+    return alloc_records_;
+  }
+
+  // Reset the bump pointer to 0 (used after pre-mapping the full heap).
+  void resetOffset() { current_offset_ = 0; }
+
   VMemAllocator(const VMemAllocator &) = delete;
   VMemAllocator &operator=(const VMemAllocator &) = delete;
 

--- a/test/gpu/run_symmetric_heap_test.sh
+++ b/test/gpu/run_symmetric_heap_test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Launch symmetric heap test with N ranks (default 2).
+# Each rank gets its own GPU via LOCAL_RANK.
+#
+# Usage: bash run_symmetric_heap_test.sh [num_ranks]
+
+set -e
+
+NUM_RANKS=${1:-2}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_BIN="${SCRIPT_DIR}/../../runtime_lib/airgpu/test_symmetric_heap"
+
+if [ ! -f "$TEST_BIN" ]; then
+  echo "Error: test binary not found at $TEST_BIN"
+  echo "Build it first: cd runtime_lib/airgpu && make test_symmetric_heap"
+  exit 1
+fi
+
+echo "=== Symmetric heap test: ${NUM_RANKS} ranks ==="
+
+PIDS=()
+PASS=1
+
+for i in $(seq 0 $((NUM_RANKS - 1))); do
+  RANK=$i WORLD_SIZE=$NUM_RANKS LOCAL_RANK=$i \
+    "$TEST_BIN" 2>&1 | sed "s/^/[rank $i] /" &
+  PIDS+=($!)
+done
+
+for pid in "${PIDS[@]}"; do
+  if ! wait "$pid"; then
+    PASS=0
+  fi
+done
+
+if [ $PASS -eq 1 ]; then
+  echo "=== ALL ${NUM_RANKS} RANKS PASSED ==="
+else
+  echo "=== SOME RANKS FAILED ==="
+  exit 1
+fi

--- a/test/gpu/run_symmetric_heap_test.sh
+++ b/test/gpu/run_symmetric_heap_test.sh
@@ -6,6 +6,7 @@
 
 set -e
 
+export AIRGPU_JOB_ID="${AIRGPU_JOB_ID:-$$}"
 NUM_RANKS=${1:-2}
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEST_BIN="${SCRIPT_DIR}/../../runtime_lib/airgpu/test_symmetric_heap"
@@ -26,8 +27,8 @@ PIDS=()
 PASS=1
 
 for i in $(seq 0 $((NUM_RANKS - 1))); do
-  RANK=$i WORLD_SIZE=$NUM_RANKS LOCAL_RANK=$i \
-    "$TEST_BIN" 2>&1 | sed "s/^/[rank $i] /" &
+  (set -o pipefail; RANK=$i WORLD_SIZE=$NUM_RANKS LOCAL_RANK=$i \
+    "$TEST_BIN" 2>&1 | sed "s/^/[rank $i] /") &
   PIDS+=($!)
 done
 

--- a/test/gpu/run_symmetric_heap_test.sh
+++ b/test/gpu/run_symmetric_heap_test.sh
@@ -10,11 +10,15 @@ NUM_RANKS=${1:-2}
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEST_BIN="${SCRIPT_DIR}/../../runtime_lib/airgpu/test_symmetric_heap"
 
+LIB_DIR="${SCRIPT_DIR}/../../runtime_lib/airgpu"
+
 if [ ! -f "$TEST_BIN" ]; then
   echo "Error: test binary not found at $TEST_BIN"
   echo "Build it first: cd runtime_lib/airgpu && make test_symmetric_heap"
   exit 1
 fi
+
+export LD_LIBRARY_PATH="${LIB_DIR}:${LD_LIBRARY_PATH}"
 
 echo "=== Symmetric heap test: ${NUM_RANKS} ranks ==="
 

--- a/test/gpu/test_symmetric_heap.cpp
+++ b/test/gpu/test_symmetric_heap.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <vector>
 #include <hip/hip_runtime.h>
 
 // Forward-declare the mgpu* C ABI

--- a/test/gpu/test_symmetric_heap.cpp
+++ b/test/gpu/test_symmetric_heap.cpp
@@ -9,8 +9,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <vector>
 #include <hip/hip_runtime.h>
+#include <vector>
 
 // Forward-declare the mgpu* C ABI
 extern "C" {

--- a/test/gpu/test_symmetric_heap.cpp
+++ b/test/gpu/test_symmetric_heap.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Multi-process test for the symmetric heap runtime.
+// Launch with run_symmetric_heap_test.sh or set RANK/WORLD_SIZE/LOCAL_RANK
+// and run directly.
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <hip/hip_runtime.h>
+
+// Forward-declare the mgpu* C ABI
+extern "C" {
+void mgpuSymmetricHeapInit(uint64_t heap_size);
+void mgpuSymmetricHeapDestroy();
+int32_t mgpuGetRank();
+int32_t mgpuGetWorldSize();
+void *mgpuSymmetricAlloc(uint64_t sizeBytes, hipStream_t stream);
+void mgpuSymmetricFree(void *ptr, hipStream_t stream);
+void *mgpuGetHeapBase(int32_t rank);
+void **mgpuGetHeapBases();
+void mgpuBarrier();
+void mgpuSetDevice(int32_t device_id);
+}
+
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t err = (expr);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error: %s (%d) at %s:%d\n",                        \
+              hipGetErrorString(err), err, __FILE__, __LINE__);                \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  // Line-buffer stdout so output appears immediately when piped through sed
+  setvbuf(stdout, nullptr, _IOLBF, 0);
+  setvbuf(stderr, nullptr, _IOLBF, 0);
+
+  // ---- Test 1: Init ----
+  printf("[test] Initializing symmetric heap (256 MB)...\n");
+  mgpuSymmetricHeapInit(256ULL << 20);
+
+  int rank = mgpuGetRank();
+  int world_size = mgpuGetWorldSize();
+  printf("[test] rank=%d world_size=%d\n", rank, world_size);
+  assert(rank >= 0 && rank < world_size);
+
+  // ---- Test 2: Allocate ----
+  size_t N = 1024;
+  float *buf =
+      static_cast<float *>(mgpuSymmetricAlloc(N * sizeof(float), nullptr));
+  assert(buf != nullptr);
+  printf("[test] rank %d: allocated %zu floats at %p\n", rank, N, buf);
+
+  // ---- Test 3: Heap bases ----
+  void **bases = mgpuGetHeapBases();
+  assert(bases != nullptr);
+  for (int r = 0; r < world_size; r++) {
+    printf("[test] rank %d: heap_bases[%d] = %p\n", rank, r, bases[r]);
+    assert(bases[r] != nullptr);
+  }
+
+  // ---- Test 4: Write local pattern and barrier ----
+  // Each rank writes its rank value to every element
+  float rank_f = static_cast<float>(rank + 1); // +1 to avoid 0.0
+  HIP_CHECK(hipMemset(buf, 0, N * sizeof(float)));
+  // Use a simple kernel-free approach: write from host
+  std::vector<float> host_buf(N, rank_f);
+  HIP_CHECK(
+      hipMemcpy(buf, host_buf.data(), N * sizeof(float), hipMemcpyHostToDevice));
+
+  mgpuBarrier();
+
+  // ---- Test 5: Read from peer's heap ----
+  if (world_size > 1) {
+    int peer = (rank + 1) % world_size;
+    float *peer_base = static_cast<float *>(bases[peer]);
+
+    // The peer wrote (peer+1) to its buffer. The buffer is at offset 0
+    // from the peer's heap base, so we can read it directly.
+    // But we need to know the offset of `buf` within the heap.
+    // Since buf is the first allocation, it's at offset = granularity-aligned(0).
+    // Let's compute the offset from our local base.
+    uintptr_t local_offset =
+        reinterpret_cast<uintptr_t>(buf) -
+        reinterpret_cast<uintptr_t>(bases[rank]);
+
+    float *peer_buf =
+        reinterpret_cast<float *>(reinterpret_cast<uintptr_t>(peer_base) +
+                                  local_offset);
+
+    // Copy peer data to a local buffer first (D2D), then read to host.
+    // Direct D2H from imported VA may not be supported.
+    float *local_copy = nullptr;
+    HIP_CHECK(hipMalloc(&local_copy, N * sizeof(float)));
+    HIP_CHECK(hipMemcpy(local_copy, peer_buf, N * sizeof(float),
+                        hipMemcpyDeviceToDevice));
+
+    std::vector<float> readback(N);
+    HIP_CHECK(hipMemcpy(readback.data(), local_copy, N * sizeof(float),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipFree(local_copy));
+
+    float expected = static_cast<float>(peer + 1);
+    int mismatches = 0;
+    for (size_t i = 0; i < N; i++) {
+      if (readback[i] != expected) {
+        if (mismatches < 5)
+          fprintf(stderr,
+                  "[test] rank %d: MISMATCH at [%zu]: got %.1f, expected %.1f\n",
+                  rank, i, readback[i], expected);
+        mismatches++;
+      }
+    }
+
+    if (mismatches == 0) {
+      printf("[test] rank %d: cross-rank read from rank %d PASSED "
+             "(all %zu values = %.1f)\n",
+             rank, peer, N, expected);
+    } else {
+      fprintf(stderr, "[test] rank %d: cross-rank read FAILED (%d/%zu "
+                      "mismatches)\n",
+              rank, mismatches, N);
+      return 1;
+    }
+  }
+
+  mgpuBarrier();
+
+  // ---- Cleanup ----
+  mgpuSymmetricFree(buf, nullptr);
+  mgpuSymmetricHeapDestroy();
+
+  printf("[test] rank %d/%d: ALL PASSED\n", rank, world_size);
+  return 0;
+}

--- a/test/gpu/test_symmetric_heap.cpp
+++ b/test/gpu/test_symmetric_heap.cpp
@@ -29,8 +29,8 @@ void mgpuSetDevice(int32_t device_id);
   do {                                                                         \
     hipError_t err = (expr);                                                   \
     if (err != hipSuccess) {                                                   \
-      fprintf(stderr, "HIP error: %s (%d) at %s:%d\n",                        \
-              hipGetErrorString(err), err, __FILE__, __LINE__);                \
+      fprintf(stderr, "HIP error: %s (%d) at %s:%d\n", hipGetErrorString(err), \
+              err, __FILE__, __LINE__);                                        \
       return 1;                                                                \
     }                                                                          \
   } while (0)
@@ -70,8 +70,8 @@ int main() {
   HIP_CHECK(hipMemset(buf, 0, N * sizeof(float)));
   // Use a simple kernel-free approach: write from host
   std::vector<float> host_buf(N, rank_f);
-  HIP_CHECK(
-      hipMemcpy(buf, host_buf.data(), N * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(buf, host_buf.data(), N * sizeof(float),
+                      hipMemcpyHostToDevice));
 
   mgpuBarrier();
 
@@ -83,15 +83,13 @@ int main() {
     // The peer wrote (peer+1) to its buffer. The buffer is at offset 0
     // from the peer's heap base, so we can read it directly.
     // But we need to know the offset of `buf` within the heap.
-    // Since buf is the first allocation, it's at offset = granularity-aligned(0).
-    // Let's compute the offset from our local base.
-    uintptr_t local_offset =
-        reinterpret_cast<uintptr_t>(buf) -
-        reinterpret_cast<uintptr_t>(bases[rank]);
+    // Since buf is the first allocation, it's at offset =
+    // granularity-aligned(0). Let's compute the offset from our local base.
+    uintptr_t local_offset = reinterpret_cast<uintptr_t>(buf) -
+                             reinterpret_cast<uintptr_t>(bases[rank]);
 
-    float *peer_buf =
-        reinterpret_cast<float *>(reinterpret_cast<uintptr_t>(peer_base) +
-                                  local_offset);
+    float *peer_buf = reinterpret_cast<float *>(
+        reinterpret_cast<uintptr_t>(peer_base) + local_offset);
 
     // Copy peer data to a local buffer first (D2D), then read to host.
     // Direct D2H from imported VA may not be supported.
@@ -110,9 +108,10 @@ int main() {
     for (size_t i = 0; i < N; i++) {
       if (readback[i] != expected) {
         if (mismatches < 5)
-          fprintf(stderr,
-                  "[test] rank %d: MISMATCH at [%zu]: got %.1f, expected %.1f\n",
-                  rank, i, readback[i], expected);
+          fprintf(
+              stderr,
+              "[test] rank %d: MISMATCH at [%zu]: got %.1f, expected %.1f\n",
+              rank, i, readback[i], expected);
         mismatches++;
       }
     }
@@ -122,8 +121,9 @@ int main() {
              "(all %zu values = %.1f)\n",
              rank, peer, N, expected);
     } else {
-      fprintf(stderr, "[test] rank %d: cross-rank read FAILED (%d/%zu "
-                      "mismatches)\n",
+      fprintf(stderr,
+              "[test] rank %d: cross-rank read FAILED (%d/%zu "
+              "mismatches)\n",
               rank, mismatches, N);
       return 1;
     }


### PR DESCRIPTION
## Summary

- Add `SymmetricHeap` runtime that establishes cross-GPU peer access at init time via HIP VMem APIs + DMA-BUF fd passing over Unix sockets
- New `mgpu*` C ABI functions (`mgpuSymmetricHeapInit`, `mgpuGetRank`, `mgpuGetWorldSize`, `mgpuSymmetricAlloc`, `mgpuGetHeapBase`, `mgpuGetHeapBases`, `mgpuBarrier`) for MLIR lowering of `air.rank` operations
- Each rank pre-maps its full heap, exports DMA-BUF handles to all peers via SCM_RIGHTS, and imports peer heaps into separate VA reservations (required for gfx950)
- Lazy-init standalone `VMemAllocator` to avoid pinning device 0 at library load time

## New files
- `fd_passing.h/cpp` — Unix socket mesh + SCM_RIGHTS fd exchange
- `symmetric_heap.h/cpp` — init-time peer setup, bump allocator, barrier

## Modified files
- `vmem_allocator.h/cpp` — exportable handle support (`hipMemHandleTypePosixFileDescriptor`), `getAllocRecords()` accessor
- `gpu_runtime.cpp` — `mgpu*` symmetric heap wrappers, lazy allocator init
- `CMakeLists.txt`, `Makefile` — new sources + test targets

## Test plan
- [x] Single-GPU VMem allocator smoke test
- [x] 2-rank cross-GPU read
- [x] 4-rank cross-GPU read
- [x] 8-rank full-node cross-GPU read (all MI355X GPUs)
- All tests verified on rad-vultr-mi355x-03, ROCm 7.1.1, gfx950
- [Test results gist](https://gist.github.com/mawad-amd/3b407c98a627626ac9f34cca5aa90f37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)