### PR TITLE
[multi-gpu] Phase 4: air-symmetric-alloc-to-mgpu lowering pass

### DIFF
--- a/mlir/include/air/Conversion/AIRSymmetricAllocToMgpuPass.h
+++ b/mlir/include/air/Conversion/AIRSymmetricAllocToMgpuPass.h
@@ -1,0 +1,22 @@
+//===- AIRSymmetricAllocToMgpuPass.h ----------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===-----------------------------------------------------------------------===//
+
+#ifndef AIR_CONVERSION_AIR_SYMMETRIC_ALLOC_TO_MGPU_PASS_H
+#define AIR_CONVERSION_AIR_SYMMETRIC_ALLOC_TO_MGPU_PASS_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace xilinx {
+namespace air {
+
+std::unique_ptr<mlir::Pass> createAIRSymmetricAllocToMgpuPass();
+
+} // namespace air
+} // namespace xilinx
+
+#endif // AIR_CONVERSION_AIR_SYMMETRIC_ALLOC_TO_MGPU_PASS_H

--- a/mlir/include/air/Conversion/GPUPassDetail.h
+++ b/mlir/include/air/Conversion/GPUPassDetail.h
@@ -28,6 +28,7 @@ using namespace mlir;
 #define GEN_PASS_DEF_CONVERTAIRTOROCDL
 #define GEN_PASS_DEF_CONVERTGPUKERNELOUTLINE
 #define GEN_PASS_DEF_AIRRANKTOMGPU
+#define GEN_PASS_DEF_AIRSYMMETRICALLOCTOMGPU
 #include "air/Conversion/GPUPasses.h.inc"
 
 } // namespace air

--- a/mlir/include/air/Conversion/GPUPasses.td
+++ b/mlir/include/air/Conversion/GPUPasses.td
@@ -49,6 +49,29 @@ def ConvertGPUKernelOutline : Pass<"air-gpu-outlining", "ModuleOp"> {
   let options = [];
 }
 
