### PR TITLE
Generalize CanonicalizeAsyncOpDeps consumer-walk to all AsyncOpInterface ops

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -51,18 +51,9 @@ void addAsyncDependency(Operation *op, Value token);
 // Erases a `air.async.token` at position index of the argument list.
 void eraseAsyncDependency(Operation *op, unsigned index);
 
-// Walks forward through async-token consumers of `root`, accumulating every
-// op transitively reachable via async-token use chains into `consumers`.
-// Token flow is followed along two edges:
-//   1. op-result -> use: a token result of op A used as an operand of op B
-//      makes B a consumer of A.
-//   2. loop init -> region iter_arg: when a token enters a
-//      LoopLikeOpInterface op as an init operand, the corresponding region
-//      iter_arg block argument carries the token into the body, so body ops
-//      using the iter_arg are also consumers.
-// `root` itself is not added to `consumers`. Runs in O(N) where N is the
-// number of async tokens reachable from `root`; the implementation
-// memoizes already-walked tokens to ensure termination.
+// Collects ops transitively reachable from `root` via async-token use chains
+// into `consumers`. Follows both op-result uses and (for LoopLikeOpInterface
+// ops) the tied region iter_arg, so body ops are reached. `root` is excluded.
 void walkAsyncTokenConsumers(Operation *root,
                              llvm::SetVector<Operation *> &consumers);
 

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -20,6 +20,7 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/TilingInterface.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <map>
@@ -49,6 +50,20 @@ public:
 void addAsyncDependency(Operation *op, Value token);
 // Erases a `air.async.token` at position index of the argument list.
 void eraseAsyncDependency(Operation *op, unsigned index);
+
+// Walks forward through async-token consumers of `root`, accumulating every
+// op transitively reachable via async-token use chains into `consumers`.
+// Token flow is followed along two edges:
+//   1. op-result -> use: a token result of op A used as an operand of op B
+//      makes B a consumer of A.
+//   2. loop init -> region iter_arg: when a token enters a
+//      LoopLikeOpInterface op as an init operand, the corresponding region
+//      iter_arg block argument carries the token into the body, so body ops
+//      using the iter_arg are also consumers.
+// `root` itself is not added to `consumers`. Termination: each Value
+// (op result or iter_arg) is enqueued at most once.
+void walkAsyncTokenConsumers(Operation *root,
+                             llvm::SetVector<Operation *> &consumers);
 
 } // namespace air
 } // namespace xilinx

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -60,8 +60,9 @@ void eraseAsyncDependency(Operation *op, unsigned index);
 //      LoopLikeOpInterface op as an init operand, the corresponding region
 //      iter_arg block argument carries the token into the body, so body ops
 //      using the iter_arg are also consumers.
