### PR TITLE
Propagate inter-herd deps during herd merge in MergeAIRHerdsPattern

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/Iterators.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -765,6 +766,35 @@ FailureOr<air::HerdOp> hoistAIRHerdInForImpl(air::HerdOp herdOp,
   return newHerdOp;
 }
 
+// Returns true iff the op's only memory effects (recursively through nested
+// regions) are `Free` effects — i.e. it does pure cleanup. Used by
+// MergeAIRHerdsPattern to exclude such ops from a herd group's "live-out"
+// async tokens, since downstream memref-flow-aware canonicalisation may
+// drop dependency edges that point to freed memory.
+//
+// `air.execute` and other container ops without the MemoryEffectOpInterface
+// or HasRecursiveMemoryEffects trait are opaque to MLIR's standard helpers,
+// so we walk into nested regions ourselves. Ops with no interface contribute
+// nothing to the tally; the walk descends into their bodies and inspects the
+// leaf ops there.
+//
+// Returns false for ops whose body mixes `Free` with any
+// `Read`/`Write`/`Allocate` (the non-Free effects are real work) and for ops
+// whose effects are entirely empty (a pure compute op, not cleanup).
+static bool isFreeOnlyOp(Operation *op) {
+  bool sawFree = false;
+  bool sawNonFree = false;
+  op->walk([&](Operation *child) {
+    if (mlir::hasEffect<MemoryEffects::Free>(child))
+      sawFree = true;
+    if (mlir::hasEffect<MemoryEffects::Read>(child) ||
+        mlir::hasEffect<MemoryEffects::Write>(child) ||
+        mlir::hasEffect<MemoryEffects::Allocate>(child))
+      sawNonFree = true;
+  });
+  return sawFree && !sawNonFree;
+}
+
 // Merge all herds which are (1) sharing one common parent region and (2) using
 // the same symname into one herd.
 struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
@@ -815,26 +845,37 @@ struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
         }))
       return failure();
 
-    // Merge all herds with the same herd name into one.
+    // Single pass over the herds to collect the merged-herd inputs:
+    //   * kernelOperands  — union of all kernel operands.
+    //   * tokenToHerdIdx  — map from each herd's async token to its index;
+    //                       used both to identify inter-herd vs external
+    //                       deps and (later) to look up the predecessor
+    //                       index without an O(N) scan.
     llvm::SetVector<Value> kernelOperands;
-    for (auto h : herdsWithSameName)
+    llvm::DenseMap<Value, unsigned> tokenToHerdIdx;
+    for (unsigned i = 0; i < herdsWithSameName.size(); i++) {
+      auto h = herdsWithSameName[i];
       kernelOperands.insert(h.getKernelOperands().begin(),
                             h.getKernelOperands().end());
-
-    // Collect the set of herd tokens being merged so we can identify
-    // inter-herd deps vs external deps.
-    llvm::DenseSet<Value> herdTokens;
-    for (auto h : herdsWithSameName)
       if (h.getAsyncToken())
-        herdTokens.insert(h.getAsyncToken());
+        tokenToHerdIdx[h.getAsyncToken()] = i;
+    }
 
-    // Build the merged herd's async deps as the union of all herds' external
-    // deps (excluding inter-herd deps that will become intra-herd ordering).
+    // Classify each herd's async deps:
+    //   * External deps become the merged herd's async dep list (deduped).
+    //   * Inter-herd deps (a dep token is another merged herd's async
+    //     token) are recorded for later barrier insertion. The walk visits
+    //     herds in ForwardDominance order so any inter-herd dep target
+    //     necessarily has a smaller index than the dependent herd.
     SmallVector<Value> mergedExternalDeps;
     llvm::SetVector<Value> seenDeps;
-    for (auto h : herdsWithSameName) {
-      for (auto dep : h.getAsyncDependencies()) {
-        if (!herdTokens.contains(dep) && seenDeps.insert(dep))
+    llvm::DenseMap<unsigned, SmallVector<unsigned>> interHerdDeps;
+    for (unsigned i = 0; i < herdsWithSameName.size(); i++) {
+      for (auto dep : herdsWithSameName[i].getAsyncDependencies()) {
+        auto it = tokenToHerdIdx.find(dep);
+        if (it != tokenToHerdIdx.end())
+          interHerdDeps[i].push_back(it->second);
+        else if (seenDeps.insert(dep))
           mergedExternalDeps.push_back(dep);
       }
     }
@@ -846,20 +887,6 @@ struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
         (bool)herdOp.getAsyncToken(), herdOp->getAttrs());
     rewriter.setInsertionPointToStart(&newMergedHerd.getBody().front());
     IRMapping remap;
-
-    // For each herd, record which predecessor herds it depends on, so we
-    // can insert intra-herd dependency edges after cloning.
-    // Key: index of the dependent herd, Value: indices of predecessor herds.
-    llvm::DenseMap<unsigned, SmallVector<unsigned>> interHerdDeps;
-    for (unsigned i = 0; i < herdsWithSameName.size(); i++) {
-      for (auto dep : herdsWithSameName[i].getAsyncDependencies()) {
-        for (unsigned j = 0; j < i; j++) {
-          if (herdsWithSameName[j].getAsyncToken() == dep) {
-            interHerdDeps[i].push_back(j);
-          }
-        }
-      }
-    }
 
     // Clone ops from each herd into the merged body, tracking the last
     // async token produced by each herd's group for inter-herd barriers.
@@ -896,54 +923,65 @@ struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
       }
 
       // Clone ops, injecting the barrier dependency where needed.
