### PR TITLE
weighted_rms_norm: add multi-tile herd_x support and profile mode

### DIFF
--- a/programming_examples/weighted_rms_norm/Makefile
+++ b/programming_examples/weighted_rms_norm/Makefile
@@ -2,6 +2,17 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+# AIE target: aie2 (NPU1) or aie2p (NPU2, default)
+AIE_TARGET ?= aie2p
+
+# Default herd_x for the multi-tile `run` target. NPU2 (aie2p) has enough
+# compute rows to fan out to 8 tiles; NPU1 (aie2) is single-tile.
+ifeq ($(AIE_TARGET),aie2p)
+  HERD_X ?= 8
+else
+  HERD_X ?= 1
+endif
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -11,14 +22,27 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+ITERATIONS ?= 5
+
 all: run
 
 print:
 	${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) -p
 
+# Default: multi-tile execution (8 tiles on NPU2, configurable via HERD_X)
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X)
+
+# Original single-tile baseline (herd_x=1)
+run_single_tile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x 1
+
+# Profile multi-tile execution (timing + bandwidth; correctness via `make run`)
+profile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X) --profile --iterations $(ITERATIONS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/weighted_rms_norm/run_makefile_peano.lit
+++ b/programming_examples/weighted_rms_norm/run_makefile_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_single_tile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/weighted_rms_norm/run_makefile_peano_multi_tile.lit
+++ b/programming_examples/weighted_rms_norm/run_makefile_peano_multi_tile.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_multi_tile
+// RUN: cd test_peano_multi_tile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR ITERATIONS=3 | FileCheck --check-prefix=PROFILE %s
+// CHECK: PASS!
+// PROFILE: Bandwidth:

--- a/programming_examples/weighted_rms_norm/weighted_rms_norm.py
+++ b/programming_examples/weighted_rms_norm/weighted_rms_norm.py
@@ -20,6 +20,7 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air.ir import *
+from air.dialects.affine import apply as affine_apply
 from air.dialects.air import *
 from air.dialects import arith, math as math_dialect
 from air.dialects.memref import AllocOp, DeallocOp, subview
@@ -40,7 +41,7 @@ EPS = 1e-5
 
 
 @module_builder
-def build_module(M, N, np_dtype, vector_size=16):
+def build_module(M, N, np_dtype, vector_size=16, herd_x=1):
     xrt_dtype = type_mapper(np_dtype)
     assert (
         N % vector_size == 0
@@ -58,6 +59,139 @@ def build_module(M, N, np_dtype, vector_size=16):
     l1RowTy = MemRefType.get([N], xrt_dtype, memory_space=l1_mem_space)
     l1VecTy = MemRefType.get([vector_size], xrt_dtype, memory_space=l1_mem_space)
 
+    if herd_x > 1:
+        assert M % herd_x == 0
+        rows_per_tile = M // herd_x
+        # Map: global_row = local_row + tx * rows_per_tile
+        row_map = AffineMap.get(
+            0,
+            2,
+            [
+                AffineExpr.get_add(
+                    AffineSymbolExpr.get(0),
+                    AffineExpr.get_mul(
+                        AffineSymbolExpr.get(1), AffineConstantExpr.get(rows_per_tile)
+                    ),
+                )
+            ],
+        )
+
+        # Multi-tile mode: each tile DMAs the full weight vector from L3
+        # (the compiler may merge these identical loads into a broadcast).
+        @FuncOp.from_py_func(l3MemrefTy, l3WeightTy, l3MemrefTy)
+        def weighted_rms_norm(arg0, arg1, arg2):
+
+            @herd(name="herd_0", sizes=[herd_x, 1], operands=[arg0, arg1, arg2])
+            def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_weight, l3_out):
+                l1_row = AllocOp(l1RowTy, [], [])
+                l1_out = AllocOp(l1RowTy, [], [])
+                l1_weight = AllocOp(l1RowTy, [], [])
+                l1_acc = AllocOp(l1VecTy, [], [])
+
+                c0 = arith.ConstantOp.create_index(0)
+                cst0 = arith.ConstantOp(xrt_dtype, 0.0)
+                n_f = arith.ConstantOp(xrt_dtype, float(N))
+                eps_f = arith.ConstantOp(xrt_dtype, EPS)
+
+                v_zero = BroadcastOp(vecTy, cst0)
+
+                # Weight DMA: same data to all tiles (broadcast)
+                dma_memcpy_nd(
+                    l1_weight,
+                    l3_weight,
+                    src_offsets=[0],
+                    src_sizes=[N],
+                    src_strides=[1],
+                )
+
+                for local_row in range_(rows_per_tile):
+                    row = affine_apply(row_map, [local_row, _tx])
+                    # DMA: load one row (tile-dependent offset)
+                    dma_memcpy_nd(
+                        l1_row,
+                        l3_in,
+                        src_offsets=[row, 0],
+                        src_sizes=[1, N],
+                        src_strides=[N, 1],
+                    )
+
+                    # Step 1: Vectorized sum of x^2
+                    transfer_write(None, v_zero, l1_acc, [c0], identity_map, [True])
+                    for j in range_(0, N, vector_size):
+                        sub_row = subview(l1_row.result, [j], [vector_size], [1])
+                        sub_tmp = subview(l1_out.result, [j], [vector_size], [1])
+                        v_x = transfer_read(
+                            vecTy, sub_row, [c0], identity_map, cst0, [True]
+                        )
+                        v_sq = arith.mulf(v_x, v_x)
+                        transfer_write(None, v_sq, sub_tmp, [c0], identity_map, [True])
+                        v_sq_rd = transfer_read(
+                            vecTy, sub_tmp, [c0], identity_map, cst0, [True]
+                        )
+                        v_acc = transfer_read(
+                            vecTy, l1_acc, [c0], identity_map, cst0, [True]
+                        )
+                        v_sum = arith.addf(v_acc, v_sq_rd)
+                        transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
+                        yield_([])
+
+                    # Horizontal reduce
+                    v_final = transfer_read(
+                        vecTy, l1_acc, [c0], identity_map, cst0, [True]
+                    )
+                    total_sum = vector_reduction(xrt_dtype, "add", v_final)
+                    rms = arith.divf(total_sum, n_f)
+
+                    # Step 2: rstd = rsqrt(rms + eps) in f32
+                    f32 = F32Type.get()
+                    rms_eps = arith.addf(rms, eps_f)
+                    rms_eps_f32 = arith.extf(f32, rms_eps)
+                    rstd_f32 = math_dialect.rsqrt(rms_eps_f32)
+                    rstd = arith.truncf(xrt_dtype, rstd_f32)
+
+                    # Step 3: y = x * rstd * weight
+                    v_rstd = BroadcastOp(vecTy, rstd)
+                    for j in range_(0, N, vector_size):
+                        sub_row = subview(l1_row.result, [j], [vector_size], [1])
+                        sub_w = subview(l1_weight.result, [j], [vector_size], [1])
+                        sub_out = subview(l1_out.result, [j], [vector_size], [1])
+                        v_x = transfer_read(
+                            vecTy, sub_row, [c0], identity_map, cst0, [True]
+                        )
+                        v_w = transfer_read(
+                            vecTy, sub_w, [c0], identity_map, cst0, [True]
+                        )
+                        v_normed = arith.mulf(v_x, v_rstd)
+                        v_weighted = arith.mulf(v_normed, v_w)
+                        transfer_write(
+                            None,
+                            v_weighted,
+                            sub_out,
+                            [c0],
+                            identity_map,
+                            [True],
+                        )
+                        yield_([])
+
+                    # DMA: write result row (tile-dependent offset)
+                    dma_memcpy_nd(
+                        l3_out,
+                        l1_out,
+                        dst_offsets=[row, 0],
+                        dst_sizes=[1, N],
+                        dst_strides=[N, 1],
+                    )
+
+                    yield_([])
+
+                DeallocOp(l1_row)
+                DeallocOp(l1_out)
+                DeallocOp(l1_weight)
+                DeallocOp(l1_acc)
+
+        return  # end of herd_x > 1 path
+
+    # Original single-tile path (herd_x == 1)
     @FuncOp.from_py_func(l3MemrefTy, l3WeightTy, l3MemrefTy)
     def weighted_rms_norm(arg0, arg1, arg2):
 
@@ -155,31 +289,42 @@ def build_module(M, N, np_dtype, vector_size=16):
             DeallocOp(l1_acc)
 
 
-if __name__ == "__main__":
-    M_DEFAULT = 32
-    N_DEFAULT = 64
-    VECTOR_SIZE = 16
-    INPUT_DATATYPE = bfloat16
+def rms_norm_reference(x, weight, eps=1e-5):
+    """CPU F32 reference for weighted RMS norm."""
+    x_f32 = x.astype(np.float32)
+    rms = np.sqrt(np.mean(x_f32**2, axis=-1, keepdims=True) + eps)
+    return ((x_f32 / rms) * weight.astype(np.float32)).astype(x.dtype)
 
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the weighted RMS normalization example",
+        description="Weighted RMS Normalization — multi-tile with profiling",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--M", type=int, default=M_DEFAULT, help="M dimension (rows)")
-    parser.add_argument("--N", type=int, default=N_DEFAULT, help="N dimension (cols)")
     parser.add_argument(
-        "--vector-size",
+        "--profile", action="store_true", help="Profile kernel execution"
+    )
+    parser.add_argument(
+        "--M", type=int, default=2048, help="Rows (default: LLAMA seq_len)"
+    )
+    parser.add_argument(
+        "--N", type=int, default=2048, help="Cols (default: LLAMA emb_dim)"
+    )
+    parser.add_argument("--vector-size", type=int, default=16)
+    parser.add_argument(
+        "--herd-x",
         type=int,
-        default=VECTOR_SIZE,
-        help="Vector size for SIMD operations",
+        default=1,
+        help="Number of tiles (1=original, 8=multi-tile)",
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=5, help="Profiling iterations"
     )
     parser.add_argument(
         "--compile-mode",
         type=str,
         choices=["compile-only", "compile-and-run"],
-        dest="compile_mode",
         default="compile-and-run",
     )
     parser.add_argument(
@@ -187,29 +332,87 @@ if __name__ == "__main__":
         type=str,
         choices=["xclbin", "elf"],
         default="xclbin",
-        dest="output_format",
     )
     args = parser.parse_args()
 
-    mlir_module = build_module(args.M, args.N, INPUT_DATATYPE, args.vector_size)
+    M, N = args.M, args.N
+    herd_x = args.herd_x if hasattr(args, "herd_x") else 1
+    print(f"Weighted RMSNorm: M={M}, N={N}, herd=[{herd_x},1]")
+
+    mlir_module = build_module(M, N, bfloat16, args.vector_size, herd_x=herd_x)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
     np.random.seed(0)
-    x_input = np.random.rand(args.M, args.N).astype(INPUT_DATATYPE)
-    weight = np.random.rand(args.N).astype(INPUT_DATATYPE)
+    x_input = np.random.rand(M, N).astype(bfloat16)
+    weight = np.random.rand(N).astype(bfloat16)
+    y_expected = rms_norm_reference(x_input, weight)
 
-    # Reference: weighted RMS normalization
-    eps = EPS
-    rms = np.sqrt(
-        np.mean(x_input.astype(np.float32) ** 2, axis=-1, keepdims=True) + eps
-    )
-    y_expected = (
-        (x_input.astype(np.float32) / rms) * weight.astype(np.float32)
-    ).astype(INPUT_DATATYPE)
+    # Function signature is (input, weight, output) for both single- and
+    # multi-tile modes. Per-tile intermediate buffers in the multi-tile path
+    # are allocated internally (in L1) and not exposed at the L3 boundary.
 
-    if args.compile_mode == "compile-and-run":
+    if args.profile:
+        import time
+        import pyxrt as xrt
+        import filelock
+
+        backend = XRTBackend(
+            verbose=False,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            instance_name="weighted_rms_norm",
+        )
+        artifact = backend.compile(mlir_module)
+
+        # Hold the NPU lock for the entire NPU-touching scope: load, BO
+        # setup, warmup, and the timed loop. Keeping load() under a separate
+        # lock would let other processes interleave on the device during the
+        # measurement and pollute the timings.
+        with filelock.FileLock("/tmp/npu.lock"):
+            backend.load(artifact)
+
+            out_buf = np.zeros((M, N), dtype=bfloat16)
+            inputs = [x_input, weight, out_buf]
+            sizes = [a.size * a.itemsize for a in inputs]
+            bos = [
+                xrt.bo(
+                    backend.device, s, xrt.bo.host_only, backend.kernel.group_id(i + 3)
+                )
+                for i, s in enumerate(sizes)
+            ]
+
+            # Warmup
+            for i, a in enumerate(inputs):
+                bos[i].write(a.view(np.int16) if a.dtype == bfloat16 else a, 0)
+                bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+            backend.bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+            h = backend.kernel(3, backend.bo_instr, len(backend.instr_v), *bos)
+            h.wait()
+
+            times = []
+            for _ in range(args.iterations):
+                for i, a in enumerate(inputs):
+                    bos[i].write(a.view(np.int16) if a.dtype == bfloat16 else a, 0)
+                    bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+                t0 = time.perf_counter()
+                h = backend.kernel(3, backend.bo_instr, len(backend.instr_v), *bos)
+                h.wait()
+                t1 = time.perf_counter()
+                times.append((t1 - t0) * 1000)
+
+        backend.unload()
+
+        # Profile mode reports timing/bandwidth only. Correctness is covered
+        # by `make run` / the compile-and-run path's correlation check.
+        data_mb = (M * N * 2 * 2 + N * 2) / 1e6  # 2 matrices + 1 weight vector
+        print(
+            f"\n  Kernel: avg={np.mean(times):.1f}ms  min={np.min(times):.1f}ms  max={np.max(times):.1f}ms"
+        )
+        print(f"  Bandwidth: {data_mb / (np.min(times)/1000) / 1000:.2f} GB/s")
+
+    elif args.compile_mode == "compile-and-run":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
@@ -224,6 +427,7 @@ if __name__ == "__main__":
                 expected_outputs=[y_expected],
                 rtol=5e-2,
                 atol=5e-1,
+                min_correlation=0.99,
             )
         )
 


