### PR TITLE
[programming_examples] Cascade GEMV with fused residual add (D = A·B + R)

### DIFF
--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
@@ -62,6 +62,35 @@ profile_4col:
 	$(MAKE) profile M=2048 K=8192 TILE_M=4 M_INPUT=1 HERD_COLS=4 N_CASCADE=4
 
 build-test-exe:
+	@$(MAKE) build-test-exe-impl SRC=test.cpp OUT=test.exe
+
+# Fused GEMV + residual add: D[M] = A[M,K] @ B[K] + R[M]
+# Note: m_input=2 minimum (m_input=1 → R per-iter = 2 bytes, sub-aligned for AIE DMA)
+M_INPUT_ADD ?= 2
+
+print_add:
+	${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+
+run_add:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir)
+
+build-test-add-exe:
+	@$(MAKE) build-test-exe-impl SRC=test_add.cpp OUT=test_add.exe
+
+profile_add: build-test-add-exe
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_add.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $(M) -K $(K)
+
+# 8 columns x 4 cascade tiles, fused GEMV+add
+run_add_8col:
+	$(MAKE) run_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf
+
+profile_add_8col:
+	$(MAKE) profile_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4
+
+build-test-exe-impl:
 	@GPP=$$( \
 		for bin in /usr/bin/g++-*; do \
 			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
@@ -82,9 +111,9 @@ build-test-exe:
 		echo "Error: AIEOPT_DIR environment variable not set. Please make sure to have sourced utils/env_setup.sh."; \
 		exit 1; \
 	fi; \
-	echo "Using compiler: $$GPP"; \
+	echo "Using compiler: $$GPP for $(SRC) -> $(OUT)"; \
 	mkdir -p $(BUILD_DIR); \
-	cd $(BUILD_DIR) && $$GPP ${srcdir}/test.cpp -o test.exe -std=c++23 -Wall \
+	cd $(BUILD_DIR) && $$GPP ${srcdir}/$(SRC) -o $(OUT) -std=c++23 -Wall \
 		-I$$XILINX_XRT/include -L$$XILINX_XRT/lib \
 		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
 		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
@@ -65,9 +65,10 @@ build-test-exe:
 	@$(MAKE) build-test-exe-impl SRC=test.cpp OUT=test.exe
 
 # Fused GEMV + residual add: D[M] = A[M,K] @ B[K] + R[M]
-# Note: M_INPUT=2 minimum for the add variant (M_INPUT=1 → R per-iter = 2
-# bytes, sub-aligned for AIE DMA). Override M_INPUT=2 on the command line
-# (or via run_add_8col / profile_add_8col below).
+# R is staged as one bulk [tile_m] L3->L2 transfer per launch iter, so
+# the AIE DMA 4-byte alignment requirement is on tile_m (asserted in
+# matvec_cascade_add.py): tile_m * sizeof(bf16) >= 4, i.e. tile_m >= 2.
+# M_INPUT (= rows per inner kernel iter) can be any divisor of tile_m.
 
 print_add:
 	${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
@@ -86,10 +87,10 @@ profile_add: build-test-add-exe
 
 # 8 columns x 4 cascade tiles, fused GEMV+add
 run_add_8col:
-	$(MAKE) run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf
+	$(MAKE) run_add M=2048 K=8192 TILE_M=2 M_INPUT=1 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf
 
 profile_add_8col:
-	$(MAKE) profile_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4
+	$(MAKE) profile_add M=2048 K=8192 TILE_M=2 M_INPUT=1 HERD_COLS=8 N_CASCADE=4
 
 build-test-exe-impl:
 	@GPP=$$( \

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
@@ -65,30 +65,31 @@ build-test-exe:
 	@$(MAKE) build-test-exe-impl SRC=test.cpp OUT=test.exe
 
 # Fused GEMV + residual add: D[M] = A[M,K] @ B[K] + R[M]
-# Note: m_input=2 minimum (m_input=1 → R per-iter = 2 bytes, sub-aligned for AIE DMA)
-M_INPUT_ADD ?= 2
+# Note: M_INPUT=2 minimum for the add variant (M_INPUT=1 → R per-iter = 2
+# bytes, sub-aligned for AIE DMA). Override M_INPUT=2 on the command line
+# (or via run_add_8col / profile_add_8col below).
 
 print_add:
-	${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 
 run_add:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir)
 
 build-test-add-exe:
 	@$(MAKE) build-test-exe-impl SRC=test_add.cpp OUT=test_add.exe
 
 profile_add: build-test-add-exe
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT_ADD) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_add.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $(M) -K $(K)
 
 # 8 columns x 4 cascade tiles, fused GEMV+add
 run_add_8col:
-	$(MAKE) run_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf
+	$(MAKE) run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf
 
 profile_add_8col:
-	$(MAKE) profile_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4
+	$(MAKE) profile_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4
 
 build-test-exe-impl:
 	@GPP=$$( \

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
@@ -107,12 +107,12 @@ def build_module(
 
     bytes_per_elem_in = np.dtype(np_dtype_in).itemsize
     bytes_per_elem_out = np.dtype(np_dtype_out).itemsize
-    # Per-(col, cascade_row) L2 chunk buffer (m_input * k_chunk bf16),
-    # plus one R buffer per col.
-    ar_l2_chunk_bytes = m_input * k_chunk * bytes_per_elem_in
+    # L2 budget: per col, 1 bulk A buffer (tile_m*k bf16) + 1 R buffer
+    # (tile_m bf16). Plus a single bulk D buffer (herd_cols*tile_m).
+    a_bulk_bytes = tile_m * k * bytes_per_elem_in
+    r_bytes = tile_m * bytes_per_elem_in
+    l2_per_col = a_bulk_bytes + r_bytes
     d_l2_bytes = herd_cols * tile_m * bytes_per_elem_out
-    # Per col: 1 R chunk buf + n_cascade A chunk bufs (each m_input*k_chunk).
-    l2_per_col = (1 + n_cascade) * ar_l2_chunk_bytes
     L2_CAPACITY = 512 * 1024
     assert herd_cols * l2_per_col + d_l2_bytes <= L2_CAPACITY, (
         f"L2 capacity exceeded: per-col={l2_per_col}B × {herd_cols} cols "
@@ -131,12 +131,21 @@ def build_module(
     memrefTyR = MemRefType.get([m], xrt_dtype_in)
     memrefTyD = MemRefType.get([m], xrt_dtype_out)
 
-    # L2 chunk buffers: shape [m_input, k_chunk] (sized for A; R fills
-    # only first m_input cells). Per-fill separate buffers — see segment
-    # body below for the rationale.
+    # L2 staging:
+    #   bulk A per col: [tile_m, k] — single L3->L2 fill per launch iter
+    #     (matches matvec_cascade.py reference). Multiple memtile MM2S
+    #     read distinct K-slices.
+    #   R per col: [tile_m] — single L3->L2 fill per launch iter, one
+    #     memtile MM2S to (col, HEAD) only.
+    # 2 BDs total per col on shim ar_L3toL2 (R + A bulk) → tiling=2 fits.
     l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-    l2MemrefTyARchunk = MemRefType.get(
-        shape=[m_input, k_chunk],
+    l2MemrefTyAbulk = MemRefType.get(
+        shape=[tile_m, k],
+        element_type=xrt_dtype_in,
+        memory_space=l2_mem_space,
+    )
+    l2MemrefTyR = MemRefType.get(
+        shape=[tile_m],
         element_type=xrt_dtype_in,
         memory_space=l2_mem_space,
     )
@@ -148,8 +157,10 @@ def build_module(
 
     # L1 MemRefTypes
     l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    # L1 A holds the full tile_m rows for this (col, ty) — single bulk
+    # transfer per launch iter.
     l1MemrefTyA = MemRefType.get(
-        shape=[m_input, k_chunk],
+        shape=[tile_m, k_chunk],
         element_type=xrt_dtype_in,
         memory_space=l1_mem_space,
     )
@@ -163,14 +174,16 @@ def build_module(
         element_type=xrt_dtype_out,
         memory_space=l1_mem_space,
     )
-    # Per j_m iter, HEAD's L1 R buffer holds m_input elements (one per
-    # output row computed this iter). m_input * sizeof(bf16) must be
-    # ≥ 4 bytes for AIE DMA alignment → m_input ≥ 2 required.
+    # HEAD's L1 R buffer holds the full tile_m R values for this col —
+    # single bulk transfer per launch iter. tile_m*sizeof(bf16) ≥ 4 bytes
+    # for AIE DMA alignment → tile_m ≥ 2 required (always satisfied since
+    # tile_m must be a multiple of m_input ≥ 1 and we use tile_m ≥ 2 in
+    # practice; explicit assert for safety).
     assert (
-        m_input * np.dtype(np_dtype_in).itemsize >= 4
-    ), f"m_input ({m_input}) * sizeof({np_dtype_in}) must be ≥ 4 bytes (AIE DMA alignment)"
+        tile_m * np.dtype(np_dtype_in).itemsize >= 4
+    ), f"tile_m ({tile_m}) * sizeof({np_dtype_in}) must be ≥ 4 bytes (AIE DMA alignment)"
     l1MemrefTyR = MemRefType.get(
-        shape=[m_input],
+        shape=[tile_m],
         element_type=xrt_dtype_in,
         memory_space=l1_mem_space,
     )
@@ -225,42 +238,39 @@ def build_module(
             )
             launch_offset_m_l = affine_apply(launch_ivx_map, [launch_ivx])
 
-            # L3-side puts on ar_L3toL2[col]: per j_m iter, R then per-ty A
-            # Order MUST match memtile-side gets in segment body.
+            # L3-side puts on ar_L3toL2[col]: 1 R + 1 A bulk per launch iter.
+            # Order: R first, then A bulk (segment-side reads in same order).
             for col in range(herd_cols):
                 c_col_idx_l = arith.ConstantOp.create_index(col)
-                for j_m_v in range(tile_m // m_input):
-                    add_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(col * tile_m + j_m_v * m_input),
-                            )
-                        ],
-                    )
-                    r_off = affine_apply(add_map, [launch_offset_m_l])
-                    ChannelPut(
-                        "ar_L3toL2",
-                        l3_r_data,
-                        indices=[c_col_idx_l],
-                        offsets=[r_off],
-                        sizes=[m_input],
-                        strides=[1],
-                    )
-                    # Reverse order so HEAD's K-slice is sent right after R
-                    # (segment-side memtile loop reads in same reverse order).
-                    for ty_v in reversed(range(n_cascade)):
-                        a_off_m = affine_apply(add_map, [launch_offset_m_l])
-                        ChannelPut(
-                            "ar_L3toL2",
-                            l3_a_data,
-                            indices=[c_col_idx_l],
-                            offsets=[a_off_m, ty_v * k_chunk],
-                            sizes=[m_input, k_chunk],
-                            strides=[k, 1],
+                col_off_map = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_add(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(col * tile_m),
                         )
+                    ],
+                )
+                col_off = affine_apply(col_off_map, [launch_offset_m_l])
+                # R bulk: tile_m elements for this col
+                ChannelPut(
+                    "ar_L3toL2",
+                    l3_r_data,
+                    indices=[c_col_idx_l],
+                    offsets=[col_off],
+                    sizes=[tile_m],
+                    strides=[1],
+                )
+                # A bulk: tile_m × k for this col
+                ChannelPut(
+                    "ar_L3toL2",
+                    l3_a_data,
+                    indices=[c_col_idx_l],
+                    offsets=[col_off, 0],
+                    sizes=[tile_m, k],
+                    strides=[k, 1],
+                )
 
             @segment(
                 name="matvec_cascade_add_seg",
@@ -271,65 +281,58 @@ def build_module(
                 l3_b_data_s,
                 l3_d_data_s,
             ):
-                # Per-fill L2 buffers: one R buffer per col + one A buffer
-                # per (col, cascade_row). Required so each S2MM/MM2S BD
-                # pair owns its own L2 buffer; sharing one L2 buffer
-                # across BD pairs with independent lock pairs lets later
-                # fills overwrite the buffer before earlier reads drain.
-                r_l2_bufs = [
-                    AllocOp(l2MemrefTyARchunk, [], []) for _ in range(herd_cols)
-                ]
-                a_l2_bufs = [
-                    [AllocOp(l2MemrefTyARchunk, [], []) for _ in range(n_cascade)]
-                    for _ in range(herd_cols)
-                ]
+                # L2: bulk A buffer per col + small R buffer per col + bulk D.
+                # Each buffer has a single L3->L2 writer (no shared-buffer
+                # race possible).
+                a_l2_bufs = [AllocOp(l2MemrefTyAbulk, [], []) for _ in range(herd_cols)]
+                r_l2_bufs = [AllocOp(l2MemrefTyR, [], []) for _ in range(herd_cols)]
                 l2_d_data = AllocOp(l2MemrefTyD, [], [])
 
-                # Memtile streaming: R to (col, HEAD), A_r to (col, r).
+                # Memtile streaming per col: 1 R get + 1 A bulk get from L3,
+                # then per-(col, ty) MM2S puts of A slices and 1 R put to HEAD.
                 c_head_idx = arith.ConstantOp.create_index(n_cascade - 1)
                 for col in range(herd_cols):
                     c_col_idx = arith.ConstantOp.create_index(col)
                     r_l2 = r_l2_bufs[col].result
-                    for j_m_v in range(tile_m // m_input):
-                        # R: GET → r_l2 (separate buffer), PUT → (col, HEAD)
-                        ChannelGet(
-                            "ar_L3toL2",
-                            r_l2,
-                            indices=[c_col_idx],
-                            offsets=[0, 0],
-                            sizes=[1, m_input],
-                            strides=[k_chunk, 1],
-                        )
+                    a_l2 = a_l2_bufs[col].result
+                    # R: GET tile_m elements from L3 → r_l2
+                    ChannelGet(
+                        "ar_L3toL2",
+                        r_l2,
+                        indices=[c_col_idx],
+                        offsets=[0],
+                        sizes=[tile_m],
+                        strides=[1],
+                    )
+                    # R: PUT r_l2 → (col, HEAD)
+                    ChannelPut(
+                        "ar_L2toL1",
+                        r_l2,
+                        indices=[c_col_idx, c_head_idx],
+                        offsets=[0],
+                        sizes=[tile_m],
+                        strides=[1],
+                    )
+                    # A bulk: GET tile_m × k from L3 → a_l2
+                    ChannelGet(
+                        "ar_L3toL2",
+                        a_l2,
+                        indices=[c_col_idx],
+                        offsets=[0, 0],
+                        sizes=[tile_m, k],
+                        strides=[k, 1],
+                    )
+                    # A slices: PUT per ty (each MM2S reads its k_chunk slice)
+                    for ty_v in range(n_cascade):
+                        c_ty_idx = arith.ConstantOp.create_index(ty_v)
                         ChannelPut(
                             "ar_L2toL1",
-                            r_l2,
-                            indices=[c_col_idx, c_head_idx],
-                            offsets=[0, 0],
-                            sizes=[1, m_input],
-                            strides=[k_chunk, 1],
+                            a_l2,
+                            indices=[c_col_idx, c_ty_idx],
+                            offsets=[0, ty_v * k_chunk],
+                            sizes=[tile_m, k_chunk],
+                            strides=[k, 1],
                         )
-                        # A per cascade row: GET → its own a_l2 buffer.
-                        # Reverse order keeps HEAD's A adjacent to R in the
-                        # L3-side put stream (compiler pairs adjacent puts).
-                        for ty_v in reversed(range(n_cascade)):
-                            c_ty_idx = arith.ConstantOp.create_index(ty_v)
-                            a_l2 = a_l2_bufs[col][ty_v].result
-                            ChannelGet(
-                                "ar_L3toL2",
-                                a_l2,
-                                indices=[c_col_idx],
-                                offsets=[0, 0],
-                                sizes=[m_input, k_chunk],
-                                strides=[k_chunk, 1],
-                            )
-                            ChannelPut(
-                                "ar_L2toL1",
-                                a_l2,
-                                indices=[c_col_idx, c_ty_idx],
-                                offsets=[0, 0],
-                                sizes=[m_input, k_chunk],
-                                strides=[k_chunk, 1],
-                            )
 
                 # L1 buffers (passed into herd as operands)
                 l1_a_data = AllocOp(l1MemrefTyA, [], [])
@@ -449,9 +452,28 @@ def build_module(
                         f32_type,
                     )
 
-                    # Hot loop: per j_m iter, HEAD receives R + A; other
-                    # cascade tiles just receive A. Cascade pipeline runs
-                    # with R added at HEAD's init accumulator.
+                    # Bulk receives outside the j_m loop (one BD each per
+                    # launch iter): HEAD-only R, plus A slice for this
+                    # (col, ty). Both fill their own L1 buffers and are
+                    # consumed across all j_m iters.
+                    if_head_r = affine.AffineIfOp(head_set, cond_operands=[ty])
+                    with InsertionPoint(if_head_r.then_block):
+                        ChannelGet(
+                            "ar_L2toL1",
+                            _l1_r,
+                            indices=[tx, ty],
+                        )
+                        affine.AffineYieldOp([])
+
+                    ChannelGet(
+                        "ar_L2toL1",
+                        _l1_a,
+                        indices=[tx, ty],
+                    )
+
+                    # Hot loop: per j_m iter, compute partial dot from
+                    # rows [j_m*m_input : (j_m+1)*m_input] of _l1_a (which
+                    # holds the full tile_m rows for this (col, ty)).
                     for j_m in range_(0, tile_m // m_input):
                         j_m_map = AffineMap.get(
                             0,
@@ -464,22 +486,16 @@ def build_module(
                             ],
                         )
                         j_m_offset = affine_apply(j_m_map, [j_m])
-
-                        # R receive: HEAD only, point-to-point
-                        if_head_r = affine.AffineIfOp(head_set, cond_operands=[ty])
-                        with InsertionPoint(if_head_r.then_block):
-                            ChannelGet(
-                                "ar_L2toL1",
-                                _l1_r,
-                                indices=[tx, ty],
-                            )
-                            affine.AffineYieldOp([])
-
-                        # A receive: each tile gets its own
-                        ChannelGet(
-                            "ar_L2toL1",
-                            _l1_a,
-                            indices=[tx, ty],
+                        # Map (j_m_offset, row) → row index in _l1_a (= j_m_offset + row)
+                        abs_row_map = AffineMap.get(
+                            0,
+                            2,
+                            [
+                                AffineExpr.get_add(
+                                    AffineSymbolExpr.get(0),
+                                    AffineSymbolExpr.get(1),
+                                )
+                            ],
                         )
 
                         # === Cascade compute ===
@@ -492,8 +508,9 @@ def build_module(
                         with InsertionPoint(if_first.then_block):
                             # HEAD: partial + R → scratch → cascade
                             for row in range_(0, m_input):
-                                partial_sum = compute_partial_dot(row, *dot_args)
-                                sub_r = subview(_l1_r, [row], [1], [1])
+                                abs_row = affine_apply(abs_row_map, [j_m_offset, row])
+                                partial_sum = compute_partial_dot(abs_row, *dot_args)
+                                sub_r = subview(_l1_r, [abs_row], [1], [1])
                                 r_val_bf16 = memref_load(sub_r, [c0])
                                 r_val_f32 = arith.extf(f32_type, r_val_bf16)
                                 init_acc = arith.addf(partial_sum, r_val_f32)
@@ -523,15 +540,17 @@ def build_module(
                                 )
 
                                 for row in range_(0, m_input):
-                                    partial_sum = compute_partial_dot(row, *dot_args)
+                                    abs_row = affine_apply(
+                                        abs_row_map, [j_m_offset, row]
+                                    )
+                                    partial_sum = compute_partial_dot(
+                                        abs_row, *dot_args
+                                    )
                                     sub_recv = subview(_l1_recv, [row], [1], [1])
                                     recv_val = memref_load(sub_recv, [c0])
                                     total_f32 = arith.addf(recv_val, partial_sum)
                                     total_bf16 = arith.truncf(xrt_dtype_out, total_f32)
-                                    out_idx = affine_apply(
-                                        row_out_map, [j_m_offset, row]
-                                    )
-                                    sub_d_out = subview(_l1_d, [out_idx], [1], [1])
+                                    sub_d_out = subview(_l1_d, [abs_row], [1], [1])
                                     memref_store(total_bf16, sub_d_out, [c0])
                                     yield_([])
 
@@ -546,7 +565,12 @@ def build_module(
                                 )
 
                                 for row in range_(0, m_input):
-                                    partial_sum = compute_partial_dot(row, *dot_args)
+                                    abs_row = affine_apply(
+                                        abs_row_map, [j_m_offset, row]
+                                    )
+                                    partial_sum = compute_partial_dot(
+                                        abs_row, *dot_args
+                                    )
                                     sub_recv = subview(_l1_recv, [row], [1], [1])
                                     recv_val = memref_load(sub_recv, [c0])
                                     total = arith.addf(recv_val, partial_sum)
@@ -609,9 +633,8 @@ def build_module(
 
                 for r_l2 in r_l2_bufs:
                     DeallocOp(r_l2)
-                for col_bufs in a_l2_bufs:
-                    for a_l2 in col_bufs:
-                        DeallocOp(a_l2)
+                for a_l2 in a_l2_bufs:
+                    DeallocOp(a_l2)
                 DeallocOp(l2_d_data)
                 DeallocOp(l1_a_data)
                 DeallocOp(l1_b_data)
@@ -688,11 +711,9 @@ if __name__ == "__main__":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
-            # Per-col ar_L3toL2 carries 1 R + n_cascade A puts per launch
-            # iter. Shim DMA limit = 4 BDs queued per channel; tiling=[1,1]
-            # keeps it at (1+n_cascade) ≤ 4 for n_cascade up to 3, and at
-            # n_cascade=4 the BDs fit just within the limit.
-            runtime_loop_tiling_sizes=[1, 1],
+            # Per-col ar_L3toL2 carries 1 R + 1 A bulk per launch iter.
+            # Shim DMA BD queue limit = 4 → tiling=2 keeps it at 4 BDs.
+            runtime_loop_tiling_sizes=[2, 2],
             output_format=args.output_format,
             instance_name="matvec_cascade_add_bf16",
             debug_ir=args.debug_ir,
@@ -712,7 +733,7 @@ if __name__ == "__main__":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
-            runtime_loop_tiling_sizes=[1, 1],
+            runtime_loop_tiling_sizes=[2, 2],
             output_format=args.output_format,
             use_lock_race_condition_fix=True,
         )

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
@@ -123,7 +123,6 @@ def build_module(
     xrt_dtype_in = type_mapper(np_dtype_in)
     xrt_dtype_out = type_mapper(np_dtype_out)
     f32_type = F32Type.get()
-    index_type = IndexType.get()
 
     # L3 MemRefTypes
     memrefTyA = MemRefType.get([m, k], xrt_dtype_in)
@@ -175,13 +174,11 @@ def build_module(
         memory_space=l1_mem_space,
     )
     # HEAD's L1 R buffer holds the full tile_m R values for this col —
-    # single bulk transfer per launch iter. tile_m*sizeof(bf16) ≥ 4 bytes
-    # for AIE DMA alignment → tile_m ≥ 2 required (always satisfied since
-    # tile_m must be a multiple of m_input ≥ 1 and we use tile_m ≥ 2 in
-    # practice; explicit assert for safety).
+    # single bulk transfer per launch iter. tile_m*sizeof(bf16) >= 4 bytes
+    # for AIE DMA alignment.
     assert (
         tile_m * np.dtype(np_dtype_in).itemsize >= 4
-    ), f"tile_m ({tile_m}) * sizeof({np_dtype_in}) must be ≥ 4 bytes (AIE DMA alignment)"
+    ), f"tile_m ({tile_m}) * sizeof({np_dtype_in}) must be >= 4 bytes (AIE DMA alignment)"
     l1MemrefTyR = MemRefType.get(
         shape=[tile_m],
         element_type=xrt_dtype_in,

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
@@ -1,0 +1,720 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Cascade-based GEMV with fused residual add: D[M] = A[M,K] @ B[K] + R[M]
+# BF16 input/output, accfloat accumulation.
+#
+# R is added at the cascade HEAD as the initial accumulator; the cascade
+# carries R + Σpartials south to the TAIL which writes D.
+#
+# A and R share the ar_L3toL2 / ar_L2toL1 channels (per-(col, cascade_row)
+# bundle slot), each fill targeting its own L2 buffer to avoid shared-
+# buffer write/read races between independent lock pairs.
+
+import argparse
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import *
+from air.dialects.affine import apply as affine_apply
+from air.dialects import affine
+from air.dialects.air import *
+from air.dialects.air import channel as channel_decl
+from air.dialects import arith, scf
+from air.dialects.memref import (
+    AllocOp,
+    DeallocOp,
+    subview,
+    load as memref_load,
+    store as memref_store,
+)
+from air.dialects.func import FuncOp
+from air.dialects.scf import for_, yield_
+from air.dialects.vector import (
+    transfer_read,
+    transfer_write,
+    BroadcastOp,
+    reduction as vector_reduction,
+    fma,
+)
+from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt import XRTBackend
+
+range_ = for_
+
+
+def compute_partial_dot(
+    row,
+    _l1_a,
+    _l1_b,
+    l1_acc_tmp,
+    c0,
+    k_chunk,
+    f32_vec_size,
+    vecTy_bf16,
+    vecTy_f32,
+    identity_map,
+    read_map_2d,
+    cst0_bf16,
+    cst0_f32,
+    f32_type,
+):
+    """Single-row bf16 dot product into f32 accumulator (verbatim from
+    matvec_cascade.py). Returns the f32 horizontal sum."""
+    zero_vec_f32 = BroadcastOp(vecTy_f32, cst0_f32)
+    transfer_write(None, zero_vec_f32, l1_acc_tmp, [c0], identity_map, [True])
+
+    for j_k in range_(0, k_chunk, f32_vec_size):
+        sub_a = subview(_l1_a, [row, j_k], [1, f32_vec_size], [1, 1])
+        sub_b = subview(_l1_b, [j_k], [f32_vec_size], [1])
+        v_a_bf16 = transfer_read(
+            vecTy_bf16, sub_a, [c0, c0], read_map_2d, cst0_bf16, [True]
+        )
+        v_b_bf16 = transfer_read(
+            vecTy_bf16, sub_b, [c0], identity_map, cst0_bf16, [True]
+        )
+        v_a_f32 = arith.extf(vecTy_f32, v_a_bf16)
+        v_b_f32 = arith.extf(vecTy_f32, v_b_bf16)
+        v_acc = transfer_read(
+            vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True]
+        )
+        v_result = fma(v_a_f32, v_b_f32, v_acc)
+        transfer_write(None, v_result, l1_acc_tmp, [c0], identity_map, [True])
+        yield_([])
+
+    v_final = transfer_read(vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True])
+    return vector_reduction(f32_type, "add", v_final)
+
+
+@module_builder
+def build_module(
+    m, k, tile_m, m_input, herd_cols, n_cascade, np_dtype_in, np_dtype_out
+):
+    assert (
+        n_cascade >= 2
+    ), f"n_cascade ({n_cascade}) must be >= 2 for a cascade pipeline"
+    k_chunk = k // n_cascade
+    assert (
+        m % (tile_m * herd_cols) == 0
+    ), f"M ({m}) must be divisible by tile_m * herd_cols ({tile_m * herd_cols})"
+    assert (
+        tile_m % m_input == 0
+    ), f"tile_m ({tile_m}) must be divisible by m_input ({m_input})"
+    assert k % n_cascade == 0, f"K ({k}) must be divisible by n_cascade ({n_cascade})"
+    assert (
+        k_chunk % 64 == 0
+    ), f"k_chunk ({k_chunk}) must be divisible by 64 (vector width)"
+
+    bytes_per_elem_in = np.dtype(np_dtype_in).itemsize
+    bytes_per_elem_out = np.dtype(np_dtype_out).itemsize
+    # Per-(col, cascade_row) L2 chunk buffer (m_input * k_chunk bf16),
+    # plus one R buffer per col.
+    ar_l2_chunk_bytes = m_input * k_chunk * bytes_per_elem_in
+    d_l2_bytes = herd_cols * tile_m * bytes_per_elem_out
+    # Per col: 1 R chunk buf + n_cascade A chunk bufs (each m_input*k_chunk).
+    l2_per_col = (1 + n_cascade) * ar_l2_chunk_bytes
+    L2_CAPACITY = 512 * 1024
+    assert herd_cols * l2_per_col + d_l2_bytes <= L2_CAPACITY, (
+        f"L2 capacity exceeded: per-col={l2_per_col}B × {herd_cols} cols "
+        f"+ D={d_l2_bytes}B = {herd_cols * l2_per_col + d_l2_bytes}B "
+        f"> {L2_CAPACITY}B."
+    )
+
+    xrt_dtype_in = type_mapper(np_dtype_in)
+    xrt_dtype_out = type_mapper(np_dtype_out)
+    f32_type = F32Type.get()
+    index_type = IndexType.get()
+
+    # L3 MemRefTypes
+    memrefTyA = MemRefType.get([m, k], xrt_dtype_in)
+    memrefTyB = MemRefType.get([k], xrt_dtype_in)
+    memrefTyR = MemRefType.get([m], xrt_dtype_in)
+    memrefTyD = MemRefType.get([m], xrt_dtype_out)
+
+    # L2 chunk buffers: shape [m_input, k_chunk] (sized for A; R fills
+    # only first m_input cells). Per-fill separate buffers — see segment
+    # body below for the rationale.
+    l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
+    l2MemrefTyARchunk = MemRefType.get(
+        shape=[m_input, k_chunk],
+        element_type=xrt_dtype_in,
+        memory_space=l2_mem_space,
+    )
+    l2MemrefTyD = MemRefType.get(
+        shape=[herd_cols, tile_m],
+        element_type=xrt_dtype_out,
+        memory_space=l2_mem_space,
+    )
+
+    # L1 MemRefTypes
+    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l1MemrefTyA = MemRefType.get(
+        shape=[m_input, k_chunk],
+        element_type=xrt_dtype_in,
+        memory_space=l1_mem_space,
+    )
+    l1MemrefTyB = MemRefType.get(
+        shape=[k_chunk],
+        element_type=xrt_dtype_in,
+        memory_space=l1_mem_space,
+    )
+    l1MemrefTyD = MemRefType.get(
+        shape=[tile_m],
+        element_type=xrt_dtype_out,
+        memory_space=l1_mem_space,
+    )
+    # Per j_m iter, HEAD's L1 R buffer holds m_input elements (one per
+    # output row computed this iter). m_input * sizeof(bf16) must be
+    # ≥ 4 bytes for AIE DMA alignment → m_input ≥ 2 required.
+    assert (
+        m_input * np.dtype(np_dtype_in).itemsize >= 4
+    ), f"m_input ({m_input}) * sizeof({np_dtype_in}) must be ≥ 4 bytes (AIE DMA alignment)"
+    l1MemrefTyR = MemRefType.get(
+        shape=[m_input],
+        element_type=xrt_dtype_in,
+        memory_space=l1_mem_space,
+    )
+    CASCADE_WIDTH = 16
+    cascade_buf_len = max(tile_m, CASCADE_WIDTH)
+    cascade_buf_len = (
+        (cascade_buf_len + CASCADE_WIDTH - 1) // CASCADE_WIDTH
+    ) * CASCADE_WIDTH
+    l1MemrefTyScratch = MemRefType.get(
+        shape=[cascade_buf_len],
+        element_type=f32_type,
+        memory_space=l1_mem_space,
+    )
+
+    # ar_L3toL2: per-col channel from L3.
+    # ar_L2toL1: per-(col, cascade_row) memtile MM2S → compute tile.
+    # R goes to slot (col, n_cascade-1) = HEAD; A_r goes to (col, r).
+    channel_decl("ar_L3toL2", size=[herd_cols])
+    channel_decl("ar_L2toL1", size=[herd_cols, n_cascade])
+    channel_decl(
+        "chan_cascade",
+        size=[herd_cols, n_cascade - 1],
+        channel_type="npu_cascade",
+    )
+
+    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyR, memrefTyD)
+    def matvec_cascade_add_bf16(arg0, arg1, arg2, arg3):
+
+        launch_size = [m // tile_m // herd_cols, 1]
+
+        @launch(operands=[arg0, arg1, arg2, arg3], sizes=launch_size)
+        def launch_body(
+            launch_ivx,
+            launch_ivy,
+            launch_sizex,
+            launch_sizey,
+            l3_a_data,
+            l3_b_data,
+            l3_r_data,
+            l3_d_data,
+        ):
+            # Row offset for this launch iter
+            launch_ivx_map = AffineMap.get(
+                0,
+                1,
+                [
+                    AffineExpr.get_mul(
+                        AffineSymbolExpr.get(0),
+                        AffineConstantExpr.get(tile_m * herd_cols),
+                    )
+                ],
+            )
+            launch_offset_m_l = affine_apply(launch_ivx_map, [launch_ivx])
+
+            # L3-side puts on ar_L3toL2[col]: per j_m iter, R then per-ty A
+            # Order MUST match memtile-side gets in segment body.
+            for col in range(herd_cols):
+                c_col_idx_l = arith.ConstantOp.create_index(col)
+                for j_m_v in range(tile_m // m_input):
+                    add_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_add(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(col * tile_m + j_m_v * m_input),
+                            )
+                        ],
+                    )
+                    r_off = affine_apply(add_map, [launch_offset_m_l])
+                    ChannelPut(
+                        "ar_L3toL2",
+                        l3_r_data,
+                        indices=[c_col_idx_l],
+                        offsets=[r_off],
+                        sizes=[m_input],
+                        strides=[1],
+                    )
+                    # Reverse order so HEAD's K-slice is sent right after R
+                    # (segment-side memtile loop reads in same reverse order).
+                    for ty_v in reversed(range(n_cascade)):
+                        a_off_m = affine_apply(add_map, [launch_offset_m_l])
+                        ChannelPut(
+                            "ar_L3toL2",
+                            l3_a_data,
+                            indices=[c_col_idx_l],
+                            offsets=[a_off_m, ty_v * k_chunk],
+                            sizes=[m_input, k_chunk],
+                            strides=[k, 1],
+                        )
+
+            @segment(
+                name="matvec_cascade_add_seg",
+                operands=[launch_ivx, l3_b_data, l3_d_data],
+            )
+            def segment_body(
+                launch_ivx_s,
+                l3_b_data_s,
+                l3_d_data_s,
+            ):
+                # Per-fill L2 buffers: one R buffer per col + one A buffer
+                # per (col, cascade_row). Required so each S2MM/MM2S BD
+                # pair owns its own L2 buffer; sharing one L2 buffer
+                # across BD pairs with independent lock pairs lets later
+                # fills overwrite the buffer before earlier reads drain.
+                r_l2_bufs = [
+                    AllocOp(l2MemrefTyARchunk, [], []) for _ in range(herd_cols)
+                ]
+                a_l2_bufs = [
+                    [AllocOp(l2MemrefTyARchunk, [], []) for _ in range(n_cascade)]
+                    for _ in range(herd_cols)
+                ]
+                l2_d_data = AllocOp(l2MemrefTyD, [], [])
+
+                # Memtile streaming: R to (col, HEAD), A_r to (col, r).
+                c_head_idx = arith.ConstantOp.create_index(n_cascade - 1)
+                for col in range(herd_cols):
+                    c_col_idx = arith.ConstantOp.create_index(col)
+                    r_l2 = r_l2_bufs[col].result
+                    for j_m_v in range(tile_m // m_input):
+                        # R: GET → r_l2 (separate buffer), PUT → (col, HEAD)
+                        ChannelGet(
+                            "ar_L3toL2",
+                            r_l2,
+                            indices=[c_col_idx],
+                            offsets=[0, 0],
+                            sizes=[1, m_input],
+                            strides=[k_chunk, 1],
+                        )
+                        ChannelPut(
+                            "ar_L2toL1",
+                            r_l2,
+                            indices=[c_col_idx, c_head_idx],
+                            offsets=[0, 0],
+                            sizes=[1, m_input],
+                            strides=[k_chunk, 1],
+                        )
+                        # A per cascade row: GET → its own a_l2 buffer.
+                        # Reverse order keeps HEAD's A adjacent to R in the
+                        # L3-side put stream (compiler pairs adjacent puts).
+                        for ty_v in reversed(range(n_cascade)):
+                            c_ty_idx = arith.ConstantOp.create_index(ty_v)
+                            a_l2 = a_l2_bufs[col][ty_v].result
+                            ChannelGet(
+                                "ar_L3toL2",
+                                a_l2,
+                                indices=[c_col_idx],
+                                offsets=[0, 0],
+                                sizes=[m_input, k_chunk],
+                                strides=[k_chunk, 1],
+                            )
+                            ChannelPut(
+                                "ar_L2toL1",
+                                a_l2,
+                                indices=[c_col_idx, c_ty_idx],
+                                offsets=[0, 0],
+                                sizes=[m_input, k_chunk],
+                                strides=[k_chunk, 1],
+                            )
+
+                # L1 buffers (passed into herd as operands)
+                l1_a_data = AllocOp(l1MemrefTyA, [], [])
+                l1_b_data = AllocOp(l1MemrefTyB, [], [])
+                l1_d_data = AllocOp(l1MemrefTyD, [], [])
+                l1_r_data = AllocOp(l1MemrefTyR, [], [])
+                l1_scratch = AllocOp(l1MemrefTyScratch, [], [])
+                l1_recv = AllocOp(l1MemrefTyScratch, [], [])
+
+                @herd(
+                    name="herd_0",
+                    sizes=[herd_cols, n_cascade],
+                    operands=[
+                        l1_a_data,
+                        l1_b_data,
+                        l1_d_data,
+                        l1_r_data,
+                        l1_scratch,
+                        l1_recv,
+                        l3_b_data_s,
+                        l2_d_data,
+                    ],
+                )
+                def herd_body(
+                    tx,
+                    ty,
+                    sx,
+                    sy,
+                    _l1_a,
+                    _l1_b,
+                    _l1_d,
+                    _l1_r,
+                    _l1_scratch,
+                    _l1_recv,
+                    _l3_b,
+                    _l2_d,
+                ):
+                    c0 = arith.ConstantOp.create_index(0)
+                    c1_idx = arith.ConstantOp.create_index(1)
+                    last_ty = arith.ConstantOp.create_index(n_cascade - 1)
+
+                    # k_offset = ty * k_chunk
+                    ty_k_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(k_chunk),
+                            )
+                        ],
+                    )
+                    k_offset = affine_apply(ty_k_map, [ty])
+
+                    # B (L3->L1) — per-tile k_chunk slice (broadcast within row
+                    # by air-broadcast-detection).
+                    dma_memcpy_nd(
+                        _l1_b,
+                        _l3_b,
+                        src_offsets=[k_offset],
+                        src_sizes=[k_chunk],
+                        src_strides=[1],
+                    )
+
+                    # head_set fires when cascade_row == n_cascade-1.
+                    head_set = IntegerSet.get(
+                        0,
+                        1,
+                        [
+                            AffineSymbolExpr.get(0)
+                            - AffineConstantExpr.get(n_cascade - 1)
+                        ],
+                        [True],
+                    )
+
+                    # Cascade pipeline setup (vector dot product utilities).
+                    f32_vec_size = 16
+                    vecTy_bf16 = VectorType.get([f32_vec_size], xrt_dtype_in)
+                    vecTy_f32 = VectorType.get([f32_vec_size], f32_type)
+                    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+                    read_map_2d = AffineMapAttr.get(
+                        AffineMap.get(2, 0, [AffineExpr.get_dim(1)])
+                    )
+                    cst0_bf16 = arith.ConstantOp(xrt_dtype_in, 0.0)
+                    cst0_f32 = arith.ConstantOp(f32_type, 0.0)
+                    row_out_map = AffineMap.get(
+                        0,
+                        2,
+                        [
+                            AffineExpr.get_add(
+                                AffineSymbolExpr.get(0),
+                                AffineSymbolExpr.get(1),
+                            )
+                        ],
+                    )
+
+                    l1MemrefTyAccTmp = MemRefType.get(
+                        shape=[f32_vec_size],
+                        element_type=f32_type,
+                        memory_space=l1_mem_space,
+                    )
+                    l1_acc_tmp = AllocOp(l1MemrefTyAccTmp, [], [])
+
+                    dot_args = (
+                        _l1_a,
+                        _l1_b,
+                        l1_acc_tmp,
+                        c0,
+                        k_chunk,
+                        f32_vec_size,
+                        vecTy_bf16,
+                        vecTy_f32,
+                        identity_map,
+                        read_map_2d,
+                        cst0_bf16,
+                        cst0_f32,
+                        f32_type,
+                    )
+
+                    # Hot loop: per j_m iter, HEAD receives R + A; other
+                    # cascade tiles just receive A. Cascade pipeline runs
+                    # with R added at HEAD's init accumulator.
+                    for j_m in range_(0, tile_m // m_input):
+                        j_m_map = AffineMap.get(
+                            0,
+                            1,
+                            [
+                                AffineExpr.get_mul(
+                                    AffineSymbolExpr.get(0),
+                                    AffineConstantExpr.get(m_input),
+                                )
+                            ],
+                        )
+                        j_m_offset = affine_apply(j_m_map, [j_m])
+
+                        # R receive: HEAD only, point-to-point
+                        if_head_r = affine.AffineIfOp(head_set, cond_operands=[ty])
+                        with InsertionPoint(if_head_r.then_block):
+                            ChannelGet(
+                                "ar_L2toL1",
+                                _l1_r,
+                                indices=[tx, ty],
+                            )
+                            affine.AffineYieldOp([])
+
+                        # A receive: each tile gets its own
+                        ChannelGet(
+                            "ar_L2toL1",
+                            _l1_a,
+                            indices=[tx, ty],
+                        )
+
+                        # === Cascade compute ===
+                        # HEAD (ty == n_cascade-1): partial = A·B; init acc
+                        # with R; put cascade.
+                        # MIDDLE: get cascade; partial; sum; put cascade.
+                        # TAIL (ty == 0): get cascade; partial; sum; write D.
+                        cmp_first = arith.CmpIOp(arith.CmpIPredicate.eq, ty, last_ty)
+                        if_first = scf.IfOp(cmp_first, has_else=True)
+                        with InsertionPoint(if_first.then_block):
+                            # HEAD: partial + R → scratch → cascade
+                            for row in range_(0, m_input):
+                                partial_sum = compute_partial_dot(row, *dot_args)
+                                sub_r = subview(_l1_r, [row], [1], [1])
+                                r_val_bf16 = memref_load(sub_r, [c0])
+                                r_val_f32 = arith.extf(f32_type, r_val_bf16)
+                                init_acc = arith.addf(partial_sum, r_val_f32)
+                                sub_scratch = subview(_l1_scratch, [row], [1], [1])
+                                memref_store(init_acc, sub_scratch, [c0])
+                                yield_([])
+
+                            prev_ty = arith.SubIOp(ty, c1_idx)
+                            ChannelPut(
+                                "chan_cascade",
+                                _l1_scratch,
+                                indices=[tx, prev_ty],
+                            )
+                            yield_([])
+
+                        with InsertionPoint(if_first.else_block):
+                            # TAIL or MIDDLE
+                            cmp_last = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
+                            if_last = scf.IfOp(cmp_last, has_else=True)
+                            with InsertionPoint(if_last.then_block):
+                                # TAIL: get cascade, add own partial, write D
+                                # (no R add — R was added at HEAD)
+                                ChannelGet(
+                                    "chan_cascade",
+                                    _l1_recv,
+                                    indices=[tx, ty],
+                                )
+
+                                for row in range_(0, m_input):
+                                    partial_sum = compute_partial_dot(row, *dot_args)
+                                    sub_recv = subview(_l1_recv, [row], [1], [1])
+                                    recv_val = memref_load(sub_recv, [c0])
+                                    total_f32 = arith.addf(recv_val, partial_sum)
+                                    total_bf16 = arith.truncf(xrt_dtype_out, total_f32)
+                                    out_idx = affine_apply(
+                                        row_out_map, [j_m_offset, row]
+                                    )
+                                    sub_d_out = subview(_l1_d, [out_idx], [1], [1])
+                                    memref_store(total_bf16, sub_d_out, [c0])
+                                    yield_([])
+
+                                yield_([])
+
+                            with InsertionPoint(if_last.else_block):
+                                # Middle tiles: cascade get → compute → cascade put
+                                ChannelGet(
+                                    "chan_cascade",
+                                    _l1_recv,
+                                    indices=[tx, ty],
+                                )
+
+                                for row in range_(0, m_input):
+                                    partial_sum = compute_partial_dot(row, *dot_args)
+                                    sub_recv = subview(_l1_recv, [row], [1], [1])
+                                    recv_val = memref_load(sub_recv, [c0])
+                                    total = arith.addf(recv_val, partial_sum)
+                                    sub_scratch = subview(_l1_scratch, [row], [1], [1])
+                                    memref_store(total, sub_scratch, [c0])
+                                    yield_([])
+
+                                prev_ty_mid = arith.SubIOp(ty, c1_idx)
+                                ChannelPut(
+                                    "chan_cascade",
+                                    _l1_scratch,
+                                    indices=[tx, prev_ty_mid],
+                                )
+                                yield_([])
+
+                            yield_([])
+
+                        yield_([])
+
+                    # ty=0 tiles write D to L2 (same pattern as matvec_cascade.py)
+                    cmp_writer = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
+                    if_writer = scf.IfOp(cmp_writer)
+                    with InsertionPoint(if_writer.then_block):
+                        dma_memcpy_nd(
+                            _l2_d,
+                            _l1_d,
+                            dst_offsets=[tx, 0],
+                            dst_sizes=[1, tile_m],
+                            dst_strides=[tile_m, 1],
+                            src_offsets=[],
+                            src_sizes=[tile_m],
+                            src_strides=[1],
+                        )
+                        yield_([])
+
+                    DeallocOp(l1_acc_tmp)
+
+                # L2 -> L3: D writeback for this launch slice.
+                launch_ivx_map_s = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_m * herd_cols),
+                        )
+                    ],
+                )
+                launch_offset_m_d = affine_apply(launch_ivx_map_s, [launch_ivx_s])
+                dma_memcpy_nd(
+                    l3_d_data_s,
+                    l2_d_data,
+                    dst_offsets=[launch_offset_m_d],
+                    dst_sizes=[herd_cols * tile_m],
+                    dst_strides=[1],
+                    src_offsets=[0, 0],
+                    src_sizes=[herd_cols, tile_m],
+                    src_strides=[tile_m, 1],
+                )
+
+                for r_l2 in r_l2_bufs:
+                    DeallocOp(r_l2)
+                for col_bufs in a_l2_bufs:
+                    for a_l2 in col_bufs:
+                        DeallocOp(a_l2)
+                DeallocOp(l2_d_data)
+                DeallocOp(l1_a_data)
+                DeallocOp(l1_b_data)
+                DeallocOp(l1_d_data)
+                DeallocOp(l1_r_data)
+                DeallocOp(l1_scratch)
+                DeallocOp(l1_recv)
+
+
+if __name__ == "__main__":
+    M = 2048
+    K = 8192
+    TILE_M = 2
+    M_INPUT = 1
+    HERD_COLS = 8
+    N_CASCADE = 4
+    INPUT_DATATYPE = bfloat16
+    OUTPUT_DATATYPE = bfloat16
+
+    parser = argparse.ArgumentParser(
+        prog="matvec_cascade_add.py",
+        description="Cascade BF16 GEMV with fused residual add: D = A @ B + R",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=M)
+    parser.add_argument("--k", type=int, default=K)
+    parser.add_argument("--tile-m", type=int, default=TILE_M, dest="tile_m")
+    parser.add_argument("--m-input", type=int, default=M_INPUT, dest="m_input")
+    parser.add_argument("--herd-cols", type=int, default=HERD_COLS, dest="herd_cols")
+    parser.add_argument("--n-cascade", type=int, default=N_CASCADE, dest="n_cascade")
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="xclbin",
+        dest="output_format",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-and-run", "compile-and-xclbin"],
+        dest="compile_mode",
+        default="compile-and-run",
+    )
+    parser.add_argument("--debug-ir", action="store_true", dest="debug_ir")
+
+    args = parser.parse_args()
+
+    mlir_module = build_module(
+        args.m,
+        args.k,
+        args.tile_m,
+        args.m_input,
+        args.herd_cols,
+        args.n_cascade,
+        INPUT_DATATYPE,
+        OUTPUT_DATATYPE,
+    )
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    if args.compile_mode == "compile-and-run":
+        np.random.seed(42)
+        input_a = (np.random.randn(args.m, args.k) * 4).astype(INPUT_DATATYPE)
+        input_b = (np.random.randn(args.k) * 4).astype(INPUT_DATATYPE)
+        input_r = (np.random.randn(args.m) * 4).astype(INPUT_DATATYPE)
+        output_d = (
+            np.dot(input_a.astype(np.float32), input_b.astype(np.float32))
+            + input_r.astype(np.float32)
+        ).astype(OUTPUT_DATATYPE)
+
+        runner = XRTRunner(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            # Per-col ar_L3toL2 carries 1 R + n_cascade A puts per launch
+            # iter. Shim DMA limit = 4 BDs queued per channel; tiling=[1,1]
+            # keeps it at (1+n_cascade) ≤ 4 for n_cascade up to 3, and at
+            # n_cascade=4 the BDs fit just within the limit.
+            runtime_loop_tiling_sizes=[1, 1],
+            output_format=args.output_format,
+            instance_name="matvec_cascade_add_bf16",
+            debug_ir=args.debug_ir,
+            use_lock_race_condition_fix=True,
+        )
+        exit(
+            runner.run_test(
+                mlir_module,
+                inputs=[input_a, input_b, input_r],
+                expected_outputs=[output_d],
+                rtol=0.04,
+                atol=1e-3,
+            )
+        )
+
+    elif args.compile_mode == "compile-and-xclbin":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            runtime_loop_tiling_sizes=[1, 1],
+            output_format=args.output_format,
+            use_lock_race_condition_fix=True,
+        )
+        backend.compile(mlir_module)
+        backend.unload()

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_1col_2cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_1col_2cascade_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// RUN: mkdir -p test_add_npu1_1col_2cascade_peano
+// RUN: cd test_add_npu1_1col_2cascade_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_add M=128 K=128 TILE_M=2 M_INPUT=2 HERD_COLS=1 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_1col_2cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_1col_2cascade_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_add_npu1_1col_2cascade_peano
 // RUN: cd test_add_npu1_1col_2cascade_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run_add M=128 K=128 TILE_M=2 M_INPUT=2 HERD_COLS=1 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=128 K=128 TILE_M=2 M_INPUT=1 HERD_COLS=1 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_add_npu1_2col_4cascade_peano
 // RUN: cd test_add_npu1_2col_4cascade_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=1 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu1, peano
 //
