### PR TITLE
[Transform] Fix air-ping-pong-transform nested-loop SSA dominance failure

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1216,47 +1216,56 @@ struct ConstructPingPongDependencyPattern
     SmallVector<Operation *> pong_consumer_fronts;
     SmallVector<Operation *> pong_consumer_backs;
 
-    new_loop_op.getBody()->walk([&](Operation *op) {
-      if (op->hasAttr("ping_pong") || op->hasAttr("unrolled_iteration")) {
-        auto ping_pong_id =
-            op->hasAttr("ping_pong")
-                ? (op->getAttrOfType<IntegerAttr>("ping_pong").getUInt())
-                : (op->getAttrOfType<IntegerAttr>("unrolled_iteration")
-                       .getInt());
-        // "Ping" producer fronts
-        if (op->hasAttr("async_front") && ping_pong_id == 0) {
-          ping_producer_fronts.push_back(op);
-        }
-        // "Pong" producer fronts
-        else if (op->hasAttr("async_front") && ping_pong_id == 1) {
-          pong_producer_fronts.push_back(op);
-        }
-        // "Ping" consumer backs
-        else if (op->hasAttr("async_back") && ping_pong_id == 0) {
-          ping_consumer_backs.push_back(op);
-        }
-        // "Pong" consumer backs
-        else if (op->hasAttr("async_back") && ping_pong_id == 1) {
-          pong_consumer_backs.push_back(op);
-        }
-        // "Ping" producer backs
-        if (op->hasAttr("producer") && ping_pong_id == 0) {
-          ping_producer_backs.push_back(op);
-        }
-        // "Pong" producer backs
-        if (op->hasAttr("producer") && ping_pong_id == 1) {
-          pong_producer_backs.push_back(op);
-        }
-        // "Ping" consumer fronts
-        if (op->hasAttr("consumer") && ping_pong_id == 0) {
-          ping_consumer_fronts.push_back(op);
-        }
-        // "Pong" consumer fronts
-        if (op->hasAttr("consumer") && ping_pong_id == 1) {
-          pong_consumer_fronts.push_back(op);
-        }
-      }
-    });
+    // Classify a single op by its ping_pong / async_front / async_back /
+    // producer / consumer annotations into the appropriate bucket. Shared
+    // between the inner-scf.for branch and the general branch below to keep
+    // the two paths in lockstep — any future bucket / attr change is made
+    // exactly once.
+    auto classifyOp = [&](Operation *op) {
+      if (!op->hasAttr("ping_pong") && !op->hasAttr("unrolled_iteration"))
+        return;
+      auto ping_pong_id =
+          op->hasAttr("ping_pong")
+              ? (op->getAttrOfType<IntegerAttr>("ping_pong").getUInt())
+              : (op->getAttrOfType<IntegerAttr>("unrolled_iteration").getInt());
+      if (op->hasAttr("async_front") && ping_pong_id == 0)
+        ping_producer_fronts.push_back(op);
+      else if (op->hasAttr("async_front") && ping_pong_id == 1)
+        pong_producer_fronts.push_back(op);
+      else if (op->hasAttr("async_back") && ping_pong_id == 0)
+        ping_consumer_backs.push_back(op);
+      else if (op->hasAttr("async_back") && ping_pong_id == 1)
+        pong_consumer_backs.push_back(op);
+      if (op->hasAttr("producer") && ping_pong_id == 0)
+        ping_producer_backs.push_back(op);
+      if (op->hasAttr("producer") && ping_pong_id == 1)
+        pong_producer_backs.push_back(op);
+      if (op->hasAttr("consumer") && ping_pong_id == 0)
+        ping_consumer_fronts.push_back(op);
+      if (op->hasAttr("consumer") && ping_pong_id == 1)
+        pong_consumer_fronts.push_back(op);
+    };
+
+    // Walk new_loop_op's body, but do NOT descend into nested scf.for ops:
+    // the greedy rewriter may have already pp-transformed an inner scf.for,
+    // in which case its body carries the inner loop's own ping_pong /
+    // producer / consumer / async_front / async_back annotations. Picking
+    // those up here would wire an outer-scope sink to an inner-region SSA
+    // value, producing "operand #0 does not dominate this use". The inner
+    // scf.for op itself is still classified — it may legitimately be a
+    // producer / consumer of the outer-level buffer — we only prune its
+    // body. Pre-order is required: WalkResult::skip prunes regions not yet
+    // visited, so under post-order the body has already been walked by the
+    // time the parent's callback fires.
+    new_loop_op.getBody()->walk<WalkOrder::PreOrder>(
+        [&](Operation *op) -> WalkResult {
+          classifyOp(op);
+          // Block::walk starts inside the body, so new_loop_op itself is
+          // never visited — every scf.for we see here is a nested one.
+          if (isa<scf::ForOp>(op))
+            return WalkResult::skip();
+          return WalkResult::advance();
+        });
 
     // Part 2: Connect producers
     for (auto sink : ping_producer_fronts) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/construct_ping_pong.mlir
@@ -623,3 +623,74 @@ module {
     return
   }
 }
