### PR TITLE
Warn when ELF instance_name doesn't match module function name

### DIFF
--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -352,8 +352,9 @@ class XRTBackend(AirBackend):
                 print("Running aircc with options:", " ".join(aircc_options))
 
             # Write the in-memory module to the input file expected by aircc
+            module_str = str(air_module)
             with open("air.mlir", "w") as f:
-                f.write(str(air_module))
+                f.write(module_str)
 
             # Invoke the C++ aircc binary
             aircc_exe = shutil.which("aircc")
@@ -379,7 +380,7 @@ class XRTBackend(AirBackend):
             # @FuncOp.from_py_func function name.
             import re
 
-            func_names = re.findall(r"func\.func @(\w+)\(", str(air_module))
+            func_names = re.findall(r"func\.func @(\w+)\(", module_str)
             if func_names and self.instance_name not in func_names:
                 import warnings
 
@@ -388,7 +389,7 @@ class XRTBackend(AirBackend):
                     f"function in the module (available: {func_names}). "
                     f"For ELF output, instance_name must match the "
                     f"@FuncOp.from_py_func function name. "
-                    f"Using the wrong name will cause a runtime deadlock.",
+                    f"Using the wrong name may cause ERT_CMD_STATE_TIMEOUT or a runtime deadlock.",
                     stacklevel=2,
                 )
             elf_kernel = f"main:{self.instance_name}"

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -374,6 +374,25 @@ class XRTBackend(AirBackend):
         # For ELF mode, the kernel identifier is "main:instance_name"
         # This is used when loading the ELF via xrt.ext.kernel()
         if self.output_format == "elf" and self.instance_name != "":
+            # Validate that instance_name matches a function in the module.
+            # For ELF output, instance_name must match the
+            # @FuncOp.from_py_func function name.
+            import re
+
+            func_names = re.findall(
+                r"func\.func @(\w+)\(", str(air_module)
+            )
+            if func_names and self.instance_name not in func_names:
+                import warnings
+
+                warnings.warn(
+                    f"instance_name='{self.instance_name}' does not match any "
+                    f"function in the module (available: {func_names}). "
+                    f"For ELF output, instance_name must match the "
+                    f"@FuncOp.from_py_func function name. "
+                    f"Using the wrong name will cause a runtime deadlock.",
+                    stacklevel=2,
+                )
             elf_kernel = f"main:{self.instance_name}"
         else:
             elf_kernel = kernel

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -379,9 +379,7 @@ class XRTBackend(AirBackend):
             # @FuncOp.from_py_func function name.
             import re
 
-            func_names = re.findall(
-                r"func\.func @(\w+)\(", str(air_module)
-            )
+            func_names = re.findall(r"func\.func @(\w+)\(", str(air_module))
             if func_names and self.instance_name not in func_names:
                 import warnings
 


### PR DESCRIPTION
## Summary
- Add compile-time validation warning when `instance_name` doesn't match any `func.func` in the module
- Prevents cryptic `ERT_CMD_STATE_TIMEOUT` deadlock when users pass the segment name instead of the function name for ELF output

## Context

Issue #1557 reported a deadlock with 2+ S2MM DMA channels on NPU2. After investigation, the root cause was the reproducer using `instance_name='seg'` (the segment name) instead of `instance_name='elemwise_mul'` (the Python function name). For ELF output, `XRTBackend.compile()` constructs the XRT kernel name as `"main:{instance_name}"`. When this doesn't match a function in the module, XRT either rejects it or executes the wrong runtime_sequence (one without `load_pdi` tile configuration), causing a deadlock.

Every working ELF example uses the function name as `instance_name` (`def matvec_cascade_bf16` → `instance_name="matvec_cascade_bf16"`, etc.), but this convention was not validated or documented.

## Test plan
- [x] Warning fires for mismatched `instance_name` (e.g., `instance_name='seg'` with `def elemwise_mul`)
- [x] No warning for correct `instance_name` (e.g., `instance_name='elemwise_mul'` with `def elemwise_mul`)
- [x] Existing examples unaffected (all use matching names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)