### PR TITLE
Document prebuilt wheel install path

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -263,8 +263,12 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}
+          # Skip body on versioned tag pushes (v*.*.*) so those releases can carry
+          # human-written or auto-generated notes; only populate body for the
+          # rolling latest-* tags.
+          omitBody: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           body: |
-            ## MLIR-AIR Wheels
+            ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
             **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
@@ -272,11 +276,11 @@ jobs:
             ### Installation
 
             ```bash
-            # MLIR-AIR (default: RTTI enabled)
-            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+            # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
+            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
 
-            # MLIR-AIE
-            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+            # MLIR-AIE (must match RTTI setting above)
+            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
 
             # Peano (llvm-aie) — AIE backend compiler
             pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
@@ -448,8 +452,12 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}
+          # Skip body on versioned tag pushes (v*.*.*) so those releases can carry
+          # human-written or auto-generated notes; only populate body for the
+          # rolling latest-* tags.
+          omitBody: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           body: |
-            ## MLIR-AIR Wheels
+            ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
             **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
@@ -457,11 +465,11 @@ jobs:
             ### Installation
 
             ```bash
-            # MLIR-AIR (default: RTTI enabled)
-            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+            # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
+            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
 
-            # MLIR-AIE
-            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+            # MLIR-AIE (must match RTTI setting above)
+            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
 
             # Peano (llvm-aie) — AIE backend compiler
             pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -282,14 +282,16 @@ jobs:
 
             ### Installation
 
-            The `mlir_air` wheel declares `mlir_aie` (pinned) and `llvm-aie` as runtime dependencies, so a single `pip install` with the right `--find-links` pages resolves the whole stack:
+            AIR supports multiple backends (AIE, GPU, VCK5000); backend dependencies are exposed as pip extras. For the AIE backend, the `[aie]` extra pulls the matching pinned `mlir_aie` and `llvm-aie` from the additional `--find-links` pages:
 
             ```bash
-            pip install mlir_air \
+            pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }} \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
+
+            Drop the `[aie]` extra to install AIR core only (e.g. when bringing your own backend).
 
             ### RTTI / no-RTTI Variants
 
@@ -471,14 +473,16 @@ jobs:
 
             ### Installation
 
-            The `mlir_air` wheel declares `mlir_aie` (pinned) and `llvm-aie` as runtime dependencies, so a single `pip install` with the right `--find-links` pages resolves the whole stack:
+            AIR supports multiple backends (AIE, GPU, VCK5000); backend dependencies are exposed as pip extras. For the AIE backend, the `[aie]` extra pulls the matching pinned `mlir_aie` and `llvm-aie` from the additional `--find-links` pages:
 
             ```bash
