### PR TITLE
Fix outlineAIECores: normalize memref types and copy attributes

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
@@ -506,11 +507,66 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
         if (auto call = dyn_cast_if_present<func::CallOp>(op)) {
           auto fn = aie_device.lookupSymbol<func::FuncOp>(call.getCallee());
           if (!fn) {
+            // Normalize memref types: strip strided layout so that
+            // convert-func-to-llvm with bare-ptr calling convention can
+            // handle the declaration. External kernels use C ABI (raw
+            // pointers), so MLIR layout metadata is irrelevant.
+            SmallVector<Type> normalizedInputs;
+            for (Type t : call.getCalleeType().getInputs()) {
+              if (auto memrefTy = dyn_cast<MemRefType>(t)) {
+                normalizedInputs.push_back(MemRefType::get(
+                    memrefTy.getShape(), memrefTy.getElementType(),
+                    MemRefLayoutAttrInterface{}, memrefTy.getMemorySpace()));
+              } else {
+                normalizedInputs.push_back(t);
+              }
+            }
+            auto normalizedType =
+                FunctionType::get(aie_device.getContext(), normalizedInputs,
+                                  call.getCalleeType().getResults());
             fn = func::FuncOp::create(aie_device.getLoc(), call.getCallee(),
-                                      call.getCalleeType());
+                                      normalizedType);
             fn.setPrivate();
+            // Copy attributes from the original declaration in the parent
+            // module (e.g. link_with, llvm.emit_c_interface).
+            if (auto parentModule = aie_device->getParentOfType<ModuleOp>()) {
+              if (auto origFn = parentModule.lookupSymbol<func::FuncOp>(
+                      call.getCallee())) {
+                for (auto attr : origFn->getDiscardableAttrs())
+                  fn->setAttr(attr.getName(), attr.getValue());
+              }
+            }
+            // Fallback: if link_with was not found from parent module,
+            // use the attribute from the aie.core op.
+            if (!fn->hasAttr("link_with")) {
+              if (auto attr = core->getAttrOfType<StringAttr>("link_with"))
+                fn->setAttr("link_with", attr);
+            }
+            if (!fn->hasAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName())) {
+              fn->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                          UnitAttr::get(aie_device.getContext()));
+            }
             aie_device.insert(aie_device.getBody()->getTerminator(), fn);
           }
