### PR TITLE
[air-split-l2-memref] Cap per-launch L3-touching channel endpoints

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1545,9 +1545,9 @@ def AIRSplitL2MemrefForBufferConstraintPass : Pass<"air-split-l2-memref", "func:
     Option<"clNumTilesPerL2Tile", "tiles-per-l2-tile", "unsigned", /*default=*/"4",
            "Number of compute tiles per L2 memory tile. Used to estimate if an air.segment shall allocate to multiple L2 memory tiles, and therefore requires L2 memref splitting.">,
     Option<"clMaxLaunchChannelsMM2S", "max-launch-channels-mm2s", "unsigned", /*default=*/"0",
-           "Per-launch cap on the number of distinct launch-scope channel endpoints in the MM2S direction (puts whose memref operand is an air.launch arg). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
+           "Per-launch cap on the number of distinct launch-scope channel endpoints in the MM2S direction (air.channel.put ops directly under air.launch, i.e. not nested in any air.segment). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
     Option<"clMaxLaunchChannelsS2MM", "max-launch-channels-s2mm", "unsigned", /*default=*/"0",
-           "Per-launch cap on the number of distinct launch-scope channel endpoints in the S2MM direction (gets whose memref operand is an air.launch arg). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
+           "Per-launch cap on the number of distinct launch-scope channel endpoints in the S2MM direction (air.channel.get ops directly under air.launch, i.e. not nested in any air.segment). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
   ];
 }
 

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1134,7 +1134,7 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
           /*default=*/"\"xcvc1902\"",
            "AIE device to target.">,
     ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
-               "Shim dma tiling sizes. Empty defaults to tiling every level by 1.",
+               "Shim dma tiling sizes, tiling shim dma bds into smaller repeating ones",
                "llvm::cl::ZeroOrMore">,
   ];
 }
@@ -1544,6 +1544,10 @@ def AIRSplitL2MemrefForBufferConstraintPass : Pass<"air-split-l2-memref", "func:
   let options = [
     Option<"clNumTilesPerL2Tile", "tiles-per-l2-tile", "unsigned", /*default=*/"4",
            "Number of compute tiles per L2 memory tile. Used to estimate if an air.segment shall allocate to multiple L2 memory tiles, and therefore requires L2 memref splitting.">,
+    Option<"clMaxLaunchChannelsMM2S", "max-launch-channels-mm2s", "unsigned", /*default=*/"0",
+           "Per-launch cap on the number of distinct launch-scope channel endpoints in the MM2S direction (puts whose memref operand is an air.launch arg). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
+    Option<"clMaxLaunchChannelsS2MM", "max-launch-channels-s2mm", "unsigned", /*default=*/"0",
+           "Per-launch cap on the number of distinct launch-scope channel endpoints in the S2MM direction (gets whose memref operand is an air.launch arg). Splits are skipped when they would push the count past this cap. 0 = no cap (legacy behavior).">,
   ];
 }
 

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1134,7 +1134,7 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
           /*default=*/"\"xcvc1902\"",
            "AIE device to target.">,
     ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
-               "Shim dma tiling sizes, tiling shim dma bds into smaller repeating ones",
+               "Shim dma tiling sizes. Empty defaults to tiling every level by 1.",
                "llvm::cl::ZeroOrMore">,
   ];
 }

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2090,6 +2090,53 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
   // the memref being accessed by multiple unique channel puts/gets.
   llvm::DenseMap<memref::AllocOp, memrefSplitInfoTy> targetMemrefsToInfoMap;
 