### PR DESCRIPTION
## Summary

Adds a multi-tile execution path to the weighted RMS normalization example, plus a `--profile` mode for benchmarking.

- `build_module` gains an `herd_x` parameter (default `1`, backward-compatible). When `herd_x > 1`, the herd shape becomes `[herd_x, 1]` and rows are partitioned across tiles via affine maps. Weight is broadcast to all tiles via DMA. Function signature is unchanged: `(input, weight, output)`.
- New `--profile` CLI flag with timing and bandwidth measurement.
- Makefile follows the `eltwise_add` pattern: `AIE_TARGET ?= aie2p`, with `HERD_X` defaulting to 8 on aie2p and 1 on aie2.
  - `make run` → multi-tile (default for NPU2)
  - `make run_single_tile` → original single-tile baseline
  - `make profile` → multi-tile + timing/bandwidth (correctness covered by `make run`)
- Reuses `XRTRunner._check_outputs(min_correlation=0.99, ...)` for verification in the `compile-and-run` path (no duplicate `np.corrcoef` logic).

## Test plan

- [x] `programming_examples/weighted_rms_norm/run_makefile_peano.lit` — single-tile (`herd_x=1`): PASS on Strix (NPU2, AIE2P)
- [x] `programming_examples/weighted_rms_norm/run_makefile_peano_multi_tile.lit` — multi-tile (`herd_x=8`) + profile mode: PASS on Strix
- [x] Manually verified `--herd-x 4`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)