### PR TITLE
Re-key DMAAllocator API entry points on AIE::TileOp (RFC #1567 Stage C #1)

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -108,8 +108,16 @@ struct allocation_info_t {
   bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
   bool foundAlloc(int32_t col, int32_t row);
   bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
-  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
+
+  // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
+  // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
+  // bookkeeping does not depend on physical placement.
+  bool foundAlloc(AIE::TileOp tile);
+  bool foundAlloc(AIE::TileOp tile, air::MemcpyInterface memcpyOp);
+  bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
+  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInTile(AIE::TileOp tile);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -101,15 +101,6 @@ struct allocation_info_t {
   std::vector<Operation *> memcpyOps;
   bool valid();
   AIE::TileOp getDmaTile();
-  bool foundAlloc(air::ChannelOp channel_op);
-  bool foundAlloc(int32_t col, int32_t row, air::MemcpyInterface memcpyOp);
-  bool foundAlloc(int32_t col, int32_t row, int chan);
-  bool foundAlloc(AIE::DMAChannel channel);
-  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
-  bool foundAlloc(int32_t col, int32_t row);
-  bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
-  bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
-
   // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
   // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
   // bookkeeping does not depend on physical placement.
@@ -118,6 +109,16 @@ struct allocation_info_t {
   bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
   bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(AIE::TileOp tile);
+
+  bool foundAlloc(air::ChannelOp channel_op);
+  bool foundAlloc(AIE::DMAChannel channel);
+
+  // Column-keyed overloads — used only by ShimDMAAllocator's pre-tile
+  // column-search path that picks a shim column before any TileOp exists.
+  // All other call sites use the TileOp-keyed overloads above.
+  bool foundAlloc(int32_t col, int32_t row);
+  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&
@@ -158,9 +159,9 @@ public:
       : device(device), dmaMemorySpace(dmaMemorySpace) {}
 
   FailureOr<allocation_info_t>
-  lookupDMAAllocation(int64_t col, int64_t row, air::MemcpyInterface &memcpyOp);
+  lookupDMAAllocation(AIE::TileOp tile, air::MemcpyInterface &memcpyOp);
   FailureOr<std::pair<AIE::LockOp, AIE::LockOp>>
-  getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
+  getLockForDMA(air::MemcpyInterface &memcpyOp, AIE::TileOp tile,
                 Operation *bufferOp, bool lockRaceConditionFix = false);
   FailureOr<allocation_info_t>
   allocNewDmaChannel(air::MemcpyInterface &memcpyOp, AIE::TileOp tile, int chan,
@@ -188,10 +189,10 @@ public:
   // A very simple scheme to allocate channels for dma operations:
   //  <description>
   FailureOr<allocation_info_t>
-  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int col, int row,
-                        int chan);
+  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, AIE::TileOp tile,
+                        int chan = -1);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 };
 
@@ -213,8 +214,8 @@ public:
                      allocation_info_t existing_alloc,
                      std::vector<Operation *> &dma_ops);
 
-  FailureOr<AIE::ExternalBufferOp> getBuffer(uint64_t &BufferId, int64_t col,
-                                             int64_t row,
+  FailureOr<AIE::ExternalBufferOp> getBuffer(uint64_t &BufferId,
+                                             AIE::TileOp tile,
                                              air::MemcpyInterface &memcpyOp);
 
   FailureOr<air::allocation_info_t>
@@ -230,12 +231,18 @@ public:
   MemTileDMAAllocator(AIE::DeviceOp device);
 
   FailureOr<allocation_info_t>
-  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int chan);
+  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int chan = -1);
   FailureOr<allocation_info_t>
   simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                         allocation_info_t &existing_alloc);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  // For MemTileDMAAllocator and CascadeAllocator the tile is derived from
+  // the memcpyOp's buffer (the buffer's defining op is the tile-bound
+  // BufferOp); the AIE::TileOp parameter is accepted only to keep the
+  // signature uniform with TileDMAAllocator/ShimDMAAllocator so the
+  // generateDmaBdProgram template can call any of them. Pass nullptr
+  // when no tile is yet known.
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 
   FailureOr<air::allocation_info_t>
