### PR TITLE
Bump mlir-aie to 52dd9bc (latest main)

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=ae8ed9dac665a4bc2668399a91a4fdf0b34d177a
-DATETIME=2026041305
+export HASH=52dd9bc487254f05dcead9228c58e9505e9198af
+DATETIME=2026050723
 WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary

- Bumps `utils/clone-mlir-aie.sh` from `ae8ed9d` (datetime `2026041305`) to `52dd9bc` (datetime `2026050723`).
- Picks up the latest mlir-aie wheels, including [#3046](https://github.com/Xilinx/mlir-aie/pull/3046) "[AIEPlacer] Read shared-L1 aie.buffer references as memory-affinity adjacency".
- Wheel version resolves to `0.0.1.2026050723+52dd9bc`.

## Test plan

- [x] Rebuilt local mlir-aie at `52dd9bc` and rebuilt mlir-air against it.
- [x] `ninja check-air-mlir`: 380 passed, 7 expected-fail, 2 failures (`Conversion/AIRToROCDL/{air_to_rocdl,air_gpu_outlining}.mlir`). Both pre-existing on `origin/main` — the test inputs do `memref.load` on an L3 memref directly inside `air.herd`, which the dialect op verifier (`HerdOp::verify` → `verifyComputeMemoryAccess`) rejects. Unrelated to this bump.
- [x] `ninja check-air-python`: 9 passed, 11 unsupported, 0 failed.
- [ ] CI to confirm wheel build / Windows / RyzenAI workflows pick up the new wheel cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)