### PR TITLE
Fix redoDepTraceIfDepOnHier to re-trace deps for air.herd ops

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -2466,10 +2466,23 @@ void dependencyCanonicalizer::fillAIRDepListUsingGraphTR(
       if (op == src_op)
         continue; // Avoid dep to itself
       if (graph.g[TRVertex].asyncEventType == "for_loop") {
-        auto value = getLoopCarriedTokenFromScfOp(
-            dyn_cast_if_present<scf::ForOp>(src_op), "argument");
-        if (value)
-          async_op.addAsyncDependency(value);
+        auto for_op = dyn_cast_if_present<scf::ForOp>(src_op);
+        if (for_op) {
+          if (for_op->isAncestor(op)) {
+            // Destination is inside the loop: use iter_arg (block argument).
+            auto value = getLoopCarriedTokenFromScfOp(for_op, "argument");
+            if (value)
+              async_op.addAsyncDependency(value);
+          } else {
+            // Destination is outside (after) the loop: use loop result.
+            for (auto res : for_op->getResults()) {
+              if (isa<air::AsyncTokenType>(res.getType())) {
+                async_op.addAsyncDependency(res);
+                break;
+              }
+            }
+          }
+        }
       } else if (graph.g[TRVertex].asyncEventType == "parallel_loop") {
         auto value = getLoopCarriedTokenFromScfOp(
             dyn_cast_if_present<scf::ParallelOp>(src_op));
@@ -2608,6 +2621,78 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
                                  exec_op);
     }
   }
+
+  // Also re-trace dependencies for air.herd ops that depend on hierarchy ops.
+  // When a herd depends on another herd, the dependency may have been
+  // established via a loop that was later folded by canonicalize, losing the
+  // intermediate dependency. Re-tracing memory deps through kernel operands
+  // recovers the correct ordering.
+  SmallVector<air::HerdOp> herd_ops;
+  func.walk([&](air::HerdOp herd_op) { herd_ops.push_back(herd_op); });
+  for (auto herd_op : herd_ops) {
+    bool hasDepToHier = false;
+    auto dep_list = herd_op.getAsyncDependencies();
+    for (auto dep : dep_list) {
+      if (dep.getDefiningOp() &&
+          isa<air::HierarchyInterface>(dep.getDefiningOp())) {
+        hasDepToHier = true;
+      }
+    }
+    if (!hasDepToHier)
+      continue;
+
+    // Split kernel operands into read vs write sets by analyzing how each
+    // memref is accessed inside the herd body.
+    SmallVector<air::partialMemref, 1> herd_memref_reads;
+    SmallVector<air::partialMemref, 1> herd_memref_writes;
+    for (unsigned i = 0; i < herd_op.getNumKernelOperands(); i++) {
+      auto operand = herd_op.getKernelOperand(i);
+      if (!isa<BaseMemRefType>(operand.getType()))
+        continue;
+      // Check if the kernel operand is read or written inside the herd.
+      auto readResult =
+          air::getAllReadAccessedMemrefOperandsFromOp(herd_op.getOperation());
+      auto writeResult =
+          air::getAllWriteAccessedMemrefOperandsFromOp(herd_op.getOperation());
+      bool isRead = false, isWritten = false;
+      if (succeeded(readResult)) {
+        for (auto &entry : *readResult)
+          if (entry.first == operand)
+            isRead = true;
+      }
+      if (succeeded(writeResult)) {
+        for (auto &entry : *writeResult)
+          if (entry.first == operand)
+            isWritten = true;
+      }
+      // If we can't determine access, conservatively assume both.
+      if (!isRead && !isWritten) {
+        isRead = true;
+        isWritten = true;
+      }
+      if (isRead)
+        herd_memref_reads.push_back(air::partialMemref(operand));
+      if (isWritten)
+        herd_memref_writes.push_back(air::partialMemref(operand));
+    }
+    if (herd_memref_reads.empty() && herd_memref_writes.empty())
+      continue;
+
+    // Erase hierarchy deps and re-trace.
+    for (auto dep : llvm::to_vector(dep_list)) {
+      if (dep.getDefiningOp() &&
+          isa<air::HierarchyInterface>(dep.getDefiningOp())) {
+        eraseAsyncDependencyFromAsyncOp(herd_op, dep);
+      }
+    }
+    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+            herd_memref_reads, herd_op, "RAW")))
+      return failure();
+    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+            herd_memref_writes, herd_op, "WAW/WAR")))
+      return failure();
+  }
+
   return success();
 }
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -2470,8 +2470,7 @@ void dependencyCanonicalizer::fillAIRDepListUsingGraphTR(
         if (for_op) {
           if (for_op->isAncestor(op)) {
             // Destination is inside the loop: use iter_arg (block argument).
-            auto value =
-                getLoopCarriedTokenFromScfOp(for_op, "argument");
+            auto value = getLoopCarriedTokenFromScfOp(for_op, "argument");
             if (value)
               async_op.addAsyncDependency(value);
           } else {
@@ -2666,13 +2665,11 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
         eraseAsyncDependencyFromAsyncOp(herd_op, dep);
       }
     }
-    if (failed(
-            depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
-                herd_memref_accesses, herd_op, "RAW")))
+    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+            herd_memref_accesses, herd_op, "RAW")))
       return failure();