@@ -255,7 +262,9 @@ public:
   FailureOr<allocation_info_t> allocNewCascade(air::MemcpyInterface &memcpyOp,
                                                AIE::TileOp tile);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  // Tile parameter is unused (derived from memcpyOp's buffer); kept for
+  // signature uniformity with TileDMAAllocator/ShimDMAAllocator.
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 
 protected:

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6049,7 +6049,7 @@ public:
       llvm::SetVector<Operation *> allocs_to_remap;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6065,7 +6065,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6106,7 +6106,7 @@ public:
           tile_dma_memcpys;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6115,7 +6115,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6146,7 +6146,7 @@ public:
       for (auto *allocList : {&core_cascade_alloc.cascade_put_allocs,
                               &core_cascade_alloc.cascade_get_allocs}) {
         for (auto &alloc : *allocList) {
-          if (!alloc.foundAlloc(x, y))
+          if (!alloc.foundAlloc(tile))
             continue;
           for (auto o : alloc.memcpyOps) {
             if (!o)
@@ -6208,7 +6208,7 @@ public:
           shim_dma_memcpys;
 
       for (auto &alloc : shimDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6217,7 +6217,7 @@ public:
         }
       }
       for (auto &alloc : shimDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6259,7 +6259,7 @@ public:
           memtile_dma_memcpys;
 
       for (auto &alloc : memTileDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6268,7 +6268,7 @@ public:
         }
       }
       for (auto &alloc : memTileDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -258,29 +258,40 @@ LogicalResult outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
     h->setAttr(row_name,
                IntegerAttr::get(IntegerType::get(ctx, 32), row_offset));
 
+  // Compute tiles emit fully constrained (phys_x, phys_y) hints. The herd's
+  // x_loc/y_loc attributes carry deliberate placement intent set by
+  // air-place-herds (or upstream callers); AIR keeps the legacy flow that
+  // explicitly sets physical coordinates rather than letting the placer
+  // pick. The SequentialPlacer is a pass-through here — placement is
+  // byte-identical to direct getPhysTileOp calls.
+  //
+  // The batched createTilesViaPlacer call (one placer invocation per herd
+  // instead of one per cell) is functionally identical to per-cell calls
+  // when hints are fully constrained, but cleaner and consistent with
+  // memtile/shim allocators in stages A/B that already use the batched
+  // API with partial constraints.
+  int64_t numCells = herd_size_y * herd_size_x;
+  SmallVector<std::pair<std::optional<int>, std::optional<int>>> hints;
+  hints.reserve(numCells);
+  for (auto y = 0; y < herd_size_y; y++) {
+    for (auto x = 0; x < herd_size_x; x++) {
+      auto phys_x = x + col_offset;
+      auto phys_y = y + row_offset;
+      hints.push_back({phys_x, phys_y});
+    }
+  }
+  SmallVector<AIE::TileOp> herdTiles;
+  if (failed(air::createTilesViaPlacer(aie_device, AIE::AIETileType::CoreTile,
+                                       hints, herdTiles)))
+    return failure();
+
   for (auto y = 0; y < herd_size_y; y++) {
     for (auto x = 0; x < herd_size_x; x++) {
       auto hloc = h.getLoc();
       IRMapping remap;
       auto phys_x = x + col_offset;
       auto phys_y = y + row_offset;
-
-      // Emit aie.logical_tile<CoreTile>(phys_x, phys_y) and resolve via
-      // mlir-aie's SequentialPlacer (RFC #1567 Stage A milestone 4). For
-      // this milestone we keep both coordinates fully constrained, so the
-      // placer is a pass-through and physical placement is identical to
-      // before. Future milestones can relax to (col, ?) or (?, ?) for
-      // herds whose communication patterns don't require strict adjacency.
-      //
-      // TODO(rfc-1567): Once constraints are relaxed, switch to a single
-      // air::createTilesViaPlacer call up-front so the placer sees all
-      // unconstrained tiles together. With fully-constrained hints the
-      // per-tile invocation here is deterministic and preserves IR order.
-      auto tileRes = air::createTileViaPlacer(
-          aie_device, AIE::AIETileType::CoreTile, phys_x, phys_y);
-      if (failed(tileRes))
-        return failure();
-      auto tile = *tileRes;
+      auto tile = herdTiles[y * herd_size_x + x];
 
       Operation *t = tile.getOperation();
       while (isa_and_present<AIE::TileLike>(t->getNextNode()))

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4972,19 +4972,19 @@ public:
       OpBuilder builder, air::MemcpyInterface memcpyOpIf,
       llvm::SetVector<Operation *> &allocs_to_remap,
       const AIE::AIETargetModel &targetModel,
-      air::TileDMAAllocator &tileDmaAlloc, int x, int y) {
+      air::TileDMAAllocator &tileDmaAlloc, AIE::TileOp tile) {
     bool UsesSemaphoreLocks =
         targetModel.hasProperty(AIE::AIETargetModel::UsesSemaphoreLocks);
-    auto dma_alloc = tileDmaAlloc.lookupDMAAllocation(x, y, memcpyOpIf);
+    auto dma_alloc = tileDmaAlloc.lookupDMAAllocation(tile, memcpyOpIf);
     if (failed(dma_alloc)) {
       return memcpyOpIf->emitOpError("failed to look up dma allocation.");
     }
     auto tile_channel = dma_alloc.value().dma_channel;
-    auto bufferOp = tileDmaAlloc.getBuffer(BufferId, x, y, memcpyOpIf);
+    auto bufferOp = tileDmaAlloc.getBuffer(BufferId, tile, memcpyOpIf);
     if (failed(bufferOp)) {
       return memcpyOpIf->emitOpError("failed to get buffer.");
     }
-    auto locks = tileDmaAlloc.getLockForDMA(memcpyOpIf, x, y,
+    auto locks = tileDmaAlloc.getLockForDMA(memcpyOpIf, tile,
                                             bufferOp.value().getOperation(),
                                             /*lockRaceConditionFix*/ false);
     if (failed(locks))
@@ -5095,7 +5095,7 @@ public:
                                        std::vector<Operation *>>
                            dma_memcpys,
                        dmaAllocatorTy dmaAlloc, mlir::Location loc, memOpTy mem,
-                       int x, int y, bool lockRaceConditionFix = false) {
+                       AIE::TileOp tile, bool lockRaceConditionFix = false) {
 
     llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
                     std::vector<Operation *>>
@@ -5187,17 +5187,17 @@ public:
             next_bd->insertBefore(end_bb);
             AIE::NextBDOp::create(b, loc, next_bd);
           }
-          auto bufferOp = dmaAlloc.getBuffer(BufferId, x, y, memcpyOp);
+          auto bufferOp = dmaAlloc.getBuffer(BufferId, tile, memcpyOp);
           if (failed(bufferOp)) {
             memcpyOp->emitOpError("failed to get buffer.");
             return failure();
           }
-          auto locks = dmaAlloc.getLockForDMA(memcpyOp, x, y,
+          auto locks = dmaAlloc.getLockForDMA(memcpyOp, tile,
                                               bufferOp.value().getOperation(),
                                               lockRaceConditionFix);
           if (failed(locks))
             return memcpyOp->emitOpError("failed to get lock for dma.");
-          auto newBD = generateDmaBd<bufferOpTy>(loc, dir, locks.value(), x, y,
+          auto newBD = generateDmaBd<bufferOpTy>(loc, dir, locks.value(), tile,
                                                  targetModel, bd, memcpyOp,
                                                  bufferOp.value(), chan);
           // Attribute task_id is necessary to ensure that BDs do not get shared
@@ -5235,7 +5235,7 @@ public:
   template <typename bufferOpTy>
   FailureOr<AIE::DMABDOp>
   generateDmaBd(mlir::Location loc, AIE::DMAChannelDir dir,
-                std::pair<AIE::LockOp, AIE::LockOp> locks, int x, int y,
+                std::pair<AIE::LockOp, AIE::LockOp> locks, AIE::TileOp tile,
                 const AIE::AIETargetModel &targetModel, Block *bd,
                 air::MemcpyInterface memcpyOp, bufferOpTy bufferOp, int chan) {
     bool UsesSemaphoreLocks =
@@ -5300,10 +5300,8 @@ public:
                            lockAqValue);
 
     // Packet flow routing: get packet flow id.
-    auto aie_device = bufferOp->template getParentOfType<AIE::DeviceOp>();
-    auto tileOp = air::getPhysTileOpOrNull(aie_device, x, y);
     auto pktFlowOp = getExistingPacketFlowOpFromDevice(
-        tileOp, AIE::WireBundle::DMA, chan, memcpyOp);
+        tile, AIE::WireBundle::DMA, chan, memcpyOp);
     AIE::PacketInfoAttr pktInfoAttr = nullptr;
     if (isMM2S && pktFlowOp) {
       auto packetID = pktFlowOp.getID();
@@ -6052,8 +6050,6 @@ public:
 
     for (AIE::CoreOp core : cores) {
       AIE::TileOp tile = core.getTileOp();
-      auto x = tile.getCol();
-      auto y = tile.getRow();
 
       // emit the acquire and release of the L1 buffer locks
       // lock_allocation_list lock_allocs;
@@ -6070,7 +6066,7 @@ public:
             return o->emitOpError("does not have air::MemcpyInterface");
           if (failed(allocateCoreLocksPerMemcpyOp(rewriter, memcpyOpIf,
                                                   allocs_to_remap, target_model,
-                                                  tileDmaAlloc, x, y))) {
+                                                  tileDmaAlloc, tile))) {
             return o->emitOpError("failed to allocate core locks");
           }
         }
@@ -6086,7 +6082,7 @@ public:
             return o->emitOpError("does not have air::MemcpyInterface");
           if (failed(allocateCoreLocksPerMemcpyOp(rewriter, memcpyOpIf,
                                                   allocs_to_remap, target_model,
-                                                  tileDmaAlloc, x, y))) {
+                                                  tileDmaAlloc, tile))) {
             return o->emitOpError("failed to allocate core locks");
           }
         }
@@ -6147,7 +6143,7 @@ public:
       if (failed(generateDmaBdProgram<air::TileDMAAllocator, AIE::BufferOp,
                                       AIE::MemOp>(
               rewriter, target_model, tile_dma_memcpys, tileDmaAlloc, loc, mem,
-              x, y))) {
+              tile))) {
         mem->emitOpError("failed to generate dma bd program.");
         return failure();
       }
