### PR TITLE
Fix hash regex to handle _no_rtti suffix in wheel names

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -45,33 +45,42 @@ jobs:
           CURRENT_SHORT=$(git rev-parse --short=7 HEAD)
           echo "Current HEAD: $CURRENT_SHORT"
 
-          # Get the most recently uploaded wheel from the latest release to extract the commit hash
-          LAST_WHEEL=$(gh api repos/${{ github.repository }}/releases/tags/latest-air-wheels \
-            --jq '.assets | sort_by(.created_at) | reverse | map(select(.name | startswith("mlir_air")) | .name) | .[0]' \
-            2>/dev/null || echo "")
+          # Returns "true" if the given release tag is stale (hash mismatch or missing).
+          check_tag() {
+            local TAG="$1"
+            local LAST_WHEEL
+            LAST_WHEEL=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" \
+              --jq '.assets | sort_by(.created_at) | reverse | map(select(.name | startswith("mlir_air")) | .name) | .[0]' \
+              2>/dev/null || echo "")
 
-          if [ -z "$LAST_WHEEL" ]; then
-            echo "No previous release found, building."
+            if [ -z "$LAST_WHEEL" ]; then
+              echo "  No wheel found for ${TAG}, needs build." >&2
+              echo "true"
+              return
+            fi
+
+            # Extract short hash from wheel name: mlir_air-0.0.1.DATETIME+HASH-...
+            local LAST_HASH
+            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\)-.*/\1/p')
+            echo "  ${TAG}: latest wheel hash=${LAST_HASH:-<none>}" >&2
+
+            if [ -z "$LAST_HASH" ] || [ "$CURRENT_SHORT" != "$LAST_HASH" ]; then
+              echo "true"
+            else
+              echo "false"
+            fi
+          }
+
+          # Check both RTTI and no-RTTI release tags; build if either is stale.
+          RTTI_STALE=$(check_tag "latest-air-wheels")
+          NO_RTTI_STALE=$(check_tag "latest-air-wheels-no-rtti")
+
+          if [ "$RTTI_STALE" = "true" ] || [ "$NO_RTTI_STALE" = "true" ]; then
+            echo "One or both releases are stale. Building."
             echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Extract short hash from wheel name: mlir_air-0.0.1.DATETIME+HASH-...
-          LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\)-.*/\1/p')
-          echo "Last released hash: $LAST_HASH"
-
-          if [ -z "$LAST_HASH" ]; then
-            echo "Could not extract hash from wheel name, building."
-            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$CURRENT_SHORT" = "$LAST_HASH" ]; then
-            echo "No new commits since last release. Skipping build."
-            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
           else
-            echo "New commits detected. Building."
-            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
+            echo "Both releases are up to date. Skipping build."
+            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
           fi
 
   get-air-project-commit:

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -60,8 +60,9 @@ jobs:
             fi
 
             # Extract short hash from wheel name: mlir_air-0.0.1.DATETIME+HASH-...
+            # No-RTTI wheels have _no_rtti after the hash, so match any char after the 7 hex digits.
             local LAST_HASH
-            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\)-.*/\1/p')
+            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\).*/\1/p')
             echo "  ${TAG}: latest wheel hash=${LAST_HASH:-<none>}" >&2
 
             if [ -z "$LAST_HASH" ] || [ "$CURRENT_SHORT" != "$LAST_HASH" ]; then

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -47,7 +47,7 @@ jobs:
 
           # Get the most recently uploaded wheel from the latest release to extract the commit hash
           LAST_WHEEL=$(gh api repos/${{ github.repository }}/releases/tags/latest-air-wheels \
-            --jq '[.assets | sort_by(.created_at) | reverse | .[].name | select(startswith("mlir_air"))] | first' \
+            --jq '.assets | sort_by(.created_at) | reverse | map(select(.name | startswith("mlir_air")) | .name) | .[0]' \
             2>/dev/null || echo "")
 
           if [ -z "$LAST_WHEEL" ]; then

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -45,9 +45,10 @@ jobs:
           CURRENT_SHORT=$(git rev-parse --short=7 HEAD)
           echo "Current HEAD: $CURRENT_SHORT"
 
-          # Get any wheel filename from the latest release to extract the commit hash
+          # Get the most recently uploaded wheel from the latest release to extract the commit hash
           LAST_WHEEL=$(gh api repos/${{ github.repository }}/releases/tags/latest-air-wheels \
-            --jq '.assets[0].name' 2>/dev/null || echo "")
+            --jq '[.assets | sort_by(.created_at) | reverse | .[].name | select(startswith("mlir_air"))] | first' \
+            2>/dev/null || echo "")
 
           if [ -z "$LAST_WHEEL" ]; then
             echo "No previous release found, building."
@@ -73,9 +74,33 @@ jobs:
             echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
           fi
 
