### PR TITLE
Three follow-up fixes for channel_type="mmio" multi-tile / non-i32 use

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2940,25 +2940,6 @@ void lowerMemRefCopyToLoops(AIE::DeviceOp d) {
   (void)applyPatternsGreedily(d, std::move(patterns));
 }
 
-/// Reinterpret a non-i32 DenseElementsAttr as i32 with identical raw bytes;
-/// splats are byte-expanded first. Caller validates 8-bit-aligned element
-/// type and 4-byte-multiple total size.
-static DenseElementsAttr repackAsI32Bytes(DenseElementsAttr orig,
-                                          RankedTensorType i32TensorTy) {
-  unsigned bits = orig.getType().getElementType().getIntOrFloatBitWidth();
-  size_t bytesPerElt = bits / 8;
-  int64_t totalBytes = orig.getType().getNumElements() * bytesPerElt;
-  SmallVector<char> raw(totalBytes);
-  ArrayRef<char> src = orig.getRawData();
-  if (orig.isSplat()) {
-    for (int64_t i = 0; i < totalBytes; i += bytesPerElt)
-      std::copy_n(src.begin(), bytesPerElt, raw.begin() + i);
-  } else {
-    std::copy(src.begin(), src.end(), raw.begin());
-  }
-  return DenseElementsAttr::getFromRawBuffer(i32TensorTy, raw);
-}
-
 /// Remove dead memref.get_global ops and their corresponding memref.global
 /// declarations. outlineAIECores creates these for ALL L2/L3 herd memref
 /// args, but DMA/channel lowering erases the ops that referenced them,
@@ -2978,14 +2959,9 @@ static void removeDeadGlobalOps(AIE::DeviceOp device) {
   device.walk(
       [&](memref::GetGlobalOp op) { referencedGlobals.insert(op.getName()); });
 
-  // Erase unreferenced memref.global declarations, but preserve any
-  // tagged with `air.mmio_global` — those are MMIO-channel mirrors of
-  // module-level globals whose runtime_sequence get_global users are
-  // synthesized later in the pipeline.
+  // Erase unreferenced memref.global declarations.
   SmallVector<memref::GlobalOp> deadGlobals;
   for (auto globalOp : device.getOps<memref::GlobalOp>()) {
-    if (globalOp->hasAttr("air.mmio_global"))
-      continue;
     if (!referencedGlobals.contains(globalOp.getSymName()))
       deadGlobals.push_back(globalOp);
   }
@@ -5837,11 +5813,20 @@ public:
             return failure();
       }
 
-      // For each L3-side put, find every matching get and emit one
-      // blockwrite per destination buffer. Match rule:
+      // For each L3-side put, find every matching get and stamp the
+      // source data onto the destination L1 buffer's `initial_value`
+      // attribute. Match rule:
       //   * non-broadcast: indices must be constant-equal between put/get;
       //   * broadcast: every device-side get on this channel matches every
       //     put (one put fans out to all destinations).
+      //
+      // The aie.buffer initial_value is loaded into the tile by
+      // AIERTControl::initBuffers (XAie_DataMemBlockWrite) at device-init
+      // time — before any core starts. This eliminates the host↔core
+      // race that would arise from placing the data delivery in the
+      // runtime sequence (where blockwrites would race CDO-started cores).
+      // It also handles bf16/other float types natively, so no i32
+      // repack is required.
       for (auto put : hostPuts) {
         Value src = put.getMemref();
         memref::GetGlobalOp getGlobalOp = getSourceGlobal(src);
@@ -5849,6 +5834,26 @@ public:
           return put.emitOpError(
               "channel_type=\"mmio\" put requires source memref defined by "
               "memref.get_global of a constant memref.global");
+
+        StringAttr origName = getGlobalOp.getNameAttr().getAttr();
+        Operation *moduleOp = device->getParentOp();
+        while (moduleOp && !isa<ModuleOp>(moduleOp))
+          moduleOp = moduleOp->getParentOp();
+        auto moduleGlobal = dyn_cast_if_present<memref::GlobalOp>(
+            moduleOp ? SymbolTable::lookupSymbolIn(moduleOp, origName)
+                     : nullptr);
+        if (!moduleGlobal)
+          return getGlobalOp.emitOpError(
+              "channel_type=\"mmio\" lowering: cannot find memref.global "
+              "for the put source at module scope");
+
+        auto initOpt = moduleGlobal.getInitialValue();
+        auto initDense =
+            initOpt ? dyn_cast<DenseElementsAttr>(*initOpt) : nullptr;
+        if (!initDense)
+          return put.emitOpError(
+              "channel_type=\"mmio\" source memref.global must have a "
+              "DenseElementsAttr initializer");
 
         unsigned matchCount = 0;
         for (auto get : deviceGets) {
@@ -5860,145 +5865,37 @@ public:
                 "channel_type=\"mmio\" get destination does not resolve to "
                 "an aie.buffer (must be an L1 allocation)");
 
-          auto bufSymOpt = bufferOp.getSymName();
-          if (!bufSymOpt)
+          // Element type and total element count must match between source
+          // and destination so the DenseElementsAttr is valid for the
+          // buffer's memref type.
+          auto bufMemTy = bufferOp.getType();
+          auto srcMemTy = cast<MemRefType>(getGlobalOp.getType());
+          if (bufMemTy.getElementType() != srcMemTy.getElementType())
             return get.emitOpError(
-                "channel_type=\"mmio\" get destination aie.buffer has no "
-                "sym_name; cannot reference from blockwrite");
-          // Hoist the blockwrite (and a clone of the source get_global)
-          // out of any enclosing air.launch — later passes recreate a
-          // fresh launch body and drop non-channel ops.
-          air::LaunchOp outerLaunch = put->getParentOfType<air::LaunchOp>();
-          Operation *insertionAnchor =
-              outerLaunch ? outerLaunch.getOperation() : put.getOperation();
-          rewriter.setInsertionPoint(insertionAnchor);
+                       "channel_type=\"mmio\" source/destination element type "
+                       "mismatch (source: ")
+                   << srcMemTy.getElementType()
+                   << ", destination: " << bufMemTy.getElementType() << ")";
+          if (bufMemTy.getNumElements() != srcMemTy.getNumElements())
+            return get.emitOpError(
+                       "channel_type=\"mmio\" source/destination element count "
+                       "mismatch (source: ")
+                   << srcMemTy.getNumElements()
+                   << ", destination: " << bufMemTy.getNumElements() << ")";
 
-          // aie.device is IsolatedFromAbove, so the runtime_sequence's
-          // get_global can't reach a module-scope memref.global. Mirror
-          // it into the device under the same name; the module-scope
-          // original is later DCE'd to avoid an llvm.mlir.global collision.
-          StringAttr origName = getGlobalOp.getNameAttr().getAttr();
-          Operation *moduleOp = device->getParentOp();
-          while (moduleOp && !isa<ModuleOp>(moduleOp))
-            moduleOp = moduleOp->getParentOp();
-          auto moduleGlobal = dyn_cast_if_present<memref::GlobalOp>(
-              moduleOp ? SymbolTable::lookupSymbolIn(moduleOp, origName)
-                       : nullptr);
-          if (!moduleGlobal)
-            return getGlobalOp.emitOpError(
-                "channel_type=\"mmio\" lowering: cannot find memref.global "
-                "for the put source at module scope");
+          // Reshape the source DenseElementsAttr to match the destination
+          // buffer's tensor shape (same bytes, possibly different rank).
+          auto bufTensorTy = RankedTensorType::get(bufMemTy.getShape(),
+                                                   bufMemTy.getElementType());
+          auto reshapedInit = initDense.reshape(bufTensorTy);
 
-          // V1: in-device mirror reuses sym_name, so module-scope original
-          // must be DCE-able by `symbol-dce` after airrt-to-npu (see
-          // tools/aircc/aircc.cpp). Reject any other module-scope users.
-          auto putFunc = put->getParentOfType<func::FuncOp>();
-          auto uses = SymbolTable::getSymbolUses(origName, moduleOp);
-          if (uses && llvm::any_of(*uses, [&](SymbolTable::SymbolUse u) {
-                return u.getUser()->getParentOfType<func::FuncOp>() != putFunc;
-              }))
-            return getGlobalOp.emitOpError(
-                "channel_type=\"mmio\" V1 requires the source memref.global "
-                "to be used only inside the func containing the put");
-
-          // blockwrite translator is i32-only. Mirror non-i32 globals as
-          // memref<Nxi32> with the same raw bytes (suffixed `_mmio_i32`).
-          // TODO: delete once mlir-aie's NpuBlockWriteOp::getDataWords and
-          // AIETxnToControlPacket.cpp drop their 32-bit-only restriction.
-          auto origMemTy = cast<MemRefType>(getGlobalOp.getType());
-          bool needsRepack = !origMemTy.getElementType().isInteger(32);
-          MemRefType cloneMemTy = origMemTy;
-          StringAttr cloneName = origName;
-          DenseElementsAttr repackedInit;
-
-          if (needsRepack) {
-            unsigned elemBits = origMemTy.getElementTypeBitWidth();
-            if (elemBits == 0 || elemBits % 8 != 0)
-              return put.emitOpError(
-                         "channel_type=\"mmio\" source element bitwidth must "
-                         "be a positive multiple of 8 (got ")
-                     << elemBits << ")";
-            int64_t totalBytes = origMemTy.getNumElements() * (elemBits / 8);
-            if (totalBytes % 4 != 0)
-              return put.emitOpError(
-                         "channel_type=\"mmio\" source size must be a multiple "
-                         "of 4 bytes (got ")
-                     << totalBytes << ")";
-            // Repack needs concrete bytes; reject declarations / UnitAttr.
-            auto initOpt = moduleGlobal.getInitialValue();
-            auto initDense =
-                initOpt ? dyn_cast<DenseElementsAttr>(*initOpt) : nullptr;
-            if (!initDense)
-              return put.emitOpError(
-                  "channel_type=\"mmio\" non-i32 source requires a "
-                  "DenseElementsAttr initializer on the memref.global");
-            cloneMemTy =
-                MemRefType::get({totalBytes / 4}, rewriter.getI32Type());
-            cloneName = StringAttr::get(
-                rewriter.getContext(), origName.getValue().str() + "_mmio_i32");
-            // Only a prior mirror is allowed to share the suffixed name.
-            if (auto *exist = SymbolTable::lookupSymbolIn(moduleOp, cloneName))
-              if (!exist->hasAttr("air.mmio_global"))
-                return put.emitOpError(
-                           "channel_type=\"mmio\" repack target name `")
-                       << cloneName.getValue()
-                       << "` already exists at module scope";
-            auto i32TensorTy = RankedTensorType::get(
-                cloneMemTy.getShape(), cloneMemTy.getElementType());
-            repackedInit = repackAsI32Bytes(initDense, i32TensorTy);
-
-            // Module-scope mirror: keeps the func-level get_global resolvable
-            // until airrt-to-npu moves the func into the device.
-            if (!SymbolTable::lookupSymbolIn(moduleOp, cloneName)) {
-              OpBuilder b(moduleOp->getRegion(0));
-              b.setInsertionPointAfter(moduleGlobal);
-              memref::GlobalOp::create(
-                  b, moduleGlobal.getLoc(), cloneName.getValue(),
-                  rewriter.getStringAttr("private"), cloneMemTy, repackedInit,
-                  moduleGlobal.getConstant(), moduleGlobal.getAlignmentAttr());
-            }
-          }
-
-          auto inDevGlobal = dyn_cast_or_null<memref::GlobalOp>(
-              SymbolTable::lookupSymbolIn(device, cloneName));
-          if (!inDevGlobal) {
-            if (needsRepack) {
-              // push_front so the global dominates the runtime_sequence.
-              OpBuilder b(device.getBody(), device.getBody()->begin());
-              inDevGlobal = memref::GlobalOp::create(
-                  b, moduleGlobal.getLoc(), cloneName.getValue(),
-                  /*sym_visibility=*/StringAttr{}, cloneMemTy, repackedInit,
-                  moduleGlobal.getConstant(), moduleGlobal.getAlignmentAttr());
-            } else {
-              auto cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
-              cloned->removeAttr(SymbolTable::getVisibilityAttrName());
-              device.getBody()->getOperations().push_front(cloned);
-              inDevGlobal = cloned;
-            }
-            inDevGlobal->setAttr("air.mmio_global",
-                                 UnitAttr::get(rewriter.getContext()));
-          }
-
-          auto hoistedGG = memref::GetGlobalOp::create(
-              rewriter, getGlobalOp.getLoc(), cloneMemTy,
-              FlatSymbolRefAttr::get(rewriter.getContext(),
-                                     inDevGlobal.getSymNameAttr()));
-          Value dataOperand = hoistedGG.getResult();
-
-          // Orphaned module-scope global is erased by `symbol-dce` after
-          // airrt-to-npu (tools/aircc/aircc.cpp NPU pipeline).
-
-          AIEX::NpuBlockWriteOp::create(
-              rewriter, put.getLoc(),
-              /*address=*/rewriter.getUI32IntegerAttr(0),
-              /*data=*/dataOperand,
-              /*buffer=*/
-              FlatSymbolRefAttr::get(rewriter.getContext(), *bufSymOpt),
-              /*column=*/IntegerAttr{},
-              /*row=*/IntegerAttr{});
+          if (auto existing = bufferOp.getInitialValue())
+            return bufferOp.emitOpError(
+                "channel_type=\"mmio\" destination aie.buffer already has an "
+                "initial_value; cannot stamp two sources into one buffer");
+          bufferOp.setInitialValueAttr(reshapedInit);
           ++matchCount;
         }
