### PR TITLE
attention_decode: fold weight-chunk BD chain to fix ELF hang

### DIFF
--- a/programming_examples/attention_decode/attn_decode_npu2.py
+++ b/programming_examples/attention_decode/attn_decode_npu2.py
@@ -328,7 +328,7 @@ def build_module(
                 # bL3ToL2 packets 1..GEMV_COUNT*chunks: weight chunks. Same
                 # [tile_k, tile_n] packet shape as the xrms head packet —
                 # the memtile S2MM and L1 S2MM are single self-loop BDs.
-                for mm_iter in range(GEMV_COUNT):
+                for mm_iter in range_(0, GEMV_COUNT):
                     ChannelPut(
                         "bL3ToL2",
                         l3_b_data,
@@ -337,6 +337,7 @@ def build_module(
                         strides=[GEMV_COUNT * n * k, n * k, n, 1],
                         indices=[c_tx_i],
                     )
+                    yield_([])
 
                 # KV cache writeback at slot pos_host for this col.
                 ChannelGet(

--- a/programming_examples/attention_decode/run_makefile_peano_attn_decode_elf.lit
+++ b/programming_examples/attention_decode/run_makefile_peano_attn_decode_elf.lit
@@ -1,0 +1,16 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Verifies the LLaMA-3.2-1B decode flash-attention design end-to-end on
+// NPU2 in ELF output format. Same configuration as the xclbin lit. The
+// ELF runtime path was previously hanging with ERT_CMD_STATE_TIMEOUT due
+// to >4 BDs queued back-to-back on the bL3ToL2 shim DMA channel; this
+// test guards against regression.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_attn_decode_npu2_elf
+// RUN: cd test_attn_decode_npu2_elf
+// RUN: make -f %S/Makefile clean PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile run-attn-decode POS=2 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!


### PR DESCRIPTION
## Summary

- `attn_decode_npu2.py` launch body emitted **7 BDs back-to-back on `bL3ToL2`** (1 xrms head + 6 weight chunks) per launch. AIE2P shim DMA task queue depth is 4 — the ELF dispatch path (`ERT_START_NPU_PREEMPT_ELF`, opcode 22) lacks the host-side backpressure of the xclbin path and the firmware deadlocked with `ERT_CMD_STATE_TIMEOUT`. Same TXN bytes via xclbin (opcode 20) ran fine.
- Root cause: the inner weight-chunk loop used Python `for mm_iter in range(GEMV_COUNT)`, which fully unrolls at IR build time into 6 independent `air.channel.put` ops. `AIRSpecializeChannelWrapAndStridePattern` only folds `scf.for` / `affine.for` loops, so it never saw a fold candidate.
- Fix: switch the loop to `range_(0, GEMV_COUNT)` (with a `yield_([])` for the async token), keeping the loop as `scf.for`. The optimizer then folds the 6 puts into a single BD with `<size = 6, stride = 131072>`. `bL3ToL2` BD count drops from 7 to 2 — comfortably under the 4-deep queue.
- Adds `run_makefile_peano_attn_decode_elf.lit` mirroring the existing xclbin lit so CI exercises the ELF path going forward (this hang was latent since the design was added — would have been caught immediately).

## Test plan

Verified on NPU2 hardware (Strix, firmware 1.1.2.64):
- [x] `make run-attn-decode POS=2 OUTPUT_FORMAT=elf NKV=1`: pre-patch HANG → post-patch PASS (corr 1.0)
- [x] `make run-attn-decode POS=2 OUTPUT_FORMAT=elf` (NKV=8 production): pre-patch HANG → post-patch PASS (corr 1.0)
- [x] `make run-attn-decode POS=2` (xclbin regression, NKV=8): PASS (corr 1.0)
- [x] BD-count check on post-lowering IR: `bL3ToL2` 7 → 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)