### PR TITLE
Add fused decode-block example: RMS->GEMV(QKV)->RoPE->Attention on NPU2

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/Makefile
+++ b/programming_examples/flash_attention/kernel_fusion_based/Makefile
@@ -176,3 +176,30 @@ compile-kernel-npu1:
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__
+
+# ============================================================================
+# decode_block_npu2_5all_v2: full RMS -> GEMV(QKV) -> RoPE -> Attention
+# decode block in a single launch+segment with cross-herd cascade for Q,
+# K_new, V_new. Toy GEMV input dim N=64; LLaMA-3.2-1B output dims
+# (NKV=8, group_size=4, dk=dv=64, lk up to 2048).
+# ============================================================================
+GROUP_SIZE ?= 4
+NUM_KV_HEADS_E2E ?= 8
+
+print-decode-block-e2e:
+	${powershell} python3 ${srcdir}/decode_block_npu2_5all_v2.py -p --lk $(LK) --lkp $(LKP) --dk $(DK) --dv $(DV) --group-size $(GROUP_SIZE) --num-kv-heads $(NUM_KV_HEADS_E2E)
+
+run-decode-block-e2e: compile-decode-block-kernels
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/decode_block_npu2_5all_v2.py --lk $(LK) --lkp $(LKP) --dk $(DK) --dv $(DV) --group-size $(GROUP_SIZE) --num-kv-heads $(NUM_KV_HEADS_E2E) $(EXTRA_PY_FLAGS)
+
+compile-decode-block-kernels:
+	mkdir -p $(BUILD_DIR)
+	@if [ -z "$(PEANO_INSTALL_DIR)" ] || [ ! -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+		echo "Error: PEANO_INSTALL_DIR not set or clang++ missing."; \
+		exit 1; \
+	fi
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -c ${srcdir}/attn_decode_npu2.cc -o $(BUILD_DIR)/attn_decode_npu2.o -Dlkp=$(LKP) -Ddk=$(DK) -Ddv=$(DV) -Dgroup_size=$(GROUP_SIZE) -Dmax_sum_buf_size=32 -DROUND_CONV_EVEN
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -c ${srcdir}/rope_multi.cc -o $(BUILD_DIR)/rope_multi.o
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -c ${srcdir}/simple_matvec.cc -o $(BUILD_DIR)/simple_matvec.o
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} -c ${srcdir}/simple_rms.cc -o $(BUILD_DIR)/simple_rms.o

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.cc
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_decode_npu2.cc
@@ -1,0 +1,427 @@
+//===- attn_decode_npu2.cc --------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Decode-phase flash attention kernels for AIE2P (NPU2).
+//
+// Uses matvec-style (mv.cc) QK computation since group_size is too small for
+// 8x8 tiled matmul.  Flat row-major buffer layout throughout.
+//
+// Compile-time parameters (pass with -D):
+//   group_size : number of Q heads per KV head (GQA ratio), e.g. 4
+//   lkp        : K/V chunk size, e.g. 64
+//   dk         : key head dimension, e.g. 64
+//   dv         : value head dimension, e.g. 64
+//
+// Buffer layouts (all flat row-major):
+//   Q        [group_size, dk]
+//   K        [lkp, dk]
+//   V        [lkp, dv]
+//   scores   [group_size, lkp]
+//   output   [group_size, dv]
+//   max_vec  [max_sum_buf_size]   (first group_size entries used)
+//   sum_vec  [max_sum_buf_size]   (first group_size entries used)
+//
+// max_sum_buf_size must be >= group_size and >= 32 (one 512-bit cascade word).
+//===----------------------------------------------------------------------===//
+
+#define NOCPP
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+#include "zero.cc"
+
+// Default values if not provided by Makefile
+#ifndef group_size
+#define group_size 4
+#endif
+
+#ifndef lkp
+#define lkp 64
+#endif
+
+#ifndef dk
+#define dk 64
+#endif
+
+#ifndef dv
+#define dv 64
+#endif
+
+// Cascade alignment: 512-bit bus = 32 bfloat16 elements.
+// max/sum buffers are padded to this size.
+#ifndef max_sum_buf_size
+#define max_sum_buf_size 32
+#endif
+
+// Scale: log2e / sqrt(dk) for attention score normalization.
+// Using the same constexpr pattern as attn_npu2.cc.
+#include <cmath>
+
+constexpr double decode_constexpr_sqrt_dk = (dk == 64)    ? 8.0
+                                            : (dk == 128) ? 11.313708498984761
+                                            : (dk == 256) ? 16.0
+                                            : (dk == 512) ? 22.627416997969522
+                                                          : 8.0;
+static_assert(dk == 64 || dk == 128 || dk == 256 || dk == 512,
+              "Unsupported dk value: update decode_constexpr_sqrt_dk");
+
+#define decode_log2e (1.44269504089 / decode_constexpr_sqrt_dk)
+
+// Bf16 special values
+static const uint16_t bf16_lowest_u16 = (uint16_t)0xff7f;  // ≈ -3.39e38
+static const uint16_t bf16_neg_inf_u16 = (uint16_t)0xff80; // -inf
+
+//===========================================================================
+// Internal: matvec C[m] = A[m,k] @ b[k]  (A row-major, b a vector)
+// Accumulates in accfloat and reduces each row to a scalar bfloat16 result.
+//===========================================================================
+template <uint32_t r>
+static void matvec_decode(uint32_t m, uint32_t k, const bfloat16 *__restrict a,
+                          const bfloat16 *__restrict b,
+                          bfloat16 *__restrict c) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  const bfloat16 *b_end = b + k;
+  for (uint32_t row = 0; row < m; row++, c++) {
+    aie::accum<accfloat, r> acc = aie::zeros<accfloat, r>();
+    const bfloat16 *b_cur = b;
+    const bfloat16 *a_cur = a + row * k;
+    for (; b_cur < b_end; b_cur += r, a_cur += r) {
+      aie::vector<bfloat16, r> a_vec = aie::load_v<r>(a_cur);
+      aie::vector<bfloat16, r> b_vec = aie::load_v<r>(b_cur);
+      acc = aie::mac(acc, a_vec, b_vec);
+    }
+    *c =
+        static_cast<bfloat16>(aie::reduce_add(acc.template to_vector<float>()));
+  }
+}
+
+extern "C" {
+
+#ifdef ROUND_CONV_EVEN
+#define SET_ROUNDING() ::aie::set_rounding(::aie::rounding_mode::conv_even)
+#else
+#define SET_ROUNDING() /* no-op */
+#endif
+
+// ============================================================
+// Initialization
+// ============================================================
+
+void decode_zero_output(bfloat16 *out) {
+  SET_ROUNDING();
+  zero_vectorized<bfloat16, group_size, dv, 32>(out);
+}
+
+void decode_zero_sum(bfloat16 *sum) {
+  SET_ROUNDING();
+  zero_vectorized<bfloat16, max_sum_buf_size, 1, 32>(sum);
+}
+
+void decode_neg_inf_max(bfloat16 *max_v) {
+  SET_ROUNDING();
+  neg_inf_vectorized<bfloat16, max_sum_buf_size, 1, 32>(max_v);
+}
+
+// ============================================================
+// QK score computation (matvec-style)
+// ============================================================
+
+// For each head h in [0, group_size):
+//   scores[h, i] = K[i, :] . Q[h, :]   for i in [0, lkp)
+// K is [lkp, dk] row-major, Q is [group_size, dk] row-major.
+// scores is [group_size, lkp] row-major.
+void compute_qk_scores_bf16(bfloat16 *K, bfloat16 *Q, bfloat16 *scores) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    matvec_decode<64>(lkp, dk, K, Q + h * dk, scores + h * lkp);
+  }
+}
+
+// ============================================================
+// Decode causal mask
+// ============================================================
+
+// Set scores[h, i] = -inf for ALL heads h when (chunk_start + i) > current_pos.
+// TODO(perf): Replace scalar conditional with aie::sel vectorized mask:
+//   aie::mask<lkp> m = aie::lt(position_vec, aie::broadcast(current_pos));
+//   scores_vec = aie::sel(neg_inf_vec, scores_vec, m);
+// This eliminates lkp scalar branches per invocation (lkp=64, group_size=4
+// → 256 scalar comparisons per call vs. one vectorized mask operation).
+void apply_decode_mask(bfloat16 *scores, int32_t chunk_start,
+                       int32_t current_pos) {
+  SET_ROUNDING();
+  bfloat16 neg_inf_val = *(const bfloat16 *)&bf16_neg_inf_u16;
+  for (int i = 0; i < lkp; i++) {
+    if (chunk_start + i > current_pos) {
+      for (int h = 0; h < group_size; h++) {
+        scores[h * lkp + i] = neg_inf_val;
+      }
+    }
+  }
+}
+
+// ============================================================
+// Online softmax
+// ============================================================
+
+// Compute per-head row-max of scores[group_size, lkp].
+// score_max[h] = max(scores[h, :]).
+// Does NOT consider any running max from previous chunks.
+void decode_softmax_max(bfloat16 *scores, bfloat16 *score_max) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::vector<bfloat16, VecLen> max_v =
+        aie::broadcast<bfloat16, VecLen>(lowest_val);
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        max_v = aie::max(max_v, aie::load_v<VecLen>(sc_h + i));
+      }
+    // Reduce 16 → 1
+    aie::vector<bfloat16, 8> r0 = max_v.extract<8>(0);
+    aie::vector<bfloat16, 8> r1 = max_v.extract<8>(1);
+    r0 = aie::max(r0, r1);
+    score_max[h] = aie::reduce_max(r0);
+  }
+}
+
+// In-place online softmax update:
+//   combined_max[h] = max(max_vec[h], score_max[h])
+//   rescale[h]      = exp(max_vec[h] - combined_max[h])   [for old output]
+//   scores[h, i]    = exp(scores[h, i] - combined_max[h]) [in-place]
+//   max_vec[h]      = combined_max[h]                      [running max
+//   updated]
+void decode_softmax_exp(bfloat16 *scores, bfloat16 *max_vec,
+                        bfloat16 *score_max, bfloat16 *rescale) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  aie::vector<bfloat16, VecLen> log2e_vec =
+      aie::broadcast<bfloat16, VecLen>((bfloat16)decode_log2e);
+  aie::vector<bfloat16, VecLen> lowest_vec =
+      aie::broadcast<bfloat16, VecLen>(lowest_val);
+
+  for (int h = 0; h < group_size; h++) {
+    float om = (float)max_vec[h];
+    float nm = (float)score_max[h];
+    float combined = (om > nm) ? om : nm;
+
+    // Rescale factor for old accumulated output: exp(old_max - new_max)
+    float diff_rescale_f = om - combined;
+    bfloat16 diff_rescale = (bfloat16)diff_rescale_f;
+    // Clamp to lowest before exp to avoid -inf input to exp2
+    if ((float)diff_rescale < (float)lowest_val)
+      diff_rescale = lowest_val;
+    {
+      aie::vector<bfloat16, 8> d8 = aie::broadcast<bfloat16, 8>(diff_rescale);
+      aie::vector<bfloat16, 8> l8 =
+          aie::broadcast<bfloat16, 8>((bfloat16)decode_log2e);
+      aie::vector<bfloat16, 8> r8 =
+          aie::exp2<bfloat16>(aie::mul(d8, l8).to_vector<float>());
+      rescale[h] = r8.get(0);
+    }
+
+    // Update running max
+    max_vec[h] = (bfloat16)combined;
+
+    // Normalize scores: scores[h,i] = exp(scores[h,i] - combined)
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::vector<bfloat16, VecLen> max_bcast =
+        aie::broadcast<bfloat16, VecLen>((bfloat16)combined);
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(sc_h + i);
+        v = aie::sub(v, max_bcast);
+        v = aie::max(v, lowest_vec); // clamp before exp
+        v = aie::exp2<bfloat16>(aie::mul(v, log2e_vec).to_vector<float>());
+        aie::store_v(sc_h + i, v);
+      }
+  }
+}
+
+// Update running sum: sum[h] = sum[h] * rescale[h] + row_sum(scores[h, :])
+// scores[h, :] must already contain exp-normalized values (after
+// decode_softmax_exp).
+void decode_softmax_sum(bfloat16 *scores, bfloat16 *rescale, bfloat16 *sum) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *sc_h = scores + h * lkp;
+    aie::accum<accfloat, VecLen> row_acc = aie::zeros<accfloat, VecLen>();
+    for (int i = 0; i < lkp; i += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        row_acc = aie::add(row_acc, aie::load_v<VecLen>(sc_h + i));
+      }
+    // Reduce 16 → scalar
+    aie::vector<float, VecLen> sum_f = row_acc.to_vector<float>();
+    aie::vector<float, 8> r0 = sum_f.extract<8>(0);
+    aie::vector<float, 8> r1 = sum_f.extract<8>(1);
+    r0 = aie::add(r0, r1);
+    float row_sum = aie::reduce_add(r0);
+    // update: sum = sum * rescale + row_sum
+    sum[h] = (bfloat16)((float)sum[h] * (float)rescale[h] + row_sum);
+  }
+}
+
+// Rescale output: output[h, :] *= rescale[h]
+void decode_rescale_output(bfloat16 *rescale, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    aie::vector<bfloat16, VecLen> r_bcast =
+        aie::broadcast<bfloat16, VecLen>(rescale[h]);
+    for (int j = 0; j < dv; j += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(out_h + j);
+        aie::accum<accfloat, VecLen> acc = aie::mul(v, r_bcast);
+        aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+      }
+  }
+}
+
+// Accumulate PV: output[h, :] += sum_i scores[h, i] * V[i, :]
+// V is [lkp, dv] row-major.  scores[h, :] must hold exp-normalized weights.
+// Uses scalar-broadcast mac: for each position i, broadcast scores[h,i] and
+// multiply with V[i, j:j+VecLen] vector chunk.
+void compute_pv_output_bf16(bfloat16 *scores, bfloat16 *V, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  bfloat16 one_bf16 = (bfloat16)1.0f;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    bfloat16 *sc_h = scores + h * lkp;
+    for (int j = 0; j < dv; j += VecLen) {
+      // Load existing output into accfloat (multiply by 1.0 to convert)
+      aie::vector<bfloat16, VecLen> existing = aie::load_v<VecLen>(out_h + j);
+      aie::vector<bfloat16, VecLen> one_vec =
+          aie::broadcast<bfloat16, VecLen>(one_bf16);
+      aie::accum<accfloat, VecLen> acc = aie::mul(existing, one_vec);
+      // Scalar-broadcast mac over K/V positions.
+      // TODO(perf): Add chess_prepare_for_pipelining pragma here (this is the
+      // most compute-intensive inner loop) once exp2 vector usage (lines above)
+      // is confirmed compatible with pipelining on AIE2P.
+      for (int i = 0; i < lkp; i++) {
+        aie::vector<bfloat16, VecLen> s_bcast =
+            aie::broadcast<bfloat16, VecLen>(sc_h[i]);
+        aie::vector<bfloat16, VecLen> v_row =
+            aie::load_v<VecLen>(V + i * dv + j);
+        acc = aie::mac(acc, s_bcast, v_row);
+      }
+      aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+    }
+  }
+}
+
+// Final division: output[h, :] /= sum[h]
+void decode_div_output(bfloat16 *sum, bfloat16 *out) {
+  SET_ROUNDING();
+  constexpr int VecLen = 16;
+  for (int h = 0; h < group_size; h++) {
+    bfloat16 *out_h = out + h * dv;
+    bfloat16 inv_sum = (bfloat16)(1.0f / (float)sum[h]);
+    aie::vector<bfloat16, VecLen> inv_bcast =
+        aie::broadcast<bfloat16, VecLen>(inv_sum);
+    for (int j = 0; j < dv; j += VecLen)
+      chess_prepare_for_pipelining chess_loop_range(4, ) {
+        aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(out_h + j);
+        aie::accum<accfloat, VecLen> acc = aie::mul(v, inv_bcast);
+        aie::store_v(out_h + j, acc.to_vector<bfloat16>());
+      }
+  }
+}
+
+// ============================================================
+// Cascade merge helpers
+// ============================================================
+
+// Element-wise max update: max_local[h] = max(max_local[h], max_recv[h])
+// Only the first group_size entries are updated.
+void decode_cascade_merge_max(bfloat16 *max_recv, bfloat16 *max_local) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    float a = (float)max_local[h];
+    float b = (float)max_recv[h];
+    max_local[h] = (bfloat16)(a > b ? a : b);
+  }
+}
+
+// Compute rescale factor: rescale[h] = exp(old_max[h] - new_max[h])
+// old_max and new_max have group_size meaningful entries.
+void decode_compute_rescale(bfloat16 *old_max, bfloat16 *new_max,
+                            bfloat16 *rescale) {
+  SET_ROUNDING();
+  bfloat16 lowest_val = *(const bfloat16 *)&bf16_lowest_u16;
+  for (int h = 0; h < group_size; h++) {
+    float diff = (float)old_max[h] - (float)new_max[h];
+    bfloat16 diff_bf16 = (bfloat16)diff;
+    if ((float)diff_bf16 < (float)lowest_val)
+      diff_bf16 = lowest_val;
+    aie::vector<bfloat16, 8> d8 = aie::broadcast<bfloat16, 8>(diff_bf16);
+    aie::vector<bfloat16, 8> l8 =
+        aie::broadcast<bfloat16, 8>((bfloat16)decode_log2e);
+    aie::vector<bfloat16, 8> r8 =
+        aie::exp2<bfloat16>(aie::mul(d8, l8).to_vector<float>());
+    rescale[h] = r8.get(0);
+  }
+}
+
+// Element-wise add: out_dst[h, :] += out_src[h, :]
+// Both are [group_size, dv] row-major.
+void decode_add_output(bfloat16 *out_src, bfloat16 *out_dst) {
+  SET_ROUNDING();
+  constexpr int VecLen = 32;
+  constexpr int num_elems = group_size * dv;
+  bfloat16 *__restrict ps = out_src;
+  bfloat16 *__restrict pd = out_dst;
+  for (int i = 0; i < num_elems; i += VecLen)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      aie::vector<bfloat16, VecLen> vs = aie::load_v<VecLen>(ps);
+      aie::vector<bfloat16, VecLen> vd = aie::load_v<VecLen>(pd);
+      aie::accum<accfloat, VecLen> acc(vd);
+      acc = aie::add(acc, vs);
+      aie::store_v(pd, acc.to_vector<bfloat16>());
+      ps += VecLen;
+      pd += VecLen;
+    }
+}
+
+// Add sums: sum_dst[h] += sum_src[h]  for h in [0, group_size)
+void decode_add_sum(bfloat16 *sum_src, bfloat16 *sum_dst) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    sum_dst[h] = (bfloat16)((float)sum_dst[h] + (float)sum_src[h]);
+  }
+}
+
+// Rescale sum in-place: sum[h] *= rescale[h]  for h in [0, group_size)
+void decode_rescale_sum(bfloat16 *rescale, bfloat16 *sum) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    sum[h] = (bfloat16)((float)sum[h] * (float)rescale[h]);
+  }
+}
+
+// Copy max/sum vector: dst[h] = src[h]  for h in [0, group_size)
+void decode_copy_max_sum(bfloat16 *src, bfloat16 *dst) {
+  SET_ROUNDING();
+  for (int h = 0; h < group_size; h++) {
+    dst[h] = src[h];
+  }
+}
+
+} // extern "C"

