### PR TITLE
[wheels] add air.tools shim so air-opt/air-translate entry points work

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,6 +38,14 @@ if(AIE_ENABLE_BINDINGS_PYTHON)
     ADD_TO_PARENT AirPythonSources
   )
 
+  # Console-script shims that exec the native air-* binaries in the wheel.
+  declare_mlir_python_sources(AirPythonSources.Tools
+    ADD_TO_PARENT AirPythonSources
+    ROOT_DIR "${AIR_PYTHON_ROOT_DIR}"
+    SOURCES
+      tools/__init__.py
+  )
+
   declare_mlir_dialect_python_bindings(
     ADD_TO_PARENT AirPythonSources.Dialects
     ROOT_DIR "${AIR_PYTHON_ROOT_DIR}"

--- a/python/air/tools/__init__.py
+++ b/python/air/tools/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Console-script shims for the native air-* binaries bundled in the wheel.
+
+Pip's ``[project.scripts]`` entry points must reference Python callables.
+These helpers exec the matching native binary out of the wheel's ``bin/``
+directory so commands like ``air-opt`` resolve transparently after a
+``pip install mlir-air``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import NoReturn
+
+__all__ = [
+    "MLIR_AIR_BIN_DIR",
+    "air_opt",
+    "air_translate",
+]
+
+
+# Wheel layout: site-packages/mlir_air/python/air/tools/__init__.py
+# Binaries:     site-packages/mlir_air/bin/<tool>
+MLIR_AIR_BIN_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "bin")
+)
+assert os.path.isdir(
+    MLIR_AIR_BIN_DIR
+), f"MLIR-AIR tools directory does not exist: {MLIR_AIR_BIN_DIR}"
+
+
+def _exec(name: str, *args: str) -> NoReturn:
+    exe = os.path.join(MLIR_AIR_BIN_DIR, name)
+    if sys.platform.startswith("win"):
+        import subprocess
+
+        raise SystemExit(subprocess.call([exe, *args], close_fds=False))
+    os.execl(exe, exe, *args)
+
+
+def air_opt() -> NoReturn:
+    _exec("air-opt", *sys.argv[1:])
+
+
+def air_translate() -> NoReturn:
+    _exec("air-translate", *sys.argv[1:])


### PR DESCRIPTION
## Summary
- The wheel's [pyproject.toml](utils/mlir_air_wheels/pyproject.toml#L24-L27) declares `air-opt = "air.tools:air_opt"` and `air-translate = "air.tools:air_translate"` as `[project.scripts]` entry points, but the `air.tools` module was never created. After `pip install mlir-air` running `air-opt` fails immediately with:
  ```
  ModuleNotFoundError: No module named 'air.tools'
  ```
- Add `python/air/tools/__init__.py`, a small shim that `os.execl`s the matching native binary out of the wheel's bundled `bin/` directory (same pattern as `aie.tools` in mlir-aie).
- Register the file in `python/CMakeLists.txt` via `declare_mlir_python_sources(AirPythonSources.Tools …)` so `cmake --install` copies it into the installed `air/` package, where the wheel picks it up.

`aircc` was already wired to `air.compiler.aircc.main:main` (a real Python entrypoint) so was unaffected.

## Test plan
- [x] `cmake --build . --target install` installs `air/tools/__init__.py` alongside the rest of the `air` package.
- [x] `PYTHONPATH=install/python python3 -c "import sys; sys.argv=['air-opt','--version']; from air.tools import air_opt; air_opt()"` exec's the native binary and prints LLVM version info.
- [ ] Build a wheel via the `buildAIRWheels.yml` workflow and confirm `pip install` + `air-opt --version` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)