### PR TITLE
Add --stack-size option to aircc

### DIFF
--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -202,6 +202,10 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
           "Switch to enable a fix for lock race condition, which protects "
           "against the risk of race condition, at the cost of inserting extra "
           "dummy DMA BDs">,
+    Option<"clStackSize", "stack-size", "int", /*default=*/"1024",
+          "Stack size in bytes to allocate per AIE core. Must be large enough "
+          "to hold the full call chain stack depth including callee frames. "
+          "Default is 1024 bytes.">,
   ];
   let description = [{
     This pass converts AIR dialect `herd` and `segment` operations into AIE

--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -202,7 +202,7 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
           "Switch to enable a fix for lock race condition, which protects "
           "against the risk of race condition, at the cost of inserting extra "
           "dummy DMA BDs">,
-    Option<"clStackSize", "stack-size", "int", /*default=*/"1024",
+    Option<"clStackSize", "stack-size", "unsigned", /*default=*/"1024",
           "Stack size in bytes to allocate per AIE core. Must be large enough "
           "to hold the full call chain stack depth including callee frames. "
           "Default is 1024 bytes.">,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -69,7 +69,7 @@ struct AIRToAIEConversionOptions {
   bool insert_trace_packet_flow;
   bool use_lock_race_condition_fix;
   AIE::AIEDevice device;
-  int stack_size;
+  unsigned stack_size;
 };
 
 // Breakpoint stages for debugging with --test-patterns
@@ -260,7 +260,8 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
       auto core = tile.getCoreOp();
       if (!core) {
         core = AIE::CoreOp::create(builder, hloc, tile);
-        core.setStackSize(options.stack_size);
+        if (options.stack_size != 1024)
+          core.setStackSize(options.stack_size);
         tileToHerdMap[tile] = h;
         if (auto a = h->getAttrOfType<StringAttr>("link_with"))
           core->setAttr("link_with", a);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -69,6 +69,7 @@ struct AIRToAIEConversionOptions {
   bool insert_trace_packet_flow;
   bool use_lock_race_condition_fix;
   AIE::AIEDevice device;
+  int stack_size;
 };
 
 // Breakpoint stages for debugging with --test-patterns
@@ -259,6 +260,7 @@ void outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
       auto core = tile.getCoreOp();
       if (!core) {
         core = AIE::CoreOp::create(builder, hloc, tile);
+        core.setStackSize(options.stack_size);
         tileToHerdMap[tile] = h;
         if (auto a = h->getAttrOfType<StringAttr>("link_with"))
           core->setAttr("link_with", a);
@@ -6008,7 +6010,8 @@ public:
           /*.generate_shim_dma = */ clGenerateShimDMA,
           /*.insert_trace_packet_flow = */ clInsertTracePacketFlow,
           /*.use_lock_race_condition_fix = */ clUseLockRaceConditionFix,
-          /*.device = */ *device};
+          /*.device = */ *device,
+          /*.stack_size = */ clStackSize};
 
       // Pre-pipeline: renumber memcpy ops at module level
       air::renumberMemcpyIfOps(&m.getRegion());
@@ -6120,7 +6123,8 @@ public:
         /* .generate_shim_dma = */ clGenerateShimDMA,
         /* .insert_trace_packet_flow = */ clInsertTracePacketFlow,
         /* .use_lock_race_condition_fix = */ clUseLockRaceConditionFix,
-        /* .device = */ *device};
+        /* .device = */ *device,
+        /* .stack_size = */ clStackSize};
     createAIEModulesAndOutlineCores(module, aie_devices, tileToHerdMap,
                                     options);
 

--- a/programming_examples/primitives/vector_examples/vector_div/vector_div.py
+++ b/programming_examples/primitives/vector_examples/vector_div/vector_div.py
@@ -265,6 +265,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_div",
             runtime_loop_tiling_sizes=[4, 4],