--- a/programming_examples/flash_attention/kernel_fusion_based/decode_block_npu2_5all_v2.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/decode_block_npu2_5all_v2.py
@@ -1,0 +1,974 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Decode block on NPU2: full 4-herd RMS->GEMV->RoPE->Attention chain.
+
+Step 5-all V2 of DECODE_FUSION_PLAN.md: extends V1a by adding a
+real `rms_herd` upstream of gemv_herd. rms_herd consumes MMIO
+x_raw + MMIO RMS weights w_rms, computes x_norm via RMSNorm, and
+broadcasts x_norm to all NKV gemv_herd tiles via an L1 broadcast
+channel. gemv_herd consumes broadcast x_norm (no longer X_mmio)
+plus MMIO W_qkv, and the rest of the chain (rope -> attention)
+is unchanged from V1a.
+
+Layout:
+  rms_herd     [1, 1]      : MMIO x_raw + w_rms -> rms -> broadcast
+                              ↓ (L1 broadcast to all NKV gemv tiles)
+  gemv_herd    [NKV, 1]    : x_norm + MMIO W_qkv -> matvec -> 3 cascades
+                              ↓
+  rope_herd    [NKV, 1]    : 3 cascades + MMIO LUT -> rope -> 3 cascades
+                              ↓
+  decode_herd  [NKV, 1]    : 3 cascades + MMIO pos
+                            + L3->memtile->L1 K/V cache reads
+                            -> flash attention + K_new/V_new splice
+
+Toy input dim N=64 keeps W_qkv in L1 — no L2 staging needed.
+Per-col shim DMA: 2 MM2S (KIn, VIn). MMIO + cascade + L1 broadcast
+do not consume shim.
+"""
+
+import argparse
+from math import sqrt
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+import air
+from air.ir import *
+from air.dialects.air import *
+from air.dialects.air import channel, Channel
+from air.dialects.arith import ConstantOp
+from air.dialects.memref import (
+    AllocOp,
+    DeallocOp,
+    GlobalOp,
+    get_global,
+    load,
+    store,
+)
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.scf import for_ as scf_range, yield_, IfOp as ScfIfOp
+from air.ir import InsertionPoint
+from air.dialects import scf, affine, arith
+from air.dialects.affine import apply as affine_apply
+
+
+def make_rope_lut(dk, pos, theta=10000.0):
+    """LUT layout matches mlir-aie/aie_kernels/aie2p/rope.cc:
+    LUT[2k]   = cos(pos * 1/theta^(2k/dk))
+    LUT[2k+1] = sin(pos * 1/theta^(2k/dk))
+    """
+    half = dk // 2
+    inv_freq = 1.0 / (theta ** (np.arange(half) * 2.0 / dk))
+    angles = pos * inv_freq
+    lut = np.empty(dk, dtype=np.float32)
+    lut[0::2] = np.cos(angles)
+    lut[1::2] = np.sin(angles)
+    return lut.astype(bfloat16)
+
+
+def apply_rope_ref(q, lut):
+    """NumPy reference matching the rope.cc kernel semantics:
+    even/odd split; out_even = even*cos - odd*sin; out_odd = even*sin + odd*cos
+    (per (q_head, dk) row; same lut shared across all heads)
+    """
+    q_f32 = q.astype(np.float32)
+    cos = lut[0::2].astype(np.float32)
+    sin = lut[1::2].astype(np.float32)
+    even = q_f32[..., 0::2]
+    odd = q_f32[..., 1::2]
+    out_even = even * cos - odd * sin
+    out_odd = even * sin + odd * cos
+    out = np.empty_like(q_f32)
+    out[..., 0::2] = out_even
+    out[..., 1::2] = out_odd
+    return out.astype(bfloat16)
+
+
+@module_builder
+def build_module(
+    w_qkv_data,
+    x_raw_data,
+    w_rms_data,
+    pos_value,
+    n_in=64,
+    lk=2048,
+    lkp=64,
+    dk=64,
+    dv=64,
+    group_size=4,
+    num_kv_heads=8,
+):
+    NS = 1
+    NKV = num_kv_heads
+    num_heads = group_size * num_kv_heads
+    m_per_col = group_size * dk + dk + dv  # Q + K_new + V_new per col
+    assert lk % lkp == 0, f"lk ({lk}) must be divisible by lkp ({lkp})"
+    chunks = lk // lkp
+    assert w_qkv_data.shape == (
+        NKV,
+        m_per_col,
+        n_in,
+    ), f"w_qkv shape {w_qkv_data.shape} != [{NKV}, {m_per_col}, {n_in}]"
+    assert x_raw_data.shape == (n_in,), f"x_raw shape != [{n_in}]"
+    assert w_rms_data.shape == (n_in,), f"w_rms shape != [{n_in}]"
+
+    bf16 = Type.parse("bf16")
+    i32 = IntegerType.get_signless(32)
+    index_type = IndexType.get()
+
+    l1_space = IntegerAttr.get(i32, 2)
+    l2_space = IntegerAttr.get(i32, 1)
+
+    q_per_col_shape = [group_size, dk]
+    knew_per_col_shape = [dk]
+    vnew_per_col_shape = [dv]
+
+    q_l1_t = MemRefType.get(q_per_col_shape, bf16, memory_space=l1_space)
+    knew_l1_t = MemRefType.get(knew_per_col_shape, bf16, memory_space=l1_space)
+    vnew_l1_t = MemRefType.get(vnew_per_col_shape, bf16, memory_space=l1_space)
+    # gemv L1: per-col W_qkv weight matrix (rows for Q+K+V) and the
+    # input vector x. Both loaded via MMIO initial_value at device init.
+    w_q_l1_t = MemRefType.get([group_size * dk, n_in], bf16, memory_space=l1_space)
+    w_k_l1_t = MemRefType.get([dk, n_in], bf16, memory_space=l1_space)
+    w_v_l1_t = MemRefType.get([dv, n_in], bf16, memory_space=l1_space)
+    q_flat_l1_t = MemRefType.get([group_size * dk], bf16, memory_space=l1_space)
+    x_l1_t = MemRefType.get([n_in], bf16, memory_space=l1_space)
+    lut_l1_t = MemRefType.get([dk], bf16, memory_space=l1_space)
+    k_l1_t = MemRefType.get([lkp, dk], bf16, memory_space=l1_space)
+    v_l1_t = MemRefType.get([lkp, dv], bf16, memory_space=l1_space)
+    scores_l1_t = MemRefType.get([group_size, lkp], bf16, memory_space=l1_space)
+    out_l1_t = MemRefType.get([group_size, dv], bf16, memory_space=l1_space)
+    ms_l1_t = MemRefType.get([max(group_size, 32)], bf16, memory_space=l1_space)
+    pos_l1_t = MemRefType.get([1], i32, memory_space=l1_space)
+
+    out_l2_t = MemRefType.get([NKV, group_size, dv], bf16, memory_space=l2_space)
+    k_l2_t = MemRefType.get([lkp, dk], bf16, memory_space=l2_space)
+    v_l2_t = MemRefType.get([lkp, dv], bf16, memory_space=l2_space)
+
+    k_l3_t = MemRefType.get([num_kv_heads, lk, dk], bf16)
+    v_l3_t = MemRefType.get([num_kv_heads, lk, dv], bf16)
+    out_l3_t = MemRefType.get([num_heads, dv], bf16)
+
+    # MMIO W_qkv globals: per-col [m_per_col, n_in] weight matrix.
+    # Split into per-output-stream (Q, K, V) globals so the destination
+    # MMIO L1 buffer types (W_q_l1, W_k_l1, W_v_l1) match cleanly.
+    w_q_global_t = MemRefType.get([group_size * dk, n_in], bf16)
+    w_k_global_t = MemRefType.get([dk, n_in], bf16)
+    w_v_global_t = MemRefType.get([dv, n_in], bf16)
+    w_q_global_names = []
+    w_k_global_names = []
+    w_v_global_names = []
+    for c in range(NKV):
+        # Q rows: [c, 0:group_size*dk, :]
+        sym_q = f"w_q_const_col{c}"
+        w_q_global_names.append(sym_q)
+        slice_q = w_qkv_data[c, : group_size * dk, :]
+        tensor_t_q = RankedTensorType.get([group_size * dk, n_in], bf16)
+        attr_q = DenseElementsAttr.get(
+            np.ascontiguousarray(slice_q).view(np.uint16), type=tensor_t_q
+        )
+        GlobalOp(
+            sym_name=sym_q,
+            type_=TypeAttr.get(w_q_global_t),
+            sym_visibility="private",
+            initial_value=attr_q,
+        )
+
+        # K_new rows: [c, group_size*dk : group_size*dk + dk, :]
+        sym_k = f"w_k_const_col{c}"
+        w_k_global_names.append(sym_k)
+        slice_k = w_qkv_data[c, group_size * dk : group_size * dk + dk, :]
+        tensor_t_k = RankedTensorType.get([dk, n_in], bf16)
+        attr_k = DenseElementsAttr.get(
+            np.ascontiguousarray(slice_k).view(np.uint16), type=tensor_t_k
+        )
+        GlobalOp(
+            sym_name=sym_k,
+            type_=TypeAttr.get(w_k_global_t),
+            sym_visibility="private",
+            initial_value=attr_k,
+        )
+
+        # V_new rows: [c, group_size*dk + dk : group_size*dk + dk + dv, :]
+        sym_v = f"w_v_const_col{c}"
+        w_v_global_names.append(sym_v)
+        slice_v = w_qkv_data[c, group_size * dk + dk : group_size * dk + dk + dv, :]
+        tensor_t_v = RankedTensorType.get([dv, n_in], bf16)
+        attr_v = DenseElementsAttr.get(
+            np.ascontiguousarray(slice_v).view(np.uint16), type=tensor_t_v
+        )
+        GlobalOp(
+            sym_name=sym_v,
+            type_=TypeAttr.get(w_v_global_t),
+            sym_visibility="private",
+            initial_value=attr_v,
+        )
+
+    # MMIO x_raw + w_rms globals: single tile (rms_herd consumes them
+    # via per-tile MMIO). One global each — rms_herd is [1, 1].
+    xraw_global_t = MemRefType.get([n_in], bf16)
+    xraw_tensor_t = RankedTensorType.get([n_in], bf16)
+    GlobalOp(
+        sym_name="x_raw_const",
+        type_=TypeAttr.get(xraw_global_t),
+        sym_visibility="private",
+        initial_value=DenseElementsAttr.get(
+            np.ascontiguousarray(x_raw_data).view(np.uint16),
+            type=xraw_tensor_t,
+        ),
+    )
+    wrms_global_t = MemRefType.get([n_in], bf16)
+    GlobalOp(
+        sym_name="w_rms_const",
+        type_=TypeAttr.get(wrms_global_t),
+        sym_visibility="private",
+        initial_value=DenseElementsAttr.get(
+            np.ascontiguousarray(w_rms_data).view(np.uint16),
+            type=xraw_tensor_t,
+        ),
+    )
+
+    # MMIO LUT globals: per-pos rope cos/sin LUT, shared across all
+    # heads of all cols. Delivered per-col for symmetry with mmio
+    # bundle dispatch.
+    rope_lut = make_rope_lut(dk, pos_value)
+    lut_global_t = MemRefType.get([dk], bf16)
+    lut_global_names = []
+    for c in range(NKV):
+        sym = f"lut_const_col{c}"
+        lut_global_names.append(sym)
+        tensor_t = RankedTensorType.get([dk], bf16)
+        const_attr = DenseElementsAttr.get(
+            np.ascontiguousarray(rope_lut).view(np.uint16),
+            type=tensor_t,
+        )
+        GlobalOp(
+            sym_name=sym,
+            type_=TypeAttr.get(lut_global_t),
+            sym_visibility="private",
+            initial_value=const_attr,
+        )
+
+    pos_global_t = MemRefType.get([1], i32)
+    pos_tensor_t = RankedTensorType.get([1], i32)
+    pos_global_names = []
+    for c in range(NKV):
+        sym = f"pos_const_col{c}"
+        pos_global_names.append(sym)
+        pos_attr = DenseElementsAttr.get(
+            np.array([pos_value], dtype=np.int32),
+            type=pos_tensor_t,
+        )
+        GlobalOp(
+            sym_name=sym,
+            type_=TypeAttr.get(pos_global_t),
+            sym_visibility="private",
+            initial_value=pos_attr,
+        )
+
+    def external_func(name, inputs, link_with=None):
+        func_type = FunctionType.get(inputs, [])
+        f = FuncOp(name=name, type=func_type, visibility="private")
+        f.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+        if link_with:
+            f.attributes["link_with"] = StringAttr.get(link_with)
+        return f
+
+    kobj = "attn_decode_npu2.o"
+    external_func("decode_zero_output", [out_l1_t], link_with=kobj)
+    external_func("decode_zero_sum", [ms_l1_t], link_with=kobj)
+    external_func("decode_neg_inf_max", [ms_l1_t], link_with=kobj)
+    external_func(
+        "compute_qk_scores_bf16", [k_l1_t, q_l1_t, scores_l1_t], link_with=kobj
+    )
+    external_func("apply_decode_mask", [scores_l1_t, i32, i32], link_with=kobj)
+    external_func("decode_softmax_max", [scores_l1_t, ms_l1_t], link_with=kobj)
+    external_func(
+        "decode_softmax_exp",
+        [scores_l1_t, ms_l1_t, ms_l1_t, ms_l1_t],
+        link_with=kobj,
+    )
+    external_func("decode_softmax_sum", [scores_l1_t, ms_l1_t, ms_l1_t], link_with=kobj)
+    external_func("decode_rescale_output", [ms_l1_t, out_l1_t], link_with=kobj)
+    external_func(
+        "compute_pv_output_bf16", [scores_l1_t, v_l1_t, out_l1_t], link_with=kobj
+    )
+    external_func("decode_div_output", [ms_l1_t, out_l1_t], link_with=kobj)
+
+    # rope_multi: applies rope to nrows consecutive bf16 rows of size
+    # dim, sharing one LUT. Wraps the upstream rope kernel — avoids
+    # per-row subview type acrobatics in the herd body.
+    rope_kobj = "rope_multi.o"
+    external_func(
+        "rope_multi",
+        [q_l1_t, lut_l1_t, q_l1_t, i32, i32],
+        link_with=rope_kobj,
+    )
+    # Same wrapper, called for K_new (single row).
+    external_func(
+        "rope_multi_knew",
+        [knew_l1_t, lut_l1_t, knew_l1_t, i32, i32],
+        link_with=rope_kobj,
+    )
+
+    # Note: row-patching of K_new/V_new into the last K/V chunk is
+    # done with scalar memref.load/store loops in the herd body
+    # rather than a kernel call — keeps decode_herd link_with
+    # pinned to attn_decode_npu2.o (one .o per herd) and avoids
+    # the per-row strided-memref subview type juggling that
+    # rope_multi originally sidestepped.
+
+    # simple_matvec_bf16(W, x, y, M, K) : y[m] = sum_k W[m, k] * x[k].
+    # Lives in simple_matvec.o. Used by gemv_herd at toy dim N=64.
+    matvec_kobj = "simple_matvec.o"
+    # The kernel C ABI takes a flat bf16* — MLIR memref shape is just
+    # used by the c_interface wrapper to extract the data pointer.
+    # Declare the Q output as q_l1_t [group_size, dk] for clean
+    # downstream cascade put (flat-shape would need an expand_shape).
+    external_func(
+        "simple_matvec_bf16",
+        [w_q_l1_t, x_l1_t, q_l1_t, i32, i32],
+        link_with=matvec_kobj,
+    )
+    external_func(
+        "simple_matvec_bf16_k",
+        [w_k_l1_t, x_l1_t, knew_l1_t, i32, i32],
+        link_with=matvec_kobj,
+    )
+    external_func(
+        "simple_matvec_bf16_v",
+        [w_v_l1_t, x_l1_t, vnew_l1_t, i32, i32],
+        link_with=matvec_kobj,
+    )
+
+    # simple_rms_bf16(x, w, y, N) : y = x * rsqrt(mean(x^2)+eps) * w.
+    # Lives in simple_rms.o. Used by rms_herd at toy dim N=64.
+    rms_kobj = "simple_rms.o"
+    external_func(
+        "simple_rms_bf16",
+        [x_l1_t, x_l1_t, x_l1_t, i32],
+        link_with=rms_kobj,
+    )
+
+    # MMIO weight channels for gemv_herd (W_qkv split per output stream).
+    channel("W_q_mmio", size=[NKV], channel_type="mmio")
+    channel("W_k_mmio", size=[NKV], channel_type="mmio")
+    channel("W_v_mmio", size=[NKV], channel_type="mmio")
+    # MMIO inputs for rms_herd (single tile, indices=[0]).
+    channel("XRaw_mmio", size=[1], channel_type="mmio")
+    channel("WRms_mmio", size=[1], channel_type="mmio")
+    # L1 broadcast: rms_herd's single tile -> all NKV gemv tiles.
+    # Uppercase Channel() supports broadcast_shape (lowercase channel
+    # forwards channel_type but not broadcast_shape — see CLAUDE.md).
+    Channel("x_norm_bcast", size=[1, 1], broadcast_shape=[NKV, 1])
+
+    # gemv -> rope cascades (3 hops on the gemv->rope segment of the
+    # column cascade wire). gemv_herd_stub gets MMIO into L1 and
+    # then immediately puts onto these cascades.
+    channel("G2R_Q", size=[NKV, 1], channel_type="cascade")
+    channel("G2R_KNew", size=[NKV, 1], channel_type="cascade")
+    channel("G2R_VNew", size=[NKV, 1], channel_type="cascade")
+
+    # rope -> decode cascades (3 hops on the rope->decode segment).
+    channel("LUT_mmio", size=[NKV], channel_type="mmio")
+    channel("Q_cascade", size=[NKV, 1], channel_type="cascade")
+    channel("KNew_cascade", size=[NKV, 1], channel_type="cascade")
+    channel("VNew_cascade", size=[NKV, 1], channel_type="cascade")
+    channel("pos_mmio", size=[NKV], channel_type="mmio")
+    channel("KIn", size=[NKV])
+    channel("K2L1", size=[NKV])
+    channel("VIn", size=[NKV])
+    channel("V2L1", size=[NKV])
+    channel("out_dec", size=[NKV])
+
+    @FuncOp.from_py_func(k_l3_t, v_l3_t, out_l3_t)
+    def decode_attention_bf16(k_in, v_in, out):
+        c1_idx = ConstantOp(index_type, 1)
+
+        @launch(operands=[k_in, v_in, out], sizes=[c1_idx])
+        def launch_body(_lx, _lsx, k_l, v_l, out_l):
+            # Single put for rms_herd's MMIO inputs (size=[1]).
+            c0_idx = ConstantOp(index_type, 0)
+            xraw_src = get_global(xraw_global_t, "x_raw_const")
+            ChannelPut("XRaw_mmio", xraw_src, indices=[c0_idx])
+            wrms_src = get_global(wrms_global_t, "w_rms_const")
+            ChannelPut("WRms_mmio", wrms_src, indices=[c0_idx])
+
+            for c in range(NKV):
+                c_idx = ConstantOp(index_type, c)
+                w_q_src = get_global(w_q_global_t, w_q_global_names[c])
+                ChannelPut("W_q_mmio", w_q_src, indices=[c_idx])
+                w_k_src = get_global(w_k_global_t, w_k_global_names[c])
+                ChannelPut("W_k_mmio", w_k_src, indices=[c_idx])
+                w_v_src = get_global(w_v_global_t, w_v_global_names[c])
+                ChannelPut("W_v_mmio", w_v_src, indices=[c_idx])
+                lut_src = get_global(lut_global_t, lut_global_names[c])
+                ChannelPut("LUT_mmio", lut_src, indices=[c_idx])
+                pos_src = get_global(pos_global_t, pos_global_names[c])
+                ChannelPut("pos_mmio", pos_src, indices=[c_idx])
+
+            for tx_i in range(NKV):
+                c_tx_i = ConstantOp(index_type, tx_i)
+                ChannelPut(
+                    "KIn",
+                    k_l,
+                    offsets=[c_tx_i, 0, 0, 0],
+                    sizes=[1, chunks, lkp, dk],
+                    strides=[lk * dk, lkp * dk, dk, 1],
+                    indices=[c_tx_i],
+                )
+                ChannelPut(
+                    "VIn",
+                    v_l,
+                    offsets=[c_tx_i, 0, 0, 0],
+                    sizes=[1, chunks, lkp, dv],
+                    strides=[lk * dv, lkp * dv, dv, 1],
+                    indices=[c_tx_i],
+                )
+
+            @segment(name="decode_seg", operands=[out_l])
+            def segment_body(out_s):
+                out_l2 = AllocOp(out_l2_t, [], [])
+                k_l2_bufs = [AllocOp(k_l2_t, [], []) for _ in range(NKV)]
+                v_l2_bufs = [AllocOp(v_l2_t, [], []) for _ in range(NKV)]
+
+                # rms_herd L1: x_raw (MMIO), w_rms (MMIO), x_norm (out
+                # via L1 broadcast to gemv).
+                xraw_rms_l1 = AllocOp(x_l1_t, [], [])
+                wrms_rms_l1 = AllocOp(x_l1_t, [], [])
+                xnorm_rms_l1 = AllocOp(x_l1_t, [], [])
+
+                # gemv_herd L1 buffers (V2: x_norm via broadcast).
+                #   W_q/W_k/W_v: per-output-stream weights (MMIO load)
+                #   x_gemv: input vector (broadcast load from rms_herd)
+                #   q_gemv/knew_gemv/vnew_gemv: matvec outputs
+                #     cascaded south to rope_herd
+                w_q_gemv_l1 = AllocOp(w_q_l1_t, [], [])
+                w_k_gemv_l1 = AllocOp(w_k_l1_t, [], [])
+                w_v_gemv_l1 = AllocOp(w_v_l1_t, [], [])
+                x_gemv_l1 = AllocOp(x_l1_t, [], [])
+                q_gemv_l1 = AllocOp(q_l1_t, [], [])
+                knew_gemv_l1 = AllocOp(knew_l1_t, [], [])
+                vnew_gemv_l1 = AllocOp(vnew_l1_t, [], [])
+
+                # rope_herd L1: now receives Q/K_new/V_new from G2R
+                # cascades (not MMIO) and post-rope into _out buffers.
+                q_prod_in_l1 = AllocOp(q_l1_t, [], [])
+                lut_l1 = AllocOp(lut_l1_t, [], [])
+                q_prod_out_l1 = AllocOp(q_l1_t, [], [])
+                knew_in_l1_prod = AllocOp(knew_l1_t, [], [])
+                knew_out_l1_prod = AllocOp(knew_l1_t, [], [])
+                vnew_l1_prod = AllocOp(vnew_l1_t, [], [])
+
+                # Consumer L1: drain buffers for K_new/V_new cascades.
+                # V0 doesn't fold them into attention, just drains.
+                knew_drain_l1 = AllocOp(knew_l1_t, [], [])
+                vnew_drain_l1 = AllocOp(vnew_l1_t, [], [])
+
+                q_l1 = AllocOp(q_l1_t, [], [])
+                k_l1 = AllocOp(k_l1_t, [], [])
+                v_l1 = AllocOp(v_l1_t, [], [])
+                scores_l1 = AllocOp(scores_l1_t, [], [])
+                out_l1 = AllocOp(out_l1_t, [], [])
+                max_l1 = AllocOp(ms_l1_t, [], [])
+                sum_l1 = AllocOp(ms_l1_t, [], [])
+                score_max_tmp = AllocOp(ms_l1_t, [], [])
+                rescale_tmp = AllocOp(ms_l1_t, [], [])
+                pos_l1 = AllocOp(pos_l1_t, [], [])
+
+                c_nkv = ConstantOp(index_type, NKV)
+                c_ns = ConstantOp(index_type, 1)
+                c_chunks_seg = ConstantOp(index_type, chunks)
+
+                for tx_i in range(NKV):
+                    c_tx_i = ConstantOp(index_type, tx_i)
+                    for _ in scf_range(0, c_chunks_seg, 1):
+                        ChannelGet(
+                            "KIn",
+                            k_l2_bufs[tx_i].result,
+                            indices=[c_tx_i],
+                        )
+                        ChannelPut(
+                            "K2L1",
+                            k_l2_bufs[tx_i].result,
+                            indices=[c_tx_i],
+                        )
+                        yield_([])
+                    for _ in scf_range(0, c_chunks_seg, 1):
+                        ChannelGet(
+                            "VIn",
+                            v_l2_bufs[tx_i].result,
+                            indices=[c_tx_i],
+                        )
+                        ChannelPut(
+                            "V2L1",
+                            v_l2_bufs[tx_i].result,
+                            indices=[c_tx_i],
+                        )
+                        yield_([])
+
+                # rms_herd: single tile, MMIO x_raw + w_rms, computes
+                # x_norm and broadcasts to all NKV gemv_herd tiles.
+                # Declared BEFORE gemv so the placer puts it north.
+                c1_seg = ConstantOp(index_type, 1)
+
+                @herd(
+                    name="rms_herd",
+                    sizes=[c1_seg, c1_seg],
+                    operands=[xraw_rms_l1, wrms_rms_l1, xnorm_rms_l1],
+                    link_with=rms_kobj,
+                )
+                def rms_body(_tx, _ty, _hsx, _hsy, _xraw, _wrms, _xnorm):
+                    ChannelGet("XRaw_mmio", _xraw, indices=[_tx])
+                    ChannelGet("WRms_mmio", _wrms, indices=[_tx])
+                    n_i32_rms = ConstantOp(i32, n_in)
+                    CallOp([], "simple_rms_bf16", [_xraw, _wrms, _xnorm, n_i32_rms])
+                    ChannelPut("x_norm_bcast", _xnorm, indices=[_tx, _ty])
+
+                # gemv_herd: real matvec. Receives MMIO W_qkv (split
+                # into 3 per-output-stream globals) + broadcast x_norm
+                # from rms_herd, computes Q/K_new/V_new via
+                # simple_matvec_bf16, cascades south to rope_herd.
+                # Declared BEFORE rope_herd so the cascade-aware
+                # placer puts it at the highest row (north of rope,
+                # which is north of decode).
+                @herd(
+                    name="gemv_herd",
+                    sizes=[c_nkv, c_ns],
+                    operands=[
+                        w_q_gemv_l1,
+                        w_k_gemv_l1,
+                        w_v_gemv_l1,
+                        x_gemv_l1,
+                        q_gemv_l1,
+                        knew_gemv_l1,
+                        vnew_gemv_l1,
+                    ],
+                    link_with=matvec_kobj,
+                )
+                def gemv_body(
+                    _tx,
+                    _ty,
+                    _hsx,
+                    _hsy,
+                    _w_q,
+                    _w_k,
+                    _w_v,
+                    _x,
+                    _q,
+                    _knew,
+                    _vnew,
+                ):
+                    ChannelGet("W_q_mmio", _w_q, indices=[_tx])
+                    ChannelGet("W_k_mmio", _w_k, indices=[_tx])
+                    ChannelGet("W_v_mmio", _w_v, indices=[_tx])
+                    # x_norm arrives via L1 broadcast from rms_herd
+                    # (size=[1, 1] producer, broadcast_shape=[NKV, 1]).
+                    ChannelGet("x_norm_bcast", _x, indices=[_tx, _ty])
+
+                    n_i32 = ConstantOp(i32, n_in)
+                    m_q_i32 = ConstantOp(i32, group_size * dk)
+                    m_k_i32 = ConstantOp(i32, dk)
+                    m_v_i32 = ConstantOp(i32, dv)
+                    CallOp([], "simple_matvec_bf16", [_w_q, _x, _q, m_q_i32, n_i32])
+                    CallOp(
+                        [], "simple_matvec_bf16_k", [_w_k, _x, _knew, m_k_i32, n_i32]
+                    )
+                    CallOp(
+                        [], "simple_matvec_bf16_v", [_w_v, _x, _vnew, m_v_i32, n_i32]
+                    )
+
+                    # Cascade south in the same order rope_herd will
+                    # consume (Q, K_new, V_new) — single physical
+                    # cascade wire serializes them.
+                    ChannelPut("G2R_Q", _q, indices=[_tx, _ty])
+                    ChannelPut("G2R_KNew", _knew, indices=[_tx, _ty])
+                    ChannelPut("G2R_VNew", _vnew, indices=[_tx, _ty])
+
+                # rope_herd: now receives Q/K_new/V_new from G2R
+                # cascades (not MMIO) and LUT from MMIO. Applies rope
+                # to Q and K_new (V passthrough), cascades 3 outputs
+                # south to decode_herd.
+                @herd(
+                    name="rope_herd",
+                    sizes=[c_nkv, c_ns],
+                    operands=[
+                        q_prod_in_l1,
+                        lut_l1,
+                        q_prod_out_l1,
+                        knew_in_l1_prod,
+                        knew_out_l1_prod,
+                        vnew_l1_prod,
+                    ],
+                    link_with=rope_kobj,
+                )
+                def rope_body(
+                    _tx,
+                    _ty,
+                    _hsx,
+                    _hsy,
+                    _q_in,
+                    _lut,
+                    _q_out,
+                    _knew_in,
+                    _knew_out,
+                    _vnew,
+                ):
+                    # Q/K_new/V_new now arrive from gemv_herd_stub
+                    # via the G2R_* cascades (north). Order matches
+                    # gemv_stub_body's puts.
+                    ChannelGet("G2R_Q", _q_in, indices=[_tx, _ty])
+                    ChannelGet("G2R_KNew", _knew_in, indices=[_tx, _ty])
+                    ChannelGet("G2R_VNew", _vnew, indices=[_tx, _ty])
+                    ChannelGet("LUT_mmio", _lut, indices=[_tx])
+
+                    q_nrows_i32 = ConstantOp(i32, group_size)
+                    knew_nrows_i32 = ConstantOp(i32, 1)
+                    dim_i32 = ConstantOp(i32, dk)
+                    CallOp(
+                        [], "rope_multi", [_q_in, _lut, _q_out, q_nrows_i32, dim_i32]
+                    )
+                    CallOp(
+                        [],
+                        "rope_multi_knew",
+                        [_knew_in, _lut, _knew_out, knew_nrows_i32, dim_i32],
+                    )
+
+                    # Cascade order: Q, K_new, V_new (consumer must
+                    # get in the same order on the same physical
+                    # cascade link).
+                    ChannelPut("Q_cascade", _q_out, indices=[_tx, _ty])
+                    ChannelPut("KNew_cascade", _knew_out, indices=[_tx, _ty])
+                    ChannelPut("VNew_cascade", _vnew, indices=[_tx, _ty])
+
+                @herd(
+                    name="decode_herd",
+                    sizes=[c_nkv, c_ns],
+                    operands=[
+                        q_l1,
+                        k_l1,
+                        v_l1,
+                        scores_l1,
+                        out_l1,
+                        max_l1,
+                        sum_l1,
+                        score_max_tmp,
+                        rescale_tmp,
+                        pos_l1,
+                        knew_drain_l1,
+                        vnew_drain_l1,
+                    ],
+                    link_with=kobj,
+                )
+                def herd_body(
+                    tx,
+                    ty,
+                    _hsx,
+                    _hsy,
+                    _q_l1,
+                    _k_l1,
+                    _v_l1,
+                    _scores_l1,
+                    _out_l1,
+                    _max_l1,
+                    _sum_l1,
+                    _score_max_tmp,
+                    _rescale_tmp,
+                    _pos_l1,
+                    _knew_drain,
+                    _vnew_drain,
+                ):
+                    # Get all 3 cascades in producer-put order
+                    # (Q, K_new, V_new) — same physical cascade link.
+                    ChannelGet("Q_cascade", _q_l1, indices=[tx, ty])
+                    ChannelGet("KNew_cascade", _knew_drain, indices=[tx, ty])
+                    ChannelGet("VNew_cascade", _vnew_drain, indices=[tx, ty])
+                    ChannelGet("pos_mmio", _pos_l1, indices=[tx])
+                    c0_idx = ConstantOp(index_type, 0)
+                    pos_val = load(_pos_l1, [c0_idx])
+
+                    CallOp([], "decode_zero_output", [_out_l1])
+                    CallOp([], "decode_neg_inf_max", [_max_l1])
+                    CallOp([], "decode_zero_sum", [_sum_l1])
+
+                    c_chunks = ConstantOp(index_type, chunks)
+                    chunk_pos_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(lkp),
+                            )
+                        ],
+                    )
+
+                    c_chunks_minus_1 = ConstantOp(index_type, chunks - 1)
+                    c_lkp_minus_1 = ConstantOp(index_type, lkp - 1)
+
+                    for chunk_idx in scf_range(0, c_chunks, 1):
+                        chunk_pos = affine_apply(chunk_pos_map, [chunk_idx])
+
+                        ChannelGet("K2L1", _k_l1, indices=[tx])
+                        ChannelGet("V2L1", _v_l1, indices=[tx])
+
+                        # On the last chunk, splice K_new/V_new
+                        # (cascade-delivered) into row lkp-1 of the
+                        # K/V tile. The host zero-stuffed slot lk-1
+                        # of the cache so cascade values are the
+                        # source of truth for that position.
+                        is_last = arith.cmpi(
+                            arith.CmpIPredicate.eq, chunk_idx, c_chunks_minus_1
+                        )
+                        if_patch = ScfIfOp(is_last)
+                        with InsertionPoint(if_patch.then_block):
+                            for i in range(dk):
+                                ci = ConstantOp(index_type, i)
+                                val = load(_knew_drain, [ci])
+                                store(val, _k_l1, [c_lkp_minus_1, ci])
+                            for i in range(dv):
+                                ci = ConstantOp(index_type, i)
+                                val = load(_vnew_drain, [ci])
+                                store(val, _v_l1, [c_lkp_minus_1, ci])
+                            yield_([])
+
+                        CallOp(
+                            [],
+                            "compute_qk_scores_bf16",
+                            [_k_l1, _q_l1, _scores_l1],
+                        )
+                        chunk_pos_i32 = arith.IndexCastOp(i32, chunk_pos).result
+                        CallOp(
+                            [],
+                            "apply_decode_mask",
+                            [_scores_l1, chunk_pos_i32, pos_val],
+                        )
+                        CallOp([], "decode_softmax_max", [_scores_l1, _score_max_tmp])
+                        CallOp(
+                            [],
+                            "decode_softmax_exp",
+                            [_scores_l1, _max_l1, _score_max_tmp, _rescale_tmp],
+                        )
+                        CallOp([], "decode_rescale_output", [_rescale_tmp, _out_l1])
+                        CallOp(
+                            [],
+                            "compute_pv_output_bf16",
+                            [_scores_l1, _v_l1, _out_l1],
+                        )
+                        CallOp(
+                            [],
+                            "decode_softmax_sum",
+                            [_scores_l1, _rescale_tmp, _sum_l1],
+                        )
+                        yield_([])
+
+                    CallOp([], "decode_div_output", [_sum_l1, _out_l1])
+                    ChannelPut("out_dec", _out_l1, indices=[tx])
+
+                for tx_i in range(NKV):
+                    c_tx_i_out = ConstantOp(index_type, tx_i)
+                    ChannelGet(
+                        "out_dec",
+                        out_l2.result,
+                        offsets=[tx_i, 0, 0],
+                        sizes=[1, group_size, dv],
+                        strides=[group_size * dv, dv, 1],
+                        indices=[c_tx_i_out],
+                    )
+
+                dma_memcpy_nd(
+                    out_s,
+                    out_l2.result,
+                    dst_offsets=[0, 0],
+                    dst_sizes=[NKV * group_size, dv],
+                    dst_strides=[dv, 1],
+                    src_offsets=[0, 0, 0],
+                    src_sizes=[NKV, group_size, dv],
+                    src_strides=[group_size * dv, dv, 1],
+                )
+
+                DeallocOp(out_l2)
+                DeallocOp(xraw_rms_l1)
+                DeallocOp(wrms_rms_l1)
+                DeallocOp(xnorm_rms_l1)
+                DeallocOp(w_q_gemv_l1)
+                DeallocOp(w_k_gemv_l1)
+                DeallocOp(w_v_gemv_l1)
+                DeallocOp(x_gemv_l1)
+                DeallocOp(q_gemv_l1)
+                DeallocOp(knew_gemv_l1)
+                DeallocOp(vnew_gemv_l1)
+                DeallocOp(q_prod_in_l1)
+                DeallocOp(lut_l1)
+                DeallocOp(q_prod_out_l1)
+                DeallocOp(knew_in_l1_prod)
+                DeallocOp(knew_out_l1_prod)
+                DeallocOp(vnew_l1_prod)
+                DeallocOp(knew_drain_l1)
+                DeallocOp(vnew_drain_l1)
+                DeallocOp(q_l1)
+                DeallocOp(k_l1)
+                DeallocOp(v_l1)
+                DeallocOp(scores_l1)
+                DeallocOp(out_l1)
+                DeallocOp(max_l1)
+                DeallocOp(sum_l1)
+                DeallocOp(score_max_tmp)
+                DeallocOp(rescale_tmp)
+                DeallocOp(pos_l1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="decode_block_npu2_5all_v1a.py",
+        description="Decode block with real GEMV in 3-herd cascade chain (toy N)",
+    )
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "--n-in",
+        type=int,
+        default=64,
+        help="GEMV input dimension (must match kernel's K=64)",
+    )
+    parser.add_argument("--lk", type=int, default=2048)
+    parser.add_argument("--lkp", type=int, default=64)
+    parser.add_argument("--dk", type=int, default=64)
+    parser.add_argument("--dv", type=int, default=64)
+    parser.add_argument("--group-size", type=int, default=4)
+    parser.add_argument("--num-kv-heads", type=int, default=8)
+    parser.add_argument("--current-pos", type=int, default=None)
+    parser.add_argument(
+        "--compile-mode",
+        choices=["compile-only", "compile-and-run"],
+        default="compile-and-run",
+    )
+    parser.add_argument("--output-format", choices=["elf"], default="elf")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    num_heads = args.group_size * args.num_kv_heads
+    current_pos = args.current_pos if args.current_pos is not None else args.lk - 1
+    m_per_col = args.group_size * args.dk + args.dk + args.dv
+
+    rng = np.random.default_rng(args.seed)
+    # Smaller weight scale so [N=64, sum] doesn't blow up bf16 range
+    # in the matvec accumulation. With val_range=0.5 and N=64 the
+    # max |dot| ~ 64 * 0.5^2 ~ 16, still well within bf16 dynamic.
+    w_range = 0.5
+    x_range = 1.0
+    val_range = 2.0
+
+    # RMS inputs: x_raw vector + w_rms scaling weights.
+    x_raw = rng.uniform(-x_range, x_range, (args.n_in,)).astype(bfloat16)
+    w_rms = rng.uniform(0.5, 1.5, (args.n_in,)).astype(bfloat16)
+
+    # GEMV inputs: per-kv-head W_qkv slice (input vec is rms output, computed below).
+    w_qkv = rng.uniform(
+        -w_range, w_range, (args.num_kv_heads, m_per_col, args.n_in)
+    ).astype(bfloat16)
+
+    # Reference RMS: x_norm = x_raw * rsqrt(mean(x_raw^2) + eps) * w_rms
+    eps = 1e-5
+    x_raw_f32 = x_raw.astype(np.float32)
+    w_rms_f32 = w_rms.astype(np.float32)
+    rstd = 1.0 / np.sqrt(np.mean(x_raw_f32**2) + eps)
+    x_norm_f32 = x_raw_f32 * rstd * w_rms_f32
+    x_norm_bf16 = x_norm_f32.astype(bfloat16)
+
+    # Reference matvec uses x_norm cast back to fp32 (matches kernel
+    # which loads x_norm bf16 then promotes for accumulation).
+    w_f32 = w_qkv.astype(np.float32)
+    x_f32 = x_norm_bf16.astype(np.float32)
+    qkv_out = (w_f32 @ x_f32).astype(bfloat16)  # [NKV, m_per_col]
+
+    # Slice into Q/K/V per kv-head, then unflatten Q into heads.
+    q_pre_rope = qkv_out[:, : args.group_size * args.dk].reshape(
+        args.num_kv_heads, args.group_size, args.dk
+    )  # [NKV, group_size, dk]
+    k_new_pre_rope = qkv_out[
+        :, args.group_size * args.dk : args.group_size * args.dk + args.dk
+    ]  # [NKV, dk]
+    v_new = qkv_out[
+        :,
+        args.group_size * args.dk
+        + args.dk : args.group_size * args.dk
+        + args.dk
+        + args.dv,
+    ]  # [NKV, dv]
+
+    # K_cache, V_cache from L3 — zeroed at slot lk-1 (cascade K_new/V_new
+    # are the source of truth for that position).
+    input_k = rng.uniform(
+        -val_range, val_range, (args.num_kv_heads, args.lk, args.dk)
+    ).astype(bfloat16)
+    input_v = rng.uniform(
+        -val_range, val_range, (args.num_kv_heads, args.lk, args.dv)
+    ).astype(bfloat16)
+    input_k[:, args.lk - 1, :] = 0
+    input_v[:, args.lk - 1, :] = 0
+
+    mlir_module = build_module(
+        w_qkv_data=w_qkv,
+        x_raw_data=x_raw,
+        w_rms_data=w_rms,
+        pos_value=current_pos,
+        n_in=args.n_in,
+        lk=args.lk,
+        lkp=args.lkp,
+        dk=args.dk,
+        dv=args.dv,
+        group_size=args.group_size,
+        num_kv_heads=args.num_kv_heads,
+    )
+
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    from air.backend.xrt_runner import XRTRunner
+
+    rope_lut = make_rope_lut(args.dk, current_pos)
+    # Reference Q after rope: per-head [num_heads, dk]
+    rotated_q = apply_rope_ref(q_pre_rope.reshape(num_heads, args.dk), rope_lut)
+    rotated_k_new = apply_rope_ref(k_new_pre_rope, rope_lut)
+    input_k_new = rotated_k_new  # alias for the splice reference below
+    input_v_new = v_new
+
+    inv_sqrt_dk = 1.0 / sqrt(args.dk)
+    expected_out = np.zeros((num_heads, args.dv), dtype=bfloat16)
+    for h in range(num_heads):
+        kv_h = h // args.group_size
+        q_h = rotated_q[h].astype(np.float32)
+        K_full = input_k[kv_h].astype(np.float32).copy()
+        V_full = input_v[kv_h].astype(np.float32).copy()
+        K_full[args.lk - 1] = rotated_k_new[kv_h].astype(np.float32)
+        V_full[args.lk - 1] = input_v_new[kv_h].astype(np.float32)
+        K_valid = K_full[: current_pos + 1, :]
+        V_valid = V_full[: current_pos + 1, :]
+        scores = K_valid @ q_h * inv_sqrt_dk
+        mx = scores.max()
+        P = np.exp(scores - mx)
+        P = P / P.sum()
+        expected_out[h] = (P @ V_valid).astype(bfloat16)
+
+    runner = XRTRunner(
+        omit_while_true_loop=False,
+        omit_pingpong="all",
+        verbose=args.verbose,
+        output_format=args.output_format,
+        instance_name="decode_attention_bf16",
+        target_device="npu2",
+    )
+
+    exit(
+        runner.run_test(
+            mlir_module,
+            inputs=[input_k, input_v],
+            expected_outputs=[expected_out],
+            atol=0.15,
+            rtol=0.04,
+            max_mismatch_percentage=2.0,
+            min_correlation=0.99,
+        )
+    )

--- a/programming_examples/flash_attention/kernel_fusion_based/rope_multi.cc
+++ b/programming_examples/flash_attention/kernel_fusion_based/rope_multi.cc
@@ -1,0 +1,77 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// rope_multi: apply rope to `nrows` consecutive bf16 rows of size `dim`.
+// Wrapper around the upstream rope kernel from
+// mlir-aie/aie_kernels/aie2p/rope.cc, called per row sharing one LUT.
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+template <typename T, int N>
+static inline void rope_kernel(const T *restrict input, const T *restrict lut,
+                               T *restrict output, int32_t dims) {
+  for (int v = 0; v < dims; v += N) {
+    ::aie::vector<T, N> x = ::aie::load_v<N>(input + v);
+    ::aie::vector<T, N> cache = ::aie::load_v<N>(lut + v);
+
+    ::aie::vector<T, N / 2> x_even = ::aie::filter_even(x, 1);
+    ::aie::vector<T, N / 2> x_odd = ::aie::filter_odd(x, 1);
+    ::aie::vector<T, N / 2> cos_val = ::aie::filter_even(cache, 1);
+    ::aie::vector<T, N / 2> sin_val = ::aie::filter_odd(cache, 1);
+
+    ::aie::vector<T, N / 2> even_cos = ::aie::mul(x_even, cos_val);
+    ::aie::vector<T, N / 2> even_sin = ::aie::mul(x_even, sin_val);
+    ::aie::vector<T, N / 2> odd_cos = ::aie::mul(x_odd, cos_val);
+    ::aie::vector<T, N / 2> odd_sin = ::aie::mul(x_odd, sin_val);
+
+    ::aie::vector<T, N / 2> output_even = ::aie::sub(even_cos, odd_sin);
+    ::aie::vector<T, N / 2> output_odd = ::aie::add(even_sin, odd_cos);
+
+    auto [low, high] = ::aie::interleave_zip(output_even, output_odd, 1);
+    ::aie::vector<T, N> y = ::aie::concat(low, high);
+    ::aie::store_v(output + v, y);
+  }
+}
+
+extern "C" {
+void rope_multi(bfloat16 *input, bfloat16 *lut, bfloat16 *output,
+                int32_t nrows, int32_t dim) {
+  event0();
+  for (int h = 0; h < nrows; h++) {
+    rope_kernel<bfloat16, 16>(input + h * dim, lut, output + h * dim, dim);
+  }
+  event1();
+}
+
+// Same body as rope_multi — distinct symbol so callers operating on
+// L1 buffers of different MLIR shapes (e.g. [group_size, dk] vs [dk])
+// can each declare an llvm.emit_c_interface external matching their
+// own memref ABI.
+void rope_multi_knew(bfloat16 *input, bfloat16 *lut, bfloat16 *output,
+                     int32_t nrows, int32_t dim) {
+  event0();
+  for (int h = 0; h < nrows; h++) {
+    rope_kernel<bfloat16, 16>(input + h * dim, lut, output + h * dim, dim);
+  }
+  event1();
+}
+
+// Patches the last row of an [nrows, dim] L1 buffer with `src`
+// ([dim] L1). Used to splice K_new/V_new (cascade-delivered) into
+// the last K/V chunk in the decode herd's reduction loop, in lieu
+// of a subview+memcpy MLIR sequence that would re-introduce the
+// per-row strided-memref type juggling rope_multi was created
+// to avoid.
+void patch_last_row(bfloat16 *buf, bfloat16 *src, int32_t nrows,
+                    int32_t dim) {
+  event0();
+  bfloat16 *dst = buf + (nrows - 1) * dim;
+  constexpr int N = 16;
+  for (int v = 0; v < dim; v += N) {
+    ::aie::vector<bfloat16, N> x = ::aie::load_v<N>(src + v);
+    ::aie::store_v(dst + v, x);
+  }
+  event1();
+}
+}

--- a/programming_examples/flash_attention/kernel_fusion_based/simple_matvec.cc
+++ b/programming_examples/flash_attention/kernel_fusion_based/simple_matvec.cc
@@ -1,0 +1,71 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// simple_matvec_bf16: y[m] = sum_k W[m, k] * x[k] for bf16 inputs/output.
+// Simple vectorized matvec for the 5-all V1a decode_block test —
+// keeps the gemv_herd compute self-contained (no rms_qkv_rope kernel
+// dependency) at the cost of being slower than the production
+// matvec_vectorized_bf16_bf16 kernel. Only used at toy dims (N<=64,
+// M<=384) where perf isn't load-bearing.
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+template <int K_VAL>
+static inline void matvec_kernel_bf16(const bfloat16 *restrict W,
+                                      const bfloat16 *restrict x,
+                                      bfloat16 *restrict y, int32_t M) {
+  constexpr int VL = 16;
+  static_assert(K_VAL % VL == 0, "K must be a multiple of vector width");
+  constexpr int K_VECS = K_VAL / VL;
+
+  // Pre-load x into vector registers (small K, fits).
+  ::aie::vector<bfloat16, VL> x_vec[K_VECS];
+  for (int i = 0; i < K_VECS; i++)
+    x_vec[i] = ::aie::load_v<VL>(x + i * VL);
+
+  for (int m = 0; m < M; m++) {
+    ::aie::accum<accfloat, VL> acc;
+    acc = ::aie::zeros<accfloat, VL>();
+    for (int i = 0; i < K_VECS; i++) {
+      auto w = ::aie::load_v<VL>(W + m * K_VAL + i * VL);
+      acc = ::aie::mac(acc, w, x_vec[i]);
+    }
+    // Reduce VL-wide accumulator to a scalar bf16.
+    ::aie::vector<float, VL> sum_vec = acc.template to_vector<float>();
+    float sum = 0.0f;
+    for (int i = 0; i < VL; i++)
+      sum += sum_vec[i];
+    y[m] = (bfloat16)sum;
+  }
+}
+
+extern "C" {
+// W: [M, K] row-major bf16
+// x: [K] bf16
+// y: [M] bf16
+//
+// Three identically-bodied entrypoints with distinct symbols so the
+// caller can declare an external_func per memref shape (Q rows: [256],
+// K rows: [64], V rows: [64]) and have the
+// llvm.emit_c_interface wrapper match each ABI.
+static inline void run(bfloat16 *W, bfloat16 *x, bfloat16 *y, int32_t M,
+                       int32_t K) {
+  event0();
+  if (K == 64)
+    matvec_kernel_bf16<64>(W, x, y, M);
+  event1();
+}
+void simple_matvec_bf16(bfloat16 *W, bfloat16 *x, bfloat16 *y, int32_t M,
+                        int32_t K) {
+  run(W, x, y, M, K);
+}
+void simple_matvec_bf16_k(bfloat16 *W, bfloat16 *x, bfloat16 *y, int32_t M,
+                          int32_t K) {
+  run(W, x, y, M, K);
+}
+void simple_matvec_bf16_v(bfloat16 *W, bfloat16 *x, bfloat16 *y, int32_t M,
+                          int32_t K) {
+  run(W, x, y, M, K);
+}
+}

--- a/programming_examples/flash_attention/kernel_fusion_based/simple_rms.cc
+++ b/programming_examples/flash_attention/kernel_fusion_based/simple_rms.cc
@@ -1,0 +1,68 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// simple_rms_bf16: y[i] = x[i] * rsqrt(mean(x^2) + eps) * w[i]
+// Standard RMSNorm over a vector of N bf16 elements with bf16 weights.
+// Used by 5-all V2 decode_block test.
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+// Quake-style fast inverse square root. AIE2P has no libm so we
+// can't pull in sqrtf. Two Newton-Raphson iterations from the
+// classic bit-magic seed give ~16 bits of mantissa precision —
+// well beyond what bf16 needs.
+static inline float fast_rsqrt(float x) {
+  union {
+    float f;
+    int32_t i;
+  } u;
+  u.f = x;
+  u.i = 0x5f3759df - (u.i >> 1);
+  float y = u.f;
+  y = y * (1.5f - 0.5f * x * y * y);
+  y = y * (1.5f - 0.5f * x * y * y);
+  return y;
+}
+
+template <int N_VAL>
+static inline void rms_kernel_bf16(const bfloat16 *restrict x,
+                                   const bfloat16 *restrict w,
+                                   bfloat16 *restrict y, float eps) {
+  constexpr int VL = 16;
+  static_assert(N_VAL % VL == 0, "N must be a multiple of vector width");
+  constexpr int N_VECS = N_VAL / VL;
+
+  // Pass 1: accumulate sum of squares.
+  ::aie::accum<accfloat, VL> ssq = ::aie::zeros<accfloat, VL>();
+  ::aie::vector<bfloat16, VL> x_vec[N_VECS];
+  for (int i = 0; i < N_VECS; i++) {
+    x_vec[i] = ::aie::load_v<VL>(x + i * VL);
+    ssq = ::aie::mac(ssq, x_vec[i], x_vec[i]);
+  }
+  ::aie::vector<float, VL> ssq_v = ssq.template to_vector<float>();
+  float total = 0.0f;
+  for (int i = 0; i < VL; i++)
+    total += ssq_v[i];
+  float rstd = fast_rsqrt(total / (float)N_VAL + eps);
+
+  // Pass 2: y = x * rstd * w (scalar fallback — small N, perf not load-
+  // bearing for the V2 plumbing test).
+  for (int i = 0; i < N_VAL; i++) {
+    float xi = (float)x[i];
+    float wi = (float)w[i];
+    y[i] = (bfloat16)(xi * rstd * wi);
+  }
+}
+
+extern "C" {
+// x: [N] bf16 input vector
+// w: [N] bf16 RMSNorm weights
+// y: [N] bf16 output vector
+void simple_rms_bf16(bfloat16 *x, bfloat16 *w, bfloat16 *y, int32_t N) {
+  event0();
+  if (N == 64)
+    rms_kernel_bf16<64>(x, w, y, 1e-5f);
+  event1();
+}
+}


### PR DESCRIPTION
## Summary

Self-contained 4-herd cascade composition example that runs an
LLaMA-3.2-1B-shaped decode flash attention end-to-end on NPU2 in a
single XRT call. RMS, GEMV (QKV projection), RoPE, and the flash
attention reduction all live in one launch + segment, with cross-
herd cascade carrying Q, K_new, and V_new on-chip.

## Architecture (per column, NKV=8 columns)

```
rms_herd     [1, 1]   : MMIO x_raw + w_rms -> RMSNorm
                        -> L1 broadcast x_norm to all NKV gemv tiles
gemv_herd    [NKV, 1] : x_norm + MMIO W_qkv -> matvec
                        -> Q[group_size, dk] + K_new[dk] + V_new[dv]
                        -> 3 cascade puts south to rope_herd
rope_herd    [NKV, 1] : 3 cascade gets + MMIO RoPE LUT
                        -> RoPE(Q), RoPE(K_new), V_new passthrough
                        -> 3 cascade puts south to decode_herd
decode_herd  [NKV, 1] : 3 cascade gets + MMIO pos
                        + L3->memtile->L1 K/V cache reads
                        -> flash attention with K_new/V_new spliced
                           into the last K/V chunk
                        -> output [num_heads, dv] to L3
```

Per-column shim DMA budget stays at the AIE2P minimum 2 MM2S (KIn,
VIn) for the K/V cache reads. Q (cascade), K_new/V_new (cascade),
x_norm (L1 broadcast), and W_qkv/x_raw/w_rms/RoPE LUT/pos (MMIO)
all bypass shim entirely.

## Scope

- LLaMA-3.2-1B output dimensions are real: 8 KV heads, group_size 4
  (=> 32 Q heads), dk=dv=64, lk up to 2048.
- GEMV input dim is a toy N=64 so the per-column W_qkv weight matrix
  fits in L1 with no L2 staging or multi-launch-iter coordination.
  Scaling N to LLaMA's full 2048 is a follow-up that requires
  multi-launch-iter weight staging through memtile.

## Hardware verification (NPU2)

| NKV | LK | correlation |
|-----|------|-------------|
| 1 | 128 | 0.999739 |
| 8 | 128 | 0.999850 |
| 8 | 2048 | 0.999622 (LLaMA-3.2-1B output dims) |

```bash
make run-decode-block-e2e LK=2048 NUM_KV_HEADS_E2E=8
```

## Files

| File | Purpose |
|---|---|
| `decode_block_npu2_5all_v2.py` | example |
| `attn_decode_npu2.cc` | flash attention kernels (compute_qk_scores, mask, softmax, pv, div) |
| `simple_matvec.cc` | bf16 matvec for gemv_herd |
| `simple_rms.cc` | RMSNorm with Quake-style fast_rsqrt (no libm on AIE2P) |
| `rope_multi.cc` | multi-row wrapper around upstream mlir-aie aie2p rope kernel |
| `Makefile` | `run-decode-block-e2e` target + `compile-decode-block-kernels` |

## Dependency

Depends on the cascade-aware placer fix in #1583. Without it the
3-herd cascade chain (gemv -> rope -> decode) at NKV >= 2 fails to
place — the AIE dialect verifier rejects with `'aie.cascade_flow'
op tiles must be adjacent`.

## Test plan

- [x] Hardware-verified at the configurations above on NPU2 (Strix)
- [ ] Land #1583 first
- [ ] Land this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)