### PR TITLE
[AIRToAIE] Distribute mem_bank across extern-kernel call args

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -61,6 +61,11 @@ generateBufferNameInStringStream(StringRef prefix, uint64_t &BufferId,
                                  mlir::StringAttr attr = nullptr, int x = -1,
                                  int y = -1);
 
+// Walks a Value back to its underlying AIE::BufferOp through chains of
+// view-like ops (subview, expand/collapse_shape, reinterpret_cast) and
+// memref.cast. Returns nullptr if the chain doesn't terminate at a BufferOp.
+AIE::BufferOp getUnderlyingBufferOp(mlir::Value buffer);
+
 AIE::ExternalBufferOp allocateExternalBufferOp(uint64_t &BufferId,
                                                MemRefType memrefTy,
                                                AIE::DeviceOp device,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2055,7 +2055,12 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
         if (!bo || !air::isL1(cast<BaseMemRefType>(bo.getType())))
           continue;
         auto size = getBufferByteSize(bo);
-        if (!size || *size > bankSize)
+        // Match the budget check in the main pinning loop. A buffer above
+        // the per-bank pin budget will never actually be pinned, so don't
+        // mark it pinnable here or the unpinned-big-buffer count below
+        // will under-report and over-aggressive pins will starve the
+        // allocator.
+        if (!size || *size > bankPinBudget)
           continue;
         localArgs.push_back(bo);
       }
@@ -2070,19 +2075,36 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
     // available memory" (e.g. xrt/26_vecmat_i8 has two 16KB unpinned
     // operands; xrt/18_matmul has one).
     unsigned needFullBanks = 0;
+    uint64_t totalL1Demand = 0;
     device.walk([&](AIE::BufferOp bo) {
       if (bo.getTileOp() != tile)
         return;
-      if (pinnableSet.count(bo))
-        return;
       if (!air::isL1(cast<BaseMemRefType>(bo.getType())))
+        return;
+      auto size = getBufferByteSize(bo);
+      if (!size)
+        return;
+      totalL1Demand += *size;
+      if (pinnableSet.count(bo))
         return;
       if (bo.getMemBank().has_value())
         return;
-      auto size = getBufferByteSize(bo);
-      if (size && *size >= bankSize / 2)
+      // A buffer spans ceil(size / bankSize) banks (e.g. a 36KB buffer on a
+      // 16KB-bank tile needs 3 banks). Anything ≥ bankSize/2 also benefits
+      // from a full bank to itself, so count that as 1.
+      if (*size >= bankSize)
+        needFullBanks += (*size + bankSize - 1) / bankSize;
+      else if (*size >= bankSize / 2)
         ++needFullBanks;
     });
+
+    // If the tile is highly loaded (≥ 75% of L1 capacity), pinning anything
+    // risks fragmenting the layout enough that the downstream allocator
+    // can't fit the remaining unpinned buffers. Skip pinning entirely on
+    // pressured tiles (e.g. flash_attention/dataflow_based tile_2_2 with
+    // ~14 buffers totalling ~50KB out of 64KB).
+    if (totalL1Demand * 4 >= targetModel.getLocalMemorySize() * 3)
+      continue;
     unsigned maxBanksToTouch =
         numBanks > needFullBanks ? numBanks - needFullBanks : 0;
     // Even when there are no big unpinned buffers, keep at least one bank

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1986,74 +1986,73 @@ private:
   std::map<AIE::BufferOp, AIE::TileOp> &bufferToMemtileMap;
 };
 