+            stack_size=2048,
         )
         exit(
             runner.run_test(

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -76,6 +76,7 @@ class XRTBackend(AirBackend):
         num_device_cols: int = 0,
         debug_ir: bool = False,
         bf16_emulation: bool = False,
+        stack_size: int = 1024,
     ):
         """Constructor for XRTBackend
 
@@ -103,6 +104,8 @@ class XRTBackend(AirBackend):
             debug_ir: enable debug mode to emit IR after each individual pass for fine-grained inspection.
                 IRs are saved to <tmpdir>/debug_ir/ with sequence numbers.
             bf16_emulation: emulate f32 vector arithmetic using bf16 operations.
+            stack_size: stack size in bytes per AIE core (default: 1024). Increase when
+                kernels have deep call chains (e.g., scalar fdiv needs ~1152 bytes).
         """
         super().__init__()
         self.verbose = verbose
@@ -130,6 +133,7 @@ class XRTBackend(AirBackend):
         self.num_device_cols = num_device_cols
         self.debug_ir = debug_ir
         self.bf16_emulation = bf16_emulation
+        self.stack_size = stack_size
 
     def __del__(self):
         self.unload()
@@ -338,6 +342,9 @@ class XRTBackend(AirBackend):
 
             if self.bf16_emulation:
                 aircc_options += ["--bf16-emulation"]
+
+            if self.stack_size != 1024:
+                aircc_options += ["--stack-size", str(self.stack_size)]
 
             if self.verbose:
                 print("Running aircc with options:", " ".join(aircc_options))

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -133,6 +133,8 @@ class XRTBackend(AirBackend):
         self.num_device_cols = num_device_cols
         self.debug_ir = debug_ir
         self.bf16_emulation = bf16_emulation
+        if not isinstance(stack_size, int) or stack_size <= 0:
+            raise ValueError("`stack_size` must be a positive integer")
         self.stack_size = stack_size
 
     def __del__(self):

--- a/python/air/backend/xrt_runner.py
+++ b/python/air/backend/xrt_runner.py
@@ -81,6 +81,7 @@ class XRTRunner:
         debug_ir: bool = False,
         bf16_emulation: bool = False,
         target_device: str = None,
+        stack_size: int = 1024,
     ):
         """
         Args:
@@ -108,6 +109,8 @@ class XRTRunner:
                 IRs are saved to <tmpdir>/debug_ir/ with sequence numbers.
             bf16_emulation: emulate f32 vector arithmetic using bf16 operations.
             target_device: specify target device explicitly ("npu1", "npu2", etc.). If None, will attempt auto-detection.
+            stack_size: stack size in bytes per AIE core (default: 1024). Increase when
+                kernels have deep call chains (e.g., scalar fdiv needs ~1152 bytes).
         """
         self.verbose = verbose
         self.omit_while_true_loop = omit_while_true_loop
@@ -134,6 +137,7 @@ class XRTRunner:
         self.debug_ir = debug_ir
         self.bf16_emulation = bf16_emulation
         self.target_device = target_device
+        self.stack_size = stack_size
 
     def run_test(
         self,
@@ -184,6 +188,7 @@ class XRTRunner:
             debug_ir=self.debug_ir,
             bf16_emulation=self.bf16_emulation,
             target_device=self.target_device,
+            stack_size=self.stack_size,
         )
 
         # Use per-test trace file if provided, otherwise use instance default

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -272,6 +272,12 @@ static cl::opt<bool>
                   cl::desc("Emulate f32 vector arithmetic using bf16"),
                   cl::init(false), cl::cat(airCompilerOptions));
 
+static cl::opt<int> stackSize(
+    "stack-size",
+    cl::desc("Stack size in bytes per AIE core (default: 1024). Increase when "
+             "kernels have deep call chains (e.g., scalar fdiv)."),
+    cl::init(1024), cl::cat(airCompilerOptions));
+
 //===----------------------------------------------------------------------===//
 // Debug IR Support
 //===----------------------------------------------------------------------===//
@@ -1038,6 +1044,7 @@ static LogicalResult runAieCompilation() {
       os << " insert-trace-packet-flow=true";
     os << " use-lock-race-condition-fix="
        << (useLockRaceConditionFix ? "true" : "false");
+    os << " stack-size=" << stackSize.getValue();
     os << "}";
     os << ",air-merge-unrolled-devices";
     os << ")";

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -272,11 +272,11 @@ static cl::opt<bool>
                   cl::desc("Emulate f32 vector arithmetic using bf16"),
                   cl::init(false), cl::cat(airCompilerOptions));
 
-static cl::opt<int> stackSize(
+static cl::opt<unsigned> stackSize(
     "stack-size",
     cl::desc("Stack size in bytes per AIE core (default: 1024). Increase when "
              "kernels have deep call chains (e.g., scalar fdiv)."),
-    cl::init(1024), cl::cat(airCompilerOptions));
+    cl::init(1024u), cl::cat(airCompilerOptions));
 
 //===----------------------------------------------------------------------===//
 // Debug IR Support
@@ -1044,7 +1044,8 @@ static LogicalResult runAieCompilation() {
       os << " insert-trace-packet-flow=true";
     os << " use-lock-race-condition-fix="
        << (useLockRaceConditionFix ? "true" : "false");
-    os << " stack-size=" << stackSize.getValue();
+    if (stackSize.getNumOccurrences() > 0)
+      os << " stack-size=" << stackSize.getValue();
     os << "}";
     os << ",air-merge-unrolled-devices";
     os << ")";


### PR DESCRIPTION
## Summary
- Add `--stack-size` option to `aircc` CLI, threaded through the `air-to-aie` pass, `XRTBackend`, and `XRTRunner` Python APIs
- The default AIE core stack size (1024 bytes) is insufficient when kernels have deep call chains (e.g., `arith.divf` on float32 lowers to `__aie2p_scalar_fdiv` → `__mulsf3`, adding 128 bytes of callee stack frames)
- When the root frame is large from register spills, the total call chain overflows into adjacent DMA buffers, causing silent data corruption
- Update `vector_div` example to use `stack_size=2048`

## Usage
```python
# Python API
runner = XRTRunner(stack_size=2048, ...)
backend = XRTBackend(stack_size=2048, ...)
```
```bash
# CLI
aircc --stack-size=2048 input.mlir
```

## Test plan
- [x] Verified on NPU2 hardware: `vector_div.py` with `stack_size=2048` passes with llvm-aie that has stack frame alignment sorting (`f02c358e`)
- [ ] CI passes (default stack_size=1024 preserves backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)