-        // The put would otherwise be erased below with no replacement.
         if (matchCount == 0)
           return put.emitOpError("channel_type=\"mmio\" put has no matching "
                                  "device-side air.channel.get");

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5898,13 +5898,123 @@ public:
                 "channel_type=\"mmio\" V1 requires the source memref.global "
                 "to be used only inside the func containing the put");
 
+          // The aiex.npu.blockwrite translator only handles i32 element
+          // types ("Only 32-bit data type is supported for now"). When
+          // the original memref.global isn't already i32-typed, mirror
+          // it into the device as a 1-D memref<Nxi32> with the same
+          // bytes — blockwrite encodes raw bytes, so the type label is
+          // irrelevant on the wire. The destination buffer keeps its
+          // natural type since `buffer = @sym` is just a symbol ref.
+          auto origMemTy = cast<MemRefType>(getGlobalOp.getType());
+          bool needsRepack = !origMemTy.getElementType().isInteger(32);
+          MemRefType cloneMemTy = origMemTy;
+          if (needsRepack) {
+            unsigned elemBits = origMemTy.getElementTypeBitWidth();
+            // Sub-byte (e.g. i1) and other non-byte-aligned element
+            // types have no portable raw-byte representation and would
+            // make the (elts*bits)/8 byte-size computation lossy.
+            // blockwrite is byte-granular, so reject up front.
+            if (elemBits == 0 || elemBits % 8 != 0)
+              return put.emitOpError(
+                         "channel_type=\"mmio\" source element bitwidth must "
+                         "be a positive multiple of 8 (got ")
+                     << elemBits << ")";
+            int64_t totalElts = 1;
+            for (int64_t d : origMemTy.getShape())
+              totalElts *= d;
+            int64_t totalBytes = totalElts * (elemBits / 8);
+            if (totalBytes % 4 != 0)
+              return put.emitOpError(
+                         "channel_type=\"mmio\" source size must be a multiple "
+                         "of 4 bytes (got ")
+                     << totalBytes << ")";
+            cloneMemTy = MemRefType::get(
+                {totalBytes / 4}, IntegerType::get(rewriter.getContext(), 32));
+          }
+
+          // Synthesize an in-device clone name. For repacked globals
+          // we suffix with `_i32` so the original (which may still be
+          // referenced by other ops) is undisturbed.
+          std::string cloneNameStr =
+              needsRepack ? (origName.getValue().str() + "_mmio_i32")
+                          : origName.getValue().str();
+          StringAttr cloneName =
+              StringAttr::get(rewriter.getContext(), cloneNameStr);
+
+          // For the repack case, also synthesize a module-scope i32
+          // global so that the get_global we're about to insert at
+          // func.func level resolves correctly until airrt-to-npu moves
+          // the func into the device.
+          // Helper: re-encode the bf16 (or other non-i32) DenseElementsAttr
+          // as i32 with the same bytes. Splat attributes only carry one
+          // element's worth of bytes, so expand them explicitly. The
+          // sub-byte / non-byte-aligned check above guarantees
+          // origElemBits is a positive multiple of 8 here.
+          auto repackAsI32 = [&](DenseElementsAttr orig,
+                                 RankedTensorType i32TensorTy) {
+            unsigned origElemBits =
+                orig.getType().getElementType().getIntOrFloatBitWidth();
+            assert(origElemBits >= 8 && origElemBits % 8 == 0 &&
+                   "non-byte-aligned element type should have been rejected");
+            size_t bytesPerElt = origElemBits / 8;
+            int64_t totalBytes = orig.getType().getNumElements() * bytesPerElt;
+            SmallVector<char> raw(totalBytes);
+            ArrayRef<char> src = orig.getRawData();
+            if (orig.isSplat()) {
+              for (int64_t i = 0; i < totalBytes; i += bytesPerElt)
+                std::copy_n(src.begin(), bytesPerElt, raw.begin() + i);
+            } else {
+              std::copy(src.begin(), src.end(), raw.begin());
+            }
+            return DenseElementsAttr::getFromRawBuffer(i32TensorTy, raw);
+          };
+
+          if (needsRepack &&
+              !SymbolTable::lookupSymbolIn(moduleOp, cloneName)) {
+            auto orig =
+                cast<DenseElementsAttr>(*moduleGlobal.getInitialValue());
+            auto i32TensorTy = RankedTensorType::get(
+                cloneMemTy.getShape(), cloneMemTy.getElementType());
+            auto repacked = repackAsI32(orig, i32TensorTy);
+            OpBuilder modBuilder(moduleOp->getRegion(0));
+            modBuilder.setInsertionPointAfter(moduleGlobal);
+            auto modI32 = memref::GlobalOp::create(
+                modBuilder, moduleGlobal.getLoc(),
+                /*sym_name=*/cloneNameStr,
+                /*sym_visibility=*/
+                StringAttr::get(modBuilder.getContext(), "private"),
+                /*type=*/cloneMemTy,
+                /*initial_value=*/repacked,
+                /*constant=*/moduleGlobal.getConstant(),
+                /*alignment=*/IntegerAttr{});
+            (void)modI32;
+          }
+
           memref::GlobalOp inDevGlobal;
           device.walk([&](memref::GlobalOp g) {
-            if (g.getSymName() == origName.getValue())
+            if (g.getSymName() == cloneName.getValue())
               inDevGlobal = g;
           });
           if (!inDevGlobal) {
-            auto cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
+            memref::GlobalOp cloned;
+            if (!needsRepack) {
+              cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
+            } else {
+              auto orig =
+                  cast<DenseElementsAttr>(*moduleGlobal.getInitialValue());
+              auto i32TensorTy = RankedTensorType::get(
+                  cloneMemTy.getShape(), cloneMemTy.getElementType());
+              auto repacked = repackAsI32(orig, i32TensorTy);
+              cloned = memref::GlobalOp::create(
+                  rewriter, moduleGlobal.getLoc(),
+                  /*sym_name=*/cloneNameStr,
+                  /*sym_visibility=*/StringAttr{},
+                  /*type=*/cloneMemTy,
+                  /*initial_value=*/repacked,
+                  /*constant=*/moduleGlobal.getConstant(),
+                  /*alignment=*/IntegerAttr{});
+              cloned->remove(); // detach from the rewriter insertion point
+            }
             cloned->removeAttr(SymbolTable::getVisibilityAttrName());
             cloned->setAttr("air.mmio_global",
                             UnitAttr::get(rewriter.getContext()));
@@ -5916,8 +6026,7 @@ public:
           }
 
           auto hoistedGG = memref::GetGlobalOp::create(
-              rewriter, getGlobalOp.getLoc(),
-              cast<MemRefType>(getGlobalOp.getResult().getType()),
+              rewriter, getGlobalOp.getLoc(), cloneMemTy,
               FlatSymbolRefAttr::get(rewriter.getContext(),
                                      inDevGlobal.getSymNameAttr()));
           Value dataOperand = hoistedGG.getResult();

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5969,7 +5969,7 @@ public:
               memref::GlobalOp::create(
                   b, moduleGlobal.getLoc(), cloneName.getValue(),
                   rewriter.getStringAttr("private"), cloneMemTy, repackedInit,
-                  moduleGlobal.getConstant(), /*alignment=*/IntegerAttr{});
+                  moduleGlobal.getConstant(), moduleGlobal.getAlignmentAttr());
             }
           }
 
@@ -5985,7 +5985,7 @@ public:
               inDevGlobal = memref::GlobalOp::create(
                   b, moduleGlobal.getLoc(), cloneName.getValue(),
                   /*sym_visibility=*/StringAttr{}, cloneMemTy, repackedInit,
-                  moduleGlobal.getConstant(), /*alignment=*/IntegerAttr{});
+                  moduleGlobal.getConstant(), moduleGlobal.getAlignmentAttr());
             } else {
               auto cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
               cloned->removeAttr(SymbolTable::getVisibilityAttrName());

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5949,6 +5949,16 @@ public:
                          "channel_type=\"mmio\" source size must be a multiple "
                          "of 4 bytes (got ")
                      << totalBytes << ")";
