### PR TITLE
Fix cross-herd broadcast channel hoisting in cloneOpsInBlock

### DIFF
--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -131,11 +131,18 @@ SmallVector<Operation *> air::cloneOpsInBlock(Block *blk, OpBuilder &builder,
                        clonedScfLoopOps.end());
     } else if (auto channel_op =
                    dyn_cast_if_present<air::ChannelInterface>(o)) {
-      if (o.hasAttr("loop-carried-dep") &&
-          o.getAttrOfType<StringAttr>("loop-carried-dep").getValue().str() ==
-              "internalGetPut") {
-        // Found channel op labelled as "internalGetPut", which
-        // shouldn't be hoisted
+      auto depAttr = o.getAttrOfType<StringAttr>("loop-carried-dep");
+      bool isInternalGetPut =
+          depAttr && depAttr.getValue().str() == "internalGetPut";
+      // A user-written channel op pulled into the backward slice by the
+      // herd-to-segment hoisting pass: has "hoist" attribute (from backward
+      // slice labeling) but no "loop-carried-dep" (not DMA-derived).
+      // Must not be cloned to segment level — replace with wait_all.
+      bool isHoistedUserChannel = o.hasAttr("hoist") && !depAttr;
+      if (isInternalGetPut || isHoistedUserChannel) {
+        // Don't hoist: either "internalGetPut" (DMA-derived internal half) or
+        // a user-written channel op that ended up in the backward slice as a
+        // dependency. Replace with wait_all to preserve async token chain.
         if (air::isAsyncOp(&o)) {
           auto wa_op =
               air::replaceAsyncOpWithWaitAll(builder, remap, &o, false);

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -134,15 +134,14 @@ SmallVector<Operation *> air::cloneOpsInBlock(Block *blk, OpBuilder &builder,
       auto depAttr = o.getAttrOfType<StringAttr>("loop-carried-dep");
       bool isInternalGetPut =
           depAttr && depAttr.getValue().str() == "internalGetPut";
-      // A user-written channel op pulled into the backward slice by the
-      // herd-to-segment hoisting pass: has "hoist" attribute (from backward
-      // slice labeling) but no "loop-carried-dep" (not DMA-derived).
-      // Must not be cloned to segment level — replace with wait_all.
-      bool isHoistedUserChannel = o.hasAttr("hoist") && !depAttr;
-      if (isInternalGetPut || isHoistedUserChannel) {
-        // Don't hoist: either "internalGetPut" (DMA-derived internal half) or
-        // a user-written channel op that ended up in the backward slice as a
-        // dependency. Replace with wait_all to preserve async token chain.
+      // A user-written channel op pulled into the backward slice as a
+      // transitive dependency of a DMA being hoisted. It has "hoist"
+      // (guaranteed true here — line 119 filters non-hoist ops) but no
+      // "loop-carried-dep" (only DMA-derived channel ops receive that
+      // attribute; see labelBackwardSlice below). Must not be cloned to
+      // segment level — replace with wait_all to preserve async token chain.
+      bool isUserWrittenChannel = !depAttr;
+      if (isInternalGetPut || isUserWrittenChannel) {
         if (air::isAsyncOp(&o)) {
           auto wa_op =
               air::replaceAsyncOpWithWaitAll(builder, remap, &o, false);
@@ -846,6 +845,13 @@ class AIRHoistExternalAIRChannelPattern : public OpRewritePattern<AIRHierOpTy> {
     // Label backward slices with attribute; ops not labelled with "hoist" flag
     // shall either not get hoisted, if IR is not async, or become air.wait_all
     // (null op) after being hoisted.
+    //
+    // Note: user-written channel ops may end up in backwardSlice as transitive
+    // dependencies (e.g., a broadcast ChannelGet whose token feeds a wait_all
+    // gating the DMA's loop). These ops receive "hoist" here but intentionally
+    // do NOT receive "loop-carried-dep" — cloneOpsInBlock uses the absence of
+    // "loop-carried-dep" to distinguish them from DMA-derived channel ops and
+    // replaces them with wait_all instead of cloning to segment level.
     backwardSlice.insert(externalGetPuts.begin(), externalGetPuts.end());
     for (auto b : backwardSlice) {
       b->setAttr("hoist", StringAttr::get(ctx, "dep"));

--- a/mlir/test/Transform/AIRDmaToChannel/cross_herd_broadcast_hoisting.mlir
+++ b/mlir/test/Transform/AIRDmaToChannel/cross_herd_broadcast_hoisting.mlir
@@ -1,0 +1,76 @@
+//===- cross_herd_broadcast_hoisting.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Verify that user-written channel ops are not duplicated to segment level
+// when DMA ops in the same herd are hoisted by air-dma-to-channel.
+//
+// Scenario: producer herd [1,1] broadcasts via @bcast, consumer herd [4,1]
+// receives the broadcast and writes to L3 via dma_memcpy_nd. The DMA's
+// backward slice includes the user-written channel.get (via async token
+// dependency). The pass must NOT clone channel.get @bcast to segment level.
+
+// RUN: air-opt %s -air-dma-to-channel | FileCheck %s
+
+// Verify channel declarations: @bcast should remain unchanged, new channels
+// should be created for the DMAs.
+// CHECK-DAG: air.channel @bcast [1, 1] {broadcast_shape = [4 : index, 1 : index]}
+// CHECK-DAG: air.channel @channel_{{.*}}
+
+// Verify that air.channel.get @bcast does NOT appear at segment level (outside
+// the herds). The segment body should have scf.parallel ops with channel ops
+// for the DMA-derived channels only, not for @bcast.
+// CHECK-LABEL: func.func @cross_herd_broadcast
+// CHECK: air.segment
+// CHECK-NOT: air.channel.get{{.*}}@bcast
+
+// Verify that air.channel.get @bcast remains inside the consumer herd.
+// CHECK: air.herd @consumer
+// CHECK: air.channel.get{{.*}}@bcast
+
+#map = affine_map<()[s0] -> (s0 * 64)>
+module {
+  air.channel @bcast [1, 1] {broadcast_shape = [4 : index, 1 : index]}
+  func.func @cross_herd_broadcast(%arg0: memref<64xbf16>, %arg1: memref<256xbf16>) {
+    %0 = air.launch async () in () args(%arg2=%arg0, %arg3=%arg1) : memref<64xbf16>, memref<256xbf16> attributes {id = 2 : i32} {
+      %1 = air.segment @seg async  args(%arg4=%arg2, %arg5=%arg3) : memref<64xbf16>, memref<256xbf16> attributes {id = 1 : i32} {
+        %c1 = arith.constant 1 : index
+        %c4 = arith.constant 4 : index
+        // Producer herd: load from L3, broadcast to consumer tiles.
+        %2 = air.herd @producer async  tile (%arg6, %arg7) in (%arg8=%c1, %arg9=%c1) args(%arg10=%arg4) : memref<64xbf16> attributes {id = 1 : i32} {
+          %async_token, %results = air.execute -> (memref<64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64xbf16, 2 : i32>
+          } {id = 1 : i32}
+          %4 = air.dma_memcpy_nd async [%async_token] (%results[] [] [], %arg10[] [] []) {id = 1 : i32} : (memref<64xbf16, 2 : i32>, memref<64xbf16>)
+          %5 = air.channel.put async [%4]  @bcast[] (%results[] [] []) {id = 1 : i32} : (memref<64xbf16, 2 : i32>)
+          %async_token_0 = air.execute [%5] {
+            memref.dealloc %results : memref<64xbf16, 2 : i32>
+          } {id = 2 : i32}
+        }
+        // Consumer herd: receive broadcast, then DMA to L3.
+        // The DMA depends on channel.get @bcast via async token %4.
+        // This is the critical pattern: the backward slice of the DMA's
+        // external half includes the user-written channel.get.
+        %3 = air.herd @consumer async  tile (%arg6, %arg7) in (%arg8=%c4, %arg9=%c1) args(%arg10=%arg5) : memref<256xbf16> attributes {id = 2 : i32} {
+          %async_token, %results = air.execute -> (memref<64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64xbf16, 2 : i32>
+          } {id = 3 : i32}
+          %4 = air.channel.get async [%async_token]  @bcast[%arg6, %arg7] (%results[] [] []) {id = 2 : i32} : (memref<64xbf16, 2 : i32>)
+          %5 = affine.apply #map()[%arg6]
+          %c64 = arith.constant 64 : index
+          %c1_0 = arith.constant 1 : index
+          %6 = air.dma_memcpy_nd async [%4] (%arg10[%5] [%c64] [%c1_0], %results[] [] []) {id = 2 : i32} : (memref<256xbf16>, memref<64xbf16, 2 : i32>)
+          %async_token_1 = air.execute [%6] {
+            memref.dealloc %results : memref<64xbf16, 2 : i32>
+          } {id = 4 : i32}
+        }
+      }
+    }
+    return
+  }
+}

--- a/programming_examples/channel_examples/broadcast/cross_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/cross_herd/Makefile
@@ -1,0 +1,26 @@
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Determine build dir based on whether PEANO_INSTALL_DIR is set
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+# Output format: xclbin (default) or elf
+OUTPUT_FORMAT ?= xclbin
+OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
+
+all: run
+
+print:
+	${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
+
+run:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
@@ -22,7 +22,7 @@ from air.dialects.affine import apply as affine_apply
 from air.dialects.air import *
 from air.dialects import arith
 from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.memref import AllocOp, DeallocOp, subview
 from air.dialects.func import FuncOp
 from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
 from air.dialects.scf import for_, yield_
@@ -30,16 +30,18 @@ from air.backend.xrt_runner import XRTRunner, type_mapper
 
 range_ = for_
 
-VECTOR_LEN = 64       # Length of vector to broadcast (like head_dim or K)
-HERD_N = 4            # Number of consumer tiles (like HERD_M in GEMV)
-VEC_SIZE = 16         # SIMD width for bf16
+VECTOR_LEN = 64  # Length of vector to broadcast (like head_dim or K)
+HERD_N = 4  # Number of consumer tiles (like HERD_M in GEMV)
+VEC_SIZE = 16  # SIMD width for bf16
 DTYPE = bfloat16
 
 
 def _make_mul_map(factor):
-    return AffineMap.get(0, 1, [
-        AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(factor))
-    ])
+    return AffineMap.get(
+        0,
+        1,
+        [AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(factor))],
+    )
 
 
 @module_builder
@@ -85,10 +87,11 @@ def build_module():
                     one_scalar = ConstantOp(xrt, 1.0)
                     v_one = BroadcastOp(vecTy, one_scalar)
                     for j in range_(0, VECTOR_LEN, VEC_SIZE):
-                        from air.dialects.memref import subview
                         sv_in = subview(l1_in.result, [j], [VEC_SIZE], [1])
                         sv_out = subview(l1_out.result, [j], [VEC_SIZE], [1])
-                        v = transfer_read(vecTy, sv_in, [c0], identity_map, cst0, [True])
+                        v = transfer_read(
+                            vecTy, sv_in, [c0], identity_map, cst0, [True]
+                        )
                         v_plus = arith.addf(v, v_one)
                         transfer_write(None, v_plus, sv_out, [c0], identity_map, [True])
                         yield_([])
@@ -110,10 +113,13 @@ def build_module():
                     # Write to output at tile-specific offset
                     mul_map = _make_mul_map(VECTOR_LEN)
                     out_off = affine_apply(mul_map, [_tx])
-                    dma_memcpy_nd(h_out, l1_buf,
+                    dma_memcpy_nd(
+                        h_out,
+                        l1_buf,
                         dst_offsets=[out_off],
                         dst_sizes=[VECTOR_LEN],
-                        dst_strides=[1])
+                        dst_strides=[1],
+                    )
 
                     DeallocOp(l1_buf)
 
@@ -126,8 +132,11 @@ if __name__ == "__main__":
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
     parser.add_argument(
-        "--output-format", type=str, choices=["xclbin", "elf"],
-        default="xclbin", dest="output_format",
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="xclbin",
+        dest="output_format",
     )
     args = parser.parse_args()
 

--- a/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Cross-herd broadcast: Herd A [1,1] puts data to a broadcast channel,
+# Herd B [N,1] gets the same data on all tiles.
+#
+# This exercises the pattern needed for RMSNorm[1,1] → GEMV[N,1] broadcast:
+# - Channel("bcast", size=[1, 1], broadcast_shape=[N, 1])
+# - Herd A [1,1]: ChannelPut("bcast", buf)           — single put, no indices
+# - Herd B [N,1]: ChannelGet("bcast", buf, [tx, ty]) — N gets via broadcast
+#
+# Test: Herd A reads input, adds 1, broadcasts.
+#       Herd B receives broadcast, each tile writes to its section of output.
+#       Output = N copies of (input + 1).
+
+import argparse
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import *
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import *
+from air.dialects import arith
+from air.dialects.arith import ConstantOp
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects.func import FuncOp
+from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
+from air.dialects.scf import for_, yield_
+from air.backend.xrt_runner import XRTRunner, type_mapper
+
+range_ = for_
+
+VECTOR_LEN = 64       # Length of vector to broadcast (like head_dim or K)
+HERD_N = 4            # Number of consumer tiles (like HERD_M in GEMV)
+VEC_SIZE = 16         # SIMD width for bf16
+DTYPE = bfloat16
+
+
+def _make_mul_map(factor):
+    return AffineMap.get(0, 1, [
+        AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(factor))
+    ])
+
+
+@module_builder
+def build_module():
+    xrt = type_mapper(DTYPE)
+    vecTy = VectorType.get([VEC_SIZE], xrt)
+    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+
+    # L3 types
+    in_ty = MemRefType.get([VECTOR_LEN], xrt)
+    out_ty = MemRefType.get([HERD_N * VECTOR_LEN], xrt)
+
+    # Memory spaces
+    l1s = IntegerAttr.get(T.i32(), MemorySpace.L1)
+
+    # L1 types
+    l1_vec_ty = MemRefType.get([VECTOR_LEN], xrt, memory_space=l1s)
+
+    # Cross-herd broadcast channel: 1 put from herd A, HERD_N gets in herd B
+    Channel("bcast", size=[1, 1], broadcast_shape=[HERD_N, 1])
+
+    @FuncOp.from_py_func(in_ty, out_ty)
+    def cross_herd_broadcast(data_in, data_out):
+
+        @launch(operands=[data_in, data_out])
+        def launch_body(l_in, l_out):
+
+            @segment(name="seg", operands=[l_in, l_out])
+            def seg(s_in, s_out):
+
+                # === Herd A [1,1]: producer — read, transform, broadcast ===
+                @herd(name="producer", sizes=[1, 1], operands=[s_in])
+                def producer(_tx, _ty, _sx, _sy, h_in):
+                    l1_in = AllocOp(l1_vec_ty, [], [])
+                    l1_out = AllocOp(l1_vec_ty, [], [])
+
+                    # Load from L3
+                    dma_memcpy_nd(l1_in, h_in)
+
+                    # Add 1 to each element (vectorized)
+                    c0 = ConstantOp(T.index(), 0)
+                    cst0 = ConstantOp(xrt, 0.0)
+                    one_scalar = ConstantOp(xrt, 1.0)
+                    v_one = BroadcastOp(vecTy, one_scalar)
+                    for j in range_(0, VECTOR_LEN, VEC_SIZE):
+                        from air.dialects.memref import subview
+                        sv_in = subview(l1_in.result, [j], [VEC_SIZE], [1])
+                        sv_out = subview(l1_out.result, [j], [VEC_SIZE], [1])
+                        v = transfer_read(vecTy, sv_in, [c0], identity_map, cst0, [True])
+                        v_plus = arith.addf(v, v_one)
+                        transfer_write(None, v_plus, sv_out, [c0], identity_map, [True])
+                        yield_([])
+
+                    # Broadcast to all consumer tiles
+                    ChannelPut("bcast", l1_out)
+
+                    DeallocOp(l1_in)
+                    DeallocOp(l1_out)
+
+                # === Herd B [HERD_N, 1]: consumer — receive broadcast, write output ===
+                @herd(name="consumer", sizes=[HERD_N, 1], operands=[s_out])
+                def consumer(_tx, _ty, _sx, _sy, h_out):
+                    l1_buf = AllocOp(l1_vec_ty, [], [])
+
+                    # Get broadcast data (each tile gets the same data)
+                    ChannelGet("bcast", l1_buf, indices=[_tx, _ty])
+
+                    # Write to output at tile-specific offset
+                    mul_map = _make_mul_map(VECTOR_LEN)
+                    out_off = affine_apply(mul_map, [_tx])
+                    dma_memcpy_nd(h_out, l1_buf,
+                        dst_offsets=[out_off],
+                        dst_sizes=[VECTOR_LEN],
+                        dst_strides=[1])
+
+                    DeallocOp(l1_buf)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="broadcast.py",
+        description="Cross-herd broadcast: [1,1] producer → [N,1] consumer via broadcast channel",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument(
+        "--output-format", type=str, choices=["xclbin", "elf"],
+        default="xclbin", dest="output_format",
+    )
+    args = parser.parse_args()
+
+    mlir_module = build_module()
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    # Test data
+    np.random.seed(42)
+    data_in = (np.random.randn(VECTOR_LEN) * 2).astype(DTYPE)
+
+    # Golden: each of HERD_N tiles gets (data_in + 1)
+    expected_tile = (data_in.astype(np.float32) + 1.0).astype(DTYPE)
+    expected_out = np.tile(expected_tile, HERD_N)
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        output_format=args.output_format,
+        instance_name="cross_herd_broadcast",
+        runtime_loop_tiling_sizes=[4, 4],
+    )
+    exit(
+        runner.run_test(
+            mlir_module,
+            inputs=[data_in],
+            expected_outputs=[expected_out],
+            rtol=0.01,
+            atol=0.01,
+        )
+    )

--- a/programming_examples/channel_examples/broadcast/cross_herd/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/broadcast/cross_herd/run_makefile_peano_elf.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!


### PR DESCRIPTION
## Summary
- Fix `cloneOpsInBlock` in `AIRDmaToChannel.cpp` to not duplicate user-written channel ops to segment level during DMA hoisting
- Add MLIR LIT test (`cross_herd_broadcast_hoisting.mlir`) exercising the exact bug scenario
- Add cross-herd broadcast programming example (`broadcast/cross_herd/`)

## Problem
When a herd body mixes explicit `ChannelGet`/`ChannelPut` (e.g., cross-herd broadcast) with `dma_memcpy_nd` ops, the `air-dma-to-channel` pass hoists the DMA external half to a segment-level `scf.parallel`. The backward slice computation pulls in the user-written channel op as a transitive dependency (via async token chain). The channel op gets labeled `"hoist"` and is unconditionally cloned to segment level, causing `air-to-aie` to fail with:

```
'air.channel.get' op memcpy op not outlined in an aie.core op.
```

## Fix
In `cloneOpsInBlock`, only clone channel ops that have a `"loop-carried-dep"` attribute with value `"external"` (DMA-derived external halves). Channel ops without `"loop-carried-dep"` are user-written ops that landed in the backward slice as transitive dependencies — replace them with `wait_all` to preserve the async token chain without duplicating the op to segment level.

The key invariant: DMA-derived channel ops always receive both `"hoist"` and `"loop-carried-dep"` (either `"internalGetPut"` or `"external"`), while user-written channel ops in the backward slice only receive `"hoist"`. This invariant is now documented in code comments at both the labeling site and the discrimination site.

## Test plan
- [x] New MLIR LIT test (`cross_herd_broadcast_hoisting.mlir`) — verifies `@bcast` channel.get is NOT duplicated to segment level
- [x] All 16 existing `AIRDmaToChannel` LIT tests — no regression
- [x] Cross-herd broadcast example (`broadcast/cross_herd/broadcast.py`) — PASS on NPU2
- [x] Existing broadcast tests (`broadcast/single_herd/`, `broadcast/multi_herd/`) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)