### PR TITLE
[Transform] Per-launch wait_all fallback + =0 sentinel in air-opt-shim-dma-bds

### DIFF
--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1134,7 +1134,10 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
           /*default=*/"\"xcvc1902\"",
            "AIE device to target.">,
     ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
-               "Shim dma tiling sizes. Empty defaults to tiling every level by 1.",
+               "Shim dma tiling sizes. Empty defaults to tiling every level "
+               "by 1. A single value of 0 (sentinel) disables tiling for all "
+               "launches; loops pass through un-tiled and rely on the "
+               "wrap-stride fold to produce multi-D BD descriptors.",
                "llvm::cl::ZeroOrMore">,
   ];
 }

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1134,10 +1134,8 @@ def AIROptimizeShimDMABDs: Pass<"air-opt-shim-dma-bds", "func::FuncOp"> {
           /*default=*/"\"xcvc1902\"",
            "AIE device to target.">,
     ListOption<"clTileSizes", "shim-dma-tile-sizes", "unsigned",
-               "Shim dma tiling sizes. Empty defaults to tiling every level "
-               "by 1. A single value of 0 (sentinel) disables tiling for all "
-               "launches; loops pass through un-tiled and rely on the "
-               "wrap-stride fold to produce multi-D BD descriptors.",
+               "Shim dma tiling sizes. Empty: tile every level by 1. "
+               "Single value 0: disable tiling (rely on wrap-stride fold).",
                "llvm::cl::ZeroOrMore">,
   ];
 }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6428,19 +6428,15 @@ public:
     IRRewriter rewriter(ctx);
     rewriter.setInsertionPoint(shimFors.front());
 
-    // Sentinel `shim-dma-tile-sizes=0`: globally disable tiling for every
-    // launch. Loops pass through un-tiled and the post-pass wrap-stride
-    // fold collapses them into multi-D BD descriptors. Useful as a kill
-    // switch when the default would over-tile (creating too many BDs).
+    // `=0` sentinel: skip tiling globally; rely on the wrap-stride fold
+    // to produce multi-D BDs. See Passes.td.
     bool tilingDisabled = clTileSizes.size() == 1 && clTileSizes[0] == 0;
 
-    // Empty shim-dma-tile-sizes defaults to tiling every level by 1.
-    // tile=1 is an iteration-count no-op but still invokes
-    // tilePerfectlyNested + the post-tile fixup that downstream lowering
-    // depends on (skipping it exhausts the BD allocator on workloads
-    // like test/xrt/14_conv2d_i8_extern_vec).
+    // Empty defaults to per-level tile=1 below. Even tile=1 must run, as
+    // the post-tile fixup is required by downstream lowering (skipping
+    // exhausts the BD allocator on e.g. test/xrt/14_conv2d_i8_extern_vec).
     SmallVector<Value> optTileSizes;
-    if (!clTileSizes.empty() && !tilingDisabled) {
+    if (!tilingDisabled && !clTileSizes.empty()) {
       optTileSizes = convertVecOfIntToVecOfValue(
           rewriter,
           SmallVector<unsigned>(clTileSizes.begin(), clTileSizes.end()));
@@ -6465,17 +6461,13 @@ public:
       }
       return actualTileSizes;
     };
-    // Tile each shim-dma for loop band.
+    // Tile each shim-dma for loop band. Launches NOT in `tiledLaunches`
+    // need the end-of-launch wait_all fallback further down.
     llvm::SetVector<scf::ForOp> forLoopsToUnroll;
-    // Track launches whose shim fors actually got tiled. Launches that did
-    // not (e.g. those whose shim DMAs sit directly in the launch body
-    // without an enclosing scf.for) still need the end-of-launch wait_all
-    // fallback below, otherwise their DMAs never get tied off and the outer
-    // multi-launch transition can drop in-flight S2MM writes.
     llvm::SetVector<air::LaunchOp> tiledLaunches;