-// `root` itself is not added to `consumers`. Termination: each Value
-// (op result or iter_arg) is enqueued at most once.
+// `root` itself is not added to `consumers`. Runs in O(N) where N is the
+// number of async tokens reachable from `root`; the implementation
+// memoizes already-walked tokens to ensure termination.
 void walkAsyncTokenConsumers(Operation *root,
                              llvm::SetVector<Operation *> &consumers);
 

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -150,9 +150,7 @@ void air::eraseAsyncDependency(Operation *op, unsigned index) {
 
 void air::walkAsyncTokenConsumers(Operation *root,
                                   llvm::SetVector<Operation *> &consumers) {
-  // `expanded` memoizes tokens already enqueued so each is walked at most
-  // once — this is what bounds the worklist and ensures termination, not
-  // the worklist data structure itself.
+  // `expanded` dedupes tokens; this is what bounds the worklist.
   llvm::SmallPtrSet<Value, 16> expanded;
   SmallVector<Value> tokenWorklist;
   auto enqueue = [&](Value v) {
@@ -170,8 +168,6 @@ void air::walkAsyncTokenConsumers(Operation *root,
       consumers.insert(user);
       for (Value res : user->getResults())
         enqueue(res);
-      // If the use is a loop init operand, the token continues into the
-      // body via the tied region iter_arg.
       if (auto loop = dyn_cast<LoopLikeOpInterface>(user))
         if (BlockArgument iterArg = loop.getTiedLoopRegionIterArg(&use))
           enqueue(iterArg);
@@ -324,27 +320,11 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  // (See `air::walkAsyncTokenConsumers` in AIRDialect.h for the consumer
-  // walk used below.)
-  // Collect the set of root memrefs accessed by `o` under `accessFn` (which
-  // selects either reads or writes).
-  //
-  // `walkConsumers` controls whether to also include accesses from the
-  // transitive forward async-token consumers of `o` (see
-  // `air::walkAsyncTokenConsumers`). Use `true` for sink-side analysis
-  // (where `o` acts as a scheduling barrier for its consumers) and `false`
-  // for source-side analysis (where we want only `o`'s own accesses).
-  // Mixing these would corrupt source-side analysis: a synchronization
-  // primitive used as a source would otherwise be credited with downstream
-  // accesses it doesn't actually perform.
-  //
-  // The sink-side path generalizes the historical wait_all "barrier"
-  // semantics to all air::AsyncOpInterface ops. Without it, a memref-flow
-  // dep injected as a scheduling barrier on a synchronization primitive
-  // (e.g. air.channel.get/put or an air.execute wrapping an alloc) gets
-  // silently pruned by the RAW/WAR/WAW step because the primitive itself
-  // doesn't touch the memref the source wrote — even though a downstream
-  // consumer reachable via the token chain does (issue #1559 race #2/#3).
+  // Root memrefs accessed by `o` under `accessFn`. With `walkConsumers=true`
+  // (sink side), also unions in accesses from `o`'s transitive async-token
+  // consumers — required for sync primitives whose own accesses don't
+  // overlap a real barrier dep (issue #1559). Must be `false` on the source
+  // side, or the source would inherit its own sink's accesses.
   auto getAllMemrefsAccessedByOp =
       [getRoot](Operation *o, bool walkConsumers,
                 llvm::function_ref<SmallVector<Value>(Operation *)> accessFn) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -269,6 +269,30 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
+  auto getAllWriteAccess = [](Operation *op) {
+    SmallVector<Value> operands;
+    if (auto linalgop = dyn_cast_if_present<linalg::LinalgOp>(op)) {
+      for (auto oper :
+           llvm::concat<Value>(linalgop.getDpsInits(), linalgop->getResults()))
+        operands.push_back(oper);
+    } else if (auto memref_copy = dyn_cast_if_present<memref::CopyOp>(op)) {
+      operands.push_back(memref_copy.getTarget());
+    } else if (auto memcpy =
+                   mlir::dyn_cast_if_present<xilinx::air::MemcpyInterface>(
+                       op)) {
+      if (memcpy.getDstMemref())
+        operands.push_back(memcpy.getDstMemref());
+    } else {
+      // Operands only — results are fresh SSA values, not writes through
+      // pre-existing storage. Body writes are picked up by the region walk
+      // in getAllMemrefsAccessedByOp.
+      for (auto oper : op->getOperands()) {
+        if (isa<MemRefType>(oper.getType()))
+          operands.push_back(oper);
+      }
+    }
+    return operands;
+  };
   // Walk forward through async-token consumers transitively, collecting all
   // ops reachable via async-token use chains. Token flow follows two edges:
   //   1. op-result → use: a token result of op A is used as an operand of op B,
@@ -308,104 +332,53 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
       }
     }
   };
-  // `walkConsumers` controls whether to also include memref accesses from the
+  // Collect the set of root memrefs accessed by `o` under `accessFn` (which
+  // selects either reads or writes).
+  //
+  // `walkConsumers` controls whether to also include accesses from the
   // transitive forward async-token consumers of `o`. Use `true` for sink-side
   // analysis (where `o` acts as a scheduling barrier for its consumers) and
   // `false` for source-side analysis (where we want only `o`'s own accesses).
   // Mixing these would corrupt source-side analysis: a synchronization
   // primitive used as a source would otherwise be credited with downstream
   // accesses it doesn't actually perform.
-  auto getAllMemrefsReadByOp = [getAllReadAccess, getRoot,
-                                walkAsyncTokenConsumers](Operation *o,
-                                                         bool walkConsumers) {
-    llvm::SetVector<Value> memrefs;
-    auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
-    for (Value v : getAllReadAccess(o))
-      insertRoot(v);
-    SmallVector<Region *> regions;
-    for (auto &region : o->getRegions())
-      regions.push_back(&region);
-    // Generalize the existing wait_all "barrier" semantics to all async ops:
-    // any air::AsyncOpInterface op acts as a scheduling anchor for its
-    // transitive consumers, so its sink-side memref access set is the union
-    // of its own accesses and all its consumers'. Without this, a memref-flow
-    // dep injected as a scheduling barrier on a synchronization primitive
-    // (e.g. air.channel.get/put or an air.execute wrapping an alloc) gets
-    // silently pruned by the RAW/WAR/WAW step because the primitive itself
-    // doesn't touch the memref the source wrote — even though a downstream
-    // consumer reachable via the token chain does (issue #1559 race #2/#3).
-    if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
-      llvm::SetVector<Operation *> consumers;
-      walkAsyncTokenConsumers(o, consumers);
-      for (auto user : consumers) {
-        for (Value v : getAllReadAccess(user))
+  //
+  // The sink-side path generalizes the historical wait_all "barrier"
+  // semantics to all air::AsyncOpInterface ops. Without it, a memref-flow
+  // dep injected as a scheduling barrier on a synchronization primitive
+  // (e.g. air.channel.get/put or an air.execute wrapping an alloc) gets
+  // silently pruned by the RAW/WAR/WAW step because the primitive itself
+  // doesn't touch the memref the source wrote — even though a downstream
+  // consumer reachable via the token chain does (issue #1559 race #2/#3).
+  auto getAllMemrefsAccessedByOp =
+      [getRoot, walkAsyncTokenConsumers](
+          Operation *o, bool walkConsumers,
+          llvm::function_ref<SmallVector<Value>(Operation *)> accessFn) {
+        llvm::SetVector<Value> memrefs;
+        auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
+        for (Value v : accessFn(o))
           insertRoot(v);
-        for (auto &region : user->getRegions())
+        SmallVector<Region *> regions;
+        for (auto &region : o->getRegions())
           regions.push_back(&region);
-      }
-    }
-    for (auto region : regions) {
-      visitUsedValuesDefinedAbove(*region, [&](OpOperand *use) {
-        if (llvm::is_contained(getAllReadAccess(use->getOwner()), use->get()))
-          insertRoot(use->get());
-      });
-    }
-    return memrefs;
-  };
-  auto getAllWriteAccess = [](Operation *op) {
-    SmallVector<Value> operands;
-    if (auto linalgop = dyn_cast_if_present<linalg::LinalgOp>(op)) {
-      for (auto oper :
-           llvm::concat<Value>(linalgop.getDpsInits(), linalgop->getResults()))
-        operands.push_back(oper);
-    } else if (auto memref_copy = dyn_cast_if_present<memref::CopyOp>(op)) {
-      operands.push_back(memref_copy.getTarget());
-    } else if (auto memcpy =
-                   mlir::dyn_cast_if_present<xilinx::air::MemcpyInterface>(
-                       op)) {
-      if (memcpy.getDstMemref())
-        operands.push_back(memcpy.getDstMemref());
-    } else {
-      // Operands only — results are fresh SSA values, not writes through
-      // pre-existing storage. Body writes are picked up by the region walk
-      // in getAllMemrefsWrittenByOp.
-      for (auto oper : op->getOperands()) {
-        if (isa<MemRefType>(oper.getType()))
-          operands.push_back(oper);
-      }
-    }
-    return operands;
-  };
-  auto getAllMemrefsWrittenByOp = [getAllWriteAccess, getRoot,
-                                   walkAsyncTokenConsumers](
-                                      Operation *o, bool walkConsumers) {
-    llvm::SetVector<Value> memrefs;
-    auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
-    for (Value v : getAllWriteAccess(o))
-      insertRoot(v);
-    SmallVector<Region *> regions;
-    for (auto &region : o->getRegions())
-      regions.push_back(&region);
-    // See sibling getAllMemrefsReadByOp comment — generalized wait_all
-    // consumer-walk to all air::AsyncOpInterface ops on the sink side.
-    if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
-      llvm::SetVector<Operation *> consumers;
-      walkAsyncTokenConsumers(o, consumers);
-      for (auto user : consumers) {
-        for (Value v : getAllWriteAccess(user))
-          insertRoot(v);
-        for (auto &region : user->getRegions())
-          regions.push_back(&region);
-      }
-    }
-    for (auto region : regions) {
-      visitUsedValuesDefinedAbove(*region, [&](OpOperand *use) {
-        if (llvm::is_contained(getAllWriteAccess(use->getOwner()), use->get()))
-          insertRoot(use->get());
-      });
-    }
-    return memrefs;
-  };
+        if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
+          llvm::SetVector<Operation *> consumers;
+          walkAsyncTokenConsumers(o, consumers);
+          for (auto user : consumers) {
+            for (Value v : accessFn(user))
+              insertRoot(v);
+            for (auto &region : user->getRegions())
+              regions.push_back(&region);
+          }
+        }
+        for (auto region : regions) {
+          visitUsedValuesDefinedAbove(*region, [&](OpOperand *use) {
+            if (llvm::is_contained(accessFn(use->getOwner()), use->get()))
+              insertRoot(use->get());
+          });
+        }
+        return memrefs;
+      };
   auto getAllSymbolRefAccess = [](Operation *o) {
     SmallVector<SymbolRefAttr> result;
     for (NamedAttribute attr : o->getAttrs()) {
@@ -463,10 +436,10 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
         }
         return result;
       };