+          // Insert memref.cast at call sites where operand types differ
+          // from the (possibly normalized) declaration types.
+          auto fnType = fn.getFunctionType();
+          OpBuilder castBuilder(call);
+          SmallVector<Value> newOperands;
+          bool needsUpdate = false;
+          for (auto [operand, inputType] :
+               llvm::zip(call.getOperands(), fnType.getInputs())) {
+            if (operand.getType() != inputType) {
+              auto cast = memref::CastOp::create(castBuilder, call.getLoc(),
+                                                 inputType, operand);
+              newOperands.push_back(cast);
+              needsUpdate = true;
+            } else {
+              newOperands.push_back(operand);
+            }
+          }
+          if (needsUpdate)
+            call->setOperands(newOperands);
         }
       });
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -557,6 +557,14 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
           for (auto [operand, inputType] :
                llvm::zip(call.getOperands(), fnType.getInputs())) {
             if (operand.getType() != inputType) {
+              if (!memref::CastOp::areCastCompatible(operand.getType(),
+                                                     inputType)) {
+                call.emitError("cannot cast operand type ")
+                    << operand.getType() << " to normalized function type "
+                    << inputType;
+                newOperands.push_back(operand);
+                continue;
+              }
               auto cast = memref::CastOp::create(castBuilder, call.getLoc(),
                                                  inputType, operand);
               newOperands.push_back(cast);

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc.mlir
@@ -18,6 +18,7 @@ func.func @foo(%arg0: i32) {
   // CHECK:   call @beefmaker_kernel(%[[VAL_1]]) : (memref<1024xi32, 2>) -> ()
   // CHECK:   aie.end
   // CHECK: } {link_with = "beefmaker.o"}
+  // CHECK: func.func private @beefmaker_kernel(memref<1024xi32, 2>) attributes {link_with = "beefmaker.o", llvm.emit_c_interface}
   air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with="beefmaker.o"} {
     %src0 = memref.alloc() : memref<1024xi32, 2>
     func.call @beefmaker_kernel(%src0) : (memref<1024xi32, 2>) -> ()

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc_offset.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc_offset.mlir
@@ -12,29 +12,72 @@
 
 // RUN: air-opt %s -air-to-aie | FileCheck %s
 
-// herd=1x1 with subview producing offset: ? memref passed to external
+// The pass creates aie.device ops in reverse order (last herd first).
+
+// Test 3: identity-layout memref (no strided layout). Verifies no spurious
+// memref.cast is inserted when operand types already match the declaration.
+// CHECK-LABEL: aie.device{{.*}}@herd_2
+// CHECK: aie.core
+// CHECK-NOT: memref.cast
+// CHECK:   call @identity_kernel(%{{.*}}) : (memref<1024xi32, 2>) -> ()
+// CHECK: func.func private @identity_kernel(memref<1024xi32, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+
+// Test 2: mixed operand types (memref with offset: ? and scalar i32).
+// Verifies that scalar arguments pass through unchanged while memref
+// arguments are normalized and cast.
+// CHECK-LABEL: aie.device{{.*}}@herd_1
+// CHECK: aie.core
+// CHECK:   memref.subview
+// CHECK:   %[[CAST2:.*]] = memref.cast
+// CHECK:   call @mixed_kernel(%[[CAST2]], %{{.*}}) : (memref<4x8xi32, 2>, i32) -> ()
+// CHECK: func.func private @mixed_kernel(memref<4x8xi32, 2>, i32) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+
+// Test 1: herd=1x1 with subview producing offset: ? memref passed to external
 // func.call. Verifies:
 // 1. Declaration inside aie.device is normalized (plain memref, no strided layout)
 // 2. link_with and llvm.emit_c_interface attributes are preserved
-// 3. memref.cast is inserted at the call site to bridge offset: ? to identity layout
-
-// CHECK-LABEL: aie.device
+// 3. memref.cast is inserted at the call site
+// CHECK-LABEL: aie.device{{.*}}@herd_0
 // CHECK: aie.core
 // CHECK:   memref.subview
 // CHECK:   %[[CAST:.*]] = memref.cast
 // CHECK:   call @extern_kernel(%[[CAST]]) : (memref<4x8xi32, 2>) -> ()
 // CHECK: func.func private @extern_kernel(memref<4x8xi32, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+
 module {
 
 func.func private @extern_kernel(memref<4x8xi32, strided<[8, 1], offset: ?>, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+func.func private @mixed_kernel(memref<4x8xi32, strided<[8, 1], offset: ?>, 2>, i32) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+func.func private @identity_kernel(memref<1024xi32, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
 
-func.func @test1() {
+func.func @test_strided_memref() {
   %cst1 = arith.constant 1 : index
   air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with = "kernel.o"} {
     %buf = memref.alloc() : memref<1x1x4x8xi32, 2>
     %sv = memref.subview %buf[%tx, %ty, 0, 0] [1, 1, 4, 8] [1, 1, 1, 1]
         : memref<1x1x4x8xi32, 2> to memref<4x8xi32, strided<[8, 1], offset: ?>, 2>
     func.call @extern_kernel(%sv) : (memref<4x8xi32, strided<[8, 1], offset: ?>, 2>) -> ()
+  }
+  return
+}
+
+func.func @test_mixed_operands() {
+  %cst1 = arith.constant 1 : index
+  %scalar = arith.constant 42 : i32
+  air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) args(%s = %scalar) : i32 attributes {link_with = "kernel.o"} {
+    %buf = memref.alloc() : memref<1x1x4x8xi32, 2>
+    %sv = memref.subview %buf[%tx, %ty, 0, 0] [1, 1, 4, 8] [1, 1, 1, 1]
+        : memref<1x1x4x8xi32, 2> to memref<4x8xi32, strided<[8, 1], offset: ?>, 2>
+    func.call @mixed_kernel(%sv, %s) : (memref<4x8xi32, strided<[8, 1], offset: ?>, 2>, i32) -> ()
+  }
+  return
+}
+
+func.func @test_identity_layout() {
+  %cst1 = arith.constant 1 : index
+  air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with = "kernel.o"} {
+    %buf = memref.alloc() : memref<1024xi32, 2>
+    func.call @identity_kernel(%buf) : (memref<1024xi32, 2>) -> ()
   }
   return
 }

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc_offset.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_extfunc_offset.mlir
@@ -1,0 +1,42 @@
+//===- air_herd_to_aie_extfunc_offset.mlir ---------------------*- MLIR -*-===//
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Test that outlineAIECores normalizes memref types (strips strided layout)
+// and copies attributes (link_with, llvm.emit_c_interface) when recreating
+// function declarations inside aie.device. This is needed when func.call
+// operands have offset: ? from memref.subview (e.g. herd=1x1 matmul).
+
+// RUN: air-opt %s -air-to-aie | FileCheck %s
+
+// herd=1x1 with subview producing offset: ? memref passed to external
+// func.call. Verifies:
+// 1. Declaration inside aie.device is normalized (plain memref, no strided layout)
+// 2. link_with and llvm.emit_c_interface attributes are preserved
+// 3. memref.cast is inserted at the call site to bridge offset: ? to identity layout
+
+// CHECK-LABEL: aie.device
+// CHECK: aie.core
+// CHECK:   memref.subview
+// CHECK:   %[[CAST:.*]] = memref.cast
+// CHECK:   call @extern_kernel(%[[CAST]]) : (memref<4x8xi32, 2>) -> ()
+// CHECK: func.func private @extern_kernel(memref<4x8xi32, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+module {
+
+func.func private @extern_kernel(memref<4x8xi32, strided<[8, 1], offset: ?>, 2>) attributes {link_with = "kernel.o", llvm.emit_c_interface}
+
+func.func @test1() {
+  %cst1 = arith.constant 1 : index
+  air.herd tile(%tx, %ty) in (%size_x = %cst1, %size_y = %cst1) attributes {link_with = "kernel.o"} {
+    %buf = memref.alloc() : memref<1x1x4x8xi32, 2>
+    %sv = memref.subview %buf[%tx, %ty, 0, 0] [1, 1, 4, 8] [1, 1, 1, 1]
+        : memref<1x1x4x8xi32, 2> to memref<4x8xi32, strided<[8, 1], offset: ?>, 2>
+    func.call @extern_kernel(%sv) : (memref<4x8xi32, strided<[8, 1], offset: ?>, 2>) -> ()
+  }
+  return
+}
+
+}


### PR DESCRIPTION
## Summary
- Fix `outlineAIECores` in `AIRToAIEPass.cpp` to normalize memref types (strip strided layout) and copy attributes (`link_with`, `llvm.emit_c_interface`) when recreating function declarations inside `aie.device`
- Insert `memref.cast` at call sites where operand types (`offset: ?`) differ from the normalized declaration

## Root Cause
Two independent bugs in `outlineAIECores` (lines 505-515):

**Bug 1 — Attributes dropped:** When function declarations are recreated inside `aie.device`, `link_with` and `llvm.emit_c_interface` from the original declaration are silently lost.

**Bug 2 — `offset: ?` breaks bare-ptr lowering:** When `air-linalg-to-func` converts linalg ops to `func.call`, the declaration inherits `offset: ?` from `memref.subview` operands. `convert-func-to-llvm` with `useBarePtrCallConv=true` calls `canConvertToBarePtr()`, which rejects `offset: ?` — the `func.func` declaration fails to convert to `llvm.func`, but `func.call` successfully converts to `llvm.call` (via `promoteOperands`). The asymmetry causes a verifier error.

This manifests as a compilation failure for herd=1x1 matmul (all dtypes). For herd >= 2, separate per-core buffers are allocated during `air-to-aie`, eliminating the subview. For herd=1x1, the identity subview persists with `offset: ?`.

## Fix
- **Normalize:** Strip strided layout from memref types in external function declarations (external kernels use C ABI with raw pointers — MLIR layout metadata is irrelevant)
- **Copy attributes:** Look up original declaration from parent module and copy discardable attributes; fallback to `aie.core` op's `link_with`
- **Cast:** Insert `memref.cast` at call sites where operand types differ from normalized declaration (valid per `CastOp::areCastCompatible`)

## Test plan
- [x] `ninja check-air-mlir` — 362/372 pass (1 pre-existing failure unrelated)
- [x] i8 matmul herd=1x1 (pb=64, pb=32) passes e2e on NPU2 **with original run.py** (no codegen workaround — compiler fix alone handles `offset: ?`)
- [x] Regression: herd=2x2 (pb=128) and herd=4x4 (pb=512) still pass e2e on NPU2

🤖 Generated with [Claude Code](https://claude.com/claude-code)