### PR TITLE
[airrt-to-npu] Honor inner-dim alignment when tiling oversized wraps

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -199,9 +199,11 @@ int findLargestFactor(int num, int max);
 int findLargestAlignedFactor(int num, int max, int alignment);
 
 // Element-count alignment required so that an inner DMA wrap stays a
-// multiple of the AIE shim address granularity (32 bits on AIE2/AIE2P).
-// Returns 1 when each element already meets or exceeds the granularity
-// (e.g. f32, i32). Returns 2 for bf16/i16, 4 for i8/ui8. 'op' is used to
+// multiple of the AIE shim address granularity. Queries the parent
+// AIE::DeviceOp's target model when reachable (preferred); otherwise falls
+// back to 32 bits (the AIE2 / AIE2P value). Returns 1 when each element
+// already meets or exceeds the granularity (e.g. f32, i32); 2 for bf16/i16;
+// 4 for i8/ui8. 'op' is used both to find the DeviceOp ancestor and to
 // resolve the DataLayout via DataLayout::closest().
 int getDmaInnerElementAlignment(mlir::BaseMemRefType memrefTy,
                                 mlir::Operation *op);

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -192,10 +192,31 @@ LogicalResult foldForLoopNestAsExtendedSizesAndStrides(
 // Find the largest factor of 'num' which is not larger than 'max'.
 int findLargestFactor(int num, int max);
 
+// Largest factor of 'num' that is <= 'max' and a multiple of 'alignment'.
+// Returns 0 when no aligned factor exists, so the caller can emit a
+// diagnostic instead of silently producing misaligned IR. With alignment<=1
+// behaves as findLargestFactor.
+int findLargestAlignedFactor(int num, int max, int alignment);
+
+// Element-count alignment required so that an inner DMA wrap stays a
+// multiple of the AIE shim address granularity (32 bits on AIE2/AIE2P).
+// Returns 1 when each element already meets or exceeds the granularity
+// (e.g. f32, i32). Returns 2 for bf16/i16, 4 for i8/ui8. 'op' is used to
+// resolve the DataLayout via DataLayout::closest().
+int getDmaInnerElementAlignment(mlir::BaseMemRefType memrefTy,
+                                mlir::Operation *op);
+
 // Canonicalize wrap and stride lists, by removing redundant dimensions.
-LogicalResult canonicalizeWrapAndStrideList(
-    OpBuilder &builder, SmallVector<Value> &offsets, SmallVector<Value> &sizes,
-    SmallVector<Value> &strides, int memref_volume, int maxSize = -1);
+// 'innerAlignment' constrains the contiguous innermost dim (stride==1) when
+// it must be split: the new inner wrap is forced to be a multiple of
+// 'innerAlignment' elements (e.g. 2 for bf16 on a 4-byte shim BD). Pass 1
+// (the default) when no extra constraint applies.
+LogicalResult canonicalizeWrapAndStrideList(OpBuilder &builder,
+                                            SmallVector<Value> &offsets,
+                                            SmallVector<Value> &sizes,
+                                            SmallVector<Value> &strides,
+                                            int memref_volume, int maxSize = -1,
+                                            int innerAlignment = 1);
 
 // If wrap-and-stride lists are empty, populate them with default data access
 // layout (contiguous, row-major).

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1216,23 +1216,24 @@ int findLargestFactor(int num, int max) {
 // Largest factor of `num` that is <= `max` and a multiple of `alignment`.
 // Used when tiling the contiguous innermost dim: the resulting inner wrap
 // times the element size must be a multiple of the shim address granularity
-// (e.g. 4 bytes), otherwise aie.dma_bd verification fails. With alignment=1
-// behavior matches findLargestFactor.
+// (e.g. 4 bytes), otherwise aie.dma_bd verification fails. With alignment<=1
+// behaves as findLargestFactor. Returns 0 when no aligned factor exists, so
+// the caller can emit a diagnostic instead of silently producing misaligned IR.
 int findLargestAlignedFactor(int num, int max, int alignment) {
   if (alignment <= 1)
     return findLargestFactor(num, max);
   if (max < alignment)
-    return findLargestFactor(num, max);
+    return 0;
   int alignedMax = (max / alignment) * alignment;
   for (int candidate = alignedMax; candidate >= alignment;
        candidate -= alignment) {
     if (num % candidate == 0)
       return candidate;
   }
-  return findLargestFactor(num, max);
+  return 0;
 }
 
-void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
+LogicalResult tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
   auto loc = memcpy_op->getLoc();
   auto ctx = memcpy_op->getContext();
   auto oper_begin = memcpy_op.getOperands().begin();
@@ -1253,12 +1254,13 @@ void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
       // factor like 683 for a bf16 transfer of length 131136 produces a
       // 1366 B inner segment that aie.dma_bd verification rejects.
       int alignment = 1;
+      unsigned elemBits = 0;
+      unsigned addrGranBits = 32; // AIE2/AIE2P shim default.
       if (const_stride == 1) {
         if (auto memrefTy = llvm::dyn_cast<BaseMemRefType>(
                 memcpy_op.getMemref().getType())) {
           mlir::DataLayout dl = mlir::DataLayout::closest(memcpy_op);
-          unsigned elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
-          unsigned addrGranBits = 32; // AIE2/AIE2P shim default.
+          elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
           if (auto dev = memcpy_op->getParentOfType<AIE::DeviceOp>())
             addrGranBits = dev.getTargetModel().getAddressGenGranularity();
           if (elemBits > 0 && elemBits < addrGranBits)
@@ -1267,6 +1269,16 @@ void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
       }
       int a_wrap = findLargestAlignedFactor(
           const_wrap, AIE2_WRAP_UPPER_BOUNDS[i] - 1, alignment);
+      if (a_wrap == 0) {
+        return memcpy_op.emitOpError()
+               << "cannot tile dim " << i << " of size " << const_wrap
+               << " into shim-legal chunks: no factor in [" << alignment << ", "
+               << (AIE2_WRAP_UPPER_BOUNDS[i] - 1) << "] is a multiple of "
+               << alignment << " elements (" << (addrGranBits / 8)
+               << "-byte shim address granularity / " << (elemBits / 8)
+               << "-byte element size). Reshape the "
+                  "transfer or pad the inner dimension.";
+      }
       int b_wrap = llvm::divideCeilSigned(const_wrap, a_wrap);
       int new_a_stride = const_stride * a_wrap;
       auto volume = air::getTensorVolume(
@@ -1396,9 +1408,10 @@ void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
   }
 
   memcpy_op.erase();
+  return success();
 }
 
-void enforceAIE2WrapLimit(ModuleOp module) {
+LogicalResult enforceAIE2WrapLimit(ModuleOp module) {
   // Identify airrt.dma_memcpy_nd ops that violate the AIE2 wrap size
   // constraint.
   SmallVector<airrt::DmaMemcpyNdOp> target_airrt_dmas;
@@ -1413,7 +1426,9 @@ void enforceAIE2WrapLimit(ModuleOp module) {
 
   // Enforce the AIE2 wrap limit by tiling that dimension.
   for (auto memcpy_op : target_airrt_dmas)
-    tileIllegalWrapDim(memcpy_op);
+    if (failed(tileIllegalWrapDim(memcpy_op)))
+      return failure();
+  return success();
 }
 
 struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
@@ -1494,7 +1509,10 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     generateNpuWaitFromAIRRtWaitAll(module);
 
     // Enforce AIE2 hardware constraints.
-    enforceAIE2WrapLimit(module);
+    if (failed(enforceAIE2WrapLimit(module))) {
+      signalPassFailure();
+      return;
+    }
 
     // Simplify arith ops (from airrt)
     RewritePatternSet canoPatterns_3(ctx);

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -1212,6 +1213,25 @@ int findLargestFactor(int num, int max) {
   return largestLowFactor;
 }
 
+// Largest factor of `num` that is <= `max` and a multiple of `alignment`.
+// Used when tiling the contiguous innermost dim: the resulting inner wrap
+// times the element size must be a multiple of the shim address granularity
+// (e.g. 4 bytes), otherwise aie.dma_bd verification fails. With alignment=1
+// behavior matches findLargestFactor.
+int findLargestAlignedFactor(int num, int max, int alignment) {
+  if (alignment <= 1)
+    return findLargestFactor(num, max);
+  if (max < alignment)
+    return findLargestFactor(num, max);
+  int alignedMax = (max / alignment) * alignment;
+  for (int candidate = alignedMax; candidate >= alignment;
+       candidate -= alignment) {
+    if (num % candidate == 0)
+      return candidate;
+  }
+  return findLargestFactor(num, max);
+}
+
 void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
   auto loc = memcpy_op->getLoc();
   auto ctx = memcpy_op->getContext();
@@ -1227,7 +1247,26 @@ void tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
     if (const_wrap >= AIE2_WRAP_UPPER_BOUNDS[i]) {
       // Found dimension with illegal wrap. Tiling. (Prefers smaller outer
       // wrap values, as long as stride fits)
-      int a_wrap = findLargestFactor(const_wrap, AIE2_WRAP_UPPER_BOUNDS[i] - 1);
+      // For the contiguous innermost case (stride == 1), enforce that the
+      // new inner wrap times the element size is a multiple of the shim
+      // address granularity (typically 4 B). Without this, picking a prime
+      // factor like 683 for a bf16 transfer of length 131136 produces a
+      // 1366 B inner segment that aie.dma_bd verification rejects.
+      int alignment = 1;
+      if (const_stride == 1) {
+        if (auto memrefTy = llvm::dyn_cast<BaseMemRefType>(
+                memcpy_op.getMemref().getType())) {
+          mlir::DataLayout dl = mlir::DataLayout::closest(memcpy_op);
+          unsigned elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
+          unsigned addrGranBits = 32; // AIE2/AIE2P shim default.
+          if (auto dev = memcpy_op->getParentOfType<AIE::DeviceOp>())
+            addrGranBits = dev.getTargetModel().getAddressGenGranularity();
+          if (elemBits > 0 && elemBits < addrGranBits)
+            alignment = addrGranBits / elemBits;
+        }
+      }
+      int a_wrap = findLargestAlignedFactor(
+          const_wrap, AIE2_WRAP_UPPER_BOUNDS[i] - 1, alignment);
       int b_wrap = llvm::divideCeilSigned(const_wrap, a_wrap);
       int new_a_stride = const_stride * a_wrap;
       auto volume = air::getTensorVolume(

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
-#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -1180,59 +1179,6 @@ bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
   return false;
 }
 
-// Find the largest factor of 'num' which is not larger than 'max'. Ref:
-// https://github.com/nod-ai/iree-amd-aie/blob/main/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp#L334
-int findLargestFactor(int num, int max) {
-  // No factors less than or equal to 0 exist
-  if (max <= 0)
-    return 0;
-
-  // Do O(1) instead of O(sqrt(num)) computation for this common case.
-  if (num <= max) {
-    return num;
-  }
-
-  int largestLowFactor = 1;
-  for (int lowFactor = 2; lowFactor <= max; ++lowFactor) {
-    const int highFactor = num / lowFactor;
-
-    // This early exit is what makes this O(sqrt(num)) instead of O(num).
-    if (highFactor < lowFactor)
-      return largestLowFactor;
-
-    const bool areActuallyFactors = num % lowFactor == 0;
-    if (areActuallyFactors) {
-      // We're certain that here lowFactor <= highFactor, and highFactor is
-      // descending in this loop. So we can return immediately if highFactor
-      // is good.
-      if (highFactor <= max)
-        return highFactor;
-      largestLowFactor = lowFactor;
-    }
-  }
-  return largestLowFactor;
-}
-
-// Largest factor of `num` that is <= `max` and a multiple of `alignment`.
-// Used when tiling the contiguous innermost dim: the resulting inner wrap
-// times the element size must be a multiple of the shim address granularity
-// (e.g. 4 bytes), otherwise aie.dma_bd verification fails. With alignment<=1
-// behaves as findLargestFactor. Returns 0 when no aligned factor exists, so
-// the caller can emit a diagnostic instead of silently producing misaligned IR.
-int findLargestAlignedFactor(int num, int max, int alignment) {
-  if (alignment <= 1)
-    return findLargestFactor(num, max);
-  if (max < alignment)
-    return 0;
-  int alignedMax = (max / alignment) * alignment;
-  for (int candidate = alignedMax; candidate >= alignment;
-       candidate -= alignment) {
-    if (num % candidate == 0)
-      return candidate;
-  }
-  return 0;
-}
-
 LogicalResult tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
   auto loc = memcpy_op->getLoc();
   auto ctx = memcpy_op->getContext();
@@ -1242,42 +1188,29 @@ LogicalResult tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
   SmallVector<Value> strides(oper_begin + 12, oper_begin + 16);
   OpBuilder builder(memcpy_op);
 
+  auto memrefTy =
+      llvm::dyn_cast<BaseMemRefType>(memcpy_op.getMemref().getType());
+  int innerAlignment =
+      memrefTy ? air::getDmaInnerElementAlignment(memrefTy, memcpy_op) : 1;
+
   for (int i = wraps.size() - 1; i >= 0; i--) {
     auto const_wrap = *getConstantIntValue(wraps[i]);
     auto const_stride = *getConstantIntValue(strides[i]);
     if (const_wrap >= AIE2_WRAP_UPPER_BOUNDS[i]) {
-      // Found dimension with illegal wrap. Tiling. (Prefers smaller outer
-      // wrap values, as long as stride fits)
-      // For the contiguous innermost case (stride == 1), enforce that the
-      // new inner wrap times the element size is a multiple of the shim
-      // address granularity (typically 4 B). Without this, picking a prime
-      // factor like 683 for a bf16 transfer of length 131136 produces a
-      // 1366 B inner segment that aie.dma_bd verification rejects.
-      int alignment = 1;
-      unsigned elemBits = 0;
-      unsigned addrGranBits = 32; // AIE2/AIE2P shim default.
-      if (const_stride == 1) {
-        if (auto memrefTy = llvm::dyn_cast<BaseMemRefType>(
-                memcpy_op.getMemref().getType())) {
-          mlir::DataLayout dl = mlir::DataLayout::closest(memcpy_op);
-          elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
-          if (auto dev = memcpy_op->getParentOfType<AIE::DeviceOp>())
-            addrGranBits = dev.getTargetModel().getAddressGenGranularity();
-          if (elemBits > 0 && elemBits < addrGranBits)
-            alignment = addrGranBits / elemBits;
-        }
-      }
-      int a_wrap = findLargestAlignedFactor(
+      // Found dimension with illegal wrap. Prefers smaller outer wrap as
+      // long as stride fits. For stride==1, force the inner wrap to a
+      // multiple of innerAlignment elements so its byte size stays aligned
+      // to the shim address granularity (otherwise aie.dma_bd rejects it).
+      int alignment = (const_stride == 1) ? innerAlignment : 1;
+      int a_wrap = air::findLargestAlignedFactor(
           const_wrap, AIE2_WRAP_UPPER_BOUNDS[i] - 1, alignment);
       if (a_wrap == 0) {
         return memcpy_op.emitOpError()
                << "cannot tile dim " << i << " of size " << const_wrap
                << " into shim-legal chunks: no factor in [" << alignment << ", "
                << (AIE2_WRAP_UPPER_BOUNDS[i] - 1) << "] is a multiple of "
-               << alignment << " elements (" << (addrGranBits / 8)
-               << "-byte shim address granularity / " << (elemBits / 8)
-               << "-byte element size). Reshape the "
-                  "transfer or pad the inner dimension.";
+               << alignment
+               << " elements. Reshape the transfer or pad the inner dimension.";
       }
       int b_wrap = llvm::divideCeilSigned(const_wrap, a_wrap);
       int new_a_stride = const_stride * a_wrap;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2686,9 +2686,13 @@ private:
     SmallVector<Value> offsets = ci.getOffsets();
     SmallVector<Value> wraps = ci.getSizes();
     SmallVector<Value> strides = ci.getStrides();
+    auto memrefTy = llvm::dyn_cast<BaseMemRefType>(ci.getMemref().getType());
+    int innerAlignment =
+        memrefTy ? air::getDmaInnerElementAlignment(memrefTy, ci) : 1;
     (void)air::canonicalizeWrapAndStrideList(
         builder, offsets, wraps, strides,
-        air::getTensorVolume(ci.getMemref().getType()), maxSize);
+        air::getTensorVolume(ci.getMemref().getType()), maxSize,
+        innerAlignment);
     air::ChannelInterface new_ci = nullptr;
     if (isa<air::ChannelPutOp>(ci))
       new_ci = air::ChannelPutOp::create(

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2196,9 +2196,14 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
     SmallVector<Value> strides = channel_op.getStrides();
 
     OpBuilder b(channel_op);
+    auto memrefTy =
+        llvm::dyn_cast<BaseMemRefType>(channel_op.getMemref().getType());
+    int innerAlignment =
+        memrefTy ? air::getDmaInnerElementAlignment(memrefTy, channel_op) : 1;
     (void)canonicalizeWrapAndStrideList(
         b, offsets, wraps, strides,
-        air::getTensorVolume(channel_op.getMemref().getType()), maxSize);
+        air::getTensorVolume(channel_op.getMemref().getType()), maxSize,
+        innerAlignment);
 
     // If empty offsets/sizes/strides, then populate the lists with default
     // values.
@@ -2225,7 +2230,8 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
 
     (void)canonicalizeWrapAndStrideList(
         rewriter, offsets, wraps, strides,
-        air::getTensorVolume(channel_op.getMemref().getType()), maxSize);
+        air::getTensorVolume(channel_op.getMemref().getType()), maxSize,
+        innerAlignment);
 
     // Whether repeat (i.e. stride = 0) is supported at highest dimension.
     if (enableRepeatAtHighestDim && !wraps.empty()) {
@@ -2605,9 +2611,13 @@ struct AIRCanonicalizeChannelPutGetOpWrapAndStrideList
       if (padBeforeCheck)
         return failure();
       // Canonicalize offsets/sizes/strides using a helper function.
+      auto memrefTy = llvm::dyn_cast<BaseMemRefType>(op.getMemref().getType());
+      int innerAlignment =
+          memrefTy ? air::getDmaInnerElementAlignment(memrefTy, op) : 1;
       if (failed(canonicalizeWrapAndStrideList(
               rewriter, offsets, sizes, strides,
-              air::getTensorVolume(op.getMemref().getType()), maxSize)))
+              air::getTensorVolume(op.getMemref().getType()), maxSize,
+              innerAlignment)))
         return failure();
 
       // When highest-dimension repeat is active, pad offsets/sizes/strides to

--- a/mlir/lib/Util/CMakeLists.txt
+++ b/mlir/lib/Util/CMakeLists.txt
@@ -2,6 +2,19 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+set(AIRUTIL_LINK_LIBS
+  MLIRIR
+  MLIRTransforms
+)
+
+# AIE target model is queried for the shim address-gen granularity when
+# computing DMA inner-element alignment. Conditional on AIR_ENABLE_AIE; the
+# fallback path in Util.cpp is used when AIE is disabled or no DeviceOp is
+# reachable from the op.
+if(AIR_ENABLE_AIE)
+  list(APPEND AIRUTIL_LINK_LIBS AIE)
+endif()
+
 add_mlir_library(AIRUtil
   Util.cpp
   Outliner.cpp
@@ -15,6 +28,5 @@ add_mlir_library(AIRUtil
   AIRDialect
 
   LINK_LIBS PUBLIC
-  MLIRIR
-  MLIRTransforms
+  ${AIRUTIL_LINK_LIBS}
 )

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
@@ -1126,10 +1127,45 @@ int air::findLargestFactor(int num, int max) {
   return largestLowFactor;
 }
 
+// AIE2/AIE2P shim address generator granularity (matches
+// AIETargetModel::getAddressGenGranularity for both devices). Hard-coded so
+// air::Util doesn't need to depend on the AIE dialect; revisit if a future
+// device reports a different value.
+static constexpr unsigned kAIEShimAddrGenBits = 32;
+
+int air::getDmaInnerElementAlignment(BaseMemRefType memrefTy, Operation *op) {
+  if (!memrefTy || !op)
+    return 1;
+  DataLayout dl = DataLayout::closest(op);
+  unsigned elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
+  if (elemBits == 0 || elemBits >= kAIEShimAddrGenBits)
+    return 1;
+  return kAIEShimAddrGenBits / elemBits;
+}
+
+// Largest factor of 'num' that is <= 'max' and a multiple of 'alignment'.
+// See header for rationale.
+int air::findLargestAlignedFactor(int num, int max, int alignment) {
+  if (alignment <= 1)
+    return findLargestFactor(num, max);
+  if (max < alignment)
+    return 0;
+  int alignedMax = (max / alignment) * alignment;
+  for (int candidate = alignedMax; candidate >= alignment;
+       candidate -= alignment) {
+    if (num % candidate == 0)
+      return candidate;
+  }
+  return 0;
+}
+
 // Canonicalize wrap and stride lists by removing redundant dimensions.
-LogicalResult air::canonicalizeWrapAndStrideList(
-    OpBuilder &builder, SmallVector<Value> &offsets, SmallVector<Value> &sizes,
-    SmallVector<Value> &strides, int memref_volume, int maxSize) {
+LogicalResult air::canonicalizeWrapAndStrideList(OpBuilder &builder,
+                                                 SmallVector<Value> &offsets,
+                                                 SmallVector<Value> &sizes,
+                                                 SmallVector<Value> &strides,
+                                                 int memref_volume, int maxSize,
+                                                 int innerAlignment) {
   // AIE2 hardware constraints. TODO: import these info from target model.
   const int AIE2_STRIDE_UPPER_BOUND = 1048576;
   bool listsHaveChanged = false;
@@ -1159,8 +1195,20 @@ LogicalResult air::canonicalizeWrapAndStrideList(
     if (const_wrap <= maxSize)
       continue;
     // Found dimension with illegal wrap. Tiling. (Prefers smaller outer wrap
-    // values, as long as stride fits)
-    int a_wrap = findLargestFactor(const_wrap, maxSize);
+    // values, as long as stride fits.) For the contiguous innermost dim
+    // (stride==1), require the new inner wrap to be a multiple of
+    // innerAlignment elements so the resulting d0 byte size stays aligned to
+    // the shim address granularity (e.g. 4 B for bf16 / i8). Falls back to
+    // findLargestFactor when innerAlignment <= 1 or stride != 1.
+    int a_wrap =
+        (const_stride == 1)
+            ? findLargestAlignedFactor(const_wrap, maxSize, innerAlignment)
+            : findLargestFactor(const_wrap, maxSize);
+    // No aligned factor exists. Leave the dim oversized and let the
+    // downstream shim lowering (tileIllegalWrapDim in AIRRtToNpuPass) emit
+    // the diagnostic with full op context.
+    if (a_wrap == 0)
+      continue;
     int b_wrap = llvm::divideCeilSigned(const_wrap, a_wrap);
     int new_a_stride = const_stride * a_wrap;
     if (memref_volume != 1)

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -9,6 +9,11 @@
 #include "air/Util/Util.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 
+#if AIR_ENABLE_AIE
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#endif
+
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -1127,20 +1132,27 @@ int air::findLargestFactor(int num, int max) {
   return largestLowFactor;
 }
 
-// AIE2/AIE2P shim address generator granularity (matches
-// AIETargetModel::getAddressGenGranularity for both devices). Hard-coded so
-// air::Util doesn't need to depend on the AIE dialect; revisit if a future
-// device reports a different value.
-static constexpr unsigned kAIEShimAddrGenBits = 32;
+// Fallback shim address-gen granularity when we can't reach an AIE::DeviceOp
+// to query the target model. Matches AIETargetModel::getAddressGenGranularity
+// for AIE2 and AIE2P. The dynamic lookup below is preferred when available so
+// future devices with a different value just work.
+static constexpr unsigned kAIEShimAddrGenBitsFallback = 32;
 
 int air::getDmaInnerElementAlignment(BaseMemRefType memrefTy, Operation *op) {
   if (!memrefTy || !op)
     return 1;
   DataLayout dl = DataLayout::closest(op);
   unsigned elemBits = dl.getTypeSizeInBits(memrefTy.getElementType());
-  if (elemBits == 0 || elemBits >= kAIEShimAddrGenBits)
+  if (elemBits == 0)
     return 1;
-  return kAIEShimAddrGenBits / elemBits;
+  unsigned addrGenBits = kAIEShimAddrGenBitsFallback;
+#if AIR_ENABLE_AIE
+  if (auto dev = op->getParentOfType<AIE::DeviceOp>())
+    addrGenBits = dev.getTargetModel().getAddressGenGranularity();
+#endif
+  if (elemBits >= addrGenBits)
+    return 1;
+  return addrGenBits / elemBits;
 }
 
 // Largest factor of 'num' that is <= 'max' and a multiple of 'alignment'.

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -airrt-to-npu -split-input-file %s | FileCheck %s
+// RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
 
 // When tileIllegalWrapDim splits a wrap that exceeds the shim 10-bit limit
 // (1023), the new innermost size in bytes must remain a multiple of the shim
@@ -67,6 +67,36 @@ module {
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
     %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// bf16 length 2049 = 3 * 683. The only factors <= 1023 are 1, 3, and 683 —
+// all odd. No even factor exists, so findLargestAlignedFactor cannot satisfy
+// the 2-element alignment that bf16 requires for a 4-byte shim BD. The pass
+// should emit a diagnostic and fail rather than silently producing IR that
+// the downstream aie.dma_bd verifier will reject.
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<2049xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2049_i64 = arith.constant 2049 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    // expected-error @+1 {{cannot tile dim 3 of size 2049 into shim-legal chunks}}
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c2049_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<2049xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -100,3 +100,65 @@ module {
     return
   }
 }
+
+// -----
+
+// i8 element type: addressGranularity / elemBits = 32 / 8 = 4. Length 1028 =
+// 4 * 257. Divisors <= 1023 are {1, 2, 4, 257, 514}. findLargestFactor would
+// pick 514 (= 2 * 257), giving 514 elem * 1 B = 514 B (not 4-aligned). With
+// alignment=4 the only multiple-of-4 factor in range is 4 itself, so the
+// inner wrap drops to 4 (* 1 B = 4 B aligned) and the outer wrap becomes 257.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<1028xi8>, 0, 1028, [<size = 257, stride = 4>, <size = 4, stride = 1>])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<1028xi8>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c1028_i64 = arith.constant 1028 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c1028_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<1028xi8>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// NPU2 (AIE2P) has the same 32-bit address granularity as AIE2, so the bf16
+// 131136 case picks the same 192-element inner wrap. Guards against future
+// device divergence going unnoticed.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 683, stride = 192>, <size = 192, stride = 1>])
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<131136xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c131136_i64 = arith.constant 131136 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -1,0 +1,72 @@
+//===- tile_illegal_wrap_alignment.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu -split-input-file %s | FileCheck %s
+
+// When tileIllegalWrapDim splits a wrap that exceeds the shim 10-bit limit
+// (1023), the new innermost size in bytes must remain a multiple of the shim
+// address granularity (4 B). For a bf16 transfer of length 131136 the only
+// factors <= 1023 are 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 192, and
+// 683. findLargestFactor would pick 683 (odd), giving an inner segment of
+// 683 elem * 2 B = 1366 B, which aie.dma_bd verification rejects. The
+// alignment-aware tiler instead picks 192 (largest even factor <= 1023),
+// yielding an inner segment of 192 * 2 B = 384 B (4-B aligned).
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 683, stride = 192>, <size = 192, stride = 1>])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<131136xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c131136_i64 = arith.constant 131136 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// f32 element type: addressGranularity / elemBits = 32 / 32 = 1 (no extra
+// alignment constraint). The largest factor of 131136 <= 1023 is 683 — used
+// directly because there is no even-factor requirement when each element
+// already covers the full granularity.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<131136xf32>, 0, 131136, [<size = 192, stride = 683>, <size = 683, stride = 1>])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<131136xf32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c131136_i64 = arith.constant 131136 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}


### PR DESCRIPTION
## Summary

`tileIllegalWrapDim` in `AIRRtToNpuPass.cpp` calls `findLargestFactor(wrap, 1023)` to split a wrap that exceeds the shim 10-bit limit. For a contiguous bf16 transfer of length 131136 the factor it picks is 683 (an odd prime), producing an inner segment of `683 elem × 2 B = 1366 B` that fails the `aie.dma_bd` 4-byte-alignment verifier:

```
error: 'aie.dma_bd' op Transfer sizes must be multiples of 4 bytes.
       683 elements at 2 bytes each equal 1366 bytes, which is not divisible by 4.
       aie.dma_bd(... [<size = 192, stride = 683>, <size = 683, stride = 1>])
```

Add `findLargestAlignedFactor`, used only when tiling the contiguous innermost dim (`stride == 1`), with `alignment = addressGenGranularity / elemBits`:
- bf16 (16 b): alignment = 2 → must pick even factor
- f32 (32 b): alignment = 1 → no extra constraint, behaves as before
- i8 (8 b): alignment = 4 → must pick multiple-of-4 factor

For the bf16 length-131136 case it now picks 192 instead of 683, yielding `[<size=683, stride=192>, <size=192, stride=1>]` — both dims 4-B aligned.

## Why this matters

This bug fires for *any* sub-32-bit transfer whose length factors cleanly only into an odd prime above ~511. Surfaced by an LLaMA-3.2-1B decode attention design where the K/V cache load is `(pos+1) × head_dim` and `pos+1 = 2049 = 3 × 683`. Other prime-heavy lengths in the same regime would hit the same verifier error.

## Test plan

- [x] Added `mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir` covering the bf16 (alignment-aware) and f32 (no-alignment-needed) paths
- [x] `ninja check-air-mlir` — new test passes; no regressions in the AIRRtToNpu suite
- [x] End-to-end: built and ran the LLaMA-3.2-1B decode attention kernel that originally triggered the bug — `Output 0 correlation: 1.000000 (threshold: 0.99) PASS!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)