+def AIRSymmetricAllocToMgpu : Pass<"air-symmetric-alloc-to-mgpu", "ModuleOp"> {
+  let summary = "Lower memref.alloc {air.symmetric} to mgpuSymmetricAlloc and "
+                "memref.dealloc of the result to mgpuSymmetricFree";
+  let constructor = "xilinx::air::createAIRSymmetricAllocToMgpuPass()";
+  let description = [{
+    Replaces each `memref.alloc` carrying the unit attribute `air.symmetric`
+    with a call to `mgpuSymmetricAlloc(size_in_bytes, stream)` returning
+    `!llvm.ptr`, then builds an LLVM memref descriptor (struct) wrapping that
+    pointer and projects it back to the original memref type via
+    `builtin.unrealized_conversion_cast` so downstream uses keep working.
+
+    For every `memref.dealloc` whose operand traces back (through a single
+    `unrealized_conversion_cast`) to such a symmetric alloc, the pass emits
+    `mgpuSymmetricFree(ptr, stream)` and erases the dealloc.
+
+    Should run before `convert-to-llvm`. Does nothing if no `air.symmetric`
+    allocations are present.
+  }];
+  let dependentDialects = [
+    "func::FuncDialect", "arith::ArithDialect", "LLVM::LLVMDialect"
+  ];
+}
+
 def AIRRankToMgpu : Pass<"air-rank-to-mgpu", "ModuleOp"> {
   let summary = "Lower air.rank to mgpu* runtime calls (multi-GPU process model)";
   let constructor = "xilinx::air::createAIRRankToMgpuPass()";

--- a/mlir/lib/Conversion/AIRSymmetricAllocToMgpuPass.cpp
+++ b/mlir/lib/Conversion/AIRSymmetricAllocToMgpuPass.cpp
@@ -1,0 +1,198 @@
+//===- AIRSymmetricAllocToMgpuPass.cpp -------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===-----------------------------------------------------------------------===//
+//
+// Lower memref.alloc carrying the `air.symmetric` attribute to a call to the
+// runtime function `mgpuSymmetricAlloc`. The returned `!llvm.ptr` is wrapped
+// in an LLVM memref descriptor (struct) and projected back to the original
+// memref type via `builtin.unrealized_conversion_cast` so that downstream
+// uses keep working.
+//
+// `memref.dealloc` ops whose operand traces (through a single
+// `unrealized_conversion_cast`) back to a symmetric alloc are rewritten to
+// `mgpuSymmetricFree`.
+//
+//===-----------------------------------------------------------------------===//
+
+#include "air/Conversion/AIRSymmetricAllocToMgpuPass.h"
+#include "air/Conversion/GPUPassDetail.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace xilinx;
+
+namespace {
+
+// Ensure a private extern func declaration exists at module scope.
+static func::FuncOp ensureExternFunc(ModuleOp module, OpBuilder &builder,
+                                     StringRef name, FunctionType type) {
+  if (auto fn = module.lookupSymbol<func::FuncOp>(name))
+    return fn;
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(module.getBody());
+  auto fn = func::FuncOp::create(builder, module.getLoc(), name, type);
+  fn.setPrivate();
+  return fn;
+}
+
+// Compute the byte size of a static-shaped memref as an i64 SSA value.
+// Returns nullptr if the memref is dynamically shaped.
+static Value computeMemrefByteSize(OpBuilder &b, Location loc, MemRefType ty) {
+  if (!ty.hasStaticShape())
+    return nullptr;
+  int64_t numElts = 1;
+  for (int64_t d : ty.getShape())
+    numElts *= d;
+  unsigned eltBits = ty.getElementType().getIntOrFloatBitWidth();
+  if (eltBits == 0 || (eltBits % 8) != 0)
+    return nullptr;
+  int64_t totalBytes = numElts * (eltBits / 8);
+  return arith::ConstantOp::create(b, loc, b.getI64Type(),
+                                   b.getI64IntegerAttr(totalBytes));
+}
+
+// Build an LLVM memref descriptor struct populated with the given pointer.
+// For now we support only static-shape, contiguous, identity-layout memrefs
+// without an offset. For dimensions: sizes from the type, strides as
+// row-major (innermost stride = 1).
+static Value buildMemrefDescriptor(OpBuilder &b, Location loc,
+                                   MemRefType memrefTy, Value ptr) {
+  ArrayRef<int64_t> shape = memrefTy.getShape();
+  unsigned rank = shape.size();
+  auto i64Ty = b.getI64Type();
+  auto ptrTy = LLVM::LLVMPointerType::get(b.getContext());
+
+  // Build the descriptor type: !llvm.struct<(ptr, ptr, i64, array<R x i64>,
+  // array<R x i64>)>. For rank-0 memrefs, MLIR omits the size/stride arrays.
+  SmallVector<Type, 5> descFields;
+  descFields.push_back(ptrTy);
+  descFields.push_back(ptrTy);
+  descFields.push_back(i64Ty);
+  if (rank > 0) {
+    descFields.push_back(LLVM::LLVMArrayType::get(i64Ty, rank));
+    descFields.push_back(LLVM::LLVMArrayType::get(i64Ty, rank));
+  }
+  auto structTy = LLVM::LLVMStructType::getLiteral(b.getContext(), descFields);
+
+  Value desc = LLVM::PoisonOp::create(b, loc, structTy);
+  desc = LLVM::InsertValueOp::create(b, loc, desc, ptr, ArrayRef<int64_t>{0});
+  desc = LLVM::InsertValueOp::create(b, loc, desc, ptr, ArrayRef<int64_t>{1});
+  Value zero = LLVM::ConstantOp::create(b, loc, i64Ty, b.getI64IntegerAttr(0));
+  desc = LLVM::InsertValueOp::create(b, loc, desc, zero, ArrayRef<int64_t>{2});
+
+  if (rank > 0) {
+    // Compute row-major strides from shape (innermost = 1).
+    SmallVector<int64_t> strides(rank, 1);
+    for (int i = static_cast<int>(rank) - 2; i >= 0; --i)
+      strides[i] = strides[i + 1] * shape[i + 1];
+    for (unsigned i = 0; i < rank; ++i) {
+      Value sz = LLVM::ConstantOp::create(b, loc, i64Ty,
+                                          b.getI64IntegerAttr(shape[i]));
+      desc = LLVM::InsertValueOp::create(b, loc, desc, sz,
+                                         ArrayRef<int64_t>{3, (int64_t)i});
+      Value st = LLVM::ConstantOp::create(b, loc, i64Ty,
+                                          b.getI64IntegerAttr(strides[i]));
+      desc = LLVM::InsertValueOp::create(b, loc, desc, st,
+                                         ArrayRef<int64_t>{4, (int64_t)i});
+    }
+  }
+  return desc;
+}
+
+struct AIRSymmetricAllocToMgpuPass
+    : public xilinx::air::impl::AIRSymmetricAllocToMgpuBase<
+          AIRSymmetricAllocToMgpuPass> {
+
+  AIRSymmetricAllocToMgpuPass() = default;
+  AIRSymmetricAllocToMgpuPass(const AIRSymmetricAllocToMgpuPass &) {}
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    OpBuilder builder(module.getContext());
+    auto i64Ty = builder.getI64Type();
+    auto ptrTy = LLVM::LLVMPointerType::get(module.getContext());
+
+    // Collect symmetric allocs.
+    SmallVector<memref::AllocOp> symAllocs;
+    module.walk([&](memref::AllocOp op) {
+      if (op->hasAttr("air.symmetric"))
+        symAllocs.push_back(op);
+    });
+
+    if (symAllocs.empty())
+      return;
+
+    auto allocFn =
+        ensureExternFunc(module, builder, "mgpuSymmetricAlloc",
+                         builder.getFunctionType({i64Ty, ptrTy}, {ptrTy}));
+    auto freeFn = ensureExternFunc(module, builder, "mgpuSymmetricFree",
+                                   builder.getFunctionType({ptrTy, ptrTy}, {}));
+
+    // Track the !llvm.ptr backing each lowered memref so deallocs can look
+    // them up.
+    DenseMap<Value, Value> symmetricMemrefToPtr;
+
+    for (memref::AllocOp alloc : symAllocs) {
+      auto memrefTy = alloc.getType();
+      Location loc = alloc.getLoc();
+      builder.setInsertionPoint(alloc);
+
+      Value sizeBytes = computeMemrefByteSize(builder, loc, memrefTy);
+      if (!sizeBytes) {
+        alloc.emitOpError(
+            "air.symmetric memref.alloc requires a static-shape memref with "
+            "byte-aligned element type");
+        signalPassFailure();
+        return;
+      }
+      Value nullPtr = LLVM::ZeroOp::create(builder, loc, ptrTy);
+      Value ptr = func::CallOp::create(builder, loc, allocFn,
+                                       ValueRange{sizeBytes, nullPtr})
+                      .getResult(0);
+
+      Value desc = buildMemrefDescriptor(builder, loc, memrefTy, ptr);
+      Value newMemref = UnrealizedConversionCastOp::create(
+                            builder, loc, TypeRange{memrefTy}, ValueRange{desc})
+                            .getResult(0);
+      symmetricMemrefToPtr[newMemref] = ptr;
+      alloc.getResult().replaceAllUsesWith(newMemref);
+      alloc.erase();
+    }
+
+    // Lower deallocs whose operand traces back to a symmetric alloc.
+    SmallVector<memref::DeallocOp> deallocs;
+    module.walk([&](memref::DeallocOp op) { deallocs.push_back(op); });
+    for (memref::DeallocOp d : deallocs) {
+      Value src = d.getMemref();
+      auto it = symmetricMemrefToPtr.find(src);
+      if (it == symmetricMemrefToPtr.end())
+        continue; // not a symmetric memref
+      builder.setInsertionPoint(d);
+      Value nullPtr = LLVM::ZeroOp::create(builder, d.getLoc(), ptrTy);
+      func::CallOp::create(builder, d.getLoc(), freeFn,
+                           ValueRange{it->second, nullPtr});
+      d.erase();
+    }
+  }
+};
+
+} // namespace
+
+namespace xilinx {
+namespace air {
+
+std::unique_ptr<mlir::Pass> createAIRSymmetricAllocToMgpuPass() {
+  return std::make_unique<AIRSymmetricAllocToMgpuPass>();
+}
+
+} // namespace air
+} // namespace xilinx

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -59,6 +59,7 @@ if(AIR_ENABLE_GPU)
     AIRTranslateToLLVMPass.cpp
     GPUKernelOutlinePass.cpp
     AIRRankToMgpuPass.cpp
