### PR TITLE
Enhance air-to-rocdl DMA lowering for GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ if(AIR_ENABLE_GPU AND NOT WIN32)
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/gpu_runtime.cpp
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/gpu_test_utils.cpp
       ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/vmem_allocator.cpp
+      ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/symmetric_heap.cpp
+      ${PROJECT_SOURCE_DIR}/runtime_lib/airgpu/fd_passing.cpp
     )
     set_property(TARGET airgpu PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(airgpu PRIVATE

--- a/mlir/lib/Conversion/AIRToROCDLPass.cpp
+++ b/mlir/lib/Conversion/AIRToROCDLPass.cpp
@@ -496,16 +496,21 @@ struct ConvertAIRToROCDLPass
       if (auto segmentOp =
               dyn_cast_if_present<xilinx::air::SegmentOp>(childOp)) {
         if (!segmentOp.getRegion().empty()) {
-          Block &segmentBlock =
-              segmentOp.getRegion()
-                  .front(); // Get the first block (body) of the herd operation
+          Block &segmentBlock = segmentOp.getRegion().front();
+
+          // Remap segment block arguments to kernel operands.
+          unsigned numKernelArgs = segmentOp.getNumKernelOperands();
+          for (unsigned i = 0; i < numKernelArgs; ++i) {
+            Value outerVal = segmentOp.getKernelOperand(i);
+            segmentBlock.getArgument(i).replaceAllUsesWith(outerVal);
+          }
 
           for (auto &operation :
                llvm::make_early_inc_range(segmentBlock.without_terminator())) {
             operation.moveBefore(segmentOp);
           }
-          segmentBlock.getTerminator()->erase(); // Erase the terminator
-          segmentOp.erase();                     // Erase the herd operation
+          segmentBlock.getTerminator()->erase();
+          segmentOp.erase();
         }
       }
     });
