### PR TITLE
Re-trace deps for every herd in redoDepTraceIfDepOnHier

### DIFF
--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -2628,26 +2628,19 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
     }
   }
 
-  // Also re-trace dependencies for air.herd ops that depend on hierarchy ops.
-  // When a herd depends on another herd, the dependency may have been
-  // established via a loop that was later folded by canonicalize, losing the
-  // intermediate dependency. Re-tracing memory deps through kernel operands
-  // recovers the correct ordering.
+  // Re-trace dependencies for every air.herd op that has memref kernel
+  // operands. Earlier passes (e.g. air-dma-to-channel) and the regular
+  // -canonicalize can both leave a herd's async dep list out of sync with
+  // the data flow on its kernel operands: dma-to-channel may rewrite the
+  // dep onto a freshly hoisted scf.parallel that does not actually write
+  // the herd's input memref, and -canonicalize then strips that stale dep
+  // because no RAW/WAR/WAW with the herd's accesses exists. We don't gate
+  // on `hasDepToHier` here — by the time we reach this pass the herd may
+  // have lost all hierarchy deps already, and that's exactly the case we
+  // need to repair.
   SmallVector<air::HerdOp> herd_ops;
   func.walk([&](air::HerdOp herd_op) { herd_ops.push_back(herd_op); });
   for (auto herd_op : herd_ops) {
-    bool hasDepToHier = false;
-    auto dep_list = herd_op.getAsyncDependencies();
-    for (auto dep : dep_list) {
-      if (dep.getDefiningOp() &&
-          isa<air::HierarchyInterface>(dep.getDefiningOp())) {
-        hasDepToHier = true;
-      }
-    }
-    if (!hasDepToHier)
-      continue;
-
-    // Build partial memref list from herd's kernel operands.
     SmallVector<air::partialMemref, 1> herd_memref_accesses;
     for (unsigned i = 0; i < herd_op.getNumKernelOperands(); i++) {
       auto operand = herd_op.getKernelOperand(i);
@@ -2658,8 +2651,9 @@ dependencyCanonicalizer::redoDepTraceIfDepOnHier(func::FuncOp func) {
     if (herd_memref_accesses.empty())
       continue;
 
-    // Erase hierarchy deps and re-trace.
-    for (auto dep : llvm::to_vector(dep_list)) {
+    // Erase any existing hierarchy deps before re-tracing so we don't
+    // leave stale edges behind.
+    for (auto dep : llvm::to_vector(herd_op.getAsyncDependencies())) {
       if (dep.getDefiningOp() &&
           isa<air::HierarchyInterface>(dep.getDefiningOp())) {
         eraseAsyncDependencyFromAsyncOp(herd_op, dep);


### PR DESCRIPTION
## Summary

Widen the herd loop in `redoDepTraceIfDepOnHier` to re-trace memory
deps on **every** herd that has memref kernel operands — not just
herds that currently carry a hierarchy dep. The existing `hasDepToHier`
gate is too narrow: by the time this pass runs, a herd may already
have lost all hierarchy deps to a stale-dep / canonicalize chain
upstream, and the gate then skips the herd that needs the most help.

## Concrete failure (matmul-i8 1×1 from #1559)

In the issue's reproducer, the output herd's dep chain on `main`
evolves like this:

| Pass | Output herd's deps |
|------|-------------------|
| `air-dependency` | `[alloc, matmul-herd]` ✓ |
| `air-dma-to-channel` | `[alloc, scf.parallel-for-input-DMA]` ✗ — matmul-herd dep replaced with a freshly-hoisted scf.parallel that doesn't actually write the herd's output buffer |
| `-canonicalize` | empty — correctly strips the stale deps |
| `air-dependency-canonicalize` (with old gate) | empty — `hasDepToHier == false` skips the herd |
| Later | empty all the way through |

After this PR:

| Pass | Output herd's deps |
|------|-------------------|
| `air-dependency-canonicalize` | `[matmul-herd]` ✓ — re-traced because the herd has memref kernel operands |

End-to-end on `placed.air.mlir`, the L1-output `air.channel.put` now
correctly carries `[alloc, matmul-loop]` instead of just `[alloc]`,
closing the put↔matmul RAW that #1559 reports.

## Scope

This PR fixes one of three races #1559 documents:
- ✓ **put↔matmul RAW** (this PR)
- ✗ matmul↔fill WAW (separate root cause in `MergeAIRHerdsPattern`'s
  barrier placement; will be a follow-up PR)
- ✗ matmul₂↔matmul₁ WAW (same root cause as above)

## Test plan

- [x] `ninja check-air-mlir`: 368/368 tracked tests pass. Single
  failure (`air_rank_iris_examples.mlir`, channel-index validation)
  reproduces on `main` without this change and is unrelated.
- [x] Issue reproducer regenerated end-to-end; `placed.air.mlir`
  inspected; put↔matmul edge confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)