### PR TITLE
Remove dead subview in matmul output DMA and add run1x1 targets

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16/Makefile
@@ -81,6 +81,33 @@ run2x2: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
+run1x1: compile-kernel-1x1
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+
+compile-kernel-1x1:
+	mkdir -p $(BUILD_DIR)
+	@if [ -n "$(PEANO_INSTALL_DIR)" ]; then \
+		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+			if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm_aie2p.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4 -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16; \
+			else \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8; \
+			fi; \
+		else \
+			echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
+			exit 1; \
+		fi; \
+	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
+		if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm_aie2p.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4 -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16; \
+		else \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8; \
+		fi; \
+	else \
+		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
+		exit 1; \
+	fi
+
 run3x3: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -404,19 +404,6 @@ def build_module(
                     _l2_b,
                     _l2_c,
                 ):
-                    l1_c_subview = subview(
-                        _l1_c,
-                        offsets=[_tx, _ty, 0, 0, 0, 0],
-                        sizes=[
-                            1,
-                            1,
-                            tile_n // mmul_mkn[2],
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            mmul_mkn[2],
-                        ],
-                        strides=[1, 1, 1, 1, 1, 1],
-                    )
                     dma_memcpy_nd(
                         _l2_c,
                         _l1_c,

--- a/programming_examples/matrix_multiplication/bf16/run_npu1_makefile_peano_compile_only_1x1.lit
+++ b/programming_examples/matrix_multiplication/bf16/run_npu1_makefile_peano_compile_only_1x1.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: peano
+//
+// RUN: mkdir -p test_npu1_peano_compile_only_1x1
+// RUN: cd test_npu1_peano_compile_only_1x1
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run1x1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2 COMPILE_MODE=compile-only | FileCheck %s
+// CHECK: Compilation completed successfully!

--- a/programming_examples/matrix_multiplication/i16/Makefile
+++ b/programming_examples/matrix_multiplication/i16/Makefile
@@ -79,6 +79,34 @@ run2x2: compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
+run1x1: compile-kernel-1x1
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+
+compile-kernel-1x1:
+	mkdir -p $(BUILD_DIR)
+	@if [ -n "$(PEANO_INSTALL_DIR)" ]; then \
+		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+			if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm_aie2p.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4; \
+			else \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8; \
+			fi; \
+		else \
+			echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
+			exit 1; \
+		fi; \
+	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
+		if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm_aie2p.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4; \
+		else \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_4=8 -DDIM_M_DIV_4=8; \
+		fi; \
+	else \
+		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
+		exit 1; \
+	fi
+
 run3x3: compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 --tile-k-l2 288 --tile-k-l1 48 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)

--- a/programming_examples/matrix_multiplication/i16/run.py
+++ b/programming_examples/matrix_multiplication/i16/run.py
@@ -400,19 +400,6 @@ def build_module(
                     _l2_b,
                     _l2_c,
                 ):
-                    l1_c_subview = subview(
-                        _l1_c,
-                        offsets=[_tx, _ty, 0, 0, 0, 0],
-                        sizes=[
-                            1,
-                            1,
-                            tile_n // mmul_mkn[2],
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            mmul_mkn[2],
-                        ],
-                        strides=[1, 1, 1, 1, 1, 1],
-                    )
                     dma_memcpy_nd(
                         _l2_c,
                         _l1_c,

--- a/programming_examples/matrix_multiplication/i16/run_npu1_makefile_peano_compile_only_1x1.lit
+++ b/programming_examples/matrix_multiplication/i16/run_npu1_makefile_peano_compile_only_1x1.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: peano
+//
+// RUN: mkdir -p test_npu1_peano_compile_only_1x1
+// RUN: cd test_npu1_peano_compile_only_1x1
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run1x1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2 COMPILE_MODE=compile-only | FileCheck %s
+// CHECK: Compilation completed successfully!

--- a/programming_examples/matrix_multiplication/i8/Makefile
+++ b/programming_examples/matrix_multiplication/i8/Makefile
@@ -74,6 +74,33 @@ run2x4: compile-kernel
 run2x2: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
+run1x1: compile-kernel-1x1
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+
+compile-kernel-1x1:
+	mkdir -p $(BUILD_DIR)
+	@if [ -n "$(PEANO_INSTALL_DIR)" ]; then \
+		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+			if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm_aie2p.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4; \
+			else \
+				$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2_FLAGS} -DBIT_WIDTH=8 -c ${srcdir}/mm.cc -o $(BUILD_DIR)/mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_4=8; \
+			fi; \
+		else \
+			echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
+			exit 1; \
+		fi; \
+	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
+		if [ "$(AIE_TARGET)" = "aie2p" ]; then \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm_aie2p.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_8=4; \
+		else \
+			cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper ${AIE_TARGET} -c ${srcdir}/mm.cc -o mm.o -DDIM_M=32 -DDIM_N=32 -DDIM_K=16 -DDIM_N_DIV_8=4 -DDIM_M_DIV_4=8; \
+		fi; \
+	else \
+		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
+		exit 1; \
+	fi
+
 run3x3: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 1152 --n 1152 --k 1152 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 	

--- a/programming_examples/matrix_multiplication/i8/run.py
+++ b/programming_examples/matrix_multiplication/i8/run.py
@@ -400,19 +400,6 @@ def build_module(
                     _l2_b,
                     _l2_c,
                 ):
-                    l1_c_subview = subview(
-                        _l1_c,
-                        offsets=[_tx, _ty, 0, 0, 0, 0],
-                        sizes=[
-                            1,
-                            1,
-                            tile_n // mmul_mkn[2],
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            mmul_mkn[2],
-                        ],
-                        strides=[1, 1, 1, 1, 1, 1],
-                    )
                     dma_memcpy_nd(
                         _l2_c,
                         _l1_c,

--- a/programming_examples/matrix_multiplication/i8/run_npu1_makefile_peano_compile_only_1x1.lit
+++ b/programming_examples/matrix_multiplication/i8/run_npu1_makefile_peano_compile_only_1x1.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: peano
+//
+// RUN: mkdir -p test_npu1_peano_compile_only_1x1
+// RUN: cd test_npu1_peano_compile_only_1x1
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run1x1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2 COMPILE_MODE=compile-only | FileCheck %s
+// CHECK: Compilation completed successfully!


### PR DESCRIPTION
## Summary
- Remove dead `memref.subview` in the output DMA herd body of i8, bf16, and i16 matmul `run.py` (result was never consumed; the DMA reads `_l1_c` directly with explicit offsets)
- Add `run1x1` Makefile target (pb=64, herd=1x1, tile_m=32, tile_n=32) and compile-only LIT test for i8, bf16, and i16

## Test plan
- [x] Dead subview removal: existing `run4x4` e2e passes on NPU2 (no behavioral change — removed code was unused)
- [x] `run1x1` target: e2e verified on NPU2 for all three dtypes (depends on #1539 for compiler-side `offset: ?` handling)
- [x] Compile-only LIT tests for herd=1x1 added for i8, bf16, i16

🤖 Generated with [Claude Code](https://claude.com/claude-code)