+  get-air-project-commit:
+    name: Get canonical AIR project commit and timestamp
+    runs-on: ubuntu-latest
+    needs: check-new-commits
+    if: always() && (github.event_name != 'schedule' || needs.check-new-commits.outputs.has_new_commits == 'true')
+    outputs:
+      AIR_PROJECT_COMMIT: ${{ steps.get_commit.outputs.AIR_PROJECT_COMMIT }}
+      DATETIME: ${{ steps.get_commit.outputs.DATETIME }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get AIR project commit and timestamp
+        id: get_commit
+        run: |
+          if [ x"${{ inputs.AIR_COMMIT }}" == x"" ]; then
+            AIR_PROJECT_COMMIT=$(git rev-parse --short=7 HEAD)
+          else
+            AIR_PROJECT_COMMIT="${{ inputs.AIR_COMMIT }}"
+            AIR_PROJECT_COMMIT="${AIR_PROJECT_COMMIT:0:7}"
+          fi
+          echo "AIR_PROJECT_COMMIT=${AIR_PROJECT_COMMIT}" | tee -a "$GITHUB_OUTPUT"
+          DATETIME=$(date +"%Y%m%d%H")
+          echo "DATETIME=${DATETIME}" | tee -a "$GITHUB_OUTPUT"
+
   build-repo:
     name: Build and upload mlir_air wheels
-    needs: check-new-commits
+    needs: [check-new-commits, get-air-project-commit]
     if: always() && (github.event_name != 'schedule' || needs.check-new-commits.outputs.has_new_commits == 'true')
 
     runs-on: ubuntu-latest
@@ -193,13 +218,8 @@ jobs:
 
             export MLIR_AIR_SOURCE_DIR=$PWD
             export WHEELHOUSE_DIR=$PWD/wheelhouse
-            if [ x"${{ inputs.AIR_COMMIT }}" == x"" ]; then
-              export AIR_PROJECT_COMMIT=$AIR_VERSION
-            else
-              AIR_VERSION="${{ inputs.AIR_COMMIT }}"
-              export AIR_PROJECT_COMMIT=${AIR_VERSION:0:7}
-            fi
-            export DATETIME=$(date +"%Y%m%d%H")
+            export AIR_PROJECT_COMMIT=${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}
+            export DATETIME=${{ needs.get-air-project-commit.outputs.DATETIME }}
             
             rm -rf $WHEELHOUSE_DIR/mlir_air*.whl
             rm -rf $WHEELHOUSE_DIR/repaired_wheel/*
@@ -231,12 +251,12 @@ jobs:
           tag: ${{ github.event_name == 'push' && github.ref_name || (matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti') }}
           name: ${{ github.event_name == 'push' && github.ref_name || (matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti') }}
           allowUpdates: true
-          replacesArtifacts: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}
 
   build-windows:
     name: Build and upload mlir_air wheels (Windows)
-    needs: check-new-commits
+    needs: [check-new-commits, get-air-project-commit]
     if: always() && (github.event_name != 'schedule' || needs.check-new-commits.outputs.has_new_commits == 'true')
 
     runs-on: windows-2022
@@ -347,13 +367,8 @@ jobs:
           export ENABLE_RTTI=${{ matrix.ENABLE_RTTI }}
           export CIBW_ARCHS=AMD64
 
-          if [ x"${{ inputs.AIR_COMMIT }}" == x"" ]; then
-            export AIR_PROJECT_COMMIT=$(git rev-parse --short HEAD)
-          else
-            export AIR_PROJECT_COMMIT="${{ inputs.AIR_COMMIT }}"
-            export AIR_PROJECT_COMMIT="${AIR_PROJECT_COMMIT:0:7}"
-          fi
-          export DATETIME=$(date +"%Y%m%d%H")
+          export AIR_PROJECT_COMMIT=${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}
+          export DATETIME=${{ needs.get-air-project-commit.outputs.DATETIME }}
 
           export WHEELHOUSE_DIR="${ROOT}/wheelhouse"
           mkdir -p "$WHEELHOUSE_DIR"
@@ -392,5 +407,5 @@ jobs:
           tag: ${{ github.event_name == 'push' && github.ref_name || (matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti') }}
           name: ${{ github.event_name == 'push' && github.ref_name || (matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti') }}
           allowUpdates: true
-          replacesArtifacts: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary

- Follow-up to #1548. The `check-new-commits` hash check was always reporting `latest-air-wheels-no-rtti` as stale because the regex required a dash (`-`) immediately after the 7-char commit hash. No-RTTI wheel names have `_no_rtti` between the hash and the dash (`+c8ec089_no_rtti-cp310-...`), so the regex never matched.
- This caused every scheduled run to rebuild and re-release all wheels even when HEAD hadn't changed — the exact bug seen in the duplicate `c8ec089` releases with timestamps `2026042202` and `2026042205`.
- Fix: match any character after the 7 hex digits instead of requiring a dash.

## Test plan

- [ ] Verify regex matches both RTTI (`+c8ec089-cp310-...`) and no-RTTI (`+c8ec089_no_rtti-cp310-...`) wheel names
- [ ] After merge, confirm next scheduled run at 4 AM UTC correctly skips if HEAD hasn't changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)