@@ -6210,9 +6206,6 @@ public:
       shimtiles.clear();
 
     for (auto tile : shimtiles) {
-      auto x = tile.getCol();
-      auto y = tile.getRow();
-
       // Collect memcpy ops wrt each DMA channel
       llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
                       std::vector<Operation *>>
@@ -6251,7 +6244,7 @@ public:
       if (failed(generateDmaBdProgram<air::ShimDMAAllocator,
                                       AIE::ExternalBufferOp, AIE::ShimDMAOp>(
               rewriter, target_model, shim_dma_memcpys, shimDmaAlloc, loc,
-              shimDMA, x, y))) {
+              shimDMA, tile))) {
         shimDMA->emitOpError("failed to generate dma bd program.");
         return failure();
       }
@@ -6260,9 +6253,6 @@ public:
     // Generate L2 DMA program
 
     for (auto tile : memTileTiles) {
-      auto x = tile.getCol();
-      auto y = tile.getRow();
-
       // Collect memcpy ops wrt each DMA channel from chessboard; make aie.mem
       // dmabd program
       llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
@@ -6302,7 +6292,7 @@ public:
       if (failed(generateDmaBdProgram<air::MemTileDMAAllocator, AIE::BufferOp,
                                       AIE::MemTileDMAOp>(
               rewriter, target_model, memtile_dma_memcpys, memTileDmaAlloc, loc,
-              memTileDMA, x, y, options.use_lock_race_condition_fix))) {
+              memTileDMA, tile, options.use_lock_race_condition_fix))) {
         memTileDMA->emitOpError("failed to generate dma bd program.");
         return failure();
       }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -675,6 +675,43 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(int32_t col,
   return false;
 }
 