-      Value lastToken;
+      // addAsyncDependencyIfNew dispatches over AsyncOpInterface, scf.for,
+      // scf.parallel and affine.if — covering all op shapes that may appear
+      // at the top of a herd body.
+      SmallVector<Operation *> clonedOps;
       for (auto &o : h.getBody().front().without_terminator()) {
         auto *cloned = rewriter.clone(o, remap);
-        // Add the barrier as a dependency to all async ops from dependent
-        // herds. Every async op in the group must wait for the predecessor
-        // herd's ops to complete, since any of them could access shared
-        // buffers.
-        if (barrierToken) {
-          if (auto asyncOp =
-                  dyn_cast_if_present<air::AsyncOpInterface>(cloned)) {
-            asyncOp.addAsyncDependency(barrierToken);
-          } else if (dyn_cast_if_present<air::ChannelInterface>(cloned)) {
-            air::addAsyncDependency(cloned, barrierToken);
-          }
-        }
-        // Track the last async token produced by this herd's ops.
-        // Skip dealloc ops — their tokens reference freed memory and
-        // canonicalize will remove deps to ops accessing different memory.
-        bool isDealloc = false;
-        if (auto execOp = dyn_cast_if_present<air::ExecuteOp>(cloned)) {
-          execOp.getBody().walk([&](memref::DeallocOp) { isDealloc = true; });
-        }
-        if (!isDealloc) {
-          if (auto forOp = dyn_cast_if_present<scf::ForOp>(cloned)) {
-            // Collect all async token results from the loop.
-            SmallVector<Value> asyncResults;
-            for (auto res : forOp->getResults()) {
-              if (isa<air::AsyncTokenType>(res.getType()))
-                asyncResults.push_back(res);
-            }
-            if (asyncResults.size() == 1) {
-              lastToken = asyncResults.front();
-            } else if (!asyncResults.empty()) {
-              auto waitAll = xilinx::air::WaitAllOp::create(
-                  rewriter, cloned->getLoc(),
-                  air::AsyncTokenType::get(cloned->getContext()), asyncResults);
-              lastToken = waitAll.getAsyncToken();
-            }
-          } else if (auto asyncOp =
-                         dyn_cast_if_present<air::AsyncOpInterface>(cloned)) {
-            if (asyncOp.getAsyncToken())
-              lastToken = asyncOp.getAsyncToken();
-          } else if (dyn_cast_if_present<air::ChannelInterface>(cloned)) {
-            auto tok = air::getAsyncTokenFromOp(cloned);
-            if (tok)
-              lastToken = tok;
-          }
-        }
+        if (barrierToken)
+          air::addAsyncDependencyIfNew(cloned, barrierToken);
+        clonedOps.push_back(cloned);
+      }
+
+      // Compute this group's live-out async tokens — tokens produced by
+      // cloned ops that no other op in the group consumes. A single
+      // overwriting `lastToken` would miss parallel fan-out at the end of
+      // a herd body (e.g. two independent channel.puts), causing the next
+      // herd's barrier to wait on only one branch.
+      //
+      // Skip dealloc executes: their tokens reference freed memory, and
+      // downstream memref-flow-aware canonicalisation may drop dependency
+      // edges to ops that access different memory, weakening the barrier.
+      llvm::SmallPtrSet<Operation *, 16> clonedSet(clonedOps.begin(),
+                                                   clonedOps.end());
+      SmallVector<Value> liveOuts;
+      for (Operation *cloned : clonedOps) {
+        // Skip ops whose only memory effect is `Free` — their tokens
+        // reference freed memory and downstream canonicalisation may drop
+        // edges to ops accessing different memory. Generalises over a bare
+        // `memref.dealloc` and any container that wraps one (air.execute,
+        // scf.for, etc.).
+        if (isFreeOnlyOp(cloned))
+          continue;
+        Value tok = air::getAsyncTokenFromOp(cloned);
+        if (!tok)
+          continue;
+        // A user nested inside another cloned top-level op (e.g. inside an
+        // scf.for body) still counts as in-group: walk up to the top-level
+        // ancestor to test membership. Free-only users are ignored — if a
+        // real-work token's only consumer is a dealloc-only op, the
+        // real-work token is still a live-out (the dealloc consumer is
+        // skipped above and its "freed memory" token shouldn't anchor the
+        // group's completion signal either).
+        bool hasInGroupUser = llvm::any_of(tok.getUsers(), [&](Operation *u) {
+          Operation *top = u;
+          while (top && !clonedSet.contains(top))
+            top = top->getParentOp();
+          return top != nullptr && !isFreeOnlyOp(top);
+        });
+        if (!hasInGroupUser)
+          liveOuts.push_back(tok);
+      }
+
+      Value lastToken;
+      if (liveOuts.size() == 1) {
+        lastToken = liveOuts.front();
+      } else if (liveOuts.size() > 1) {
+        auto joinWaitAll = xilinx::air::WaitAllOp::create(
+            rewriter, clonedOps.back()->getLoc(),
+            air::AsyncTokenType::get(rewriter.getContext()), liveOuts);
+        lastToken = joinWaitAll.getAsyncToken();
       }
       lastAsyncTokenPerHerd[herdIdx] = lastToken;
     }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -820,15 +820,52 @@ struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
     for (auto h : herdsWithSameName)
       kernelOperands.insert(h.getKernelOperands().begin(),
                             h.getKernelOperands().end());
