### PR TITLE
Re-key DMA allocator on AIE::TileOp (RFC #1567 Stage C #1)

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -108,8 +108,16 @@ struct allocation_info_t {
   bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
   bool foundAlloc(int32_t col, int32_t row);
   bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
-  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
+
+  // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
+  // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
+  // bookkeeping does not depend on physical placement.
+  bool foundAlloc(AIE::TileOp tile);
+  bool foundAlloc(AIE::TileOp tile, air::MemcpyInterface memcpyOp);
+  bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
+  bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInTile(AIE::TileOp tile);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -101,15 +101,6 @@ struct allocation_info_t {
   std::vector<Operation *> memcpyOps;
   bool valid();
   AIE::TileOp getDmaTile();
-  bool foundAlloc(air::ChannelOp channel_op);
-  bool foundAlloc(int32_t col, int32_t row, air::MemcpyInterface memcpyOp);
-  bool foundAlloc(int32_t col, int32_t row, int chan);
-  bool foundAlloc(AIE::DMAChannel channel);
-  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
-  bool foundAlloc(int32_t col, int32_t row);
-  bool foundAlloc(int32_t col, int32_t row, air::ChannelOp channel_op);
-  bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
-
   // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
   // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
   // bookkeeping does not depend on physical placement.
@@ -118,6 +109,16 @@ struct allocation_info_t {
   bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
   bool foundAlloc(AIE::TileOp tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(AIE::TileOp tile);
+
+  bool foundAlloc(air::ChannelOp channel_op);
+  bool foundAlloc(AIE::DMAChannel channel);
+
+  // Column-keyed overloads — used only by ShimDMAAllocator's pre-tile
+  // column-search path that picks a shim column before any TileOp exists.
+  // All other call sites use the TileOp-keyed overloads above.
+  bool foundAlloc(int32_t col, int32_t row);
+  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&
@@ -158,9 +159,9 @@ public:
       : device(device), dmaMemorySpace(dmaMemorySpace) {}
 
   FailureOr<allocation_info_t>
-  lookupDMAAllocation(int64_t col, int64_t row, air::MemcpyInterface &memcpyOp);
+  lookupDMAAllocation(AIE::TileOp tile, air::MemcpyInterface &memcpyOp);
   FailureOr<std::pair<AIE::LockOp, AIE::LockOp>>
-  getLockForDMA(air::MemcpyInterface &memcpyOp, int col, int row,
+  getLockForDMA(air::MemcpyInterface &memcpyOp, AIE::TileOp tile,
                 Operation *bufferOp, bool lockRaceConditionFix = false);
   FailureOr<allocation_info_t>
   allocNewDmaChannel(air::MemcpyInterface &memcpyOp, AIE::TileOp tile, int chan,
@@ -188,10 +189,10 @@ public:
   // A very simple scheme to allocate channels for dma operations:
   //  <description>
   FailureOr<allocation_info_t>
-  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int col, int row,
-                        int chan);
+  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, AIE::TileOp tile,
+                        int chan = -1);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 };
 
@@ -213,8 +214,8 @@ public:
                      allocation_info_t existing_alloc,
                      std::vector<Operation *> &dma_ops);
 
-  FailureOr<AIE::ExternalBufferOp> getBuffer(uint64_t &BufferId, int64_t col,
-                                             int64_t row,
+  FailureOr<AIE::ExternalBufferOp> getBuffer(uint64_t &BufferId,
+                                             AIE::TileOp tile,
                                              air::MemcpyInterface &memcpyOp);
 
   FailureOr<air::allocation_info_t>
@@ -230,12 +231,18 @@ public:
   MemTileDMAAllocator(AIE::DeviceOp device);
 
   FailureOr<allocation_info_t>
-  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int chan);
+  simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp, int chan = -1);
   FailureOr<allocation_info_t>
   simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                         allocation_info_t &existing_alloc);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  // For MemTileDMAAllocator and CascadeAllocator the tile is derived from
+  // the memcpyOp's buffer (the buffer's defining op is the tile-bound
+  // BufferOp); the AIE::TileOp parameter is accepted only to keep the
+  // signature uniform with TileDMAAllocator/ShimDMAAllocator so the
+  // generateDmaBdProgram template can call any of them. Pass nullptr
+  // when no tile is yet known.
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 
   FailureOr<air::allocation_info_t>
@@ -255,7 +262,9 @@ public:
   FailureOr<allocation_info_t> allocNewCascade(air::MemcpyInterface &memcpyOp,
                                                AIE::TileOp tile);
 
-  FailureOr<AIE::BufferOp> getBuffer(uint64_t, int64_t col, int64_t row,
+  // Tile parameter is unused (derived from memcpyOp's buffer); kept for
+  // signature uniformity with TileDMAAllocator/ShimDMAAllocator.
+  FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 
 protected:

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -101,9 +101,6 @@ struct allocation_info_t {
   std::vector<Operation *> memcpyOps;
   bool valid();
   AIE::TileOp getDmaTile();
-  // TileOp-keyed overloads (RFC #1567 Stage C #1). Identify allocations by
-  // their owning AIE::TileOp pointer rather than by (col, row) coordinates so
-  // bookkeeping does not depend on physical placement.
   bool foundAlloc(AIE::TileOp tile);
   bool foundAlloc(AIE::TileOp tile, air::MemcpyInterface memcpyOp);
   bool foundAlloc(AIE::TileOp tile, air::ChannelOp channel_op);
@@ -113,12 +110,10 @@ struct allocation_info_t {
   bool foundAlloc(air::ChannelOp channel_op);
   bool foundAlloc(AIE::DMAChannel channel);
 
-  // Column-keyed overloads — used only by ShimDMAAllocator's pre-tile
-  // column-search path that picks a shim column before any TileOp exists.
-  // All other call sites use the TileOp-keyed overloads above.
-  bool foundAlloc(int32_t col, int32_t row);
-  bool foundAlloc(int32_t col, int32_t row, AIE::DMAChannel channel);
-  bool foundPacketFlowAllocInTile(int32_t col, int32_t row);
+  // Column-keyed; row is implied (shim is always row 0).
+  bool foundAllocInColumn(int32_t col);
+  bool foundAllocInColumn(int32_t col, AIE::DMAChannel channel);
+  bool foundPacketFlowAllocInColumn(int32_t col);
 
   bool operator==(const allocation_info_t &other) const {
     return dma_tile == other.dma_tile && col == other.col && row == other.row &&
@@ -236,12 +231,7 @@ public:
   simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                         allocation_info_t &existing_alloc);
 
-  // For MemTileDMAAllocator and CascadeAllocator the tile is derived from
-  // the memcpyOp's buffer (the buffer's defining op is the tile-bound
-  // BufferOp); the AIE::TileOp parameter is accepted only to keep the
-  // signature uniform with TileDMAAllocator/ShimDMAAllocator so the
-  // generateDmaBdProgram template can call any of them. Pass nullptr
-  // when no tile is yet known.
+  // tile derived from memcpyOp's buffer; param kept for signature uniformity.
   FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 
@@ -254,16 +244,13 @@ class CascadeAllocator {
 
 public:
   CascadeAllocator() = delete;
-  // CascadeAllocator constructor: only core-to-core (L1-level) cascade
-  // connection supported.
   CascadeAllocator(AIE::DeviceOp device)
       : device(device), dmaMemorySpace(air::MemorySpace::L1) {}
   FailureOr<allocation_info_t> coreCascadeAlloc(air::MemcpyInterface &memcpyOp);
   FailureOr<allocation_info_t> allocNewCascade(air::MemcpyInterface &memcpyOp,
                                                AIE::TileOp tile);
 
-  // Tile parameter is unused (derived from memcpyOp's buffer); kept for
-  // signature uniformity with TileDMAAllocator/ShimDMAAllocator.
+  // tile derived from memcpyOp's buffer; param kept for signature uniformity.
   FailureOr<AIE::BufferOp> getBuffer(uint64_t, AIE::TileOp tile,
                                      air::MemcpyInterface &memcpyOp);
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6049,7 +6049,7 @@ public:
       llvm::SetVector<Operation *> allocs_to_remap;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6065,7 +6065,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         for (auto o : alloc.memcpyOps) {
           if (!o)
@@ -6106,7 +6106,7 @@ public:
           tile_dma_memcpys;
 
       for (auto &alloc : tileDmaAlloc.mm2s_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6115,7 +6115,7 @@ public:
         }
       }
       for (auto &alloc : tileDmaAlloc.s2mm_allocs) {
-        if (!alloc.foundAlloc(x, y))
+        if (!alloc.foundAlloc(tile))
           continue;
         std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
             alloc.dma_channel.direction, alloc.dma_channel.channel};
@@ -6146,7 +6146,7 @@ public:
       for (auto *allocList : {&core_cascade_alloc.cascade_put_allocs,
                               &core_cascade_alloc.cascade_get_allocs}) {
         for (auto &alloc : *allocList) {
-          if (!alloc.foundAlloc(x, y))
+          if (!alloc.foundAlloc(tile))
             continue;
           for (auto o : alloc.memcpyOps) {
             if (!o)
@@ -6208,7 +6208,7 @@ public:
           shim_dma_memcpys;
 
       for (auto &alloc : shimDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6217,7 +6217,7 @@ public:
         }
       }
       for (auto &alloc : shimDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6259,7 +6259,7 @@ public:
           memtile_dma_memcpys;
 
       for (auto &alloc : memTileDmaAlloc.mm2s_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> mm2s_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {
@@ -6268,7 +6268,7 @@ public:
         }
       }
       for (auto &alloc : memTileDmaAlloc.s2mm_allocs) {
-        if (alloc.foundAlloc(x, y)) {
+        if (alloc.foundAlloc(tile)) {
           std::pair<AIE::DMAChannelDir, int> s2mm_chan = {
               alloc.dma_channel.direction, alloc.dma_channel.channel};
           for (auto &o : alloc.memcpyOps) {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4961,19 +4961,19 @@ public:
       OpBuilder builder, air::MemcpyInterface memcpyOpIf,
       llvm::SetVector<Operation *> &allocs_to_remap,
       const AIE::AIETargetModel &targetModel,
-      air::TileDMAAllocator &tileDmaAlloc, int x, int y) {
+      air::TileDMAAllocator &tileDmaAlloc, AIE::TileOp tile) {
     bool UsesSemaphoreLocks =
         targetModel.hasProperty(AIE::AIETargetModel::UsesSemaphoreLocks);
-    auto dma_alloc = tileDmaAlloc.lookupDMAAllocation(x, y, memcpyOpIf);
+    auto dma_alloc = tileDmaAlloc.lookupDMAAllocation(tile, memcpyOpIf);
     if (failed(dma_alloc)) {
       return memcpyOpIf->emitOpError("failed to look up dma allocation.");
     }
     auto tile_channel = dma_alloc.value().dma_channel;
-    auto bufferOp = tileDmaAlloc.getBuffer(BufferId, x, y, memcpyOpIf);
+    auto bufferOp = tileDmaAlloc.getBuffer(BufferId, tile, memcpyOpIf);
     if (failed(bufferOp)) {
       return memcpyOpIf->emitOpError("failed to get buffer.");
     }
-    auto locks = tileDmaAlloc.getLockForDMA(memcpyOpIf, x, y,
+    auto locks = tileDmaAlloc.getLockForDMA(memcpyOpIf, tile,
                                             bufferOp.value().getOperation(),
                                             /*lockRaceConditionFix*/ false);
     if (failed(locks))
@@ -5084,7 +5084,7 @@ public:
                                        std::vector<Operation *>>
                            dma_memcpys,
                        dmaAllocatorTy dmaAlloc, mlir::Location loc, memOpTy mem,
-                       int x, int y, bool lockRaceConditionFix = false) {
+                       AIE::TileOp tile, bool lockRaceConditionFix = false) {
 
     llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
                     std::vector<Operation *>>
@@ -5176,17 +5176,17 @@ public:
             next_bd->insertBefore(end_bb);
             AIE::NextBDOp::create(b, loc, next_bd);
           }
-          auto bufferOp = dmaAlloc.getBuffer(BufferId, x, y, memcpyOp);
+          auto bufferOp = dmaAlloc.getBuffer(BufferId, tile, memcpyOp);
           if (failed(bufferOp)) {
             memcpyOp->emitOpError("failed to get buffer.");
             return failure();
           }
-          auto locks = dmaAlloc.getLockForDMA(memcpyOp, x, y,
+          auto locks = dmaAlloc.getLockForDMA(memcpyOp, tile,
                                               bufferOp.value().getOperation(),
                                               lockRaceConditionFix);
           if (failed(locks))
             return memcpyOp->emitOpError("failed to get lock for dma.");
-          auto newBD = generateDmaBd<bufferOpTy>(loc, dir, locks.value(), x, y,
+          auto newBD = generateDmaBd<bufferOpTy>(loc, dir, locks.value(), tile,
                                                  targetModel, bd, memcpyOp,
                                                  bufferOp.value(), chan);
           // Attribute task_id is necessary to ensure that BDs do not get shared
@@ -5224,7 +5224,7 @@ public:
   template <typename bufferOpTy>
   FailureOr<AIE::DMABDOp>
   generateDmaBd(mlir::Location loc, AIE::DMAChannelDir dir,
-                std::pair<AIE::LockOp, AIE::LockOp> locks, int x, int y,
+                std::pair<AIE::LockOp, AIE::LockOp> locks, AIE::TileOp tile,
                 const AIE::AIETargetModel &targetModel, Block *bd,
                 air::MemcpyInterface memcpyOp, bufferOpTy bufferOp, int chan) {
     bool UsesSemaphoreLocks =
@@ -5289,10 +5289,8 @@ public:
                            lockAqValue);
 
     // Packet flow routing: get packet flow id.
-    auto aie_device = bufferOp->template getParentOfType<AIE::DeviceOp>();
-    auto tileOp = air::getPhysTileOpOrNull(aie_device, x, y);
     auto pktFlowOp = getExistingPacketFlowOpFromDevice(
-        tileOp, AIE::WireBundle::DMA, chan, memcpyOp);
+        tile, AIE::WireBundle::DMA, chan, memcpyOp);
     AIE::PacketInfoAttr pktInfoAttr = nullptr;
     if (isMM2S && pktFlowOp) {
       auto packetID = pktFlowOp.getID();
@@ -6041,8 +6039,6 @@ public:
 
     for (AIE::CoreOp core : cores) {
       AIE::TileOp tile = core.getTileOp();
-      auto x = tile.getCol();
-      auto y = tile.getRow();
 
       // emit the acquire and release of the L1 buffer locks
       // lock_allocation_list lock_allocs;
@@ -6059,7 +6055,7 @@ public:
             return o->emitOpError("does not have air::MemcpyInterface");
           if (failed(allocateCoreLocksPerMemcpyOp(rewriter, memcpyOpIf,
                                                   allocs_to_remap, target_model,
-                                                  tileDmaAlloc, x, y))) {
+                                                  tileDmaAlloc, tile))) {
             return o->emitOpError("failed to allocate core locks");
           }
         }
@@ -6075,7 +6071,7 @@ public:
             return o->emitOpError("does not have air::MemcpyInterface");
           if (failed(allocateCoreLocksPerMemcpyOp(rewriter, memcpyOpIf,
                                                   allocs_to_remap, target_model,
-                                                  tileDmaAlloc, x, y))) {
+                                                  tileDmaAlloc, tile))) {
             return o->emitOpError("failed to allocate core locks");
           }
         }
@@ -6136,7 +6132,7 @@ public:
       if (failed(generateDmaBdProgram<air::TileDMAAllocator, AIE::BufferOp,
                                       AIE::MemOp>(
               rewriter, target_model, tile_dma_memcpys, tileDmaAlloc, loc, mem,
-              x, y))) {
+              tile))) {
         mem->emitOpError("failed to generate dma bd program.");
         return failure();
       }
@@ -6199,9 +6195,6 @@ public:
       shimtiles.clear();
 
     for (auto tile : shimtiles) {
-      auto x = tile.getCol();
-      auto y = tile.getRow();
-
       // Collect memcpy ops wrt each DMA channel
       llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
                       std::vector<Operation *>>
@@ -6240,7 +6233,7 @@ public:
       if (failed(generateDmaBdProgram<air::ShimDMAAllocator,
                                       AIE::ExternalBufferOp, AIE::ShimDMAOp>(
               rewriter, target_model, shim_dma_memcpys, shimDmaAlloc, loc,
-              shimDMA, x, y))) {
+              shimDMA, tile))) {
         shimDMA->emitOpError("failed to generate dma bd program.");
         return failure();
       }
@@ -6249,9 +6242,6 @@ public:
     // Generate L2 DMA program
 
     for (auto tile : memTileTiles) {
-      auto x = tile.getCol();
-      auto y = tile.getRow();
-
       // Collect memcpy ops wrt each DMA channel from chessboard; make aie.mem
       // dmabd program
       llvm::MapVector<std::pair<AIE::DMAChannelDir, int>,
@@ -6291,7 +6281,7 @@ public:
       if (failed(generateDmaBdProgram<air::MemTileDMAAllocator, AIE::BufferOp,
                                       AIE::MemTileDMAOp>(
               rewriter, target_model, memtile_dma_memcpys, memTileDmaAlloc, loc,
-              memTileDMA, x, y, options.use_lock_race_condition_fix))) {
+              memTileDMA, tile, options.use_lock_race_condition_fix))) {
         memTileDMA->emitOpError("failed to generate dma bd program.");
         return failure();
       }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -610,12 +610,8 @@ bool xilinx::air::allocation_info_t::foundAlloc(air::ChannelOp channel_op) {
   return false;
 }
 
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row) {
-  if (!getDmaTile())
-    return false;
-  if (col == getDmaTile().getCol() && row == getDmaTile().getRow())
-    return true;
-  return false;
+bool xilinx::air::allocation_info_t::foundAllocInColumn(int32_t col) {
+  return getDmaTile() && getDmaTile().getCol() == col;
 }
 
 bool xilinx::air::allocation_info_t::foundAlloc(AIE::DMAChannel channel) {
@@ -626,9 +622,9 @@ bool xilinx::air::allocation_info_t::foundAlloc(AIE::DMAChannel channel) {
     return false;
 }
 
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                AIE::DMAChannel channel) {
-  return foundAlloc(col, row) && foundAlloc(channel);
+bool xilinx::air::allocation_info_t::foundAllocInColumn(
+    int32_t col, AIE::DMAChannel channel) {
+  return foundAllocInColumn(col) && foundAlloc(channel);
 }
 
 bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
@@ -639,10 +635,9 @@ bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
     return false;
 }
 
-// Found existence of a packet flow allocation in provided coordinates.
-bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(int32_t col,
-                                                                int32_t row) {
-  if (!foundAlloc(col, row))
+// Is there a packet-flow allocation owned by a tile in the given column?
+bool xilinx::air::allocation_info_t::foundPacketFlowAllocInColumn(int32_t col) {
+  if (!foundAllocInColumn(col))
     return false;
   for (auto o : memcpyOps) {
     auto memcpy_op = dyn_cast_if_present<air::MemcpyInterface>(o);
@@ -650,7 +645,7 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(int32_t col,
       continue;
     auto chanTypeRes = air::getChannelType(memcpy_op);
     if (succeeded(chanTypeRes))
-      return chanTypeRes.value().str() == "npu_dma_packet";
+      return chanTypeRes.value() == "npu_dma_packet";
   }
   return false;
 }
@@ -687,7 +682,7 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(
       continue;
     auto chanTypeRes = air::getChannelType(memcpy_op);
     if (succeeded(chanTypeRes))
-      return chanTypeRes.value().str() == "npu_dma_packet";
+      return chanTypeRes.value() == "npu_dma_packet";
   }
   return false;
 }
@@ -960,7 +955,7 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   bool isPacketFlowOp = false;
   auto chanTypeRes = getChannelType(memcpyOp);
   if (succeeded(chanTypeRes)) {
-    isPacketFlowOp = chanTypeRes.value().str() == "npu_dma_packet";
+    isPacketFlowOp = chanTypeRes.value() == "npu_dma_packet";
   }
 
   // Search for existing dma channel allocation
@@ -1034,7 +1029,7 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   bool isPacketFlowOp = false;
   auto chanTypeRes = getChannelType(memcpyOp);
   if (succeeded(chanTypeRes)) {
-    isPacketFlowOp = chanTypeRes.value().str() == "npu_dma_packet";
+    isPacketFlowOp = chanTypeRes.value() == "npu_dma_packet";
   }
 
   // Search for existing dma channel allocation
@@ -1064,7 +1059,7 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   // one.
   if (isPacketFlowOp) {
     for (auto &t : *allocs) {
-      if (t.foundPacketFlowAllocInTile(dma_col, 0)) {
+      if (t.foundPacketFlowAllocInColumn(dma_col)) {
         auto tileRes = air::createTileViaPlacer(
             device, AIE::AIETileType::ShimNOCTile, dma_col,
             /*row_hint=*/std::nullopt);
@@ -1096,7 +1091,7 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   int dma_channel = 0;
   int colTripCount = 0;
   while (any_of(allocs->begin(), allocs->end(), [&](air::allocation_info_t &a) {
-    return a.foundAlloc(dma_col, 0, AIE::DMAChannel{dir, dma_channel});
+    return a.foundAllocInColumn(dma_col, AIE::DMAChannel{dir, dma_channel});
   })) {
     dma_channel++;
     if (dma_channel >= shim_dma_channels) {
@@ -1258,7 +1253,7 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   bool isPacketFlowOp = false;
   auto chanTypeRes = getChannelType(memcpyOp);
   if (succeeded(chanTypeRes)) {
-    isPacketFlowOp = chanTypeRes.value().str() == "npu_dma_packet";
+    isPacketFlowOp = chanTypeRes.value() == "npu_dma_packet";
   }
 
   // Search for existing dma channel allocation

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -675,6 +675,43 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(int32_t col,
   return false;
 }
 
+// TileOp-keyed overloads (RFC #1567 Stage C #1). Pointer-equality on
+// dma_tile replaces (col, row) integer comparison; same answer, no
+// dependence on physical placement coordinates.
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile) {
+  return tile && tile == getDmaTile();
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::MemcpyInterface memcpyOp) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps)
+    if (memcpyOp.getOperation() == o)
+      return true;
+  return false;
+}
+
+bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
+                                                air::ChannelOp channel_op) {
+  return foundAlloc(tile) && foundAlloc(channel_op);
+}
+
+bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(
+    AIE::TileOp tile) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps) {
+    auto memcpy_op = dyn_cast_if_present<air::MemcpyInterface>(o);
+    if (!memcpy_op)
+      continue;
+    auto chanTypeRes = air::getChannelType(memcpy_op);
+    if (succeeded(chanTypeRes))
+      return chanTypeRes.value().str() == "npu_dma_packet";
+  }
+  return false;
+}
+
 // DMAAllocator impl.
 
 // A simple selection sorting implementation.
@@ -885,17 +922,16 @@ FailureOr<air::allocation_info_t> air::DMAAllocator::allocNewDmaChannel(
       isMM2S.value() ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
   aie_chan.channel = chan;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       if (t.dma_channel.direction == aie_chan.direction &&
           t.dma_channel.channel == aie_chan.channel) {
         t.memcpyOps.push_back(memcpyOp.getOperation());
         return t;
       }
     }
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1240,16 +1276,15 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow()))
+    if (t.foundAlloc(tile))
       num_allocs++;
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp)) {
+    if (t.foundAlloc(tile, memcpyOp)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
     // reuse the channel allocation.
-    if (isPacketFlowOp &&
-        t.foundPacketFlowAllocInTile(tile.getCol(), tile.getRow())) {
+    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
@@ -1368,7 +1403,7 @@ air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
 
   // Search for an existing allocation for this tile and memcpyOp
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow(), memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
   }
 
@@ -1394,15 +1429,14 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 
   // Check if allocation already exists for this tile
   for (auto &t : *allocs) {
-    if (t.foundAlloc(tile.getCol(), tile.getRow())) {
+    if (t.foundAlloc(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Also check for an allocation tied to the channel declaration
-    if (t.foundAlloc(tile.getCol(), tile.getRow(),
-                     getChannelDeclarationThroughSymbol(
-                         dyn_cast_if_present<air::ChannelInterface>(
-                             memcpyOp.getOperation())))) {
+    if (t.foundAlloc(tile, getChannelDeclarationThroughSymbol(
+                               dyn_cast_if_present<air::ChannelInterface>(
+                                   memcpyOp.getOperation())))) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -618,20 +618,6 @@ bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row) {
   return false;
 }
 
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                air::MemcpyInterface memcpyOp) {
-  if (foundAlloc(col, row))
-    for (auto o : memcpyOps)
-      if (memcpyOp.getOperation() == o)
-        return true;
-  return false;
-}
-
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                int chan) {
-  return foundAlloc(col, row) && (chan == dma_channel.channel);
-}
-
 bool xilinx::air::allocation_info_t::foundAlloc(AIE::DMAChannel channel) {
   if (channel.direction == dma_channel.direction &&
       channel.channel == dma_channel.channel)
@@ -651,12 +637,6 @@ bool xilinx::air::allocation_info_t::foundAlloc(AIE::TileOp tile,
     return true;
   else
     return false;
-}
-
-bool xilinx::air::allocation_info_t::foundAlloc(int32_t col, int32_t row,
-                                                air::ChannelOp channel_op) {
-
-  return foundAlloc(col, row) && foundAlloc(channel_op);
 }
 
 // Found existence of a packet flow allocation in provided coordinates.
@@ -740,7 +720,7 @@ static void selection(std::vector<Operation *> &a) {
 namespace xilinx {
 
 FailureOr<air::allocation_info_t>
-air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
+air::DMAAllocator::lookupDMAAllocation(AIE::TileOp tile,
                                        air::MemcpyInterface &memcpyOp) {
 
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
@@ -748,7 +728,7 @@ air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(col, row, memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
   }
   return memcpyOp.emitOpError(
@@ -759,14 +739,17 @@ air::DMAAllocator::lookupDMAAllocation(int64_t col, int64_t row,
 // Allocate a reader/writer lock pair. These may be the same or different
 // locks depending on the target device.
 FailureOr<std::pair<AIE::LockOp, AIE::LockOp>>
-air::DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp, int col,
-                                 int row, Operation *bufferOp,
+air::DMAAllocator::getLockForDMA(air::MemcpyInterface &memcpyOp,
+                                 AIE::TileOp tile, Operation *bufferOp,
                                  bool lockRaceConditionFix) {
-  auto alloc = lookupDMAAllocation(col, row, memcpyOp);
+  auto alloc = lookupDMAAllocation(tile, memcpyOp);
   if (failed(alloc))
     return memcpyOp->emitOpError("failed to look up dma allocation.");
   AIE::DMAChannel channel = alloc.value().dma_channel;
-  AIE::TileOp tile = alloc.value().getDmaTile();
+  // Coordinates derived from the tile for predicates like
+  // target_model.isMemTile.
+  int col = tile.getCol();
+  int row = tile.getRow();
   air::ChannelOp air_chan = nullptr;
   if (auto air_chan_op =
           dyn_cast_if_present<air::ChannelInterface>(memcpyOp.getOperation())) {
@@ -961,7 +944,12 @@ void air::DMAAllocator::sortMemcpyOps(std::vector<Operation *> dma_memcpy_ops) {
 //  <description>
 FailureOr<air::allocation_info_t>
 air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
-                                             int col, int row, int chan = -1) {
+                                             AIE::TileOp tile, int chan) {
+  if (!tile) {
+    return memcpyOp.emitOpError(
+        "failed to get a tile. This indicates a potential compilation "
+        "failure.");
+  }
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
@@ -978,28 +966,25 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
-    if (t.foundAlloc(col, row))
+    if (t.foundAlloc(tile))
       num_allocs++;
-    if (t.foundAlloc(col, row, memcpyOp))
+    if (t.foundAlloc(tile, memcpyOp))
       return t;
-    if (t.foundAlloc(col, row, chan)) {
+    if (t.foundAlloc(tile,
+                     AIE::DMAChannel{isMM2S.value() ? AIE::DMAChannelDir::MM2S
+                                                    : AIE::DMAChannelDir::S2MM,
+                                     chan})) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
     // reuse the channel allocation.
-    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(col, row)) {
+    if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
   }
   // Need to allocate a new one
-  auto tile = getPhysTileOpOrNull(device, col, row);
-  if (!tile) {
-    return memcpyOp.emitOpError(
-        "failed to get a tile at specified col and row. This "
-        "indicates a potential compilation failre.");
-  }
   int tile_dma_channels =
       isMM2S.value() ? tile.getNumSourceConnections(AIE::WireBundle::DMA)
                      : tile.getNumDestConnections(AIE::WireBundle::DMA);
@@ -1009,7 +994,7 @@ air::TileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
 }
 
 FailureOr<AIE::BufferOp>
-air::TileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::TileDMAAllocator::getBuffer(uint64_t, AIE::TileOp tile,
                                  air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1177,7 +1162,7 @@ air::ShimDMAAllocator::allocNewDmaChannel(air::MemcpyInterface &memcpyOp,
 }
 
 FailureOr<AIE::ExternalBufferOp>
-air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
+air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, AIE::TileOp tile,
                                  air::MemcpyInterface &memcpyOp) {
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
@@ -1191,10 +1176,13 @@ air::ShimDMAAllocator::getBuffer(uint64_t &BufferId, int64_t col, int64_t row,
       air::MemorySpaceAttr::get(memcpyOp->getContext(), dmaMemorySpace);
   memrefTy = MemRefType::get(memrefTy.getShape(), memrefTy.getElementType(),
                              AffineMap(), memSpaceAttr);
+  // Names use shim coords: tile is the shim NOC tile that owns the external
+  // buffer's DMA program (the L3 buffer itself has no tile, but its name
+  // ties it to the shim that drives it).
   AIE::ExternalBufferOp bufferOp = allocateExternalBufferOp(
       BufferId, memrefTy, device,
       memcpyOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()),
-      col, row);
+      tile ? (int)tile.getCol() : -1, tile ? (int)tile.getRow() : -1);
   return bufferOp;
 }
 
@@ -1249,14 +1237,14 @@ air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
 
 FailureOr<air::allocation_info_t>
 air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
-                                                int chan = -1) {
+                                                int chan) {
   auto isMM2S = isTileOutbound(memcpyOp, dmaMemorySpace);
   if (failed(isMM2S))
     return failure();
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
 
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1307,7 +1295,7 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(
   auto allocs = isMM2S.value() ? &mm2s_allocs : &s2mm_allocs;
 
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1363,7 +1351,7 @@ air::MemTileDMAAllocator::foundFlowReuseOpportunity(
 }
 
 FailureOr<AIE::BufferOp>
-air::MemTileDMAAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::MemTileDMAAllocator::getBuffer(uint64_t, AIE::TileOp,
                                     air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1392,7 +1380,7 @@ air::CascadeAllocator::coreCascadeAlloc(air::MemcpyInterface &memcpyOp) {
 
   // Retrieve the buffer and the tile where this memcpyOp operates
   const int dummy{0};
-  auto buffer = getBuffer(dummy, -1, -1, memcpyOp);
+  auto buffer = getBuffer(dummy, /*tile=*/nullptr, memcpyOp);
   if (failed(buffer)) {
     return memcpyOp->emitOpError("failed to get buffer.");
   }
@@ -1457,7 +1445,7 @@ air::CascadeAllocator::allocNewCascade(air::MemcpyInterface &memcpyOp,
 
 // Retrieves the underlying AIE::BufferOp associated with the given memcpyOp.
 FailureOr<AIE::BufferOp>
-air::CascadeAllocator::getBuffer(uint64_t, int64_t col, int64_t row,
+air::CascadeAllocator::getBuffer(uint64_t, AIE::TileOp,
                                  air::MemcpyInterface &memcpyOp) {
   auto isInbound = isTileInbound(memcpyOp, dmaMemorySpace);
   if (failed(isInbound))
@@ -1630,14 +1618,12 @@ LogicalResult air::simpleDMAChannelAllocation(
               "memcpy op not outlined in an aie.core op.");
         }
         auto tile = core.getTileOp();
-        int x = tile.getCol();
-        int y = tile.getRow();
 
         FailureOr<air::allocation_info_t> alloc_res;
         if (f.memcpyResourceType == "npu_dma_stream" ||
             f.memcpyResourceType == "npu_dma_packet") {
           alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-              memcpyOpIf, x, y, f.MM2S_alloc.dma_channel.channel);
+              memcpyOpIf, tile, f.MM2S_alloc.dma_channel.channel);
           if (failed(alloc_res))
             return failure();
         } else if (f.memcpyResourceType == "npu_cascade") {
@@ -1661,14 +1647,12 @@ LogicalResult air::simpleDMAChannelAllocation(
                 "memcpy op not outlined in an aie.core op.");
           }
           auto tile = core.getTileOp();
-          int x = tile.getCol();
-          int y = tile.getRow();
 
           FailureOr<air::allocation_info_t> alloc_res;
           if (f.memcpyResourceType == "npu_dma_stream" ||
               f.memcpyResourceType == "npu_dma_packet") {
             alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-                memcpyOpIf, x, y, f.S2MM_alloc[i].dma_channel.channel);
+                memcpyOpIf, tile, f.S2MM_alloc[i].dma_channel.channel);
             if (failed(alloc_res))
               return failure();
           } else if (f.memcpyResourceType == "npu_cascade") {


### PR DESCRIPTION
## Summary

Consolidates RFC #1567 Stage C #1 work into a single PR (was split across closed PRs #1597 and #1598, plus this one).

Reworks `allocation_info_t.foundAlloc` and the `DMAAllocator` API to identify allocations by `AIE::TileOp` pointer instead of `(col, row)` integer pairs. Pure mechanical refactor + dead code deletion. **No behavior change.**

## Commits (4)

1. **Re-key DMA allocator identity lookups on AIE::TileOp** — 17 callsites converted from `foundAlloc(tile.getCol(), tile.getRow(), ...)` to `foundAlloc(tile, ...)`. Adds 4 new TileOp-keyed overloads.
2. **Batch outlineAIECores via createTilesViaPlacer** — Uses the batched placer API in `outlineAIECores`. No behavior change.
3. **Re-key DMAAllocator API entry points on AIE::TileOp** — 4 API entry points converted: `lookupDMAAllocation`, `getLockForDMA`, `simpleDmaChannelAlloc`, `getBuffer × 4 allocators`. `generateDmaBdProgram` and `allocateCoreLocksPerMemcpyOp` no longer take `int x, int y`. Deletes 3 dead `(col, row)` overloads.
4. **Convert ShimDMAAllocator column-search to foundAllocInColumn** — Last 2 holdouts: ShimDMA's column-search path that picks a shim column before any TileOp exists. The `(col, row=0)` was a meaningless implementation artifact (shim is always row 0). Renamed to `foundAllocInColumn(col)` to make column-keyed semantics explicit. Deletes the last `(col, row)` integer overloads.

## End state

The API is uniformly TileOp-keyed for identity hashes, with column-keyed search overloads explicitly named for the one search-before-tile use case (ShimDMA's column-pick path).

## Diff

+184 / −151 across 3 files (`AIRToAIESchedulingUtils.h`, `AIRToAIESchedulingUtils.cpp`, `AIRToAIEPass.cpp`).

## Test plan

- [x] `check-air-mlir` 384/384 (2 pre-existing AIRToROCDL failures unrelated)
- [x] CI on this PR
- [x] clang-format-17 clean