+
+// Regression: nested scf.for loops, both matching the ping-pong pattern.
+// The greedy rewriter processes the inner scf.for first (bottom-up),
+// leaving inner-region ops annotated with
+// ping_pong/producer/consumer/async_front/async_back. The outer rewrite
+// must not pick up those inner-region annotations when wiring its own
+// dependency edges -- doing so references inner-region SSA values from
+// outer scope ("operand #0 does not dominate this use"). Pass succeeds
+// iff the classification walk prunes nested scf.for bodies.
+// CHECK-LABEL: nested_ping_pong
+// CHECK: scf.for {{.*}} -> (!air.async.token, !air.async.token, !air.async.token, !air.async.token)
+// CHECK:   scf.for {{.*}} -> (!air.async.token, !air.async.token, !air.async.token, !air.async.token)
+// CHECK:   scf.yield {{.*}} : !air.async.token, !air.async.token, !air.async.token, !air.async.token
+
+air.channel @nested_ch_in [1, 1]
+air.channel @nested_ch_mid [1, 1]
+air.channel @nested_ch_out [1, 1]
+func.func @nested_ping_pong() {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+    %1 = air.segment async {
+      %c0_0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c128_0 = arith.constant 128 : index
+      %c256_0 = arith.constant 256 : index
+      %async_token_out, %results_out = air.execute -> (memref<32x32xbf16, 1>) {
+        %alloc = memref.alloc() : memref<32x32xbf16, 1>
+        air.execute_terminator %alloc : memref<32x32xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+      %async_token_out1, %results_out1 = air.execute [%async_token_out] -> (memref<32x32xbf16, 1>) {
+        %alloc = memref.alloc() : memref<32x32xbf16, 1>
+        air.execute_terminator %alloc : memref<32x32xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %outer_for = scf.for %arg_o = %c0_0 to %c256_0 step %c128_0 iter_args(%tok_o = %async_token_out1) -> (!air.async.token) {
+        %get_o0 = air.channel.get async [%tok_o] @nested_ch_in[] (%results_out1[] [] []) {async_front = true, unrolled_iteration = 0 : i32} : (memref<32x32xbf16, 1>)
+        %async_token_in, %results_in = air.execute [%get_o0] -> (memref<32x32xbf16, 2>) {
+          %alloc = memref.alloc() : memref<32x32xbf16, 2>
+          air.execute_terminator %alloc : memref<32x32xbf16, 2>
+        } {unrolled_iteration = 1 : i32}
+        %async_token_in1, %results_in1 = air.execute [%async_token_in] -> (memref<32x32xbf16, 2>) {
+          %alloc = memref.alloc() : memref<32x32xbf16, 2>
+          air.execute_terminator %alloc : memref<32x32xbf16, 2>
+        } {unrolled_iteration = 0 : i32}
+        %inner_for = scf.for %arg_i = %c0_0 to %c128_0 step %c1_0 iter_args(%tok_i = %async_token_in1) -> (!air.async.token) {
+          %get_i0 = air.channel.get async [%tok_i] @nested_ch_mid[] (%results_in1[] [] []) {async_front = true, unrolled_iteration = 0 : i32} : (memref<32x32xbf16, 2>)
+          %put_i0 = air.channel.put async [%get_i0] @nested_ch_out[] (%results_in1[] [] []) {async_back = true, unrolled_iteration = 0 : i32} : (memref<32x32xbf16, 2>)
+          %get_i1 = air.channel.get async [%put_i0] @nested_ch_mid[] (%results_in[] [] []) {async_front = true, unrolled_iteration = 1 : i32} : (memref<32x32xbf16, 2>)
+          %put_i1 = air.channel.put async [%get_i1] @nested_ch_out[] (%results_in[] [] []) {async_back = true, unrolled_iteration = 1 : i32} : (memref<32x32xbf16, 2>)
+          scf.yield %put_i1 : !air.async.token
+        } {unroll = 2 : i32}
+        %dealloc_in = air.execute [%inner_for] {
+          memref.dealloc %results_in1 : memref<32x32xbf16, 2>
+        } {unrolled_iteration = 0 : i32}
+        %dealloc_in1 = air.execute [%inner_for] {
+          memref.dealloc %results_in : memref<32x32xbf16, 2>
+        } {unrolled_iteration = 1 : i32}
+        %put_o0 = air.channel.put async [%inner_for] @nested_ch_in[] (%results_out1[] [] []) {async_back = true, unrolled_iteration = 0 : i32} : (memref<32x32xbf16, 1>)
+        %get_o1 = air.channel.get async [%put_o0] @nested_ch_in[] (%results_out[] [] []) {async_front = true, unrolled_iteration = 1 : i32} : (memref<32x32xbf16, 1>)
+        %put_o1 = air.channel.put async [%get_o1] @nested_ch_in[] (%results_out[] [] []) {async_back = true, unrolled_iteration = 1 : i32} : (memref<32x32xbf16, 1>)
+        scf.yield %put_o1 : !air.async.token
+      } {unroll = 2 : i32}
+      %dealloc_out = air.execute [%outer_for] {
+        memref.dealloc %results_out1 : memref<32x32xbf16, 1>
+      } {unrolled_iteration = 0 : i32}
+      %dealloc_out1 = air.execute [%outer_for] {
+        memref.dealloc %results_out : memref<32x32xbf16, 1>
+      } {unrolled_iteration = 1 : i32}
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`ConstructPingPongDependencyPattern`'s classification walk descended into nested `scf.for` bodies via the default post-order walk. When greedy pattern application had already pp-transformed an inner `scf.for` first, the inner-region ops carried their own producer/consumer/async_front/async_back annotations. The outer pass then picked up those inner ops and wired the outer-scope sink to an inner-region SSA value, producing:

```
error: operand #0 does not dominate this use
```

Fix: walk in pre-order with `WalkResult::skip` to prune nested `scf.for` bodies before they are visited. The inner `scf.for` op itself is still classified (it may legitimately be a producer/consumer of the outer-level buffer), but the walk does not descend into its body.

## Test plan

- [ ] Existing pp lit tests pass unchanged.
- [ ] A matvec-like design with nested `scf.for` + alloc children on both levels compiles cleanly with pp enabled (previously hit the dominance error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)