### PR TITLE
Fix GPU-only build (AIR_ENABLE_AIE=OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ if(AIR_ENABLE_GPU AND NOT WIN32)
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/gpu_runtime.cpp
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/gpu_test_utils.cpp
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/vmem_allocator.cpp
+      ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/symmetric_heap.cpp
+      ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/fd_passing.cpp
     )
     set_property(TARGET airgpu PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(airgpu PRIVATE

--- a/mlir/lib/Conversion/Passes.cpp
+++ b/mlir/lib/Conversion/Passes.cpp
@@ -26,7 +26,19 @@ namespace air_gpu_passes {
 #endif
 
 void xilinx::air::registerConversionPasses() {
+#if AIR_ENABLE_AIE
   air_conv_passes::registerPasses();
+#else
+  // Register only non-AIE conversion passes.
+  air_conv_passes::registerParallelToHerd();
+  air_conv_passes::registerParallelToLaunch();
+  air_conv_passes::registerParallelToSegment();
+  air_conv_passes::registerCopyToDma();
+  air_conv_passes::registerAIRToAsync();
+  air_conv_passes::registerInsertEmptyLaunchOverHerd();
+  air_conv_passes::registerAIRRankToLaunch();
+  air_conv_passes::registerAIRWrapFuncWithParallelPass();
+#endif
 #if AIR_ENABLE_GPU
   air_gpu_passes::registerPasses();
 #endif

--- a/mlir/lib/Conversion/Passes.cpp
+++ b/mlir/lib/Conversion/Passes.cpp
@@ -30,6 +30,8 @@ void xilinx::air::registerConversionPasses() {
   air_conv_passes::registerPasses();
 #else
   // Register only non-AIE conversion passes.
+  // TODO: Split Passes.td into AIE-independent and AIE-dependent .td files
+  // so that registerPasses() can remain the single source of truth.
   air_conv_passes::registerParallelToHerd();
   air_conv_passes::registerParallelToLaunch();
   air_conv_passes::registerParallelToSegment();

--- a/mlir/lib/Transform/Passes.cpp
+++ b/mlir/lib/Transform/Passes.cpp
@@ -16,8 +16,10 @@ namespace {
 
 void xilinx::air::registerTransformPasses() { registerPasses(); }
 #else
-// When AIE is disabled, only register passes whose implementations are
+// When AIE is disabled, register only passes whose implementations are
 // compiled (i.e., those that don't depend on AIE headers).
+// TODO: Split Passes.td into AIE-independent and AIE-dependent .td files
+// so that registerPasses() can remain the single source of truth.
 namespace {
 #define GEN_PASS_REGISTRATION
 #include "air/Transform/Passes.h.inc"

--- a/mlir/lib/Transform/Passes.cpp
+++ b/mlir/lib/Transform/Passes.cpp
@@ -8,9 +8,53 @@
 
 #include "air/Transform/Passes.h"
 
+#if AIR_ENABLE_AIE
 namespace {
 #define GEN_PASS_REGISTRATION
 #include "air/Transform/Passes.h.inc"
 } // namespace
 
 void xilinx::air::registerTransformPasses() { registerPasses(); }
+#else
+// When AIE is disabled, only register passes whose implementations are
+// compiled (i.e., those that don't depend on AIE headers).
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "air/Transform/Passes.h.inc"
+} // namespace
+
+void xilinx::air::registerTransformPasses() {
+  registerAffineLoopOptPass();
+  registerAIRAutomaticTiling();
+  registerAIRCollapseHerdPass();
+  registerAIRDependency();
+  registerAIRDependencyCanonicalize();
+  registerAIRDependencyParseGraph();
+  registerDmaToChannel();
+  registerAIRExamplePass();
+  registerAIRFuseNestedHerdPass();
+  registerAIRFuseParallelHerdPass();
+  registerAIRHerdAssign();
+  registerAIRHerdPlacementPass();
+  registerAIRHerdVectorizePass();
+  registerAIRLinalgCodegen();
+  registerAIRLinalgNamePass();
+  registerAIRLinalgOpStats();
+  registerAIRLabelBroadcastChannelWithTilePass();
+  registerAIRLoopMergingPass();
+  registerAIRLoopPermutation();
+  registerAIRLowerHerdParallelPass();
+  registerAIROverrideMemRefMemorySpace();
+  registerAIRPipelineReducePass();
+  registerAIRRegularizeLoop();
+  registerAIRRemoveLinalgNamePass();
+  registerAIRRenumberDmaIdPass();
+  registerAIRReturnElimination();
+  registerAIRresolveTensorOpOperandConflictsWithNewTensors();
+  registerAIRSpecializeDmaBroadcast();
+  registerAIRSplitL2MemrefForBufferConstraintPass();
+  registerAIRSplitLaunchForPadding();
+  registerAIRTransformInterpreterPass();
+  registerAIRUnrollOuterPerfectlyNestedLoopsPass();
+}
+#endif

--- a/runtime_lib/airgpu/fd_passing.cpp
+++ b/runtime_lib/airgpu/fd_passing.cpp
@@ -3,6 +3,7 @@
 
 #include "fd_passing.h"
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -221,6 +221,8 @@ extern "C" void mgpuSetDefaultDevice(int32_t device) {
   HIP_REPORT_IF_ERROR(hipSetDevice(device));
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C" StridedMemRefType<float, 1>
 mgpuMemGetDeviceMemRef1dFloat(float *allocated, float *aligned, int64_t offset,
                               int64_t size, int64_t stride) {
@@ -244,6 +246,7 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   result.strides[0] = stride;
   return result;
 }
+#pragma clang diagnostic pop
 
 // ===========================================================================
 // Symmetric Heap — multi-GPU memory sharing

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -221,8 +221,10 @@ extern "C" void mgpuSetDefaultDevice(int32_t device) {
   HIP_REPORT_IF_ERROR(hipSetDevice(device));
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
 extern "C" StridedMemRefType<float, 1>
 mgpuMemGetDeviceMemRef1dFloat(float *allocated, float *aligned, int64_t offset,
                               int64_t size, int64_t stride) {
@@ -246,7 +248,9 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   result.strides[0] = stride;
   return result;
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 // ===========================================================================
 // Symmetric Heap — multi-GPU memory sharing


### PR DESCRIPTION
## Summary
- Add `symmetric_heap.cpp` and `fd_passing.cpp` to airgpu library sources (missing from CMakeLists.txt)
- Add missing `<cstdint>` include in `fd_passing.cpp`
- Suppress `-Wreturn-type-c-linkage` for MemRef helper functions in `gpu_runtime.cpp`
- Register only non-AIE passes in `Transform/Passes.cpp` and `Conversion/Passes.cpp` when `AIR_ENABLE_AIE=OFF` to avoid undefined symbol linker errors

## Test plan
- [x] GPU-only build completes (`-DAIR_ENABLE_AIE=OFF -DAIR_ENABLE_GPU=ON`)
- [x] `air-opt --help` lists GPU passes (`air-to-rocdl`, `air-gpu-outlining`)
- [x] Matmul e2e test passes on MI300A (gfx942): "Output Matched!"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)