+            // Repack needs concrete bytes — reject pure declarations and
+            // uninitialized definitions (UnitAttr) up front; either would
+            // crash the dereference / cast below.
+            auto initOpt = moduleGlobal.getInitialValue();
+            auto initDense =
+                initOpt ? dyn_cast<DenseElementsAttr>(*initOpt) : nullptr;
+            if (!initDense)
+              return put.emitOpError(
+                  "channel_type=\"mmio\" non-i32 source requires a "
+                  "DenseElementsAttr initializer on the memref.global");
             cloneMemTy =
                 MemRefType::get({totalBytes / 4}, rewriter.getI32Type());
             cloneName = StringAttr::get(
@@ -5963,9 +5973,7 @@ public:
                        << "` already exists at module scope";
             auto i32TensorTy = RankedTensorType::get(
                 cloneMemTy.getShape(), cloneMemTy.getElementType());
-            repackedInit = repackAsI32Bytes(
-                cast<DenseElementsAttr>(*moduleGlobal.getInitialValue()),
-                i32TensorTy);
+            repackedInit = repackAsI32Bytes(initDense, i32TensorTy);
 
             // Synthesize a module-scope mirror so the func-level get_global
             // we're about to insert resolves before airrt-to-npu moves the

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2940,11 +2940,9 @@ void lowerMemRefCopyToLoops(AIE::DeviceOp d) {
   (void)applyPatternsGreedily(d, std::move(patterns));
 }
 
-/// Repack a non-i32 DenseElementsAttr as an i32-typed tensor with identical
-/// raw bytes. Splat attributes carry one element's worth of bytes; expand
-/// to the full size before reinterpretation. Caller must have validated
-/// that the source element bitwidth is a positive multiple of 8 and the
-/// total byte size is a multiple of 4.
+/// Reinterpret a non-i32 DenseElementsAttr as i32 with identical raw bytes;
+/// splats are byte-expanded first. Caller validates 8-bit-aligned element
+/// type and 4-byte-multiple total size.
 static DenseElementsAttr repackAsI32Bytes(DenseElementsAttr orig,
                                           RankedTensorType i32TensorTy) {
   unsigned bits = orig.getType().getElementType().getIntOrFloatBitWidth();
@@ -5867,31 +5865,18 @@ public:
             return get.emitOpError(
                 "channel_type=\"mmio\" get destination aie.buffer has no "
                 "sym_name; cannot reference from blockwrite");
-          // The blockwrite must end up OUTSIDE any enclosing air.launch:
-          // later passes (AIROptimizeShimDMABDs / AIRLaunchToScfForPattern)
-          // recreate a fresh dummy launch and only carry forward channel
-          // ops, dropping any other ops that happened to live in the
-          // launch body. Hoisting the blockwrite to the func.func level
-          // also forces us to hoist a clone of the source
-          // `memref.get_global` so SSA dominance is preserved when the
-          // original get_global lives inside the launch.
+          // Hoist the blockwrite (and a clone of the source get_global)
+          // out of any enclosing air.launch — later passes recreate a
+          // fresh launch body and drop non-channel ops.
           air::LaunchOp outerLaunch = put->getParentOfType<air::LaunchOp>();
           Operation *insertionAnchor =
               outerLaunch ? outerLaunch.getOperation() : put.getOperation();
           rewriter.setInsertionPoint(insertionAnchor);
 
-          // The blockwrite carries a constant payload that must remain
-          // resolvable from inside `aie.runtime_sequence` (which lives
-          // inside `aie.device`) after AIRRtToNpuPass wraps the func.
-          // `aie.device` is `IsolatedFromAbove`, so a get_global inside
-          // it cannot reference a `memref.global` at module scope.
-          // Mirror the global into the device under the SAME name
-          // (different SymbolTables admit identical names — vanilla
-          // MLIR verifiers accept this), then erase the module-level
-          // original. The aircc LLVM-lowering pipeline promotes
-          // memref.global to llvm.mlir.global at module scope, where
-          // duplicates collide; deleting the module-level original
-          // keeps the in-device copy as the unique source of truth.
+          // aie.device is IsolatedFromAbove, so the runtime_sequence's
+          // get_global can't reach a module-scope memref.global. Mirror
+          // it into the device under the same name; the module-scope
+          // original is later DCE'd to avoid an llvm.mlir.global collision.
           StringAttr origName = getGlobalOp.getNameAttr().getAttr();
           Operation *moduleOp = device->getParentOp();
           while (moduleOp && !isa<ModuleOp>(moduleOp))
@@ -5904,13 +5889,9 @@ public:
                 "channel_type=\"mmio\" lowering: cannot find memref.global "
                 "for the put source at module scope");
 
-          // V1 limitation: the in-device mirror is cloned under the same
-          // sym_name, so the `symbol-dce` pass invoked in the NPU pipeline
-          // (tools/aircc/aircc.cpp, after `airrt-to-npu`) must be able to
-          // erase the module-level original to avoid a duplicate-symbol
-          // collision in LLVM lowering. That requires no users to survive
-          // outside the func that becomes the runtime_sequence and moves
-          // into the device. Reject other module-scope users loudly.
+          // V1: in-device mirror reuses sym_name, so module-scope original
+          // must be DCE-able by `symbol-dce` after airrt-to-npu (see
+          // tools/aircc/aircc.cpp). Reject any other module-scope users.
           auto putFunc = put->getParentOfType<func::FuncOp>();
           auto uses = SymbolTable::getSymbolUses(origName, moduleOp);
           if (uses && llvm::any_of(*uses, [&](SymbolTable::SymbolUse u) {
@@ -5920,17 +5901,10 @@ public:
                 "channel_type=\"mmio\" V1 requires the source memref.global "
                 "to be used only inside the func containing the put");
 
-          // The aiex.npu.blockwrite translator only handles i32 element
-          // types. Mirror non-i32 globals as memref<Nxi32> with identical
-          // raw bytes (suffixed `_mmio_i32`); the destination buffer keeps
-          // its natural type since `buffer = @sym` is just a symbol ref.
-          //
-          // TODO: drop this entire repack path (and the `_mmio_i32` mirror
-          // globals) once the upstream blockwrite translator learns to
-          // handle non-i32 element types. The 32-bit-only check lives in
-          // mlir-aie at AIEXDialect.cpp `NpuBlockWriteOp::getDataWords`
-          // and AIETxnToControlPacket.cpp (both currently emit
-          // "Only 32-bit data type is supported for now").
+          // blockwrite translator is i32-only. Mirror non-i32 globals as
+          // memref<Nxi32> with the same raw bytes (suffixed `_mmio_i32`).
+          // TODO: delete once mlir-aie's NpuBlockWriteOp::getDataWords and
+          // AIETxnToControlPacket.cpp drop their 32-bit-only restriction.
           auto origMemTy = cast<MemRefType>(getGlobalOp.getType());
           bool needsRepack = !origMemTy.getElementType().isInteger(32);
           MemRefType cloneMemTy = origMemTy;
@@ -5950,9 +5924,7 @@ public:
                          "channel_type=\"mmio\" source size must be a multiple "
                          "of 4 bytes (got ")
                      << totalBytes << ")";
-            // Repack needs concrete bytes — reject pure declarations and
-            // uninitialized definitions (UnitAttr) up front; either would
-            // crash the dereference / cast below.
+            // Repack needs concrete bytes; reject declarations / UnitAttr.
             auto initOpt = moduleGlobal.getInitialValue();
             auto initDense =
                 initOpt ? dyn_cast<DenseElementsAttr>(*initOpt) : nullptr;
@@ -5964,8 +5936,7 @@ public:
                 MemRefType::get({totalBytes / 4}, rewriter.getI32Type());
             cloneName = StringAttr::get(
                 rewriter.getContext(), origName.getValue().str() + "_mmio_i32");
-            // Reject collision with an unrelated pre-existing symbol; only
-            // a previously-synthesized mirror is allowed to share the name.
+            // Only a prior mirror is allowed to share the suffixed name.
             if (auto *exist = SymbolTable::lookupSymbolIn(moduleOp, cloneName))
               if (!exist->hasAttr("air.mmio_global"))
                 return put.emitOpError(
@@ -5976,9 +5947,8 @@ public:
                 cloneMemTy.getShape(), cloneMemTy.getElementType());
             repackedInit = repackAsI32Bytes(initDense, i32TensorTy);
 
-            // Synthesize a module-scope mirror so the func-level get_global
-            // we're about to insert resolves before airrt-to-npu moves the
-            // func into the device.
+            // Module-scope mirror: keeps the func-level get_global resolvable
+            // until airrt-to-npu moves the func into the device.
             if (!SymbolTable::lookupSymbolIn(moduleOp, cloneName)) {
               OpBuilder b(moduleOp->getRegion(0));
               b.setInsertionPointAfter(moduleGlobal);
@@ -6015,10 +5985,8 @@ public:
                                      inDevGlobal.getSymNameAttr()));
           Value dataOperand = hoistedGG.getResult();
 
-          // After `airrt-to-npu` moves the func into the device, the
-          // module-scope original (or repacked mirror) becomes orphaned
-          // and is erased by the `symbol-dce` pass run immediately after
-          // (see tools/aircc/aircc.cpp NPU pipeline).
+          // Orphaned module-scope global is erased by `symbol-dce` after
+          // airrt-to-npu (tools/aircc/aircc.cpp NPU pipeline).
 
           AIEX::NpuBlockWriteOp::create(
               rewriter, put.getLoc(),

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2940,6 +2940,27 @@ void lowerMemRefCopyToLoops(AIE::DeviceOp d) {
   (void)applyPatternsGreedily(d, std::move(patterns));
 }
 
+/// Repack a non-i32 DenseElementsAttr as an i32-typed tensor with identical
+/// raw bytes. Splat attributes carry one element's worth of bytes; expand
+/// to the full size before reinterpretation. Caller must have validated
+/// that the source element bitwidth is a positive multiple of 8 and the
+/// total byte size is a multiple of 4.
+static DenseElementsAttr repackAsI32Bytes(DenseElementsAttr orig,
+                                          RankedTensorType i32TensorTy) {
+  unsigned bits = orig.getType().getElementType().getIntOrFloatBitWidth();
+  size_t bytesPerElt = bits / 8;
+  int64_t totalBytes = orig.getType().getNumElements() * bytesPerElt;
+  SmallVector<char> raw(totalBytes);
+  ArrayRef<char> src = orig.getRawData();
+  if (orig.isSplat()) {
+    for (int64_t i = 0; i < totalBytes; i += bytesPerElt)
+      std::copy_n(src.begin(), bytesPerElt, raw.begin() + i);
+  } else {
+    std::copy(src.begin(), src.end(), raw.begin());
+  }
+  return DenseElementsAttr::getFromRawBuffer(i32TensorTy, raw);
+}
+
 /// Remove dead memref.get_global ops and their corresponding memref.global
 /// declarations. outlineAIECores creates these for ALL L2/L3 herd memref
 /// args, but DMA/channel lowering erases the ops that referenced them,
@@ -5899,130 +5920,80 @@ public:
                 "to be used only inside the func containing the put");
 
           // The aiex.npu.blockwrite translator only handles i32 element
-          // types ("Only 32-bit data type is supported for now"). When
-          // the original memref.global isn't already i32-typed, mirror
-          // it into the device as a 1-D memref<Nxi32> with the same
-          // bytes — blockwrite encodes raw bytes, so the type label is
-          // irrelevant on the wire. The destination buffer keeps its
-          // natural type since `buffer = @sym` is just a symbol ref.
+          // types. Mirror non-i32 globals as memref<Nxi32> with identical
+          // raw bytes (suffixed `_mmio_i32`); the destination buffer keeps
+          // its natural type since `buffer = @sym` is just a symbol ref.
           auto origMemTy = cast<MemRefType>(getGlobalOp.getType());
           bool needsRepack = !origMemTy.getElementType().isInteger(32);
           MemRefType cloneMemTy = origMemTy;
+          StringAttr cloneName = origName;
+          DenseElementsAttr repackedInit;
+
           if (needsRepack) {
             unsigned elemBits = origMemTy.getElementTypeBitWidth();
-            // Sub-byte (e.g. i1) and other non-byte-aligned element
-            // types have no portable raw-byte representation and would
-            // make the (elts*bits)/8 byte-size computation lossy.
-            // blockwrite is byte-granular, so reject up front.
             if (elemBits == 0 || elemBits % 8 != 0)
               return put.emitOpError(
                          "channel_type=\"mmio\" source element bitwidth must "
                          "be a positive multiple of 8 (got ")
                      << elemBits << ")";
-            int64_t totalElts = 1;
-            for (int64_t d : origMemTy.getShape())
-              totalElts *= d;
-            int64_t totalBytes = totalElts * (elemBits / 8);
+            int64_t totalBytes = origMemTy.getNumElements() * (elemBits / 8);
             if (totalBytes % 4 != 0)
               return put.emitOpError(
                          "channel_type=\"mmio\" source size must be a multiple "
                          "of 4 bytes (got ")
                      << totalBytes << ")";
-            cloneMemTy = MemRefType::get(
-                {totalBytes / 4}, IntegerType::get(rewriter.getContext(), 32));
-          }
-
-          // Synthesize an in-device clone name. For repacked globals
-          // we suffix with `_i32` so the original (which may still be
-          // referenced by other ops) is undisturbed.
-          std::string cloneNameStr =
-              needsRepack ? (origName.getValue().str() + "_mmio_i32")
-                          : origName.getValue().str();
-          StringAttr cloneName =
-              StringAttr::get(rewriter.getContext(), cloneNameStr);
-
-          // For the repack case, also synthesize a module-scope i32
-          // global so that the get_global we're about to insert at
-          // func.func level resolves correctly until airrt-to-npu moves
-          // the func into the device.
-          // Helper: re-encode the bf16 (or other non-i32) DenseElementsAttr
-          // as i32 with the same bytes. Splat attributes only carry one
-          // element's worth of bytes, so expand them explicitly. The
-          // sub-byte / non-byte-aligned check above guarantees
-          // origElemBits is a positive multiple of 8 here.
-          auto repackAsI32 = [&](DenseElementsAttr orig,
-                                 RankedTensorType i32TensorTy) {
-            unsigned origElemBits =
-                orig.getType().getElementType().getIntOrFloatBitWidth();
-            assert(origElemBits >= 8 && origElemBits % 8 == 0 &&
-                   "non-byte-aligned element type should have been rejected");
-            size_t bytesPerElt = origElemBits / 8;
-            int64_t totalBytes = orig.getType().getNumElements() * bytesPerElt;
-            SmallVector<char> raw(totalBytes);
-            ArrayRef<char> src = orig.getRawData();
-            if (orig.isSplat()) {
-              for (int64_t i = 0; i < totalBytes; i += bytesPerElt)
-                std::copy_n(src.begin(), bytesPerElt, raw.begin() + i);
-            } else {
-              std::copy(src.begin(), src.end(), raw.begin());
-            }
-            return DenseElementsAttr::getFromRawBuffer(i32TensorTy, raw);
-          };
-
-          if (needsRepack &&
-              !SymbolTable::lookupSymbolIn(moduleOp, cloneName)) {
-            auto orig =
-                cast<DenseElementsAttr>(*moduleGlobal.getInitialValue());
+            cloneMemTy =
+                MemRefType::get({totalBytes / 4}, rewriter.getI32Type());
+            cloneName = StringAttr::get(
+                rewriter.getContext(), origName.getValue().str() + "_mmio_i32");
+            // Reject collision with an unrelated pre-existing symbol; only
+            // a previously-synthesized mirror is allowed to share the name.
+            if (auto *exist = SymbolTable::lookupSymbolIn(moduleOp, cloneName))
+              if (!exist->hasAttr("air.mmio_global"))
+                return put.emitOpError(
+                           "channel_type=\"mmio\" repack target name `")
+                       << cloneName.getValue()
+                       << "` already exists at module scope";
             auto i32TensorTy = RankedTensorType::get(
                 cloneMemTy.getShape(), cloneMemTy.getElementType());
-            auto repacked = repackAsI32(orig, i32TensorTy);
-            OpBuilder modBuilder(moduleOp->getRegion(0));
-            modBuilder.setInsertionPointAfter(moduleGlobal);
-            auto modI32 = memref::GlobalOp::create(
-                modBuilder, moduleGlobal.getLoc(),
-                /*sym_name=*/cloneNameStr,
-                /*sym_visibility=*/
-                StringAttr::get(modBuilder.getContext(), "private"),
-                /*type=*/cloneMemTy,
-                /*initial_value=*/repacked,
-                /*constant=*/moduleGlobal.getConstant(),
-                /*alignment=*/IntegerAttr{});
-            (void)modI32;
+            repackedInit = repackAsI32Bytes(
+                cast<DenseElementsAttr>(*moduleGlobal.getInitialValue()),
+                i32TensorTy);
+
+            // Synthesize a module-scope mirror so the func-level get_global
+            // we're about to insert resolves before airrt-to-npu moves the
+            // func into the device.
+            if (!SymbolTable::lookupSymbolIn(moduleOp, cloneName)) {
+              OpBuilder b(moduleOp->getRegion(0));
+              b.setInsertionPointAfter(moduleGlobal);
+              memref::GlobalOp::create(
+                  b, moduleGlobal.getLoc(), cloneName.getValue(),
+                  rewriter.getStringAttr("private"), cloneMemTy, repackedInit,
+                  moduleGlobal.getConstant(), /*alignment=*/IntegerAttr{});
+            }
           }
 
           memref::GlobalOp inDevGlobal;
           device.walk([&](memref::GlobalOp g) {
-            if (g.getSymName() == cloneName.getValue())
+            if (g.getSymNameAttr() == cloneName)
               inDevGlobal = g;
           });
           if (!inDevGlobal) {
-            memref::GlobalOp cloned;
-            if (!needsRepack) {
-              cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
+            if (needsRepack) {
+              // push_front so the global dominates the runtime_sequence.
+              OpBuilder b(device.getBody(), device.getBody()->begin());
+              inDevGlobal = memref::GlobalOp::create(
+                  b, moduleGlobal.getLoc(), cloneName.getValue(),
+                  /*sym_visibility=*/StringAttr{}, cloneMemTy, repackedInit,
+                  moduleGlobal.getConstant(), /*alignment=*/IntegerAttr{});
             } else {
-              auto orig =
-                  cast<DenseElementsAttr>(*moduleGlobal.getInitialValue());
-              auto i32TensorTy = RankedTensorType::get(
-                  cloneMemTy.getShape(), cloneMemTy.getElementType());
-              auto repacked = repackAsI32(orig, i32TensorTy);
-              cloned = memref::GlobalOp::create(
-                  rewriter, moduleGlobal.getLoc(),
-                  /*sym_name=*/cloneNameStr,
-                  /*sym_visibility=*/StringAttr{},
-                  /*type=*/cloneMemTy,
-                  /*initial_value=*/repacked,
-                  /*constant=*/moduleGlobal.getConstant(),
-                  /*alignment=*/IntegerAttr{});
-              cloned->remove(); // detach from the rewriter insertion point
+              auto cloned = cast<memref::GlobalOp>(moduleGlobal->clone());
+              cloned->removeAttr(SymbolTable::getVisibilityAttrName());
+              device.getBody()->getOperations().push_front(cloned);
+              inDevGlobal = cloned;
             }
-            cloned->removeAttr(SymbolTable::getVisibilityAttrName());
-            cloned->setAttr("air.mmio_global",
-                            UnitAttr::get(rewriter.getContext()));
-            // Place at the very top of the device body so it dominates
-            // the runtime_sequence created later. push_front bypasses
-            // SymbolTable::insert renaming logic.
-            device.getBody()->getOperations().push_front(cloned);
-            inDevGlobal = cloned;
+            inDevGlobal->setAttr("air.mmio_global",
+                                 UnitAttr::get(rewriter.getContext()));
           }
 
           auto hoistedGG = memref::GetGlobalOp::create(
@@ -6031,12 +6002,9 @@ public:
                                      inDevGlobal.getSymNameAttr()));
           Value dataOperand = hoistedGG.getResult();
 
-          // After this point the hoisted get_global at module scope
-          // resolves to the module-level original; once airrt-to-npu
-          // moves the surrounding func into the device, lookup will
-          // pick up the in-device copy first. The module-level original
-          // is not removed here because there may be a brief window
-          // where the func still references it.
+          // The module-scope original (or repacked mirror) is removed
+          // later by symbol-DCE once airrt-to-npu moves the func into
+          // the device and the in-device copy becomes the unique source.
 
           AIEX::NpuBlockWriteOp::create(
               rewriter, put.getLoc(),

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5973,11 +5973,8 @@ public:
             }
           }
 