-// RUN: mkdir -p test_add_npu1_2col_4cascade
-// RUN: cd test_add_npu1_2col_4cascade
+// RUN: mkdir -p test_add_npu1_2col_4cascade_peano
+// RUN: cd test_add_npu1_2col_4cascade_peano
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_2col_4cascade_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// RUN: mkdir -p test_add_npu1_2col_4cascade
+// RUN: cd test_add_npu1_2col_4cascade
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai_npu1, peano
 //
-// RUN: mkdir -p test_add_npu1_4col_4cascade
-// RUN: cd test_add_npu1_4col_4cascade
+// RUN: mkdir -p test_add_npu1_4col_4cascade_peano
+// RUN: cd test_add_npu1_4col_4cascade_peano
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=4 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_add_npu1_4col_4cascade_peano
 // RUN: cd test_add_npu1_4col_4cascade_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=4 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=1 HERD_COLS=4 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu1_4col_4cascade_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// RUN: mkdir -p test_add_npu1_4col_4cascade
+// RUN: cd test_add_npu1_4col_4cascade
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=4 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_2cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_2cascade_peano.lit
@@ -8,5 +8,5 @@
 // RUN: make -f %S/Makefile clean
 //
 // Correctness: D = A·B + R, M=256, K=512, 2 columns x 2 cascade tiles (n_cascade=2 boundary)
-// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=1 HERD_COLS=2 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_2cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_2cascade_peano.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_add_npu2_2col_2cascade_peano
+// RUN: cd test_add_npu2_2col_2cascade_peano
+// RUN: make -f %S/Makefile clean
+//
+// Correctness: D = A·B + R, M=256, K=512, 2 columns x 2 cascade tiles (n_cascade=2 boundary)
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=2 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_4cascade_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_add_npu2_2col_4cascade_peano
+// RUN: cd test_add_npu2_2col_4cascade_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_2col_4cascade_peano.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_add_npu2_2col_4cascade_peano
 // RUN: cd test_add_npu2_2col_4cascade_peano
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=2 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=256 K=512 TILE_M=4 M_INPUT=1 HERD_COLS=2 N_CASCADE=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
@@ -8,6 +8,6 @@
 // RUN: make -f %S/Makefile clean
 //
 // Correctness: D = A·B + R, M=2048, K=8192, 8 columns x 4 cascade tiles
-// (m_input=2 minimum: m_input=1 makes R per-iter sub-aligned for AIE DMA)
-// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// (M_INPUT=2 minimum: M_INPUT=1 makes R per-iter sub-aligned for AIE DMA)
+// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
@@ -1,0 +1,13 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_add_npu2_8col_4cascade_peano
+// RUN: cd test_add_npu2_8col_4cascade_peano
+// RUN: make -f %S/Makefile clean
+//
+// Correctness: D = A·B + R, M=2048, K=8192, 8 columns x 4 cascade tiles
+// (m_input=2 minimum: m_input=1 makes R per-iter sub-aligned for AIE DMA)
+// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT_ADD=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/run_add_npu2_8col_4cascade_peano.lit
@@ -8,6 +8,5 @@
 // RUN: make -f %S/Makefile clean
 //
 // Correctness: D = A·B + R, M=2048, K=8192, 8 columns x 4 cascade tiles
