### PR TITLE
Enable Windows Wheels for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -27,6 +27,13 @@ concurrency:
   group: ci-build-air-wheels-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+# Keep wheel matrix jobs from failing on transient package-download issues.
+env:
+  PIP_RETRIES: "3"
+  PIP_RESUME_RETRIES: "3"
+  PIP_TIMEOUT: "60"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 jobs:
   check-new-commits:
     name: Check for new commits since last release
@@ -184,6 +191,10 @@ jobs:
           base_image: quay.io/pypa/manylinux_2_34_x86_64:latest
           githubToken: ${{ github.token }}
           env: |
+            PIP_RETRIES: ${{ env.PIP_RETRIES }}
+            PIP_RESUME_RETRIES: ${{ env.PIP_RESUME_RETRIES }}
+            PIP_TIMEOUT: ${{ env.PIP_TIMEOUT }}
+            PIP_DISABLE_PIP_VERSION_CHECK: ${{ env.PIP_DISABLE_PIP_VERSION_CHECK }}
             AIR_WHEEL_VERSION: ${{ (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) && github.ref_name || '""' }}
           run: |
             git config --global --add safe.directory $PWD
@@ -218,7 +229,7 @@ jobs:
             else
               MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/"
             fi
-            
+
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
             pip -q download --no-deps "mlir$NO_RTTI==$VERSION" \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -236,7 +247,7 @@ jobs:
             export WHEELHOUSE_DIR=$PWD/wheelhouse
             export AIR_PROJECT_COMMIT=${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}
             export DATETIME=${{ needs.get-air-project-commit.outputs.DATETIME }}