-          memref::GlobalOp inDevGlobal;
-          device.walk([&](memref::GlobalOp g) {
-            if (g.getSymNameAttr() == cloneName)
-              inDevGlobal = g;
-          });
+          auto inDevGlobal = dyn_cast_or_null<memref::GlobalOp>(
+              SymbolTable::lookupSymbolIn(device, cloneName));
           if (!inDevGlobal) {
             if (needsRepack) {
               // push_front so the global dominates the runtime_sequence.

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2536,6 +2536,15 @@ struct SpecializeChannelBundlePattern
     if (channel.getBundleSize() <= 1)
       return failure();
 
+    // mmio channels are handled directly by lowerAIRMMIOChannelOps, which
+    // matches host-side puts to per-core gets by constant index across the
+    // full bundle. Splitting the bundle here would orphan the original
+    // host-side puts (they sit outside the device, where this pattern's
+    // rewrites don't reach), leaving them to fail later as
+    // "no matching device-side air.channel.get".
+    if (channel.getChannelType() == "mmio")
+      return failure();
+
     std::vector<air::ChannelPutOp> channelPuts =
         getChannelPutOpThroughSymbol(channel, device);
     std::vector<air::ChannelGetOp> channelGets =

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5923,6 +5923,13 @@ public:
           // types. Mirror non-i32 globals as memref<Nxi32> with identical
           // raw bytes (suffixed `_mmio_i32`); the destination buffer keeps
           // its natural type since `buffer = @sym` is just a symbol ref.
+          //
+          // TODO: drop this entire repack path (and the `_mmio_i32` mirror
+          // globals) once the upstream blockwrite translator learns to
+          // handle non-i32 element types. The 32-bit-only check lives in
+          // mlir-aie at AIEXDialect.cpp `NpuBlockWriteOp::getDataWords`
+          // and AIETxnToControlPacket.cpp (both currently emit
+          // "Only 32-bit data type is supported for now").
           auto origMemTy = cast<MemRefType>(getGlobalOp.getType());
           bool needsRepack = !origMemTy.getElementType().isInteger(32);
           MemRefType cloneMemTy = origMemTy;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5905,11 +5905,12 @@ public:
                 "for the put source at module scope");
 
           // V1 limitation: the in-device mirror is cloned under the same
-          // sym_name, so a later symbol-dce of the module-level original
-          // is required to avoid a duplicate-symbol collision in LLVM
-          // lowering. That requires no users to survive outside the
-          // func that becomes the runtime_sequence and moves into the
-          // device. Reject other module-scope users loudly.
+          // sym_name, so the `symbol-dce` pass invoked in the NPU pipeline
+          // (tools/aircc/aircc.cpp, after `airrt-to-npu`) must be able to
+          // erase the module-level original to avoid a duplicate-symbol
+          // collision in LLVM lowering. That requires no users to survive
+          // outside the func that becomes the runtime_sequence and moves
+          // into the device. Reject other module-scope users loudly.
           auto putFunc = put->getParentOfType<func::FuncOp>();
           auto uses = SymbolTable::getSymbolUses(origName, moduleOp);
           if (uses && llvm::any_of(*uses, [&](SymbolTable::SymbolUse u) {
@@ -6014,9 +6015,10 @@ public:
                                      inDevGlobal.getSymNameAttr()));
           Value dataOperand = hoistedGG.getResult();
 
-          // The module-scope original (or repacked mirror) is removed
-          // later by symbol-DCE once airrt-to-npu moves the func into
-          // the device and the in-device copy becomes the unique source.
+          // After `airrt-to-npu` moves the func into the device, the
+          // module-scope original (or repacked mirror) becomes orphaned
+          // and is erased by the `symbol-dce` pass run immediately after
+          // (see tools/aircc/aircc.cpp NPU pipeline).
 
           AIEX::NpuBlockWriteOp::create(
               rewriter, put.getLoc(),

--- a/mlir/lib/Transform/AIRDmaToChannel.cpp
+++ b/mlir/lib/Transform/AIRDmaToChannel.cpp
@@ -1603,6 +1603,12 @@ struct DmaToChannelPass : public air::impl::DmaToChannelBase<DmaToChannelPass> {
         if (!chanOp)
           continue;
 
+        // mmio channels are runtime-sequence MMIO writes, not shim DMA, so
+        // they neither contribute to per-column shim pressure nor are
+        // eligible for dma_packet upgrade.
+        if (chanOp.getChannelType() == "mmio")
+          continue;
+
         bool isAlreadyPacket = (chanOp.getChannelType() == "dma_packet");
         auto channelName = chanOp.getSymName();
 

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -18,7 +18,7 @@
 // `air_channel_mmio_invalid.mlir`. Each split here uses its own check
 // prefix so directives don't leak across split boundaries.
 
-// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16
+// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS
 
 // -----
 
@@ -204,15 +204,14 @@ func.func @indexed() {
 
 // -----
 
-// Non-i32 element type (here bf16): the `aiex.npu.blockwrite` translator
-// only handles i32 so the lowering mirrors the bf16 global into the
-// device as a 1-D `memref<Nxi32>` with the same raw bytes (suffixed
-// `_mmio_i32` to keep the original undisturbed). Blockwrite carries the
-// i32 view; the destination buffer keeps its natural bf16 type since
-// `buffer = @sym` is just a symbol ref.
+// Non-i32 element type (here splat bf16): the `aiex.npu.blockwrite`
+// translator only handles i32, so the lowering mirrors the bf16 global
+// into the device as a 1-D `memref<Nxi32>` with the same raw bytes
+// (suffixed `_mmio_i32`). Splat bf16(1.5) = 0x3FC0 packs to i32
+// 0x3FC03FC0 = 1069563840, and the resulting payload remains splat.
 //
 // CHECK-BF16-LABEL: aie.device(npu1)
-// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32>{{.*}}{air.mmio_global}
+// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32> = dense<1069563840> {air.mmio_global}
 //
 // CHECK-BF16-LABEL: func.func @bf16_payload
 // CHECK-BF16:         memref.get_global @qbf16_mmio_i32 : memref<2xi32>
@@ -230,6 +229,40 @@ func.func @bf16_payload() {
       air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
         %alloc = memref.alloc() : memref<2x2xbf16, 2>
         air.channel.get @qbf16_chan[] (%alloc[] [] []) : (memref<2x2xbf16, 2>)
+        memref.dealloc %alloc : memref<2x2xbf16, 2>
+      }
+    }
+  }
+  return
+}
+
+// -----
+
+// Non-splat bf16: exercises the non-splat branch of repackAsI32Bytes,
+// which copies the raw byte buffer wholesale. With elements
+// {1.5, 2.5, 3.5, 4.5} the bf16 hex bytes are
+// {3FC0, 4020, 4060, 4090}; LE-packed into two i32s this gives
+// 0x40203FC0 = 1075855296 and 0x40904060 = 1083195488.
+//
+// CHECK-BF16NS-LABEL: aie.device(npu1)
+// CHECK-BF16NS:         memref.global @qbf16ns_mmio_i32 : memref<2xi32> = dense<[1075855296, 1083195488]> {air.mmio_global}
+//
+// CHECK-BF16NS-LABEL: func.func @bf16_nonsplat
+// CHECK-BF16NS:         memref.get_global @qbf16ns_mmio_i32 : memref<2xi32>
+// CHECK-BF16NS:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<2xi32>
+
+memref.global "private" @qbf16ns : memref<2x2xbf16> = dense<[[1.5, 2.5], [3.5, 4.5]]>
+air.channel @qbf16ns_chan [] {channel_type = "mmio"}
+func.func @bf16_nonsplat() {
+  %src = memref.get_global @qbf16ns : memref<2x2xbf16>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<2x2xbf16> {
+    air.channel.put @qbf16ns_chan[] (%a[] [] []) : (memref<2x2xbf16>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<2x2xbf16, 2>
+        air.channel.get @qbf16ns_chan[] (%alloc[] [] []) : (memref<2x2xbf16, 2>)
         memref.dealloc %alloc : memref<2x2xbf16, 2>
       }
     }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -18,7 +18,7 @@
 // `air_channel_mmio_invalid.mlir`. Each split here uses its own check
 // prefix so directives don't leak across split boundaries.
 
-// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST
+// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED
 
 // -----
 
@@ -147,3 +147,58 @@ func.func @bcast() {
   }
   return
 }
+
+// -----
+
+// Non-broadcast indexed mmio with a multi-tile herd: the bundled channel
+// `[N]` has N puts at constant indices and N herd-side gets at the
+// herd induction var that resolves per tile. After herd outlining each
+// tile gets its own constant-indexed get; the lowering matches one put
+// to each get and emits N blockwrites, each targeting the matching
+// tile's L1 buffer.
+//
+// This case used to be broken by `specializeChannelBundle` splitting
+// the bundle into per-position channels but leaving the host-side puts
+// orphaned on the original symbol. The fix makes that pattern skip mmio
+// channels and lets the MMIO lowering match across the bundle directly.
+//
+// CHECK-INDEXED-LABEL: aie.device(npu1)
+// CHECK-INDEXED-DAG:     memref.global @c0 : memref<8xi32> = dense<10> {air.mmio_global}
+// CHECK-INDEXED-DAG:     memref.global @c1 : memref<8xi32> = dense<20> {air.mmio_global}
+// CHECK-INDEXED-DAG:     aie.tile(0, 2)
+// CHECK-INDEXED-DAG:     aie.tile(1, 2)
+// CHECK-INDEXED-NOT:     air.channel.put @qm
+// CHECK-INDEXED-NOT:     air.channel.get @qm
+// CHECK-INDEXED-NOT:     aie.shim_dma_allocation
+//
+// CHECK-INDEXED-LABEL: func.func @indexed
+// CHECK-INDEXED:         memref.get_global @c0
+// CHECK-INDEXED:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<8xi32>
+// CHECK-INDEXED:         memref.get_global @c1
+// CHECK-INDEXED:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<8xi32>
+
+memref.global "private" @c0 : memref<8xi32> = dense<10>
+memref.global "private" @c1 : memref<8xi32> = dense<20>
+air.channel @qm [2] {channel_type = "mmio"}
+func.func @indexed() {
+  %g0 = memref.get_global @c0 : memref<8xi32>
+  %g1 = memref.get_global @c1 : memref<8xi32>
+  %c1i = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1i) args(%a0 = %g0, %a1 = %g1) : memref<8xi32>, memref<8xi32> {
+    %c0i = arith.constant 0 : index
+    %c1ii = arith.constant 1 : index
+    air.channel.put @qm[%c0i] (%a0[] [] []) : (memref<8xi32>)
+    air.channel.put @qm[%c1ii] (%a1[] [] []) : (memref<8xi32>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c2_0 = arith.constant 2 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c2_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<8xi32, 2>
+        air.channel.get @qm[%tx] (%alloc[] [] []) : (memref<8xi32, 2>)
+        memref.dealloc %alloc : memref<8xi32, 2>
+      }
+    }
+  }
+  return
+}
+

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -18,7 +18,7 @@
 // `air_channel_mmio_invalid.mlir`. Each split here uses its own check
 // prefix so directives don't leak across split boundaries.
 
-// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS
+// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS,CHECK-I8,CHECK-I16
 
 // -----
 
@@ -265,6 +265,73 @@ func.func @bf16_nonsplat() {
         %alloc = memref.alloc() : memref<2x2xbf16, 2>
         air.channel.get @qbf16ns_chan[] (%alloc[] [] []) : (memref<2x2xbf16, 2>)
         memref.dealloc %alloc : memref<2x2xbf16, 2>
+      }
+    }
+  }
+  return
+}
+
+// -----
+
+// i8 splat: exercises the bytesPerElt=1 case of the splat-expansion
+// loop, where each iteration copies a single byte. dense<66> across
+// 4 i8 elements packs into one i32 with all four bytes equal to 0x42,
+// i.e. 0x42424242 = 1111638594.
+//
+// CHECK-I8-LABEL: aie.device(npu1)
+// CHECK-I8:         memref.global @c8s_mmio_i32 : memref<1xi32> = dense<1111638594> {air.mmio_global}
+//
+// CHECK-I8-LABEL: func.func @i8_splat
+// CHECK-I8:         memref.get_global @c8s_mmio_i32 : memref<1xi32>
+// CHECK-I8:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<1xi32>
+
+memref.global "private" @c8s : memref<4xi8> = dense<66>
+air.channel @c8s_chan [] {channel_type = "mmio"}
+func.func @i8_splat() {
+  %src = memref.get_global @c8s : memref<4xi8>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<4xi8> {
+    air.channel.put @c8s_chan[] (%a[] [] []) : (memref<4xi8>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<4xi8, 2>
+        air.channel.get @c8s_chan[] (%alloc[] [] []) : (memref<4xi8, 2>)
+        memref.dealloc %alloc : memref<4xi8, 2>
+      }
+    }
+  }
+  return
+}
+
+// -----
+
+// i16 non-splat: covers the non-splat branch at a different stride
+// from the bf16 case (also 16-bit, but reaches the helper through a
+// pure-int storage path). With elements {0x1234, 0xABCD} the LE byte
+// stream is {34, 12, CD, AB}, packing into one signed i32
+// 0xABCD1234 = -1412623820.
+//
+// CHECK-I16-LABEL: aie.device(npu1)
+// CHECK-I16:         memref.global @c16ns_mmio_i32 : memref<1xi32> = dense<-1412623820> {air.mmio_global}
+//
+// CHECK-I16-LABEL: func.func @i16_nonsplat
+// CHECK-I16:         memref.get_global @c16ns_mmio_i32 : memref<1xi32>
+// CHECK-I16:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<1xi32>
+
+memref.global "private" @c16ns : memref<2xi16> = dense<[4660, -21555]>
+air.channel @c16ns_chan [] {channel_type = "mmio"}
+func.func @i16_nonsplat() {
+  %src = memref.get_global @c16ns : memref<2xi16>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<2xi16> {
+    air.channel.put @c16ns_chan[] (%a[] [] []) : (memref<2xi16>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<2xi16, 2>
+        air.channel.get @c16ns_chan[] (%alloc[] [] []) : (memref<2xi16, 2>)
+        memref.dealloc %alloc : memref<2xi16, 2>
       }
     }
   }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -5,26 +5,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Positive tests for the channel_type="mmio" lowering in air-to-aie:
-//   * the L3 put becomes aiex.npu.blockwrite targeting the matching get's
-//     L1 aie.buffer, and the get is erased;
-//   * no DMA channel, shim allocation, or aie.flow is reserved for an
-//     mmio channel;
-//   * mmio channels coexist with regular dma_stream channels;
-//   * mmio with `broadcast_shape` fans out to N back-to-back blockwrites,
-//     one per destination L1 buffer (no hardware fanout).
-//
-// The negative case (non-constant put source) is in
-// `air_channel_mmio_invalid.mlir`. Each split here uses its own check
-// prefix so directives don't leak across split boundaries.
+// Positive tests for channel_type="mmio" in air-to-aie. Each split has
+// its own CHECK prefix so directives don't leak across boundaries.
+// Negative cases live in `air_channel_mmio_invalid.mlir`.
 
 // RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS,CHECK-I8,CHECK-I16
 
 // -----
 
-// Simple one-to-one mmio transfer: put at L3 lowers to a single
-// aiex.npu.blockwrite into the L1 aie.buffer; the get is erased; no shim
-// DMA, no aie.flow.
+// One-to-one: L3 put → one blockwrite into the L1 buffer; get erased;
+// no shim DMA, no aie.flow.
 //
 // CHECK-SIMPLE-LABEL: aie.device(npu1)
 // CHECK-SIMPLE:         memref.global @const_data : memref<8xi32> = dense<42> {air.mmio_global}