+
+    // Collect the set of herd tokens being merged so we can identify
+    // inter-herd deps vs external deps.
+    llvm::DenseSet<Value> herdTokens;
+    for (auto h : herdsWithSameName)
+      if (h.getAsyncToken())
+        herdTokens.insert(h.getAsyncToken());
+
+    // Build the merged herd's async deps as the union of all herds' external
+    // deps (excluding inter-herd deps that will become intra-herd ordering).
+    SmallVector<Value> mergedExternalDeps;
+    llvm::SetVector<Value> seenDeps;
+    for (auto h : herdsWithSameName) {
+      for (auto dep : h.getAsyncDependencies()) {
+        if (!herdTokens.contains(dep) && seenDeps.insert(dep))
+          mergedExternalDeps.push_back(dep);
+      }
+    }
+
     rewriter.setInsertionPointAfter(herdsWithSameName.back());
     auto newMergedHerd = air::HerdOp::create(
-        rewriter, herdOp->getLoc(),
-        herdsWithSameName.back().getAsyncDependencies(),
+        rewriter, herdOp->getLoc(), mergedExternalDeps,
         herdOp.getSizeOperands(), kernelOperands.takeVector(),
         (bool)herdOp.getAsyncToken(), herdOp->getAttrs());
     rewriter.setInsertionPointToStart(&newMergedHerd.getBody().front());
     IRMapping remap;
