### PR TITLE
Add subview alias analysis to CanonicalizeAsyncOpDeps

### DIFF
--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -206,6 +206,35 @@ static void printAsyncDependencies(OpAsmPrinter &printer, Operation *op,
 template <class OpT>
 static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
                                              PatternRewriter &rewriter) {
+  // Walk view-like ops, hierarchy body args, and loop iter_args back to a
+  // root memref. Conservative: disjoint views of the same root are reported
+  // as aliasing (safe — only suppresses dead-edge removal). The collectors
+  // below resolve every memref through this walk before inserting, so the
+  // RAW/WAR/WAW comparisons can be plain set-membership.
+  auto getRoot = [](Value v) -> Value {
+    while (true) {
+      if (auto view = v.getDefiningOp<ViewLikeOpInterface>()) {
+        v = view.getViewSource();
+        continue;
+      }
+      if (auto barg = dyn_cast<BlockArgument>(v)) {
+        Operation *parent = barg.getOwner()->getParentOp();
+        if (auto h = dyn_cast_if_present<air::HierarchyInterface>(parent)) {
+          if (Value outer = h.getTiedKernelOperand(barg)) {
+            v = outer;
+            continue;
+          }
+        }
+        if (auto loop = dyn_cast_if_present<LoopLikeOpInterface>(parent)) {
+          if (OpOperand *init = loop.getTiedLoopInit(barg)) {
+            v = init->get();
+            continue;
+          }
+        }
+      }
+      return v;
+    }
+  };
   auto getAllReadAccess = [](Operation *op) {
     SmallVector<Value> operands;
     if (auto linalgop = dyn_cast_if_present<linalg::LinalgOp>(op)) {
@@ -227,10 +256,11 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  auto getAllMemrefsReadByOp = [getAllReadAccess](Operation *o) {
+  auto getAllMemrefsReadByOp = [getAllReadAccess, getRoot](Operation *o) {
     llvm::SetVector<Value> memrefs;
-    auto opReadAccesses = getAllReadAccess(o);
-    memrefs.insert(opReadAccesses.begin(), opReadAccesses.end());
+    auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
+    for (Value v : getAllReadAccess(o))
+      insertRoot(v);
     SmallVector<Region *> regions;
     for (auto &region : o->getRegions())
       regions.push_back(&region);
@@ -239,17 +269,16 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     auto waitAllOp = dyn_cast_if_present<air::WaitAllOp>(o);
     if (waitAllOp && waitAllOp.getAsyncToken()) {
       for (auto user : waitAllOp.getAsyncToken().getUsers()) {
-        auto userReadAccesses = getAllReadAccess(user);
-        memrefs.insert(userReadAccesses.begin(), userReadAccesses.end());
+        for (Value v : getAllReadAccess(user))
+          insertRoot(v);
         for (auto &region : user->getRegions())
           regions.push_back(&region);
       }
     }
     for (auto region : regions) {
-      visitUsedValuesDefinedAbove(*region, [&memrefs,
-                                            getAllReadAccess](OpOperand *use) {
+      visitUsedValuesDefinedAbove(*region, [&](OpOperand *use) {
         if (llvm::is_contained(getAllReadAccess(use->getOwner()), use->get()))
-          memrefs.insert(use->get());
+          insertRoot(use->get());
       });
     }
     return memrefs;
@@ -278,10 +307,11 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  auto getAllMemrefsWrittenByOp = [getAllWriteAccess](Operation *o) {
+  auto getAllMemrefsWrittenByOp = [getAllWriteAccess, getRoot](Operation *o) {
     llvm::SetVector<Value> memrefs;
-    auto opWriteAccesses = getAllWriteAccess(o);
-    memrefs.insert(opWriteAccesses.begin(), opWriteAccesses.end());
+    auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
+    for (Value v : getAllWriteAccess(o))
+      insertRoot(v);
     SmallVector<Region *> regions;
     for (auto &region : o->getRegions())
       regions.push_back(&region);
@@ -290,17 +320,16 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     auto waitAllOp = dyn_cast_if_present<air::WaitAllOp>(o);
     if (waitAllOp && waitAllOp.getAsyncToken()) {
       for (auto user : waitAllOp.getAsyncToken().getUsers()) {
-        auto userWriteAccesses = getAllWriteAccess(user);
-        memrefs.insert(userWriteAccesses.begin(), userWriteAccesses.end());
+        for (Value v : getAllWriteAccess(user))
+          insertRoot(v);
         for (auto &region : user->getRegions())
           regions.push_back(&region);
       }
     }
     for (auto region : regions) {
-      visitUsedValuesDefinedAbove(*region, [&memrefs,
-                                            getAllWriteAccess](OpOperand *use) {
+      visitUsedValuesDefinedAbove(*region, [&](OpOperand *use) {
         if (llvm::is_contained(getAllWriteAccess(use->getOwner()), use->get()))
-          memrefs.insert(use->get());
+          insertRoot(use->get());
       });
     }
     return memrefs;
@@ -396,54 +425,18 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
           llvm::range_size(llvm::concat<Value>(memrefsReadBySinkOp,
                                                memrefsWrittenBySinkOp)) != 0;
       if (sourceOpTouchesMemref && sinkOpTouchesMemref) {
-        // Walk view-like ops, hierarchy body args, and loop iter_args
-        // back to a root memref. Conservative: disjoint views of the same
-        // root are reported as aliasing (safe — only suppresses dead-edge
-        // removal).
-        auto mayAlias = [](Value a, Value b) {
-          auto getRoot = [](Value v) -> Value {
-            while (true) {
-              if (auto view = v.getDefiningOp<ViewLikeOpInterface>()) {
-                v = view.getViewSource();
-                continue;
-              }
-              if (auto barg = dyn_cast<BlockArgument>(v)) {
-                Operation *parent = barg.getOwner()->getParentOp();
-                if (auto h =
-                        dyn_cast_if_present<air::HierarchyInterface>(parent)) {
-                  if (Value outer = h.getTiedKernelOperand(barg)) {
-                    v = outer;
-                    continue;
-                  }
-                }
-                if (auto loop =
-                        dyn_cast_if_present<LoopLikeOpInterface>(parent)) {
-                  if (OpOperand *init = loop.getTiedLoopInit(barg)) {
-                    v = init->get();
-                    continue;
-                  }
-                }
-              }
-              return v;
-            }
-          };
-          return getRoot(a) == getRoot(b);
-        };
-        auto containsOrAliases = [&mayAlias](const llvm::SetVector<Value> &set,
-                                             Value v) {
-          return llvm::any_of(
-              set, [&](Value s) { return s == v || mayAlias(s, v); });
-        };
+        // Sets already contain root memrefs (resolved by the collectors),
+        // so RAW/WAR/WAW checks reduce to plain set-membership.
         bool RAWNotFound =
             llvm::none_of(memrefsWrittenBySourceOp, [&](Value v) {
-              return containsOrAliases(memrefsReadBySinkOp, v);
+              return memrefsReadBySinkOp.contains(v);
             });
         bool WARNotFound = llvm::none_of(memrefsReadBySourceOp, [&](Value v) {
-          return containsOrAliases(memrefsWrittenBySinkOp, v);
+          return memrefsWrittenBySinkOp.contains(v);
         });
         bool WAWNotFound =
             llvm::none_of(memrefsWrittenBySourceOp, [&](Value v) {
-              return containsOrAliases(memrefsWrittenBySinkOp, v);
+              return memrefsWrittenBySinkOp.contains(v);
             });
         bool noSharedResource = llvm::none_of(
             resourcesUsedBySourceOp, [&resourcesUsedBySinkOp](SymbolRefAttr r) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -206,11 +206,24 @@ static void printAsyncDependencies(OpAsmPrinter &printer, Operation *op,
 template <class OpT>
 static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
                                              PatternRewriter &rewriter) {
-  // Walk view-like ops, hierarchy body args, and loop iter_args back to a
-  // root memref. Conservative: disjoint views of the same root are reported
-  // as aliasing (safe — only suppresses dead-edge removal). The collectors
-  // below resolve every memref through this walk before inserting, so the
-  // RAW/WAR/WAW comparisons can be plain set-membership.
+  // Walk view-like ops, air.hierarchy body args, and loop iter_args back
+  // to a root memref. The collectors below resolve every memref through
+  // this walk before inserting, so the RAW/WAR/WAW comparisons reduce to
+  // set-membership.
+  //
+  // Intentionally conservative — DO NOT TIGHTEN without a strong reason:
+  //   * Two disjoint views of the same root return the same root and
+  //     are reported as aliasing. Modeling subview offsets/sizes to
+  //     prove disjointness was the bug behind #1559: the original code
+  //     compared SSA identity (the strictest possible "alias" predicate)
+  //     and dropped real RAW edges between fill and channel.put.
+  //   * iter_args resolve to the loop init; a body that conditionally
+  //     yields a different memref will under-approximate roots seen
+  //     across iterations, but still over-approximates aliasing.
+  //
+  // Over-approximating aliasing is the safe direction here: this
+  // predicate gates dead-edge *removal*, so false positives only
+  // suppress an optimization, never invent a race.
   auto getRoot = [](Value v) -> Value {
     while (true) {
       if (auto view = v.getDefiningOp<ViewLikeOpInterface>()) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -395,17 +395,42 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
           llvm::range_size(llvm::concat<Value>(memrefsReadBySinkOp,
                                                memrefsWrittenBySinkOp)) != 0;
       if (sourceOpTouchesMemref && sinkOpTouchesMemref) {
-        bool RAWNotFound = llvm::none_of(
-            memrefsWrittenBySourceOp, [&memrefsReadBySinkOp](Value v) {
-              return llvm::is_contained(memrefsReadBySinkOp, v);
+        // Check if two memref values may alias through view-like op chains.
+        // Walks through memref.subview, memref.cast, and other
+        // ViewLikeOpInterface ops to find the root memref, then checks if
+        // they share the same root.
+        auto mayAlias = [](Value a, Value b) {
+          auto getRoot = [](Value v) -> Value {
+            bool changed = true;
+            while (changed) {
+              changed = false;
+              if (auto viewOp = v.getDefiningOp<ViewLikeOpInterface>()) {
+                v = viewOp.getViewSource();
+                changed = true;
+              } else if (auto castOp = v.getDefiningOp<memref::CastOp>()) {
+                v = castOp.getSource();
+                changed = true;
+              }
+            }
+            return v;
+          };
+          return getRoot(a) == getRoot(b);
+        };
+        auto containsOrAliases = [&mayAlias](const llvm::SetVector<Value> &set,
+                                             Value v) {
+          return llvm::any_of(
+              set, [&](Value s) { return s == v || mayAlias(s, v); });
+        };
+        bool RAWNotFound =
+            llvm::none_of(memrefsWrittenBySourceOp, [&](Value v) {
+              return containsOrAliases(memrefsReadBySinkOp, v);
             });
-        bool WARNotFound = llvm::none_of(
-            memrefsReadBySourceOp, [&memrefsWrittenBySinkOp](Value v) {
-              return llvm::is_contained(memrefsWrittenBySinkOp, v);
-            });
-        bool WAWNotFound = llvm::none_of(
-            memrefsWrittenBySourceOp, [&memrefsWrittenBySinkOp](Value v) {
-              return llvm::is_contained(memrefsWrittenBySinkOp, v);
+        bool WARNotFound = llvm::none_of(memrefsReadBySourceOp, [&](Value v) {
+          return containsOrAliases(memrefsWrittenBySinkOp, v);
+        });
+        bool WAWNotFound =
+            llvm::none_of(memrefsWrittenBySourceOp, [&](Value v) {
+              return containsOrAliases(memrefsWrittenBySinkOp, v);
             });
         bool noSharedResource = llvm::none_of(
             resourcesUsedBySourceOp, [&resourcesUsedBySinkOp](SymbolRefAttr r) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -396,22 +396,17 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
                                                memrefsWrittenBySinkOp)) != 0;
       if (sourceOpTouchesMemref && sinkOpTouchesMemref) {
         // Check if two memref values may alias through view-like op chains.
-        // Walks through memref.subview, memref.cast, and other
-        // ViewLikeOpInterface ops to find the root memref, then checks if
-        // they share the same root.
+        // Walks any ViewLikeOpInterface (subview, cast, expand_shape,
+        // collapse_shape, reinterpret_cast, transpose, ...) to its source,
+        // and treats two values that resolve to the same root as aliasing.
+        // Conservative: disjoint views of the same root are reported as
+        // aliasing — safe for dependency-removal canonicalization, since
+        // over-approximating aliasing only suppresses dead-edge removal,
+        // never invents races.
         auto mayAlias = [](Value a, Value b) {
           auto getRoot = [](Value v) -> Value {
-            bool changed = true;
-            while (changed) {
-              changed = false;
-              if (auto viewOp = v.getDefiningOp<ViewLikeOpInterface>()) {
-                v = viewOp.getViewSource();
-                changed = true;
-              } else if (auto castOp = v.getDefiningOp<memref::CastOp>()) {
-                v = castOp.getSource();
-                changed = true;
-              }
-            }
+            while (auto view = v.getDefiningOp<ViewLikeOpInterface>())
+              v = view.getViewSource();
             return v;
           };
           return getRoot(a) == getRoot(b);

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -395,19 +396,36 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
           llvm::range_size(llvm::concat<Value>(memrefsReadBySinkOp,
                                                memrefsWrittenBySinkOp)) != 0;
       if (sourceOpTouchesMemref && sinkOpTouchesMemref) {
-        // Check if two memref values may alias through view-like op chains.
-        // Walks any ViewLikeOpInterface (subview, cast, expand_shape,
-        // collapse_shape, reinterpret_cast, transpose, ...) to its source,
-        // and treats two values that resolve to the same root as aliasing.
-        // Conservative: disjoint views of the same root are reported as
-        // aliasing — safe for dependency-removal canonicalization, since
-        // over-approximating aliasing only suppresses dead-edge removal,
-        // never invents races.
+        // Walk view-like ops, hierarchy body args, and loop iter_args
+        // back to a root memref. Conservative: disjoint views of the same
+        // root are reported as aliasing (safe — only suppresses dead-edge
+        // removal).
         auto mayAlias = [](Value a, Value b) {
           auto getRoot = [](Value v) -> Value {
-            while (auto view = v.getDefiningOp<ViewLikeOpInterface>())
-              v = view.getViewSource();
-            return v;
+            while (true) {
+              if (auto view = v.getDefiningOp<ViewLikeOpInterface>()) {
+                v = view.getViewSource();
+                continue;
+              }
+              if (auto barg = dyn_cast<BlockArgument>(v)) {
+                Operation *parent = barg.getOwner()->getParentOp();
+                if (auto h =
+                        dyn_cast_if_present<air::HierarchyInterface>(parent)) {
+                  if (Value outer = h.getTiedKernelOperand(barg)) {
+                    v = outer;
+                    continue;
+                  }
+                }
+                if (auto loop =
+                        dyn_cast_if_present<LoopLikeOpInterface>(parent)) {
+                  if (OpOperand *init = loop.getTiedLoopInit(barg)) {
+                    v = init->get();
+                    continue;
+                  }
+                }
+              }
+              return v;
+            }
           };
           return getRoot(a) == getRoot(b);
         };

--- a/mlir/test/Dialect/AIR/canonicalize_subview_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_subview_dep.mlir
@@ -1,0 +1,59 @@
+// RUN: air-opt -canonicalize %s | FileCheck %s
+
+// Verify that canonicalize does not remove an async dependency between ops
+// that access the same memory through a subview alias. The channel.put reads
+// the base memref %buf, while the execute writes to %subview (a subview of
+// %buf). The dependency must be preserved.
+
+// CHECK-LABEL: func.func @subview_dep_preserved
+// CHECK: air.execute -> (memref
+// CHECK: memref.subview
+// CHECK: %[[FILL_TOK:.*]] = air.execute [
+// CHECK: linalg.fill
+// The channel.put must still depend on the fill token (not removed
+// despite fill writing to %subview and channel.put reading from %buf,
+// because they alias through memref.subview):
+// CHECK: air.channel.put async [%[[FILL_TOK]]]
+
+module {
+  air.channel @channel_out [1, 1]
+  func.func @subview_dep_preserved() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c256 = arith.constant 256 : index
+    %c1024 = arith.constant 1024 : index
+    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c1_s = arith.constant 1 : index
+        %2 = air.herd @herd_0 async tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) attributes {id = 3 : i32} {
+          %c0_i16 = arith.constant 0 : i16
+          %c0_0 = arith.constant 0 : index
+          %c1_0 = arith.constant 1 : index
+          %c8_0 = arith.constant 8 : index
+          %c32_0 = arith.constant 32 : index
+          %c256_0 = arith.constant 256 : index
+          %c1024_0 = arith.constant 1024 : index
+          // Alloc the output buffer
+          %async_token_alloc, %buf = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<1x1x4x8x4x8xi16, 2 : i32>
+            air.execute_terminator %alloc : memref<1x1x4x8x4x8xi16, 2 : i32>
+          } {id = 4 : i32}
+          // Create subview
+          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          // Write to subview
+          %async_token_fill = air.execute [%async_token_alloc] {
+            linalg.fill ins(%c0_i16 : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
+          } {id = 5 : i32}
+          // Read from base memref — should preserve dep on fill
+          %3 = air.channel.put async [%async_token_alloc, %async_token_fill] @channel_out[%tx, %ty] (%buf[%c0_0, %c0_0, %c0_0, %c0_0, %c0_0, %c0_0] [%c1_0, %c1_0, %c8_0, %c8_0, %c8_0, %c8_0] [%c1024_0, %c1024_0, %c32_0, %c8_0, %c256_0, %c1_0]) {id = 6 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
+          %async_token_dealloc = air.execute [%3] {
+            memref.dealloc %buf : memref<1x1x4x8x4x8xi16, 2 : i32>
+          } {id = 7 : i32}
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/AIR/canonicalize_subview_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_subview_dep.mlir
@@ -1,56 +1,113 @@
-// RUN: air-opt -canonicalize %s | FileCheck %s
+// RUN: air-opt -canonicalize -split-input-file %s | FileCheck %s
 
-// Verify that canonicalize does not remove an async dependency between ops
-// that access the same memory through a subview alias. The channel.put reads
-// the base memref %buf, while the execute writes to %subview (a subview of
-// %buf). The dependency must be preserved.
+// Reproducer for #1559, lifted from the herd body of
+// programming_examples/matrix_multiplication/i8 build_peano/air_project_1x1/
+// placed.air_input.mlir (--herd-m 1 --herd-n 1 --m 32 --n 32 --k 32
+// --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32).
+//
+// The fill writes %subview = memref.subview %results_17[...]; the
+// channel.put reads the base %results_17. Without alias-aware
+// CanonicalizeAsyncOpDeps, the dep on the fill token (%async_token_18)
+// is incorrectly dropped because %subview and %results_17 are different
+// SSA values.
 
-// CHECK-LABEL: func.func @subview_dep_preserved
-// CHECK: air.execute -> (memref
-// CHECK: memref.subview
-// CHECK: %[[FILL_TOK:.*]] = air.execute [
-// CHECK: linalg.fill
-// The channel.put must still depend on the fill token (not removed
-// despite fill writing to %subview and channel.put reading from %buf,
-// because they alias through memref.subview):
-// CHECK: air.channel.put async [%[[FILL_TOK]]]
+// CHECK-LABEL: func.func @reproducer_subview_alias
+// CHECK: %{{.*}}, %[[BUF:[a-zA-Z0-9_]+]] = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>)
+// CHECK: memref.subview %[[BUF]]
+// CHECK: %[[FILL_TOK:[a-zA-Z0-9_]+]] = air.execute [
+// CHECK:   func.call @linalg_fill_i16_view1x1x4x8x4x8xi16as2
+// The fill→channel.put RAW edge must survive canonicalize:
+// CHECK: air.channel.put async [%[[FILL_TOK]]] @channel_4{{.*}} (%[[BUF]]
 
 module {
-  air.channel @channel_out [1, 1]
-  func.func @subview_dep_preserved() {
-    %c0 = arith.constant 0 : index
+  air.channel @channel_4 [1, 1]
+  func.func private @linalg_fill_i16_view1x1x4x8x4x8xi16as2(i16, memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>) attributes {link_with = "mm.o", llvm.emit_c_interface}
+  func.func @reproducer_subview_alias() {
     %c1 = arith.constant 1 : index
-    %c8 = arith.constant 8 : index
-    %c32 = arith.constant 32 : index
-    %c256 = arith.constant 256 : index
-    %c1024 = arith.constant 1024 : index
-    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
-      %1 = air.segment @seg async attributes {id = 2 : i32} {
-        %c1_s = arith.constant 1 : index
-        %2 = air.herd @herd_0 async tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) attributes {id = 3 : i32} {
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @matmul_seg async attributes {id = 2 : i32} {
+        %c1_3 = arith.constant 1 : index
+        %2 = air.herd @herd_0 async tile (%arg10, %arg11) in (%arg12=%c1_3, %arg13=%c1_3) attributes {id = 5 : i32} {
           %c0_i16 = arith.constant 0 : i16
-          %c0_0 = arith.constant 0 : index
-          %c1_0 = arith.constant 1 : index
-          %c8_0 = arith.constant 8 : index
-          %c32_0 = arith.constant 32 : index
-          %c256_0 = arith.constant 256 : index
-          %c1024_0 = arith.constant 1024 : index
-          // Alloc the output buffer
-          %async_token_alloc, %buf = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
+          %c0_13 = arith.constant 0 : index
+          %c1_12 = arith.constant 1 : index
+          %c4_15 = arith.constant 4 : index
+          %c8_14 = arith.constant 8 : index
+          %c32_11 = arith.constant 32 : index
+          %c256 = arith.constant 256 : index
+          %async_token_16, %results_17 = air.execute -> (memref<1x1x4x8x4x8xi16, 2 : i32>) {
             %alloc = memref.alloc() : memref<1x1x4x8x4x8xi16, 2 : i32>
             air.execute_terminator %alloc : memref<1x1x4x8x4x8xi16, 2 : i32>
-          } {id = 4 : i32}
-          // Create subview
-          %subview = memref.subview %buf[%tx, %ty, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
-          // Write to subview
-          %async_token_fill = air.execute [%async_token_alloc] {
-            linalg.fill ins(%c0_i16 : i16) outs(%subview : memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>)
-          } {id = 5 : i32}
-          // Read from base memref — should preserve dep on fill
-          %3 = air.channel.put async [%async_token_alloc, %async_token_fill] @channel_out[%tx, %ty] (%buf[%c0_0, %c0_0, %c0_0, %c0_0, %c0_0, %c0_0] [%c1_0, %c1_0, %c8_0, %c8_0, %c8_0, %c8_0] [%c1024_0, %c1024_0, %c32_0, %c8_0, %c256_0, %c1_0]) {id = 6 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
-          %async_token_dealloc = air.execute [%3] {
-            memref.dealloc %buf : memref<1x1x4x8x4x8xi16, 2 : i32>
-          } {id = 7 : i32}
+          }
+          %subview = memref.subview %results_17[%arg10, %arg11, 0, 0, 0, 0] [1, 1, 4, 8, 4, 8] [1, 1, 1, 1, 1, 1] : memref<1x1x4x8x4x8xi16, 2 : i32> to memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>
+          %async_token_18 = air.execute [%async_token_16] {
+            func.call @linalg_fill_i16_view1x1x4x8x4x8xi16as2(%c0_i16, %subview) : (i16, memref<1x1x4x8x4x8xi16, strided<[1024, 1024, 256, 32, 8, 1], offset: ?>, 2 : i32>) -> ()
+          }
+          %20 = air.channel.put async [%async_token_16, %async_token_18] @channel_4[%arg10, %arg11] (%results_17[%c0_13, %c0_13, %c0_13] [%c32_11, %c4_15, %c8_14] [%c8_14, %c256, %c1_12]) {id = 13 : i32} : (memref<1x1x4x8x4x8xi16, 2 : i32>)
+          %async_token_33 = air.execute [%20] {
+            memref.dealloc %results_17 : memref<1x1x4x8x4x8xi16, 2 : i32>
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Negative test: confirms canonicalize STILL removes a genuinely dead
+// async dep. Two independent allocs %A and %B; the channel.put reads
+// only %A but lists both fill tokens as deps. The dep on the fill of
+// %B has no RAW/WAR/WAW with the put and must be dropped — otherwise
+// a buggy mayAlias that always returns true would also pass the
+// reproducer test above.
+
+// CHECK-LABEL: func.func @dead_dep_removed
+// CHECK: %{{.*}}, %[[A:[a-zA-Z0-9_]+]] = air.execute -> (memref<8x8xi16
+// CHECK: %{{.*}}, %[[B:[a-zA-Z0-9_]+]] = air.execute -> (memref<8x8xi16
+// CHECK: %[[FILL_A:[a-zA-Z0-9_]+]] = air.execute [%{{.*}}] {
+// CHECK-NEXT:   linalg.fill {{.*}} outs(%[[A]]
+// CHECK: %[[FILL_B:[a-zA-Z0-9_]+]] = air.execute [%{{.*}}] {
+// CHECK-NEXT:   linalg.fill {{.*}} outs(%[[B]]
+// The put reads %A only; the dep on %FILL_B (which writes %B) must be
+// dropped. CHECK requires the remaining dep list to be exactly
+// [%FILL_A] — a buggy mayAlias that always returns true would leave
+// both deps and fail this check.
+// CHECK: air.channel.put async [%[[FILL_A]]] @channel_x[] (%[[A]]
+
+module {
+  air.channel @channel_x []
+  func.func @dead_dep_removed() {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32} {
+        %c0_i16 = arith.constant 0 : i16
+        %c0_s = arith.constant 0 : index
+        %c1_s = arith.constant 1 : index
+        %c8_s = arith.constant 8 : index
+        %tok_A, %A = air.execute -> (memref<8x8xi16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<8x8xi16, 1 : i32>
+          air.execute_terminator %alloc : memref<8x8xi16, 1 : i32>
+        }
+        %tok_B, %B = air.execute -> (memref<8x8xi16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<8x8xi16, 1 : i32>
+          air.execute_terminator %alloc : memref<8x8xi16, 1 : i32>
+        }
+        %fill_A = air.execute [%tok_A] {
+          linalg.fill ins(%c0_i16 : i16) outs(%A : memref<8x8xi16, 1 : i32>)
+        }
+        %fill_B = air.execute [%tok_B] {
+          linalg.fill ins(%c0_i16 : i16) outs(%B : memref<8x8xi16, 1 : i32>)
+        }
+        %put = air.channel.put async [%fill_A, %fill_B] @channel_x[] (%A[%c0_s, %c0_s] [%c8_s, %c8_s] [%c8_s, %c1_s]) {id = 1 : i32} : (memref<8x8xi16, 1 : i32>)
+        %dA = air.execute [%put] {
+          memref.dealloc %A : memref<8x8xi16, 1 : i32>
+        }
+        %dB = air.execute [%fill_B] {
+          memref.dealloc %B : memref<8x8xi16, 1 : i32>
         }
       }
     }


### PR DESCRIPTION
## Summary
- `CanonicalizeAsyncOpDeps` used SSA value identity to check if two ops access the same memref, which missed aliases through `memref.subview`
- Adds a `mayAlias` helper that walks `memref.subview` defining-op chains to compare root memrefs
- RAW/WAR/WAW checks now use alias-aware comparison, preventing incorrect removal of deps where the source writes to a subview and the sink reads from the base memref

## Root cause
The pattern compared `%subview` against `%arg14` using `llvm::is_contained` (pointer equality). Since `%subview = memref.subview %arg14[...]` is a different SSA value, the check returned "no overlap" and the dependency was dropped — even though they alias the same memory.

## Test plan
- [x] `ninja check-air-mlir` — all existing tests pass
- Part 3 of 3 for fixing #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)