+  // Launch-level endpoint cap state. Each approved split multiplies the
+  // post-split endpoint count on the single-channel-side symbol. Track those
+  // multipliers across iterations so the cap check sees the cumulative effect
+  // (otherwise N allocs sharing one symbol can each pass an isolated check yet
+  // collectively overflow the cap).
+  // rawLaunchEndpoints[launch][{symRef, isPut}] = distinct launch-level
+  //   (sym, indices) endpoint count in the IR before any splits.
+  // committedFactor[{launch, symRef}] = cumulative multiplier from approved
+  //   splits affecting `symRef` in this launch (defaults to 1).
+  llvm::DenseMap<air::LaunchOp,
+                 llvm::DenseMap<std::pair<StringRef, unsigned>, unsigned>>
+      rawLaunchEndpoints;
+  llvm::DenseMap<std::pair<air::LaunchOp, StringRef>, unsigned> committedFactor;
+  auto getRawLaunchEndpoints = [&rawLaunchEndpoints](air::LaunchOp launch)
+      -> const llvm::DenseMap<std::pair<StringRef, unsigned>, unsigned> & {
+    auto cached = rawLaunchEndpoints.find(launch);
+    if (cached != rawLaunchEndpoints.end())
+      return cached->second;
+    // Per (sym, isPut) bucket: collected SmallVector<Value> indices, deduped
+    // by SSA identity. Same pattern as `push_back_if_unique` used elsewhere
+    // in this file.
+    llvm::DenseMap<std::pair<StringRef, unsigned>,
+                   SmallVector<SmallVector<Value, 4>, 4>>
+        seenIndices;
+    launch.walk([&](air::ChannelInterface ci) {
+      // Launch-level = not nested in any segment within this launch.
+      if (ci->getParentOfType<air::SegmentOp>())
+        return WalkResult::advance();
+      unsigned isPut = isa<air::ChannelPutOp>(ci.getOperation()) ? 1u : 0u;
+      auto key = std::make_pair(ci.getChanName(), isPut);
+      SmallVector<Value, 4> idx(ci.getIndices().begin(), ci.getIndices().end());
+      auto &bucket = seenIndices[key];
+      if (!llvm::is_contained(bucket, idx))
+        bucket.push_back(std::move(idx));
+      return WalkResult::advance();
+    });
+    auto &out = rawLaunchEndpoints[launch];
+    for (auto &kv : seenIndices)
+      out[kv.first] = kv.second.size();
+    return out;
+  };
+  auto effectiveFactor = [&committedFactor](air::LaunchOp launch,
+                                            StringRef sym) -> unsigned {
+    auto it = committedFactor.find({launch, sym});
+    return it == committedFactor.end() ? 1u : it->second;
+  };
+
   // If there is an affine.apply operating on offsets[offsetDim], then
   // log the affine.map.
   auto getAffineMapOnMemrefSplitDim = [](air::ChannelInterface chanOp,
@@ -2188,6 +2235,11 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     // doing so would push the total past the user-supplied cap. The cap
     // expresses the AIR-level budget for launch-arg-touching channels in one
     // launch; backends map it to their own resource (e.g. shim DMAs for AIE).
+    // Track commit (a few lines below) so cumulative splits across allocs
+    // sharing one channel symbol are accounted for.
+    StringRef pendingCommitSym;
+    air::LaunchOp pendingCommitLaunch;
+    unsigned pendingCommitFactor = 1;
     if (clMaxLaunchChannelsMM2S != 0 || clMaxLaunchChannelsS2MM != 0) {
       auto launch = allocOp->getParentOfType<air::LaunchOp>();
       air::ChannelOp singleChan = nullptr;
@@ -2209,54 +2261,42 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
       unsigned cap =
           launchDirIsMM2S ? clMaxLaunchChannelsMM2S : clMaxLaunchChannelsS2MM;
       if (launch && singleChan && cap != 0) {
-        // Canonicalize an endpoint as "channelSym(,constIdx)*". Non-constant
-        // indices fall back to a per-op identity so dynamic-index ops each
-        // count as distinct endpoints.
-        auto endpointKey = [](air::ChannelInterface op) -> std::string {
-          std::string k = op.getChanName().str();
-          for (auto idx : op.getIndices()) {
-            if (auto c = getConstantIntValue(idx))
-              k += ",c" + std::to_string(*c);
-            else
-              k += ",d" + std::to_string(reinterpret_cast<uintptr_t>(
-                              idx.getAsOpaquePointer()));
-          }
-          return k;
-        };
-        llvm::StringSet<> endpointsAll;
-        llvm::StringSet<> endpointsThisChan;
         StringRef singleSym = singleChan.getSymName();
-        launch.walk([&](Operation *op) {
-          air::ChannelInterface ci = dyn_cast<air::ChannelInterface>(op);
-          if (!ci)
-            return WalkResult::advance();
-          // Launch-level = not nested in any segment within this launch.
-          if (op->getParentOfType<air::SegmentOp>())
-            return WalkResult::advance();
-          bool isPut = isa<air::ChannelPutOp>(op);
-          if (isPut != launchDirIsMM2S)
-            return WalkResult::advance();
-          std::string k = endpointKey(ci);
-          endpointsAll.insert(k);
-          if (ci.getChanName() == singleSym)
-            endpointsThisChan.insert(k);
-          return WalkResult::advance();
-        });
+        unsigned launchDirKey = launchDirIsMM2S ? 1u : 0u;
+        const auto &rawEndpoints = getRawLaunchEndpoints(launch);
+        auto thisRawIt = rawEndpoints.find({singleSym, launchDirKey});
+        unsigned thisRaw =
+            thisRawIt == rawEndpoints.end() ? 0u : thisRawIt->second;
         // If the single-channel side has no launch-level ops, splitting it
         // is free at the launch level (e.g. memtile↔compute only). Allow.
-        if (!endpointsThisChan.empty()) {
-          unsigned pre = endpointsAll.size();
-          unsigned postThisChan = tilingFactor * endpointsThisChan.size();
-          unsigned post = pre - endpointsThisChan.size() + postThisChan;
-          if (post > cap) {
-            allocOp->emitRemark(
-                "air-split-l2-memref: skipping split (factor=")
-                << tilingFactor << ") on memref to avoid pushing launch "
+        if (thisRaw > 0) {
+          unsigned currentTotal = 0;
+          for (auto &kv : rawEndpoints)
+            if (kv.first.second == launchDirKey)
+              currentTotal +=
+                  kv.second * effectiveFactor(launch, kv.first.first);
+          unsigned currFactor = effectiveFactor(launch, singleSym);
+          // Splitting a memref reshapes its single-side channel symbol once;
+          // multiple allocs sharing that symbol are tiled in lockstep, so the
+          // symbol's effective multiplier is max(currFactor, tilingFactor),
+          // not a product. Only the delta over what's already committed adds
+          // to the launch-level endpoint count.
+          unsigned newFactor = std::max(currFactor, (unsigned)tilingFactor);
+          unsigned hypTotal = currentTotal + thisRaw * (newFactor - currFactor);
+          if (hypTotal > cap) {
+            allocOp->emitRemark("air-split-l2-memref: skipping split (factor=")
+                << tilingFactor << ") on memref @" << singleSym
+                << " to avoid pushing launch "
                 << (launchDirIsMM2S ? "MM2S" : "S2MM")
-                << " endpoint count from " << pre << " to " << post
+                << " endpoint count from " << currentTotal << " to " << hypTotal
                 << " (cap=" << cap << ")";
             continue;
           }
+          // Plan commit; finalize once the alloc is recorded in the split
+          // plan below.
+          pendingCommitLaunch = launch;
+          pendingCommitSym = singleSym;
+          pendingCommitFactor = newFactor;
         }
       }
     }
@@ -2368,6 +2408,10 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
                                            infoEntryMap};
       }
     }