-    for (auto h : herdsWithSameName) {
+
+    // For each herd, record which predecessor herds it depends on, so we
+    // can insert intra-herd dependency edges after cloning.
+    // Key: index of the dependent herd, Value: indices of predecessor herds.
+    llvm::DenseMap<unsigned, SmallVector<unsigned>> interHerdDeps;
+    for (unsigned i = 0; i < herdsWithSameName.size(); i++) {
+      for (auto dep : herdsWithSameName[i].getAsyncDependencies()) {
+        for (unsigned j = 0; j < i; j++) {
+          if (herdsWithSameName[j].getAsyncToken() == dep) {
+            interHerdDeps[i].push_back(j);
+          }
+        }
+      }
+    }
+
+    // Clone ops from each herd into the merged body, tracking the last
+    // async token produced by each herd's group for inter-herd barriers.
+    SmallVector<Value> lastAsyncTokenPerHerd(herdsWithSameName.size());
+    for (unsigned herdIdx = 0; herdIdx < herdsWithSameName.size(); herdIdx++) {
+      auto h = herdsWithSameName[herdIdx];
       // Update "link_with" attr
       if (h.getLinkWith())
         newMergedHerd.setLinkWith(h.getLinkWith());
@@ -840,9 +877,75 @@ struct MergeAIRHerdsPattern : public OpRewritePattern<air::HerdOp> {
         remap.map(h.getKernelArgument(i),
                   newMergedHerd.getTiedKernelArgument(
                       h.getTiedKernelOperand(h.getKernelArgument(i))));
-      // Clone ops
-      for (auto &o : h.getBody().front().without_terminator())
-        rewriter.clone(o, remap);
+
+      // If this herd depends on a predecessor herd, insert a wait_all
+      // barrier that collects the predecessor's last async tokens.
+      Value barrierToken;
+      if (interHerdDeps.count(herdIdx)) {
+        SmallVector<Value> barrierDeps;
+        for (unsigned predIdx : interHerdDeps[herdIdx]) {
+          if (lastAsyncTokenPerHerd[predIdx])
+            barrierDeps.push_back(lastAsyncTokenPerHerd[predIdx]);
+        }
+        if (!barrierDeps.empty()) {
+          auto barrierWaitAll = xilinx::air::WaitAllOp::create(
+              rewriter, h->getLoc(), air::AsyncTokenType::get(h->getContext()),
+              barrierDeps);
+          barrierToken = barrierWaitAll.getAsyncToken();
+        }
+      }
+
+      // Clone ops, injecting the barrier dependency where needed.
+      Value lastToken;
+      for (auto &o : h.getBody().front().without_terminator()) {
+        auto *cloned = rewriter.clone(o, remap);
+        // Add the barrier as a dependency to all async ops from dependent
+        // herds. Every async op in the group must wait for the predecessor
+        // herd's ops to complete, since any of them could access shared
+        // buffers.
+        if (barrierToken) {
+          if (auto asyncOp =
+                  dyn_cast_if_present<air::AsyncOpInterface>(cloned)) {
+            asyncOp.addAsyncDependency(barrierToken);
+          } else if (dyn_cast_if_present<air::ChannelInterface>(cloned)) {
+            air::addAsyncDependency(cloned, barrierToken);
+          }
+        }
+        // Track the last async token produced by this herd's ops.
+        // Skip dealloc ops — their tokens reference freed memory and
+        // canonicalize will remove deps to ops accessing different memory.
+        bool isDealloc = false;
+        if (auto execOp = dyn_cast_if_present<air::ExecuteOp>(cloned)) {
+          execOp.getBody().walk([&](memref::DeallocOp) { isDealloc = true; });
+        }
+        if (!isDealloc) {
+          if (auto forOp = dyn_cast_if_present<scf::ForOp>(cloned)) {
+            // Collect all async token results from the loop.
+            SmallVector<Value> asyncResults;
+            for (auto res : forOp->getResults()) {
+              if (isa<air::AsyncTokenType>(res.getType()))
+                asyncResults.push_back(res);
+            }
+            if (asyncResults.size() == 1) {
+              lastToken = asyncResults.front();
+            } else if (!asyncResults.empty()) {
+              auto waitAll = xilinx::air::WaitAllOp::create(
+                  rewriter, cloned->getLoc(),
+                  air::AsyncTokenType::get(cloned->getContext()), asyncResults);
+              lastToken = waitAll.getAsyncToken();
+            }
+          } else if (auto asyncOp =
+                         dyn_cast_if_present<air::AsyncOpInterface>(cloned)) {
+            if (asyncOp.getAsyncToken())
+              lastToken = asyncOp.getAsyncToken();
+          } else if (dyn_cast_if_present<air::ChannelInterface>(cloned)) {
+            auto tok = air::getAsyncTokenFromOp(cloned);
+            if (tok)
+              lastToken = tok;
+          }
+        }
+      }
+      lastAsyncTokenPerHerd[herdIdx] = lastToken;
     }
 
     // Erase original herds; replace async token uses if async.

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/herd_merge_dep_propagation.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/herd_merge_dep_propagation.mlir
@@ -1,0 +1,68 @@
+// RUN: air-opt %s -air-isolate-async-dma-loop-nests="scope=func" | FileCheck %s
+
+// Verify that when multiple same-named herds with inter-herd dependencies are
+// merged into one, the inter-herd ordering is preserved as intra-herd deps.
+// Herd 2 (compute) depends on herd 1 (fill), and herd 3 (output) depends on
+// herd 2. After merge, the output group's ops must depend on the compute
+// group's completion.
+
+// CHECK-LABEL: func.func @herd_merge_dep_propagation
+// CHECK: air.segment
+// After merge, there should be a single herd with barrier deps between groups.
+// After merge, single herd with correct intra-herd dependency chain:
+// CHECK: air.herd @herd_0 async
+// The fill group:
+// CHECK: %[[FILL_TOK:.*]] = air.execute
+// CHECK-NEXT: linalg.fill
+// The compute group's execute must depend on fill (barrier from fill_herd):
+// CHECK: %[[COMPUTE_TOK:.*]] = air.execute [%[[FILL_TOK]]
+// CHECK-NEXT: linalg.fill
+// The output channel.put must depend on compute (barrier from compute_herd):
+// CHECK: air.channel.put async [%[[COMPUTE_TOK]]
+
+module {
+  air.channel @channel_out [1, 1]
+  func.func @herd_merge_dep_propagation(%arg0: memref<32x32xi16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<32x32xi16> attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c0 = arith.constant 0 : index
+        %c1_0 = arith.constant 1 : index
+        %c8 = arith.constant 8 : index
+        %c32 = arith.constant 32 : index
+        %c256 = arith.constant 256 : index
+        %c1024 = arith.constant 1024 : index
+        %async_token_0, %alloc_L1 = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<1x1x4x8x4x8xi16, 2 : i32>
+          air.execute_terminator %a : memref<1x1x4x8x4x8xi16, 2 : i32>
+        } {id = 1 : i32}
+        // Herd 1: fill
+        %2 = air.herd @herd_0 async [%async_token_0] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 3 : i32} {
+          %cst = arith.constant 0 : i16
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 4 : i32}
+        }
+        // Herd 2: compute (depends on herd 1)
+        %3 = air.herd @herd_0 async [%2] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 5 : i32} {
+          %cst = arith.constant 0 : i16
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 6 : i32}
+        }
+        // Herd 3: output channel.put (depends on herd 2)
+        %4 = air.herd @herd_0 async [%3] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 7 : i32} {
+          %ci1 = arith.constant 1 : index
+          %ci8 = arith.constant 8 : index
+          %ci32 = arith.constant 32 : index
+          %ci256 = arith.constant 256 : index
+          %ci1024 = arith.constant 1024 : index
+          %5 = air.channel.put async @channel_out[%tx, %ty] (%buf[%tx, %ty, %tx, %tx, %tx, %tx] [%ci1, %ci1, %ci8, %ci8, %ci8, %ci8] [%ci1024, %ci1024, %ci32, %ci8, %ci256, %ci1]) {id = 8 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/herd_merge_dep_propagation.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/herd_merge_dep_propagation.mlir
@@ -1,42 +1,61 @@
-// RUN: air-opt %s -air-isolate-async-dma-loop-nests="scope=func" | FileCheck %s
+//===- herd_merge_dep_propagation.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
 
-// Verify that when multiple same-named herds with inter-herd dependencies are
-// merged into one, the inter-herd ordering is preserved as intra-herd deps.
-// Herd 2 (compute) depends on herd 1 (fill), and herd 3 (output) depends on
-// herd 2. After merge, the output group's ops must depend on the compute
-// group's completion.
+// RUN: air-opt %s -air-isolate-async-dma-loop-nests="scope=func" --split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @herd_merge_dep_propagation
-// CHECK: air.segment
-// After merge, there should be a single herd with barrier deps between groups.
-// After merge, single herd with correct intra-herd dependency chain:
+// Verify that MergeAIRHerdsPattern correctly propagates inter-herd async
+// dependencies as intra-herd ordering when collapsing same-named herds into
+// a single herd body. Five scenarios:
+//   1. Linear chain  — herd_0 → herd_0 → herd_0 (transitive ordering)
+//   2. Negative      — same-named herds with NO inter-herd dep (no
+//                      spurious barrier should be inserted)
+//   3. Multi-predecessor — herd_0 depends on TWO independent predecessor
+//                          herds (barrier must aggregate both tokens)
+//   4. Fan-out join  — predecessor herd's body ends with TWO parallel
+//                      async ops; the next herd's barrier must wait on
+//                      BOTH branches, not just the lexically last one
+//   5. Free-only container — predecessor herd ends with an scf.for whose
+//                            body only deallocates; the next herd must
+//                            wait on the real-work fill, NOT on the
+//                            dealloc loop's "freed memory" token
+
+//===----------------------------------------------------------------------===//
+// Scenario 1: linear chain. Three @herd_0 instances, each depending on the
+// previous. After merge, the body must preserve the ordering as intra-herd
+// async deps. The single-source barrier wait_all is folded away by
+// canonicalisation, leaving direct token edges between the cloned execute
+// ops.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @chain
+// Single merged herd (all three @herd_0 collapse into one):
 // CHECK: air.herd @herd_0 async
-// The fill group:
-// CHECK: %[[FILL_TOK:.*]] = air.execute
-// CHECK-NEXT: linalg.fill
-// The compute group's execute must depend on fill (barrier from fill_herd):
-// CHECK: %[[COMPUTE_TOK:.*]] = air.execute [%[[FILL_TOK]]
-// CHECK-NEXT: linalg.fill
-// The output channel.put must depend on compute (barrier from compute_herd):
-// CHECK: air.channel.put async [%[[COMPUTE_TOK]]
+// CHECK-NOT: air.herd @herd_0
+// First fill (from producer herd):
+// CHECK: %[[FILL0:.*]] = air.execute
+// CHECK: linalg.fill ins(%c0_i16
+// Second fill (from middle herd) must depend on the first:
+// CHECK: %[[FILL1:.*]] = air.execute {{\[}}%[[FILL0]]{{\]}}
+// CHECK: linalg.fill ins(%c1_i16
+// channel.put (from output herd) must depend transitively on the second:
+// CHECK: air.channel.put async {{\[}}%[[FILL1]]{{\]}}
 
 module {
-  air.channel @channel_out [1, 1]
-  func.func @herd_merge_dep_propagation(%arg0: memref<32x32xi16>) {
+  air.channel @channel_out_a [1, 1]
+  func.func @chain(%arg0: memref<32x32xi16>) {
     %c1 = arith.constant 1 : index
     %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) args(%arg5=%arg0) : memref<32x32xi16> attributes {id = 1 : i32} {
       %1 = air.segment @seg async attributes {id = 2 : i32} {
-        %c0 = arith.constant 0 : index
         %c1_0 = arith.constant 1 : index
-        %c8 = arith.constant 8 : index
-        %c32 = arith.constant 32 : index
-        %c256 = arith.constant 256 : index
-        %c1024 = arith.constant 1024 : index
         %async_token_0, %alloc_L1 = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
           %a = memref.alloc() : memref<1x1x4x8x4x8xi16, 2 : i32>
           air.execute_terminator %a : memref<1x1x4x8x4x8xi16, 2 : i32>
         } {id = 1 : i32}
-        // Herd 1: fill
+        // Herd 1: fill with 0
         %2 = air.herd @herd_0 async [%async_token_0] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 3 : i32} {
           %cst = arith.constant 0 : i16
           %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
@@ -44,22 +63,290 @@ module {
             linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
           } {id = 4 : i32}
         }
-        // Herd 2: compute (depends on herd 1)
+        // Herd 2: fill with 1, depends on herd 1
         %3 = air.herd @herd_0 async [%2] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 5 : i32} {
-          %cst = arith.constant 0 : i16
+          %cst = arith.constant 1 : i16
           %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
           %t = air.execute {
             linalg.fill ins(%cst : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
           } {id = 6 : i32}
         }
-        // Herd 3: output channel.put (depends on herd 2)
+        // Herd 3: channel.put, depends on herd 2
         %4 = air.herd @herd_0 async [%3] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%buf=%alloc_L1) : memref<1x1x4x8x4x8xi16, 2 : i32> attributes {id = 7 : i32} {
           %ci1 = arith.constant 1 : index
           %ci8 = arith.constant 8 : index
           %ci32 = arith.constant 32 : index
           %ci256 = arith.constant 256 : index
           %ci1024 = arith.constant 1024 : index
-          %5 = air.channel.put async @channel_out[%tx, %ty] (%buf[%tx, %ty, %tx, %tx, %tx, %tx] [%ci1, %ci1, %ci8, %ci8, %ci8, %ci8] [%ci1024, %ci1024, %ci32, %ci8, %ci256, %ci1]) {id = 8 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
+          %5 = air.channel.put async @channel_out_a[%tx, %ty] (%buf[%tx, %ty, %tx, %tx, %tx, %tx] [%ci1, %ci1, %ci8, %ci8, %ci8, %ci8] [%ci1024, %ci1024, %ci32, %ci8, %ci256, %ci1]) {id = 8 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Scenario 2: negative. Two same-named herds operating on DISJOINT buffers
+// with NO inter-herd dependency. Merge must collapse them into a single
+// herd body without inserting a spurious barrier or serialising the two
+// independent fills.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @negative_no_dep
+// Single merged herd:
+// CHECK: air.herd @herd_n async
+// CHECK-NOT: air.herd @herd_n
+// First fill has no async deps (empty bracket list elided):
+// CHECK: air.execute {
+// CHECK: linalg.fill ins(%c7_i16
+// No barrier wait_all between the two independent fills:
+// CHECK-NOT: air.wait_all
+// Second fill also has no async deps — it must NOT have been pessimised
+// to depend on the first:
+// CHECK: air.execute {
+// CHECK: linalg.fill ins(%c9_i16
+
+module {
+  func.func @negative_no_dep() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_a, %allocA = air.execute -> (memref<8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %a : memref<8xi16, 2 : i32>
+        } {id = 1 : i32}
+        %async_token_b, %allocB = air.execute -> (memref<8xi16, 2 : i32>) {
+          %b = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %b : memref<8xi16, 2 : i32>
+        } {id = 2 : i32}
+        // Two independent same-named herds; no inter-herd token dep.
+        %2 = air.herd @herd_n async [%async_token_a] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufA=%allocA) : memref<8xi16, 2 : i32> attributes {id = 3 : i32} {
+          %cst = arith.constant 7 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufA : memref<8xi16, 2 : i32>)
+          } {id = 4 : i32}
+        }
+        %3 = air.herd @herd_n async [%async_token_b] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufB=%allocB) : memref<8xi16, 2 : i32> attributes {id = 5 : i32} {
+          %cst = arith.constant 9 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufB : memref<8xi16, 2 : i32>)
+          } {id = 6 : i32}
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Scenario 3: multi-predecessor. Herd 3 depends on BOTH herd 1 AND herd 2
+// (independent predecessors). Merge must aggregate both predecessors'
+// tokens into the dependent group's barrier — exercising the
+// `barrierDeps` SmallVector code path with size > 1.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @multi_predecessor
+// CHECK: air.herd @herd_m async
+// CHECK-NOT: air.herd @herd_m
+// Two independent producer fills (different buffers):
+// CHECK: %[[FILL_A:.*]] = air.execute
+// CHECK: linalg.fill ins(%c1_i16
+// CHECK: %[[FILL_B:.*]] = air.execute
+// CHECK: linalg.fill ins(%c2_i16
+// Consumer fill must depend on BOTH predecessors. The dep list is order-
+// dependent on canonicalisation; the current pipeline emits B then A.
+// CHECK: air.execute {{\[}}%[[FILL_B]], %[[FILL_A]]{{\]}}
+// CHECK: linalg.fill ins(%c3_i16
+
+module {
+  func.func @multi_predecessor() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_a, %allocA = air.execute -> (memref<8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %a : memref<8xi16, 2 : i32>
+        } {id = 1 : i32}
+        %async_token_b, %allocB = air.execute -> (memref<8xi16, 2 : i32>) {
+          %b = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %b : memref<8xi16, 2 : i32>
+        } {id = 2 : i32}
+        %async_token_c, %allocC = air.execute -> (memref<8xi16, 2 : i32>) {
+          %c = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %c : memref<8xi16, 2 : i32>
+        } {id = 3 : i32}
+        // Two independent producer herds (different buffers, no shared deps).
+        %2 = air.herd @herd_m async [%async_token_a] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufA=%allocA) : memref<8xi16, 2 : i32> attributes {id = 4 : i32} {
+          %cst = arith.constant 1 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufA : memref<8xi16, 2 : i32>)
+          } {id = 5 : i32}
+        }
+        %3 = air.herd @herd_m async [%async_token_b] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufB=%allocB) : memref<8xi16, 2 : i32> attributes {id = 6 : i32} {
+          %cst = arith.constant 2 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufB : memref<8xi16, 2 : i32>)
+          } {id = 7 : i32}
+        }
+        // Consumer herd depends on BOTH predecessor herds.
+        %4 = air.herd @herd_m async [%2, %3, %async_token_c] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufC=%allocC) : memref<8xi16, 2 : i32> attributes {id = 8 : i32} {
+          %cst = arith.constant 3 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufC : memref<8xi16, 2 : i32>)
+          } {id = 9 : i32}
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Scenario 4: parallel fan-out at body end. The producer herd's body ends
+// with TWO independent async ops (parallel branches that write to disjoint
+// buffers). The consumer herd's first op must wait on BOTH branches.
+//
+// This is a true regression test: with the original single-overwrite
+// `lastToken` (only the lexically last op recorded as the predecessor's
+// completion token), the consumer would only depend on ONE branch and the
+// other would race. Data-flow canonicalisation does NOT restore the lost
+// edge here because the lost producer writes to a buffer the consumer
+// never reads.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @fanout_join
+// CHECK: air.herd @herd_f async
+// CHECK-NOT: air.herd @herd_f
+// Two parallel producer fills (no inter-dep, disjoint buffers):
+// CHECK: %[[FILL_P1:.*]] = air.execute
+// CHECK: linalg.fill ins(%c1_i16
+// CHECK: %[[FILL_P2:.*]] = air.execute
+// CHECK: linalg.fill ins(%c2_i16
+// Consumer fill must depend on BOTH parallel producer tokens. The
+// pipeline emits the second producer's token first in the dep list.
+// CHECK: air.execute {{\[}}%[[FILL_P2]], %[[FILL_P1]]{{\]}}
+// CHECK: linalg.fill ins(%c9_i16
+
+module {
+  func.func @fanout_join() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_a, %allocA = air.execute -> (memref<8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %a : memref<8xi16, 2 : i32>
+        } {id = 1 : i32}
+        %async_token_b, %allocB = air.execute -> (memref<8xi16, 2 : i32>) {
+          %b = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %b : memref<8xi16, 2 : i32>
+        } {id = 2 : i32}
+        %async_token_c, %allocC = air.execute -> (memref<8xi16, 2 : i32>) {
+          %c = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %c : memref<8xi16, 2 : i32>
+        } {id = 3 : i32}
+        // Producer herd body ends with TWO parallel fills on disjoint buffers.
+        %2 = air.herd @herd_f async [%async_token_a, %async_token_b] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufA=%allocA, %bufB=%allocB) : memref<8xi16, 2 : i32>, memref<8xi16, 2 : i32> attributes {id = 4 : i32} {
+          %cst1 = arith.constant 1 : i16
+          %cst2 = arith.constant 2 : i16
+          %t1 = air.execute {
+            linalg.fill ins(%cst1 : i16) outs(%bufA : memref<8xi16, 2 : i32>)
+          } {id = 5 : i32}
+          %t2 = air.execute {
+            linalg.fill ins(%cst2 : i16) outs(%bufB : memref<8xi16, 2 : i32>)
+          } {id = 6 : i32}
+        }
+        // Consumer herd writes to a buffer NEITHER producer fill touched —
+        // so memref-flow canonicalisation cannot re-derive the deps. The
+        // explicit token chain is the only ordering signal.
+        %3 = air.herd @herd_f async [%2, %async_token_c] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufC=%allocC) : memref<8xi16, 2 : i32> attributes {id = 7 : i32} {
+          %cst3 = arith.constant 9 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst3 : i16) outs(%bufC : memref<8xi16, 2 : i32>)
+          } {id = 8 : i32}
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Scenario 5: free-only container at end of producer body. The producer
+// herd's body ends with an scf.for whose body only deallocates a buffer.
+// The scf.for is async and has a token, but its only memory effect is
+// `Free`. The consumer herd's first op must wait on the producer's REAL
+// WORK (the fill), NOT on the dealloc-loop's "freed memory" token.
+//
+// True regression test for the generalised free-only filter: the original
+// narrow check only inspected `air.execute` bodies for `memref.dealloc`,
+// missing scf.for / affine.if / etc. wrapping a dealloc, and would pick
+// the dealloc loop's token as the group's completion signal.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @free_only_container
+// CHECK: air.herd @herd_d async
+// CHECK-NOT: air.herd @herd_d
+// Producer fill on its own buffer:
+// CHECK: %[[FILL_TOK:.*]] = air.execute
+// CHECK: linalg.fill ins(%c7_i16
+// Producer's scf.for-of-deallocs (still emitted, just not chosen as the
+// group's live-out):
+// CHECK: scf.for
+// CHECK: memref.dealloc
+// Consumer fill must depend on the producer FILL token, NOT on the
+// scf.for token.
+// CHECK: air.execute {{\[}}%[[FILL_TOK]]{{\]}}
+// CHECK: linalg.fill ins(%c9_i16
+
+module {
+  func.func @free_only_container() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg1, %arg2) in (%arg3=%c1, %arg4=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_a, %allocA = air.execute -> (memref<8xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %a : memref<8xi16, 2 : i32>
+        } {id = 1 : i32}
+        %async_token_b, %allocB = air.execute -> (memref<8xi16, 2 : i32>) {
+          %b = memref.alloc() : memref<8xi16, 2 : i32>
+          air.execute_terminator %b : memref<8xi16, 2 : i32>
+        } {id = 2 : i32}
+        // Producer: fill, then async scf.for body of only dealloc.
+        %2 = air.herd @herd_d async [%async_token_a] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufA=%allocA) : memref<8xi16, 2 : i32> attributes {id = 3 : i32} {
+          %cstv = arith.constant 7 : i16
+          %ci0 = arith.constant 0 : index
+          %ci1 = arith.constant 1 : index
+          %ci2 = arith.constant 2 : index
+          %tfill = air.execute {
+            linalg.fill ins(%cstv : i16) outs(%bufA : memref<8xi16, 2 : i32>)
+          } {id = 4 : i32}
+          %seed = air.wait_all async [%tfill]
+          %loop = scf.for %iv = %ci0 to %ci2 step %ci1 iter_args(%tok = %seed) -> (!air.async.token) {
+            %tdealloc = air.execute [%tok] {
+              memref.dealloc %bufA : memref<8xi16, 2 : i32>
+            } {id = 99 : i32}
+            scf.yield %tdealloc : !air.async.token
+          }
+        }
+        // Consumer.
+        %3 = air.herd @herd_d async [%2, %async_token_b] tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) args(%bufB=%allocB) : memref<8xi16, 2 : i32> attributes {id = 5 : i32} {
+          %cst = arith.constant 9 : i16
+          %t = air.execute {
+            linalg.fill ins(%cst : i16) outs(%bufB : memref<8xi16, 2 : i32>)
+          } {id = 6 : i32}
         }
       }
     }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/isolate_async_dma_loop_nest.mlir
