### PR TITLE
Separate development from true runtime dependencies

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -162,6 +162,7 @@ jobs:
             source ${{ github.workspace }}/air-venv/bin/activate
 
             pip install -r utils/requirements.txt
+            pip install -r utils/requirements_dev.txt
 
             export ENABLE_RTTI=${{ matrix.ENABLE_RTTI }}
 
@@ -286,6 +287,7 @@ jobs:
         shell: bash
         run: |
           pip install -r utils/requirements.txt
+          pip install -r utils/requirements_dev.txt
           pip install setuptools wheel delvewheel importlib_metadata "ninja!=1.13.0"
 
       - name: Get MLIR

--- a/utils/mlir_air_wheels/pyproject.toml
+++ b/utils/mlir_air_wheels/pyproject.toml
@@ -8,6 +8,9 @@ authors = [
   { name="AMD Inc." },
 ]
 
+[project.optional-dependencies]
+dev = ["cmake>=3.30", "pybind11", "nanobind>=2.9", "lit", "psutil"]
+
 [project.urls]
 "Homepage" = "https://github.com/Xilinx/mlir-air"
 

--- a/utils/mlir_air_wheels/pyproject.toml
+++ b/utils/mlir_air_wheels/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 
 [project.optional-dependencies]
+# Keep this list in sync with utils/requirements_dev.txt.
 dev = ["cmake>=3.30", "pybind11", "nanobind>=2.9", "lit", "psutil"]
 
 [project.urls]

--- a/utils/mlir_air_wheels/requirements.txt
+++ b/utils/mlir_air_wheels/requirements.txt
@@ -1,13 +1,3 @@
-PyYAML>=6.0.2
-aiofiles
-filelock==3.13.1
-lit
-joblib
-ipykernel
-psutil
-rich
-pybind11
-nanobind>=2.9
 numpy
-cmake>=3.30
 ml_dtypes
+filelock==3.13.1

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,13 +1,3 @@
-PyYAML>=6.0.2
-aiofiles
-filelock==3.13.1
-lit
-joblib
-ipykernel
-psutil
-rich
-pybind11
-nanobind>=2.9
 numpy>=1.19.5, <2.0
-cmake>=3.30
 ml_dtypes
+filelock==3.13.1

--- a/utils/requirements_dev.txt
+++ b/utils/requirements_dev.txt
@@ -1,0 +1,6 @@
+cmake>=3.30
+pybind11
+nanobind>=2.9
+lit
+# lit requires psutil to set timeouts
+psutil

--- a/utils/setup_python_packages.sh
+++ b/utils/setup_python_packages.sh
@@ -14,7 +14,9 @@
 # Set up python venv 'sandbox'
 python3 -m venv sandbox
 source sandbox/bin/activate
-# Install essential python packages
+# Install runtime dependencies and build/dev/test dependencies.
+# End users installing the mlir-air wheel only get runtime deps;
+# this script installs both since it sets up a build environment.
 python3 -m pip install --upgrade pip
 python3 -m pip install -r utils/requirements.txt
 python3 -m pip install -r utils/requirements_dev.txt

--- a/utils/setup_python_packages.sh
+++ b/utils/setup_python_packages.sh
@@ -17,3 +17,4 @@ source sandbox/bin/activate
 # Install essential python packages
 python3 -m pip install --upgrade pip
 python3 -m pip install -r utils/requirements.txt
+python3 -m pip install -r utils/requirements_dev.txt


### PR DESCRIPTION
## Summary

Addresses #1536. Separates build/dev/test dependencies from true runtime dependencies to reduce installed size and avoid development headaches (e.g., pip-installed `cmake` shadowing system cmake).

- **Runtime deps** (`utils/requirements.txt`, wheel `install_requires`): `numpy`, `ml_dtypes`, `filelock` — only 3 packages actually imported by `python/air/backend/`
- **Dev/build deps** (`utils/requirements_dev.txt`, wheel `[dev]` extra): `cmake`, `pybind11`, `nanobind`, `lit`, `psutil`
- **Removed entirely**: `PyYAML`, `aiofiles`, `rich` (transitive via mlir-aie), `joblib` (dead code from retired Python aircc), `ipykernel` (zero imports)

Follows the same pattern as mlir-aie's `python/requirements.txt` / `python/requirements_dev.txt` split.

### Files changed
- `utils/requirements.txt` — trimmed to 3 runtime deps
- `utils/requirements_dev.txt` — new file with 5 build/dev deps
- `utils/mlir_air_wheels/requirements.txt` — trimmed to runtime-only (drives wheel `install_requires`)
- `utils/mlir_air_wheels/pyproject.toml` — added `[project.optional-dependencies] dev` for `pip install mlir-air[dev]`
- `utils/setup_python_packages.sh` — installs both requirements files
- `.github/workflows/buildAIRWheels.yml` — installs dev deps in CI build steps

## Test plan
- [x] Clean venv with only new requirements: `pip install` succeeds
- [x] Clean build (`cmake` + `ninja` 353/353) succeeds
- [x] `ninja check-air-mlir`: 363 passed (same as baseline)
- [x] `ninja check-air-python`: 9 passed (same as baseline)
- [x] Verified zero imports of removed packages (`PyYAML`, `aiofiles`, `rich`, `joblib`, `ipykernel`) in mlir-air source

🤖 Generated with [Claude Code](https://claude.com/claude-code)