+// TileOp-keyed overloads (RFC #1567 Stage C #1). Pointer-equality on
+// dma_tile replaces (col, row) integer comparison; same answer, no
+// dependence on physical placement coordinates.
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile) {
+  return tile && tile == getDmaTile();
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::MemcpyInterface memcpyOp) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps)
+    if (memcpyOp.getOperation() == o)
+      return true;
+  return false;
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::ChannelOp channel_op) {
+  return foundAlloc(tile) && foundAlloc(channel_op);
+}
+
+bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(
+    AIE::TileOp tile) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps) {
+    auto memcpy_op = dyn_cast_if_present<air::MemcpyInterface>(o);
+    if (!memcpy_op)
+      continue;
+    auto chanTypeRes = air::getChannelType(memcpy_op);
+    if (succeeded(chanTypeRes))
+      return chanTypeRes.value().str() == "npu_dma_packet";
+  }
+  return false;
+}
+
 // DMAAllocator impl.
 
 // A simple selection sorting implementation.
@@ -885,17 +922,16 @@ FailureOr<air::allocation_info_t> air::DMAAllocator::allocNewDmaChannel(
       isMM2S.value() ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
   aie_chan.channel = chan;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       if (t.dma_channel.direction == aie_chan.direction &&
           t.dma_channel.channel == aie_chan.channel) {
         t.memcpyOps.push_back(memcpyOp.getOperation());
         return t;
       }
     }
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1240,16 +1276,15 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow()))
+    if (t.foundAlloc(tile))
       num_allocs++;
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp)) {
+    if (t.foundAlloc(tile, memcpyOp)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
     // reuse the channel allocation.
-    if (isPacketFlowOp &&
-        t.foundPacketFlowAllocInTile(tile.getCol(), tile.getRow())) {
+    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1368,7 +1403,7 @@ air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
 
   // Search for an existing allocation for this tile and memcpyOp
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
   }
 
@@ -1394,15 +1429,14 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 
   // Check if allocation already exists for this tile
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Also check for an allocation tied to the channel declaration
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -618,20 +618,6 @@ bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row) {
   return false;
 }
 
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                air::MemcpyInterface memcpyOp) {
-  if (foundAlloc(col, row))
-    for (auto o : memcpyOps)
-      if (memcpyOp.getOperation() == o)
-        return true;
-  return false;
-}
-
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                int chan) {
-  return foundAlloc(col, row) && (chan == dma_channel.channel);
-}
-
 bool xilinx::air::allocation_info_t::foundAlloc(AIE::DMAChannel channel) {
   if (channel.direction == dma_channel.direction &&
       channel.channel == dma_channel.channel)
@@ -651,12 +637,6 @@ bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
     return true;
   else
     return false;
-}
-
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                air::ChannelOp channel_op) {
-
-  return foundAlloc(col, row) && foundAlloc(channel_op);
 }
 
 // Found existence of a packet flow allocation in provided coordinates.
