### PR TITLE
Add decode flash attention for NPU2 (kernel_fusion_based)

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/Makefile
+++ b/programming_examples/flash_attention/kernel_fusion_based/Makefile
@@ -16,6 +16,11 @@ NUM_KV_HEADS ?= $(NUM_HEADS)
 NUM_Q_TILES ?= 4
 LQP_TILE := $(shell echo $$(($(LQP) / $(NUM_Q_TILES))))
 
+# Decode-specific parameters
+GROUP_SIZE ?= 4
+NUM_KV_PARALLEL ?= 4
+NUM_CASCADE_STAGES ?= 4
+
 
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
@@ -159,6 +164,79 @@ compile-kernel-npu1:
 	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
 		echo "Using xchesscc_wrapper from PATH for AIE2 (NPU1)"; \
 		cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2 -c ${srcdir}/attn_npu1.cc -o attn_npu1.o -I${srcdir}/../dataflow_based -Dlqp=$(LQP_TILE) -Dlkp=$(LKP) -Ddk=$(LKP) -Ddk_full=$(DK) -Ddv=$(LKP) -Ddv_full=$(DV); \
+	else \
+		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
+		exit 1; \
+	fi
+
+# ============================================================================
+# Decode targets (NPU2 / AIE2P)
+# ============================================================================
+
+# Decode requires kv_head_groups=1 to stay within the 16-BD-per-shim-column
+# budget (2 MM2S x 4 BDs + 1 S2MM output = 9 <= 16).
+NUM_KV_HEADS_DECODE ?= $(NUM_KV_PARALLEL)
+
+print-decode:
+	${powershell} python3 ${srcdir}/attn_decode_npu2.py -p --lk $(LK) --lkp $(LKP) --dk $(DK) --dv $(DV) --group-size $(GROUP_SIZE) --num-kv-heads $(NUM_KV_HEADS_DECODE) --num-kv-parallel $(NUM_KV_PARALLEL) --num-cascade-stages $(NUM_CASCADE_STAGES)
+
+run-decode: compile-kernel-decode
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py --lk $(LK) --lkp $(LKP) --dk $(DK) --dv $(DV) --group-size $(GROUP_SIZE) --num-kv-heads $(NUM_KV_HEADS_DECODE) --num-kv-parallel $(NUM_KV_PARALLEL) --num-cascade-stages $(NUM_CASCADE_STAGES) $(EXTRA_PY_FLAGS)
+
+profile-decode: compile-kernel-decode build-test-exe-decode
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py \
+		--lk $(LK) --lkp $(LKP) --dk $(DK) --dv $(DV) --group-size $(GROUP_SIZE) \
+		--num-kv-heads $(NUM_KV_HEADS_DECODE) --num-kv-parallel $(NUM_KV_PARALLEL) --num-cascade-stages $(NUM_CASCADE_STAGES) \
+		--compile-mode compile-only
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_decode_elf_npu2.exe -e air.elf -k "main:decode_attention_bf16" \
+		--lk $(LK) --dk $(DK) --dv $(DV) \
+		--num-heads $(shell echo $$(($(GROUP_SIZE) * $(NUM_KV_HEADS_DECODE)))) \
+		--num-kv-heads $(NUM_KV_HEADS_DECODE)
+
+build-test-exe-decode:
+	@GPP=$$( \
+		for bin in /usr/bin/g++-*; do \
+			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
+			if [ "$$ver" -ge 13 ] 2>/dev/null; then \
+				echo "$$ver $$bin"; \
+			fi; \
+		done | sort -nr | head -n1 | awk '{print $$2}' \
+	); \
+	if [ -z "$$GPP" ]; then \
+		echo "Error: No g++ version >= 13 found in /usr/bin."; \
+		exit 1; \
+	fi; \
+	if [ -z "$$XILINX_XRT" ]; then \
+		echo "Error: XILINX_XRT environment variable not set. Please make sure to have sourced xrt/setup.sh."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(AIEOPT_DIR)" ]; then \
+		echo "Error: AIEOPT_DIR environment variable not set. Please make sure to have sourced utils/env_setup.sh."; \
+		exit 1; \
+	fi; \
+	echo "Using compiler: $$GPP"; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && $$GPP ${srcdir}/test_decode_elf_npu2.cpp -o test_decode_elf_npu2.exe -std=c++23 -Wall \
+		-I$$XILINX_XRT/include -L$$XILINX_XRT/lib \
+		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
+		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
+
+compile-kernel-decode:
+	mkdir -p $(BUILD_DIR)
+	@if [ -n "$(PEANO_INSTALL_DIR)" ]; then \
+		echo "Detected PEANO_INSTALL_DIR from environment: $(PEANO_INSTALL_DIR)"; \
+		if [ -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+			echo "Using clang++ from PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)"; \
+			$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -c ${srcdir}/attn_decode_npu2.cc -o $(BUILD_DIR)/attn_decode_npu2.o -Dlkp=$(LKP) -Ddk=$(DK) -Ddv=$(DV) -Dgroup_size=$(GROUP_SIZE) -Dmax_sum_buf_size=32 -DROUND_CONV_EVEN $(EXTRA_KERNEL_FLAGS); \
+		else \
+			echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
+			exit 1; \
+		fi; \
+	elif command -v xchesscc_wrapper >/dev/null 2>&1; then \
+		echo "Using xchesscc_wrapper from PATH"; \
+		cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2p -c ${srcdir}/attn_decode_npu2.cc -o attn_decode_npu2.o -Dlkp=$(LKP) -Ddk=$(DK) -Ddv=$(DV) -Dgroup_size=$(GROUP_SIZE) -Dmax_sum_buf_size=32 -DROUND_CONV_EVEN; \
 	else \
 		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
 		exit 1; \

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.cc
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.cc
@@ -1,0 +1,427 @@
+//===- attn_decode_npu2.cc --------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Decode-phase flash attention kernels for AIE2P (NPU2).
+//
+// Uses matvec-style (mv.cc) QK computation since group_size is too small for
+// 8x8 tiled matmul.  Flat row-major buffer layout throughout.
+//
+// Compile-time parameters (pass with -D):
+//   group_size : number of Q heads per KV head (GQA ratio), e.g. 4
+//   lkp        : K/V chunk size, e.g. 64
+//   dk         : key head dimension, e.g. 64
+//   dv         : value head dimension, e.g. 64
+//
+// Buffer layouts (all flat row-major):
+//   Q        [group_size, dk]
+//   K        [lkp, dk]
+//   V        [lkp, dv]
+//   scores   [group_size, lkp]
+//   output   [group_size, dv]
+//   max_vec  [max_sum_buf_size]   (first group_size entries used)
+//   sum_vec  [max_sum_buf_size]   (first group_size entries used)
+//
+// max_sum_buf_size must be >= group_size and >= 32 (one 512-bit cascade word).
+//===----------------------------------------------------------------------===//
+
+#define NOCPP
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+#include "zero.cc"
+
+// Default values if not provided by Makefile
+#ifndef group_size
+#define group_size 4
+#endif
+
+#ifndef lkp
+#define lkp 64
+#endif
+
+#ifndef dk
+#define dk 64
+#endif
+
+#ifndef dv
+#define dv 64
+#endif
+
+// Cascade alignment: 512-bit bus = 32 bfloat16 elements.
+// max/sum buffers are padded to this size.
+#ifndef max_sum_buf_size
+#define max_sum_buf_size 32
+#endif
+
+// Scale: log2e / sqrt(dk) for attention score normalization.
+// Using the same constexpr pattern as attn_npu2.cc.
+#include <cmath>
+
+constexpr double decode_constexpr_sqrt_dk = (dk == 64)    ? 8.0
+                                            : (dk == 128) ? 11.313708498984761
+                                            : (dk == 256) ? 16.0
+                                            : (dk == 512) ? 22.627416997969522
+                                                          : 8.0;
+static_assert(dk == 64 || dk == 128 || dk == 256 || dk == 512,
+              "Unsupported dk value: update decode_constexpr_sqrt_dk");
+
+#define decode_log2e (1.44269504089 / decode_constexpr_sqrt_dk)
+
+// Bf16 special values
+static const uint16_t bf16_lowest_u16 = (uint16_t)0xff7f;  // ≈ -3.39e38
+static const uint16_t bf16_neg_inf_u16 = (uint16_t)0xff80; // -inf
+
+//===========================================================================
+// Internal: matvec C[m] = A[m,k] @ b[k]  (A row-major, b a vector)
+// Accumulates in accfloat and reduces each row to a scalar bfloat16 result.
+//===========================================================================
+template <uint32_t r>
+static void matvec_decode(uint32_t m, uint32_t k, const bfloat16 *__restrict a,
+                          const bfloat16 *__restrict b,
+                          bfloat16 *__restrict c) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  const bfloat16 *b_end = b + k;
+  for (uint32_t row = 0; row < m; row++, c++) {
+    aie::accum<accfloat, r> acc = aie::zeros<accfloat, r>();
+    const bfloat16 *b_cur = b;
+    const bfloat16 *a_cur = a + row * k;
+    for (; b_cur < b_end; b_cur += r, a_cur += r) {
+      aie::vector<bfloat16, r> a_vec = aie::load_v<r>(a_cur);
+      aie::vector<bfloat16, r> b_vec = aie::load_v<r>(b_cur);
+      acc = aie::mac(acc, a_vec, b_vec);
+    }
+    *c =
+        static_cast<bfloat16>(aie::reduce_add(acc.template to_vector<float>()));
+  }
+}
+
+extern "C" {
+
+#ifdef ROUND_CONV_EVEN
+#define SET_ROUNDING() ::aie::set_rounding(::aie::rounding_mode::conv_even)
+#else
+#define SET_ROUNDING() /* no-op */
+#endif
+
+// ============================================================
+// Initialization
+// ============================================================
+
+void decode_zero_output(bfloat16 *out) {
+  SET_ROUNDING();
+  zero_vectorized<bfloat16, group_size, dv, 32>(out);
+}
+
+void decode_zero_sum(bfloat16 *sum) {
+  SET_ROUNDING();
+  zero_vectorized<bfloat16, max_sum_buf_size, 1, 32>(sum);
+}
+
+void decode_neg_inf_max(bfloat16 *max_v) {
+  SET_ROUNDING();
+  neg_inf_vectorized<bfloat16, max_sum_buf_size, 1, 32>(max_v);
+}
+
+// ============================================================
+// QK score computation (matvec-style)
+// ============================================================
+
+// For each head h in [0, group_size):
+//   scores[h, i] = K[i, :] . Q[h, :]   for i in [0, lkp)
+// K is [lkp, dk] row-major, Q is [group_size, dk] row-major.
+// scores is [group_size, lkp] row-major.
+void compute_qk_scores_bf16(bfloat16 *K, bfloat16 *Q, bfloat16 *scores) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    matvec_decode<64>(lkp, dk, K, Q + h * dk, scores + h * lkp);
+  }
+}
+
+// ============================================================
+// Decode causal mask
+// ============================================================
+
+// Set scores[h, i] = -inf for ALL heads h when (chunk_start + i) > current_pos.
+// TODO(perf): Replace scalar conditional with aie::sel vectorized mask:
+//   aie::mask<lkp> m = aie::lt(position_vec, aie::broadcast(current_pos));
+//   scores_vec = aie::sel(neg_inf_vec, scores_vec, m);
+// This eliminates lkp scalar branches per invocation (lkp=64, group_size=4
+// → 256 scalar comparisons per call vs. one vectorized mask operation).
+void apply_decode_mask(bfloat16 *scores, int32_t chunk_start,
+                       int32_t current_pos) {
+  SET_ROUNDING();
+  bfloat16 neg_inf_val = *(const bfloat16 *)&bf16_neg_inf_u16;
+  for (int i = 0; i < lkp; i++) {
+    if (chunk_start + i > current_pos) {
+      for (int h = 0; h < group_size; h++) {
+        scores[h * lkp + i] = neg_inf_val;
+      }
+    }
+  }
+}
+
+// ============================================================
+// Online softmax
+// ============================================================
+
+// Compute per-head row-max of scores[group_size, lkp].
+// score_max[h] = max(scores[h, :]).
+// Does NOT consider any running max from previous chunks.
+void decode_softmax_max(bfloat16 *scores, bfloat16 *score_max) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::vector<bfloat16, VecLen> max_v =
+        aie::broadcast<bfloat16, VecLen>(lowest_val);
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        max_v = aie::max(max_v, aie::load_v<VecLen>(sc_h + i));
+      }
+    // Reduce 16 → 1
+    aie::vector<bfloat16, 8> r0 = max_v.extract<8>(0);
+    aie::vector<bfloat16, 8> r1 = max_v.extract<8>(1);
+    r0 = aie::max(r0, r1);
+    score_max[h] = aie::reduce_max(r0);
+  }
+}
+
+// In-place online softmax update:
+//   combined_max[h] = max(max_vec[h], score_max[h])
+//   rescale[h]      = exp(max_vec[h] - combined_max[h])   [for old output]
+//   scores[h, i]    = exp(scores[h, i] - combined_max[h]) [in-place]
+//   max_vec[h]      = combined_max[h]                      [running max
+//   updated]
+void decode_softmax_exp(bfloat16 *scores, bfloat16 *max_vec,
+                        bfloat16 *score_max, bfloat16 *rescale) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  aie::vector<bfloat16, VecLen> log2e_vec =
+      aie::broadcast<bfloat16, VecLen>((bfloat16)decode_log2e);
+  aie::vector<bfloat16, VecLen> lowest_vec =
+      aie::broadcast<bfloat16, VecLen>(lowest_val);
+
+  for (int h = 0; h < group_size; h++) {
+    float om = (float)max_vec[h];
+    float nm = (float)score_max[h];
+    float combined = (om > nm) ? om : nm;
+
+    // Rescale factor for old accumulated output: exp(old_max - new_max)
+    float diff_rescale_f = om - combined;
+    bfloat16 diff_rescale = (bfloat16)diff_rescale_f;
+    // Clamp to lowest before exp to avoid -inf input to exp2
+    if ((float)diff_rescale < (float)lowest_val)
+      diff_rescale = lowest_val;
+    {
+      aie::vector<bfloat16, 8> d8 = aie::broadcast<bfloat16, 8>(diff_rescale);
+      aie::vector<bfloat16, 8> l8 =
+          aie::broadcast<bfloat16, 8>((bfloat16)decode_log2e);
+      aie::vector<bfloat16, 8> r8 =
+          aie::exp2<bfloat16>(aie::mul(d8, l8).to_vector<float>());
+      rescale[h] = r8.get(0);
+    }
+
+    // Update running max
+    max_vec[h] = (bfloat16)combined;
+
+    // Normalize scores: scores[h,i] = exp(scores[h,i] - combined)
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::vector<bfloat16, VecLen> max_bcast =
+        aie::broadcast<bfloat16, VecLen>((bfloat16)combined);
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(sc_h + i);
+        v = aie::sub(v, max_bcast);
+        v = aie::max(v, lowest_vec); // clamp before exp
+        v = aie::exp2<bfloat16>(aie::mul(v, log2e_vec).to_vector<float>());
+        aie::store_v(sc_h + i, v);
+      }
+  }
+}
+
+// Update running sum: sum[h] = sum[h] * rescale[h] + row_sum(scores[h, :])
+// scores[h, :] must already contain exp-normalized values (after
+// decode_softmax_exp).
+void decode_softmax_sum(bfloat16 *scores, bfloat16 *rescale, bfloat16 *sum) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::accum<accfloat, VecLen> row_acc = aie::zeros<accfloat, VecLen>();
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        row_acc = aie::add(row_acc, aie::load_v<VecLen>(sc_h + i));
+      }
+    // Reduce 16 → scalar
+    aie::vector<float, VecLen> sum_f = row_acc.to_vector<float>();
+    aie::vector<float, 8> r0 = sum_f.extract<8>(0);
+    aie::vector<float, 8> r1 = sum_f.extract<8>(1);
+    r0 = aie::add(r0, r1);
+    float row_sum = aie::reduce_add(r0);
+    // update: sum = sum * rescale + row_sum
+    sum[h] = (bfloat16)((float)sum[h] * (float)rescale[h] + row_sum);
+  }
+}
+
+// Rescale output: output[h, :] *= rescale[h]
+void decode_rescale_output(bfloat16 *rescale, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    aie::vector<bfloat16, VecLen> r_bcast =
+        aie::broadcast<bfloat16, VecLen>(rescale[h]);
+    for (int j = 0; j < dv; j += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(out_h + j);
+        aie::accum<accfloat, VecLen> acc = aie::mul(v, r_bcast);
+        aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+      }
+  }
+}
+
+// Accumulate PV: output[h, :] += sum_i scores[h, i] * V[i, :]
+// V is [lkp, dv] row-major.  scores[h, :] must hold exp-normalized weights.
+// Uses scalar-broadcast mac: for each position i, broadcast scores[h,i] and
+// multiply with V[i, j:j+VecLen] vector chunk.
+void compute_pv_output_bf16(bfloat16 *scores, bfloat16 *V, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 one_bf16 = (bfloat16)1.0f;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    bfloat16 *sc_h = scores + h * lkp;
+    for (int j = 0; j < dv; j += VecLen) {
+      // Load existing output into accfloat (multiply by 1.0 to convert)
+      aie::vector<bfloat16, VecLen> existing = aie::load_v<VecLen>(out_h + j);
+      aie::vector<bfloat16, VecLen> one_vec =
+          aie::broadcast<bfloat16, VecLen>(one_bf16);
+      aie::accum<accfloat, VecLen> acc = aie::mul(existing, one_vec);
+      // Scalar-broadcast mac over K/V positions.
+      // TODO(perf): Add chess_prepare_for_pipelining pragma here (this is the
+      // most compute-intensive inner loop) once exp2 vector usage (lines above)
+      // is confirmed compatible with pipelining on AIE2P.
+      for (int i = 0; i < lkp; i++) {
+        aie::vector<bfloat16, VecLen> s_bcast =
+            aie::broadcast<bfloat16, VecLen>(sc_h[i]);
+        aie::vector<bfloat16, VecLen> v_row =
+            aie::load_v<VecLen>(V + i * dv + j);
+        acc = aie::mac(acc, s_bcast, v_row);
+      }
+      aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+    }
+  }
+}
+
+// Final division: output[h, :] /= sum[h]
+void decode_div_output(bfloat16 *sum, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    bfloat16 inv_sum = (bfloat16)(1.0f / (float)sum[h]);
+    aie::vector<bfloat16, VecLen> inv_bcast =
+        aie::broadcast<bfloat16, VecLen>(inv_sum);
+    for (int j = 0; j < dv; j += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(out_h + j);
+        aie::accum<accfloat, VecLen> acc = aie::mul(v, inv_bcast);
+        aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+      }
+  }
+}
+
+// ============================================================
+// Cascade merge helpers
+// ============================================================
+
+// Element-wise max update: max_local[h] = max(max_local[h], max_recv[h])
+// Only the first group_size entries are updated.
+void decode_cascade_merge_max(bfloat16 *max_recv, bfloat16 *max_local) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    float a = (float)max_local[h];
+    float b = (float)max_recv[h];
+    max_local[h] = (bfloat16)(a > b ? a : b);
+  }
+}
+
+// Compute rescale factor: rescale[h] = exp(old_max[h] - new_max[h])
+// old_max and new_max have group_size meaningful entries.
+void decode_compute_rescale(bfloat16 *old_max, bfloat16 *new_max,
+                            bfloat16 *rescale) {
+  SET_ROUNDING();
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  for (int h = 0; h < group_size; h++) {
+    float diff = (float)old_max[h] - (float)new_max[h];
+    bfloat16 diff_bf16 = (bfloat16)diff;
+    if ((float)diff_bf16 < (float)lowest_val)
+      diff_bf16 = lowest_val;
+    aie::vector<bfloat16, 8> d8 = aie::broadcast<bfloat16, 8>(diff_bf16);
+    aie::vector<bfloat16, 8> l8 =
+        aie::broadcast<bfloat16, 8>((bfloat16)decode_log2e);
+    aie::vector<bfloat16, 8> r8 =
+        aie::exp2<bfloat16>(aie::mul(d8, l8).to_vector<float>());
+    rescale[h] = r8.get(0);
+  }
+}
+
+// Element-wise add: out_dst[h, :] += out_src[h, :]
+// Both are [group_size, dv] row-major.
+void decode_add_output(bfloat16 *out_src, bfloat16 *out_dst) {
+  SET_ROUNDING();
+  constexpr int VecLen = 32;
+  constexpr int num_elems = group_size * dv;
+  bfloat16 *__restrict ps = out_src;
+  bfloat16 *__restrict pd = out_dst;
+  for (int i = 0; i < num_elems; i += VecLen)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      aie::vector<bfloat16, VecLen> vs = aie::load_v<VecLen>(ps);
+      aie::vector<bfloat16, VecLen> vd = aie::load_v<VecLen>(pd);
+      aie::accum<accfloat, VecLen> acc(vd);
+      acc = aie::add(acc, vs);
+      aie::store_v(pd, acc.to_vector<bfloat16>());
+      ps += VecLen;
+      pd += VecLen;
+    }
+}
+
+// Add sums: sum_dst[h] += sum_src[h]  for h in [0, group_size)
+void decode_add_sum(bfloat16 *sum_src, bfloat16 *sum_dst) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    sum_dst[h] = (bfloat16)((float)sum_dst[h] + (float)sum_src[h]);
+  }
+}
+
+// Rescale sum in-place: sum[h] *= rescale[h]  for h in [0, group_size)
+void decode_rescale_sum(bfloat16 *rescale, bfloat16 *sum) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    sum[h] = (bfloat16)((float)sum[h] * (float)rescale[h]);
+  }
+}
+
+// Copy max/sum vector: dst[h] = src[h]  for h in [0, group_size)
+void decode_copy_max_sum(bfloat16 *src, bfloat16 *dst) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    dst[h] = src[h];
+  }
+}
+
+} // extern "C"

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.py
@@ -1,0 +1,908 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Decode-phase flash attention on NPU2 (AIE2P).
+
+Implements a drop-in replacement for decode_attention_cpu() using matvec-style
+kernels (group_size too small for 8x8 tiled matmul).
+
+Architecture:
+  Herd: [num_kv_parallel, num_cascade_stages]  (e.g. [4,4] = 16 tiles)
+    tx = KV head index within the current launch group
+    ty = cascade stage (partitions the KV sequence)
+  Launch iterations: num_kv_heads // num_kv_parallel
+
+Per tile (tx, ty):
+  - DMA pos [1] from L3 via QKV_dec (once)
+  - DMA Q [group_size, dk] from L3 via QKV_dec (once)
+  - Init output, max, sum
+  - For each of chunks_per_stage K/V chunks:
+      DMA K [lkp, dk] and V [lkp, dv] from L3
+      compute_qk_scores  -> scores[group_size, lkp]
+      apply_decode_mask  -> set scores to -inf for positions > current_pos
+      online softmax update (max, exp, sum, rescale, PV accumulate)
+  - Cascade merge (north-to-south: ty=NS-1 first, ty=0 last)
+  - ty==0: decode_div_output, write result to L2, then segment DMA to L3
+
+Default parameters:
+  lk=2048, lkp=64, dk=64, dv=64, group_size=4,
+  num_kv_heads=4, num_kv_parallel=4, num_cascade_stages=4
+
+DMA channel budget per tile (2 S2MM + 2 MM2S):
+  S2MM 0: pos (once), Q (once), then K and V chunks interleaved in loop
+  MM2S 0: output L1->L2 (ty==0 only)
+  Cascade put/get use cascade stream hardware (separate from DMA channels)
+  Note: K and V share S2MM 0 via QKV_dec to avoid S2MM-1 infinite-BD-loop
+  deadlock and to keep shim MM2S channels ≤ NKV*NS ≤ 16 total.
+  Note: num_kv_heads must equal num_kv_parallel (kv_head_groups=1) to stay
+  within the 16-BD-per-shim-column budget (2 MM2S × 4 BDs + 1 S2MM = 9 ≤ 16).
+
+Design deviation from ticket T003:
+  T003 prescribed two separate channels (QK_dec for Q+K on S2MM 0, V_dec for
+  V on S2MM 1). The two-channel approach was implemented (commit be5a4ec7) but
+  produced 30.86% output mismatch due to S2MM-1 BD-chain ordering deadlock.
+  The single QKV_dec channel (this implementation) avoids the deadlock by
+  routing all inputs through S2MM 0, with segment ChannelPuts Python-loop-
+  unrolled to guarantee K₀,V₀,K₁,V₁,... ordering that matches the tile BD
+  chain. This produces O(chunks_per_stage × NKV × NS) MLIR ops; for lk=2048
+  with defaults this is 8×4×4=128 K+V ops (manageable). Users targeting
+  lk > 4096 should expect proportionally larger MLIR modules.
+  TODO: Investigate restoring S2MM-1 for V traffic (would allow larger lk
+  with fewer unrolled ops) once the BD-chain ordering issue is resolved.
+
+Output path: L1 -> L2 (herd, ty==0) -> L3 (segment, after herd)
+"""
+
+import argparse
+from math import sqrt
+
+import numpy as np
+
+import air
+from air.ir import *
+from air.dialects.air import *
+from air.dialects.air import channel
+from air.dialects.arith import ConstantOp
+from air.dialects.memref import AllocOp, DeallocOp, load, store
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.scf import for_ as scf_range, yield_
+from air.dialects import scf, affine, arith
+from air.dialects.affine import apply as affine_apply
+
+
+@module_builder
+def build_module(
+    lk=2048,
+    lkp=64,
+    dk=64,
+    dv=64,
+    group_size=4,
+    num_kv_heads=4,
+    num_kv_parallel=4,
+    num_cascade_stages=4,
+):
+    """Build decode flash attention module.
+
+    Args:
+        lk: Maximum KV cache sequence length (default: 2048)
+        lkp: K/V chunk size per cascade stage chunk (default: 64)
+        dk: Key head dimension (default: 64)
+        dv: Value head dimension (default: 64)
+        group_size: Q heads per KV head (= num_heads // num_kv_heads, default: 4)
+        num_kv_heads: Number of KV heads (default: 8)
+        num_kv_parallel: KV heads processed in parallel / herd x-dim (default: 4)
+        num_cascade_stages: Cascade depth / herd y-dim (NS, default: 4)
+    """
+    assert lk % lkp == 0, f"lk ({lk}) must be divisible by lkp ({lkp})"
+    assert (
+        lk % (lkp * num_cascade_stages) == 0
+    ), f"lk ({lk}) must be divisible by lkp*NS ({lkp * num_cascade_stages})"
+    assert num_kv_heads % num_kv_parallel == 0, (
+        f"num_kv_heads ({num_kv_heads}) must be divisible by "
+        f"num_kv_parallel ({num_kv_parallel})"
+    )
+
+    num_heads = group_size * num_kv_heads
+    kv_head_groups = num_kv_heads // num_kv_parallel
+    assert kv_head_groups == 1, (
+        f"Decode requires kv_head_groups==1 (num_kv_heads==num_kv_parallel) "
+        f"to stay within the 16-BD-per-shim-column budget. "
+        f"Got kv_head_groups={kv_head_groups}"
+    )
+    NS = num_cascade_stages
+    NKV = num_kv_parallel
+    num_chunks = lk // lkp
+    chunks_per_stage = num_chunks // NS
+
+    # Cascade alignment: 512-bit bus = 32 bfloat16 elements.
+    max_sum_buf_size = max(group_size, 32)
+
+    bf16 = Type.parse("bf16")
+    i32 = IntegerType.get_signless(32)
+    index_type = IndexType.get()
+
+    # Memory spaces
+    l1_space = IntegerAttr.get(i32, 2)
+    l2_space = IntegerAttr.get(i32, 1)
+
+    # L1 MemRefTypes
+    q_l1_t = MemRefType.get([group_size, dk], bf16, memory_space=l1_space)
+    k_l1_t = MemRefType.get([lkp, dk], bf16, memory_space=l1_space)
+    v_l1_t = MemRefType.get([lkp, dv], bf16, memory_space=l1_space)
+    scores_l1_t = MemRefType.get([group_size, lkp], bf16, memory_space=l1_space)
+    out_l1_t = MemRefType.get([group_size, dv], bf16, memory_space=l1_space)
+    ms_l1_t = MemRefType.get([max_sum_buf_size], bf16, memory_space=l1_space)
+    pos_l1_t = MemRefType.get([1], i32, memory_space=l1_space)
+    # L2 MemRefTypes
+    # Output staging: [NKV, group_size, dv] — one row per tx (filled by ty==0 tiles)
+    out_l2_t = MemRefType.get([NKV, group_size, dv], bf16, memory_space=l2_space)
+
+    # L3 MemRefTypes
+    q_l3_t = MemRefType.get([num_heads, dk], bf16)
+    k_l3_t = MemRefType.get([num_kv_heads, lk, dk], bf16)
+    v_l3_t = MemRefType.get([num_kv_heads, lk, dv], bf16)
+    pos_l3_t = MemRefType.get([1], i32)
+    out_l3_t = MemRefType.get([num_heads, dv], bf16)
+
+    # ------------------------------------------------------------------
+    # External function declarations (link with decode kernel .o)
+    # ------------------------------------------------------------------
+    def external_func(name, inputs, link_with=None):
+        func_type = FunctionType.get(inputs, [])
+        func = FuncOp(name=name, type=func_type, visibility="private")
+        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+        if link_with:
+            func.attributes["link_with"] = StringAttr.get(link_with)
+        return func
+
+    kobj = "attn_decode_npu2.o"
+    external_func("decode_zero_output", [out_l1_t], link_with=kobj)
+    external_func("decode_zero_sum", [ms_l1_t], link_with=kobj)
+    external_func("decode_neg_inf_max", [ms_l1_t], link_with=kobj)
+    external_func(
+        "compute_qk_scores_bf16", [k_l1_t, q_l1_t, scores_l1_t], link_with=kobj
+    )
+    external_func("apply_decode_mask", [scores_l1_t, i32, i32], link_with=kobj)
+    external_func("decode_softmax_max", [scores_l1_t, ms_l1_t], link_with=kobj)
+    external_func(
+        "decode_softmax_exp",
+        [scores_l1_t, ms_l1_t, ms_l1_t, ms_l1_t],
+        link_with=kobj,
+    )
+    external_func("decode_softmax_sum", [scores_l1_t, ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_rescale_output", [ms_l1_t, out_l1_t], link_with=kobj)
+    external_func(
+        "compute_pv_output_bf16", [scores_l1_t, v_l1_t, out_l1_t], link_with=kobj
+    )
+    external_func("decode_div_output", [ms_l1_t, out_l1_t], link_with=kobj)
+    external_func("decode_cascade_merge_max", [ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_compute_rescale", [ms_l1_t, ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_add_output", [out_l1_t, out_l1_t], link_with=kobj)
+    external_func("decode_add_sum", [ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_rescale_sum", [ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_copy_max_sum", [ms_l1_t, ms_l1_t], link_with=kobj)
+
+    # ------------------------------------------------------------------
+    # DMA channels: QKV_dec routes pos, Q, then interleaved K+V chunks
+    #               (→ S2MM 0 only; avoids S2MM 1 infinite-BD-loop bug
+    #               and keeps NKV*NS ≤ 16 total shim MM2S channels),
+    #               out_dec routes L1→L2 output (ty==0 tiles only)
+    # ------------------------------------------------------------------
+    channel("QKV_dec", size=[NKV, NS])
+    channel("out_dec", size=[NKV, 1])
+
+    # ------------------------------------------------------------------
+    # Cascade channels (north-to-south: ty=NS-1 first, ty=0 last)
+    # ------------------------------------------------------------------
+    channel("cascade_out_dec", size=[NKV, NS - 1], channel_type="cascade")
+    channel("cascade_max_dec", size=[NKV, NS - 1], channel_type="cascade")
+    channel("cascade_sum_dec", size=[NKV, NS - 1], channel_type="cascade")
+
+    # ------------------------------------------------------------------
+    # Main decode attention function
+    # ------------------------------------------------------------------
+    @FuncOp.from_py_func(q_l3_t, k_l3_t, v_l3_t, pos_l3_t, out_l3_t)
+    def decode_attention_bf16(q_in, k_in, v_in, pos_in, out):
+        c_kv_groups = ConstantOp(index_type, kv_head_groups)
+
+        @launch(
+            operands=[q_in, k_in, v_in, pos_in, out],
+            sizes=[c_kv_groups],
+        )
+        def launch_body(lx, lsx, q, k, v, pos, gp_out):
+
+            @segment(
+                name="decode_seg",
+                operands=[lx, q, k, v, pos, gp_out],
+            )
+            def segment_body(lx_s, q_s, k_s, v_s, pos_s, out_s):
+                # ----------------------------------------------------------
+                # L2 output staging buffer: each tx tile writes to its row
+                # ----------------------------------------------------------
+                out_l2 = AllocOp(out_l2_t, [], [])
+
+                # L1 per-tile scratch buffers (shared across tile instances)
+                q_l1 = AllocOp(q_l1_t, [], [])
+                k_l1 = AllocOp(k_l1_t, [], [])
+                v_l1 = AllocOp(v_l1_t, [], [])
+                scores_l1 = AllocOp(scores_l1_t, [], [])
+                out_l1 = AllocOp(out_l1_t, [], [])
+                max_l1 = AllocOp(ms_l1_t, [], [])
+                sum_l1 = AllocOp(ms_l1_t, [], [])
+                score_max_tmp = AllocOp(ms_l1_t, [], [])
+                rescale_tmp = AllocOp(ms_l1_t, [], [])
+                # Cascade receive buffers
+                out_c = AllocOp(out_l1_t, [], [])
+                max_c = AllocOp(ms_l1_t, [], [])
+                sum_c = AllocOp(ms_l1_t, [], [])
+                # For cascade merge: save old max to compute two rescales
+                old_max_save = AllocOp(ms_l1_t, [], [])
+                rescale_recv_c = AllocOp(ms_l1_t, [], [])
+                rescale_local_c = AllocOp(ms_l1_t, [], [])
+                pos_l1 = AllocOp(pos_l1_t, [], [])
+
+                c_nkv = ConstantOp(index_type, NKV)
+                c_ns = ConstantOp(index_type, NS)
+
+                # ----------------------------------------------------------
+                # Segment ChannelPut loops: feed pos, Q, K, V to herd via QKV_dec.
+                #   QKV_dec → S2MM 0: pos (once), Q (once), then per chunk K then V.
+                #   Single channel avoids the S2MM-1 infinite-BD-loop deadlock
+                #   and keeps total shim MM2S ≤ NKV*NS ≤ 16.
+                # ----------------------------------------------------------
+                # Affine maps for per-tile (tx_i) offset calculation.
+                # kv_h = lx_s * NKV + tx_i
+                kv_head_map_seg = AffineMap.get(
+                    0,
+                    2,
+                    [
+                        AffineExpr.get_add(
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(NKV),
+                            ),
+                            AffineSymbolExpr.get(1),
+                        )
+                    ],
+                )
+                # q_head_base = kv_h * group_size
+                q_head_map_seg = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(group_size),
+                        )
+                    ],
+                )
+                # --- pos ChannelPuts (once per tile, sent first) ---
+                for tx_i in range(NKV):
+                    c_tx_i_pos = ConstantOp(index_type, tx_i)
+                    for ty_i in range(NS):
+                        c_ty_i_pos = ConstantOp(index_type, ty_i)
+                        ChannelPut(
+                            "QKV_dec",
+                            pos_s,
+                            offsets=[0],
+                            sizes=[1],
+                            strides=[1],
+                            indices=[c_tx_i_pos, c_ty_i_pos],
+                        )
+
+                # --- Q ChannelPuts (once per tile) ---
+                for tx_i in range(NKV):
+                    c_tx_i = ConstantOp(index_type, tx_i)
+                    kv_h_q = affine_apply(kv_head_map_seg, [lx_s, c_tx_i])
+                    q_base_seg = affine_apply(q_head_map_seg, [kv_h_q])
+                    for ty_i in range(NS):
+                        c_ty_i = ConstantOp(index_type, ty_i)
+                        ChannelPut(
+                            "QKV_dec",
+                            q_s,
+                            offsets=[q_base_seg, 0],
+                            sizes=[group_size, dk],
+                            strides=[dk, 1],
+                            indices=[c_tx_i, c_ty_i],
+                        )
+
+                # --- K and V ChannelPuts interleaved per chunk, per tile ---
+                # K then V on QKV_dec (S2MM 0): avoids the V S2MM-1 deadlock.
+                # Use Python range (not scf_range) so each chunk becomes a separate
+                # DMA task, preserving K0,V0,K1,V1 ordering that matches the tile
+                # S2MM BD chain (repeat_count = chunks_per_stage - 1).
+                for chunk_i_val in range(chunks_per_stage):
+                    for tx_i in range(NKV):
+                        c_tx_i = ConstantOp(index_type, tx_i)
+                        kv_h_kv = affine_apply(kv_head_map_seg, [lx_s, c_tx_i])
+                        for ty_i in range(NS):
+                            c_ty_i = ConstantOp(index_type, ty_i)
+                            chunk_pos_val = (
+                                ty_i * chunks_per_stage * lkp + chunk_i_val * lkp
+                            )
+                            c_chunk_pos = ConstantOp(index_type, chunk_pos_val)
+                            ChannelPut(
+                                "QKV_dec",
+                                k_s,
+                                offsets=[kv_h_kv, c_chunk_pos, 0],
+                                sizes=[1, lkp, dk],
+                                strides=[lk * dk, dk, 1],
+                                indices=[c_tx_i, c_ty_i],
+                            )
+                            ChannelPut(
+                                "QKV_dec",
+                                v_s,
+                                offsets=[kv_h_kv, c_chunk_pos, 0],
+                                sizes=[1, lkp, dv],
+                                strides=[lk * dv, dv, 1],
+                                indices=[c_tx_i, c_ty_i],
+                            )
+
+                @herd(
+                    name="decode_herd",
+                    sizes=[c_nkv, c_ns],
+                    operands=[
+                        q_l1,
+                        k_l1,
+                        v_l1,
+                        scores_l1,
+                        out_l1,
+                        max_l1,
+                        sum_l1,
+                        score_max_tmp,
+                        rescale_tmp,
+                        out_c,
+                        max_c,
+                        sum_c,
+                        old_max_save,
+                        rescale_recv_c,
+                        rescale_local_c,
+                        pos_l1,
+                    ],
+                    link_with="attn_decode_npu2.o",
+                )
+                def herd_body(
+                    tx,
+                    ty,
+                    hsx,
+                    hsy,
+                    _q_l1,
+                    _k_l1,
+                    _v_l1,
+                    _scores_l1,
+                    _out_l1,
+                    _max_l1,
+                    _sum_l1,
+                    _score_max_tmp,
+                    _rescale_tmp,
+                    _out_c,
+                    _max_c,
+                    _sum_c,
+                    _old_max_save,
+                    _rescale_recv_c,
+                    _rescale_local_c,
+                    _pos_l1,
+                ):
+                    # ------------------------------------------------
+                    # Compute per-tile stage offset for causal mask.
+                    # kv_h offset is handled in segment ChannelPuts.
+                    # ty_pos_start = ty * chunks_per_stage * lkp
+                    # ------------------------------------------------
+                    # ty_pos_start = ty * chunks_per_stage * lkp
+                    ty_pos_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(chunks_per_stage * lkp),
+                            )
+                        ],
+                    )
+                    ty_pos_start = affine_apply(ty_pos_map, [ty])
+
+                    # ------------------------------------------------
+                    # pos [1] L3->L1 via QKV_dec (sent first in segment)
+                    # ------------------------------------------------
+                    ChannelGet("QKV_dec", _pos_l1, indices=[tx, ty])
+                    c0_idx = ConstantOp(index_type, 0)
+                    pos_val = load(_pos_l1, [c0_idx])
+
+                    # ------------------------------------------------
+                    # Q [group_size, dk] L3->L1 via QKV_dec channel
+                    # (segment ChannelPut sends correct slice per tile)
+                    # ------------------------------------------------
+                    ChannelGet("QKV_dec", _q_l1, indices=[tx, ty])
+
+                    # ------------------------------------------------
+                    # Initialize output, max, sum
+                    # ------------------------------------------------
+                    CallOp([], "decode_zero_output", [_out_l1])
+                    CallOp([], "decode_neg_inf_max", [_max_l1])
+                    CallOp([], "decode_zero_sum", [_sum_l1])
+
+                    # ------------------------------------------------
+                    # Chunk loop: process chunks_per_stage K/V chunks
+                    # K then V both via QKV_dec (single S2MM 0 channel)
+                    # ------------------------------------------------
+                    c_chunks = ConstantOp(index_type, chunks_per_stage)
+
+                    # chunk_pos_map: ty_pos_start + chunk_idx * lkp
+                    chunk_pos_map = AffineMap.get(
+                        0,
+                        2,
+                        [
+                            AffineExpr.get_add(
+                                AffineSymbolExpr.get(0),
+                                AffineExpr.get_mul(
+                                    AffineSymbolExpr.get(1),
+                                    AffineConstantExpr.get(lkp),
+                                ),
+                            )
+                        ],
+                    )
+
+                    for chunk_idx in scf_range(0, c_chunks, 1):
+                        chunk_pos = affine_apply(
+                            chunk_pos_map, [ty_pos_start, chunk_idx]
+                        )
+
+                        # K chunk via QKV_dec (S2MM 0)
+                        ChannelGet("QKV_dec", _k_l1, indices=[tx, ty])
+
+                        # V chunk via QKV_dec (S2MM 0, same channel as K)
+                        ChannelGet("QKV_dec", _v_l1, indices=[tx, ty])
+
+                        # QK scores: scores[h,i] = K[i,:].Q[h,:]
+                        CallOp(
+                            [],
+                            "compute_qk_scores_bf16",
+                            [_k_l1, _q_l1, _scores_l1],
+                        )
+
+                        # Causal mask for decode
+                        chunk_pos_i32 = arith.IndexCastOp(i32, chunk_pos).result
+                        CallOp(
+                            [],
+                            "apply_decode_mask",
+                            [_scores_l1, chunk_pos_i32, pos_val],
+                        )
+
+                        # Online softmax:
+                        #   score_max_tmp = row_max(scores)
+                        CallOp(
+                            [],
+                            "decode_softmax_max",
+                            [_scores_l1, _score_max_tmp],
+                        )
+                        #   rescale_tmp = exp(old_max - new_max)
+                        #   scores = exp(scores - new_max)   [in-place]
+                        #   max_l1 updated to max(max_l1, score_max_tmp)
+                        CallOp(
+                            [],
+                            "decode_softmax_exp",
+                            [_scores_l1, _max_l1, _score_max_tmp, _rescale_tmp],
+                        )
+                        #   Rescale accumulated output
+                        CallOp(
+                            [],
+                            "decode_rescale_output",
+                            [_rescale_tmp, _out_l1],
+                        )
+                        #   Accumulate P @ V
+                        CallOp(
+                            [],
+                            "compute_pv_output_bf16",
+                            [_scores_l1, _v_l1, _out_l1],
+                        )
+                        #   Update running sum
+                        CallOp(
+                            [],
+                            "decode_softmax_sum",
+                            [_scores_l1, _rescale_tmp, _sum_l1],
+                        )
+
+                        yield_([])
+
+                    # ------------------------------------------------
+                    # Cascade merge (north-to-south)
+                    # ty = NS-1 (northernmost): just send cascade south
+                    # ty = 1..NS-2 (middle): receive, merge, send
+                    # ty = 0 (southernmost): receive, merge, div, output
+                    # ------------------------------------------------
+                    c1_idx = ConstantOp(index_type, 1)
+                    ns_m1 = AffineConstantExpr.get(NS - 1)
+                    s0 = AffineSymbolExpr.get(0)
+                    s1 = AffineSymbolExpr.get(1)
+
+                    set_first_stage = IntegerSet.get(
+                        0, 2, [s0, s1 - ns_m1], [False, True]
+                    )
+                    set_middle_stage = IntegerSet.get(
+                        0,
+                        2,
+                        [
+                            AffineExpr.get_add(s1, AffineConstantExpr.get(-1)),
+                            AffineExpr.get_add(
+                                AffineConstantExpr.get(NS - 2),
+                                AffineExpr.get_mul(s1, AffineConstantExpr.get(-1)),
+                            ),
+                            s0,
+                            AffineExpr.get_add(
+                                AffineConstantExpr.get(NKV - 1),
+                                AffineExpr.get_mul(s0, AffineConstantExpr.get(-1)),
+                            ),
+                        ],
+                        [False, False, False, False],
+                    )
+
+                    # ty == NS-1: send cascade south
+                    if_last = affine.AffineIfOp(
+                        set_first_stage,
+                        cond_operands=[tx, ty],
+                        has_else=True,
+                    )
+                    with InsertionPoint(if_last.then_block):
+                        subi_l = arith.SubIOp(ty, c1_idx)
+                        ChannelPut("cascade_out_dec", _out_l1, indices=[tx, subi_l])
+                        ChannelPut("cascade_max_dec", _max_l1, indices=[tx, subi_l])
+                        ChannelPut("cascade_sum_dec", _sum_l1, indices=[tx, subi_l])
+                        affine.AffineYieldOp([])
+
+                    with InsertionPoint(if_last.else_block):
+                        if_mid = affine.AffineIfOp(
+                            set_middle_stage,
+                            cond_operands=[tx, ty],
+                            has_else=True,
+                        )
+
+                        # --- Middle stages: receive, merge, send ---
+                        with InsertionPoint(if_mid.then_block):
+                            ChannelGet("cascade_out_dec", _out_c, indices=[tx, ty])
+                            ChannelGet("cascade_max_dec", _max_c, indices=[tx, ty])
+                            ChannelGet("cascade_sum_dec", _sum_c, indices=[tx, ty])
+                            _cascade_merge(
+                                _out_l1,
+                                _max_l1,
+                                _sum_l1,
+                                _out_c,
+                                _max_c,
+                                _sum_c,
+                                _old_max_save,
+                                _rescale_recv_c,
+                                _rescale_local_c,
+                            )
+                            subi_m = arith.SubIOp(ty, c1_idx)
+                            ChannelPut("cascade_out_dec", _out_l1, indices=[tx, subi_m])
+                            ChannelPut("cascade_max_dec", _max_l1, indices=[tx, subi_m])
+                            ChannelPut("cascade_sum_dec", _sum_l1, indices=[tx, subi_m])
+                            affine.AffineYieldOp([])
+
+                        # --- ty == 0: receive, merge, div, write output ---
+                        with InsertionPoint(if_mid.else_block):
+                            ChannelGet("cascade_out_dec", _out_c, indices=[tx, ty])
+                            ChannelGet("cascade_max_dec", _max_c, indices=[tx, ty])
+                            ChannelGet("cascade_sum_dec", _sum_c, indices=[tx, ty])
+                            _cascade_merge(
+                                _out_l1,
+                                _max_l1,
+                                _sum_l1,
+                                _out_c,
+                                _max_c,
+                                _sum_c,
+                                _old_max_save,
+                                _rescale_recv_c,
+                                _rescale_local_c,
+                            )
+                            # Final normalization
+                            CallOp([], "decode_div_output", [_sum_l1, _out_l1])
+                            # Send result L1 -> L2 via explicit out_dec channel
+                            # (ty==0 only; segment ChannelGet receives into out_l2)
+                            c0_h = ConstantOp(index_type, 0)
+                            ChannelPut("out_dec", _out_l1, indices=[tx, c0_h])
+                            affine.AffineYieldOp([])
+
+                        affine.AffineYieldOp([])
+
+                # --------------------------------------------------------
+                # Receive herd output into L2 staging via out_dec channel.
+                # Each ty==0 tile (tx=0..NKV-1) puts _out_l1 to out_dec[tx, 0].
+                # The matching segment ChannelGets fill out_l2[tx, :, :].
+                # --------------------------------------------------------
+                c0_out = ConstantOp(index_type, 0)
+                for tx_i in range(NKV):
+                    c_tx_i_out = ConstantOp(index_type, tx_i)
+                    ChannelGet(
+                        "out_dec",
+                        out_l2.result,
+                        offsets=[tx_i, 0, 0],
+                        sizes=[1, group_size, dv],
+                        strides=[group_size * dv, dv, 1],
+                        indices=[c_tx_i_out, c0_out],
+                    )
+
+                # --------------------------------------------------------
+                # After herd: DMA output L2 -> L3
+                # q_head_base_launch = lx_s * NKV * group_size
+                # --------------------------------------------------------
+                q_launch_map = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(NKV * group_size),
+                        )
+                    ],
+                )
+                q_launch_base = affine_apply(q_launch_map, [lx_s])
+
+                dma_memcpy_nd(
+                    out_s,
+                    out_l2.result,
+                    dst_offsets=[q_launch_base, 0],
+                    dst_sizes=[NKV * group_size, dv],
+                    dst_strides=[dv, 1],
+                    src_offsets=[0, 0, 0],
+                    src_sizes=[NKV, group_size, dv],
+                    src_strides=[group_size * dv, dv, 1],
+                )
+
+                # Deallocate all scratch buffers
+                DeallocOp(out_l2)
+                DeallocOp(q_l1)
+                DeallocOp(k_l1)
+                DeallocOp(v_l1)
+                DeallocOp(scores_l1)
+                DeallocOp(out_l1)
+                DeallocOp(max_l1)
+                DeallocOp(sum_l1)
+                DeallocOp(score_max_tmp)
+                DeallocOp(rescale_tmp)
+                DeallocOp(out_c)
+                DeallocOp(max_c)
+                DeallocOp(sum_c)
+                DeallocOp(old_max_save)
+                DeallocOp(rescale_recv_c)
+                DeallocOp(rescale_local_c)
+                DeallocOp(pos_l1)
+
+
+def _cascade_merge(
+    out_local,
+    max_local,
+    sum_local,
+    out_recv,
+    max_recv,
+    sum_recv,
+    old_max_save,
+    rescale_recv,
+    rescale_local,
+):
+    """Emit IR to merge two partial softmax results via cascade.
+
+    Both partial results (local and received) are combined into the local
+    buffers using the log-sum-exp identity:
+        new_max   = max(max_local, max_recv)
+        r_local   = exp(old_max_local - new_max)
+        r_recv    = exp(max_recv    - new_max)
+        out_local = r_local * out_local + r_recv * out_recv
+        sum_local = r_local * sum_local + r_recv * sum_recv
+        max_local = new_max
+    """
+    # Save old local max before updating
+    CallOp([], "decode_copy_max_sum", [max_local, old_max_save])
+    # max_local = max(max_local, max_recv)
+    CallOp([], "decode_cascade_merge_max", [max_recv, max_local])
+    # Compute rescale factors from old maxes to combined max
+    CallOp([], "decode_compute_rescale", [max_recv, max_local, rescale_recv])
+    CallOp([], "decode_compute_rescale", [old_max_save, max_local, rescale_local])
+    # Rescale both output buffers and merge
+    CallOp([], "decode_rescale_output", [rescale_recv, out_recv])
+    CallOp([], "decode_rescale_output", [rescale_local, out_local])
+    CallOp([], "decode_add_output", [out_recv, out_local])
+    # Rescale both sum buffers and merge
+    CallOp([], "decode_rescale_sum", [rescale_recv, sum_recv])
+    CallOp([], "decode_rescale_sum", [rescale_local, sum_local])
+    CallOp([], "decode_add_sum", [sum_recv, sum_local])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="attn_decode_npu2.py",
+        description="Decode-phase flash attention on NPU2 (AIE2P)",
+    )
+    parser.add_argument(
+        "-p",
+        "--print-module-only",
+        action="store_true",
+        help="Print MLIR module and exit",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
+    )
+    parser.add_argument(
+        "--lk",
+        type=int,
+        default=2048,
+        help="Maximum KV cache sequence length (default: 2048)",
+    )
+    parser.add_argument(
+        "--lkp",
+        type=int,
+        default=64,
+        help="K/V chunk size per cascade stage chunk (default: 64)",
+    )
+    parser.add_argument("--dk", type=int, default=64, help="Key head dim (default: 64)")
+    parser.add_argument(
+        "--dv", type=int, default=64, help="Value head dim (default: 64)"
+    )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=4,
+        help="Q heads per KV head / GQA group size (default: 4)",
+    )
+    parser.add_argument(
+        "--num-kv-heads",
+        type=int,
+        default=4,
+        help="Number of KV heads (default: 4, must equal num-kv-parallel)",
+    )
+    parser.add_argument(
+        "--num-kv-parallel",
+        type=int,
+        default=4,
+        help="KV heads in parallel / herd x-dim (default: 4)",
+    )
+    parser.add_argument(
+        "--num-cascade-stages",
+        type=int,
+        default=4,
+        help="Cascade stages / herd y-dim (default: 4)",
+    )
+    parser.add_argument(
+        "--current-pos",
+        type=int,
+        default=None,
+        help="Current decode position (default: lk-1 = full cache)",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        default="elf",
+        choices=["elf"],
+        help="Output format (must be 'elf'; decode uses air.launch iteration space "
+        "which requires ELF format on NPU2)",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        default="compile-and-run",
+        choices=["compile-only", "compile-and-run"],
+        help="Compilation mode (default: compile-and-run)",
+    )
+    args = parser.parse_args()
+
+    lk = args.lk
+    lkp = args.lkp
+    dk = args.dk
+    dv = args.dv
+    group_size = args.group_size
+    num_kv_heads = args.num_kv_heads
+    num_kv_parallel = args.num_kv_parallel
+    num_cascade_stages = args.num_cascade_stages
+    num_heads = group_size * num_kv_heads
+    current_pos = args.current_pos if args.current_pos is not None else lk - 1
+
+    mlir_module = build_module(
+        lk=lk,
+        lkp=lkp,
+        dk=dk,
+        dv=dv,
+        group_size=group_size,
+        num_kv_heads=num_kv_heads,
+        num_kv_parallel=num_kv_parallel,
+        num_cascade_stages=num_cascade_stages,
+    )
+
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    from air.backend.xrt_runner import XRTRunner
+    from air.backend.xrt import XRTBackend
+    from ml_dtypes import bfloat16
+
+    INPUT_DATATYPE = OUTPUT_DATATYPE = bfloat16
+    rng = np.random.default_rng(42)
+    val_range = 2.0
+
+    # Inputs
+    input_q = rng.uniform(-val_range, val_range, (num_heads, dk)).astype(INPUT_DATATYPE)
+    input_k = rng.uniform(-val_range, val_range, (num_kv_heads, lk, dk)).astype(
+        INPUT_DATATYPE
+    )
+    input_v = rng.uniform(-val_range, val_range, (num_kv_heads, lk, dv)).astype(
+        INPUT_DATATYPE
+    )
+    input_pos = np.array([current_pos], dtype=np.int32)
+
+    # NumPy reference: decode attention (causal, only positions 0..current_pos)
+    inv_sqrt_dk = 1.0 / sqrt(dk)
+    expected_out = np.zeros((num_heads, dv), dtype=OUTPUT_DATATYPE)
+    for h in range(num_heads):
+        kv_h = h // group_size
+        q_h = input_q[h].astype(np.float32)
+        K_valid = input_k[kv_h, : current_pos + 1, :].astype(np.float32)
+        V_valid = input_v[kv_h, : current_pos + 1, :].astype(np.float32)
+        scores = K_valid @ q_h * inv_sqrt_dk  # [current_pos+1]
+        mx = scores.max()
+        P = np.exp(scores - mx)
+        P = P / P.sum()
+        expected_out[h] = (P @ V_valid).astype(OUTPUT_DATATYPE)
+
+    backend_opts = dict(
+        omit_while_true_loop=False,
+        omit_pingpong="all",
+        verbose=args.verbose,
+        output_format=args.output_format,
+        instance_name="decode_attention_bf16",
+        target_device="npu2",
+    )
+
+    if args.compile_mode == "compile-and-run":
+        runner = XRTRunner(**backend_opts)
+
+        # Test 1: specified current_pos (default: lk-1 = full cache, mask no-op).
+        ret = runner.run_test(
+            mlir_module,
+            inputs=[input_q, input_k, input_v, input_pos],
+            expected_outputs=[expected_out],
+            atol=0.15,
+            rtol=0.04,
+            # 2.0% tolerance (4x prefill's 0.5%): matvec-based online softmax with
+            # cascade merge accumulates more bf16 rounding steps than tiled matmul.
+            max_mismatch_percentage=2.0,
+            min_correlation=0.99,
+        )
+        if ret != 0:
+            exit(ret)
+
+        # Test 2: mid-sequence position to exercise causal masking code path.
+        # apply_decode_mask sets scores[h,i]=-inf for (chunk_start+i) > current_pos.
+        # Using lk//2-1 ensures positions in the upper half are masked to -inf,
+        # validating the masking logic that is a no-op with the default lk-1 position.
+        masked_pos = lk // 2 - 1
+        if masked_pos != current_pos:
+            masked_out = np.zeros((num_heads, dv), dtype=OUTPUT_DATATYPE)
+            for h in range(num_heads):
+                kv_h = h // group_size
+                q_h = input_q[h].astype(np.float32)
+                K_valid = input_k[kv_h, : masked_pos + 1, :].astype(np.float32)
+                V_valid = input_v[kv_h, : masked_pos + 1, :].astype(np.float32)
+                scores_ref = K_valid @ q_h * inv_sqrt_dk
+                mx = scores_ref.max()
+                P = np.exp(scores_ref - mx)
+                P = P / P.sum()
+                masked_out[h] = (P @ V_valid).astype(OUTPUT_DATATYPE)
+            exit(
+                runner.run_test(
+                    mlir_module,
+                    inputs=[
+                        input_q,
+                        input_k,
+                        input_v,
+                        np.array([masked_pos], dtype=np.int32),
+                    ],
+                    expected_outputs=[masked_out],
+                    atol=0.15,
+                    rtol=0.04,
+                    max_mismatch_percentage=2.0,
+                    min_correlation=0.99,
+                )
+            )
+        exit(0)
+    elif args.compile_mode == "compile-only":
+        backend = XRTBackend(**backend_opts)
+        backend.compile(mlir_module)
+        print("Compilation complete.")

--- a/programming_examples/flash_attention/kernel_fusion_based/run_npu2_peano_decode_channels.lit
+++ b/programming_examples/flash_attention/kernel_fusion_based/run_npu2_peano_decode_channels.lit
@@ -1,0 +1,13 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Lightweight FileCheck test: verify decode attention MLIR uses a single
+// QKV_dec channel (not separate QK_dec + V_dec channels) to avoid the
+// S2MM-1 infinite-BD-loop deadlock.  Runs without hardware or Peano.
+//
+// RUN: python3 %S/attn_decode_npu2.py -p --lk 512 --lkp 64 --dk 64 --dv 64 \
+// RUN:   --group-size 4 --num-kv-heads 4 --num-kv-parallel 4 \
+// RUN:   --num-cascade-stages 4 | FileCheck %s
+// CHECK: air.channel @QKV_dec
+// CHECK-NOT: air.channel @V_dec
+// CHECK-NOT: air.channel @QK_dec

--- a/programming_examples/flash_attention/kernel_fusion_based/test_decode_elf_npu2.cpp
+++ b/programming_examples/flash_attention/kernel_fusion_based/test_decode_elf_npu2.cpp
@@ -1,0 +1,209 @@
+//===- test_decode_elf_npu2.cpp --------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+// Profiling harness for decode flash attention on NPU2.
+// Kernel signature: decode_attention_bf16(Q, K_cache, V_cache, pos, Output)
+//   Q:      [num_heads, dk]           bf16
+//   K:      [num_kv_heads, lk, dk]    bf16
+//   V:      [num_kv_heads, lk, dv]    bf16
+//   pos:    [1]                       i32  (current_pos)
+//   Output: [num_heads, dv]           bf16
+
+#include "cxxopts.hpp"
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+
+using DATATYPE = std::bfloat16_t;
+
+static inline DATATYPE random_bf16() {
+  return DATATYPE(4.0f * (float)rand() / (float)RAND_MAX);
+}
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("test_decode_elf_npu2", "Decode attention profiler");
+
+  options.add_options()("help,h", "produce help message")(
+      "elf,e", "the input elf path", cxxopts::value<std::string>())(
+      "kernel,k", "kernel name (format: <kernel>:<instance>)",
+      cxxopts::value<std::string>())("verbosity,v", "verbosity level",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "lk", "KV cache sequence length",
+      cxxopts::value<int>()->default_value("512"))(
+      "dk", "Key head dimension", cxxopts::value<int>()->default_value("64"))(
+      "dv", "Value head dimension", cxxopts::value<int>()->default_value("64"))(
+      "num-heads", "Total Q heads (num_kv_heads * group_size)",
+      cxxopts::value<int>()->default_value("16"))(
+      "num-kv-heads", "Number of KV heads",
+      cxxopts::value<int>()->default_value("4"))(
+      "current-pos", "Token position for masking (default: lk-1 = full cache)",
+      cxxopts::value<int>()->default_value("-1"))(
+      "warmup,w", "Warmup iterations",
+      cxxopts::value<int>()->default_value("10"))(
+      "iterations,n", "Timed iterations",
+      cxxopts::value<int>()->default_value("20"))(
+      "trace-size,t", "Trace buffer size (0 to disable)",
+      cxxopts::value<int>()->default_value("0"));
+
+  auto vm = options.parse(argc, argv);
+  if (vm.count("help")) {
+    std::cout << options.help() << std::endl;
+    return 1;
+  }
+  if (!vm.count("elf") || !vm.count("kernel")) {
+    std::cerr << "Error: --elf and --kernel are required\n"
+              << options.help() << std::endl;
+    return 1;
+  }
+
+  int trace_size = vm["trace-size"].as<int>();
+  int lk = vm["lk"].as<int>();
+  int dk = vm["dk"].as<int>();
+  int dv = vm["dv"].as<int>();
+  int num_heads = vm["num-heads"].as<int>();
+  int num_kv_heads = vm["num-kv-heads"].as<int>();
+  int current_pos = vm["current-pos"].as<int>();
+  if (current_pos < 0)
+    current_pos = lk - 1;
+  int verbosity = vm["verbosity"].as<int>();
+
+  // Buffer sizes
+  size_t Q_VOL = (size_t)num_heads * dk;
+  size_t K_VOL = (size_t)num_kv_heads * lk * dk;
+  size_t V_VOL = (size_t)num_kv_heads * lk * dv;
+  size_t OUT_VOL = (size_t)num_heads * dv;
+  size_t POS_SIZE = sizeof(int32_t);
+
+  size_t Q_SIZE = Q_VOL * sizeof(DATATYPE);
+  size_t K_SIZE = K_VOL * sizeof(DATATYPE);
+  size_t V_SIZE = V_VOL * sizeof(DATATYPE);
+  size_t OUT_SIZE = OUT_VOL * sizeof(DATATYPE);
+
+  // XRT setup
+  auto device = xrt::device(0);
+  std::string elfPath = vm["elf"].as<std::string>();
+  xrt::elf ctx_elf{elfPath};
+  xrt::hw_context context = xrt::hw_context(device, ctx_elf);
+  std::string kernelName = vm["kernel"].as<std::string>();
+  auto kernel = xrt::ext::kernel(context, kernelName);
+
+  // Allocate BOs: Q, K, V, pos, Output
+  xrt::bo bo_q = xrt::ext::bo{device, Q_SIZE};
+  xrt::bo bo_k = xrt::ext::bo{device, K_SIZE};
+  xrt::bo bo_v = xrt::ext::bo{device, V_SIZE};
+  xrt::bo bo_pos = xrt::ext::bo{device, POS_SIZE};
+  xrt::bo bo_out =
+      xrt::ext::bo{device, OUT_SIZE + static_cast<size_t>(trace_size)};
+
+  // Fill with random data
+  DATATYPE *bufQ = bo_q.map<DATATYPE *>();
+  for (size_t i = 0; i < Q_VOL; i++)
+    bufQ[i] = random_bf16();
+
+  DATATYPE *bufK = bo_k.map<DATATYPE *>();
+  for (size_t i = 0; i < K_VOL; i++)
+    bufK[i] = random_bf16();
+
+  DATATYPE *bufV = bo_v.map<DATATYPE *>();
+  for (size_t i = 0; i < V_VOL; i++)
+    bufV[i] = random_bf16();
+
+  int32_t *bufPos = bo_pos.map<int32_t *>();
+  bufPos[0] = current_pos;
+
+  DATATYPE *bufOut = bo_out.map<DATATYPE *>();
+  memset(bufOut, 0, OUT_SIZE + trace_size);
+
+  bo_q.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_k.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_v.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_pos.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_warmup = vm["warmup"].as<int>();
+  unsigned n_iter = vm["iterations"].as<int>();
+  unsigned total = n_warmup + n_iter;
+
+  float time_total = 0, time_min = std::numeric_limits<float>::max(),
+        time_max = 0;
+
+  // FLOPs: per KV head: group_size * (QK: lk*dk*2 + PV: lk*dv*2)
+  int group_size = num_heads / num_kv_heads;
+  float macs = (float)num_kv_heads * group_size *
+               ((float)lk * dk * 2.0f + (float)lk * dv * 2.0f);
+
+  std::cout << "Decode Attention Benchmark (ELF format)" << std::endl;
+  std::cout << "  num_heads=" << num_heads << ", num_kv_heads=" << num_kv_heads
+            << ", group_size=" << group_size << std::endl;
+  std::cout << "  lk=" << lk << ", dk=" << dk << ", dv=" << dv
+            << ", current_pos=" << current_pos << std::endl;
+  std::cout << "  Q: [" << num_heads << "x" << dk << "] (" << Q_SIZE
+            << " bytes)" << std::endl;
+  std::cout << "  K: [" << num_kv_heads << "x" << lk << "x" << dk << "] ("
+            << K_SIZE << " bytes)" << std::endl;
+  std::cout << "  V: [" << num_kv_heads << "x" << lk << "x" << dv << "] ("
+            << V_SIZE << " bytes)" << std::endl;
+  std::cout << "  Output: [" << num_heads << "x" << dv << "] (" << OUT_SIZE
+            << " bytes)" << std::endl;
+
+  for (unsigned iter = 0; iter < total; iter++) {
+    if (verbosity >= 1)
+      std::cout << "Iteration " << iter << (iter < n_warmup ? " (warmup)" : "")
+                << "\n";
+
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo_q);
+    run.set_arg(1, bo_k);
+    run.set_arg(2, bo_v);
+    run.set_arg(3, bo_pos);
+    run.set_arg(4, bo_out);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    run.start();
+    run.wait2();
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    if (iter < n_warmup)
+      continue;
+
+    float us =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+    time_total += us;
+    time_min = std::min(time_min, us);
+    time_max = std::max(time_max, us);
+  }
+
+  std::cout << "\nAvg NPU decode attention time: " << time_total / n_iter
+            << " us" << std::endl;
+  std::cout << "Avg NPU gflops: " << macs / (1000 * time_total / n_iter)
+            << std::endl;
+  std::cout << "\nMin NPU time: " << time_min << " us" << std::endl;
+  std::cout << "Max NPU gflops: " << macs / (1000 * time_min) << std::endl;
+  std::cout << "\nMax NPU time: " << time_max << " us" << std::endl;
+  std::cout << "Min NPU gflops: " << macs / (1000 * time_max) << std::endl;
+
+  if (trace_size > 0)
+    test_utils::write_out_trace(((char *)bufOut) + OUT_SIZE, trace_size,
+                                "trace_decode.txt");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Implements NPU-accelerated decode attention using matvec-style kernels (group_size=4 is too small for 8x8 tiled matmul) with cascade-based online softmax reduction across KV sequence chunks
- Targets single-token decode in LLaMA-style GQA models as a drop-in replacement for CPU `decode_attention_cpu()`
- Supports runtime `current_pos` masking for variable-length KV cache (fixed max_seq_len buffer with -inf masking for positions beyond current_pos)
- Architecture: herd `[num_kv_parallel, num_cascade_stages]` (default `[4, 4]`), cascade merge north-to-south, all inputs via single QKV_dec channel on S2MM 0
- Includes C++ profiling harness (`test_decode_elf_npu2.cpp`) and `make profile-decode` target

### Performance (NPU2 Strix, 4 KV heads, lk=512, group_size=4, dk=dv=64)
| | Avg | Min |
|---|---|---|
| NPU | **432 us** | 428 us |
| CPU (NumPy) | 905 us | 901 us |
| **Speedup** | **2.1x** | **2.1x** |

### Files
| File | Lines | Purpose |
|---|---|---|
| `attn_decode_npu2.cc` | 427 | C++ AIE kernels: matvec Q@K^T, softmax, weighted-sum P@V, cascade merge |
| `attn_decode_npu2.py` | 908 | Python MLIR generator with explicit QKV channel |
| `test_decode_elf_npu2.cpp` | 209 | C++ profiling harness (ELF format) |
| `Makefile` | +78 | `run-decode`, `profile-decode`, `compile-kernel-decode` targets |
| `run_npu2_peano_decode_channels.lit` | 13 | LIT test |

### Known Limitations
- `num_kv_heads` must equal `num_kv_parallel` (single launch iteration) due to shim BD budget with direct L3→L1 data path
- Scaling to 8 KV heads / lk=2048 (full LLaMA-3.2-1B) requires L2 memtile relay (future work)

## Test plan
- [x] `make run-decode` — correctness verified (correlation > 0.998)
- [x] `make profile-decode` — performance measured (432 us avg)
- [x] Masking test with `current_pos < lk-1` verified
- [ ] CI: LIT test `run_npu2_peano_decode_channels.lit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)