@@ -64,11 +54,8 @@ func.func @mmio_simple() {
 
 // -----
 
-// An mmio channel coexists with a regular dma_stream channel without
-// interference: the dma_stream side still receives its shim DMA / flow
-// allocation, and the mmio side still lowers to a blockwrite. The
-// dma_stream put survives in the L3 control func (it lowers later in
-// AIRLoweringPass), while the mmio put and get are gone.
+// mmio + dma_stream coexist: dma_stream keeps its shim/flow allocation
+// and survives in the L3 control func; mmio lowers to blockwrite.
 //
 // CHECK-MIXED-LABEL: func.func @mixed
 // CHECK-MIXED:         memref.get_global @mmio_const
@@ -103,11 +90,8 @@ func.func @mixed(%dma_src: memref<16xi32>) {
 
 // -----
 
-// Broadcast mmio: one put with `broadcast_shape` fans out to two distinct
-// L1 buffers via two back-to-back blockwrites. There is no hardware
-// fanout for MMIO writes (unlike aie.flow), so the controller writes each
-// destination separately. Per MMIO_BENCHMARK.md this remains essentially
-// free at decode-attention payload sizes.
+// Broadcast mmio: one put with `broadcast_shape` → N back-to-back
+// blockwrites (no hardware fanout for MMIO).
 //
 // CHECK-BCAST-LABEL: aie.device(npu1)
 // CHECK-BCAST:         aie.tile(0, 2)
@@ -150,17 +134,10 @@ func.func @bcast() {
 
 // -----
 
-// Non-broadcast indexed mmio with a multi-tile herd: the bundled channel
-// `[N]` has N puts at constant indices and N herd-side gets at the
-// herd induction var that resolves per tile. After herd outlining each
-// tile gets its own constant-indexed get; the lowering matches one put
-// to each get and emits N blockwrites, each targeting the matching
-// tile's L1 buffer.
-//
-// This case used to be broken by `specializeChannelBundle` splitting
-// the bundle into per-position channels but leaving the host-side puts
-// orphaned on the original symbol. The fix makes that pattern skip mmio
-// channels and lets the MMIO lowering match across the bundle directly.
+// Indexed mmio over a `[N]` bundle on a multi-tile herd: each constant
+// index pairs one host-side put with one per-tile get, lowering to N
+// blockwrites. Regression: specializeChannelBundle used to split the
+// bundle and orphan the host-side puts (now skipped for mmio).
 //
 // CHECK-INDEXED-LABEL: aie.device(npu1)
 // CHECK-INDEXED-DAG:     memref.global @c0 : memref<8xi32> = dense<10> {air.mmio_global}
@@ -204,12 +181,9 @@ func.func @indexed() {
 
 // -----
 
-// Non-i32 element type (here splat bf16): the `aiex.npu.blockwrite`
-// translator only handles i32, so the lowering mirrors the bf16 global
-// into the device as a 1-D `memref<Nxi32>` with the same raw bytes
-// (suffixed `_mmio_i32`). Splat bf16(1.5) = 0x3FC0 packs to i32
-// 0x3FC03FC0 = 1069563840, and the resulting payload remains splat.
-// The source alignment also propagates to the i32 mirror.
+// Splat bf16: blockwrite's i32-only translator forces a `memref<Nxi32>`
+// mirror (suffixed `_mmio_i32`). bf16(1.5)=0x3FC0 → i32 0x3FC03FC0 =
+// 1069563840, splat preserved. Alignment also round-trips.
 //
 // CHECK-BF16-LABEL: aie.device(npu1)
 // CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32> = dense<1069563840> {air.mmio_global, alignment = 64 : i64}
@@ -239,11 +213,9 @@ func.func @bf16_payload() {
 
 // -----
 
-// Non-splat bf16: exercises the non-splat branch of repackAsI32Bytes,
-// which copies the raw byte buffer wholesale. With elements
-// {1.5, 2.5, 3.5, 4.5} the bf16 hex bytes are
-// {3FC0, 4020, 4060, 4090}; LE-packed into two i32s this gives
-// 0x40203FC0 = 1075855296 and 0x40904060 = 1083195488.
+// Non-splat bf16: hits the wholesale-copy branch. bf16 bytes
+// {3FC0, 4020, 4060, 4090} LE-pack to i32 {0x40203FC0, 0x40904060}
+// = {1075855296, 1083195488}.
 //
 // CHECK-BF16NS-LABEL: aie.device(npu1)
 // CHECK-BF16NS:         memref.global @qbf16ns_mmio_i32 : memref<2xi32> = dense<[1075855296, 1083195488]> {air.mmio_global}
@@ -273,10 +245,7 @@ func.func @bf16_nonsplat() {
 
 // -----
 
-// i8 splat: exercises the bytesPerElt=1 case of the splat-expansion
-// loop, where each iteration copies a single byte. dense<66> across
-// 4 i8 elements packs into one i32 with all four bytes equal to 0x42,
-// i.e. 0x42424242 = 1111638594.
+// i8 splat: bytesPerElt=1 stride. dense<66> × 4 → 0x42424242 = 1111638594.
 //
 // CHECK-I8-LABEL: aie.device(npu1)
 // CHECK-I8:         memref.global @c8s_mmio_i32 : memref<1xi32> = dense<1111638594> {air.mmio_global}
@@ -306,11 +275,8 @@ func.func @i8_splat() {
 
 // -----
 
-// i16 non-splat: covers the non-splat branch at a different stride
-// from the bf16 case (also 16-bit, but reaches the helper through a
-// pure-int storage path). With elements {0x1234, 0xABCD} the LE byte
-// stream is {34, 12, CD, AB}, packing into one signed i32
-// 0xABCD1234 = -1412623820.
+// i16 non-splat: pure-int storage path. {0x1234, 0xABCD} LE → i32
+// 0xABCD1234 = -1412623820 (signed).
 //
 // CHECK-I16-LABEL: aie.device(npu1)
 // CHECK-I16:         memref.global @c16ns_mmio_i32 : memref<1xi32> = dense<-1412623820> {air.mmio_global}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -18,7 +18,7 @@
 // `air_channel_mmio_invalid.mlir`. Each split here uses its own check
 // prefix so directives don't leak across split boundaries.
 
-// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED
+// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16
 
 // -----
 
@@ -202,3 +202,37 @@ func.func @indexed() {
   return
 }
 
+// -----
+
+// Non-i32 element type (here bf16): the `aiex.npu.blockwrite` translator
+// only handles i32 so the lowering mirrors the bf16 global into the
+// device as a 1-D `memref<Nxi32>` with the same raw bytes (suffixed
+// `_mmio_i32` to keep the original undisturbed). Blockwrite carries the
+// i32 view; the destination buffer keeps its natural bf16 type since
+// `buffer = @sym` is just a symbol ref.
+//
+// CHECK-BF16-LABEL: aie.device(npu1)
+// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32>{{.*}}{air.mmio_global}
+//
+// CHECK-BF16-LABEL: func.func @bf16_payload
+// CHECK-BF16:         memref.get_global @qbf16_mmio_i32 : memref<2xi32>
+// CHECK-BF16:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<2xi32>
+
+memref.global "private" @qbf16 : memref<2x2xbf16> = dense<1.5>
+air.channel @qbf16_chan [] {channel_type = "mmio"}
+func.func @bf16_payload() {
+  %src = memref.get_global @qbf16 : memref<2x2xbf16>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<2x2xbf16> {
+    air.channel.put @qbf16_chan[] (%a[] [] []) : (memref<2x2xbf16>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<2x2xbf16, 2>
+        air.channel.get @qbf16_chan[] (%alloc[] [] []) : (memref<2x2xbf16, 2>)
+        memref.dealloc %alloc : memref<2x2xbf16, 2>
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -8,30 +8,30 @@
 // Positive tests for channel_type="mmio" in air-to-aie. Each split has
 // its own CHECK prefix so directives don't leak across boundaries.
 // Negative cases live in `air_channel_mmio_invalid.mlir`.
+//
+// The mmio lowering stamps the source memref.global's initializer onto
+// the destination L1 aie.buffer's `initial_value` attribute.
+// AIERTControl::initBuffers loads this into the tile via
+// XAie_DataMemBlockWrite at device-init time — before any core starts —
+// which makes the data delivery race-free relative to core execution
+// and natively handles any element type (no i32 repack required).
 
-// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS,CHECK-I8,CHECK-I16
+// RUN: air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" | FileCheck %s --check-prefixes=CHECK-SIMPLE,CHECK-MIXED,CHECK-BCAST,CHECK-INDEXED,CHECK-BF16,CHECK-BF16NS,CHECK-I8
 
 // -----
 
-// One-to-one: L3 put → one blockwrite into the L1 buffer; get erased;
-// no shim DMA, no aie.flow.
+// One-to-one: L3 put → destination L1 aie.buffer's initial_value is set;
+// get/put erased; no shim DMA, no aie.flow.
 //
 // CHECK-SIMPLE-LABEL: aie.device(npu1)
-// CHECK-SIMPLE:         memref.global @const_data : memref<8xi32> = dense<42> {air.mmio_global}
 // CHECK-SIMPLE:         %[[TILE:.+]] = aie.tile(0, 2)
-// CHECK-SIMPLE:         %[[BUF:.+]] = aie.buffer(%[[TILE]]) {sym_name = "[[BUFNAME:.+]]"} : memref<8xi32, 2>
+// CHECK-SIMPLE:         %[[BUF:.+]] = aie.buffer(%[[TILE]]) {sym_name = "[[BUFNAME:.+]]"} : memref<8xi32, 2> = dense<42>
 // CHECK-SIMPLE:         aie.core(%[[TILE]])
 // CHECK-SIMPLE-NOT:     air.channel.put @mmio_chan
 // CHECK-SIMPLE-NOT:     air.channel.get @mmio_chan
 // CHECK-SIMPLE-NOT:     aie.flow
 // CHECK-SIMPLE-NOT:     aie.shim_dma_allocation
-//
-// CHECK-SIMPLE-LABEL: func.func @mmio_simple
-// CHECK-SIMPLE:         memref.get_global @const_data
-// CHECK-SIMPLE:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @[[BUFNAME]]} : memref<8xi32>
-// CHECK-SIMPLE:         air.launch
-// CHECK-SIMPLE-NOT:     air.channel.put @mmio_chan
-// CHECK-SIMPLE-NOT:     air.channel.get @mmio_chan
+// CHECK-SIMPLE-NOT:     aiex.npu.blockwrite
 
 memref.global "private" @const_data : memref<8xi32> = dense<42>
 air.channel @mmio_chan [] {channel_type = "mmio"}
@@ -55,12 +55,13 @@ func.func @mmio_simple() {
 // -----
 
 // mmio + dma_stream coexist: dma_stream keeps its shim/flow allocation
-// and survives in the L3 control func; mmio lowers to blockwrite.
+// and survives in the L3 control func; mmio sets buffer initial_value.
+//
+// CHECK-MIXED-LABEL: aie.device(npu1)
+// CHECK-MIXED:         aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<8xi32, 2> = dense<7>
+// CHECK-MIXED-NOT:     aiex.npu.blockwrite
 //
 // CHECK-MIXED-LABEL: func.func @mixed
-// CHECK-MIXED:         memref.get_global @mmio_const
-// CHECK-MIXED:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<8xi32>
-// CHECK-MIXED:         air.launch
 // CHECK-MIXED-NOT:     air.channel.put @mmio_chan2
 // CHECK-MIXED-NOT:     air.channel.get @mmio_chan2
 
@@ -90,26 +91,19 @@ func.func @mixed(%dma_src: memref<16xi32>) {
 
 // -----
 
-// Broadcast mmio: one put with `broadcast_shape` → N back-to-back
-// blockwrites (no hardware fanout for MMIO).
+// Broadcast mmio: one put with `broadcast_shape` stamps the same
+// initial_value onto each destination L1 buffer.
 //
 // CHECK-BCAST-LABEL: aie.device(npu1)
 // CHECK-BCAST:         aie.tile(0, 2)
 // CHECK-BCAST:         aie.tile(0, 3)
-// CHECK-BCAST-DAG:     aie.buffer(%{{.+}}) {sym_name = "[[BUF0:.+]]"} : memref<8xi32, 2>
-// CHECK-BCAST-DAG:     aie.buffer(%{{.+}}) {sym_name = "[[BUF1:.+]]"} : memref<8xi32, 2>
+// CHECK-BCAST-DAG:     aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<8xi32, 2> = dense<5>
+// CHECK-BCAST-DAG:     aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<8xi32, 2> = dense<5>
 // CHECK-BCAST-NOT:     air.channel.put @bcast_mmio
 // CHECK-BCAST-NOT:     air.channel.get @bcast_mmio
 // CHECK-BCAST-NOT:     aie.flow
 // CHECK-BCAST-NOT:     aie.shim_dma_allocation
-//
-// CHECK-BCAST-LABEL: func.func @bcast
-// CHECK-BCAST:         memref.get_global @const_q
-// CHECK-BCAST:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{buf[01]}}} : memref<8xi32>
-// CHECK-BCAST:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{buf[01]}}} : memref<8xi32>
-// CHECK-BCAST:         air.launch
-// CHECK-BCAST-NOT:     air.channel.put @bcast_mmio
-// CHECK-BCAST-NOT:     air.channel.get @bcast_mmio
+// CHECK-BCAST-NOT:     aiex.npu.blockwrite
 
 memref.global "private" @const_q : memref<8xi32> = dense<5>
 air.channel @bcast_mmio [1] {channel_type = "mmio", broadcast_shape = [2]}
@@ -135,24 +129,20 @@ func.func @bcast() {
 // -----
 
 // Indexed mmio over a `[N]` bundle on a multi-tile herd: each constant
-// index pairs one host-side put with one per-tile get, lowering to N
-// blockwrites. Regression: specializeChannelBundle used to split the
-// bundle and orphan the host-side puts (now skipped for mmio).
+// index pairs one host-side put with one per-tile get; each destination
+// buffer gets its own initial_value. Regression: specializeChannelBundle
+// used to split the bundle and orphan the host-side puts (now skipped
+// for mmio).
 //
 // CHECK-INDEXED-LABEL: aie.device(npu1)
-// CHECK-INDEXED-DAG:     memref.global @c0 : memref<8xi32> = dense<10> {air.mmio_global}
-// CHECK-INDEXED-DAG:     memref.global @c1 : memref<8xi32> = dense<20> {air.mmio_global}
 // CHECK-INDEXED-DAG:     aie.tile(0, 2)
 // CHECK-INDEXED-DAG:     aie.tile(1, 2)
+// CHECK-INDEXED-DAG:     aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<8xi32, 2> = dense<10>
+// CHECK-INDEXED-DAG:     aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<8xi32, 2> = dense<20>
 // CHECK-INDEXED-NOT:     air.channel.put @qm
 // CHECK-INDEXED-NOT:     air.channel.get @qm
 // CHECK-INDEXED-NOT:     aie.shim_dma_allocation
-//
-// CHECK-INDEXED-LABEL: func.func @indexed
-// CHECK-INDEXED:         memref.get_global @c0
-// CHECK-INDEXED:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<8xi32>
-// CHECK-INDEXED:         memref.get_global @c1
-// CHECK-INDEXED:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<8xi32>
+// CHECK-INDEXED-NOT:     aiex.npu.blockwrite
 
 memref.global "private" @c0 : memref<8xi32> = dense<10>
 memref.global "private" @c1 : memref<8xi32> = dense<20>
@@ -181,18 +171,15 @@ func.func @indexed() {
 
 // -----
 
-// Splat bf16: blockwrite's i32-only translator forces a `memref<Nxi32>`
-// mirror (suffixed `_mmio_i32`). bf16(1.5)=0x3FC0 → i32 0x3FC03FC0 =
-// 1069563840, splat preserved. Alignment also round-trips.
+// Splat bf16: AIERTControl::initBuffers handles float types natively
+// (XAie_DataMemBlockWrite copies APFloat bytes), so no i32 repack — the
+// destination bf16 buffer takes the bf16 splat directly.
 //
 // CHECK-BF16-LABEL: aie.device(npu1)
-// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32> = dense<1069563840> {air.mmio_global, alignment = 64 : i64}
-//
-// CHECK-BF16-LABEL: func.func @bf16_payload
-// CHECK-BF16:         memref.get_global @qbf16_mmio_i32 : memref<2xi32>
-// CHECK-BF16:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<2xi32>
+// CHECK-BF16:         aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<2x2xbf16, 2> = dense<1.500000e+00>
+// CHECK-BF16-NOT:     aiex.npu.blockwrite
 
-memref.global "private" @qbf16 : memref<2x2xbf16> = dense<1.5> {alignment = 64 : i64}
+memref.global "private" @qbf16 : memref<2x2xbf16> = dense<1.5>
 air.channel @qbf16_chan [] {channel_type = "mmio"}
 func.func @bf16_payload() {
   %src = memref.get_global @qbf16 : memref<2x2xbf16>
@@ -213,16 +200,12 @@ func.func @bf16_payload() {
 
 // -----
 
-// Non-splat bf16: hits the wholesale-copy branch. bf16 bytes
-// {3FC0, 4020, 4060, 4090} LE-pack to i32 {0x40203FC0, 0x40904060}
-// = {1075855296, 1083195488}.
+// Non-splat bf16: same path, full element list preserved on the
+// destination buffer.
 //
 // CHECK-BF16NS-LABEL: aie.device(npu1)
-// CHECK-BF16NS:         memref.global @qbf16ns_mmio_i32 : memref<2xi32> = dense<[1075855296, 1083195488]> {air.mmio_global}
-//
-// CHECK-BF16NS-LABEL: func.func @bf16_nonsplat
-// CHECK-BF16NS:         memref.get_global @qbf16ns_mmio_i32 : memref<2xi32>
-// CHECK-BF16NS:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<2xi32>
+// CHECK-BF16NS:         aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<2x2xbf16, 2> = dense<{{\[}}{{\[}}1.500000e+00, 2.500000e+00{{\]}}, {{\[}}3.500000e+00, 4.500000e+00{{\]}}{{\]}}>
+// CHECK-BF16NS-NOT:     aiex.npu.blockwrite
 
 memref.global "private" @qbf16ns : memref<2x2xbf16> = dense<[[1.5, 2.5], [3.5, 4.5]]>
 air.channel @qbf16ns_chan [] {channel_type = "mmio"}
@@ -245,14 +228,13 @@ func.func @bf16_nonsplat() {
 
 // -----
 
-// i8 splat: bytesPerElt=1 stride. dense<66> × 4 → 0x42424242 = 1111638594.
+// i8 splat: integer types are also handled natively by initBuffers
+// (XAie_DataMemBlockWrite copies APInt bytes), so the destination i8
+// buffer takes the i8 splat as-is.
 //
 // CHECK-I8-LABEL: aie.device(npu1)
-// CHECK-I8:         memref.global @c8s_mmio_i32 : memref<1xi32> = dense<1111638594> {air.mmio_global}
-//
-// CHECK-I8-LABEL: func.func @i8_splat
-// CHECK-I8:         memref.get_global @c8s_mmio_i32 : memref<1xi32>
-// CHECK-I8:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<1xi32>
+// CHECK-I8:         aie.buffer(%{{.+}}) {sym_name = "{{.+}}"} : memref<4xi8, 2> = dense<66>
+// CHECK-I8-NOT:     aiex.npu.blockwrite
 
 memref.global "private" @c8s : memref<4xi8> = dense<66>
 air.channel @c8s_chan [] {channel_type = "mmio"}
@@ -267,37 +249,6 @@ func.func @i8_splat() {
         %alloc = memref.alloc() : memref<4xi8, 2>
         air.channel.get @c8s_chan[] (%alloc[] [] []) : (memref<4xi8, 2>)
         memref.dealloc %alloc : memref<4xi8, 2>
-      }
-    }
-  }
-  return
-}
-
-// -----
-
-// i16 non-splat: pure-int storage path. {0x1234, 0xABCD} LE → i32
-// 0xABCD1234 = -1412623820 (signed).
-//
-// CHECK-I16-LABEL: aie.device(npu1)
-// CHECK-I16:         memref.global @c16ns_mmio_i32 : memref<1xi32> = dense<-1412623820> {air.mmio_global}
-//
-// CHECK-I16-LABEL: func.func @i16_nonsplat
-// CHECK-I16:         memref.get_global @c16ns_mmio_i32 : memref<1xi32>
-// CHECK-I16:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<1xi32>
-
-memref.global "private" @c16ns : memref<2xi16> = dense<[4660, -21555]>
-air.channel @c16ns_chan [] {channel_type = "mmio"}
-func.func @i16_nonsplat() {
-  %src = memref.get_global @c16ns : memref<2xi16>
-  %c1 = arith.constant 1 : index
-  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<2xi16> {
-    air.channel.put @c16ns_chan[] (%a[] [] []) : (memref<2xi16>)
-    air.segment @seg {
-      %c1_0 = arith.constant 1 : index
-      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
-        %alloc = memref.alloc() : memref<2xi16, 2>
-        air.channel.get @c16ns_chan[] (%alloc[] [] []) : (memref<2xi16, 2>)
-        memref.dealloc %alloc : memref<2xi16, 2>
       }
     }
   }

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio.mlir
@@ -209,15 +209,16 @@ func.func @indexed() {
 // into the device as a 1-D `memref<Nxi32>` with the same raw bytes
 // (suffixed `_mmio_i32`). Splat bf16(1.5) = 0x3FC0 packs to i32
 // 0x3FC03FC0 = 1069563840, and the resulting payload remains splat.
+// The source alignment also propagates to the i32 mirror.
 //
 // CHECK-BF16-LABEL: aie.device(npu1)
-// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32> = dense<1069563840> {air.mmio_global}
+// CHECK-BF16:         memref.global @qbf16_mmio_i32 : memref<2xi32> = dense<1069563840> {air.mmio_global, alignment = 64 : i64}
 //
 // CHECK-BF16-LABEL: func.func @bf16_payload
 // CHECK-BF16:         memref.get_global @qbf16_mmio_i32 : memref<2xi32>
 // CHECK-BF16:         aiex.npu.blockwrite(%{{.+}}) {address = 0 : ui32, buffer = @{{.+}}} : memref<2xi32>
 
-memref.global "private" @qbf16 : memref<2x2xbf16> = dense<1.5>
+memref.global "private" @qbf16 : memref<2x2xbf16> = dense<1.5> {alignment = 64 : i64}
 air.channel @qbf16_chan [] {channel_type = "mmio"}
 func.func @bf16_payload() {
   %src = memref.get_global @qbf16 : memref<2x2xbf16>

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -10,8 +10,9 @@
 
 // RUN: not air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" 2>&1 | FileCheck %s
 
-// blockwrite encodes data directly in the instruction stream, so the
-// put source must be a compile-time constant.
+// The source data is stamped onto the destination L1 buffer's
+// initial_value, so the put source must be a compile-time constant
+// memref.global.
 // CHECK: channel_type="mmio" put requires source memref defined by memref.get_global
 air.channel @mmio_nc [] {channel_type = "mmio"}
 func.func @mmio_nonconst(%h: memref<8xi32>) {
@@ -82,26 +83,44 @@ func.func @mmio_no_match() {
 
 // -----
 
-// V1: source memref.global must have no users outside the put's func,
-// or the post-airrt-to-npu `symbol-dce` (tools/aircc/aircc.cpp) can't
-// drop the module-level original → llvm.mlir.global collision.
-// CHECK: channel_type="mmio" V1 requires the source memref.global to be used only inside the func containing the put
-memref.global "private" @shared_const : memref<8xi32> = dense<3>
-air.channel @sc_chan [] {channel_type = "mmio"}
-func.func @other_user() -> memref<8xi32> {
-  %g = memref.get_global @shared_const : memref<8xi32>
-  return %g : memref<8xi32>
-}
-func.func @mmio_shared_global() {
-  %src = memref.get_global @shared_const : memref<8xi32>
+// The destination L1 buffer's element type must match the source so the
+// initializer is type-compatible.
+// CHECK: channel_type="mmio" source/destination element type mismatch
+memref.global "private" @i32_src : memref<4xi32> = dense<7>
+air.channel @typemis_chan [] {channel_type = "mmio"}
+func.func @mmio_type_mismatch() {
+  %src = memref.get_global @i32_src : memref<4xi32>
   %c1 = arith.constant 1 : index
-  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<8xi32> {
-    air.channel.put @sc_chan[] (%a[] [] []) : (memref<8xi32>)
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<4xi32> {
+    air.channel.put @typemis_chan[] (%a[] [] []) : (memref<4xi32>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<4xbf16, 2>
+        air.channel.get @typemis_chan[] (%alloc[] [] []) : (memref<4xbf16, 2>)
+        memref.dealloc %alloc : memref<4xbf16, 2>
+      }
+    }
+  }
+  return
+}
+
+// -----
+
+// Source/destination must agree on total element count.
+// CHECK: channel_type="mmio" source/destination element count mismatch
+memref.global "private" @short_src : memref<4xi32> = dense<7>
+air.channel @sizemis_chan [] {channel_type = "mmio"}
+func.func @mmio_size_mismatch() {
+  %src = memref.get_global @short_src : memref<4xi32>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<4xi32> {
+    air.channel.put @sizemis_chan[] (%a[] [] []) : (memref<4xi32>)
     air.segment @seg {
       %c1_0 = arith.constant 1 : index
       air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
         %alloc = memref.alloc() : memref<8xi32, 2>
-        air.channel.get @sc_chan[] (%alloc[] [] []) : (memref<8xi32, 2>)
+        air.channel.get @sizemis_chan[] (%alloc[] [] []) : (memref<8xi32, 2>)
         memref.dealloc %alloc : memref<8xi32, 2>
       }
     }
@@ -111,57 +130,9 @@ func.func @mmio_shared_global() {
 
 // -----
 
-// Sub-byte / non-byte-aligned element types have no portable raw-byte
-// repack; reject up front.
-// CHECK: channel_type="mmio" source element bitwidth must be a positive multiple of 8
-memref.global "private" @i1_const : memref<32xi1> = dense<true>
-air.channel @i1_chan [] {channel_type = "mmio"}
-func.func @mmio_subbyte_elt() {
-  %src = memref.get_global @i1_const : memref<32xi1>
-  %c1 = arith.constant 1 : index
-  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<32xi1> {
-    air.channel.put @i1_chan[] (%a[] [] []) : (memref<32xi1>)
-    air.segment @seg {
-      %c1_0 = arith.constant 1 : index
-      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
-        %alloc = memref.alloc() : memref<32xi1, 2>
-        air.channel.get @i1_chan[] (%alloc[] [] []) : (memref<32xi1, 2>)
-        memref.dealloc %alloc : memref<32xi1, 2>
-      }
-    }
-  }
-  return
-}
-
-// -----
-
-// blockwrite is i32-granular; payloads not a multiple of 4 bytes
-// (here 3 bf16 = 6 bytes) can't be repacked to memref<Nxi32>.
-// CHECK: channel_type="mmio" source size must be a multiple of 4 bytes (got 6)
-memref.global "private" @bf16_unaligned : memref<3xbf16> = dense<1.5>
-air.channel @bf16u_chan [] {channel_type = "mmio"}
-func.func @mmio_unaligned_payload() {
-  %src = memref.get_global @bf16_unaligned : memref<3xbf16>
-  %c1 = arith.constant 1 : index
-  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<3xbf16> {
-    air.channel.put @bf16u_chan[] (%a[] [] []) : (memref<3xbf16>)
-    air.segment @seg {
-      %c1_0 = arith.constant 1 : index
-      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
-        %alloc = memref.alloc() : memref<3xbf16, 2>
-        air.channel.get @bf16u_chan[] (%alloc[] [] []) : (memref<3xbf16, 2>)
-        memref.dealloc %alloc : memref<3xbf16, 2>
-      }
-    }
-  }
-  return
-}
-
-// -----
-
-// Repack needs a DenseElementsAttr initializer; a pure declaration
-// (no `= dense<...>`) used to crash on the optional dereference.
-// CHECK: channel_type="mmio" non-i32 source requires a DenseElementsAttr initializer on the memref.global
+// initial_value is set by the lowering, so the source memref.global
+// needs a DenseElementsAttr initializer to copy from.
+// CHECK: channel_type="mmio" source memref.global must have a DenseElementsAttr initializer
 memref.global "private" @uninit_bf16 : memref<2x2xbf16>
 air.channel @uninit_chan [] {channel_type = "mmio"}
 func.func @mmio_uninitialized_global() {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -112,3 +112,29 @@ func.func @mmio_shared_global() {
   }
   return
 }
+
+// -----
+
+// Sub-byte (e.g. i1) and other non-byte-aligned element types have no
+// portable raw-byte representation and would make the (elts*bits)/8
+// repack accounting lossy. Reject them up front rather than emitting
+// a malformed blockwrite.
+// CHECK: channel_type="mmio" source element bitwidth must be a positive multiple of 8
+memref.global "private" @i1_const : memref<32xi1> = dense<true>
+air.channel @i1_chan [] {channel_type = "mmio"}
+func.func @mmio_subbyte_elt() {
+  %src = memref.get_global @i1_const : memref<32xi1>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<32xi1> {
+    air.channel.put @i1_chan[] (%a[] [] []) : (memref<32xi1>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<32xi1, 2>
+        air.channel.get @i1_chan[] (%alloc[] [] []) : (memref<32xi1, 2>)
+        memref.dealloc %alloc : memref<32xi1, 2>
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -163,3 +163,29 @@ func.func @mmio_unaligned_payload() {
   }
   return
 }
+
+// -----
+
+// Repack needs concrete bytes from the source memref.global. A pure
+// declaration (no `= dense<...>` initializer) has none, and previously
+// crashed via `std::optional::operator*` on getInitialValue(). Reject
+// with a clean diagnostic.
+// CHECK: channel_type="mmio" non-i32 source requires a DenseElementsAttr initializer on the memref.global
+memref.global "private" @uninit_bf16 : memref<2x2xbf16>
+air.channel @uninit_chan [] {channel_type = "mmio"}
+func.func @mmio_uninitialized_global() {
+  %src = memref.get_global @uninit_bf16 : memref<2x2xbf16>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<2x2xbf16> {
+    air.channel.put @uninit_chan[] (%a[] [] []) : (memref<2x2xbf16>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<2x2xbf16, 2>
+        air.channel.get @uninit_chan[] (%alloc[] [] []) : (memref<2x2xbf16, 2>)
+        memref.dealloc %alloc : memref<2x2xbf16, 2>
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -5,14 +5,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Negative tests for the channel_type="mmio" lowering. Each split is run
-// individually with `not` so the FileCheck directive after it sees only
-// that split's diagnostic.
+// Negative tests for channel_type="mmio". Each split runs under `not`
+// so FileCheck sees only that split's diagnostic.
 
 // RUN: not air-opt %s -split-input-file -air-to-aie="row-offset=2 col-offset=0 device=npu1" 2>&1 | FileCheck %s
 
-// The runtime-sequence blockwrite encodes the data directly in the
-// instruction stream, so the put source must be a compile-time constant.
+// blockwrite encodes data directly in the instruction stream, so the
+// put source must be a compile-time constant.
 // CHECK: channel_type="mmio" put requires source memref defined by memref.get_global
 air.channel @mmio_nc [] {channel_type = "mmio"}
 func.func @mmio_nonconst(%h: memref<8xi32>) {
@@ -33,9 +32,8 @@ func.func @mmio_nonconst(%h: memref<8xi32>) {
 
 // -----
 
-// Non-broadcast mmio with a non-constant index would silently fail to
-// match any device-side get and the put would be erased with no
-// blockwrite emitted. Reject up front.
+// Non-broadcast mmio with non-constant index can't match any get;
+// would silently erase the put. Reject up front.
 // CHECK: channel_type="mmio" non-broadcast put requires compile-time constant indices
 memref.global "private" @nci_const : memref<8xi32> = dense<1>
 air.channel @nci_chan [1] {channel_type = "mmio"}
@@ -59,8 +57,7 @@ func.func @mmio_nonconst_index(%n: index) {
 
 // -----
 
-// Non-broadcast put whose constant index does not match any device-side
-// get would otherwise be erased with no blockwrite emitted.
+// Constant-index put with no matching get would be silently erased.
 // CHECK: channel_type="mmio" put has no matching device-side air.channel.get
 memref.global "private" @nm_const : memref<8xi32> = dense<2>
 air.channel @nm_chan [2] {channel_type = "mmio"}
@@ -85,11 +82,9 @@ func.func @mmio_no_match() {
 
 // -----
 
-// V1 limitation: the source memref.global must have no users outside the
-// func containing the put — otherwise the `symbol-dce` pass run after
-// `airrt-to-npu` (in tools/aircc/aircc.cpp's NPU pipeline) can't remove
-// the module-level original and a duplicate-symbol collision occurs in
-// LLVM lowering.
+// V1: source memref.global must have no users outside the put's func,
+// or the post-airrt-to-npu `symbol-dce` (tools/aircc/aircc.cpp) can't
+// drop the module-level original → llvm.mlir.global collision.
 // CHECK: channel_type="mmio" V1 requires the source memref.global to be used only inside the func containing the put
 memref.global "private" @shared_const : memref<8xi32> = dense<3>
 air.channel @sc_chan [] {channel_type = "mmio"}
@@ -116,10 +111,8 @@ func.func @mmio_shared_global() {
 
 // -----
 
-// Sub-byte (e.g. i1) and other non-byte-aligned element types have no
-// portable raw-byte representation and would make the (elts*bits)/8
-// repack accounting lossy. Reject them up front rather than emitting
-// a malformed blockwrite.
+// Sub-byte / non-byte-aligned element types have no portable raw-byte
+// repack; reject up front.
 // CHECK: channel_type="mmio" source element bitwidth must be a positive multiple of 8
 memref.global "private" @i1_const : memref<32xi1> = dense<true>
 air.channel @i1_chan [] {channel_type = "mmio"}
@@ -142,9 +135,8 @@ func.func @mmio_subbyte_elt() {
 
 // -----
 
-// blockwrite is i32-granular on the wire. A byte-aligned element type
-// whose total payload size isn't a multiple of 4 bytes (here 3 bf16 = 6
-// bytes) cannot be safely repacked to memref<Nxi32>; reject up front.
+// blockwrite is i32-granular; payloads not a multiple of 4 bytes
+// (here 3 bf16 = 6 bytes) can't be repacked to memref<Nxi32>.
 // CHECK: channel_type="mmio" source size must be a multiple of 4 bytes (got 6)
 memref.global "private" @bf16_unaligned : memref<3xbf16> = dense<1.5>
 air.channel @bf16u_chan [] {channel_type = "mmio"}
@@ -167,10 +159,8 @@ func.func @mmio_unaligned_payload() {
 
 // -----
 
-// Repack needs concrete bytes from the source memref.global. A pure
-// declaration (no `= dense<...>` initializer) has none, and previously
-// crashed via `std::optional::operator*` on getInitialValue(). Reject
-// with a clean diagnostic.
+// Repack needs a DenseElementsAttr initializer; a pure declaration
+// (no `= dense<...>`) used to crash on the optional dereference.
 // CHECK: channel_type="mmio" non-i32 source requires a DenseElementsAttr initializer on the memref.global
 memref.global "private" @uninit_bf16 : memref<2x2xbf16>
 air.channel @uninit_chan [] {channel_type = "mmio"}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -86,9 +86,10 @@ func.func @mmio_no_match() {
 // -----
 
 // V1 limitation: the source memref.global must have no users outside the
-// func containing the put — otherwise symbol-dce later in the pipeline
-// can't remove the module-level original and a duplicate-symbol
-// collision occurs in LLVM lowering.
+// func containing the put — otherwise the `symbol-dce` pass run after
+// `airrt-to-npu` (in tools/aircc/aircc.cpp's NPU pipeline) can't remove
+// the module-level original and a duplicate-symbol collision occurs in
+// LLVM lowering.
 // CHECK: channel_type="mmio" V1 requires the source memref.global to be used only inside the func containing the put
 memref.global "private" @shared_const : memref<8xi32> = dense<3>
 air.channel @sc_chan [] {channel_type = "mmio"}

--- a/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_mmio_invalid.mlir
@@ -138,3 +138,28 @@ func.func @mmio_subbyte_elt() {
   }
   return
 }
+
+// -----
+
+// blockwrite is i32-granular on the wire. A byte-aligned element type
+// whose total payload size isn't a multiple of 4 bytes (here 3 bf16 = 6
+// bytes) cannot be safely repacked to memref<Nxi32>; reject up front.
+// CHECK: channel_type="mmio" source size must be a multiple of 4 bytes (got 6)
+memref.global "private" @bf16_unaligned : memref<3xbf16> = dense<1.5>
+air.channel @bf16u_chan [] {channel_type = "mmio"}
+func.func @mmio_unaligned_payload() {
+  %src = memref.get_global @bf16_unaligned : memref<3xbf16>
+  %c1 = arith.constant 1 : index
+  air.launch (%lx) in (%sx = %c1) args(%a = %src) : memref<3xbf16> {
+    air.channel.put @bf16u_chan[] (%a[] [] []) : (memref<3xbf16>)
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile (%tx, %ty) in (%nx = %c1_0, %ny = %c1_0) {
+        %alloc = memref.alloc() : memref<3xbf16, 2>
+        air.channel.get @bf16u_chan[] (%alloc[] [] []) : (memref<3xbf16, 2>)
+        memref.dealloc %alloc : memref<3xbf16, 2>
+      }
+    }
+  }
+  return
+}

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1118,9 +1118,6 @@ static LogicalResult runAieCompilation() {
       os << ",affine-expand-index-ops";
       os << ",canonicalize,cse";
       os << "," << airrtToNpuPass;
-      // symbol-dce: drop module-level globals orphaned by mmio lowering
-      // before aiecc promotes them to llvm.mlir.global at module scope.
-      os << ",symbol-dce";
       os << ",canonicalize,cse";
       os << ")";
     }


### PR DESCRIPTION
## Summary

Follow-up to #1568. Three independent bugs surfaced when using `channel_type=\"mmio\"` beyond the single-tile i32-only positive lit test that landed there. Each is a small, focused fix with a corresponding lit-test addition.

### 1. `air-dma-to-channel` shim-pressure auto-upgrade clobbered mmio channels

The pressure heuristic counted L3-bound mmio channels in the shim S2MM/MM2S budget and force-flipped them to `dma_packet` once the limit was exceeded — destroying the type tag before the mmio lowering ran. mmio is runtime-sequence MMIO writes, not shim DMA, so it neither contributes to pressure nor is eligible for upgrade. Skip them at the top of the channel-collection loop.

### 2. `specializeChannelBundle` orphaned the host-side puts of multi-tile non-broadcast mmio channels

`specializeChannelBundle` splits a `[N]`-sized channel into N single-position channels and rewrites all matching put/get ops *inside the device*. The host-side puts on the bundled symbol live outside the device and don't get rewritten, so for an mmio channel of size `[N>1]` they were left orphaned while the per-tile gets had been moved to new specialized channel names. The mmio lowering then saw N hostPuts on the bundled channel with 0 matching device-side gets and rejected with `\"channel_type=\\\"mmio\\\" put has no matching device-side air.channel.get\"`. Skip mmio channels in the bundle pattern; `lowerAIRMMIOChannelOps` already matches host puts to per-core gets across the bundle by constant index.

### 3. `aiex.npu.blockwrite` translator only accepts i32 element type

A bf16 source memref hit the warning `\"Only 32-bit data type is supported for now\"` from `AIETranslateNpuToBinary` and then segfaulted. The destination `aie.buffer` type is irrelevant on the wire (`buffer = @sym` is just a symbol ref), so the fix is local to the data side: when the original `memref.global` isn't already i32-typed, mirror it into the device as a 1-D `memref<Nxi32>` with the same raw bytes (suffixed `_mmio_i32`) and reference that from the blockwrite. Splat attributes are expanded to a full byte buffer before reinterpretation so they don't trip the `getRaw` size assertion.

## Test plan

- [x] All 379 existing `check-air-mlir` lit tests still pass (one pre-existing unrelated failure on origin/main, unchanged)
- [x] Two new positive lit tests in `air_channel_mmio.mlir` (CHECK-INDEXED for #2, CHECK-BF16 for #3)
- [x] The existing `mmio.py` programming example still PASSes on local NPU2 hardware
- [x] An `[8,1]`-herd attention example built on top of these fixes (using non-broadcast indexed mmio for Q + bf16 payload) compiles end-to-end through aircc and reaches the runtime; correctness debugging continues separately and is out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)