@@ -740,7 +720,7 @@ static void selection(std::vector<Operation *> &a) {
 namespace xilinx {
 
 FailureOr<air::allocation_info_t>
-air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
+air::DMAAllocator::lookupDMAAllocation(AIE::TileOp tile,
                                        air::MemcpyInterface &memcpyOp) {
 
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
@@ -748,7 +728,7 @@ air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(col, row, memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
   }
   return memcpyOp.emitOpError(
@@ -759,14 +739,17 @@ air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
 // Allocate a reader/writer lock pair. These may be the same or different
 // locks depending on the target device.
 FailureOr<std::pair<AIE::LockOp, AIE::LockOp>>
-air::DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp, int col,
-                                 int row, Operation *bufferOp,
+air::DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp,
+                                 AIE::TileOp tile, Operation *bufferOp,
                                  bool lockRaceConditionFix) {
-  auto alloc = lookupDMAAllocation(col, row, memcpyOp);
+  auto alloc = lookupDMAAllocation(tile, memcpyOp);
   if (failed(alloc))
     return memcpyOp->emitOpError("failed to look up dma allocation.");
   AIE::DMAChannel channel = alloc.value().dma_channel;
-  AIE::TileOp tile = alloc.value().getDmaTile();
+  // Coordinates derived from the tile for predicates like
+  // target_model.isMemTile.
+  int col = tile.getCol();
+  int row = tile.getRow();
   air::ChannelOp air_chan = nullptr;
   if (auto air_chan_op =
           dyn_cast_if_present<air::ChannelInterface>(memcpyOp.getOperation())) {
@@ -961,7 +944,12 @@ void air::DMAAllocator::sortMemcpyOps(std::vector<Operation *> dma_memcpy_ops) {
 //  <description>
 FailureOr<air::allocation_info_t>
 air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
-                                             int col, int row, int chan = -1) {
+                                             AIE::TileOp tile, int chan) {
+  if (!tile) {
+    return memcpyOp.emitOpError(
+        "failed to get a tile. This indicates a potential compilation "
+        "failure.");
+  }
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
@@ -978,28 +966,25 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(col, row))
+    if (t.foundAlloc(tile))
       num_allocs++;
-    if (t.foundAlloc(col, row, memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
-    if (t.foundAlloc(col, row, chan)) {
+    if (t.foundAlloc(tile,
+                     AIE::DMAChannel{isMM2S.value() ? AIE::DMAChannelDir::MM2S
+                                                    : AIE::DMAChannelDir::S2MM,
+                                     chan})) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
     // reuse the channel allocation.
-    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(col, row)) {
+    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
   }
   // Need to allocate a new one
-  auto tile = getPhysTileOpOrNull(device, col, row);
-  if (!tile) {
-    return memcpyOp.emitOpError(
-        "failed to get a tile at specified col and row. This "
-        "indicates a potential compilation failre.");
-  }
   int tile_dma_channels =
       isMM2S.value() ? tile.getNumSourceConnections(AIE::WireBundle::DMA)
                      : tile.getNumDestConnections(AIE::WireBundle::DMA);
@@ -1009,7 +994,7 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
 }
 
 FailureOr<AIE::BufferOp>
-air::TileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::TileDMAAllocator::getBuffer(uint64_t, AIE::TileOp tile,
                                  air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1177,7 +1162,7 @@ air::ShimDMAAllocator::allocNewDmaChannel(air::MemcpyInterface &memcpyOp,
 }
 
 FailureOr<AIE::ExternalBufferOp>
-air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
+air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, AIE::TileOp tile,
                                  air::MemcpyInterface &memcpyOp) {
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
@@ -1191,10 +1176,13 @@ air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
       air::MemorySpaceAttr::get(memcpyOp->getContext(), dmaMemorySpace);
   memrefTy = MemRefType::get(memrefTy.getShape(), memrefTy.getElementType(),
                              AffineMap(), memSpaceAttr);
+  // Names use shim coords: tile is the shim NOC tile that owns the external
+  // buffer's DMA program (the L3 buffer itself has no tile, but its name
+  // ties it to the shim that drives it).
   AIE::ExternalBufferOp bufferOp = allocateExternalBufferOp(
       BufferId, memrefTy, device,
       memcpyOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()),
-      col, row);
+      tile ? (int)tile.getCol() : -1, tile ? (int)tile.getRow() : -1);
   return bufferOp;
 }
 
@@ -1249,14 +1237,14 @@ air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
 
 FailureOr<air::allocation_info_t>
 air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
-                                                int chan = -1) {
+                                                int chan) {
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
 
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1307,7 +1295,7 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
 
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1363,7 +1351,7 @@ air::MemTileDMAAllocator::foundFlowReuseOpportunity(
 }
 
 FailureOr<AIE::BufferOp>
-air::MemTileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::MemTileDMAAllocator::getBuffer(uint64_t, AIE::TileOp,
                                     air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1392,7 +1380,7 @@ air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
 
   // Retrieve the buffer and the tile where this memcpyOp operates
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1457,7 +1445,7 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 
 // Retrieves the underlying AIE::BufferOp associated with the given memcpyOp.
 FailureOr<AIE::BufferOp>
-air::CascadeAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::CascadeAllocator::getBuffer(uint64_t, AIE::TileOp,
                                  air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1630,14 +1618,12 @@ LogicalResult air::simpleDMAChannelAllocation(
               "memcpy op not outlined in an aie.core op.");
         }
         auto tile = core.getTileOp();
-        int x = tile.getCol();
-        int y = tile.getRow();
 
         FailureOr<air::allocation_info_t> alloc_res;
         if (f.memcpyResourceType == "npu_dma_stream" ||
             f.memcpyResourceType == "npu_dma_packet") {
           alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-              memcpyOpIf, x, y, f.MM2S_alloc.dma_channel.channel);
+              memcpyOpIf, tile, f.MM2S_alloc.dma_channel.channel);
           if (failed(alloc_res))
             return failure();
         } else if (f.memcpyResourceType == "npu_cascade") {
@@ -1661,14 +1647,12 @@ LogicalResult air::simpleDMAChannelAllocation(
                 "memcpy op not outlined in an aie.core op.");
           }
           auto tile = core.getTileOp();
-          int x = tile.getCol();
-          int y = tile.getRow();
 
           FailureOr<air::allocation_info_t> alloc_res;
           if (f.memcpyResourceType == "npu_dma_stream" ||
               f.memcpyResourceType == "npu_dma_packet") {
             alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-                memcpyOpIf, x, y, f.S2MM_alloc[i].dma_channel.channel);
+                memcpyOpIf, tile, f.S2MM_alloc[i].dma_channel.channel);
             if (failed(alloc_res))
               return failure();
           } else if (f.memcpyResourceType == "npu_cascade") {


### PR DESCRIPTION
## Summary

Finishes the Stage C #1 cleanup started in #1597. The previous PR re-keyed the 17 identity-hash `foundAlloc` callsites; this PR re-keys the four `DMAAllocator` API entry points themselves so callers no longer need to extract `(col, row)` integers from a `TileOp` they already have.

### API changes

```cpp
// Before
DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row, MemcpyInterface&);
DMAAllocator::getLockForDMA(MemcpyInterface&, int col, int row, ...);
TileDMAAllocator::simpleDmaChannelAlloc(MemcpyInterface&, int col, int row, int chan);
TileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row, MemcpyInterface&);
ShimDMAAllocator::getBuffer(uint64_t&, int64_t col, int64_t row, MemcpyInterface&);
MemTileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row, MemcpyInterface&);
CascadeAllocator::getBuffer(uint64_t, int64_t col, int64_t row, MemcpyInterface&);

// After
DMAAllocator::lookupDMAAllocation(AIE::TileOp tile, MemcpyInterface&);
DMAAllocator::getLockForDMA(MemcpyInterface&, AIE::TileOp tile, ...);
TileDMAAllocator::simpleDmaChannelAlloc(MemcpyInterface&, AIE::TileOp tile, int chan);
TileDMAAllocator::getBuffer(uint64_t, AIE::TileOp tile, MemcpyInterface&);
ShimDMAAllocator::getBuffer(uint64_t&, AIE::TileOp tile, MemcpyInterface&);
MemTileDMAAllocator::getBuffer(uint64_t, AIE::TileOp tile, MemcpyInterface&);  // tile unused
CascadeAllocator::getBuffer(uint64_t, AIE::TileOp tile, MemcpyInterface&);     // tile unused
```

`getBuffer` keeps a uniform signature across all four allocators so `generateDmaBdProgram` can call any of them. MemTile/Cascade derive the tile from the `memcpyOp`'s buffer internally; their `tile` arg is unused but kept for uniformity. The two internal `getBuffer` call sites that don't have a tile yet (in `MemTile`/`Cascade` `simpleDmaChannelAlloc`/`coreCascadeAlloc`, where the whole point is to derive the tile) pass `nullptr`.

### Knock-on cleanups

- `generateDmaBdProgram` and `generateDmaBd` no longer take `int x, int y`.
- `allocateCoreLocksPerMemcpyOp` no longer takes `int x, int y`.
- Three `(col, row)` integer `foundAlloc` overloads on `allocation_info_t` deleted: `foundAlloc(col, row, MemcpyInterface)`, `foundAlloc(col, row, int chan)`, `foundAlloc(col, row, ChannelOp)` — no longer called.

### Kept for now

Three `(col, row)` integer overloads stay: `foundAlloc(col, row)`, `foundAlloc(col, row, DMAChannel)`, `foundPacketFlowAllocInTile(col, row)`. They're still used by `ShimDMAAllocator`'s pre-tile column-search path that picks a shim column before any `TileOp` exists. That's a separate problem (the column-search needs a column→TileOp pre-allocation table or similar) and out of scope here.

## Dependencies

Stacks on #1597 (the `foundAlloc(AIE::TileOp, ...)` overloads added there are what this PR's API entry points use). After #1597 merges this rebases cleanly onto main.

## Test plan

- [x] `check-air-mlir` 384/384 (2 pre-existing AIRToROCDL failures unrelated)
- [x] CI on this PR
- [x] clang-format-17 clean