+    AIRSymmetricAllocToMgpuPass.cpp
   )
   list(APPEND CONVERSION_LINK_LIBS
     MLIRGPUDialect

--- a/mlir/lib/Conversion/Passes.cpp
+++ b/mlir/lib/Conversion/Passes.cpp
@@ -10,6 +10,7 @@
 
 #if AIR_ENABLE_GPU
 #include "air/Conversion/AIRRankToMgpuPass.h"
+#include "air/Conversion/AIRSymmetricAllocToMgpuPass.h"
 #include "air/Conversion/AIRToROCDLPass.h"
 #include "air/Conversion/AIRTranslateToLLVMPass.h"
 #include "air/Conversion/GPUKernelOutlinePass.h"

--- a/mlir/test/Conversion/AIRSymmetricAllocToMgpu/symmetric_alloc.mlir
+++ b/mlir/test/Conversion/AIRSymmetricAllocToMgpu/symmetric_alloc.mlir
@@ -1,0 +1,107 @@
+//===- symmetric_alloc.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===-----------------------------------------------------------------------===//
+
+// REQUIRES: gpu
+// RUN: air-opt %s --split-input-file -air-symmetric-alloc-to-mgpu | FileCheck %s
+
+// Basic 1D alloc + dealloc.
+// CHECK-LABEL: func.func @basic_alloc_dealloc
+// CHECK: %[[SZ:.*]] = arith.constant 4096 : i64
+// CHECK: %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: %[[PTR:.*]] = call @mgpuSymmetricAlloc(%[[SZ]], %[[NULL]]) : (i64, !llvm.ptr) -> !llvm.ptr
+// Descriptor build (poison + insertvalue) then unrealized cast.
+// CHECK: llvm.mlir.poison
+// CHECK: llvm.insertvalue %[[PTR]]
+// CHECK: llvm.insertvalue %[[PTR]]
+// CHECK: builtin.unrealized_conversion_cast {{.*}} : !llvm.struct<{{.*}}> to memref<1024xf32>
+// Dealloc -> mgpuSymmetricFree.
+// CHECK: call @mgpuSymmetricFree(%[[PTR]],
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: memref.dealloc
+func.func @basic_alloc_dealloc() {
+  %buf = memref.alloc() {air.symmetric} : memref<1024xf32>
+  memref.dealloc %buf : memref<1024xf32>
+  return
+}
+
+// -----
+
+// 2D alloc: 64*64*4 = 16384 bytes; descriptor strides should be [64, 1].
+// CHECK-LABEL: func.func @alloc_2d
+// CHECK: arith.constant 16384 : i64
+// CHECK: call @mgpuSymmetricAlloc
+// Strides 64 then 1 in the descriptor (innermost-most-contiguous).
+// CHECK: llvm.mlir.constant(64 : i64)
+// CHECK: llvm.insertvalue
+// CHECK: llvm.mlir.constant(1 : i64)
+// CHECK: llvm.insertvalue
+// CHECK: builtin.unrealized_conversion_cast {{.*}} : !llvm.struct<{{.*}}> to memref<64x64xf32>
+func.func @alloc_2d() -> memref<64x64xf32> {
+  %buf = memref.alloc() {air.symmetric} : memref<64x64xf32>
+  return %buf : memref<64x64xf32>
+}
+
+// -----
+
+// f64 element type (8 bytes): 1024 * 8 = 8192 bytes.
+// CHECK-LABEL: func.func @f64_element
+// CHECK: arith.constant 8192 : i64
+func.func @f64_element() {
+  %buf = memref.alloc() {air.symmetric} : memref<1024xf64>
+  memref.dealloc %buf : memref<1024xf64>
+  return
+}
+
+// -----
+
+// i32 element type (4 bytes): 256 * 4 = 1024 bytes.
+// CHECK-LABEL: func.func @i32_element
+// CHECK: arith.constant 1024 : i64
+func.func @i32_element() {
+  %buf = memref.alloc() {air.symmetric} : memref<256xi32>
+  memref.dealloc %buf : memref<256xi32>
+  return
+}
+
+// -----
+
+// Multiple symmetric allocs in one function: each lowered independently;
+// extern decls are emitted exactly once at module scope.
+// Match the actual emission order: Free decl before Alloc decl.
+// CHECK-COUNT-1: func.func private @mgpuSymmetricFree
+// CHECK-NOT: func.func private @mgpuSymmetricFree
+// CHECK-COUNT-1: func.func private @mgpuSymmetricAlloc
+// CHECK-NOT: func.func private @mgpuSymmetricAlloc
+// CHECK-LABEL: func.func @two_allocs
+// CHECK-COUNT-2: call @mgpuSymmetricAlloc
+// CHECK-COUNT-2: call @mgpuSymmetricFree
+func.func @two_allocs() {
+  %a = memref.alloc() {air.symmetric} : memref<32xf32>
+  %b = memref.alloc() {air.symmetric} : memref<64xf32>
+  memref.dealloc %a : memref<32xf32>
+  memref.dealloc %b : memref<64xf32>
+  return
+}
+
+// -----
+
+// LAST partition: cases that test the pass leaves things untouched.
+// Both `ignores_non_symmetric` and `no_symmetric_alloc` are folded here
+// so the trailing CHECK-NOTs only need to match against this one (final)
+// partition's text.
+// CHECK-LABEL: func.func @no_symmetric_changes
+// CHECK: memref.alloc() : memref<1024xf32>
+// CHECK: memref.alloc() : memref<32xf32>
+// CHECK-NOT: mgpuSymmetricAlloc
+// CHECK-NOT: mgpuSymmetricFree
+func.func @no_symmetric_changes() {
+  %a = memref.alloc() : memref<1024xf32>
+  memref.dealloc %a : memref<1024xf32>
+  %b = memref.alloc() : memref<32xf32>
+  memref.dealloc %b : memref<32xf32>
+  return
+}

--- a/test/gpu/multi_gpu/air_alloc/Makefile
+++ b/test/gpu/multi_gpu/air_alloc/Makefile
@@ -1,0 +1,139 @@
+# Multi-process symmetric-heap multi-GPU e2e — air.rank +
+# memref.alloc {air.symmetric} wrapped tests.
+#
+# These tests express both the multi-process world (via air.rank) AND
+# the symmetric-heap allocations (via memref.alloc {air.symmetric}) at
+# the MLIR-dialect level. The lowering chain is:
+#
+#   air-rank-to-mgpu              # air.rank → mgpuGetRank + heap init/destroy
+#   air-symmetric-alloc-to-mgpu   # memref.alloc{air.symmetric} → mgpuSymmetricAlloc
+#   air-translate-to-llvm         # air.translate → memref descriptor rebase
+#   <standard GPU compile chain>
+#
+# After lowering each variant is functionally equivalent to the
+# corresponding ../handwritten/ test.
+#
+# Variants (selected via INPUT):
+#   cacheline  Wrap of ../handwritten/cacheline.mlir (producer/consumer,
+#              1-to-1, cache-line atomicity).
+#
+# Usage:
+#   make                       # default: INPUT=cacheline NUM_RANKS=2
+#   make NUM_RANKS=4
+#   make clean
+#
+# Required environment (auto-detected when sourced via env_setup_gpu.sh):
+#   MLIR_AIR_INSTALL_DIR  — path containing lib/libairgpu.so
+#   LLVM_INSTALL_DIR      — path containing bin/mlir-opt + lib/libmlir_*.so
+#
+# This Makefile is intentionally self-contained — no included files, no
+# sourced helpers. Other multi_gpu/<level>/ subdirs each have their own
+# complete Makefile so that each phase's PR touches only its own dir.
+
+SHELL       := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+INPUT      ?= cacheline
+NUM_RANKS  ?= 2
+TMPDIR     ?= /tmp/air_multi_gpu_air_alloc
+
+SCRIPT_DIR := $(patsubst %/,%,$(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
+
+# Derive install dirs from PATH if not explicitly provided.
+LLVM_INSTALL_DIR     ?= $(shell dirname "$$(dirname "$$(command -v mlir-opt)")" 2>/dev/null)
+MLIR_AIR_INSTALL_DIR ?= $(shell dirname "$$(dirname "$$(command -v air-opt)")" 2>/dev/null)
+LLVM_LIB_DIR         ?= $(LLVM_INSTALL_DIR)/lib
+AIRGPU_LIB           ?= $(MLIR_AIR_INSTALL_DIR)/lib/libairgpu.so
+
+ifeq ($(filter $(INPUT),cacheline),)
+$(error Unknown INPUT=$(INPUT); expected 'cacheline')
+endif
+
+SRC_MLIR    := $(SCRIPT_DIR)/$(INPUT).mlir
+POST_LOWER  := $(TMPDIR)/$(INPUT)_post_lower.mlir
+LOWERED     := $(TMPDIR)/$(INPUT)_lowered.mlir
+
+.PHONY: run clean check-preconditions
+.DEFAULT_GOAL := run
+
+$(TMPDIR):
+	@mkdir -p $@
+
+# Step 1a: lower air.rank → mgpu*, memref.alloc{air.symmetric} →
+# mgpuSymmetricAlloc, expand air.translate.
+$(POST_LOWER): $(SRC_MLIR) | $(TMPDIR)
+	@echo "Step 1a: Lower air.rank + air.symmetric + air.translate ($(INPUT))"
+	air-opt $< -air-rank-to-mgpu -air-symmetric-alloc-to-mgpu \
+	    --air-translate-to-llvm -o $@
+
+# Step 1b: compile gpu.module to AMDGPU binary + finalize host. Same
+# pipeline as ../handwritten/Makefile.
+$(LOWERED): $(POST_LOWER)
+	@echo "Step 1b: Compile gpu.module to AMDGPU binary + finalize host"
+	mlir-opt $< \
+	    --pass-pipeline='builtin.module(rocdl-attach-target{chip=gfx942 O=3},gpu.module(convert-scf-to-cf,convert-gpu-to-rocdl{chipset=gfx942 runtime=HIP},reconcile-unrealized-casts),gpu-module-to-binary,func.func(gpu-async-region,convert-scf-to-cf),gpu-to-llvm,convert-to-llvm,reconcile-unrealized-casts)' \
+	    -o $@
+
+check-preconditions:
+	@if [ ! -d "$(LLVM_LIB_DIR)" ]; then                                       \
+	  echo "ERROR: LLVM_LIB_DIR=$(LLVM_LIB_DIR) does not exist." >&2;         \
+	  echo "       Source utils/env_setup_gpu.sh or set LLVM_INSTALL_DIR."    \
+	       >&2;                                                                \
+	  exit 1;                                                                  \
+	fi
+	@if [ ! -f "$(AIRGPU_LIB)" ]; then                                         \
+	  echo "ERROR: AIRGPU_LIB=$(AIRGPU_LIB) does not exist." >&2;             \
+	  echo "       Source utils/env_setup_gpu.sh or set"                      \
+	       "MLIR_AIR_INSTALL_DIR." >&2;                                        \
+	  exit 1;                                                                  \
+	fi
+	@if [ "$(NUM_RANKS)" -lt 2 ]; then                                         \
+	  echo "ERROR: NUM_RANKS=$(NUM_RANKS); requires >= 2 ranks (producer +"   \
+	       "consumer)." >&2;                                                   \
+	  exit 1;                                                                  \
+	fi
+	@if [ -n "$${HIP_VISIBLE_DEVICES:-}" ]; then                               \
+	  NUM_GPUS=$$(echo "$$HIP_VISIBLE_DEVICES" | tr ',' '\n' | grep -c .);     \
+	else                                                                       \
+	  NUM_GPUS=$$(grep -l '^simd_count [1-9]'                                  \
+	      /sys/class/kfd/kfd/topology/nodes/*/properties 2>/dev/null | wc -l); \
+	fi;                                                                        \
+	if [ "$$NUM_GPUS" -lt "$(NUM_RANKS)" ]; then                               \
+	  echo "ERROR: need >= $(NUM_RANKS) GPUs to validate cross-rank XGMI"     \
+	       "traffic; found $$NUM_GPUS." >&2;                                   \
+	  echo "       This test refuses to colocate ranks on a single GPU"      \
+	       "because it would silently" >&2;                                    \
+	  echo "       bypass the symmetric-heap path and report false PASSes." \
+	       >&2;                                                                \
+	  exit 1;                                                                  \
+	fi
+
+run: check-preconditions $(LOWERED)
+	@echo "Step 2: Run as $(NUM_RANKS) processes"
+	@export AIRGPU_JOB_ID="$${AIRGPU_JOB_ID:-$$$$}";                     \
+	PIDS=();                                                              \
+	PASS=1;                                                               \
+	for i in $$(seq 0 $$(($(NUM_RANKS) - 1))); do                         \
+	  ( set -o pipefail;                                                  \
+	    RANK=$$i WORLD_SIZE=$(NUM_RANKS) LOCAL_RANK=0                     \
+	    HIP_VISIBLE_DEVICES=$$i                                           \
+	    mlir-runner --entry-point-result=void                             \
+	        --shared-libs="$(LLVM_LIB_DIR)/libmlir_rocm_runtime.so"       \
+	        --shared-libs="$(AIRGPU_LIB)"                                 \
+	        --shared-libs="$(LLVM_LIB_DIR)/libmlir_runner_utils.so"       \
+	        --shared-libs="$(LLVM_LIB_DIR)/libmlir_c_runner_utils.so"     \
+	        $(LOWERED) 2>&1 | sed "s/^/[rank $$i] /") &                   \
+	  PIDS+=($$!);                                                        \
+	done;                                                                 \
+	for pid in "$${PIDS[@]}"; do                                          \
+	  if ! wait "$$pid"; then PASS=0; fi;                                 \
+	done;                                                                 \
+	if [ $$PASS -eq 1 ]; then                                             \
+	  echo "=== ALL $(NUM_RANKS) RANKS PASSED ===";                       \
+	else                                                                  \
+	  echo "=== SOME RANKS FAILED ===";                                   \
+	  exit 1;                                                             \
+	fi
+
+clean:
+	rm -rf $(TMPDIR)

--- a/test/gpu/multi_gpu/air_alloc/cacheline.mlir
+++ b/test/gpu/multi_gpu/air_alloc/cacheline.mlir
@@ -1,0 +1,333 @@
+//===- air_alloc/cacheline.mlir - air.rank + memref.alloc{air.symmetric} -===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===-----------------------------------------------------------------------===//
+//
+// High-level version of handwritten/cacheline.mlir using BOTH Phase 3
+// (air.rank) AND Phase 4 (memref.alloc {air.symmetric}) abstractions.
+//
+// This file is a 1:1 wrap of air_rank/cacheline.mlir, with the symmetric
+// data buffer's runtime-ABI dance:
+//
+//   %ptr   = mgpuSymmetricAlloc(size, stream)
+//   %bytes = wrap_bytes(%ptr, size)            // hand-built memref<?xi8>
+//   %m     = memref.view %bytes[0][]           // retype to memref<T>
+//   ...
+//   mgpuSymmetricFree(%ptr, stream)
+//
+// replaced by the MLIR-native form:
+//
+//   %m = memref.alloc() {air.symmetric} : memref<T>
+//   ...
+//   memref.dealloc %m
+//
+// The `air-symmetric-alloc-to-mgpu` pass (Phase 4) lowers each
+// `memref.alloc {air.symmetric}` to `mgpuSymmetricAlloc` plus a descriptor
+// build + unrealized_conversion_cast back to the original memref type
+// (so downstream uses keep working through `convert-to-llvm`). Each
+// matching `memref.dealloc` becomes `mgpuSymmetricFree`.
+//
+// After lowering through the full pipeline (-air-rank-to-mgpu
+// -air-symmetric-alloc-to-mgpu -air-translate-to-llvm + standard LLVM)
+// the IR is functionally equivalent to handwritten/cacheline.mlir.
+//
+// Sister files:
+//   handwritten/cacheline.mlir — Phase 2 reference (no abstractions).
+//   air_rank/cacheline.mlir    — Phase 3 wrap (air.rank only).
+//   air_alloc/cacheline.mlir   — this file (air.rank + air.symmetric).
+//
+// Only the symmetric data buffer is converted; the non-symmetric staging
+// allocations (verify_buf, heap_bases device copy) still go through
+// mgpuMemAlloc + the wrap_bytes helper. A future pass for non-symmetric
+// device allocs could remove that helper too.
+//
+// Pinned to W=2 because air.translate today requires static-shape source
+// memref. Same constraint as the cacheline + air_rank tests.
+//
+// Launcher: `make INPUT=cacheline` from this subdir forks 2 processes.
+//
+//===-----------------------------------------------------------------------===//
+
+module attributes {gpu.container_module} {
+  // ---- mgpu* C ABI declarations -----------------------------------------
+  // Note: SymmetricAlloc/Free + SymmetricHeapInit/Destroy/GetRank/
+  // GetWorldSize are emitted by the air-rank-to-mgpu and
+  // air-symmetric-alloc-to-mgpu passes; user IR doesn't reference them
+  // directly.
+  func.func private @mgpuGetHeapBases() -> !llvm.ptr
+  func.func private @mgpuBarrier()
+  func.func private @mgpuMemAlloc(i64, !llvm.ptr, i1) -> !llvm.ptr
+  func.func private @mgpuMemFree(!llvm.ptr, !llvm.ptr)
+  func.func private @mgpuMemcpy(!llvm.ptr, !llvm.ptr, i64, !llvm.ptr)
+
+  func.func private @exit(i32)
+
+  llvm.func @printf(!llvm.ptr, ...) -> i32
+
+  llvm.mlir.global internal constant @msg_init(
+      "[mlir/alloc] rank %d / world %d, init OK\0A\00") {addr_space = 0 : i32}
+  llvm.mlir.global internal constant @msg_pass_p(
+      "[mlir/alloc] rank 0 (producer): kernel returned\0A\00") {addr_space = 0 : i32}
+  llvm.mlir.global internal constant @msg_pass_c(
+      "[mlir/alloc] rank 1 (consumer): cache-line message PASS (data[0]=%d, flag=%d)\0A\00") {addr_space = 0 : i32}
+  llvm.mlir.global internal constant @msg_fail(
+      "[mlir/alloc] rank 1 (consumer): MISMATCH at idx=%ld got=%d expected=%d\0A\00") {addr_space = 0 : i32}
+  llvm.mlir.global internal constant @msg_done(
+      "[mlir/alloc] rank %d: ALL PASSED\0A\00") {addr_space = 0 : i32}
+
+  // ---- GPU kernels (verbatim from handwritten/cacheline.mlir) -----------
+  gpu.module @sym_kernels {
+
+    gpu.func @producer(%data : memref<32xi32>,
+                       %bases : memref<?xindex>) kernel
+                       attributes {gpu.known_block_size = array<i32: 64, 1, 1>,
+                                   gpu.known_grid_size  = array<i32: 1, 1, 1>} {
+      %c1_i32   = arith.constant 1   : i32
+      %c100_i32 = arith.constant 100 : i32
+      %c31      = arith.constant 31  : index
+      %c32      = arith.constant 32  : index
+      %from = arith.constant 0 : index
+      %to   = arith.constant 1 : index
+
+      %tid = gpu.thread_id x
+      %active = arith.cmpi ult, %tid, %c32 : index
+      %peer_data = air.translate %data, %from, %to, %bases
+          : memref<32xi32>, memref<?xindex>
+
+      scf.if %active {
+        %is_flag  = arith.cmpi eq, %tid, %c31 : index
+        %tid_i32  = arith.index_cast %tid : index to i32
+        %payload  = arith.addi %tid_i32, %c100_i32 : i32
+        %val      = arith.select %is_flag, %c1_i32, %payload : i32
+        memref.store %val, %peer_data[%tid] : memref<32xi32>
+      }
+      gpu.return
+    }
+
+    gpu.func @consumer(%data       : memref<32xi32>,
+                       %verify_buf : memref<32xi32>) kernel
+                       attributes {gpu.known_block_size = array<i32: 64, 1, 1>,
+                                   gpu.known_grid_size  = array<i32: 1, 1, 1>} {
+      %c0_i32  = arith.constant 0  : i32
+      %c1_i32  = arith.constant 1  : i32
+      %c31_i32 = arith.constant 31 : i32
+      %c64_i32 = arith.constant 64 : i32
+      %c32     = arith.constant 32 : index
+
+      %tid = gpu.thread_id x
+      %active = arith.cmpi ult, %tid, %c32 : index
+
+      %final_v = scf.while (%dummy = %c0_i32) : (i32) -> i32 {
+        %v = scf.if %active -> i32 {
+          %loaded = memref.load %data[%tid] : memref<32xi32>
+          scf.yield %loaded : i32
+        } else {
+          scf.yield %c0_i32 : i32
+        }
+        %flag, %valid = gpu.shuffle idx %v, %c31_i32, %c64_i32 : i32
+        %not_ready = arith.cmpi ne, %flag, %c1_i32 : i32
+        scf.condition(%not_ready) %v : i32
+      } do {
+      ^bb0(%v_iter : i32):
+        scf.yield %v_iter : i32
+      }
+
+      scf.if %active {
+        memref.store %final_v, %verify_buf[%tid] : memref<32xi32>
+      }
+      gpu.return
+    }
+  }
+
+  // ---- Helpers ---------------------------------------------------------
+  // wrap_bytes is still needed for the non-symmetric staging allocations
+  // (verify_buf in HBM, heap_bases device copy). The symmetric data
+  // buffer no longer needs it — it comes from `memref.alloc {air.symmetric}`
+  // and the air-symmetric-alloc-to-mgpu pass synthesizes the equivalent
+  // descriptor build. A future pass for non-symmetric device allocs would
+  // remove this helper too.
+  func.func private @wrap_bytes(%ptr : !llvm.ptr, %size : i64) -> memref<?xi8> {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %d0 = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %d1 = llvm.insertvalue %ptr,    %d0[0]    : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %d2 = llvm.insertvalue %ptr,    %d1[1]    : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %d3 = llvm.insertvalue %c0_i64, %d2[2]    : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %d4 = llvm.insertvalue %size,   %d3[3, 0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %d5 = llvm.insertvalue %c1_i64, %d4[4, 0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    %m  = builtin.unrealized_conversion_cast %d5
+        : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)> to memref<?xi8>
+    return %m : memref<?xi8>
+  }
+
+  // ---- main: cacheline test wrapped in air.rank, symmetric data via
+  //            memref.alloc {air.symmetric} ----------------------------
+  func.func @main() {
+    %c2 = arith.constant 2 : index
+
+    air.rank (%rid) in (%rsize = %c2) {
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c0_i64 = arith.constant 0 : i64
+      %c128_bytes = arith.constant 128 : i64
+      %nullptr = llvm.mlir.zero : !llvm.ptr
+      %false = arith.constant false
+
+      %c0_idx = arith.constant 0 : index
+      %c1_idx = arith.constant 1 : index
+      %c1 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+
+      %rid_i64 = arith.index_cast %rid : index to i64
+      %rid_i32 = arith.trunci %rid_i64 : i64 to i32
+      %rsize_i64 = arith.index_cast %rsize : index to i64
+      %rsize_i32 = arith.trunci %rsize_i64 : i64 to i32
+
+      %fmt_init = llvm.mlir.addressof @msg_init : !llvm.ptr
+      llvm.call @printf(%fmt_init, %rid_i32, %rsize_i32)
+          vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i32, i32) -> i32
+
+      // Phase 4 lowering target: memref.alloc {air.symmetric} replaces
+      // the mgpuSymmetricAlloc + wrap_bytes + memref.view triplet.
+      %data_m = memref.alloc() {air.symmetric} : memref<32xi32>
+
+      // Zero-init data from host. mgpuMemcpy still wants !llvm.ptr, so
+      // extract one back from the symmetric memref.
+      %data_host = memref.alloc() : memref<32xi32>
+      %dc32 = arith.constant 32 : index
+      scf.for %i = %c0_idx to %dc32 step %c1_idx {
+        memref.store %c0_i32, %data_host[%i] : memref<32xi32>
+      }
+      %data_host_intptr = memref.extract_aligned_pointer_as_index %data_host
+          : memref<32xi32> -> index
+      %data_host_int = arith.index_cast %data_host_intptr : index to i64
+      %data_host_ptr = llvm.inttoptr %data_host_int : i64 to !llvm.ptr
+      %data_intptr = memref.extract_aligned_pointer_as_index %data_m
+          : memref<32xi32> -> index
+      %data_int = arith.index_cast %data_intptr : index to i64
+      %data_ptr = llvm.inttoptr %data_int : i64 to !llvm.ptr
+      func.call @mgpuMemcpy(%data_ptr, %data_host_ptr, %c128_bytes, %nullptr)
+          : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr) -> ()
+      memref.dealloc %data_host : memref<32xi32>
+
+      func.call @mgpuBarrier() : () -> ()
+
+      %c0_view = arith.constant 0 : index
+
+      // heap_bases (host ptr → device copy). Non-symmetric, still uses
+      // mgpuMemAlloc + wrap_bytes.
+      %c8_i64 = arith.constant 8 : i64
+      %bases_size = arith.muli %rsize_i64, %c8_i64 : i64
+      %bases_host = func.call @mgpuGetHeapBases() : () -> !llvm.ptr
+      %bases_devptr = func.call @mgpuMemAlloc(%bases_size, %nullptr, %false)
+          : (i64, !llvm.ptr, i1) -> !llvm.ptr
+      func.call @mgpuMemcpy(%bases_devptr, %bases_host, %bases_size, %nullptr)
+          : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr) -> ()
+      %bases_bytes = func.call @wrap_bytes(%bases_devptr, %bases_size)
+          : (!llvm.ptr, i64) -> memref<?xi8>
+      %bases = memref.view %bases_bytes[%c0_view][%rsize]
+          : memref<?xi8> to memref<?xindex>
+
+      %is_producer = arith.cmpi eq, %rid, %c0_idx : index
+      scf.if %is_producer {
+        gpu.launch_func @sym_kernels::@producer
+            blocks  in (%c1, %c1, %c1)
+            threads in (%c64, %c1, %c1)
+            args(%data_m : memref<32xi32>,
+                 %bases  : memref<?xindex>)
+        %fmt_p = llvm.mlir.addressof @msg_pass_p : !llvm.ptr
+        llvm.call @printf(%fmt_p)
+            vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
+      } else {
+        %is_consumer = arith.cmpi eq, %rid, %c1_idx : index
+        scf.if %is_consumer {
+          // verify_buf is local HBM — non-symmetric, still uses
+          // mgpuMemAlloc + wrap_bytes.
+          %verify_ptr = func.call @mgpuMemAlloc(%c128_bytes, %nullptr, %false)
+              : (i64, !llvm.ptr, i1) -> !llvm.ptr
+          %verify_bytes = func.call @wrap_bytes(%verify_ptr, %c128_bytes)
+              : (!llvm.ptr, i64) -> memref<?xi8>
+          %verify_m = memref.view %verify_bytes[%c0_view][]
+              : memref<?xi8> to memref<32xi32>
+          gpu.launch_func @sym_kernels::@consumer
+              blocks  in (%c1, %c1, %c1)
+              threads in (%c64, %c1, %c1)
+              args(%data_m  : memref<32xi32>,
+                   %verify_m: memref<32xi32>)
+
+          // D2H readback verify_buf and check all 32 ints.
+          %hb = memref.alloc() : memref<32xi32>
+          %hb_intptr = memref.extract_aligned_pointer_as_index %hb
+              : memref<32xi32> -> index
+          %hb_int = arith.index_cast %hb_intptr : index to i64
+          %hb_ptr = llvm.inttoptr %hb_int : i64 to !llvm.ptr
+          func.call @mgpuMemcpy(%hb_ptr, %verify_ptr, %c128_bytes, %nullptr)
+              : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr) -> ()
+
+          %c31_idx  = arith.constant 31  : index
+          %c32_idx  = arith.constant 32  : index
+          %c100_i32 = arith.constant 100 : i32
+
+          %nfail = scf.for %i = %c0_idx to %c32_idx step %c1_idx
+                          iter_args(%nfail_acc = %c0_i32) -> (i32) {
+            %v = memref.load %hb[%i] : memref<32xi32>
+            %is_flag_idx = arith.cmpi eq, %i, %c31_idx : index
+            %expected = scf.if %is_flag_idx -> i32 {
+              scf.yield %c1_i32 : i32
+            } else {
+              %i_i32 = arith.index_cast %i : index to i32
+              %e = arith.addi %i_i32, %c100_i32 : i32
+              scf.yield %e : i32
+            }
+            %ne = arith.cmpi ne, %v, %expected : i32
+            %new_nfail = scf.if %ne -> i32 {
+              %is_first = arith.cmpi eq, %nfail_acc, %c0_i32 : i32
+              scf.if %is_first {
+                %fmt_fail = llvm.mlir.addressof @msg_fail : !llvm.ptr
+                %i_i64 = arith.index_cast %i : index to i64
+                llvm.call @printf(%fmt_fail, %rid_i32, %i_i64, %v, %expected)
+                    vararg(!llvm.func<i32 (ptr, ...)>)
+                    : (!llvm.ptr, i32, i64, i32, i32) -> i32
+              }
+              %inc = arith.addi %nfail_acc, %c1_i32 : i32
+              scf.yield %inc : i32
+            } else {
+              scf.yield %nfail_acc : i32
+            }
+            scf.yield %new_nfail : i32
+          }
+
+          %ok_all = arith.cmpi eq, %nfail, %c0_i32 : i32
+          scf.if %ok_all {
+            %fmt_c = llvm.mlir.addressof @msg_pass_c : !llvm.ptr
+            %v0 = memref.load %hb[%c0_idx] : memref<32xi32>
+            %vf = memref.load %hb[%c31_idx] : memref<32xi32>
+            llvm.call @printf(%fmt_c, %v0, %vf)
+                vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i32, i32) -> i32
+          } else {
+            func.call @exit(%c1_i32) : (i32) -> ()
+          }
+
+          memref.dealloc %hb : memref<32xi32>
+          func.call @mgpuMemFree(%verify_ptr, %nullptr) : (!llvm.ptr, !llvm.ptr) -> ()
+        }
+      }
+
+      func.call @mgpuBarrier() : () -> ()
+      func.call @mgpuMemFree(%bases_devptr, %nullptr) : (!llvm.ptr, !llvm.ptr) -> ()
+
+      // Phase 4 lowering target: memref.dealloc on a symmetric memref
+      // becomes mgpuSymmetricFree.
+      memref.dealloc %data_m : memref<32xi32>
+
+      %fmt_done = llvm.mlir.addressof @msg_done : !llvm.ptr
+      llvm.call @printf(%fmt_done, %rid_i32)
+          vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i32) -> i32
+
+      air.rank_terminator
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the multi-GPU stack: a new `air-symmetric-alloc-to-mgpu` conversion pass that uplevels symmetric-heap allocations from the runtime-ABI level (`mgpuSymmetricAlloc` + a hand-built memref descriptor) to the standard memref dialect.

## What it does

Replaces the runtime-ABI dance:

```mlir
%ptr   = call @mgpuSymmetricAlloc(size, stream)
%bytes = wrap_bytes(%ptr, size)            // hand-built memref<?xi8>
%m     = memref.view %bytes[0][]           // retype to memref<T>
...
call @mgpuSymmetricFree(%ptr, stream)
```

with the MLIR-native form:

```mlir
%m = memref.alloc() {air.symmetric} : memref<T>
...
memref.dealloc %m
```

The pass lowers each `memref.alloc {air.symmetric}` to a runtime call plus an LLVM memref descriptor build + `unrealized_conversion_cast` back to the original memref type (so downstream uses keep working through `convert-to-llvm`). Each `memref.dealloc` whose operand traces back through the cast becomes `mgpuSymmetricFree`. No-op when no `air.symmetric` allocations are present.

## Why this matters

Every test in main today carries a 15-line `wrap_bytes` helper that builds a memref descriptor by hand from a runtime `!llvm.ptr` — leaking the LLVM-struct ABI into the test IR. Phase 4 replaces this with the standard `memref.alloc` op + an attribute, putting the symmetric allocation at the same dialect level as the rest of the IR.

This is the foundation for phases 5/6 (DMA + channel ops): they can operate on clean `memref<T>` values from the user's perspective, without each test having to reconstruct memrefs from raw pointers.

## What's new

- **`mlir/include/air/Conversion/AIRSymmetricAllocToMgpuPass.h` / `.cpp`** — pass implementation (~200 LOC)
- **`mlir/include/air/Conversion/GPUPasses.td`** — `air-symmetric-alloc-to-mgpu` def
- **`mlir/test/Conversion/AIRSymmetricAllocToMgpu/symmetric_alloc.mlir`** — FileCheck unit tests with `// REQUIRES: gpu` (the pass isn't registered in non-GPU builds):
  - 1D alloc + dealloc shape (size, descriptor, cast, free)
  - 2D alloc with row-major strides in descriptor
  - Element type byte-size: f32 (4B), f64 (8B), i32 (4B)
  - Multiple symmetric allocs share one decl pair
  - Pass is a no-op for non-symmetric allocs
  - Pass is a no-op when there are zero symmetric allocs
- **`test/gpu/multi_gpu/air_alloc/cacheline.mlir`** — e2e test that wraps the producer/consumer cacheline reference in `air.rank` AND uses `memref.alloc {air.symmetric}` for the symmetric data buffer. 1:1 wrap of the air_rank/cacheline reference, with only the symmetric alloc/free swapped for the new abstraction. After lowering through `-air-rank-to-mgpu -air-symmetric-alloc-to-mgpu -air-translate-to-llvm`, functionally equivalent to handwritten/cacheline.mlir.
- **`test/gpu/multi_gpu/air_alloc/Makefile`** — self-contained, follows the same pattern as `air_rank/Makefile`.

## Test plan

- [x] FileCheck unit tests pass (6 cases above)
- [x] E2E on real 2x MI325X (rad-mi325x-1, NUM_RANKS=2): cache-line message PASS (`data[0]=100, flag=1`) — output structurally identical to `INPUT=cacheline` in handwritten/ and air_rank/, only distinguished by the `[mlir/alloc]` log tag. 3/3 stability runs.
- [x] Equivalence demonstrated: the same payload values (lane+100 for lanes 0..30, flag=1 at lane 31) and the same cache-line atomicity contract reach the consumer in all three variants (handwritten/cacheline, air_rank/cacheline, air_alloc/cacheline).
- [x] `git clang-format origin/main` applied; "Python and C/C++ Check Format" check should pass

## Followup

The non-symmetric staging allocations (verify_buf, heap_bases device copy) still go through `mgpuMemAlloc + wrap_bytes`. A future pass for non-symmetric device allocs would remove that helper too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
