### PR TITLE
Fix hash regex to handle _no_rtti suffix in wheel names

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -60,8 +60,9 @@ jobs:
             fi
 
             # Extract short hash from wheel name: mlir_air-0.0.1.DATETIME+HASH-...
+            # No-RTTI wheels have _no_rtti after the hash, so match any char after the 7 hex digits.
             local LAST_HASH
-            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\)-.*/\1/p')
+            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\).*/\1/p')
             echo "  ${TAG}: latest wheel hash=${LAST_HASH:-<none>}" >&2
 
             if [ -z "$LAST_HASH" ] || [ "$CURRENT_SHORT" != "$LAST_HASH" ]; then

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -50,7 +50,7 @@ jobs:
             local TAG="$1"
             local LAST_WHEEL
             LAST_WHEEL=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" \
-              --jq '.assets | sort_by(.created_at) | reverse | map(select(.name | startswith("mlir_air")) | .name) | .[0]' \
+              --jq '.assets | sort_by(.created_at) | reverse | map(select(.name | startswith("mlir_air")) | .name) | .[0] // empty' \
               2>/dev/null || echo "")
 
             if [ -z "$LAST_WHEEL" ]; then
@@ -62,7 +62,7 @@ jobs:
             # Extract short hash from wheel name: mlir_air-0.0.1.DATETIME+HASH-...
             # No-RTTI wheels have _no_rtti after the hash, so match any char after the 7 hex digits.
             local LAST_HASH
-            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\).*/\1/p')
+            LAST_HASH=$(echo "$LAST_WHEEL" | sed -n 's/.*+\([a-f0-9]\{7\}\)[^a-f0-9].*/\1/p')
             echo "  ${TAG}: latest wheel hash=${LAST_HASH:-<none>}" >&2
 
             if [ -z "$LAST_HASH" ] || [ "$CURRENT_SHORT" != "$LAST_HASH" ]; then


### PR DESCRIPTION
## Summary

- Follow-up to #1548. The `check-new-commits` hash extraction regex required a dash (`-`) immediately after the 7-char commit hash, but no-RTTI wheel names have `_no_rtti` between the hash and the dash (`+c8ec089_no_rtti-cp310-...`). The regex never matched, so `check_tag` always reported `latest-air-wheels-no-rtti` as stale, triggering redundant builds on every scheduled run even when HEAD hadn't changed.
- This is the root cause of the duplicate `c8ec089` releases with timestamps `2026042202` and `2026042205`.
- Fix: match any character after the 7 hex digits instead of requiring a dash.

## Test plan

- [ ] Verify regex matches both RTTI (`+c8ec089-cp310-...`) and no-RTTI (`+c8ec089_no_rtti-cp310-...`) wheel names
- [ ] After merge, confirm next scheduled run at 4 AM UTC correctly skips if HEAD hasn't changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)