-    if (failed(
-            depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
-                herd_memref_accesses, herd_op, "WAW/WAR")))
+    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+            herd_memref_accesses, herd_op, "WAW/WAR")))
       return failure();
   }
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -2470,7 +2470,8 @@ void dependencyCanonicalizer::fillAIRDepListUsingGraphTR(
         if (for_op) {
           if (for_op->isAncestor(op)) {
             // Destination is inside the loop: use iter_arg (block argument).
-            auto value = getLoopCarriedTokenFromScfOp(for_op, "argument");
+            auto value =
+                getLoopCarriedTokenFromScfOp(for_op, "argument");
             if (value)
               async_op.addAsyncDependency(value);
           } else {
@@ -2601,11 +2602,17 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
     for (auto dep : dep_list) {
       if (dep.getDefiningOp() &&
           isa<air::HierarchyInterface>(dep.getDefiningOp())) {
-        eraseAsyncDependencyFromAsyncOp(exec_op, dep);
         hasDepToHier = true;
       }
     }
     if (hasDepToHier) {
+      // Snapshot before erasing to avoid mutating OperandRange while iterating.
+      for (auto dep : llvm::to_vector(dep_list)) {
+        if (dep.getDefiningOp() &&
+            isa<air::HierarchyInterface>(dep.getDefiningOp())) {
+          eraseAsyncDependencyFromAsyncOp(exec_op, dep);
+        }
+      }
       // Trace dependency of op again
       if (failed(
               depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
@@ -2641,41 +2648,15 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
     if (!hasDepToHier)
       continue;
 
-    // Split kernel operands into read vs write sets by analyzing how each
-    // memref is accessed inside the herd body.
-    SmallVector<air::partialMemref, 1> herd_memref_reads;
-    SmallVector<air::partialMemref, 1> herd_memref_writes;
+    // Build partial memref list from herd's kernel operands.
+    SmallVector<air::partialMemref, 1> herd_memref_accesses;
     for (unsigned i = 0; i < herd_op.getNumKernelOperands(); i++) {
       auto operand = herd_op.getKernelOperand(i);
-      if (!isa<BaseMemRefType>(operand.getType()))
-        continue;
-      // Check if the kernel operand is read or written inside the herd.
-      auto readResult =
-          air::getAllReadAccessedMemrefOperandsFromOp(herd_op.getOperation());
-      auto writeResult =
-          air::getAllWriteAccessedMemrefOperandsFromOp(herd_op.getOperation());
-      bool isRead = false, isWritten = false;
-      if (succeeded(readResult)) {
-        for (auto &entry : *readResult)
-          if (entry.first == operand)
-            isRead = true;
+      if (isa<BaseMemRefType>(operand.getType())) {
+        herd_memref_accesses.push_back(air::partialMemref(operand));
       }
-      if (succeeded(writeResult)) {
-        for (auto &entry : *writeResult)
-          if (entry.first == operand)
-            isWritten = true;
-      }
-      // If we can't determine access, conservatively assume both.
-      if (!isRead && !isWritten) {
-        isRead = true;
-        isWritten = true;
-      }
-      if (isRead)
-        herd_memref_reads.push_back(air::partialMemref(operand));
-      if (isWritten)
-        herd_memref_writes.push_back(air::partialMemref(operand));
     }
-    if (herd_memref_reads.empty() && herd_memref_writes.empty())
+    if (herd_memref_accesses.empty())
       continue;
 
     // Erase hierarchy deps and re-trace.
@@ -2685,11 +2666,13 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
         eraseAsyncDependencyFromAsyncOp(herd_op, dep);
       }
     }
-    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
-            herd_memref_reads, herd_op, "RAW")))
+    if (failed(
+            depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+                herd_memref_accesses, herd_op, "RAW")))
       return failure();
-    if (failed(depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
-            herd_memref_writes, herd_op, "WAW/WAR")))
+    if (failed(
+            depTracer.template traceDependencyFromOp<air::AsyncOpInterface>(
+                herd_memref_accesses, herd_op, "WAW/WAR")))
       return failure();
   }
 

