### PR TITLE
DMA allocator re-key on TileOp + outlineAIECores batched cleanup (RFC #1567 Stage C #1)

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -108,8 +108,16 @@ struct allocation_info_t {
   bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
   bool foundAlloc(int32_t col, int32_t row);
   bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
-  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
+
+  // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
+  // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
+  // bookkeeping does not depend on physical placement.
+  bool foundAlloc(AIE::TileOp tile);
+  bool foundAlloc(AIE::TileOp tile, air::MemcpyInterface memcpyOp);
+  bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
+  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInTile(AIE::TileOp tile);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6049,7 +6049,7 @@ public:
       llvm::SetVector<Operation *> allocs_to_remap;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6065,7 +6065,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6106,7 +6106,7 @@ public:
           tile_dma_memcpys;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6115,7 +6115,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6146,7 +6146,7 @@ public:
       for (auto *allocList : {&core_cascade_alloc.cascade_put_allocs,
                               &core_cascade_alloc.cascade_get_allocs}) {
         for (auto &alloc : *allocList) {
-          if (!alloc.foundAlloc(x, y))
+          if (!alloc.foundAlloc(tile))
             continue;
           for (auto o : alloc.memcpyOps) {
             if (!o)
@@ -6208,7 +6208,7 @@ public:
           shim_dma_memcpys;
 
       for (auto &alloc : shimDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6217,7 +6217,7 @@ public:
         }
       }
       for (auto &alloc : shimDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6259,7 +6259,7 @@ public:
           memtile_dma_memcpys;
 
       for (auto &alloc : memTileDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6268,7 +6268,7 @@ public:
         }
       }
       for (auto &alloc : memTileDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -258,29 +258,40 @@ LogicalResult outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
     h->setAttr(row_name,
                IntegerAttr::get(IntegerType::get(ctx, 32), row_offset));
 
+  // Compute tiles emit fully constrained (phys_x, phys_y) hints. The herd's
+  // x_loc/y_loc attributes carry deliberate placement intent set by
+  // air-place-herds (or upstream callers); AIR keeps the legacy flow that
+  // explicitly sets physical coordinates rather than letting the placer
+  // pick. The SequentialPlacer is a pass-through here — placement is
+  // byte-identical to direct getPhysTileOp calls.
+  //
+  // The batched createTilesViaPlacer call (one placer invocation per herd
+  // instead of one per cell) is functionally identical to per-cell calls
+  // when hints are fully constrained, but cleaner and consistent with
+  // memtile/shim allocators in stages A/B that already use the batched
+  // API with partial constraints.
+  int64_t numCells = herd_size_y * herd_size_x;
+  SmallVector<std::pair<std::optional<int>, std::optional<int>>> hints;
+  hints.reserve(numCells);
+  for (auto y = 0; y < herd_size_y; y++) {
+    for (auto x = 0; x < herd_size_x; x++) {
+      auto phys_x = x + col_offset;
+      auto phys_y = y + row_offset;
+      hints.push_back({phys_x, phys_y});
+    }
+  }
+  SmallVector<AIE::TileOp> herdTiles;
+  if (failed(air::createTilesViaPlacer(aie_device, AIE::AIETileType::CoreTile,
+                                       hints, herdTiles)))
+    return failure();
+
   for (auto y = 0; y < herd_size_y; y++) {
     for (auto x = 0; x < herd_size_x; x++) {
       auto hloc = h.getLoc();
       IRMapping remap;
       auto phys_x = x + col_offset;
       auto phys_y = y + row_offset;
-
-      // Emit aie.logical_tile<CoreTile>(phys_x, phys_y) and resolve via
-      // mlir-aie's SequentialPlacer (RFC #1567 Stage A milestone 4). For
-      // this milestone we keep both coordinates fully constrained, so the
-      // placer is a pass-through and physical placement is identical to
-      // before. Future milestones can relax to (col, ?) or (?, ?) for
-      // herds whose communication patterns don't require strict adjacency.
-      //
-      // TODO(rfc-1567): Once constraints are relaxed, switch to a single
-      // air::createTilesViaPlacer call up-front so the placer sees all
-      // unconstrained tiles together. With fully-constrained hints the
-      // per-tile invocation here is deterministic and preserves IR order.
-      auto tileRes = air::createTileViaPlacer(
-          aie_device, AIE::AIETileType::CoreTile, phys_x, phys_y);
-      if (failed(tileRes))
-        return failure();
-      auto tile = *tileRes;
+      auto tile = herdTiles[y * herd_size_x + x];
 
       Operation *t = tile.getOperation();
       while (isa_and_present<AIE::TileLike>(t->getNextNode()))

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -675,6 +675,43 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(int32_t col,
   return false;
 }
 
+// TileOp-keyed overloads (RFC #1567 Stage C #1). Pointer-equality on
+// dma_tile replaces (col, row) integer comparison; same answer, no
+// dependence on physical placement coordinates.
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile) {
+  return tile && tile == getDmaTile();
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::MemcpyInterface memcpyOp) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps)
+    if (memcpyOp.getOperation() == o)
+      return true;
+  return false;
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::ChannelOp channel_op) {
+  return foundAlloc(tile) && foundAlloc(channel_op);
+}
+
+bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(
+    AIE::TileOp tile) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps) {
+    auto memcpy_op = dyn_cast_if_present<air::MemcpyInterface>(o);
+    if (!memcpy_op)
+      continue;
+    auto chanTypeRes = air::getChannelType(memcpy_op);
+    if (succeeded(chanTypeRes))
+      return chanTypeRes.value().str() == "npu_dma_packet";
+  }
+  return false;
+}
+
 // DMAAllocator impl.
 
 // A simple selection sorting implementation.
@@ -885,17 +922,16 @@ FailureOr<air::allocation_info_t> air::DMAAllocator::allocNewDmaChannel(
       isMM2S.value() ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
   aie_chan.channel = chan;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       if (t.dma_channel.direction == aie_chan.direction &&
           t.dma_channel.channel == aie_chan.channel) {
         t.memcpyOps.push_back(memcpyOp.getOperation());
         return t;
       }
     }
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1240,16 +1276,15 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow()))
+    if (t.foundAlloc(tile))
       num_allocs++;
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp)) {
+    if (t.foundAlloc(tile, memcpyOp)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
     // reuse the channel allocation.
-    if (isPacketFlowOp &&
-        t.foundPacketFlowAllocInTile(tile.getCol(), tile.getRow())) {
+    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1368,7 +1403,7 @@ air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
 
   // Search for an existing allocation for this tile and memcpyOp
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
   }
 
@@ -1394,15 +1429,14 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 
   // Check if allocation already exists for this tile
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Also check for an allocation tied to the channel declaration
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }


### PR DESCRIPTION
## Summary

Two RFC #1567 cleanup items. The original M5 row-relaxation scope was dropped after design discussion (see below).

### Stage C #1 — DMA allocator identity re-key on TileOp

17 `foundAlloc` callsites converted from `(tile.getCol(), tile.getRow(), ...)` integer-pair identity to `(tile, ...)` pointer identity. New TileOp-keyed overloads on `allocation_info_t`:
- `foundAlloc(AIE::TileOp tile)`
- `foundAlloc(AIE::TileOp tile, air::MemcpyInterface memcpyOp)`
- `foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op)`
- `foundPacketFlowAllocInTile(AIE::TileOp tile)`

The `(col, row)` integer overloads stay (used by the `ShimDMAAllocator` column-search path and four DMAAllocator API entry points — separate cleanup item). Also fixes a typo (`"dma_packet"` → `"npu_dma_packet"`) in one of the new overloads.

### outlineAIECores cleanup — batched createTilesViaPlacer

Replaces per-cell `air::createTileViaPlacer` calls with a single batched `air::createTilesViaPlacer` invocation per herd. Functionally identical to per-cell calls when hints are fully constrained — placer is a pass-through, IR is byte-identical — but consistent with the memtile/shim allocators in stages A/B that already use the batched API.

## On the dropped M5 row relaxation

The original PR scope included relaxing compute-tile row constraints to `(col, ?)` and letting the SequentialPlacer pick the row. **Dropped after design discussion**: the herd's `x_loc`/`y_loc` attributes carry deliberate placement intent set by `air-place-herds` (or upstream callers). Letting the placer override them:

- Loses placement determinism across releases.
- Risks correctness issues. Concrete failure case found: multi-herd-per-segment configurations that share L1 buffers across herds rely on `getPhysTileOp` deduplication at the same physical tile. The shared `aie.buffer` is materialized AFTER `outlineAIECores` runs, so the placer's buffer-adjacency mechanism can't see the cross-herd constraint at placement time. With `(col, ?)` hints, the second herd's placer would pick a different row, breaking the buffer sharing.

For compute tiles, AIR keeps the legacy flow that explicitly sets physical coordinates. RFC tracking issue updated.

## Dependencies

Xilinx/mlir-aie#3060 (placer swap-based search fix) is no longer required by this PR. It remains a real bug fix in mlir-aie's `SequentialPlacer` (partial-constraint hints can produce non-contiguous row placement) but is independent — leaving it open as standalone improvement.

## Test plan

- [x] `check-air-mlir` 384/384 (2 pre-existing AIRToROCDL failures unrelated)
- [x] CI on this PR
- [x] clang-format-17 clean