-            pip install mlir_air \
+            pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }} \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
+
+            Drop the `[aie]` extra to install AIR core only (e.g. when bringing your own backend).
 
             ### RTTI / no-RTTI Variants
 

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -263,6 +263,35 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}
+          body: |
+            ## MLIR-AIR Wheels
+
+            **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
+            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
+
+            ### Installation
+
+            ```bash
+            # MLIR-AIR (default: RTTI enabled)
+            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+
+            # MLIR-AIE
+            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+
+            # Peano (llvm-aie) — AIE backend compiler
+            pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+            ```
+
+            ### RTTI / no-RTTI Variants
+
+            Both RTTI-enabled and RTTI-disabled wheels are released for downstream integration convenience:
+
+            - [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) — RTTI **on**. Default; use this for standalone development.
+            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from [`latest-wheels-no-rtti`](https://github.com/Xilinx/mlir-aie/releases/tag/latest-wheels-no-rtti).
+
+            When mixing wheels into a downstream build, all three of `mlir`, `mlir_aie`, and `mlir_air` must agree on RTTI.
+
+            Full setup guide: [docs/buildingRyzenLin.md](https://github.com/Xilinx/mlir-air/blob/main/docs/buildingRyzenLin.md#install-prebuilt-wheels-recommended)
 
   build-windows:
     name: Build and upload mlir_air wheels (Windows)
@@ -419,3 +448,32 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: ${{ github.event_name == 'push' }}
+          body: |
+            ## MLIR-AIR Wheels
+
+            **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
+            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
+
+            ### Installation
+
+            ```bash
+            # MLIR-AIR (default: RTTI enabled)
+            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+
+            # MLIR-AIE
+            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+
+            # Peano (llvm-aie) — AIE backend compiler
+            pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+            ```
+
+            ### RTTI / no-RTTI Variants
+
+            Both RTTI-enabled and RTTI-disabled wheels are released for downstream integration convenience:
+
+            - [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) — RTTI **on**. Default; use this for standalone development.
+            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from [`latest-wheels-no-rtti`](https://github.com/Xilinx/mlir-aie/releases/tag/latest-wheels-no-rtti).
+
+            When mixing wheels into a downstream build, all three of `mlir`, `mlir_aie`, and `mlir_air` must agree on RTTI.
+
+            Full setup guide: [docs/buildingRyzenLin.md](https://github.com/Xilinx/mlir-air/blob/main/docs/buildingRyzenLin.md#install-prebuilt-wheels-recommended)

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -92,6 +92,7 @@ jobs:
     outputs:
       AIR_PROJECT_COMMIT: ${{ steps.get_commit.outputs.AIR_PROJECT_COMMIT }}
       DATETIME: ${{ steps.get_commit.outputs.DATETIME }}
+      MLIR_AIE_VERSION: ${{ steps.get_commit.outputs.MLIR_AIE_VERSION }}
     steps:
       - uses: actions/checkout@v4
 
@@ -107,6 +108,11 @@ jobs:
           echo "AIR_PROJECT_COMMIT=${AIR_PROJECT_COMMIT}" | tee -a "$GITHUB_OUTPUT"
           DATETIME=$(date +"%Y%m%d%H")
           echo "DATETIME=${DATETIME}" | tee -a "$GITHUB_OUTPUT"
+          # The pinned mlir-aie wheel version that this AIR commit was built and
+          # tested against. Surfaced into the release body so users install the
+          # matching mlir-aie wheel rather than guessing latest.
+          MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
+          echo "MLIR_AIE_VERSION=${MLIR_AIE_VERSION}" | tee -a "$GITHUB_OUTPUT"
 
   build-repo:
     name: Build and upload mlir_air wheels
@@ -279,8 +285,10 @@ jobs:
             # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
             pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
 
-            # MLIR-AIE (must match RTTI setting above)
-            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
+            # MLIR-AIE — pinned to the version this AIR commit was built and
+            # tested against (must match RTTI setting above).
+            pip install "mlir_aie==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}" \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
 
             # Peano (llvm-aie) — AIE backend compiler
             pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
@@ -468,8 +476,10 @@ jobs:
             # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
             pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
 
-            # MLIR-AIE (must match RTTI setting above)
-            pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
+            # MLIR-AIE — pinned to the version this AIR commit was built and
+            # tested against (must match RTTI setting above).
+            pip install "mlir_aie==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}" \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
 
             # Peano (llvm-aie) — AIE backend compiler
             pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -226,7 +226,7 @@ jobs:
             find mlir$NO_RTTI_UNDERSCORE -exec touch -a -m -t 201108231405.14 {} \;
             export MLIR_INSTALL_ABS_PATH=$PWD/mlir$NO_RTTI_UNDERSCORE
 
-            MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
+            export MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
             pip -q download --no-deps --platform manylinux_2_35_x86_64 "mlir_aie==${MLIR_AIE_VERSION}${NO_RTTI_DOT}" \
               -f "$MLIR_AIE_WHEELS_URL"
             unzip -q mlir_aie*.whl
@@ -277,21 +277,18 @@ jobs:
             ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
+            **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
             **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
 
             ### Installation
 
+            The `mlir_air` wheel declares `mlir_aie` (pinned) and `llvm-aie` as runtime dependencies, so a single `pip install` with the right `--find-links` pages resolves the whole stack:
+
             ```bash
-            # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
-            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
-
-            # MLIR-AIE — pinned to the version this AIR commit was built and
-            # tested against (must match RTTI setting above).
-            pip install "mlir_aie==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}" \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
-
-            # Peano (llvm-aie) — AIE backend compiler
-            pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+            pip install mlir_air \
+              -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }} \
+              -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 
             ### RTTI / no-RTTI Variants
@@ -299,7 +296,7 @@ jobs:
             Both RTTI-enabled and RTTI-disabled wheels are released for downstream integration convenience:
 
             - [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) — RTTI **on**. Default; use this for standalone development.
-            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from [`latest-wheels-no-rtti`](https://github.com/Xilinx/mlir-aie/releases/tag/latest-wheels-no-rtti).
+            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`.
 
             When mixing wheels into a downstream build, all three of `mlir`, `mlir_aie`, and `mlir_air` must agree on RTTI.
 
@@ -420,6 +417,7 @@ jobs:
 
           export AIR_PROJECT_COMMIT=${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}
           export DATETIME=${{ needs.get-air-project-commit.outputs.DATETIME }}
+          export MLIR_AIE_VERSION=${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}
 
           export WHEELHOUSE_DIR="${ROOT}/wheelhouse"
           mkdir -p "$WHEELHOUSE_DIR"
@@ -468,21 +466,18 @@ jobs:
             ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
+            **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
             **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
 
             ### Installation
 
+            The `mlir_air` wheel declares `mlir_aie` (pinned) and `llvm-aie` as runtime dependencies, so a single `pip install` with the right `--find-links` pages resolves the whole stack:
+
             ```bash
-            # MLIR-AIR (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI enabled' || 'RTTI disabled' }})
-            pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }}
-
-            # MLIR-AIE — pinned to the version this AIR commit was built and
-            # tested against (must match RTTI setting above).
-            pip install "mlir_aie==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}" \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }}
-
-            # Peano (llvm-aie) — AIE backend compiler
-            pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+            pip install mlir_air \
+              -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-3' || 'latest-wheels-no-rtti' }} \
+              -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 
             ### RTTI / no-RTTI Variants
@@ -490,7 +485,7 @@ jobs:
             Both RTTI-enabled and RTTI-disabled wheels are released for downstream integration convenience:
 
             - [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) — RTTI **on**. Default; use this for standalone development.
-            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from [`latest-wheels-no-rtti`](https://github.com/Xilinx/mlir-aie/releases/tag/latest-wheels-no-rtti).
+            - [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) — RTTI **off**. For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`.
 
             When mixing wheels into a downstream build, all three of `mlir`, `mlir_aie`, and `mlir_air` must agree on RTTI.
 

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -14,7 +14,7 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
 
 ### Steps
 
-MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time. The `mlir_air` wheel declares both as runtime dependencies (`mlir_aie` is pinned to the exact version AIR was built and tested against), so a single `pip install` with the right `--find-links` pages installs the whole stack — no clone, no helper script.
+AIR supports multiple backends — AIE (NPU / Versal AI Engines), [GPU](buildingGPU.md), and [VCK5000](buildingVCK5000.md). Backend dependencies are exposed as pip **extras** so you only install what you need. For the AIE backend on Ryzen™ AI, use the `[aie]` extra; pip reads the pinned `mlir_aie==<version>` and `llvm-aie` from the wheel's metadata and resolves them from the additional `--find-links` pages.
 
 1. **Create a virtual environment:**
    ```bash
@@ -23,15 +23,17 @@ MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time.
    pip install --upgrade pip
    ```
 
-2. **Install MLIR-AIR and its pinned dependencies:**
+2. **Install MLIR-AIR with the AIE backend:**
    ```bash
-   pip install mlir_air \
+   pip install 'mlir_air[aie]' \
      -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels \
      -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3 \
      -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
    ```
 
-   Pip reads the `mlir_aie==<pinned>` and `llvm-aie` requirements from `mlir_air`'s wheel metadata and resolves them from the additional `--find-links` pages. The exact pinned `mlir_aie` version this AIR wheel was tested against is shown on the [release page](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels).
+   The `[aie]` extra pulls `mlir_aie` (pinned to the exact version this AIR wheel was tested against) and `llvm-aie` (the Peano backend compiler — nightly). The pinned `mlir_aie` version is shown on the [release page](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels).
+
+   To install AIR core only (e.g. when bringing your own backend), drop the `[aie]` extra and the last two `-f` flags.
 
 3. **Set up environment variables** (paths derived from `pip show`):
    ```bash
@@ -67,7 +69,7 @@ We release **both RTTI and no-RTTI variants** so downstream projects can match t
 For the no-RTTI variant, point both find-links at the no-RTTI pages so pip resolves the matching `mlir_aie`:
 
 ```bash
-pip install mlir_air \
+pip install 'mlir_air[aie]' \
   -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
   -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
   -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -1,6 +1,78 @@
 # Getting Started and Running on Linux Ryzen™ AI
 
-## Quick Start: Build with Prebuilt Wheels
+## Install Prebuilt Wheels (Recommended)
+
+The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source build, no CMake, no LLVM clone. Use this path unless you need to modify MLIR-AIR itself or run on an unsupported Python/platform.
+
+### Prerequisites
+
+- **Python 3.10–3.14** on Linux x86_64, or **Python 3.10–3.12** on Windows AMD64
+- **pip**
+- **XRT** (optional, required only for running on hardware) — see [mlir-aie's XRT install instructions](https://github.com/Xilinx/mlir-aie#install-the-xdna-driver-and-xrt)
+
+### Steps
+
+1. **Create a virtual environment:**
+   ```bash
+   python3 -m venv airenv
+   source airenv/bin/activate
+   pip install --upgrade pip
+   ```
+
+2. **Install MLIR-AIR and its companion wheels:**
+   ```bash
+   # MLIR-AIR (default: RTTI-enabled)
+   pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+
+   # MLIR-AIE
+   pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+
+   # Peano (llvm-aie) — AIE backend compiler
+   pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+   ```
+
+3. **Set up environment variables** (paths derived from `pip show`):
+   ```bash
+   export MLIR_AIR_INSTALL_DIR=$(python3 -m pip show mlir_air | grep ^Location: | awk '{print $2}')/mlir_air
+   export MLIR_AIE_INSTALL_DIR=$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie
+   export PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie
+
+   export PATH=$MLIR_AIR_INSTALL_DIR/bin:$MLIR_AIE_INSTALL_DIR/bin:$PATH
+   export PYTHONPATH=$MLIR_AIR_INSTALL_DIR/python:$MLIR_AIE_INSTALL_DIR/python:$PYTHONPATH
+   export LD_LIBRARY_PATH=$MLIR_AIR_INSTALL_DIR/lib:$MLIR_AIE_INSTALL_DIR/lib:$LD_LIBRARY_PATH
+
+   # Only if you have XRT installed:
+   source /opt/xilinx/xrt/setup.sh
+   ```
+
+4. **Verify the install:**
+   ```bash
+   air-opt --help
+   ```
+
+You can now jump to [Running a Quick Example](#running-a-quick-example) below.
+
+### Choosing a Wheel Release
+
+| Tag | When to use |
+|-----|-------------|
+| [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) | Default. RTTI enabled. Use this for standalone development. |
+| [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) | For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from `latest-wheels-no-rtti`. |
+| [`v*.*.*`](https://github.com/Xilinx/mlir-air/releases) (e.g. `v1.0.0`) | Pinned tagged release, for reproducible builds: `pip install mlir_air==<ver> -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/v<ver>` |
+
+We release **both RTTI and no-RTTI variants** so downstream projects can match their LLVM build configuration without having to rebuild MLIR-AIR from source. When mixing wheels into a downstream build, all three (`mlir`, `mlir_aie`, `mlir_air`) must agree on RTTI.
+
+### Running Examples Against a Wheel Install
+
+When checking out the MLIR-AIR repo to run programming examples, sync to the commit hash embedded in the wheel filename (`mlir_air-0.0.1.{DATETIME}+{HASH}-...`) so the example sources match the installed compiler.
+
+If the wheel install path doesn't fit your needs, see the source-build instructions below.
+
+---
+
+## Build From Source Using Prebuilt Dependencies
+
+This path builds MLIR-AIR from source but installs LLVM, MLIR-AIE, and Peano from prebuilt wheels — useful when you're hacking on MLIR-AIR itself but don't want to also rebuild its dependencies.
 
 ### Prerequisites
 

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -14,9 +14,7 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
 
 ### Steps
 
-MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time but not at pip-install time — the three wheels are pre-built binaries that don't need to be installed in any particular order. All three just need to be present before you run `aircc` or `air-opt`.
-
-> **Important:** MLIR-AIR is verified only against the specific MLIR-AIE wheel version that AIR was built against (pinned in [`utils/clone-mlir-aie.sh`](../utils/clone-mlir-aie.sh)). Installing the latest `mlir_aie` may pick up a newer MLIR-AIE that breaks AIR. The steps below derive the pinned version from the script.
+MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time. The `mlir_air` wheel declares both as runtime dependencies (`mlir_aie` is pinned to the exact version AIR was built and tested against), so a single `pip install` with the right `--find-links` pages installs the whole stack — no clone, no helper script.
 
 1. **Create a virtual environment:**
    ```bash
@@ -25,32 +23,17 @@ MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time 
    pip install --upgrade pip
    ```
 
-2. **Clone the MLIR-AIR repository** (needed for the version-pinning script and for the programming examples):
+2. **Install MLIR-AIR and its pinned dependencies:**
    ```bash
-   git clone https://github.com/Xilinx/mlir-air.git
-   cd mlir-air
+   pip install mlir_air \
+     -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels \
+     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3 \
+     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
    ```
 
-3. **Install MLIR-AIR** (latest wheel):
-   ```bash
-   pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
-   ```
+   Pip reads the `mlir_aie==<pinned>` and `llvm-aie` requirements from `mlir_air`'s wheel metadata and resolves them from the additional `--find-links` pages. The exact pinned `mlir_aie` version this AIR wheel was tested against is shown on the [release page](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels).
 
-   For best reproducibility, after the install also `git checkout` the AIR commit hash that the wheel was built from — it's the 7-char hash in the wheel filename (`mlir_air-0.0.1.{DATETIME}+{HASH}-...`) and is also shown on the [release page](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels).
-
-4. **Install MLIR-AIE pinned to the version this AIR was tested against:**
-   ```bash
-   MLIR_AIE_VERSION=$(./utils/clone-mlir-aie.sh --get-wheel-version)
-   pip install "mlir_aie==${MLIR_AIE_VERSION}" \
-     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
-   ```
-
-5. **Install Peano** (AIE backend compiler — latest nightly):
-   ```bash
-   pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-   ```
-
-6. **Set up environment variables** (paths derived from `pip show`):
+3. **Set up environment variables** (paths derived from `pip show`):
    ```bash
    export MLIR_AIR_INSTALL_DIR=$(python3 -m pip show mlir_air | grep ^Location: | awk '{print $2}')/mlir_air
    export MLIR_AIE_INSTALL_DIR=$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie
@@ -64,7 +47,7 @@ MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time 
    source /opt/xilinx/xrt/setup.sh
    ```
 
-7. **Verify the install:**
+4. **Verify the install:**
    ```bash
    air-opt --help
    ```
@@ -73,13 +56,24 @@ You can now jump to [Running a Quick Example](#running-a-quick-example) below.
 
 ### Choosing a Wheel Release
 
+We release **both RTTI and no-RTTI variants** so downstream projects can match their LLVM build configuration without having to rebuild MLIR-AIR from source.
+
 | Tag | When to use |
 |-----|-------------|
-| [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) | Default. RTTI enabled. Use this for standalone development. |
-| [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) | For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Pair with `mlir_aie` from `latest-wheels-no-rtti`. |
-| [`v*.*.*`](https://github.com/Xilinx/mlir-air/releases) (e.g. `v1.0.0`) | Pinned tagged release, for reproducible builds: `pip install mlir_air==<ver> -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/v<ver>` |
+| [`latest-air-wheels`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels) | Default. RTTI enabled. Use this for standalone development. The install command in step 2 above targets this tag. |
+| [`latest-air-wheels-no-rtti`](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti) | For integrating MLIR-AIR into a downstream project whose LLVM is built with `-DLLVM_ENABLE_RTTI=OFF`. Use the no-RTTI install snippet below. |
+| [`v*.*.*`](https://github.com/Xilinx/mlir-air/releases) (e.g. `v1.0.0`) | Pinned tagged release, for reproducible builds. Replace the find-links URL with `.../expanded_assets/v<ver>` and the package spec with `mlir_air==<ver>`. |
 
-We release **both RTTI and no-RTTI variants** so downstream projects can match their LLVM build configuration without having to rebuild MLIR-AIR from source. When mixing wheels into a downstream build, all three (`mlir`, `mlir_aie`, `mlir_air`) must agree on RTTI.
+For the no-RTTI variant, point both find-links at the no-RTTI pages so pip resolves the matching `mlir_aie`:
+
+```bash
+pip install mlir_air \
+  -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
+  -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
+  -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+```
+
+When mixing wheels into a downstream build, all three (`mlir`, `mlir_aie`, `mlir_air`) must agree on RTTI.
 
 If the wheel install path doesn't fit your needs, see the source-build instructions below.
 

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -14,6 +14,10 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
 
 ### Steps
 
+MLIR-AIR depends on **MLIR-AIE** and **Peano (`llvm-aie`)** at compile/run time but not at pip-install time — the three wheels are pre-built binaries that don't need to be installed in any particular order. All three just need to be present before you run `aircc` or `air-opt`.
+
+> **Important:** MLIR-AIR is verified only against the specific MLIR-AIE wheel version that AIR was built against (pinned in [`utils/clone-mlir-aie.sh`](../utils/clone-mlir-aie.sh)). Installing the latest `mlir_aie` may pick up a newer MLIR-AIE that breaks AIR. The steps below derive the pinned version from the script.
+
 1. **Create a virtual environment:**
    ```bash
    python3 -m venv airenv
@@ -21,19 +25,32 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
    pip install --upgrade pip
    ```
 
-2. **Install MLIR-AIR and its companion wheels:**
+2. **Clone the MLIR-AIR repository** (needed for the version-pinning script and for the programming examples):
    ```bash
-   # MLIR-AIR (default: RTTI-enabled)
+   git clone https://github.com/Xilinx/mlir-air.git
+   cd mlir-air
+   ```
+
+3. **Install MLIR-AIR** (latest wheel):
+   ```bash
    pip install mlir_air -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels
+   ```
 
-   # MLIR-AIE
-   pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+   For best reproducibility, after the install also `git checkout` the AIR commit hash that the wheel was built from — it's the 7-char hash in the wheel filename (`mlir_air-0.0.1.{DATETIME}+{HASH}-...`) and is also shown on the [release page](https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels).
 
-   # Peano (llvm-aie) — AIE backend compiler
+4. **Install MLIR-AIE pinned to the version this AIR was tested against:**
+   ```bash
+   MLIR_AIE_VERSION=$(./utils/clone-mlir-aie.sh --get-wheel-version)
+   pip install "mlir_aie==${MLIR_AIE_VERSION}" \
+     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+   ```
+
+5. **Install Peano** (AIE backend compiler — latest nightly):
+   ```bash
    pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
    ```
 
-3. **Set up environment variables** (paths derived from `pip show`):
+6. **Set up environment variables** (paths derived from `pip show`):
    ```bash
    export MLIR_AIR_INSTALL_DIR=$(python3 -m pip show mlir_air | grep ^Location: | awk '{print $2}')/mlir_air
    export MLIR_AIE_INSTALL_DIR=$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie
@@ -47,7 +64,7 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
    source /opt/xilinx/xrt/setup.sh
    ```
 
-4. **Verify the install:**
+7. **Verify the install:**
    ```bash
    air-opt --help
    ```
@@ -63,10 +80,6 @@ You can now jump to [Running a Quick Example](#running-a-quick-example) below.
 | [`v*.*.*`](https://github.com/Xilinx/mlir-air/releases) (e.g. `v1.0.0`) | Pinned tagged release, for reproducible builds: `pip install mlir_air==<ver> -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/v<ver>` |
 
 We release **both RTTI and no-RTTI variants** so downstream projects can match their LLVM build configuration without having to rebuild MLIR-AIR from source. When mixing wheels into a downstream build, all three (`mlir`, `mlir_aie`, `mlir_air`) must agree on RTTI.
-
-### Running Examples Against a Wheel Install
-
-When checking out the MLIR-AIR repo to run programming examples, sync to the commit hash embedded in the wheel filename (`mlir_air-0.0.1.{DATETIME}+{HASH}-...`) so the example sources match the installed compiler.
 
 If the wheel install path doesn't fit your needs, see the source-build instructions below.
 

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -6,9 +6,11 @@ The fastest way to get MLIR-AIR is to install the prebuilt wheel — no source b
 
 ### Prerequisites
 
-- **Python 3.10–3.14** on Linux x86_64, or **Python 3.10–3.12** on Windows AMD64
+- **Python 3.10–3.14**
 - **pip**
 - **XRT** (optional, required only for running on hardware) — see [mlir-aie's XRT install instructions](https://github.com/Xilinx/mlir-aie#install-the-xdna-driver-and-xrt)
+
+> Windows wheels are also published. This guide covers Linux only; Windows users will need to translate the `source`/`export` commands to PowerShell equivalents.
 
 ### Steps
 

--- a/utils/mlir_air_wheels/pyproject.toml
+++ b/utils/mlir_air_wheels/pyproject.toml
@@ -3,14 +3,15 @@ name = "mlir-air"
 description = "MLIR-based toolchain for spatial accelerators"
 readme = { text = """MLIR AIR provides MLIR-based infrastructure for 
 programming spatial accelerators.""", content-type = "text/markdown" }
-dynamic = ["dependencies", "requires-python", "version", "license"]
+dynamic = ["dependencies", "optional-dependencies", "requires-python", "version", "license"]
 authors = [
   { name="AMD Inc." },
 ]
 
-[project.optional-dependencies]
-# Keep this list in sync with utils/requirements_dev.txt.
-dev = ["cmake>=3.30", "pybind11", "nanobind>=2.9", "lit", "psutil"]
+# Note: extras (a.k.a. optional-dependencies) are populated dynamically in
+# setup.py — get_extras_require() injects the AIE backend extra with the
+# build-time-pinned mlir_aie version. Per PEP 621, when this field is
+# listed in `dynamic` above, it cannot also be declared statically here.
 
 [project.urls]
 "Homepage" = "https://github.com/Xilinx/mlir-air"

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -305,11 +305,17 @@ def parse_requirements(filename):
 
 
 def get_extras_require():
+    # All extras (a.k.a. optional-dependencies) live here because
+    # pyproject.toml lists `optional-dependencies` as dynamic — required
+    # so we can inject the build-time mlir_aie pin into the [aie] extra.
+    extras = {
+        # Mirrors utils/requirements_dev.txt; keep in sync.
+        "dev": ["cmake>=3.30", "pybind11", "nanobind>=2.9", "lit", "psutil"],
+    }
     # AIR supports multiple backends (AIE, GPU, VCK5000), so backend
-    # dependencies live in `extras_require` rather than `install_requires`.
-    # `pip install mlir_air[aie]` pulls the matching mlir_aie + Peano;
-    # users targeting other backends skip the extra.
-    extras = {}
+    # dependencies live under per-backend extras rather than as hard
+    # `install_requires`. `pip install mlir_air[aie]` pulls the matching
+    # mlir_aie + Peano; users targeting other backends skip the extra.
     mlir_aie_version = os.getenv("MLIR_AIE_VERSION", "")
     if mlir_aie_version:
         no_rtti_dot = "" if check_env("ENABLE_RTTI", 1) else ".no.rtti"

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -304,21 +304,22 @@ def parse_requirements(filename):
         ]
 
 
-def get_install_requires():
-    reqs = parse_requirements(Path(__file__).parent / "requirements.txt")
-    # Pin mlir_aie to the version this AIR wheel was built and tested
-    # against, so users only need a single `pip install mlir_air -f ... -f
-    # ...` and pip resolves the matching mlir_aie wheel automatically.
-    # Falls back to no pin when MLIR_AIE_VERSION isn't set (e.g. local dev
-    # builds outside CI).
+def get_extras_require():
+    # AIR supports multiple backends (AIE, GPU, VCK5000), so backend
+    # dependencies live in `extras_require` rather than `install_requires`.
+    # `pip install mlir_air[aie]` pulls the matching mlir_aie + Peano;
+    # users targeting other backends skip the extra.
+    extras = {}
     mlir_aie_version = os.getenv("MLIR_AIE_VERSION", "")
     if mlir_aie_version:
         no_rtti_dot = "" if check_env("ENABLE_RTTI", 1) else ".no.rtti"
-        reqs.append(f"mlir_aie=={mlir_aie_version}{no_rtti_dot}")
-    # Peano (Xilinx llvm-aie) is the AIE backend compiler. No version pin
-    # — AIR tracks the nightly build.
-    reqs.append("llvm-aie")
-    return reqs
+        # mlir_aie is pinned to the version this AIR wheel was built and
+        # tested against. llvm-aie (Peano) tracks nightly — no pin.
+        extras["aie"] = [
+            f"mlir_aie=={mlir_aie_version}{no_rtti_dot}",
+            "llvm-aie",
+        ]
+    return extras
 
 
 setup(
@@ -334,5 +335,6 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["wheelhouse", "mlir-air"]),
     python_requires=">=3.10",
-    install_requires=get_install_requires(),
+    install_requires=parse_requirements(Path(__file__).parent / "requirements.txt"),
+    extras_require=get_extras_require(),
 )

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -304,6 +304,23 @@ def parse_requirements(filename):
         ]
 
 
+def get_install_requires():
+    reqs = parse_requirements(Path(__file__).parent / "requirements.txt")
+    # Pin mlir_aie to the version this AIR wheel was built and tested
+    # against, so users only need a single `pip install mlir_air -f ... -f
+    # ...` and pip resolves the matching mlir_aie wheel automatically.
+    # Falls back to no pin when MLIR_AIE_VERSION isn't set (e.g. local dev
+    # builds outside CI).
+    mlir_aie_version = os.getenv("MLIR_AIE_VERSION", "")
+    if mlir_aie_version:
+        no_rtti_dot = "" if check_env("ENABLE_RTTI", 1) else ".no.rtti"
+        reqs.append(f"mlir_aie=={mlir_aie_version}{no_rtti_dot}")
+    # Peano (Xilinx llvm-aie) is the AIE backend compiler. No version pin
+    # — AIR tracks the nightly build.
+    reqs.append("llvm-aie")
+    return reqs
+
+
 setup(
     version=get_version(),
     license="MIT",
@@ -317,5 +334,5 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["wheelhouse", "mlir-air"]),
     python_requires=">=3.10",
-    install_requires=parse_requirements(Path(__file__).parent / "requirements.txt"),
+    install_requires=get_install_requires(),
 )


### PR DESCRIPTION
## Summary

- Add a wheel-first install section to `docs/buildingRyzenLin.md` so users can `pip install mlir_air` instead of building MLIR-AIR from source. Renames the existing "Quick Start" section to "Build From Source Using Prebuilt Dependencies" — it was actually a source build that uses wheels only for LLVM/AIE/Peano dependencies, which was easy to confuse with a wheel install.
- Populate the GitHub release description for both `latest-air-wheels` and `latest-air-wheels-no-rtti` tags via inline `body:` on the release action in `buildAIRWheels.yml`. The release page currently shows just a list of `.whl` files with no usage instructions.
- Document the RTTI / no-RTTI choice — both variants are released so downstream projects can match their LLVM build configuration without rebuilding MLIR-AIR from source.

## Test plan

- [ ] Confirm `docs/buildingRyzenLin.md` renders cleanly on the docs site
- [ ] After merge, trigger the `Build mlir-air Wheels` workflow (or wait for the next nightly cron) and verify the release body appears at https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels and https://github.com/Xilinx/mlir-air/releases/tag/latest-air-wheels-no-rtti
- [ ] Verify the install snippet in the docs works end-to-end on a clean venv (this has been smoke-tested locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)