--- a/mlir/test/Transform/AIRDependencyCanonicalization/herd_dep_retrace.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/herd_dep_retrace.mlir
@@ -1,3 +1,10 @@
+//===- herd_dep_retrace.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
 // RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
 
 // Verify that air-dependency-canonicalize correctly establishes deps between

--- a/mlir/test/Transform/AIRDependencyCanonicalization/herd_dep_retrace.mlir
+++ b/mlir/test/Transform/AIRDependencyCanonicalization/herd_dep_retrace.mlir
@@ -1,0 +1,55 @@
+// RUN: air-opt %s -air-dependency-canonicalize | FileCheck %s
+
+// Verify that air-dependency-canonicalize correctly establishes deps between
+// herds that access the same memref. When herd_1 (fill) and herd_2 (compute)
+// both write to %alloc_L1, and herd_3 (output) reads from %alloc_L1, herd_3
+// must depend on herd_2 (not just herd_1).
+
+// CHECK-LABEL: func.func @herd_dep_retrace
+// CHECK: %[[ALLOC_L1:.*]], %{{.*}} = air.execute
+// CHECK: %[[FILL_HERD:.*]] = air.herd @herd_0 async [%[[ALLOC_L1]]]
+// CHECK: %[[COMPUTE_HERD:.*]] = air.herd @herd_0 async [%[[FILL_HERD]]]
+// The output herd must depend on the compute herd (not just fill).
+// CHECK: air.herd @herd_0 async [%[[COMPUTE_HERD]]]
+
+module {
+  func.func @herd_dep_retrace(%arg0: memref<32x32xi16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<32x32xi16> attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c0 = arith.constant 0 : index
+        %c1_0 = arith.constant 1 : index
+        // Allocate shared L1 output buffer
+        %async_token_0, %alloc_L1 = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<1x1x4x8x4x8xi16, 2 : i32>
+          air.execute_terminator %a : memref<1x1x4x8x4x8xi16, 2 : i32>
+        } {id = 1 : i32}
+        // Herd 1: fill the L1 buffer
+        %2 = air.herd @herd_0 async [%async_token_0] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 3 : i32} {
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %cst = arith.constant 0 : i16
+          %async_token_fill = air.execute {
+            linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 4 : i32}
+        }
+        // Herd 2: compute (writes to same L1 buffer)
+        %3 = air.herd @herd_0 async [%2] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 5 : i32} {
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %cst = arith.constant 0 : i16
+          %async_token_compute = air.execute {
+            linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 6 : i32}
+        }
+        // Herd 3: output (reads from same L1 buffer) — should depend on herd 2
+        %4 = air.herd @herd_0 async [%2] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 7 : i32} {
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %cst = arith.constant 0 : i16
+          %async_token_output = air.execute {
+            linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 8 : i32}
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- Extends `redoDepTraceIfDepOnHier` in `air-dependency-canonicalize` to also process `air::HerdOp` (previously only handled `air::ExecuteOp`)
- When a herd depends on another hierarchy op, re-traces memory dependencies through the herd's kernel operands to recover correct predecessor ordering
- Also fixes `fillAIRDepListUsingGraphTR` to use `scf.for` loop result for post-loop consumers instead of iter_arg

## Test plan
- [x] `ninja check-air-mlir` — all existing tests pass
- Part 1 of 3 for fixing #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)