### PR TITLE
[ci] revert llvm-aie pin now that llvm-aie#1005 has landed

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -79,12 +79,7 @@ jobs:
       - name: Get llvm-aie
         run: |
           source air-venv/bin/activate
-          # TEMPORARY: pin to last known-good nightly while
-          # Xilinx/llvm-aie#1005 (findPrologueEpilogue assert) is in review.
-          # Nightlies from 2026-05-16 onwards crash llc on legitimate
-          # non-pipelined single-MBB loops in 9+ xrt tests. Revert to
-          # unpinned `llvm-aie` once #1005 lands and a new nightly publishes.
-          python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026051501+f4933ef7" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       - name: Build and test mlir-air
         run: |

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -50,11 +50,8 @@ export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${PATH}
 export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
 export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
-# Install llvm-aie. TEMPORARY: pinned to last known-good nightly while
-# Xilinx/llvm-aie#1005 (findPrologueEpilogue assert) is in review.
-# Nightlies from 2026-05-16 onwards crash llc on non-pipelined single-MBB
-# loops. Revert to unpinned `llvm-aie` once #1005 lands.
-python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026051501+f4933ef7" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+# Install llvm-aie
+python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"
 


### PR DESCRIPTION
## Summary

Reverts the temporary pin from #1617. [Xilinx/llvm-aie#1005](https://github.com/Xilinx/llvm-aie/pull/1005) merged 2026-05-19, and the first nightly built after the merge — `llvm-aie==21.0.0.2026052001+5ed15934` — contains the fix.

## Changes

Restores both install sites pinned in #1617 to the unpinned form:

```diff
- python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026051501+f4933ef7" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+ python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
```

- [.github/workflows/buildAndTestRyzenAI.yml](.github/workflows/buildAndTestRyzenAI.yml)
- [utils/build-mlir-air-using-wheels.sh](utils/build-mlir-air-using-wheels.sh)

Stale `TEMPORARY:` comments pointing at llvm-aie#1005 are removed.

## Local verification

Reproduced the CI's `lit --filter peano` setup on NPU Phoenix (npu1) with the new nightly installed. All 9 tests from #1617 pass:

| Test | Time |
|---|---|
| `xrt/02_mul_shim_1x1/run_peano.lit` | 2.14s ✓ |
| `xrt/03_mul_L1L2_1x1/run_peano.lit` | 2.36s ✓ |
| `xrt/06_add_shim_bf16/run_peano.lit` | 0.95s ✓ |
| `xrt/07_extern_linalg/run_npu1_peano.lit` | 3.31s ✓ |
| `xrt/28_gemm_loop_nest_bf16/run_peano.lit` | 13.40s ✓ |
| `xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run_peano.lit` | 18.70s ✓ |
| `xrt/34_cascade_vecadd/run_npu1_peano.lit` | 1.39s ✓ |
| `xrt/36_cascade_vecmat_i32/run_npu1_peano.lit` | 2.27s ✓ |
| `xrt/38_cascade_vecmat_transform_2x4_i32/run_npu1_peano.lit` | 2.17s ✓ |

## Test plan

- [ ] Watch this PR's Ryzen AI checks (npu1 amd8845hs + npu2 amdhx370) for green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)