+    if (tilingDisabled)
+      shimFors.clear();
     for (auto forOp : shimFors) {
-      if (tilingDisabled)
-        continue;
       SmallVector<Value> perLoopTileSizes;
       if (!optTileSizes.empty()) {
         perLoopTileSizes = optTileSizes;
@@ -6580,41 +6572,31 @@ public:
     // Apply DMA folding.
     applyAIRL3DmaFoldingPatterns(func, *device);
 
-    // Emit an end-of-block air.wait_all gathering channel tokens for:
-    //   * the func body (only when nothing in the whole module was tiled,
-    //     preserving the original fallback for the no-launch case), and
-    //   * every air.LaunchOp whose shim fors were NOT tiled above.
-    // Without per-launch coverage, a module that mixes tiled and un-tiled
-    // launches gets no wait_all in the un-tiled ones, leaving their DMAs
-    // fire-and-forget across multi-launch transitions.
+    // Fallback end-of-block wait_all: func body when nothing tiled anywhere
+    // (no-launch case), plus every async launch whose shim fors did NOT get
+    // tiled above (avoids fire-and-forget DMAs across launch transitions).
     SmallVector<Block *> blocksToFixup;
     if (forLoopsToUnroll.empty())
       blocksToFixup.push_back(&func.getBody().front());
-    func.walk([&blocksToFixup, &tiledLaunches](air::LaunchOp launch) {
+    func.walk([&](air::LaunchOp launch) {
       if (air::isAsyncOp(launch) && !tiledLaunches.contains(launch))
         blocksToFixup.push_back(&launch.getRegion().front());
     });
-    if (!blocksToFixup.empty()) {
-      for (auto blk : blocksToFixup) {
-        {
-          OpBuilder::InsertionGuard guard(rewriter);
-          SmallVector<Value> chanTokens;
-          for (auto chan : blk->getOps<air::ChannelInterface>())
-            if (air::isAsyncOp(chan))
-              chanTokens.push_back(air::getAsyncTokenFromOp(chan));
+    for (auto blk : blocksToFixup) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      SmallVector<Value> chanTokens;
+      for (auto chan : blk->getOps<air::ChannelInterface>())
+        if (air::isAsyncOp(chan))
+          chanTokens.push_back(air::getAsyncTokenFromOp(chan));
 
-          if (blk->mightHaveTerminator())
-            rewriter.setInsertionPoint(blk->getTerminator());
-          else
-            rewriter.setInsertionPointToEnd(blk);
-          auto launchEndWaitAll =
-              air::WaitAllOp::create(rewriter, rewriter.getUnknownLoc(),
-                                     /*result_type*/ Type(), chanTokens);
-          // Label this wait_all as the end of a launch body so that later
-          // passes can identify it for reconfiguration operations.
-          launchEndWaitAll->setAttr("air.launch_end", rewriter.getUnitAttr());
-        }
-      }
+      if (blk->mightHaveTerminator())
+        rewriter.setInsertionPoint(blk->getTerminator());
+      else
+        rewriter.setInsertionPointToEnd(blk);
+      auto launchEndWaitAll =
+          air::WaitAllOp::create(rewriter, rewriter.getUnknownLoc(),
+                                 /*result_type*/ Type(), chanTokens);
+      launchEndWaitAll->setAttr("air.launch_end", rewriter.getUnitAttr());
     }
   }
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6428,13 +6428,19 @@ public:
     IRRewriter rewriter(ctx);
     rewriter.setInsertionPoint(shimFors.front());
 
+    // Sentinel `shim-dma-tile-sizes=0`: globally disable tiling for every
+    // launch. Loops pass through un-tiled and the post-pass wrap-stride
+    // fold collapses them into multi-D BD descriptors. Useful as a kill
+    // switch when the default would over-tile (creating too many BDs).
+    bool tilingDisabled = clTileSizes.size() == 1 && clTileSizes[0] == 0;
+
     // Empty shim-dma-tile-sizes defaults to tiling every level by 1.
     // tile=1 is an iteration-count no-op but still invokes
     // tilePerfectlyNested + the post-tile fixup that downstream lowering
     // depends on (skipping it exhausts the BD allocator on workloads
     // like test/xrt/14_conv2d_i8_extern_vec).
     SmallVector<Value> optTileSizes;
-    if (!clTileSizes.empty()) {
+    if (!clTileSizes.empty() && !tilingDisabled) {
       optTileSizes = convertVecOfIntToVecOfValue(
           rewriter,
           SmallVector<unsigned>(clTileSizes.begin(), clTileSizes.end()));
@@ -6461,7 +6467,15 @@ public:
     };
     // Tile each shim-dma for loop band.
     llvm::SetVector<scf::ForOp> forLoopsToUnroll;
+    // Track launches whose shim fors actually got tiled. Launches that did
+    // not (e.g. those whose shim DMAs sit directly in the launch body
+    // without an enclosing scf.for) still need the end-of-launch wait_all
+    // fallback below, otherwise their DMAs never get tied off and the outer
+    // multi-launch transition can drop in-flight S2MM writes.
+    llvm::SetVector<air::LaunchOp> tiledLaunches;
     for (auto forOp : shimFors) {
+      if (tilingDisabled)
+        continue;
       SmallVector<Value> perLoopTileSizes;
       if (!optTileSizes.empty()) {
         perLoopTileSizes = optTileSizes;
@@ -6475,6 +6489,8 @@ public:
             rewriter, SmallVector<unsigned>(depth, 1));
       }
       assert(!perLoopTileSizes.empty());
+      if (auto launchOp = forOp->getParentOfType<air::LaunchOp>())
+        tiledLaunches.insert(launchOp);
       SmallVector<Value> actualTileSizes =
           getActualTileSizesPerScfRoot(rewriter, forOp, perLoopTileSizes);
       auto tiledLoops = tilePerfectlyNested(forOp, ArrayRef(actualTileSizes));
@@ -6564,15 +6580,22 @@ public:
     // Apply DMA folding.
     applyAIRL3DmaFoldingPatterns(func, *device);
 
-    if (forLoopsToUnroll.empty()) {
-      // If no loop unrolling was performed, gather all air.channel_put/get
-      // tokens from block, and generate a blocking wait all.
-      SmallVector<Block *> funcAndLaunchBlocks(1, &func.getBody().front());
-      func.walk([&funcAndLaunchBlocks](air::LaunchOp launch) {
-        if (air::isAsyncOp(launch))
-          funcAndLaunchBlocks.push_back(&launch.getRegion().front());
-      });
-      for (auto blk : funcAndLaunchBlocks) {
+    // Emit an end-of-block air.wait_all gathering channel tokens for:
+    //   * the func body (only when nothing in the whole module was tiled,
+    //     preserving the original fallback for the no-launch case), and
+    //   * every air.LaunchOp whose shim fors were NOT tiled above.
+    // Without per-launch coverage, a module that mixes tiled and un-tiled
+    // launches gets no wait_all in the un-tiled ones, leaving their DMAs
+    // fire-and-forget across multi-launch transitions.
+    SmallVector<Block *> blocksToFixup;
+    if (forLoopsToUnroll.empty())
+      blocksToFixup.push_back(&func.getBody().front());
+    func.walk([&blocksToFixup, &tiledLaunches](air::LaunchOp launch) {
+      if (air::isAsyncOp(launch) && !tiledLaunches.contains(launch))
+        blocksToFixup.push_back(&launch.getRegion().front());
+    });
+    if (!blocksToFixup.empty()) {
+      for (auto blk : blocksToFixup) {
         {
           OpBuilder::InsertionGuard guard(rewriter);
           SmallVector<Value> chanTokens;

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6429,8 +6429,16 @@ public:
     rewriter.setInsertionPoint(shimFors.front());
 
     // `=0` sentinel: skip tiling globally; rely on the wrap-stride fold
-    // to produce multi-D BDs. See Passes.td.
+    // to produce multi-D BDs. See Passes.td. Any `0` mixed with other
+    // sizes would hit assert(max > 0) in findLargestFactor below -- reject
+    // explicitly so the user gets a diagnostic instead of an assert.
     bool tilingDisabled = clTileSizes.size() == 1 && clTileSizes[0] == 0;
+    if (!tilingDisabled && llvm::is_contained(clTileSizes, 0u)) {
+      func.emitError("shim-dma-tile-sizes=0 is only valid as a single-value "
+                     "sentinel; got a list containing 0");
+      signalPassFailure();
+      return;
+    }
 
     // Empty defaults to per-level tile=1 below. Even tile=1 must run, as
     // the post-tile fixup is required by downstream lowering (skipping
@@ -6575,6 +6583,9 @@ public:
     // Fallback end-of-block wait_all: func body when nothing tiled anywhere
     // (no-launch case), plus every async launch whose shim fors did NOT get
     // tiled above (avoids fire-and-forget DMAs across launch transitions).
+    // Use generateWaitAllToTerminateBlock so we gather ALL dangling async
+    // tokens in the block, not just channel ops directly at block scope --
+    // tokens produced by surviving scf.for loops would otherwise be missed.
     SmallVector<Block *> blocksToFixup;
     if (forLoopsToUnroll.empty())
       blocksToFixup.push_back(&func.getBody().front());
@@ -6584,18 +6595,8 @@ public:
     });
     for (auto blk : blocksToFixup) {
       OpBuilder::InsertionGuard guard(rewriter);
-      SmallVector<Value> chanTokens;
-      for (auto chan : blk->getOps<air::ChannelInterface>())
-        if (air::isAsyncOp(chan))
-          chanTokens.push_back(air::getAsyncTokenFromOp(chan));
-
-      if (blk->mightHaveTerminator())
-        rewriter.setInsertionPoint(blk->getTerminator());
-      else
-        rewriter.setInsertionPointToEnd(blk);
-      auto launchEndWaitAll =
-          air::WaitAllOp::create(rewriter, rewriter.getUnknownLoc(),
-                                 /*result_type*/ Type(), chanTokens);
+      auto launchEndWaitAll = air::generateWaitAllToTerminateBlock(
+          *blk, rewriter, /*isBlocking=*/true);
       launchEndWaitAll->setAttr("air.launch_end", rewriter.getUnitAttr());
     }
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
@@ -8,12 +8,17 @@
 // Per-launch coverage of the `air.launch_end` wait_all fallback in
 // `air-opt-shim-dma-bds`. Each async launch must end with EXACTLY ONE such
 // wait_all, whether it came from the tiling fixup (tiled path) or from the
-// end-of-block fallback (sentinel / no-for path).
+// end-of-block fallback (sentinel / no-for path). Positive CHECKs require
+// the wait_all to carry at least one operand (`[%...]`); a regression to
+// the old empty-operand fallback would fail them.
 
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1 shim-dma-tile-sizes=0" \
 // RUN:   | FileCheck %s --check-prefix=SENTINEL
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1" \
 // RUN:   | FileCheck %s --check-prefix=DEFAULT
+// RUN: not air-opt %s -air-opt-shim-dma-bds="device=npu1 shim-dma-tile-sizes=0,1" \
+// RUN:   2>&1 | FileCheck %s --check-prefix=REJECT
+// REJECT: shim-dma-tile-sizes=0 is only valid as a single-value sentinel
 
 module {
 
@@ -24,12 +29,12 @@ module {
 
   // SENTINEL-LABEL: func.func @sentinel_two_launches
   // SENTINEL:       air.launch
-  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
   // SENTINEL:       air.launch
-  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
-  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
   // SENTINEL:       return
   func.func @sentinel_two_launches(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
@@ -68,10 +73,10 @@ module {
 
   // DEFAULT-LABEL: func.func @mixed_tiled_and_no_for
   // DEFAULT:       air.launch
-  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
   // DEFAULT:       air.launch
-  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
   // DEFAULT:       return
   func.func @mixed_tiled_and_no_for(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
@@ -106,7 +111,7 @@ module {
 
   // DEFAULT-LABEL: func.func @tiled_only_no_double_launch_end
   // DEFAULT:       air.launch
-  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       air.wait_all{{.*\[%[^]]+\].*}}{air.launch_end}
   // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
   // DEFAULT:       return
   func.func @tiled_only_no_double_launch_end(%arg0: memref<512x512xbf16>) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
@@ -5,29 +5,35 @@
 //
 //===----------------------------------------------------------------------===//
 
-// `air-opt-shim-dma-bds` must emit an end-of-launch `air.wait_all` carrying
-// `air.launch_end` in EVERY async launch that did not get its shim DMA for
-// loops tiled. The legacy fallback only ran when *no* launch in the module
-// was tiled, which left un-tiled launches in mixed modules without a
-// wait_all -- their DMAs were fire-and-forget across multi-launch
-// transitions.
-//
-// The `shim-dma-tile-sizes=0` sentinel forces skip-tiling globally and is
-// the easiest way to exercise the per-launch fallback path.
+// Per-launch coverage of the `air.launch_end` wait_all fallback in
+// `air-opt-shim-dma-bds`. Each async launch must end with EXACTLY ONE such
+// wait_all, whether it came from the tiling fixup (tiled path) or from the
+// end-of-block fallback (sentinel / no-for path).
 
 // RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1 shim-dma-tile-sizes=0" \
-// RUN:   | FileCheck %s
+// RUN:   | FileCheck %s --check-prefix=SENTINEL
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1" \
+// RUN:   | FileCheck %s --check-prefix=DEFAULT
 
 module {
 
-  // Two async launches in one func. Both contain shim scf.for loops with
-  // air.channel.put/get; both must be skipped under sentinel=0 and both
-  // must end up with an `air.wait_all` annotated `air.launch_end`.
+  // Sentinel `=0` skips tiling for every launch. Each of the two launches
+  // gets a `launch_end` from the per-launch fallback; the func body also
+  // gets one (preserved from the original `forLoopsToUnroll.empty()`
+  // path). Three total, no more.
 
-  // CHECK-LABEL: func.func @mixed_launches
-  func.func @mixed_launches(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
+  // SENTINEL-LABEL: func.func @sentinel_two_launches
+  // SENTINEL:       air.launch
+  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       air.launch
+  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // SENTINEL:       return
+  func.func @sentinel_two_launches(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
     %c1 = arith.constant 1 : index
-    // CHECK: air.launch
     %0 = air.launch async (%tx) in (%sx=%c1) args(%buf=%arg0) : memref<512x512xbf16> {
       %c0 = arith.constant 0 : index
       %c1_0 = arith.constant 1 : index
@@ -39,9 +45,7 @@ module {
         %3 = air.channel.put async [%tok]  @channel_0[%c0, %c0] (%buf[%c0, %i] [%c256, %c64] [%c512, %c1_0]) {id = 1 : i32} : (memref<512x512xbf16>)
         scf.yield %3 : !air.async.token
       }
-      // CHECK: air.wait_all{{.*}}{air.launch_end}
     }
-    // CHECK: air.launch
     %4 = air.launch async [%0] (%ty) in (%sy=%c1) args(%buf2=%arg1) : memref<512x512xbf16> {
       %c0 = arith.constant 0 : index
       %c1_0 = arith.constant 1 : index
@@ -53,7 +57,71 @@ module {
         %7 = air.channel.get async [%tok2]  @channel_1[%c0, %c0] (%buf2[%c0, %j] [%c256, %c64] [%c512, %c1_0]) {id = 2 : i32} : (memref<512x512xbf16>)
         scf.yield %7 : !air.async.token
       }
-      // CHECK: air.wait_all{{.*}}{air.launch_end}
+    }
+    return
+  }
+
+  // Mixed: launch A has a shim scf.for (gets tiled under default tile=1, so
+  // the launch_end wait_all comes from the tiling fixup). Launch B has only
+  // direct channel ops (no scf.for at shim), so it falls through to the
+  // per-launch fallback. Each must still end up with exactly one launch_end.
+
+  // DEFAULT-LABEL: func.func @mixed_tiled_and_no_for
+  // DEFAULT:       air.launch
+  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       air.launch
+  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       return
+  func.func @mixed_tiled_and_no_for(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx) in (%sx=%c1) args(%buf=%arg0) : memref<512x512xbf16> {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %c256 = arith.constant 256 : index
+      %c512 = arith.constant 512 : index
+      %1 = air.wait_all async
+      %2 = scf.for %i = %c0 to %c512 step %c256 iter_args(%tok = %1) -> (!air.async.token) {
+        %3 = air.channel.put async [%tok]  @channel_0[%c0, %c0] (%buf[%c0, %i] [%c256, %c64] [%c512, %c1_0]) {id = 1 : i32} : (memref<512x512xbf16>)
+        scf.yield %3 : !air.async.token
+      }
+    }
+    %4 = air.launch async [%0] (%ty) in (%sy=%c1) args(%buf2=%arg1) : memref<512x512xbf16> {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %c512 = arith.constant 512 : index
+      %5 = air.channel.get async @channel_1[%c0, %c0] (%buf2[%c0, %c0] [%c512, %c512] [%c512, %c1_0]) {id = 2 : i32} : (memref<512x512xbf16>)
+    }
+    return
+  }
+
+  // Tiled-only sanity check: under default tile=1, the single launch's shim
+  // scf.for goes through the tiling fixup, which inserts the launch_end
+  // wait_all. The per-launch fallback MUST skip this launch, so the count
+  // stays at one (a regression that re-added the fallback unconditionally
+  // would produce two).
+
+  // DEFAULT-LABEL: func.func @tiled_only_no_double_launch_end
+  // DEFAULT:       air.launch
+  // DEFAULT:       air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT-NOT:   air.wait_all{{.*}}{air.launch_end}
+  // DEFAULT:       return
+  func.func @tiled_only_no_double_launch_end(%arg0: memref<512x512xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx) in (%sx=%c1) args(%buf=%arg0) : memref<512x512xbf16> {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %c256 = arith.constant 256 : index
+      %c512 = arith.constant 512 : index
+      %1 = air.wait_all async
+      %2 = scf.for %i = %c0 to %c512 step %c256 iter_args(%tok = %1) -> (!air.async.token) {
+        %3 = air.channel.put async [%tok]  @channel_0[%c0, %c0] (%buf[%c0, %i] [%c256, %c64] [%c512, %c1_0]) {id = 1 : i32} : (memref<512x512xbf16>)
+        scf.yield %3 : !air.async.token
+      }
     }
     return
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_shim_dma_bds_per_launch_wait_all.mlir
@@ -1,0 +1,60 @@
+//===- opt_shim_dma_bds_per_launch_wait_all.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// `air-opt-shim-dma-bds` must emit an end-of-launch `air.wait_all` carrying
+// `air.launch_end` in EVERY async launch that did not get its shim DMA for
+// loops tiled. The legacy fallback only ran when *no* launch in the module
+// was tiled, which left un-tiled launches in mixed modules without a
+// wait_all -- their DMAs were fire-and-forget across multi-launch
+// transitions.
+//
+// The `shim-dma-tile-sizes=0` sentinel forces skip-tiling globally and is
+// the easiest way to exercise the per-launch fallback path.
+
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1 shim-dma-tile-sizes=0" \
+// RUN:   | FileCheck %s
+
+module {
+
+  // Two async launches in one func. Both contain shim scf.for loops with
+  // air.channel.put/get; both must be skipped under sentinel=0 and both
+  // must end up with an `air.wait_all` annotated `air.launch_end`.
+
+  // CHECK-LABEL: func.func @mixed_launches
+  func.func @mixed_launches(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) {
+    %c1 = arith.constant 1 : index
+    // CHECK: air.launch
+    %0 = air.launch async (%tx) in (%sx=%c1) args(%buf=%arg0) : memref<512x512xbf16> {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %c256 = arith.constant 256 : index
+      %c512 = arith.constant 512 : index
+      %1 = air.wait_all async
+      %2 = scf.for %i = %c0 to %c512 step %c256 iter_args(%tok = %1) -> (!air.async.token) {
+        %3 = air.channel.put async [%tok]  @channel_0[%c0, %c0] (%buf[%c0, %i] [%c256, %c64] [%c512, %c1_0]) {id = 1 : i32} : (memref<512x512xbf16>)
+        scf.yield %3 : !air.async.token
+      }
+      // CHECK: air.wait_all{{.*}}{air.launch_end}
+    }
+    // CHECK: air.launch
+    %4 = air.launch async [%0] (%ty) in (%sy=%c1) args(%buf2=%arg1) : memref<512x512xbf16> {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %c256 = arith.constant 256 : index
+      %c512 = arith.constant 512 : index
+      %5 = air.wait_all async
+      %6 = scf.for %j = %c0 to %c512 step %c256 iter_args(%tok2 = %5) -> (!air.async.token) {
+        %7 = air.channel.get async [%tok2]  @channel_1[%c0, %c0] (%buf2[%c0, %j] [%c256, %c64] [%c512, %c1_0]) {id = 2 : i32} : (memref<512x512xbf16>)
+        scf.yield %7 : !air.async.token
+      }
+      // CHECK: air.wait_all{{.*}}{air.launch_end}
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

Refactor the post-tile wait_all fallback in `air-opt-shim-dma-bds` so it
runs **per `air.LaunchOp`** instead of all-or-nothing across the whole
module. Previously the fallback was gated on `forLoopsToUnroll.empty()`,
meaning any module that mixed launches with and without tiled shim DMA
fors left the un-tiled launches without an end-of-launch `air.wait_all`.

In multi-launch designs (output format = ELF on NPU2), the lightweight
reset device between launches can transition before in-flight S2MM
writes drain, dropping their data. This patch tracks the set of
launches whose shim fors actually went through `tilePerfectlyNested`
and emits the `air.launch_end`-tagged wait_all in every other async
launch.

To make the new per-launch path testable, this patch also adds a
`shim-dma-tile-sizes=0` **global sentinel** that disables tiling for
all launches (loops pass through un-tiled, rely on the wrap-stride
fold to produce multi-D BD descriptors). Useful as a kill switch when
the default would over-tile, and as a bisect lever.

## Test plan

- [x] New lit test `opt_shim_dma_bds_per_launch_wait_all.mlir` —
  two-launch module compiled with `--shim-dma-tile-sizes=0` must emit
  an `air.launch_end` wait_all in each launch body. Test crashes on
  unpatched main (tile-by-0 hits the largest-factor assert), passes
  with this PR.
- [x] Full `mlir/test/Transform/AIRDependencyScheduleOpt/` (25 tests):
  all pass.

## Follow-ups (separate PRs)

This is the first of a 3-PR series that progressively makes shim DMA
tiling opt-in per launch. Next two PRs add:
1. Per-launch `air.shim_dma_tile_sizes` IR attribute so each
   `air.launch` can carry its own tile preference.
2. Revert of #1616 (the empty-default auto-fill that doubled NPU time
   for non-cascade multi-launch ELFs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)