-void allocL1Buffers(AIE::DeviceOp m, uint64_t &BufferId) {
-  auto ctx = m->getContext();
-  RewritePatternSet patterns(ctx);
-  patterns.insert<AllocL1BuffersPattern>(ctx, BufferId);
-  // AllocL1TensorsPattern
-  (void)applyPatternsGreedily(m, std::move(patterns));
-}
-
-// Chase a Value back to its underlying AIE::BufferOp through view-like ops
-// (subview, collapse_shape, expand_shape, reinterpret_cast, cast).
-static AIE::BufferOp findUnderlyingBufferOp(Value v) {
-  Value cur = v;
-  while (cur) {
-    if (auto bo = cur.getDefiningOp<AIE::BufferOp>())
-      return bo;
-    if (auto viewOp = cur.getDefiningOp<ViewLikeOpInterface>()) {
-      cur = viewOp.getViewSource();
-      continue;
-    }
-    return nullptr;
-  }
-  return nullptr;
+// Byte size of a memref-typed BufferOp; nullopt if the element type has no
+// static bitwidth.
+static std::optional<uint64_t> getBufferByteSize(AIE::BufferOp bo) {
+  auto memrefTy = dyn_cast<MemRefType>(bo.getType());
+  if (!memrefTy || !memrefTy.hasStaticShape())
+    return std::nullopt;
+  auto elemTy = memrefTy.getElementType();
+  if (!elemTy.isIntOrFloat())
+    return std::nullopt;
+  return (uint64_t)memrefTy.getNumElements() * elemTy.getIntOrFloatBitWidth() /
+         8;
 }
 
 // Distribute mem_bank assignments on L1 BufferOps so that buffers passed as
-// different positional arguments of the same extern (link_with) kernel call
-// land in different memory banks. Without this, the downstream
-// aie-assign-buffer-addresses pass can place all arguments of a kernel call
-// in the same bank, causing AIE2P bank arbitration to serialize the kernel's
-// parallel vector loads (e.g., matvec reading A and B simultaneously). The
-// "No memory bank assigned" Peano warning on such kernels is symptomatic of
-// this — bank contention can cause the kernel to stall or hang at runtime.
-//
-// Algorithm: for each core, walk extern kernel calls in program order.
-// Greedy-assign banks to each call's memref args so all args of any one
-// call sit on distinct banks (cycling through the 4 L1 banks of AIE2P). A
-// buffer reused across calls keeps its first assignment. Existing
-// (upstream-set) mem_bank attrs are preserved.
+// different positional arguments of the same extern ("link_with") kernel call
+// land in different memory banks, avoiding bank-arbitration stalls on parallel
+// vector loads (e.g. matvec reading A and B simultaneously) that the downstream
+// aie-assign-buffer-addresses pass otherwise allows. Only buffers that fit in
+// a single bank are pinned — over-bank-sized buffers must remain free for the
+// downstream allocator to spread across banks (pinning them produces "would
+// override existing mem_bank" failures). Existing mem_bank attrs and buffer
+// reuse across calls are preserved. AIE1 has no per-tile bank model the AIR
+// pass can reason about, so this is gated on AIE2/AIE2p.
 void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
-  // AIE2/AIE2P compute tile L1 has 4 banks of 16KB each.
-  const int kMaxBanks = 4;
-  MLIRContext *ctx = device.getContext();
-  auto i32Ty = IntegerType::get(ctx, 32);
+  const auto &targetModel = device.getTargetModel();
+  auto arch = targetModel.getTargetArch();
+  if (arch != AIE::AIEArch::AIE2 && arch != AIE::AIEArch::AIE2p)
+    return;
+
+  auto i32Ty = IntegerType::get(device.getContext(), 32);
 
   for (auto core : device.getOps<AIE::CoreOp>()) {
-    // Per-buffer bank assignment for this core (stable across calls).
-    DenseMap<AIE::BufferOp, int> bufBank;
+    AIE::TileOp tile = core.getTileOp();
+    unsigned numBanks = targetModel.getNumBanks(tile.getCol(), tile.getRow());
+    if (numBanks < 2)
+      continue;
+    uint64_t bankSize = targetModel.getLocalMemorySize() / numBanks;
+
+    // MapVector keeps insertion order so the writeback below is deterministic.
+    llvm::MapVector<AIE::BufferOp, int> bufBank;
 
     core.walk([&](func::CallOp callOp) {
-      auto callee =
-          dyn_cast_or_null<func::FuncOp>(SymbolTable::lookupNearestSymbolFrom(
-              callOp, callOp.getCalleeAttr()));
+      auto callee = dyn_cast_or_null<func::FuncOp>(
+          SymbolTable::lookupNearestSymbolFrom(callOp, callOp.getCalleeAttr()));
       if (!callee || !callee->hasAttr("link_with"))
         return;
 
-      // Collect underlying BufferOps for the call's memref operands.
       SmallVector<AIE::BufferOp> args;
       for (Value operand : callOp.getOperands()) {
         if (!isa<MemRefType>(operand.getType()))
           continue;
-        if (auto bo = findUnderlyingBufferOp(operand))
-          args.push_back(bo);
+        auto bo = air::getUnderlyingBufferOp(operand);
+        if (!bo)
+          continue;
+        // mem_bank is meaningful only for tile-local (L1) buffers.
+        if (!air::isL1(cast<BaseMemRefType>(bo.getType())))
+          continue;
+        // Pinning a buffer larger than a single bank is unsatisfiable; leave
+        // it free for the downstream allocator to spread across banks.
+        auto size = getBufferByteSize(bo);
+        if (!size || *size > bankSize)
+          continue;
+        args.push_back(bo);
       }
       if (args.size() < 2)
         return;
 
-      // Banks already taken by this call's args (either from a prior call
-      // or from an upstream-set attribute).
       llvm::SmallSet<int, 4> taken;
       for (auto bo : args) {
         auto it = bufBank.find(bo);
@@ -2063,40 +2062,53 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
           taken.insert(*existing);
       }
 
-      // Assign banks to args not yet pinned, picking the smallest bank
-      // not yet used by another arg of this same call.
+      // The constraint can't be satisfied if a single call has more memref
+      // args than the tile has banks; warn once and fall through to a true
+      // round-robin so we at least spread the overflow.
+      if (args.size() > numBanks)
+        core.emitWarning()
+            << "extern kernel call to '" << callee.getName() << "' has "
+            << args.size() << " memref args but only " << numBanks
+            << " L1 banks are available; bank contention is unavoidable";
+
+      unsigned rrIdx = 0;
       for (auto bo : args) {
         if (bufBank.count(bo))
           continue;
-        if (bo.getMemBank().has_value()) {
-          bufBank[bo] = *bo.getMemBank();
+        if (auto existing = bo.getMemBank()) {
+          bufBank[bo] = *existing;
           continue;
         }
         int chosen = -1;
-        for (int b = 0; b < kMaxBanks; ++b) {
+        for (unsigned b = 0; b < numBanks; ++b) {
           if (!taken.count(b)) {
             chosen = b;
             break;
           }
         }
-        // If the call has more memref args than available banks, fall back
-        // to round-robin from 0 (constraint can't be satisfied with 4 banks).
         if (chosen < 0)
-          chosen = 0;
+          chosen = rrIdx++ % numBanks;
         bufBank[bo] = chosen;
         taken.insert(chosen);
       }
     });
 
-    // Apply the chosen banks back to BufferOps.
     for (auto &kv : bufBank) {
       AIE::BufferOp bo = kv.first;
-      int bank = kv.second;
       if (bo.getMemBank().has_value())
         continue;
-      bo.setMemBankAttr(IntegerAttr::get(i32Ty, bank));
+      bo.setMemBankAttr(IntegerAttr::get(i32Ty, kv.second));
     }
   }
+}
+
+void allocL1Buffers(AIE::DeviceOp m, uint64_t &BufferId) {
+  auto ctx = m->getContext();
+  RewritePatternSet patterns(ctx);
+  patterns.insert<AllocL1BuffersPattern>(ctx, BufferId);
+  // AllocL1TensorsPattern
+  (void)applyPatternsGreedily(m, std::move(patterns));
+  assignBanksForExternKernelCalls(m);
 }
 
 bool areReferencedByTheSameAIRChannel(Value memref_a, Value memref_b) {
@@ -3086,7 +3098,6 @@ public:
       allocL1Buffers(device, BufferId);
       allocL2Buffers(device, bufferToMemtileMap, BufferId);
     }
-    assignBanksForExternKernelCalls(device);
     if (stopAfter == PipelineStage::AfterAllocBuffers)
       return success();
 
@@ -6576,7 +6587,6 @@ public:
           return;
         }
         allocL1Buffers(device, BufferId);
-        assignBanksForExternKernelCalls(device);
       } else {
         cloneL2AndL3MemcpysToDeviceOp(
             builder, device, module, /*clone_l2*/ true, /*clone_l3*/ true,
@@ -6593,7 +6603,6 @@ public:
         specializeL2MemrefsIntoMemtiles(device);
         allocL1Buffers(device, BufferId);
         allocL2Buffers(device, bufferToMemtileMap, BufferId);
-        assignBanksForExternKernelCalls(device);
         air::renumberMemcpyIfOps(&device.getRegion(),
                                  chan_renumber_reverse_map);
         if (failed(lowerAIRMemcpyOp<air::ChannelInterface>(device, shimDmaAlloc,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -13,6 +13,7 @@
 #include "air/Transform/AIRDependencyScheduleOpt.h"
 #include "air/Util/Dependency.h"
 #include "air/Util/Util.h"
+#include <limits>
 #include <numeric>
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
@@ -2003,12 +2004,19 @@ static std::optional<uint64_t> getBufferByteSize(AIE::BufferOp bo) {
 // different positional arguments of the same extern ("link_with") kernel call
 // land in different memory banks, avoiding bank-arbitration stalls on parallel
 // vector loads (e.g. matvec reading A and B simultaneously) that the downstream
-// aie-assign-buffer-addresses pass otherwise allows. Only buffers that fit in
-// a single bank are pinned — over-bank-sized buffers must remain free for the
-// downstream allocator to spread across banks (pinning them produces "would
-// override existing mem_bank" failures). Existing mem_bank attrs and buffer
-// reuse across calls are preserved. AIE1 has no per-tile bank model the AIR
-// pass can reason about, so this is gated on AIE2/AIE2p.
+// aie-assign-buffer-addresses pass otherwise allows.
+//
+// Bin-packing rules per tile:
+//   * Buffers larger than one bank are never pinned (the AIE allocator must
+//     remain free to spread them across banks).
+//   * Each bank's pinned load is capped to leave headroom for unpinned and
+//     pre-allocated buffers (stack, rtp, etc.); skip the pin if it would
+//     exceed the cap.
+//   * Among permitted banks, pick the least-loaded one to balance across the
+//     tile. Distinct args of the same call must land in distinct banks.
+//   * Existing mem_bank attrs and buffer reuse across calls are preserved.
+//
+// Gated on AIE2/AIE2p; AIE1's memory model isn't modeled here.
 void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
   const auto &targetModel = device.getTargetModel();
   auto arch = targetModel.getTargetArch();
@@ -2023,9 +2031,15 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
     if (numBanks < 2)
       continue;
     uint64_t bankSize = targetModel.getLocalMemorySize() / numBanks;
+    // Leave 1/4 of each bank free for unpinned buffers and stack/rtp the
+    // downstream allocator will place after us. Without headroom, our pins
+    // can force "would override existing mem_bank" failures when the
+    // allocator can't fit the remaining buffers anywhere.
+    uint64_t bankPinBudget = bankSize - bankSize / 4;
 
     // MapVector keeps insertion order so the writeback below is deterministic.
     llvm::MapVector<AIE::BufferOp, int> bufBank;
+    SmallVector<uint64_t> bankLoad(numBanks, 0);
 
     core.walk([&](func::CallOp callOp) {
       auto callee = dyn_cast_or_null<func::FuncOp>(
@@ -2033,63 +2047,59 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
       if (!callee || !callee->hasAttr("link_with"))
         return;
 
-      SmallVector<AIE::BufferOp> args;
+      SmallVector<std::pair<AIE::BufferOp, uint64_t>> args;
       for (Value operand : callOp.getOperands()) {
         if (!isa<MemRefType>(operand.getType()))
           continue;
         auto bo = air::getUnderlyingBufferOp(operand);
         if (!bo)
           continue;
-        // mem_bank is meaningful only for tile-local (L1) buffers.
         if (!air::isL1(cast<BaseMemRefType>(bo.getType())))
           continue;
-        // Pinning a buffer larger than a single bank is unsatisfiable; leave
-        // it free for the downstream allocator to spread across banks.
         auto size = getBufferByteSize(bo);
         if (!size || *size > bankSize)
           continue;
-        args.push_back(bo);
+        args.emplace_back(bo, *size);
       }
       if (args.size() < 2)
         return;
 
-      llvm::SmallSet<int, 4> taken;
-      for (auto bo : args) {
-        auto it = bufBank.find(bo);
-        if (it != bufBank.end())
-          taken.insert(it->second);
+      // Banks consumed by args already pinned (this call or earlier calls).
+      llvm::SmallSet<int, 4> takenThisCall;
+      for (auto &[bo, _] : args) {
+        if (auto it = bufBank.find(bo); it != bufBank.end())
+          takenThisCall.insert(it->second);
         else if (auto existing = bo.getMemBank())
-          taken.insert(*existing);
+          takenThisCall.insert(*existing);
       }
 
-      // The constraint can't be satisfied if a single call has more memref
-      // args than the tile has banks; warn once and fall through to a true
-      // round-robin so we at least spread the overflow.
-      if (args.size() > numBanks)
-        core.emitWarning()
-            << "extern kernel call to '" << callee.getName() << "' has "
-            << args.size() << " memref args but only " << numBanks
-            << " L1 banks are available; bank contention is unavoidable";
-
-      unsigned rrIdx = 0;
-      for (auto bo : args) {
+      for (auto &[bo, size] : args) {
         if (bufBank.count(bo))
           continue;
         if (auto existing = bo.getMemBank()) {
           bufBank[bo] = *existing;
           continue;
         }
+        // Choose the least-loaded bank that still has room and isn't taken
+        // by another arg of this same call.
         int chosen = -1;
+        uint64_t minLoad = std::numeric_limits<uint64_t>::max();
         for (unsigned b = 0; b < numBanks; ++b) {
-          if (!taken.count(b)) {
+          if (takenThisCall.count(b))
+            continue;
+          if (bankLoad[b] + size > bankPinBudget)
+            continue;
+          if (bankLoad[b] < minLoad) {
+            minLoad = bankLoad[b];
             chosen = b;
-            break;
           }
         }
         if (chosen < 0)
-          chosen = rrIdx++ % numBanks;
+          continue; // can't pin without violating the budget; let allocator
+                    // decide
         bufBank[bo] = chosen;
-        taken.insert(chosen);
+        bankLoad[chosen] += size;
+        takenThisCall.insert(chosen);
       }
     });
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1994,6 +1994,111 @@ void allocL1Buffers(AIE::DeviceOp m, uint64_t &BufferId) {
   (void)applyPatternsGreedily(m, std::move(patterns));
 }
 
+// Chase a Value back to its underlying AIE::BufferOp through view-like ops
+// (subview, collapse_shape, expand_shape, reinterpret_cast, cast).
+static AIE::BufferOp findUnderlyingBufferOp(Value v) {
+  Value cur = v;
+  while (cur) {
+    if (auto bo = cur.getDefiningOp<AIE::BufferOp>())
+      return bo;
+    if (auto viewOp = cur.getDefiningOp<ViewLikeOpInterface>()) {
+      cur = viewOp.getViewSource();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+// Distribute mem_bank assignments on L1 BufferOps so that buffers passed as
+// different positional arguments of the same extern (link_with) kernel call
+// land in different memory banks. Without this, the downstream
+// aie-assign-buffer-addresses pass can place all arguments of a kernel call
+// in the same bank, causing AIE2P bank arbitration to serialize the kernel's
+// parallel vector loads (e.g., matvec reading A and B simultaneously). The
+// "No memory bank assigned" Peano warning on such kernels is symptomatic of
+// this — bank contention can cause the kernel to stall or hang at runtime.
+//
+// Algorithm: for each core, walk extern kernel calls in program order.
+// Greedy-assign banks to each call's memref args so all args of any one
+// call sit on distinct banks (cycling through the 4 L1 banks of AIE2P). A
+// buffer reused across calls keeps its first assignment. Existing
+// (upstream-set) mem_bank attrs are preserved.
+void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
+  // AIE2/AIE2P compute tile L1 has 4 banks of 16KB each.
+  const int kMaxBanks = 4;
+  MLIRContext *ctx = device.getContext();
+  auto i32Ty = IntegerType::get(ctx, 32);
+
+  for (auto core : device.getOps<AIE::CoreOp>()) {
+    // Per-buffer bank assignment for this core (stable across calls).
+    DenseMap<AIE::BufferOp, int> bufBank;
+
+    core.walk([&](func::CallOp callOp) {
+      auto callee =
+          dyn_cast_or_null<func::FuncOp>(SymbolTable::lookupNearestSymbolFrom(
+              callOp, callOp.getCalleeAttr()));
+      if (!callee || !callee->hasAttr("link_with"))
+        return;
+
+      // Collect underlying BufferOps for the call's memref operands.
+      SmallVector<AIE::BufferOp> args;
+      for (Value operand : callOp.getOperands()) {
+        if (!isa<MemRefType>(operand.getType()))
+          continue;
+        if (auto bo = findUnderlyingBufferOp(operand))
+          args.push_back(bo);
+      }
+      if (args.size() < 2)
+        return;
+
+      // Banks already taken by this call's args (either from a prior call
+      // or from an upstream-set attribute).
+      llvm::SmallSet<int, 4> taken;
+      for (auto bo : args) {
+        auto it = bufBank.find(bo);
+        if (it != bufBank.end())
+          taken.insert(it->second);
+        else if (auto existing = bo.getMemBank())
+          taken.insert(*existing);
+      }
+
+      // Assign banks to args not yet pinned, picking the smallest bank
+      // not yet used by another arg of this same call.
+      for (auto bo : args) {
+        if (bufBank.count(bo))
+          continue;
+        if (bo.getMemBank().has_value()) {
+          bufBank[bo] = *bo.getMemBank();
+          continue;
+        }
+        int chosen = -1;
+        for (int b = 0; b < kMaxBanks; ++b) {
+          if (!taken.count(b)) {
+            chosen = b;
+            break;
+          }
+        }
+        // If the call has more memref args than available banks, fall back
+        // to round-robin from 0 (constraint can't be satisfied with 4 banks).
+        if (chosen < 0)
+          chosen = 0;
+        bufBank[bo] = chosen;
+        taken.insert(chosen);
+      }
+    });
+
+    // Apply the chosen banks back to BufferOps.
+    for (auto &kv : bufBank) {
+      AIE::BufferOp bo = kv.first;
+      int bank = kv.second;
+      if (bo.getMemBank().has_value())
+        continue;
+      bo.setMemBankAttr(IntegerAttr::get(i32Ty, bank));
+    }
+  }
+}
+
 bool areReferencedByTheSameAIRChannel(Value memref_a, Value memref_b) {
   for (auto user_a : memref_a.getUsers()) {
     for (auto user_b : memref_b.getUsers()) {
@@ -2981,6 +3086,7 @@ public:
       allocL1Buffers(device, BufferId);
       allocL2Buffers(device, bufferToMemtileMap, BufferId);
     }
+    assignBanksForExternKernelCalls(device);
     if (stopAfter == PipelineStage::AfterAllocBuffers)
       return success();
 
@@ -6470,6 +6576,7 @@ public:
           return;
         }
         allocL1Buffers(device, BufferId);
+        assignBanksForExternKernelCalls(device);
       } else {
         cloneL2AndL3MemcpysToDeviceOp(
             builder, device, module, /*clone_l2*/ true, /*clone_l3*/ true,
@@ -6486,6 +6593,7 @@ public:
         specializeL2MemrefsIntoMemtiles(device);
         allocL1Buffers(device, BufferId);
         allocL2Buffers(device, bufferToMemtileMap, BufferId);
+        assignBanksForExternKernelCalls(device);
         air::renumberMemcpyIfOps(&device.getRegion(),
                                  chan_renumber_reverse_map);
         if (failed(lowerAIRMemcpyOp<air::ChannelInterface>(device, shimDmaAlloc,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2036,11 +2036,61 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
     // can force "would override existing mem_bank" failures when the
     // allocator can't fit the remaining buffers anywhere.
     uint64_t bankPinBudget = bankSize - bankSize / 4;
-    // Always keep at least one bank entirely untouched so the downstream
-    // allocator has room for a full-bank-sized unpinned buffer (e.g. a 16KB
-    // output tile). Without this, tiles that mix a few small pinnable args
-    // with one large unpinned operand hit "exceeded available memory".
-    unsigned maxBanksToTouch = numBanks - 1;
+
+    // Pre-scan: identify the buffers we *would* consider pinning (memref
+    // operands of any link_with call with ≥ 2 such args, fitting in a
+    // single bank). Everything else on the tile is unpinned and competes
+    // for bank room with our pins.
+    llvm::DenseSet<AIE::BufferOp> pinnableSet;
+    core.walk([&](func::CallOp callOp) {
+      auto callee = dyn_cast_or_null<func::FuncOp>(
+          SymbolTable::lookupNearestSymbolFrom(callOp, callOp.getCalleeAttr()));
+      if (!callee || !callee->hasAttr("link_with"))
+        return;
+      SmallVector<AIE::BufferOp> localArgs;
+      for (Value operand : callOp.getOperands()) {
+        if (!isa<MemRefType>(operand.getType()))
+          continue;
+        auto bo = air::getUnderlyingBufferOp(operand);
+        if (!bo || !air::isL1(cast<BaseMemRefType>(bo.getType())))
+          continue;
+        auto size = getBufferByteSize(bo);
+        if (!size || *size > bankSize)
+          continue;
+        localArgs.push_back(bo);
+      }
+      if (localArgs.size() >= 2)
+        for (auto bo : localArgs)
+          pinnableSet.insert(bo);
+    });
+
+    // Reserve one full bank per unpinned L1 buffer ≥ bankSize/2. Those
+    // need a near-full bank to themselves; if our pins fragment every
+    // bank, they have nowhere to go and the allocator hits "exceeded
+    // available memory" (e.g. xrt/26_vecmat_i8 has two 16KB unpinned
+    // operands; xrt/18_matmul has one).
+    unsigned needFullBanks = 0;
+    device.walk([&](AIE::BufferOp bo) {
+      if (bo.getTileOp() != tile)
+        return;
+      if (pinnableSet.count(bo))
+        return;
+      if (!air::isL1(cast<BaseMemRefType>(bo.getType())))
+        return;
+      if (bo.getMemBank().has_value())
+        return;
+      auto size = getBufferByteSize(bo);
+      if (size && *size >= bankSize / 2)
+        ++needFullBanks;
+    });
+    unsigned maxBanksToTouch =
+        numBanks > needFullBanks ? numBanks - needFullBanks : 0;
+    // Even when there are no big unpinned buffers, keep at least one bank
+    // untouched as a safety margin for stack + small unpinned buffers.
+    if (maxBanksToTouch >= numBanks)
+      maxBanksToTouch = numBanks - 1;
+    if (maxBanksToTouch == 0)
+      continue;
 
     // MapVector keeps insertion order so the writeback below is deterministic.
     llvm::MapVector<AIE::BufferOp, int> bufBank;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2036,10 +2036,16 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
     // can force "would override existing mem_bank" failures when the
     // allocator can't fit the remaining buffers anywhere.
     uint64_t bankPinBudget = bankSize - bankSize / 4;
+    // Always keep at least one bank entirely untouched so the downstream
+    // allocator has room for a full-bank-sized unpinned buffer (e.g. a 16KB
+    // output tile). Without this, tiles that mix a few small pinnable args
+    // with one large unpinned operand hit "exceeded available memory".
+    unsigned maxBanksToTouch = numBanks - 1;
 
     // MapVector keeps insertion order so the writeback below is deterministic.
     llvm::MapVector<AIE::BufferOp, int> bufBank;
     SmallVector<uint64_t> bankLoad(numBanks, 0);
+    llvm::SmallSet<int, 4> touchedBanks;
 
     core.walk([&](func::CallOp callOp) {
       auto callee = dyn_cast_or_null<func::FuncOp>(
@@ -2078,10 +2084,12 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
           continue;
         if (auto existing = bo.getMemBank()) {
           bufBank[bo] = *existing;
+          touchedBanks.insert(*existing);
           continue;
         }
         // Choose the least-loaded bank that still has room and isn't taken
-        // by another arg of this same call.
+        // by another arg of this same call. Don't touch a brand-new bank if
+        // doing so would leave zero banks untouched.
         int chosen = -1;
         uint64_t minLoad = std::numeric_limits<uint64_t>::max();
         for (unsigned b = 0; b < numBanks; ++b) {
@@ -2089,16 +2097,18 @@ void assignBanksForExternKernelCalls(AIE::DeviceOp device) {
             continue;
           if (bankLoad[b] + size > bankPinBudget)
             continue;
+          if (!touchedBanks.count(b) && touchedBanks.size() >= maxBanksToTouch)
+            continue;
           if (bankLoad[b] < minLoad) {
             minLoad = bankLoad[b];
             chosen = b;
           }
         }
         if (chosen < 0)
-          continue; // can't pin without violating the budget; let allocator
-                    // decide
+          continue; // can't pin safely; let the allocator decide
         bufBank[bo] = chosen;
         bankLoad[chosen] += size;
+        touchedBanks.insert(chosen);
         takenThisCall.insert(chosen);
       }
     });

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -570,25 +570,24 @@ air::getLockValuePair(const AIE::AIETargetModel &targetModel,
                         unique_write_buffers.size());
 }
 
-// Helper function that tries to retrieve the underlying AIE::BufferOp by
-// unwrapping common memref wrappers (cast or subview)
-AIE::BufferOp getUnderlyingBufferOp(Value buffer) {
-  // Case 1: Directly defined by an AIE::BufferOp
-  if (auto bufferOp = buffer.getDefiningOp<AIE::BufferOp>())
-    return bufferOp;
-
-  // Case 2: Defined by a cast (e.g., memref.cast)
-  if (auto castOp = buffer.getDefiningOp<CastOpInterface>())
-    if (auto innerBuffer = castOp->getOperand(0).getDefiningOp<AIE::BufferOp>())
-      return innerBuffer;
-
-  // Case 3: Defined by a view-like op (e.g., memref.subview)
-  if (auto viewLikeOp = buffer.getDefiningOp<ViewLikeOpInterface>())
-    if (auto innerBuffer =
-            viewLikeOp->getOperand(0).getDefiningOp<AIE::BufferOp>())
-      return innerBuffer;
-
-  // No underlying BufferOp found
+// Walk a Value back to its underlying AIE::BufferOp through chains of
+// view-like (subview, expand/collapse_shape, reinterpret_cast) and cast
+// (memref.cast) ops. Returns nullptr if the chain doesn't terminate at a
+// BufferOp.
+AIE::BufferOp air::getUnderlyingBufferOp(Value buffer) {
+  while (buffer) {
+    if (auto bufferOp = buffer.getDefiningOp<AIE::BufferOp>())
+      return bufferOp;
+    if (auto viewLikeOp = buffer.getDefiningOp<ViewLikeOpInterface>()) {
+      buffer = viewLikeOp.getViewSource();
+      continue;
+    }
+    if (auto castOp = buffer.getDefiningOp<CastOpInterface>()) {
+      buffer = castOp->getOperand(0);
+      continue;
+    }
+    return nullptr;
+  }
   return nullptr;
 }
 
@@ -997,7 +996,7 @@ air::TileDMAAllocator::getBuffer(uint64_t, AIE::TileOp tile,
     return failure();
   Value buffer =
       isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
-  auto bufferOp = getUnderlyingBufferOp(buffer);
+  auto bufferOp = air::getUnderlyingBufferOp(buffer);
   if (!bufferOp)
     return failure();
   return bufferOp;
@@ -1354,7 +1353,7 @@ air::MemTileDMAAllocator::getBuffer(uint64_t, AIE::TileOp,
     return failure();
   Value buffer =
       isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
-  auto bufferOp = getUnderlyingBufferOp(buffer);
+  auto bufferOp = air::getUnderlyingBufferOp(buffer);
   if (!bufferOp)
     return failure();
   return bufferOp;
@@ -1452,7 +1451,7 @@ air::CascadeAllocator::getBuffer(uint64_t, AIE::TileOp,
       isInbound.value() ? (memcpyOp.getDstMemref()) : (memcpyOp.getSrcMemref());
 
   // Resolve the actual underlying buffer op
-  auto bufferOp = getUnderlyingBufferOp(buffer);
+  auto bufferOp = air::getUnderlyingBufferOp(buffer);
   if (!bufferOp)
     return failure();
   return bufferOp;

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -570,24 +570,20 @@ air::getLockValuePair(const AIE::AIETargetModel &targetModel,
                         unique_write_buffers.size());
 }
 
-// Walk a Value back to its underlying AIE::BufferOp through chains of
-// view-like (subview, expand/collapse_shape, reinterpret_cast) and cast
-// (memref.cast) ops. Returns nullptr if the chain doesn't terminate at a
-// BufferOp.
+// Helper that tries to retrieve the underlying AIE::BufferOp by unwrapping
+// common memref wrappers (cast or subview). Single-level only — recursing
+// changes what existing callers (lock and DMA placement) see and silently
+// shifts lock scope, which broke runtime correctness in xrt/40_triton_vec_add.
 AIE::BufferOp air::getUnderlyingBufferOp(Value buffer) {
-  while (buffer) {
-    if (auto bufferOp = buffer.getDefiningOp<AIE::BufferOp>())
-      return bufferOp;
-    if (auto viewLikeOp = buffer.getDefiningOp<ViewLikeOpInterface>()) {
-      buffer = viewLikeOp.getViewSource();
-      continue;
-    }
-    if (auto castOp = buffer.getDefiningOp<CastOpInterface>()) {
-      buffer = castOp->getOperand(0);
-      continue;
-    }
-    return nullptr;
-  }
+  if (auto bufferOp = buffer.getDefiningOp<AIE::BufferOp>())
+    return bufferOp;
+  if (auto castOp = buffer.getDefiningOp<CastOpInterface>())
+    if (auto innerBuffer = castOp->getOperand(0).getDefiningOp<AIE::BufferOp>())
+      return innerBuffer;
+  if (auto viewLikeOp = buffer.getDefiningOp<ViewLikeOpInterface>())
+    if (auto innerBuffer =
+            viewLikeOp->getOperand(0).getDefiningOp<AIE::BufferOp>())
+      return innerBuffer;
   return nullptr;
 }
 

--- a/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_bank_distribute.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_to_aie_bank_distribute.mlir
@@ -1,0 +1,41 @@
+//===- air_herd_to_aie_bank_distribute.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Verify that on AIE2/AIE2P targets the L1 buffers passed as different
+// positional arguments of an extern (link_with) kernel call receive distinct
+// `mem_bank` attributes, so the downstream `aie-assign-buffer-addresses`
+// pass does not collapse them into a single bank.
+
+// RUN: air-opt %s -air-to-aie='device=npu1 row-offset=2 col-offset=0' | FileCheck %s --check-prefix=NPU1
+// RUN: air-opt %s -air-to-aie='device=xcvc1902' | FileCheck %s --check-prefix=AIE1
+
+// NPU1-LABEL: aie.device(npu1)
+// NPU1: %[[A:.*]] = aie.buffer({{.*}}) {{.*mem_bank = 0.*}} : memref<256xbf16, 2>
+// NPU1: %[[B:.*]] = aie.buffer({{.*}}) {{.*mem_bank = 1.*}} : memref<256xbf16, 2>
+// NPU1: %[[C:.*]] = aie.buffer({{.*}}) {{.*mem_bank = 2.*}} : memref<256xi32, 2>
+// NPU1: aie.core
+// NPU1:   call @matvec_kernel(%[[A]], %[[B]], %[[C]])
+
+// AIE1: aie.device(xcvc1902)
+// AIE1-NOT: mem_bank
+
+module {
+
+func.func private @matvec_kernel(memref<256xbf16, 2>, memref<256xbf16, 2>, memref<256xi32, 2>) attributes {link_with = "matvec.o", llvm.emit_c_interface}
+
+func.func @test_bank_distribute() {
+  %c1 = arith.constant 1 : index
+  air.herd tile(%tx, %ty) in (%size_x = %c1, %size_y = %c1) attributes {link_with = "matvec.o"} {
+    %a = memref.alloc() : memref<256xbf16, 2>
+    %b = memref.alloc() : memref<256xbf16, 2>
+    %c = memref.alloc() : memref<256xi32, 2>
+    func.call @matvec_kernel(%a, %b, %c) : (memref<256xbf16, 2>, memref<256xbf16, 2>, memref<256xi32, 2>) -> ()
+  }
+  return
+}
+
+}


### PR DESCRIPTION
## Summary

After `allocL1Buffers`, walk each `aie.core`'s `func.call` ops whose callee carries `link_with` (extern kernel) and greedy-assign `mem_bank` attributes on the call's memref args so that arguments of the same call sit on distinct AIE2/AIE2P L1 banks. Without this, the downstream `aie-assign-buffer-addresses` pass can place A and B of a matvec call in the same bank, causing AIE2P bank arbitration to serialize the kernel's parallel vector loads and (combined with the Peano "No memory bank assigned" code path) stall the kernel at runtime.

Arguments already pinned by an upstream pass are preserved. Buffers reused across calls keep their first assignment.

## Test plan

- [ ] `ninja check-air-mlir` (full lit suite) passes.
- [ ] On a matvec call where A and B previously shared a bank, after the pass A/B/partial each sit on distinct banks (verified against the handwritten reference bank assignment in `aie_la_2tile.mlir.prj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)