-// (M_INPUT=2 minimum: M_INPUT=1 makes R per-iter sub-aligned for AIE DMA)
-// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=2 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run_add M=2048 K=8192 TILE_M=2 M_INPUT=1 HERD_COLS=8 N_CASCADE=4 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/test_add.cpp
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/test_add.cpp
@@ -1,0 +1,231 @@
+//===- test_add.cpp ---------------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// XRT profiling harness for fused GEMV + residual add:
+//   D[M] = A[M,K] @ B[K] + R[M]
+//
+
+#include "cxxopts.hpp"
+#include <bits/stdc++.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdfloat>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+using A_DATATYPE = std::bfloat16_t;
+using B_DATATYPE = std::bfloat16_t;
+using R_DATATYPE = std::bfloat16_t;
+using D_DATATYPE = std::bfloat16_t;
+
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>())(
+      "size_m,M", "Matrix rows M (output dimension)",
+      cxxopts::value<int>()->default_value("2048"))(
+      "size_k,K", "Vector size K (reduction dimension)",
+      cxxopts::value<int>()->default_value("8192"));
+}
+
+static inline std::bfloat16_t random_bfloat16_t() {
+  return std::bfloat16_t(4.0 * (float)rand() / (float)(RAND_MAX));
+}
+
+int main(int argc, const char *argv[]) {
+
+  cxxopts::Options options("GEMV+Add BF16 Profiling");
+  cxxopts::ParseResult vm;
+  add_default_options(options);
+  test_utils::parse_options(argc, argv, options, vm);
+  int verbosity = vm["verbosity"].as<int>();
+
+  int M = vm["size_m"].as<int>();
+  int K = vm["size_k"].as<int>();
+
+  int A_VOLUME = M * K;
+  int B_VOLUME = K;
+  int R_VOLUME = M;
+  int D_VOLUME = M;
+
+  int A_SIZE = (A_VOLUME * sizeof(A_DATATYPE));
+  int B_SIZE = (B_VOLUME * sizeof(B_DATATYPE));
+  int R_SIZE = (R_VOLUME * sizeof(R_DATATYPE));
+  int D_SIZE = (D_VOLUME * sizeof(D_DATATYPE));
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel_it = std::find_if(xkernels.begin(), xkernels.end(),
+                                 [Node, verbosity](xrt::xclbin::kernel &k) {
+                                   auto name = k.get_name();
+                                   if (verbosity >= 1) {
+                                     std::cout << "Name: " << name << std::endl;
+                                   }
+                                   return name.rfind(Node, 0) == 0;
+                                 });
+  if (xkernel_it == xkernels.end()) {
+    std::cerr << "Error: kernel '" << Node << "' not found in xclbin '"
+              << vm["xclbin"].as<std::string>() << "'. Available kernels:";
+    for (auto &k : xkernels)
+      std::cerr << "\n  - " << k.get_name();
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
+  }
+  auto xkernel = *xkernel_it;
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  // Kernel signature: (opcode, instr, instr_count, A, B, R, D)
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(uint32_t),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_a =
+      xrt::bo(device, A_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_b =
+      xrt::bo(device, B_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_r =
+      xrt::bo(device, R_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+  auto bo_d =
+      xrt::bo(device, D_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(6));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
+  std::vector<A_DATATYPE> AVec(A_VOLUME);
+  for (int i = 0; i < A_VOLUME; i++) {
+    AVec[i] = random_bfloat16_t();
+  }
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
+
+  B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
+  std::vector<B_DATATYPE> BVec(B_VOLUME);
+  for (int i = 0; i < B_VOLUME; i++) {
+    BVec[i] = random_bfloat16_t();
+  }
+  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
+
+  R_DATATYPE *bufR = bo_r.map<R_DATATYPE *>();
+  std::vector<R_DATATYPE> RVec(R_VOLUME);
+  for (int i = 0; i < R_VOLUME; i++) {
+    RVec[i] = random_bfloat16_t();
+  }
+  memcpy(bufR, RVec.data(), (RVec.size() * sizeof(R_DATATYPE)));
+
+  D_DATATYPE *bufD = bo_d.map<D_DATATYPE *>();
+  std::vector<D_DATATYPE> DVec(D_VOLUME, 0);
+  memcpy(bufD, DVec.data(), (DVec.size() * sizeof(D_DATATYPE)));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(uint32_t));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_r.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_d.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iterations = 20;
+  unsigned n_warmup_iterations = 10;
+  unsigned num_iter = n_iterations + n_warmup_iterations;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+
+  // GEMV+add: D = A·B + R, MACs = 2·M·K (the +R is M scalar adds, ignored).
+  float macs = 2.0 * float(M) * float(K);
+
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+
+    if (verbosity >= 1) {
+      std::cout << "Running Kernel.\n";
+    }
+    auto start = std::chrono::high_resolution_clock::now();
+    unsigned int opcode = 3;
+    auto run = kernel(opcode, bo_instr, instr_v.size(), bo_a, bo_b, bo_r, bo_d);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+    bo_d.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    if (iter < n_warmup_iterations) {
+      continue;
+    }
+
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+  }
+
+  std::cout << std::endl
+            << "GEMV+Add size: M=" << M << ", K=" << K << std::endl;
+
+  std::cout << std::endl
+            << "Avg NPU GEMV+Add time: " << npu_time_total / n_iterations
+            << "us." << std::endl;
+  std::cout << "Avg NPU gflops: "
+            << macs / (1000 * npu_time_total / n_iterations) << std::endl;
+
+  std::cout << std::endl
+            << "Min NPU GEMV+Add time: " << npu_time_min << "us." << std::endl;
+  std::cout << "Max NPU gflops: " << macs / (1000 * npu_time_min) << std::endl;
+
+  std::cout << std::endl
+            << "Max NPU GEMV+Add time: " << npu_time_max << "us." << std::endl;
+  std::cout << "Min NPU gflops: " << macs / (1000 * npu_time_max) << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds `matvec_cascade_add.py` — a variant of `matvec_cascade` that fuses a residual add into the cascade pipeline:

$$D[M] = A[M, K] \cdot B[K] + R[M]$$

R is added at the cascade **HEAD** as the initial accumulator value; the cascade naturally carries `R + Σpartials` south to the TAIL, which writes D. This avoids loading R at the TAIL (which would exceed the per-tile S2MM budget shared with B and A).

## Design notes

**Channels** (per (col, cascade_row) point-to-point):
- `ar_L3toL2[col]`: shim → memtile, sequenced as R then n_cascade A puts per j_m iter
- `ar_L2toL1[col, cascade_row]`: memtile → compute. R goes to slot `(col, n_cascade-1)` (HEAD); A_r goes to `(col, r)`
- `chan_cascade[col, cascade_row]`: cascade-channel reduction (NPU2 cascade hardware)

**Per-fill separate L2 buffers** — non-obvious correctness requirement. Sharing one L2 buffer across multiple S2MM/MM2S BD pairs with **independent** lock pairs allows later fills to overwrite the buffer before earlier reads drain. Each fill therefore targets its own L2 buffer (`r_l2_bufs[col]`, `a_l2_bufs[col][cascade_row]`).

**`m_input ≥ 2` minimum.** R per j_m iter = `m_input` bf16 elements. At `m_input=1` that's 2 bytes, violating AIE DMA's 4-byte alignment.

## Test plan

- [x] `make run_add_8col` (M=2048, K=8192, herd_cols=8, n_cascade=4) — PASSES on NPU2
- [x] LIT test added: `run_add_npu2_8col_4cascade_peano.lit`
- [x] Profile target: `make profile_add_8col` reports ~2.78 ms / 12 GFLOPS

## Files

- `matvec_cascade_add.py` — the fused-add design
- `test_add.cpp` — XRT profiling harness with R input
- `run_add_npu2_8col_4cascade_peano.lit` — full-config correctness test
- `Makefile` — `run_add`, `profile_add`, `run_add_8col`, `profile_add_8col` targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)