+    // Commit the planned cap multiplier now that this alloc is recorded.
+    if (pendingCommitLaunch)
+      committedFactor[{pendingCommitLaunch, pendingCommitSym}] =
+          pendingCommitFactor;
   }
   return targetMemrefsToInfoMap;
 }

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2181,6 +2181,86 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
       if (isSplittingChannelPutsOnHerd())
         continue;
 
+    // Launch-level endpoint cap. Splitting tiles the single-channel side from
+    // 1 → tilingFactor instances per memref. When that channel has any
+    // launch-level ops (memref operand is an air.launch arg), tiling multiplies
+    // the per-launch endpoint count for that direction. Skip the split when
+    // doing so would push the total past the user-supplied cap. The cap
+    // expresses the AIR-level budget for launch-arg-touching channels in one
+    // launch; backends map it to their own resource (e.g. shim DMAs for AIE).
+    if (clMaxLaunchChannelsMM2S != 0 || clMaxLaunchChannelsS2MM != 0) {
+      auto launch = allocOp->getParentOfType<air::LaunchOp>();
+      air::ChannelOp singleChan = nullptr;
+      // Single side of the memref → opposite side is what appears on the
+      // channel's launch-level endpoints:
+      //   memref S2MM (gets-into-memref) single → channel puts at launch
+      //                                            → launch MM2S direction
+      //   memref MM2S (puts-from-memref) single → channel gets at launch
+      //                                            → launch S2MM direction
+      bool launchDirIsMM2S = false;
+      if (getChanCount(MM2SChannels) > 1 && getChanCount(S2MMChannels) == 1) {
+        singleChan = S2MMChannels.begin()->first;
+        launchDirIsMM2S = true;
+      } else if (getChanCount(S2MMChannels) > 1 &&
+                 getChanCount(MM2SChannels) == 1) {
+        singleChan = MM2SChannels.begin()->first;
+        launchDirIsMM2S = false;
+      }
+      unsigned cap =
+          launchDirIsMM2S ? clMaxLaunchChannelsMM2S : clMaxLaunchChannelsS2MM;
+      if (launch && singleChan && cap != 0) {
+        // Canonicalize an endpoint as "channelSym(,constIdx)*". Non-constant
+        // indices fall back to a per-op identity so dynamic-index ops each
+        // count as distinct endpoints.
+        auto endpointKey = [](air::ChannelInterface op) -> std::string {
+          std::string k = op.getChanName().str();
+          for (auto idx : op.getIndices()) {
+            if (auto c = getConstantIntValue(idx))
+              k += ",c" + std::to_string(*c);
+            else
+              k += ",d" + std::to_string(reinterpret_cast<uintptr_t>(
+                              idx.getAsOpaquePointer()));
+          }
+          return k;
+        };
+        llvm::StringSet<> endpointsAll;
+        llvm::StringSet<> endpointsThisChan;
+        StringRef singleSym = singleChan.getSymName();
+        launch.walk([&](Operation *op) {
+          air::ChannelInterface ci = dyn_cast<air::ChannelInterface>(op);
+          if (!ci)
+            return WalkResult::advance();
+          // Launch-level = not nested in any segment within this launch.
+          if (op->getParentOfType<air::SegmentOp>())
+            return WalkResult::advance();
+          bool isPut = isa<air::ChannelPutOp>(op);
+          if (isPut != launchDirIsMM2S)
+            return WalkResult::advance();
+          std::string k = endpointKey(ci);
+          endpointsAll.insert(k);
+          if (ci.getChanName() == singleSym)
+            endpointsThisChan.insert(k);
+          return WalkResult::advance();
+        });
+        // If the single-channel side has no launch-level ops, splitting it
+        // is free at the launch level (e.g. memtile↔compute only). Allow.
+        if (!endpointsThisChan.empty()) {
+          unsigned pre = endpointsAll.size();
+          unsigned postThisChan = tilingFactor * endpointsThisChan.size();
+          unsigned post = pre - endpointsThisChan.size() + postThisChan;
+          if (post > cap) {
+            allocOp->emitRemark(
+                "air-split-l2-memref: skipping split (factor=")
+                << tilingFactor << ") on memref to avoid pushing launch "
+                << (launchDirIsMM2S ? "MM2S" : "S2MM")
+                << " endpoint count from " << pre << " to " << post
+                << " (cap=" << cap << ")";
+            continue;
+          }
+        }
+      }
+    }
+
     llvm::MapVector<int, SmallVector<infoEntryTy>> infoEntryMap;
     std::optional<int> splitDimOffset = std::nullopt;
     std::optional<int> splitDimSize = std::nullopt;

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2230,11 +2230,13 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
 
     // Launch-level endpoint cap. Splitting tiles the single-channel side from
     // 1 → tilingFactor instances per memref. When that channel has any