@@ -753,18 +753,18 @@ module {
 // CHECK: air.herd
 // CHECK: %[[for_loop_1:.*]] = scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[arg11:.*]] =
 // CHECK: %[[for_loop_2:.*]] = scf.for %{{.*}} = %c0{{.*}} to %c512{{.*}} step %c256{{.*}} iter_args(%[[arg13:.*]] = %[[arg11]]
-// CHECK: air.execute [%[[arg13]]] {
+// CHECK: %[[fill_token:.*]] = air.execute [%[[arg13]]] {
 // CHECK-NEXT: linalg.fill
 // CHECK-NEXT: }
 
-// CHECK: %[[for_loop_3:.*]] = scf.for %{{.*}} = %c0{{.*}} to %c8{{.*}} step %c1{{.*}} iter_args(%[[arg15:.*]] = %[[arg13]]
+// CHECK: %[[for_loop_3:.*]] = scf.for %{{.*}} = %c0{{.*}} to %c8{{.*}} step %c1{{.*}} iter_args(%[[arg15:.*]] = %[[fill_token]]
 // CHECK: air.execute [%[[arg15]]] {
 // CHECK-NEXT: linalg.fill
 // CHECK-NEXT: }
 // CHECK-NEXT: scf.yield
 // CHECK-NEXT: }
 
-// CHECK: air.execute [%[[arg13]]] {
+// CHECK: air.execute [%[[for_loop_3]]] {
 // CHECK-NEXT: linalg.fill
 // CHECK-NEXT: }
 


### PR DESCRIPTION
## Summary
- `MergeAIRHerdsPattern` now collects the union of all herds' external async deps (not just the last herd's)
- Injects `air.wait_all` barriers between groups when inter-herd deps exist, ensuring ops from dependent herds wait for predecessor herds to complete
- Tracks the last non-dealloc async token per group (preferring `scf.for` results) so barrier deps survive canonicalization
- Updates `isolate_async_dma_loop_nest.mlir` CHECK patterns for the corrected dependency structure

## Test plan
- [x] `ninja check-air-mlir` — all existing tests pass (test updated)
- Part 2 of 3 for fixing #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)