@@ -513,14 +518,39 @@ struct ConvertAIRToROCDLPass
 
   void deleteAirHerd(xilinx::air::SegmentOp segmentOp, OpBuilder &builder,
                      gpu::LaunchOp gpuLaunchOp) {
-    // Traverse the children of the segment to find the air.herd
     segmentOp.walk([&](Operation *childOp) {
       if (auto herdOp = dyn_cast_if_present<xilinx::air::HerdOp>(childOp)) {
-        // Check if the herd operation has a region (body)
         if (!herdOp.getRegion().empty()) {
-          Block &herdBlock =
-              herdOp.getRegion()
-                  .front(); // Get the first block (body) of the herd operation
+          Block &herdBlock = herdOp.getRegion().front();
+          Location loc = herdOp.getLoc();
+
+          // Remap herd block arguments before moving ops out.
+          // Block args layout: [tile_x, tile_y, size_x, size_y, kernel_args...]
+          builder.setInsertionPoint(herdOp);
+          Value tidx = gpu::ThreadIdOp::create(builder, loc,
+                                                builder.getIndexType(),
+                                                gpu::Dimension::x);
+          Value tidy = gpu::ThreadIdOp::create(builder, loc,
+                                                builder.getIndexType(),
+                                                gpu::Dimension::y);
+          Value bdimx = gpu::BlockDimOp::create(builder, loc,
+                                                 builder.getIndexType(),
+                                                 gpu::Dimension::x);
+          Value bdimy = gpu::BlockDimOp::create(builder, loc,
+                                                 builder.getIndexType(),
+                                                 gpu::Dimension::y);
+
+          herdBlock.getArgument(0).replaceAllUsesWith(tidx);
+          herdBlock.getArgument(1).replaceAllUsesWith(tidy);
+          herdBlock.getArgument(2).replaceAllUsesWith(bdimx);
+          herdBlock.getArgument(3).replaceAllUsesWith(bdimy);
+
+          // Remap kernel operands to the values passed from enclosing scope.
+          unsigned numKernelArgs = herdOp.getNumKernelOperands();
+          for (unsigned i = 0; i < numKernelArgs; ++i) {
+            Value outerVal = herdOp.getKernelOperand(i);
+            herdBlock.getArgument(4 + i).replaceAllUsesWith(outerVal);
+          }
 
           for (auto &operation :
                llvm::make_early_inc_range(herdBlock.without_terminator())) {
@@ -600,136 +630,201 @@ struct ConvertAIRToROCDLPass
     launchOp.walk([&](memref::DeallocOp deallocOp) { deallocOp.erase(); });
   }
 
-  // Convert air.dma_memcpy_nd -> llvm.memcpy or gpu.global_to_shared for memory
-  // operations
-  void convertDMAToGPUMemcpy(xilinx::air::DmaMemcpyNdOp dmaMemcpyOp,
+  // Delinearize a flat index into multi-dimensional indices for a given shape.
+  static SmallVector<Value> delinearizeIndex(OpBuilder &b, Location loc,
+                                             Value linear,
+                                             ArrayRef<int64_t> shape) {
+    int rank = shape.size();
+    SmallVector<Value> indices(rank);
+    Value remaining = linear;
+    for (int i = rank - 1; i >= 0; --i) {
+      Value dimSize =
+          arith::ConstantIndexOp::create(b, loc, shape[i]);
+      indices[i] = arith::RemSIOp::create(b, loc, remaining, dimSize);
+      remaining = arith::DivSIOp::create(b, loc, remaining, dimSize);
+    }
+    return indices;
+  }
+
+  // Linearize multi-dimensional indices into a flat index for a given shape.
+  static Value linearizeIndices(OpBuilder &b, Location loc,
+                                ArrayRef<Value> indices,
+                                ArrayRef<int64_t> shape) {
+    int rank = indices.size();
+    assert(rank == (int)shape.size());
+    Value flat = arith::ConstantIndexOp::create(b, loc, 0);
+    for (int i = 0; i < rank; ++i) {
+      int64_t stride = 1;
+      for (int j = i + 1; j < rank; ++j)
+        stride *= shape[j];
+      Value strideVal = arith::ConstantIndexOp::create(b, loc, stride);
+      Value term = arith::MulIOp::create(b, loc, indices[i], strideVal);
+      flat = arith::AddIOp::create(b, loc, flat, term);
+    }
+    return flat;
+  }
+
+  // Compute memref indices from transfer indices, offsets, and strides.
+  // Handles rank mismatches between transfer descriptor and memref.
+  SmallVector<Value> computeMemrefIndices(
+      OpBuilder &b, Location loc, ArrayRef<Value> transferIndices,
+      ArrayRef<Value> offsets, ArrayRef<Value> strides,
+      MemRefType memrefType, ArrayRef<Value> transferSizes) {
+    int memrefRank = memrefType.getRank();
+    int transferRank = transferIndices.size();
+
+    if (offsets.empty()) {
+      // Entire memref addressed.
+      if (memrefRank == transferRank)
+        return SmallVector<Value>(transferIndices);
+      // Rank mismatch: linearize transfer indices, delinearize into memref.
+      SmallVector<int64_t> transferShape;
+      for (auto sz : transferSizes) {
+        APInt val;
+        if (matchPattern(sz, m_ConstantInt(&val)))
+          transferShape.push_back(val.getSExtValue());
+        else
+          transferShape.push_back(1);
+      }
+      Value flat = linearizeIndices(b, loc, transferIndices, transferShape);
+      return delinearizeIndex(b, loc, flat, memrefType.getShape());
+    }
+
+    if (memrefRank == transferRank) {
+      // Same rank: idx[i] = offset[i] + transferIdx[i]
+      SmallVector<Value> result(memrefRank);
+      for (int i = 0; i < memrefRank; ++i)
+        result[i] = arith::AddIOp::create(b, loc, offsets[i],
+                                           transferIndices[i]);
+      return result;
+    }
+
+    // Rank-reducing: offsets are in memref dimensions, transfer is lower rank.
+    // Linearize: base_flat = linearize(offsets, memref_shape)
+    //            flat = base_flat + iv[0] * strides[0] (+ iv[1]*strides[1]...)
+    // Then delinearize flat back into memref shape.
+    Value baseFlat = linearizeIndices(b, loc,
+        SmallVector<Value>(offsets.begin(), offsets.end()),
+        memrefType.getShape());
+    Value transferFlat = arith::ConstantIndexOp::create(b, loc, 0);
+    for (int i = 0; i < transferRank; ++i) {
+      Value s = (i < (int)strides.size())
+                    ? strides[i]
+                    : arith::ConstantIndexOp::create(b, loc, 1);
+      Value term = arith::MulIOp::create(b, loc, transferIndices[i], s);
+      transferFlat = arith::AddIOp::create(b, loc, transferFlat, term);
+    }
+    Value flat = arith::AddIOp::create(b, loc, baseFlat, transferFlat);
+    return delinearizeIndex(b, loc, flat, memrefType.getShape());
+  }
+
+  // Lower air.dma_memcpy_nd to SCF loops with memref.load/store.
+  // L3→L2 transfers use thread-cooperative loading with gpu.barrier.
+  // All other transfers use per-thread nested loops.
+  void convertDMAToGPUMemcpy(xilinx::air::DmaMemcpyNdOp dmaOp,
                              OpBuilder &builder) {
-    builder.setInsertionPointAfter(dmaMemcpyOp);
+    builder.setInsertionPointAfter(dmaOp);
+    Location loc = dmaOp.getLoc();
 
-    // Extract the operands (memrefs)
-    Value destMemref = dmaMemcpyOp.getDstMemref(); // Destination memref
-    Value srcMemref = dmaMemcpyOp.getSrcMemref();  // Source memref
-    SmallVector<Value, 4> src_offsets = dmaMemcpyOp.getSrcOffsets();
-    SmallVector<Value, 4> dst_offsets = dmaMemcpyOp.getDstOffsets();
-    SmallVector<Value, 4> src_sizes = dmaMemcpyOp.getSrcSizes();
-    SmallVector<Value, 4> dst_sizes = dmaMemcpyOp.getDstSizes();
-    SmallVector<Value, 4> src_strides = dmaMemcpyOp.getSrcStrides();
-    SmallVector<Value, 4> dst_strides = dmaMemcpyOp.getDstStrides();
+    Value srcMemref = dmaOp.getSrcMemref();
+    Value dstMemref = dmaOp.getDstMemref();
+    auto srcType = cast<MemRefType>(srcMemref.getType());
+    auto dstType = cast<MemRefType>(dstMemref.getType());
+    SmallVector<Value> srcOffsets(dmaOp.getSrcOffsets());
+    SmallVector<Value> dstOffsets(dmaOp.getDstOffsets());
+    SmallVector<Value> srcSizes(dmaOp.getSrcSizes());
+    SmallVector<Value> dstSizes(dmaOp.getDstSizes());
+    SmallVector<Value> srcStrides(dmaOp.getSrcStrides());
+    SmallVector<Value> dstStrides(dmaOp.getDstStrides());
 
-    // Create SCF loops to simulate the memory copy
-    // We'll assume a 2D memory region and use sizes for both dimensions
+    // Determine transfer sizes from whichever side has explicit sizes,
+    // or fall back to the smaller memref's static shape.
+    SmallVector<Value> transferSizes;
+    if (!srcSizes.empty()) {
+      transferSizes = srcSizes;
+    } else if (!dstSizes.empty()) {
+      transferSizes = dstSizes;
+    } else {
+      ArrayRef<int64_t> shape = (srcType.getRank() <= dstType.getRank())
+                                    ? srcType.getShape()
+                                    : dstType.getShape();
+      for (int64_t s : shape)
+        transferSizes.push_back(
+            arith::ConstantIndexOp::create(builder, loc, s));
+    }
+    int transferRank = transferSizes.size();
 
-    // Extract the precomputed indices from the dma_memcpy_nd operation (i.e.,
-    // %1 and %0) Constants for SCF loop bounds and steps
-    Value c0 = arith::ConstantIndexOp::create(builder, dmaMemcpyOp.getLoc(), 0);
-    Value c1 = arith::ConstantIndexOp::create(builder, dmaMemcpyOp.getLoc(), 1);
-    // Extract the number of dimensions from the memref type
-    auto srcMemrefType =
-        mlir::dyn_cast_or_null<MemRefType>(srcMemref.getType());
-    auto destMemrefType =
-        mlir::dyn_cast_or_null<MemRefType>(destMemref.getType());
-    int64_t destRank = destMemrefType.getRank();
+    Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
 
-    // Generate SCF loops for the destination memref (64x64xi32)
-    SmallVector<scf::ForOp, 4> loops;
-    // Generate loops for each dimension of the destination
-    for (int i = 0; i < destRank; ++i) {
-      Value loopStart = c0; // Start of loop (e.g., 0)
-      Value loopEnd =
-          (src_sizes.size() > 0)
-              ? src_sizes[i]
-              : dst_sizes[i]; // Determine the loop end based on the dimensions
-      Value loopStep = c1;    // Step size (e.g., 1)
+    unsigned srcSpace = srcType.getMemorySpaceAsInt();
+    unsigned dstSpace = dstType.getMemorySpaceAsInt();
+    bool isGlobalToShared = (srcSpace == 0 && dstSpace >= 1) ||
+                            (air::isL3(srcType) && air::isL2(dstType));
 
-      // Create a loop for each dimension
-      auto loop = scf::ForOp::create(builder, dmaMemcpyOp.getLoc(), loopStart,
-                                     loopEnd, loopStep);
-      loops.push_back(loop);
+    if (isGlobalToShared) {
+      // Thread-cooperative loading: distribute total elements across threads.
+      Value total = transferSizes[0];
+      for (int i = 1; i < transferRank; ++i)
+        total = arith::MulIOp::create(builder, loc, total, transferSizes[i]);
 
-      // Set insertion point to inside the loop body
+      Value tidx = gpu::ThreadIdOp::create(builder, loc,
+                                            builder.getIndexType(),
+                                            gpu::Dimension::x);
+      Value bdim = gpu::BlockDimOp::create(builder, loc,
+                                            builder.getIndexType(),
+                                            gpu::Dimension::x);
+
+      auto loop = scf::ForOp::create(builder, loc, tidx, total, bdim);
       builder.setInsertionPointToStart(loop.getBody());
+      Value linear = loop.getInductionVar();
+
+      // Delinearize into transfer-dimension indices.
+      SmallVector<int64_t> transferShape;
+      for (auto sz : transferSizes) {
+        APInt val;
+        if (matchPattern(sz, m_ConstantInt(&val)))
+          transferShape.push_back(val.getSExtValue());
+        else
+          transferShape.push_back(1);
+      }
+      SmallVector<Value> tIdx = delinearizeIndex(builder, loc, linear,
+                                                  transferShape);
+
+      SmallVector<Value> sIdx = computeMemrefIndices(
+          builder, loc, tIdx, srcOffsets, srcStrides, srcType, transferSizes);
+      SmallVector<Value> dIdx = computeMemrefIndices(
+          builder, loc, tIdx, dstOffsets, dstStrides, dstType, transferSizes);
+
+      Value val = memref::LoadOp::create(builder, loc, srcMemref, sIdx);
+      memref::StoreOp::create(builder, loc, val, dstMemref, dIdx);
+
+      builder.setInsertionPointAfter(loop);
+      gpu::BarrierOp::create(builder, loc);
+    } else {
+      // Per-thread path: nested loops over transfer dimensions.
+      SmallVector<scf::ForOp> loops;
+      for (int i = 0; i < transferRank; ++i) {
+        auto loop = scf::ForOp::create(builder, loc, c0,
+                                        transferSizes[i], c1);
+        loops.push_back(loop);
+        builder.setInsertionPointToStart(loop.getBody());
+      }
+
+      SmallVector<Value> tIdx;
+      for (auto &loop : loops)
+        tIdx.push_back(loop.getInductionVar());
+
+      SmallVector<Value> sIdx = computeMemrefIndices(
+          builder, loc, tIdx, srcOffsets, srcStrides, srcType, transferSizes);
+      SmallVector<Value> dIdx = computeMemrefIndices(
+          builder, loc, tIdx, dstOffsets, dstStrides, dstType, transferSizes);
+
+      Value val = memref::LoadOp::create(builder, loc, srcMemref, sIdx);
+      memref::StoreOp::create(builder, loc, val, dstMemref, dIdx);
     }
 
-    // Generate load/store operations inside the innermost loop
-    builder.setInsertionPointToStart(loops.back().getBody());
-    SmallVector<Value, 4> indices;
-
-    // Collect the loop induction variables to create indices
-    for (int i = 0; i < destRank; ++i) {
-      indices.push_back(loops[i].getInductionVar());
-    }
-
-    // Check for dimension mismatch and adjust indices accordingly
-    // Handle the case where the destination is larger than the source
-    if (destMemrefType.getShape()[0] > srcMemrefType.getShape()[0] &&
-        destMemrefType.getShape()[1] > srcMemrefType.getShape()[1]) {
-      // Both x and y dimensions are larger in the destination, need to adjust
-      // for chunks
-      Value idxRow = arith::AddIOp::create(
-          builder, dmaMemcpyOp.getLoc(), dst_offsets[0],
-          indices[0]); // Adjust row index for source access
-      Value idxCol = arith::AddIOp::create(
-          builder, dmaMemcpyOp.getLoc(), dst_offsets[1],
-          indices[1]); // Adjust column index for source access
-
-      // Load from the source memref (e.g., memref<64x64xi32>)
-      Value loadSrc = memref::LoadOp::create(builder, dmaMemcpyOp.getLoc(),
-                                             srcMemref, indices);
-
-      // Store to the destination memref (e.g., memref<32x32xi32>)
-      memref::StoreOp::create(builder, dmaMemcpyOp.getLoc(), loadSrc,
-                              destMemref, ValueRange{idxRow, idxCol});
-    } else if (srcMemrefType.getShape()[0] > destMemrefType.getShape()[0] &&
-               srcMemrefType.getShape()[1] > destMemrefType.getShape()[1]) {
-      // Both x and y dimensions are larger in the source matrix, need to adjust
-      // for chunks
-      Value idxRow =
-          arith::AddIOp::create(builder, dmaMemcpyOp.getLoc(), src_offsets[0],
-                                indices[0]); // Adjust row index
-      Value idxCol =
-          arith::AddIOp::create(builder, dmaMemcpyOp.getLoc(), src_offsets[1],
-                                indices[1]); // Adjust column index
-
-      // Load from the source memref (e.g., memref<64x64xi32>)
-      Value loadSrc = memref::LoadOp::create(
-          builder, dmaMemcpyOp.getLoc(), srcMemref, ValueRange{idxRow, idxCol});
-
-      // Store to the destination memref (e.g., memref<32x32xi32>)
-      memref::StoreOp::create(builder, dmaMemcpyOp.getLoc(), loadSrc,
-                              destMemref, indices);
-
-    } else if (srcMemrefType.getShape()[0] > destMemrefType.getShape()[0]) {
-      // Only the x dimension differs, adjust only the x index
-      Value idxRow =
-          arith::AddIOp::create(builder, dmaMemcpyOp.getLoc(), src_offsets[0],
-                                indices[0]); // Adjust row index for larger x
-
-      // Load from the source memref (e.g., memref<64x64xi32>)
-      Value loadSrc =
-          memref::LoadOp::create(builder, dmaMemcpyOp.getLoc(), srcMemref,
-                                 ValueRange{idxRow, indices[1]});
-
-      // Store to the destination memref (e.g., memref<32x32xi32>)
-      memref::StoreOp::create(builder, dmaMemcpyOp.getLoc(), loadSrc,
-                              destMemref, indices);
-
-    } else if (srcMemrefType.getShape()[1] > destMemrefType.getShape()[1]) {
-      // Only the y dimension differs, adjust only the y index
-      Value idxCol =
-          arith::AddIOp::create(builder, dmaMemcpyOp.getLoc(), src_offsets[1],
-                                indices[1]); // Adjust column index for larger y
-
-      // Load from the source memref (e.g., memref<64x64xi32>)
-      Value loadSrc =
-          memref::LoadOp::create(builder, dmaMemcpyOp.getLoc(), srcMemref,
-                                 ValueRange{indices[0], idxCol});
-
-      // Store to the destination memref (e.g., memref<32x32xi32>)
-      memref::StoreOp::create(builder, dmaMemcpyOp.getLoc(), loadSrc,
-                              destMemref, indices);
-    }
-    // Remove the air.dma_memcpy_nd operation
-    dmaMemcpyOp.erase();
+    dmaOp.erase();
   }
 };
 } // namespace

--- a/mlir/lib/Conversion/AIRToROCDLPass.cpp
+++ b/mlir/lib/Conversion/AIRToROCDLPass.cpp
@@ -527,18 +527,14 @@ struct ConvertAIRToROCDLPass
           // Remap herd block arguments before moving ops out.
           // Block args layout: [tile_x, tile_y, size_x, size_y, kernel_args...]
           builder.setInsertionPoint(herdOp);
-          Value tidx = gpu::ThreadIdOp::create(builder, loc,
-                                                builder.getIndexType(),
-                                                gpu::Dimension::x);
-          Value tidy = gpu::ThreadIdOp::create(builder, loc,
-                                                builder.getIndexType(),
-                                                gpu::Dimension::y);
-          Value bdimx = gpu::BlockDimOp::create(builder, loc,
-                                                 builder.getIndexType(),
-                                                 gpu::Dimension::x);
-          Value bdimy = gpu::BlockDimOp::create(builder, loc,
-                                                 builder.getIndexType(),
-                                                 gpu::Dimension::y);
+          Value tidx = gpu::ThreadIdOp::create(
+              builder, loc, builder.getIndexType(), gpu::Dimension::x);
+          Value tidy = gpu::ThreadIdOp::create(
+              builder, loc, builder.getIndexType(), gpu::Dimension::y);
+          Value bdimx = gpu::BlockDimOp::create(
+              builder, loc, builder.getIndexType(), gpu::Dimension::x);
+          Value bdimy = gpu::BlockDimOp::create(
+              builder, loc, builder.getIndexType(), gpu::Dimension::y);
 
           herdBlock.getArgument(0).replaceAllUsesWith(tidx);
           herdBlock.getArgument(1).replaceAllUsesWith(tidy);
@@ -638,8 +634,7 @@ struct ConvertAIRToROCDLPass
     SmallVector<Value> indices(rank);
     Value remaining = linear;
     for (int i = rank - 1; i >= 0; --i) {
-      Value dimSize =
-          arith::ConstantIndexOp::create(b, loc, shape[i]);
+      Value dimSize = arith::ConstantIndexOp::create(b, loc, shape[i]);
       indices[i] = arith::RemSIOp::create(b, loc, remaining, dimSize);
       remaining = arith::DivSIOp::create(b, loc, remaining, dimSize);
     }
@@ -666,10 +661,12 @@ struct ConvertAIRToROCDLPass
 
   // Compute memref indices from transfer indices, offsets, and strides.
   // Handles rank mismatches between transfer descriptor and memref.
-  SmallVector<Value> computeMemrefIndices(
-      OpBuilder &b, Location loc, ArrayRef<Value> transferIndices,
-      ArrayRef<Value> offsets, ArrayRef<Value> strides,
-      MemRefType memrefType, ArrayRef<Value> transferSizes) {
+  SmallVector<Value> computeMemrefIndices(OpBuilder &b, Location loc,
+                                          ArrayRef<Value> transferIndices,
+                                          ArrayRef<Value> offsets,
+                                          ArrayRef<Value> strides,
+                                          MemRefType memrefType,
+                                          ArrayRef<Value> transferSizes) {
     int memrefRank = memrefType.getRank();
     int transferRank = transferIndices.size();
 
@@ -694,8 +691,8 @@ struct ConvertAIRToROCDLPass
       // Same rank: idx[i] = offset[i] + transferIdx[i]
       SmallVector<Value> result(memrefRank);
       for (int i = 0; i < memrefRank; ++i)
-        result[i] = arith::AddIOp::create(b, loc, offsets[i],
-                                           transferIndices[i]);
+        result[i] =
+            arith::AddIOp::create(b, loc, offsets[i], transferIndices[i]);
       return result;
     }
 
@@ -703,8 +700,8 @@ struct ConvertAIRToROCDLPass
     // Linearize: base_flat = linearize(offsets, memref_shape)
     //            flat = base_flat + iv[0] * strides[0] (+ iv[1]*strides[1]...)
     // Then delinearize flat back into memref shape.
-    Value baseFlat = linearizeIndices(b, loc,
-        SmallVector<Value>(offsets.begin(), offsets.end()),
+    Value baseFlat = linearizeIndices(
+        b, loc, SmallVector<Value>(offsets.begin(), offsets.end()),
         memrefType.getShape());
     Value transferFlat = arith::ConstantIndexOp::create(b, loc, 0);
     for (int i = 0; i < transferRank; ++i) {
@@ -721,6 +718,8 @@ struct ConvertAIRToROCDLPass
   // Lower air.dma_memcpy_nd to SCF loops with memref.load/store.
   // L3→L2 transfers use thread-cooperative loading with gpu.barrier.
   // All other transfers use per-thread nested loops.
+  // TODO: Handle async form (async_dependencies and async_token result).
+  // Currently only synchronous DMAs are supported on the GPU path.
   void convertDMAToGPUMemcpy(xilinx::air::DmaMemcpyNdOp dmaOp,
                              OpBuilder &builder) {
     builder.setInsertionPointAfter(dmaOp);
@@ -757,10 +756,7 @@ struct ConvertAIRToROCDLPass
     Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
     Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
 
-    unsigned srcSpace = srcType.getMemorySpaceAsInt();
-    unsigned dstSpace = dstType.getMemorySpaceAsInt();
-    bool isGlobalToShared = (srcSpace == 0 && dstSpace >= 1) ||
-                            (air::isL3(srcType) && air::isL2(dstType));
+    bool isGlobalToShared = air::isL3(srcType) && air::isL2(dstType);
 
     if (isGlobalToShared) {
       // Thread-cooperative loading: distribute total elements across threads.
@@ -768,12 +764,27 @@ struct ConvertAIRToROCDLPass
       for (int i = 1; i < transferRank; ++i)
         total = arith::MulIOp::create(builder, loc, total, transferSizes[i]);
 
-      Value tidx = gpu::ThreadIdOp::create(builder, loc,
-                                            builder.getIndexType(),
-                                            gpu::Dimension::x);
-      Value bdim = gpu::BlockDimOp::create(builder, loc,
-                                            builder.getIndexType(),
-                                            gpu::Dimension::x);
+      // Linearize 3D thread index to handle multi-dimensional blocks.
+      Value tx = gpu::ThreadIdOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::x);
+      Value ty = gpu::ThreadIdOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::y);
+      Value tz = gpu::ThreadIdOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::z);
+      Value bx = gpu::BlockDimOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::x);
+      Value by = gpu::BlockDimOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::y);
+      Value bz = gpu::BlockDimOp::create(builder, loc, builder.getIndexType(),
+                                         gpu::Dimension::z);
+      // tidx = tx + ty * bx + tz * bx * by
+      Value tyBx = arith::MulIOp::create(builder, loc, ty, bx);
+      Value bxBy = arith::MulIOp::create(builder, loc, bx, by);
+      Value tzBxBy = arith::MulIOp::create(builder, loc, tz, bxBy);
+      Value tidx = arith::AddIOp::create(builder, loc, tx, tyBx);
+      tidx = arith::AddIOp::create(builder, loc, tidx, tzBxBy);
+      // bdim = bx * by * bz
+      Value bdim = arith::MulIOp::create(builder, loc, bxBy, bz);
 
       auto loop = scf::ForOp::create(builder, loc, tidx, total, bdim);
       builder.setInsertionPointToStart(loop.getBody());
@@ -788,8 +799,8 @@ struct ConvertAIRToROCDLPass
         else
           transferShape.push_back(1);
       }
-      SmallVector<Value> tIdx = delinearizeIndex(builder, loc, linear,
-                                                  transferShape);
+      SmallVector<Value> tIdx =
+          delinearizeIndex(builder, loc, linear, transferShape);
 
       SmallVector<Value> sIdx = computeMemrefIndices(
           builder, loc, tIdx, srcOffsets, srcStrides, srcType, transferSizes);
@@ -805,8 +816,7 @@ struct ConvertAIRToROCDLPass
       // Per-thread path: nested loops over transfer dimensions.
       SmallVector<scf::ForOp> loops;
       for (int i = 0; i < transferRank; ++i) {
-        auto loop = scf::ForOp::create(builder, loc, c0,
-                                        transferSizes[i], c1);
+        auto loop = scf::ForOp::create(builder, loc, c0, transferSizes[i], c1);
         loops.push_back(loop);
         builder.setInsertionPointToStart(loop.getBody());
       }

--- a/mlir/lib/Conversion/Passes.cpp
+++ b/mlir/lib/Conversion/Passes.cpp
@@ -26,7 +26,19 @@ namespace air_gpu_passes {
 #endif
 
 void xilinx::air::registerConversionPasses() {
+#if AIR_ENABLE_AIE
   air_conv_passes::registerPasses();
+#else
+  // Register only non-AIE conversion passes.
+  air_conv_passes::registerParallelToHerd();
+  air_conv_passes::registerParallelToLaunch();
+  air_conv_passes::registerParallelToSegment();
+  air_conv_passes::registerCopyToDma();
+  air_conv_passes::registerAIRToAsync();
+  air_conv_passes::registerInsertEmptyLaunchOverHerd();
+  air_conv_passes::registerAIRRankToLaunch();
+  air_conv_passes::registerAIRWrapFuncWithParallelPass();
+#endif
 #if AIR_ENABLE_GPU
   air_gpu_passes::registerPasses();
 #endif

--- a/mlir/lib/Conversion/Passes.cpp
+++ b/mlir/lib/Conversion/Passes.cpp
@@ -30,6 +30,8 @@ void xilinx::air::registerConversionPasses() {
   air_conv_passes::registerPasses();
 #else
   // Register only non-AIE conversion passes.
+  // TODO: Split Passes.td into AIE-independent and AIE-dependent .td files
+  // so that registerPasses() can remain the single source of truth.
   air_conv_passes::registerParallelToHerd();
   air_conv_passes::registerParallelToLaunch();
   air_conv_passes::registerParallelToSegment();

--- a/mlir/lib/Transform/Passes.cpp
+++ b/mlir/lib/Transform/Passes.cpp
@@ -16,8 +16,10 @@ namespace {
 
 void xilinx::air::registerTransformPasses() { registerPasses(); }
 #else
-// When AIE is disabled, only register passes whose implementations are
+// When AIE is disabled, register only passes whose implementations are
 // compiled (i.e., those that don't depend on AIE headers).
+// TODO: Split Passes.td into AIE-independent and AIE-dependent .td files
+// so that registerPasses() can remain the single source of truth.
 namespace {
 #define GEN_PASS_REGISTRATION
 #include "air/Transform/Passes.h.inc"

--- a/mlir/lib/Transform/Passes.cpp
+++ b/mlir/lib/Transform/Passes.cpp
@@ -8,9 +8,53 @@
 
 #include "air/Transform/Passes.h"
 
+#if AIR_ENABLE_AIE
 namespace {
 #define GEN_PASS_REGISTRATION
 #include "air/Transform/Passes.h.inc"
 } // namespace
 
 void xilinx::air::registerTransformPasses() { registerPasses(); }
+#else
+// When AIE is disabled, only register passes whose implementations are
+// compiled (i.e., those that don't depend on AIE headers).
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "air/Transform/Passes.h.inc"
+} // namespace
+
+void xilinx::air::registerTransformPasses() {
+  registerAffineLoopOptPass();
+  registerAIRAutomaticTiling();
+  registerAIRCollapseHerdPass();
+  registerAIRDependency();
+  registerAIRDependencyCanonicalize();
+  registerAIRDependencyParseGraph();
+  registerDmaToChannel();
+  registerAIRExamplePass();
+  registerAIRFuseNestedHerdPass();
+  registerAIRFuseParallelHerdPass();
+  registerAIRHerdAssign();
+  registerAIRHerdPlacementPass();
+  registerAIRHerdVectorizePass();
+  registerAIRLinalgCodegen();
+  registerAIRLinalgNamePass();
+  registerAIRLinalgOpStats();
+  registerAIRLabelBroadcastChannelWithTilePass();
+  registerAIRLoopMergingPass();
+  registerAIRLoopPermutation();
+  registerAIRLowerHerdParallelPass();
+  registerAIROverrideMemRefMemorySpace();
+  registerAIRPipelineReducePass();
+  registerAIRRegularizeLoop();
+  registerAIRRemoveLinalgNamePass();
+  registerAIRRenumberDmaIdPass();
+  registerAIRReturnElimination();
+  registerAIRresolveTensorOpOperandConflictsWithNewTensors();
+  registerAIRSpecializeDmaBroadcast();
+  registerAIRSplitL2MemrefForBufferConstraintPass();
+  registerAIRSplitLaunchForPadding();
+  registerAIRTransformInterpreterPass();
+  registerAIRUnrollOuterPerfectlyNestedLoopsPass();
+}
+#endif

--- a/runtime_lib/airgpu/fd_passing.cpp
+++ b/runtime_lib/airgpu/fd_passing.cpp
@@ -3,6 +3,7 @@
 
 #include "fd_passing.h"
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -221,6 +221,8 @@ extern "C" void mgpuSetDefaultDevice(int32_t device) {
   HIP_REPORT_IF_ERROR(hipSetDevice(device));
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C" StridedMemRefType<float, 1>
 mgpuMemGetDeviceMemRef1dFloat(float *allocated, float *aligned, int64_t offset,
                               int64_t size, int64_t stride) {
@@ -244,6 +246,7 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   result.strides[0] = stride;
   return result;
 }
+#pragma clang diagnostic pop
 
 // ===========================================================================
 // Symmetric Heap — multi-GPU memory sharing

--- a/runtime_lib/airgpu/gpu_runtime.cpp
+++ b/runtime_lib/airgpu/gpu_runtime.cpp
@@ -221,8 +221,10 @@ extern "C" void mgpuSetDefaultDevice(int32_t device) {
   HIP_REPORT_IF_ERROR(hipSetDevice(device));
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
 extern "C" StridedMemRefType<float, 1>
 mgpuMemGetDeviceMemRef1dFloat(float *allocated, float *aligned, int64_t offset,
                               int64_t size, int64_t stride) {
@@ -246,7 +248,9 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   result.strides[0] = stride;
   return result;
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 // ===========================================================================
 // Symmetric Heap — multi-GPU memory sharing

--- a/test/gpu/dma_copy/air_dma_copy.mlir
+++ b/test/gpu/dma_copy/air_dma_copy.mlir
@@ -1,0 +1,159 @@
+//===- air_dma_copy.mlir - DMA data movement e2e test --------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===------------------------------------------------------------------===//
+//
+// Focused e2e test exercising air.dma_memcpy_nd through all three memory
+// levels on GPU:
+//
+//   L3 (global) -> L2 (shared/LDS) -> L1 (private/VGPRs) -> L3 (global)
+//
+// A 64x64 input matrix is tiled into 4 blocks of 32x32.  Each workgroup
+// copies one 32x32 tile through the full memory hierarchy and writes it
+// back to a 64x64 output matrix.  The test harness compares input and
+// output element-by-element.
+//
+//===------------------------------------------------------------------===//
+
+#map = affine_map<()[s0] -> (s0 * 32)>
+module {
+  llvm.func @printf(!llvm.ptr, ...) -> i32
+  llvm.mlir.global internal constant @pass_msg("PASS: all elements match\0A\00") {addr_space = 0 : i32}
+  llvm.mlir.global internal constant @fail_msg("FAIL at [%ld,%ld]: expected %f, got %f\0A\00") {addr_space = 0 : i32}
+
+  func.func @main() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %cst = arith.constant 0.000000e+00 : f32
+
+    %input = memref.alloc() : memref<64x64xf32>
+    %output = memref.alloc() : memref<64x64xf32>
+
+    // Initialize input: val = row * 64 + col (as float)
+    scf.for %i = %c0 to %c64 step %c1 {
+      scf.for %j = %c0 to %c64 step %c1 {
+        %row = arith.muli %i, %c64 : index
+        %flat = arith.addi %row, %j : index
+        %flat_i32 = arith.index_cast %flat : index to i32
+        %val = arith.sitofp %flat_i32 : i32 to f32
+        memref.store %val, %input[%i, %j] : memref<64x64xf32>
+        memref.store %cst, %output[%i, %j] : memref<64x64xf32>
+      }
+    }
+
+    // Allocate GPU buffers and copy input
+    %g_in = gpu.alloc () : memref<64x64xf32>
+    gpu.memcpy %g_in, %input : memref<64x64xf32>, memref<64x64xf32>
+    %g_out = gpu.alloc () : memref<64x64xf32>
+    gpu.memcpy %g_out, %output : memref<64x64xf32>, memref<64x64xf32>
+
+    // Run kernel: copy through L3 -> L2 -> L1 -> L3
+    call @copy_kernel(%g_in, %g_out) : (memref<64x64xf32>, memref<64x64xf32>) -> ()
+
+    // Copy result back to host
+    gpu.memcpy %output, %g_out : memref<64x64xf32>, memref<64x64xf32>
+
+    // Verify
+    %pass = memref.alloc() : memref<1xi32>
+    %c1_i32 = arith.constant 1 : i32
+    memref.store %c1_i32, %pass[%c0] : memref<1xi32>
+
+    scf.for %i = %c0 to %c64 step %c1 {
+      scf.for %j = %c0 to %c64 step %c1 {
+        %expected = memref.load %input[%i, %j] : memref<64x64xf32>
+        %actual = memref.load %output[%i, %j] : memref<64x64xf32>
+        %diff = arith.subf %expected, %actual : f32
+        %abs = math.absf %diff : f32
+        %eps = arith.constant 1.0e-6 : f32
+        %ok = arith.cmpf "olt", %abs, %eps : f32
+        scf.if %ok {
+        } else {
+          %c0_i32 = arith.constant 0 : i32
+          memref.store %c0_i32, %pass[%c0] : memref<1xi32>
+          %fmt = llvm.mlir.addressof @fail_msg : !llvm.ptr
+          %ii = arith.index_cast %i : index to i64
+          %jj = arith.index_cast %j : index to i64
+          %e64 = arith.extf %expected : f32 to f64
+          %a64 = arith.extf %actual : f32 to f64
+          llvm.call @printf(%fmt, %ii, %jj, %e64, %a64) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i64, i64, f64, f64) -> i32
+        }
+      }
+    }
+
+    %result = memref.load %pass[%c0] : memref<1xi32>
+    %c1_check = arith.constant 1 : i32
+    %passed = arith.cmpi "eq", %result, %c1_check : i32
+    scf.if %passed {
+      %fmt = llvm.mlir.addressof @pass_msg : !llvm.ptr
+      llvm.call @printf(%fmt) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
+    }
+
+    return
+  }
+
+  // Kernel: 2x2 grid of workgroups, each copies a 32x32 tile through
+  // L3 -> L2 -> L1 -> L3 using air.dma_memcpy_nd at every level.
+  func.func @copy_kernel(%in: memref<64x64xf32>, %out: memref<64x64xf32>) {
+    %c2 = arith.constant 2 : index
+    air.launch (%bx, %by) in (%nbx=%c2, %nby=%c2)
+        args(%arg_in=%in, %arg_out=%out)
+        : memref<64x64xf32>, memref<64x64xf32> {
+
+      air.segment @tile_copy
+          args(%sbx=%bx, %sby=%by, %sin=%arg_in, %sout=%arg_out)
+          : index, index, memref<64x64xf32>, memref<64x64xf32> {
+
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c32 = arith.constant 32 : index
+        %c64 = arith.constant 64 : index
+
+        %row_off = affine.apply #map()[%sby]
+        %col_off = affine.apply #map()[%sbx]
+
+        // L2 tile buffer (shared memory)
+        %tile_l2 = memref.alloc() : memref<32x32xf32, 1>
+
+        // Phase 1: L3 -> L2  (cooperative DMA)
+        air.dma_memcpy_nd (%tile_l2[] [] [],
+                           %sin[%row_off, %col_off] [%c32, %c32] [%c64, %c1])
+            : (memref<32x32xf32, 1>, memref<64x64xf32>)
+        gpu.barrier
+
+        // Phase 2+3: L2 -> L1 -> L3 inside herd
+        // 32 threads, each handles one row of the 32x32 tile
+        air.herd @copy_herd tile (%tx, %ty) in (%ntx=%c32, %nty=%c1)
+            args(%hl2=%tile_l2, %hout=%sout, %hrow=%row_off, %hcol=%col_off)
+            : memref<32x32xf32, 1>, memref<64x64xf32>, index, index {
+
+          %c0_h = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c32_h = arith.constant 32 : index
+          %c64_h = arith.constant 64 : index
+
+          // L1 row buffer (private memory) — one row of 32 elements
+          %row_l1 = memref.alloc() : memref<32xf32, 2>
+
+          // Phase 2: L2 -> L1  (per-thread DMA, one row)
+          air.dma_memcpy_nd (%row_l1[] [] [],
+                             %hl2[%tx, %c0_h] [%c32_h] [%c1_h])
+              : (memref<32xf32, 2>, memref<32x32xf32, 1>)
+
+          // Phase 3: L1 -> L3  (per-thread DMA, write row to global output)
+          %dst_r = arith.addi %hrow, %tx : index
+          air.dma_memcpy_nd (%hout[%dst_r, %hcol] [%c1_h, %c32_h] [%c64_h, %c1_h],
+                             %row_l1[] [] [])
+              : (memref<64x64xf32>, memref<32xf32, 2>)
+
+          air.herd_terminator
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}

--- a/test/gpu/dma_copy/air_dma_copy.mlir
+++ b/test/gpu/dma_copy/air_dma_copy.mlir
@@ -118,10 +118,10 @@ module {
         %tile_l2 = memref.alloc() : memref<32x32xf32, 1>
 
         // Phase 1: L3 -> L2  (cooperative DMA)
+        // The lowering inserts gpu.barrier after cooperative copies automatically.
         air.dma_memcpy_nd (%tile_l2[] [] [],
                            %sin[%row_off, %col_off] [%c32, %c32] [%c64, %c1])
             : (memref<32x32xf32, 1>, memref<64x64xf32>)
-        gpu.barrier
 
         // Phase 2+3: L2 -> L1 -> L3 inside herd
         // 32 threads, each handles one row of the 32x32 tile

--- a/test/gpu/dma_copy/run.sh
+++ b/test/gpu/dma_copy/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#===- run.sh - DMA copy e2e test --------------------------*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#===------------------------------------------------------------------===//
+#
+# Compile and run the DMA data movement e2e test on GPU.
+# Assumes environment is set up via: source utils/env_setup_gpu.sh install
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="${TMPDIR:-/tmp/air_dma_copy}"
+mkdir -p "$TMPDIR"
+
+echo "Step 1: AIR to ROCDL"
+air-opt "$SCRIPT_DIR/air_dma_copy.mlir" -air-to-rocdl -o "$TMPDIR/step1.mlir"
+
+echo "Step 2: GPU kernel outlining"
+air-opt "$TMPDIR/step1.mlir" -air-gpu-outlining -o "$TMPDIR/step2.mlir"
+
+echo "Step 3: LLVM lowering"
+mlir-opt "--pass-pipeline=builtin.module(func.func(lower-affine, convert-linalg-to-loops, convert-scf-to-cf), gpu-kernel-outlining)" \
+    "$TMPDIR/step2.mlir" -o "$TMPDIR/step3.mlir"
+
+echo "Step 4: ROCDL binary generation"
+mlir-opt "--pass-pipeline=builtin.module(rocdl-attach-target{chip=gfx942 O=3},gpu.module(convert-gpu-to-rocdl{chipset=gfx942 runtime=HIP},reconcile-unrealized-casts),gpu-module-to-binary, func.func(gpu-async-region),gpu-to-llvm,convert-to-llvm,reconcile-unrealized-casts)" \
+    "$TMPDIR/step3.mlir" -o "$TMPDIR/step4.mlir"
+
+echo "Step 5: Running on GPU"
+LLVM_LIB_DIR="${LLVM_INSTALL_DIR:-$(dirname "$(which mlir-opt)")/..}/lib"
+AIRGPU_LIB="${MLIR_AIR_INSTALL_DIR:-$(dirname "$(which air-opt)")/..}/lib/libairgpu.so"
+
+mlir-runner --entry-point-result=void \
+    --shared-libs="$LLVM_LIB_DIR/libmlir_rocm_runtime.so" \
+    --shared-libs="$AIRGPU_LIB" \
+    --shared-libs="$LLVM_LIB_DIR/libmlir_runner_utils.so" \
+    --shared-libs="$LLVM_LIB_DIR/libmlir_c_runner_utils.so" \
+    "$TMPDIR/step4.mlir"


### PR DESCRIPTION
## Summary
- Rewrite `convertDMAToGPUMemcpy` to properly lower `air.dma_memcpy_nd` to SCF loops on GPU (per AIRComputeModel.md §4.4)
- L3→L2 transfers use thread-cooperative loading (`gpu.thread_id` + `gpu.barrier`)
- L2→L1 and L1→L3 transfers use per-thread nested loops with stride and rank-mismatch support
- Fix `deleteAirHerd`/`deleteAirSegment` to remap block arguments before moving operations
- Add focused e2e test (`test/gpu/dma_copy/`) exercising DMA through all three memory levels

Depends on #1541.

## Test plan
- [x] DMA copy e2e test passes on MI300A: "PASS: all elements match"
- [x] Existing matmul test still passes: "Output Matched!"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)