-            
+
             rm -rf $WHEELHOUSE_DIR/mlir_air*.whl
             rm -rf $WHEELHOUSE_DIR/repaired_wheel/*
 
@@ -278,7 +289,7 @@ jobs:
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
             **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
-            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
+            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.14)
 
             ### Installation
 
@@ -337,8 +348,18 @@ jobs:
 
           - python_version: "3.12"
             ENABLE_RTTI: OFF
-          # Python 3.13+ requires numpy>=2.0 which is incompatible with
-          # our numpy<2.0 pin.  Expand once the pin is lifted.
+
+          - python_version: "3.13"
+            ENABLE_RTTI: ON
+
+          - python_version: "3.13"
+            ENABLE_RTTI: OFF
+
+          - python_version: "3.14"
+            ENABLE_RTTI: ON
+
+          - python_version: "3.14"
+            ENABLE_RTTI: OFF
 
     steps:
       - uses: actions/checkout@v4
@@ -469,7 +490,7 @@ jobs:
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
             **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
-            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.12)
+            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.14)
 
             ### Installation
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,6 +32,13 @@ if(AIE_ENABLE_BINDINGS_PYTHON)
       _mlir_libs/_site_initialize_0.py
   )
 
+  declare_mlir_python_sources(AirPythonSources.Tools
+    ADD_TO_PARENT AirPythonSources
+    ROOT_DIR "${AIR_PYTHON_ROOT_DIR}"
+    SOURCES
+      tools.py
+  )
+
   declare_mlir_python_sources(AirPythonExtensions)
 
   declare_mlir_python_sources(AirPythonSources.Dialects

--- a/python/air/backend/linalg_on_tensors.py
+++ b/python/air/backend/linalg_on_tensors.py
@@ -23,7 +23,7 @@ import air.compiler.util
 # Used to get the paths used to configure aircc
 from air.compiler.aircc.configure import *
 
-import shutil
+from air.tools import resolve_tool
 import subprocess
 
 import ctypes
@@ -187,11 +187,13 @@ class LinalgOnTensorsAirBackend(AirBackend):
             with open("torch.mlir", "w") as f:
                 f.write(str(air_module))
 
-            aircc_exe = shutil.which("aircc")
-            if not aircc_exe:
-                raise RuntimeError("aircc binary not found in PATH")
+            # Invoke the C++ aircc binary. Prefer the tool bundled in the wheel.
+            try:
+                aircc_exe = resolve_tool("aircc")
+            except RuntimeError as exc:
+                raise RuntimeError(str(exc)) from exc
             result = subprocess.run(
-                [aircc_exe] + aircc_options,
+                [str(aircc_exe)] + aircc_options,
                 capture_output=True,
                 text=True,
             )

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -19,6 +19,8 @@ import os
 import shutil
 import subprocess
 
+from air.tools import resolve_tool
+
 from ml_dtypes import bfloat16
 
 # Device name mappings aligned with mlir-aie (hostruntime.py, lit_config_helpers.py)
@@ -356,15 +358,13 @@ class XRTBackend(AirBackend):
             with open("air.mlir", "w") as f:
                 f.write(module_str)
 
-            # Invoke the C++ aircc binary
-            aircc_exe = shutil.which("aircc")
-            if not aircc_exe:
-                raise AirBackendError(
-                    "aircc binary not found in PATH. "
-                    "Ensure mlir-air is installed and aircc is on PATH."
-                )
+            # Invoke the C++ aircc binary. Prefer the tool bundled in the wheel.
+            try:
+                aircc_exe = resolve_tool("aircc")
+            except RuntimeError as exc:
+                raise AirBackendError(str(exc)) from exc
             result = subprocess.run(
-                [aircc_exe] + aircc_options,
+                [str(aircc_exe)] + aircc_options,
                 capture_output=True,
                 text=True,
             )

--- a/python/air/tools.py
+++ b/python/air/tools.py
@@ -1,0 +1,85 @@
+# ./python/air/tools.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Console entry points for MLIR-AIR native tools.
+
+The wheel installs native tool binaries under ``mlir_air/bin``. These wrappers
+make the pip-generated console scripts dispatch to those bundled binaries so a
+plain virtual-environment install can run ``air-opt``, ``air-translate``, and
+``aircc``, and ``air-runner`` without requiring users to manually edit PATH first.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+def _package_root() -> Path:
+    """Return the installed ``mlir_air`` directory that owns this Python package."""
+    # Installed wheel layout: mlir_air/python/air/tools.py
+    return Path(__file__).resolve().parents[2]
+
+
+def _tool_executable_name(tool_name: str) -> str:
+    """Return the platform-specific executable name for an MLIR-AIR tool."""
+    return f"{tool_name}.exe" if os.name == "nt" else tool_name
+
+
+def bundled_tool_path(tool_name: str) -> Path:
+    """Return the expected path to a bundled native tool in the installed wheel."""
+    return _package_root() / "bin" / _tool_executable_name(tool_name)
+
+
+def resolve_tool(tool_name: str) -> Path:
+    """Resolve an MLIR-AIR native tool, preferring the tool bundled in the wheel.
+
+    Installed wheels place native executables under ``mlir_air/bin``. Prefer that
+    package-local binary so Python APIs work from IDEs, notebooks, and other
+    processes that may not have the virtual environment's script directory on
+    PATH. Fall back to PATH for source-tree and developer builds.
+    """
+    bundled_tool = bundled_tool_path(tool_name)
+    if bundled_tool.is_file():
+        return bundled_tool
+
+    executable_name = _tool_executable_name(tool_name)
+    path_tool = shutil.which(executable_name)
+    if path_tool:
+        return Path(path_tool)
+
+    raise RuntimeError(
+        f"MLIR-AIR tool '{tool_name}' was not found at {bundled_tool} or on PATH"
+    )
+
+
+def _run_tool(tool_name: str, argv: Sequence[str] | None = None) -> int:
+    """Run an MLIR-AIR native tool and return its process exit code."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    completed = subprocess.run([str(resolve_tool(tool_name)), *args], check=False)
+    return completed.returncode
+
+
+def air_opt() -> int:
+    """Entry point for the bundled ``air-opt`` binary."""
+    return _run_tool("air-opt")
+
+
+def air_translate() -> int:
+    """Entry point for the bundled ``air-translate`` binary."""
+    return _run_tool("air-translate")
+
+
+def aircc() -> int:
+    """Entry point for the bundled ``aircc`` binary."""
+    return _run_tool("aircc")
+
+
+def air_runner() -> int:
+    """Entry point for the bundled ``air-runner`` binary."""
+    return _run_tool("air-runner")

--- a/utils/mlir_air_wheels/pyproject.toml
+++ b/utils/mlir_air_wheels/pyproject.toml
@@ -23,4 +23,5 @@ build-backend = "setuptools.build_meta"
 [project.scripts]
 air-opt = "air.tools:air_opt"
 air-translate = "air.tools:air_translate"
-aircc = "air.compiler.aircc.main:main"
+aircc = "air.tools:aircc"
+air-runner = "air.tools:air_runner"

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from pprint import pprint
 from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
 from setuptools.command.develop import develop
@@ -201,7 +200,7 @@ class CMakeBuild(build_ext):
         # Add XRT support if available
         if os.getenv("XRT_ROOT"):
             xrt_dir = Path(os.getenv("XRT_ROOT")).absolute()
-            cmake_args.append(f"-DXRT_ROOT={xrt_dir}")
+            cmake_args.append(f"-DXRT_ROOT={_cmake_path(xrt_dir)}")
             cmake_args.append("-DENABLE_RUN_XRT_TESTS=ON")
 
         if shutil.which("ccache"):
@@ -241,7 +240,9 @@ class CMakeBuild(build_ext):
         elif not build_temp.exists():
             build_temp.mkdir(parents=True)
 
-        print("ENV", pprint(os.environ), file=sys.stderr)
+        print(f"cmake source: {_cmake_path(cmake_source_dir)}", file=sys.stderr)
+        print(f"cmake build:  {_cmake_path(build_temp)}", file=sys.stderr)
+        print(f"cmake install:{_cmake_path(install_dir)}", file=sys.stderr)
         print("cmake", " ".join(cmake_args), file=sys.stderr)
 
         subprocess.run(
@@ -300,7 +301,9 @@ def parse_requirements(filename):
     with open(filename) as f:
         lines = f.read().splitlines()
         return [
-            line.strip() for line in lines if line.strip() and not line.startswith("#")
+            line.strip()
+            for line in lines
+            if line.strip() and not line.strip().startswith("#")
         ]
 
 

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.19.5, <2.0
+numpy
 ml_dtypes
 filelock==3.13.1


### PR DESCRIPTION
### Summary

This expands the matrix in the CI/CD workflow to build and distribute Windows wheels for Python 3.13 and 3.14, enabled by unpinning the `numpy` version in the `requirements.txt` file. The package metadata used for the wheel already depends on plain `numpy`, and the Linux wheel jobs for Python 3.13/3.14 build fine with that policy. Pip should automatically resolve the NumPy version for the selected Python interpreters.

Also, while testing, I noticed that the bundled tools were not executable from the command line (at least on Windows) as it appears they were intended to be. So I added a Python wrapper to get those working as well.

### Changes

- Add Windows wheel builds for Python 3.13 and 3.14, matching the Linux wheel matrix.
- Add pip retry/timeout policy to the workflow to prevent the expanded matrix jobs failing due to network errors.
- Remove stale `numpy<2.0` build-time pin from `utils/requirements.txt`.
- Add `air.tools` wrappers for bundled native tools.
- Route `air-opt`, `air-translate`, `aircc`, and `air-runner` console entry points through the bundled tools.

### Testing

Locally tested Windows wheel builds with Python 3.13 for both RTTI modes.

Both wheels built successfully, installed into a clean virtual environment, exposed the expected console entry points, and passed a basic AIR Python import/parse test.