-  auto memrefsReadBySinkOp =
-      getAllMemrefsReadByOp(op.getOperation(), /*walkConsumers=*/true);
-  auto memrefsWrittenBySinkOp =
-      getAllMemrefsWrittenByOp(op.getOperation(), /*walkConsumers=*/true);
+  auto memrefsReadBySinkOp = getAllMemrefsAccessedByOp(
+      op.getOperation(), /*walkConsumers=*/true, getAllReadAccess);
+  auto memrefsWrittenBySinkOp = getAllMemrefsAccessedByOp(
+      op.getOperation(), /*walkConsumers=*/true, getAllWriteAccess);
   auto resourcesUsedBySinkOp = getSymbolRefsUsedByOp(op.getOperation());
   // make a list of new async token operands
   std::function<void(SmallVector<Value>, SmallVector<Value> &)>
@@ -488,10 +461,10 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
   for (auto v : directDeps) {
     // don't include any false (RAR) dependencies
     if (v.getDefiningOp()) {
-      auto memrefsReadBySourceOp =
-          getAllMemrefsReadByOp(v.getDefiningOp(), /*walkConsumers=*/false);
-      auto memrefsWrittenBySourceOp =
-          getAllMemrefsWrittenByOp(v.getDefiningOp(), /*walkConsumers=*/false);
+      auto memrefsReadBySourceOp = getAllMemrefsAccessedByOp(
+          v.getDefiningOp(), /*walkConsumers=*/false, getAllReadAccess);
+      auto memrefsWrittenBySourceOp = getAllMemrefsAccessedByOp(
+          v.getDefiningOp(), /*walkConsumers=*/false, getAllWriteAccess);
       auto resourcesUsedBySourceOp = getSymbolRefsUsedByOp(v.getDefiningOp());
       bool sourceOpTouchesMemref =
           llvm::range_size(llvm::concat<Value>(memrefsReadBySourceOp,

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -269,7 +269,39 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  auto getAllMemrefsReadByOp = [getAllReadAccess, getRoot](Operation *o) {
+  // Walk forward through async-token consumers transitively, collecting all
+  // ops reachable via async-token use chains. Bounded by a worklist over
+  // already-visited ops to ensure termination.
+  auto walkAsyncTokenConsumers = [](Operation *root,
+                                    llvm::SetVector<Operation *> &consumers) {
+    SmallVector<Operation *> worklist;
+    auto pushTokenUsers = [&worklist, &consumers](Value tok) {
+      if (!tok || !isa<air::AsyncTokenType>(tok.getType()))
+        return;
+      for (auto user : tok.getUsers())
+        if (consumers.insert(user))
+          worklist.push_back(user);
+    };
+    auto pushOpAsyncTokens = [&pushTokenUsers](Operation *o) {
+      for (auto res : o->getResults())
+        pushTokenUsers(res);
+    };
+    pushOpAsyncTokens(root);
+    while (!worklist.empty()) {
+      auto *o = worklist.pop_back_val();
+      pushOpAsyncTokens(o);
+    }
+  };
+  // `walkConsumers` controls whether to also include memref accesses from the
+  // transitive forward async-token consumers of `o`. Use `true` for sink-side
+  // analysis (where `o` acts as a scheduling barrier for its consumers) and
+  // `false` for source-side analysis (where we want only `o`'s own accesses).
+  // Mixing these would corrupt source-side analysis: a synchronization
+  // primitive used as a source would otherwise be credited with downstream
+  // accesses it doesn't actually perform.
+  auto getAllMemrefsReadByOp = [getAllReadAccess, getRoot,
+                                walkAsyncTokenConsumers](Operation *o,
+                                                         bool walkConsumers) {
     llvm::SetVector<Value> memrefs;
     auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
     for (Value v : getAllReadAccess(o))
@@ -277,11 +309,19 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     SmallVector<Region *> regions;
     for (auto &region : o->getRegions())
       regions.push_back(&region);
-    // If air.wait_all, then we analyze the dependency by collecting all
-    // operations that depend on it.
-    auto waitAllOp = dyn_cast_if_present<air::WaitAllOp>(o);
-    if (waitAllOp && waitAllOp.getAsyncToken()) {
-      for (auto user : waitAllOp.getAsyncToken().getUsers()) {
+    // Generalize the existing wait_all "barrier" semantics to all async ops:
+    // any air::AsyncOpInterface op acts as a scheduling anchor for its
+    // transitive consumers, so its sink-side memref access set is the union
+    // of its own accesses and all its consumers'. Without this, a memref-flow
+    // dep injected as a scheduling barrier on a synchronization primitive
+    // (e.g. air.channel.get/put or an air.execute wrapping an alloc) gets
+    // silently pruned by the RAW/WAR/WAW step because the primitive itself
+    // doesn't touch the memref the source wrote — even though a downstream
+    // consumer reachable via the token chain does (issue #1559 race #2/#3).
+    if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
+      llvm::SetVector<Operation *> consumers;
+      walkAsyncTokenConsumers(o, consumers);
+      for (auto user : consumers) {
         for (Value v : getAllReadAccess(user))
           insertRoot(v);
         for (auto &region : user->getRegions())
@@ -320,7 +360,9 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  auto getAllMemrefsWrittenByOp = [getAllWriteAccess, getRoot](Operation *o) {
+  auto getAllMemrefsWrittenByOp = [getAllWriteAccess, getRoot,
+                                   walkAsyncTokenConsumers](
+                                      Operation *o, bool walkConsumers) {
     llvm::SetVector<Value> memrefs;
     auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
     for (Value v : getAllWriteAccess(o))
@@ -328,11 +370,12 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     SmallVector<Region *> regions;
     for (auto &region : o->getRegions())
       regions.push_back(&region);
-    // If air.wait_all, then we analyze the dependency by collecting all
-    // operations that depend on it.
-    auto waitAllOp = dyn_cast_if_present<air::WaitAllOp>(o);
-    if (waitAllOp && waitAllOp.getAsyncToken()) {
-      for (auto user : waitAllOp.getAsyncToken().getUsers()) {
+    // See sibling getAllMemrefsReadByOp comment — generalized wait_all
+    // consumer-walk to all air::AsyncOpInterface ops on the sink side.
+    if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
+      llvm::SetVector<Operation *> consumers;
+      walkAsyncTokenConsumers(o, consumers);
+      for (auto user : consumers) {
         for (Value v : getAllWriteAccess(user))
           insertRoot(v);
         for (auto &region : user->getRegions())
@@ -404,8 +447,10 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
         }
         return result;
       };
-  auto memrefsReadBySinkOp = getAllMemrefsReadByOp(op.getOperation());
-  auto memrefsWrittenBySinkOp = getAllMemrefsWrittenByOp(op.getOperation());
+  auto memrefsReadBySinkOp =
+      getAllMemrefsReadByOp(op.getOperation(), /*walkConsumers=*/true);
+  auto memrefsWrittenBySinkOp =
+      getAllMemrefsWrittenByOp(op.getOperation(), /*walkConsumers=*/true);
   auto resourcesUsedBySinkOp = getSymbolRefsUsedByOp(op.getOperation());
   // make a list of new async token operands
   std::function<void(SmallVector<Value>, SmallVector<Value> &)>
@@ -427,9 +472,10 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
   for (auto v : directDeps) {
     // don't include any false (RAR) dependencies
     if (v.getDefiningOp()) {
-      auto memrefsReadBySourceOp = getAllMemrefsReadByOp(v.getDefiningOp());
+      auto memrefsReadBySourceOp =
+          getAllMemrefsReadByOp(v.getDefiningOp(), /*walkConsumers=*/false);
       auto memrefsWrittenBySourceOp =
-          getAllMemrefsWrittenByOp(v.getDefiningOp());
+          getAllMemrefsWrittenByOp(v.getDefiningOp(), /*walkConsumers=*/false);
       auto resourcesUsedBySourceOp = getSymbolRefsUsedByOp(v.getDefiningOp());
       bool sourceOpTouchesMemref =
           llvm::range_size(llvm::concat<Value>(memrefsReadBySourceOp,

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -150,6 +150,9 @@ void air::eraseAsyncDependency(Operation *op, unsigned index) {
 
 void air::walkAsyncTokenConsumers(Operation *root,
                                   llvm::SetVector<Operation *> &consumers) {
+  // `expanded` memoizes tokens already enqueued so each is walked at most
+  // once — this is what bounds the worklist and ensures termination, not
+  // the worklist data structure itself.
   llvm::SmallPtrSet<Value, 16> expanded;
   SmallVector<Value> tokenWorklist;
   auto enqueue = [&](Value v) {

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -148,6 +148,34 @@ void air::eraseAsyncDependency(Operation *op, unsigned index) {
   op->setAttr(attrName, Builder(op->getContext()).getDenseI32ArrayAttr(sizes));
 }
 
+void air::walkAsyncTokenConsumers(Operation *root,
+                                  llvm::SetVector<Operation *> &consumers) {
+  llvm::SmallPtrSet<Value, 16> expanded;
+  SmallVector<Value> tokenWorklist;
+  auto enqueue = [&](Value v) {
+    if (!v || !isa<air::AsyncTokenType>(v.getType()))
+      return;
+    if (expanded.insert(v).second)
+      tokenWorklist.push_back(v);
+  };
+  for (Value res : root->getResults())
+    enqueue(res);
+  while (!tokenWorklist.empty()) {
+    Value tok = tokenWorklist.pop_back_val();
+    for (OpOperand &use : tok.getUses()) {
+      Operation *user = use.getOwner();
+      consumers.insert(user);
+      for (Value res : user->getResults())
+        enqueue(res);
+      // If the use is a loop init operand, the token continues into the
+      // body via the tied region iter_arg.
+      if (auto loop = dyn_cast<LoopLikeOpInterface>(user))
+        if (BlockArgument iterArg = loop.getTiedLoopRegionIterArg(&use))
+          enqueue(iterArg);
+    }
+  }
+}
+
 static ParseResult parseAsyncDependencies(
     OpAsmParser &parser, Type &asyncTokenType,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &asyncDependencies) {
@@ -293,52 +321,16 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     }
     return operands;
   };
-  // Walk forward through async-token consumers transitively, collecting all
-  // ops reachable via async-token use chains. Token flow follows two edges:
-  //   1. op-result → use: a token result of op A is used as an operand of op B,
-  //      so B is a consumer of A.
-  //   2. loop init → region iter_arg: when a token enters a LoopLikeOpInterface
-  //      op as an init operand, the corresponding region iter_arg block
-  //      argument carries the token into the loop body — body ops that use
-  //      the iter_arg are also consumers. Without this descent, body-side
-  //      consumers would be missed and the helper's contract would be a
-  //      shallower "downstream-of-op consumers" rather than truly transitive.
-  // Termination: each Value (op result or block arg) is enqueued at most once,
-  // tracked by the `expanded` set.
-  auto walkAsyncTokenConsumers = [](Operation *root,
-                                    llvm::SetVector<Operation *> &consumers) {
-    llvm::SmallPtrSet<Value, 16> expanded;
-    SmallVector<Value> tokenWorklist;
-    auto enqueue = [&](Value v) {
-      if (!v || !isa<air::AsyncTokenType>(v.getType()))
-        return;
-      if (expanded.insert(v).second)
-        tokenWorklist.push_back(v);
-    };
-    for (Value res : root->getResults())
-      enqueue(res);
-    while (!tokenWorklist.empty()) {
-      Value tok = tokenWorklist.pop_back_val();
-      for (OpOperand &use : tok.getUses()) {
-        Operation *user = use.getOwner();
-        consumers.insert(user);
-        for (Value res : user->getResults())
-          enqueue(res);
-        // If the use is a loop init operand, the token continues into the
-        // body via the tied region iter_arg.
-        if (auto loop = dyn_cast<LoopLikeOpInterface>(user))
-          if (BlockArgument iterArg = loop.getTiedLoopRegionIterArg(&use))
-            enqueue(iterArg);
-      }
-    }
-  };
+  // (See `air::walkAsyncTokenConsumers` in AIRDialect.h for the consumer
+  // walk used below.)
   // Collect the set of root memrefs accessed by `o` under `accessFn` (which
   // selects either reads or writes).
   //
   // `walkConsumers` controls whether to also include accesses from the
-  // transitive forward async-token consumers of `o`. Use `true` for sink-side
-  // analysis (where `o` acts as a scheduling barrier for its consumers) and
-  // `false` for source-side analysis (where we want only `o`'s own accesses).
+  // transitive forward async-token consumers of `o` (see
+  // `air::walkAsyncTokenConsumers`). Use `true` for sink-side analysis
+  // (where `o` acts as a scheduling barrier for its consumers) and `false`
+  // for source-side analysis (where we want only `o`'s own accesses).
   // Mixing these would corrupt source-side analysis: a synchronization
   // primitive used as a source would otherwise be credited with downstream
   // accesses it doesn't actually perform.
@@ -351,9 +343,8 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
   // doesn't touch the memref the source wrote — even though a downstream
   // consumer reachable via the token chain does (issue #1559 race #2/#3).
   auto getAllMemrefsAccessedByOp =
-      [getRoot, walkAsyncTokenConsumers](
-          Operation *o, bool walkConsumers,
-          llvm::function_ref<SmallVector<Value>(Operation *)> accessFn) {
+      [getRoot](Operation *o, bool walkConsumers,
+                llvm::function_ref<SmallVector<Value>(Operation *)> accessFn) {
         llvm::SetVector<Value> memrefs;
         auto insertRoot = [&](Value v) { memrefs.insert(getRoot(v)); };
         for (Value v : accessFn(o))
@@ -363,7 +354,7 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
           regions.push_back(&region);
         if (walkConsumers && isa<air::AsyncOpInterface>(o)) {
           llvm::SetVector<Operation *> consumers;
-          walkAsyncTokenConsumers(o, consumers);
+          air::walkAsyncTokenConsumers(o, consumers);
           for (auto user : consumers) {
             for (Value v : accessFn(user))
               insertRoot(v);

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -270,26 +270,42 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
     return operands;
   };
   // Walk forward through async-token consumers transitively, collecting all
-  // ops reachable via async-token use chains. Bounded by a worklist over
-  // already-visited ops to ensure termination.
+  // ops reachable via async-token use chains. Token flow follows two edges:
+  //   1. op-result → use: a token result of op A is used as an operand of op B,
+  //      so B is a consumer of A.
+  //   2. loop init → region iter_arg: when a token enters a LoopLikeOpInterface
+  //      op as an init operand, the corresponding region iter_arg block
+  //      argument carries the token into the loop body — body ops that use
+  //      the iter_arg are also consumers. Without this descent, body-side
+  //      consumers would be missed and the helper's contract would be a
+  //      shallower "downstream-of-op consumers" rather than truly transitive.
+  // Termination: each Value (op result or block arg) is enqueued at most once,
+  // tracked by the `expanded` set.
   auto walkAsyncTokenConsumers = [](Operation *root,
                                     llvm::SetVector<Operation *> &consumers) {
-    SmallVector<Operation *> worklist;
-    auto pushTokenUsers = [&worklist, &consumers](Value tok) {
-      if (!tok || !isa<air::AsyncTokenType>(tok.getType()))
+    llvm::SmallPtrSet<Value, 16> expanded;
+    SmallVector<Value> tokenWorklist;
+    auto enqueue = [&](Value v) {
+      if (!v || !isa<air::AsyncTokenType>(v.getType()))
         return;
-      for (auto user : tok.getUsers())
-        if (consumers.insert(user))
-          worklist.push_back(user);
+      if (expanded.insert(v).second)
+        tokenWorklist.push_back(v);
     };
-    auto pushOpAsyncTokens = [&pushTokenUsers](Operation *o) {
-      for (auto res : o->getResults())
-        pushTokenUsers(res);
-    };
-    pushOpAsyncTokens(root);
-    while (!worklist.empty()) {
-      auto *o = worklist.pop_back_val();
-      pushOpAsyncTokens(o);
+    for (Value res : root->getResults())
+      enqueue(res);
+    while (!tokenWorklist.empty()) {
+      Value tok = tokenWorklist.pop_back_val();
+      for (OpOperand &use : tok.getUses()) {
+        Operation *user = use.getOwner();
+        consumers.insert(user);
+        for (Value res : user->getResults())
+          enqueue(res);
+        // If the use is a loop init operand, the token continues into the
+        // body via the tied region iter_arg.
+        if (auto loop = dyn_cast<LoopLikeOpInterface>(user))
+          if (BlockArgument iterArg = loop.getTiedLoopRegionIterArg(&use))
+            enqueue(iterArg);
+      }
     }
   };
   // `walkConsumers` controls whether to also include memref accesses from the

--- a/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
@@ -85,3 +85,178 @@ module {
     return
   }
 }
+
+// -----
+
+// Same scenario as above, but the sink op carrying the fill-loop barrier dep
+// is `air.channel.put` instead of `air.channel.get`. The put reads a fresh
+// staging buffer (not %argbuf), so the source op's write-set and the sink's
+// own read-set don't overlap. The dep is real because the put's transitive
+// async-token consumer (the matmul scf.for) reads %argbuf.
+
+// CHECK-LABEL: func.func @chan_put_barrier_dep_preserved
+// CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
+// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK: air.channel.put async [%[[FILL]]
+
+module {
+  air.channel @ch_p [1, 1]
+  func.func @chan_put_barrier_dep_preserved() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) {
+      %1 = air.segment @seg async {
+        %c1_s = arith.constant 1 : index
+        %tok_out, %out_buf = air.execute -> (memref<32x32xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<32x32xi16, 2 : i32>
+          air.execute_terminator %a : memref<32x32xi16, 2 : i32>
+        }
+        %h = air.herd @h async [%tok_out] tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) args(%argbuf=%out_buf) : memref<32x32xi16, 2 : i32> {
+          %c0_i16 = arith.constant 0 : i16
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c32 = arith.constant 32 : index
+          %wa_init = air.wait_all async
+          %fill_loop = scf.for %i = %c0 to %c32 step %c1_h iter_args(%it = %wa_init) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              memref.store %c0_i16, %argbuf[%i, %i] : memref<32x32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+          %tk_stage, %stage_buf = air.execute -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          // Sink: chan.put reads %stage_buf (fresh, disjoint from %argbuf).
+          // Barrier dep on %fill_loop must survive — downstream loop reads %argbuf.
+          %p = air.channel.put async [%fill_loop, %tk_stage] @ch_p[%tx, %ty] (%stage_buf[] [] []) : (memref<32xi16, 2 : i32>)
+          %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %p) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              %v = memref.load %argbuf[%k, %k] : memref<32x32xi16, 2 : i32>
+              memref.store %v, %stage_buf[%k] : memref<32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Sink op is `air.dma_memcpy_nd`. The DMA copies between two fresh L1 buffers
+// (%src_buf → %dst_buf), neither of which is %argbuf. Without the consumer-
+// walk, the fill→DMA barrier dep would be dropped: source writes %argbuf,
+// sink reads %src_buf and writes %dst_buf — no RAW/WAR/WAW match. The matmul
+// loop downstream reads %argbuf, making the barrier real.
+
+// CHECK-LABEL: func.func @dma_barrier_dep_preserved
+// CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
+// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK: air.dma_memcpy_nd async [%[[FILL]]
+
+module {
+  func.func @dma_barrier_dep_preserved() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) {
+      %1 = air.segment @seg async {
+        %c1_s = arith.constant 1 : index
+        %tok_out, %out_buf = air.execute -> (memref<32x32xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<32x32xi16, 2 : i32>
+          air.execute_terminator %a : memref<32x32xi16, 2 : i32>
+        }
+        %h = air.herd @h async [%tok_out] tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) args(%argbuf=%out_buf) : memref<32x32xi16, 2 : i32> {
+          %c0_i16 = arith.constant 0 : i16
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c32 = arith.constant 32 : index
+          %wa_init = air.wait_all async
+          %fill_loop = scf.for %i = %c0 to %c32 step %c1_h iter_args(%it = %wa_init) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              memref.store %c0_i16, %argbuf[%i, %i] : memref<32x32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+          %tk_src, %src_buf = air.execute -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          %tk_dst, %dst_buf = air.execute -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          // Sink: DMA between two fresh buffers. Barrier dep on %fill_loop
+          // must survive — downstream loop reads %argbuf via %dma's token.
+          %dma = air.dma_memcpy_nd async [%fill_loop, %tk_src, %tk_dst] (%dst_buf[] [] [], %src_buf[] [] []) : (memref<32xi16, 2 : i32>, memref<32xi16, 2 : i32>)
+          %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %dma) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              %v = memref.load %argbuf[%k, %k] : memref<32x32xi16, 2 : i32>
+              memref.store %v, %dst_buf[%k] : memref<32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Sink op is `air.execute` wrapping a pure `memref.alloc`. The execute body
+// does not touch %argbuf — its only memref result is a freshly-allocated
+// buffer. Without the consumer-walk, the fill→execute barrier dep would be
+// dropped (source writes %argbuf; sink writes a fresh memref result). The
+// matmul loop downstream reads %argbuf via the execute's token, making the
+// barrier real. This case also exercises the region-walking path of the
+// generalized sink-side analysis (air.execute carries a body region).
+
+// CHECK-LABEL: func.func @execute_barrier_dep_preserved
+// CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
+// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK: %{{.*}}, %{{.*}} = air.execute [%[[FILL]]]
+
+module {
+  func.func @execute_barrier_dep_preserved() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) {
+      %1 = air.segment @seg async {
+        %c1_s = arith.constant 1 : index
+        %tok_out, %out_buf = air.execute -> (memref<32x32xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<32x32xi16, 2 : i32>
+          air.execute_terminator %a : memref<32x32xi16, 2 : i32>
+        }
+        %h = air.herd @h async [%tok_out] tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) args(%argbuf=%out_buf) : memref<32x32xi16, 2 : i32> {
+          %c0_i16 = arith.constant 0 : i16
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c32 = arith.constant 32 : index
+          %wa_init = air.wait_all async
+          %fill_loop = scf.for %i = %c0 to %c32 step %c1_h iter_args(%it = %wa_init) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              memref.store %c0_i16, %argbuf[%i, %i] : memref<32x32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+          // Sink: air.execute wrapping a pure alloc. Body does not touch
+          // %argbuf. Barrier dep on %fill_loop must survive — downstream
+          // loop reads %argbuf via the execute's token chain.
+          %tk_scratch, %scratch = air.execute [%fill_loop] -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %tk_scratch) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              %v = memref.load %argbuf[%k, %k] : memref<32x32xi16, 2 : i32>
+              memref.store %v, %scratch[%k] : memref<32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
@@ -1,30 +1,20 @@
+//===- canonicalize_channel_get_barrier_dep.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
 // RUN: air-opt -canonicalize -split-input-file %s | FileCheck %s
 
-// Reproducer for the residual race in issue #1559 (race #2/#3 family,
-// post-`fb14adaf9`). After `air-ping-pong-transform` restructures the merged
-// herd body, the `MergeAIRHerds`-injected barrier dep on the fill scf.for
-// migrates to an `air.channel.get` that fetches input data into a freshly-
-// allocated input buffer.
-//
-// Before the fix below, `CanonicalizeAsyncOpDeps` would drop the dep:
-//   - source = fill scf.for, writes %output_buf
-//   - sink = chan.get, writes %input_buf (no read of %output_buf)
-//   - no RAW/WAR/WAW match → dep dropped
-//
-// But the chan.get is just a synchronization primitive; its async-token
-// consumer chain (chan.get → wait_all → matmul scf.for) reads %output_buf.
-// Dropping the dep removes the only ordering edge between fill and matmul
-// → race on %output_buf.
-//
-// Fix: when computing the sink op's effective memref accesses for the
-// RAW/WAR/WAW pruning, walk forward through the sink's async-token consumer
-// chain and union in their accesses too. The chan.get inherits the matmul's
-// reads of %output_buf, so RAW(fill, chan.get) matches and the dep is kept.
+// A barrier dep injected on an async sync primitive (channel.get/put,
+// dma_memcpy_nd, alloc execute) must survive canonicalization when its
+// transitive token consumers — not the primitive itself — touch the source's
+// memref. Issue #1559 race #2/#3.
 
 // CHECK-LABEL: func.func @chan_get_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
 // CHECK:{{ *}}memref.store {{.*}} : memref<32x32xi16, 2 : i32>
-// The barrier dep on the fill loop must survive on the chan.get sinks:
 // CHECK: air.channel.get async [%[[FILL]]
 // CHECK: air.channel.get async [%[[FILL]]
 
@@ -60,11 +50,6 @@ module {
             %a = memref.alloc() : memref<32xi16, 2 : i32>
             air.execute_terminator %a : memref<32xi16, 2 : i32>
           }
-          // These chan.get ops carry a scheduling barrier on the fill loop.
-          // The fill loop writes %argbuf; the chan.gets write distinct fresh
-          // input buffers — so naive RAW/WAR/WAW analysis would drop the
-          // %fill_loop dep. But the matmul scf.for below (the chan.gets'
-          // transitive consumer) READS %argbuf, so the barrier is real.
           %g1 = air.channel.get async [%fill_loop, %tk_in1] @ch_a[%tx, %ty] (%in_buf1[] [] []) : (memref<32xi16, 2 : i32>)
           %g2 = air.channel.get async [%fill_loop, %tk_in2] @ch_b[%tx, %ty] (%in_buf2[] [] []) : (memref<32xi16, 2 : i32>)
           %wa = air.wait_all async [%g1, %g2]
@@ -88,11 +73,7 @@ module {
 
 // -----
 
-// Same scenario as above, but the sink op carrying the fill-loop barrier dep
-// is `air.channel.put` instead of `air.channel.get`. The put reads a fresh
-// staging buffer (not %argbuf), so the source op's write-set and the sink's
-// own read-set don't overlap. The dep is real because the put's transitive
-// async-token consumer (the matmul scf.for) reads %argbuf.
+// Sink is air.channel.put reading a fresh staging buffer; consumer loop reads %argbuf.
 
 // CHECK-LABEL: func.func @chan_put_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
@@ -126,8 +107,6 @@ module {
             %a = memref.alloc() : memref<32xi16, 2 : i32>
             air.execute_terminator %a : memref<32xi16, 2 : i32>
           }
-          // Sink: chan.put reads %stage_buf (fresh, disjoint from %argbuf).
-          // Barrier dep on %fill_loop must survive — downstream loop reads %argbuf.
           %p = air.channel.put async [%fill_loop, %tk_stage] @ch_p[%tx, %ty] (%stage_buf[] [] []) : (memref<32xi16, 2 : i32>)
           %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %p) -> (!air.async.token) {
             %tk = air.execute [%it] {
@@ -145,11 +124,7 @@ module {
 
 // -----
 
-// Sink op is `air.dma_memcpy_nd`. The DMA copies between two fresh L1 buffers
-// (%src_buf → %dst_buf), neither of which is %argbuf. Without the consumer-
-// walk, the fill→DMA barrier dep would be dropped: source writes %argbuf,
-// sink reads %src_buf and writes %dst_buf — no RAW/WAR/WAW match. The matmul
-// loop downstream reads %argbuf, making the barrier real.
+// Sink is air.dma_memcpy_nd between two fresh buffers; consumer loop reads %argbuf.
 
 // CHECK-LABEL: func.func @dma_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
@@ -186,8 +161,6 @@ module {
             %a = memref.alloc() : memref<32xi16, 2 : i32>
             air.execute_terminator %a : memref<32xi16, 2 : i32>
           }
-          // Sink: DMA between two fresh buffers. Barrier dep on %fill_loop
-          // must survive — downstream loop reads %argbuf via %dma's token.
           %dma = air.dma_memcpy_nd async [%fill_loop, %tk_src, %tk_dst] (%dst_buf[] [] [], %src_buf[] [] []) : (memref<32xi16, 2 : i32>, memref<32xi16, 2 : i32>)
           %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %dma) -> (!air.async.token) {
             %tk = air.execute [%it] {
@@ -205,13 +178,7 @@ module {
 
 // -----
 
-// Sink op is `air.execute` wrapping a pure `memref.alloc`. The execute body
-// does not touch %argbuf — its only memref result is a freshly-allocated
-// buffer. Without the consumer-walk, the fill→execute barrier dep would be
-// dropped (source writes %argbuf; sink writes a fresh memref result). The
-// matmul loop downstream reads %argbuf via the execute's token, making the
-// barrier real. This case also exercises the region-walking path of the
-// generalized sink-side analysis (air.execute carries a body region).
+// Sink is air.execute wrapping a pure alloc; consumer loop reads %argbuf.
 
 // CHECK-LABEL: func.func @execute_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
@@ -240,9 +207,6 @@ module {
             }
             scf.yield %tk : !air.async.token
           }
-          // Sink: air.execute wrapping a pure alloc. Body does not touch
-          // %argbuf. Barrier dep on %fill_loop must survive — downstream
-          // loop reads %argbuf via the execute's token chain.
           %tk_scratch, %scratch = air.execute [%fill_loop] -> (memref<32xi16, 2 : i32>) {
             %a = memref.alloc() : memref<32xi16, 2 : i32>
             air.execute_terminator %a : memref<32xi16, 2 : i32>

--- a/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
@@ -1,0 +1,87 @@
+// RUN: air-opt -canonicalize -split-input-file %s | FileCheck %s
+
+// Reproducer for the residual race in issue #1559 (race #2/#3 family,
+// post-`fb14adaf9`). After `air-ping-pong-transform` restructures the merged
+// herd body, the `MergeAIRHerds`-injected barrier dep on the fill scf.for
+// migrates to an `air.channel.get` that fetches input data into a freshly-
+// allocated input buffer.
+//
+// Before the fix below, `CanonicalizeAsyncOpDeps` would drop the dep:
+//   - source = fill scf.for, writes %output_buf
+//   - sink = chan.get, writes %input_buf (no read of %output_buf)
+//   - no RAW/WAR/WAW match → dep dropped
+//
+// But the chan.get is just a synchronization primitive; its async-token
+// consumer chain (chan.get → wait_all → matmul scf.for) reads %output_buf.
+// Dropping the dep removes the only ordering edge between fill and matmul
+// → race on %output_buf.
+//
+// Fix: when computing the sink op's effective memref accesses for the
+// RAW/WAR/WAW pruning, walk forward through the sink's async-token consumer
+// chain and union in their accesses too. The chan.get inherits the matmul's
+// reads of %output_buf, so RAW(fill, chan.get) matches and the dep is kept.
+
+// CHECK-LABEL: func.func @chan_get_barrier_dep_preserved
+// CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
+// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// The barrier dep on the fill loop must survive on the chan.get sinks:
+// CHECK: air.channel.get async [%[[FILL]]
+// CHECK: air.channel.get async [%[[FILL]]
+
+module {
+  air.channel @ch_a [1, 1]
+  air.channel @ch_b [1, 1]
+  func.func @chan_get_barrier_dep_preserved() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) {
+      %1 = air.segment @seg async {
+        %c1_s = arith.constant 1 : index
+        %tok_out, %out_buf = air.execute -> (memref<32x32xi16, 2 : i32>) {
+          %a = memref.alloc() : memref<32x32xi16, 2 : i32>
+          air.execute_terminator %a : memref<32x32xi16, 2 : i32>
+        }
+        %h = air.herd @h async [%tok_out] tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) args(%argbuf=%out_buf) : memref<32x32xi16, 2 : i32> {
+          %c0_i16 = arith.constant 0 : i16
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c32 = arith.constant 32 : index
+          %wa_init = air.wait_all async
+          %fill_loop = scf.for %i = %c0 to %c32 step %c1_h iter_args(%it = %wa_init) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              memref.store %c0_i16, %argbuf[%i, %i] : memref<32x32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+          %tk_in1, %in_buf1 = air.execute -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          %tk_in2, %in_buf2 = air.execute -> (memref<32xi16, 2 : i32>) {
+            %a = memref.alloc() : memref<32xi16, 2 : i32>
+            air.execute_terminator %a : memref<32xi16, 2 : i32>
+          }
+          // These chan.get ops carry a scheduling barrier on the fill loop.
+          // The fill loop writes %argbuf; the chan.gets write distinct fresh
+          // input buffers — so naive RAW/WAR/WAW analysis would drop the
+          // %fill_loop dep. But the matmul scf.for below (the chan.gets'
+          // transitive consumer) READS %argbuf, so the barrier is real.
+          %g1 = air.channel.get async [%fill_loop, %tk_in1] @ch_a[%tx, %ty] (%in_buf1[] [] []) : (memref<32xi16, 2 : i32>)
+          %g2 = air.channel.get async [%fill_loop, %tk_in2] @ch_b[%tx, %ty] (%in_buf2[] [] []) : (memref<32xi16, 2 : i32>)
+          %wa = air.wait_all async [%g1, %g2]
+          %loop = scf.for %k = %c0 to %c32 step %c1_h iter_args(%it = %wa) -> (!air.async.token) {
+            %tk = air.execute [%it] {
+              %v = memref.load %argbuf[%k, %k] : memref<32x32xi16, 2 : i32>
+              %v1 = memref.load %in_buf1[%k] : memref<32xi16, 2 : i32>
+              %v2 = memref.load %in_buf2[%k] : memref<32xi16, 2 : i32>
+              %sum = arith.addi %v1, %v2 : i16
+              %sum2 = arith.addi %sum, %v : i16
+              memref.store %sum2, %argbuf[%k, %k] : memref<32x32xi16, 2 : i32>
+            }
+            scf.yield %tk : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
+++ b/mlir/test/Dialect/AIR/canonicalize_channel_get_barrier_dep.mlir
@@ -23,7 +23,7 @@
 
 // CHECK-LABEL: func.func @chan_get_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
-// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK:{{ *}}memref.store {{.*}} : memref<32x32xi16, 2 : i32>
 // The barrier dep on the fill loop must survive on the chan.get sinks:
 // CHECK: air.channel.get async [%[[FILL]]
 // CHECK: air.channel.get async [%[[FILL]]
@@ -96,7 +96,7 @@ module {
 
 // CHECK-LABEL: func.func @chan_put_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
-// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK:{{ *}}memref.store {{.*}} : memref<32x32xi16, 2 : i32>
 // CHECK: air.channel.put async [%[[FILL]]
 
 module {
@@ -153,7 +153,7 @@ module {
 
 // CHECK-LABEL: func.func @dma_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
-// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK:{{ *}}memref.store {{.*}} : memref<32x32xi16, 2 : i32>
 // CHECK: air.dma_memcpy_nd async [%[[FILL]]
 
 module {
@@ -215,7 +215,7 @@ module {
 
 // CHECK-LABEL: func.func @execute_barrier_dep_preserved
 // CHECK: %[[FILL:[a-zA-Z0-9_]+]] = scf.for {{.*}} iter_args
-// CHECK:   memref.store {{.*}} : memref<32x32xi16, 2 : i32>
+// CHECK:{{ *}}memref.store {{.*}} : memref<32x32xi16, 2 : i32>
 // CHECK: %{{.*}}, %{{.*}} = air.execute [%[[FILL]]]
 
 module {

--- a/test/airrunner/matmul/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul/run_makefile_airrunner.lit
@@ -5,4 +5,4 @@
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run | FileCheck %s
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 1129.01us
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 1127.23us


### PR DESCRIPTION
## Summary

- The sink-side memref analysis in `CanonicalizeAsyncOpDeps` only walked async-token consumers for `air.wait_all`. For every other AIR async op (channel.get/put, execute, dma, …) the sink memref set was just the op's own accesses — empty for synchronization primitives. As a result, a memref-flow dep injected as a scheduling barrier on a sync primitive (e.g. fill→channel.get to serialize across merged herds in #1559) was wrongly pruned by the RAW/WAR/WAW filter.
- Generalize the existing `air.wait_all` "barrier" semantics to all `air::AsyncOpInterface` ops: any async op acts as a scheduling anchor for its transitive forward async-token consumers, so its sink-side memref set is the union of its own and all its consumers'. Termination bounded by a worklist over visited ops.
- Critical: the consumer walk is gated by a `walkConsumers` flag, true for sink-side analysis, false for source-side. Applying it on the source side regresses cases where a sync primitive is used as a source (caught by `segment_async_1` in `air_canonicalize.mlir`) — it would get credited with downstream accesses it doesn't actually perform.

End-to-end on the matmul-i8 1×1 reproducer (`programming_examples/matrix_multiplication/i8`): both per-core matmul chains in `placed.air.mlir` now correctly serialize after the fill loop. Resolves race #2/#3 of #1559. Pairs with #1571 (which fixes a related but independent bug in the same function).

## Test plan

- [x] `ninja check-air-mlir` clean (372/372 tracked pass; only pre-existing `air_rank_iris_examples.mlir` failure)
- [x] New focused test `canonicalize_channel_get_barrier_dep.mlir` mutation-verified: fails without the fix, passes with it
- [x] Sibling tests `air_canonicalize.mlir` (incl. `segment_async_1`, `chan_4`, `func3`, `func4`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)