-    // launch-level ops (memref operand is an air.launch arg), tiling multiplies
-    // the per-launch endpoint count for that direction. Skip the split when
-    // doing so would push the total past the user-supplied cap. The cap
-    // expresses the AIR-level budget for launch-arg-touching channels in one
-    // launch; backends map it to their own resource (e.g. shim DMAs for AIE).
+    // launch-level put/get ops (here: ChannelInterface ops directly under
+    // air.launch, i.e. not nested in any air.segment — the structural proxy
+    // used in `getRawLaunchEndpoints`), tiling multiplies the per-launch
+    // endpoint count for that direction. Skip the split when doing so would
+    // push the total past the user-supplied cap. The cap expresses the
+    // AIR-level budget for launch-scope channels in one launch; backends map
+    // it to their own resource (e.g. shim DMAs for AIE).
     // Track commit (a few lines below) so cumulative splits across allocs
     // sharing one channel symbol are accounted for.
     StringRef pendingCommitSym;
@@ -2285,7 +2287,7 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
           unsigned hypTotal = currentTotal + thisRaw * (newFactor - currFactor);
           if (hypTotal > cap) {
             allocOp->emitRemark("air-split-l2-memref: skipping split (factor=")
-                << tilingFactor << ") on memref @" << singleSym
+                << tilingFactor << ") on L2 alloc via channel @" << singleSym
                 << " to avoid pushing launch "
                 << (launchDirIsMM2S ? "MM2S" : "S2MM")
                 << " endpoint count from " << currentTotal << " to " << hypTotal

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
@@ -1,0 +1,93 @@
+//===- air_split_l2_memref_launch_cap.mlir ---------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1 max-launch-channels-mm2s=4 max-launch-channels-s2mm=4" | FileCheck %s
+
+// chan_in [4] has 4 launch-level puts (1/col). Splitting the L2 buf 2x would
+// prepend a 2 to the channel shape, doubling launch-level MM2S endpoint count
+// to 8. With the cap set to 4, the pass must skip the split, leaving chan_in
+// unchanged and the per-col 8x1024 L2 bufs intact.
+
+// CHECK: air.channel @chan_in [4]
+// CHECK-NOT: [2, 4]
+// CHECK-LABEL: func.func @test
+// CHECK: air.channel.put {{.*}} @chan_in[%{{.*}}]
+// CHECK: air.segment
+// CHECK-COUNT-4: memref.alloc() : memref<8x1024xbf16, 1 : i32>
+// CHECK-COUNT-4: air.channel.get {{.*}} @chan_in
+
+#map = affine_map<()[s0] -> (s0 * 32)>
+air.channel @chan_in [4]
+air.channel @chan_out [4, 2]
+func.func @test(%arg0: memref<128x1024xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg1) in (%arg2=%c1) args(%arg3=%arg0) : memref<128x1024xbf16> attributes {id = 1 : i32} {
+    %c0 = arith.constant 0 : index
+    %c1_l = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %c8 = arith.constant 8 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %1 = air.channel.put async @chan_in[%c0] (%arg3[%c0, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 1 : i32} : (memref<128x1024xbf16>)
+    %2 = air.channel.put async @chan_in[%c1_l] (%arg3[%c8, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 2 : i32} : (memref<128x1024xbf16>)
+    %3 = air.channel.put async @chan_in[%c2] (%arg3[%c0, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 3 : i32} : (memref<128x1024xbf16>)
+    %4 = air.channel.put async @chan_in[%c3] (%arg3[%c8, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 4 : i32} : (memref<128x1024xbf16>)
+    %5 = air.segment @seg async {
+      %c0_0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c2_0 = arith.constant 2 : index
+      %c3_0 = arith.constant 3 : index
+      %c8_0 = arith.constant 8 : index
+      %c512 = arith.constant 512 : index
+      %c1024_0 = arith.constant 1024 : index
+      %async_token_a, %a0 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_b, %a1 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_c, %a2 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_d, %a3 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %g0 = air.channel.get async [%async_token_a] @chan_in[%c0_0] (%a0[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %g1 = air.channel.get async [%async_token_b] @chan_in[%c1_0] (%a1[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %g2 = air.channel.get async [%async_token_c] @chan_in[%c2_0] (%a2[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %g3 = air.channel.get async [%async_token_d] @chan_in[%c3_0] (%a3[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %p00 = air.channel.put async [%g0] @chan_out[%c0_0, %c0_0] (%a0[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p01 = air.channel.put async [%g0] @chan_out[%c0_0, %c1_0] (%a0[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p10 = air.channel.put async [%g1] @chan_out[%c1_0, %c0_0] (%a1[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p11 = air.channel.put async [%g1] @chan_out[%c1_0, %c1_0] (%a1[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p20 = air.channel.put async [%g2] @chan_out[%c2_0, %c0_0] (%a2[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p21 = air.channel.put async [%g2] @chan_out[%c2_0, %c1_0] (%a2[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p30 = air.channel.put async [%g3] @chan_out[%c3_0, %c0_0] (%a3[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p31 = air.channel.put async [%g3] @chan_out[%c3_0, %c1_0] (%a3[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %c4_0 = arith.constant 4 : index
+      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) args(%a=%a0, %b=%a1, %c=%a2, %d=%a3) : memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32> {
+        %async_token_h, %r = air.execute -> (memref<8x512xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<8x512xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<8x512xbf16, 2 : i32>
+        }
+        %gh = air.channel.get async [%async_token_h] @chan_out[%tx, %ty] (%r[] [] []) : (memref<8x512xbf16, 2 : i32>)
+        air.herd_terminator
+      }
+      air.segment_terminator
+    }
+    air.launch_terminator
+  }
+  return
+}

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
@@ -5,20 +5,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1 max-launch-channels-mm2s=4 max-launch-channels-s2mm=4" | FileCheck %s
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1 max-launch-channels-mm2s=4 max-launch-channels-s2mm=4" 2>&1 | FileCheck %s
 
 // chan_in [4] has 4 launch-level puts (1/col). Splitting the L2 buf 2x would
 // prepend a 2 to the channel shape, doubling launch-level MM2S endpoint count
-// to 8. With the cap set to 4, the pass must skip the split, leaving chan_in
-// unchanged and the per-col 8x1024 L2 bufs intact.
+// from 4 → 8. With cap=4 set, the pass must emit a skip remark for every
+// candidate alloc and leave chan_in unchanged. The cumulative-tracking logic
+// records committedFactor[chan_in] = max(1, 2) = 2 on the first attempted
+// (skipped) alloc so later allocs sharing chan_in see the same total, not a
+// 2^N inflation. Legacy behavior (cap=0) is covered by air_split_l2_memref.mlir.
 
+// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on memref @chan_in to avoid pushing launch MM2S endpoint count from 4 to 8 (cap=4)
 // CHECK: air.channel @chan_in [4]
-// CHECK-NOT: [2, 4]
+// CHECK-NOT: air.channel @chan_in [2, 4]
 // CHECK-LABEL: func.func @test
-// CHECK: air.channel.put {{.*}} @chan_in[%{{.*}}]
-// CHECK: air.segment
 // CHECK-COUNT-4: memref.alloc() : memref<8x1024xbf16, 1 : i32>
-// CHECK-COUNT-4: air.channel.get {{.*}} @chan_in
 
 #map = affine_map<()[s0] -> (s0 * 32)>
 air.channel @chan_in [4]

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
@@ -10,12 +10,15 @@
 // chan_in [4] has 4 launch-level puts (1/col). Splitting the L2 buf 2x would
 // prepend a 2 to the channel shape, doubling launch-level MM2S endpoint count
 // from 4 → 8. With cap=4 set, the pass must emit a skip remark for every
-// candidate alloc and leave chan_in unchanged. The cumulative-tracking logic
-// records committedFactor[chan_in] = max(1, 2) = 2 on the first attempted
-// (skipped) alloc so later allocs sharing chan_in see the same total, not a
-// 2^N inflation. Legacy behavior (cap=0) is covered by air_split_l2_memref.mlir.
+// candidate alloc and leave chan_in unchanged. Cumulative tracking only
+// commits a factor AFTER an alloc is recorded in the split plan, so skipped
+// allocs do not raise the running total — each of the 4 sharing allocs sees
+// the same pre=4, hypTotal=8 view and is independently rejected. Cumulative
+// tracking matters in the NOSKIP regime: it caps the per-symbol multiplier
+// at max(1, 2) = 2 instead of 2^4. Legacy behavior (cap=0) is covered by
+// air_split_l2_memref.mlir.
 
-// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on memref @chan_in to avoid pushing launch MM2S endpoint count from 4 to 8 (cap=4)
+// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on L2 alloc via channel @chan_in to avoid pushing launch MM2S endpoint count from 4 to 8 (cap=4)
 // CHECK: air.channel @chan_in [4]
 // CHECK-NOT: air.channel @chan_in [2, 4]
 // CHECK-LABEL: func.func @test

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
@@ -13,7 +13,7 @@
 // so the launch S2MM count is 4. Splitting 2× would lift it to 8 > cap=4 and
 // must be rejected via the S2MM-direction branch of the cap check.
 
-// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on memref @chan_out to avoid pushing launch S2MM endpoint count from 4 to 8 (cap=4)
+// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on L2 alloc via channel @chan_out to avoid pushing launch S2MM endpoint count from 4 to 8 (cap=4)
 // CHECK: air.channel @chan_out [4]
 // CHECK-NOT: air.channel @chan_out [2, 4]
 // CHECK-LABEL: func.func @test_s2mm

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
@@ -1,0 +1,90 @@
+//===- air_split_l2_memref_launch_cap_s2mm.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1 max-launch-channels-mm2s=4 max-launch-channels-s2mm=4" 2>&1 | FileCheck %s
+
+// Mirror of the MM2S launch-cap test with directions reversed. The per-col L2
+// allocs have multiple herd-side puts (compute → L2 via chan_in) and a single
+// L3-bound get (L2 → L3 via chan_out). chan_out [4] has 4 launch-level GETS,
+// so the launch S2MM count is 4. Splitting 2× would lift it to 8 > cap=4 and
+// must be rejected via the S2MM-direction branch of the cap check.
+
+// CHECK-COUNT-4: remark: air-split-l2-memref: skipping split (factor=2) on memref @chan_out to avoid pushing launch S2MM endpoint count from 4 to 8 (cap=4)
+// CHECK: air.channel @chan_out [4]
+// CHECK-NOT: air.channel @chan_out [2, 4]
+// CHECK-LABEL: func.func @test_s2mm
+// CHECK-COUNT-4: memref.alloc() : memref<8x1024xbf16, 1 : i32>
+
+air.channel @chan_in [4, 2]
+air.channel @chan_out [4]
+func.func @test_s2mm(%arg0: memref<128x1024xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg1) in (%arg2=%c1) args(%arg3=%arg0) : memref<128x1024xbf16> attributes {id = 1 : i32} {
+    %c0 = arith.constant 0 : index
+    %c1_l = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %c8 = arith.constant 8 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    // 4 launch-level gets on chan_out → S2MM raw endpoints = 4.
+    %g0 = air.channel.get async @chan_out[%c0] (%arg3[%c0, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 1 : i32} : (memref<128x1024xbf16>)
+    %g1 = air.channel.get async @chan_out[%c1_l] (%arg3[%c8, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 2 : i32} : (memref<128x1024xbf16>)
+    %g2 = air.channel.get async @chan_out[%c2] (%arg3[%c0, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 3 : i32} : (memref<128x1024xbf16>)
+    %g3 = air.channel.get async @chan_out[%c3] (%arg3[%c8, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 4 : i32} : (memref<128x1024xbf16>)
+    %5 = air.segment @seg async {
+      %c0_0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c2_0 = arith.constant 2 : index
+      %c3_0 = arith.constant 3 : index
+      %c8_0 = arith.constant 8 : index
+      %c512 = arith.constant 512 : index
+      %c1024_0 = arith.constant 1024 : index
+      %async_token_a, %a0 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_b, %a1 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_c, %a2 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      %async_token_d, %a3 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      // Multiple gets into each L2 alloc from herd-side puts (S2MM side > 1).
+      %p00 = air.channel.get async [%async_token_a] @chan_in[%c0_0, %c0_0] (%a0[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p01 = air.channel.get async [%async_token_a] @chan_in[%c0_0, %c1_0] (%a0[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p10 = air.channel.get async [%async_token_b] @chan_in[%c1_0, %c0_0] (%a1[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p11 = air.channel.get async [%async_token_b] @chan_in[%c1_0, %c1_0] (%a1[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p20 = air.channel.get async [%async_token_c] @chan_in[%c2_0, %c0_0] (%a2[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p21 = air.channel.get async [%async_token_c] @chan_in[%c2_0, %c1_0] (%a2[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p30 = air.channel.get async [%async_token_d] @chan_in[%c3_0, %c0_0] (%a3[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p31 = air.channel.get async [%async_token_d] @chan_in[%c3_0, %c1_0] (%a3[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      // Single put per L2 alloc → chan_out (MM2S side = 1).
+      %op0 = air.channel.put async [%p00, %p01] @chan_out[%c0_0] (%a0[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %op1 = air.channel.put async [%p10, %p11] @chan_out[%c1_0] (%a1[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %op2 = air.channel.put async [%p20, %p21] @chan_out[%c2_0] (%a2[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %op3 = air.channel.put async [%p30, %p31] @chan_out[%c3_0] (%a3[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      %c4_0 = arith.constant 4 : index
+      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) args(%a=%a0) : memref<8x1024xbf16, 1 : i32> {
+        %async_token_h, %r = air.execute -> (memref<8x512xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<8x512xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<8x512xbf16, 2 : i32>
+        }
+        %ph = air.channel.put async [%async_token_h] @chan_in[%tx, %ty] (%r[] [] []) : (memref<8x512xbf16, 2 : i32>)
+        air.herd_terminator
+      }
+      air.segment_terminator
+    }
+    air.launch_terminator
+  }
+  return
+}

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -803,7 +803,7 @@ static LogicalResult runGpuCompilation() {
 //===----------------------------------------------------------------------===//
 
 /// Build the AIR optimization pass pipeline string.
-static std::string buildOptimizationPipeline() {
+static std::string buildOptimizationPipeline(int resolvedNumCols) {
   std::string pipeline;
   raw_string_ostream os(pipeline);
 
@@ -834,24 +834,15 @@ static std::string buildOptimizationPipeline() {
 
   // L2 splitting (skip for npu_1col)
   if (deviceName.getValue().find("npu_1col") == std::string::npos) {
-    // Per-direction launch-arg channel caps. The split pass may multiply the
-    // number of launch-scope (L3-touching) channel endpoints; the AIE backend
-    // can only map up to (num_cols * 2) per direction (2 MM2S + 2 S2MM per
-    // shim col). Pass the cap so the split bails before exceeding it.
-    int splitNumCols = numCols;
-    if (splitNumCols < 0) {
-      if (deviceName.getValue().find("npu1") != std::string::npos)
-        splitNumCols = 4;
-      else if (deviceName.getValue() == "npu2_4col")
-        splitNumCols = 4;
-      else if (deviceName.getValue().find("npu2") != std::string::npos)
-        splitNumCols = 8;
-      else
-        splitNumCols = 0; // 0 → disables the cap (legacy behavior)
-    }
+    // Per-direction launch-arg channel cap. The split pass may multiply the
+    // number of launch-scope (L3-touching) channel endpoints; the AIE shim
+    // budget is (num_cols * 2) per direction (2 MM2S + 2 S2MM per shim col).
+    // resolvedNumCols already encodes per-device defaults; a non-positive
+    // value disables the cap (legacy behavior).
+    unsigned cap = resolvedNumCols > 0 ? unsigned(resolvedNumCols) * 2 : 0;
     os << ",func.func(air-split-l2-memref{"
-       << "max-launch-channels-mm2s=" << splitNumCols * 2 << " "
-       << "max-launch-channels-s2mm=" << splitNumCols * 2 << "})"
+       << "max-launch-channels-mm2s=" << cap << " "
+       << "max-launch-channels-s2mm=" << cap << "})"
        << ",canonicalize,cse";
     os << ",air-isolate-async-dma-loop-nests{scope=launch},canonicalize,cse";
   }
@@ -1016,7 +1007,7 @@ static LogicalResult runAieCompilation() {
 
     // Add optimization passes for NPU targets
     if (deviceName.getValue().find("npu") != std::string::npos) {
-      os << "," << buildOptimizationPipeline();
+      os << "," << buildOptimizationPipeline(resolvedNumCols);
     }
 
     // Place herds

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -834,7 +834,25 @@ static std::string buildOptimizationPipeline() {
 
   // L2 splitting (skip for npu_1col)
   if (deviceName.getValue().find("npu_1col") == std::string::npos) {
-    os << ",func.func(air-split-l2-memref),canonicalize,cse";
+    // Per-direction launch-arg channel caps. The split pass may multiply the
+    // number of launch-scope (L3-touching) channel endpoints; the AIE backend
+    // can only map up to (num_cols * 2) per direction (2 MM2S + 2 S2MM per
+    // shim col). Pass the cap so the split bails before exceeding it.
+    int splitNumCols = numCols;
+    if (splitNumCols < 0) {
+      if (deviceName.getValue().find("npu1") != std::string::npos)
+        splitNumCols = 4;
+      else if (deviceName.getValue() == "npu2_4col")
+        splitNumCols = 4;
+      else if (deviceName.getValue().find("npu2") != std::string::npos)
+        splitNumCols = 8;
+      else
+        splitNumCols = 0; // 0 → disables the cap (legacy behavior)
+    }
+    os << ",func.func(air-split-l2-memref{"
+       << "max-launch-channels-mm2s=" << splitNumCols * 2 << " "
+       << "max-launch-channels-s2mm=" << splitNumCols * 2 << "})"
+       << ",canonicalize,cse";
     os << ",air-isolate-async-dma-loop-nests{scope=launch},canonicalize,cse";
   }
 


### PR DESCRIPTION
## Summary

The `air-split-l2-memref` pass can multiply launch-scope (L3-touching) channel endpoint count when it tiles the single-channel side of a 1-in-N-out L2 memref. Backends mapping launch-arg channels to fixed-budget hardware (e.g. AIE shim: 2 MM2S + 2 S2MM per col) can silently overflow.

Adds two pass options:
- `max-launch-channels-mm2s` (default 0 = no cap, legacy)
- `max-launch-channels-s2mm` (default 0 = no cap, legacy)

Before adding a candidate alloc to the split target map, the pass now computes the post-split distinct `(channel_sym, index_tuple)` endpoint count at the enclosing `air.launch` scope in the relevant direction and skips the split (with a remark) when it would exceed the cap.

`aircc` plumbs per-device defaults: 8 endpoints/dir for `npu1` / `npu2_4col`, 16 for `npu2` (= `num_cols * 2`).

## Why

Concrete repro: a cascade GEMV with K-split per col on a kernel that also broadcasts B on cols 0/1 fails with `'air.channel.put' op failed to map to shim dma channels: out of channels.` In that case `air-split-l2-memref` was splitting the per-col A staging buffer 2× along K, expanding `@ar_L3toL2 [8]` (8 MM2S) into `@channel_X [2, 8]` (16 MM2S). Combined with B's 2 broadcast streams on cols 0/1, post-split per-col demand reached 3 MM2S — over the 2/col budget.

With the new cap, the pass detects that post-split MM2S would jump from 10 → 18 (> 16 cap) and skips the split. The L2 staging stays at the per-col `<8x2048>` shape and launch MM2S demand remains 10. air-to-aie now maps cleanly.

## Test plan
- [x] New lit test `air_split_l2_memref_launch_cap.mlir` covers the skip path (cap=4 + 4-endpoint single-side channel + 1-in-2-out memref → split skipped, channel preserved).
- [x] All existing AIRMiscPasses lit tests still pass (cap defaults to 0 = legacy behavior).
- [x] `ninja check-air-mlir` passes (384/384 tests + 7 XFAIL).
- [x] End-to-end: the cascade GEMV repro that previously failed at air-to-aie now compiles past the split-l2-memref pass on NPU2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)