### PR TITLE
[AIRRtToNpu] Skip wrap-tiling for contiguous row-major shim DMA

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -236,6 +236,13 @@ void copyPaddingAttributes(Operation *src, Operation *dst);
 // access pattern.
 bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
                                 SmallVector<Value> memcpy_strides);
+// Check if the wraps and strides describe a shim BD that lowers to a single
+// linear stream using the wide buffer_length register: a contiguous row-major
+// body, optionally with any number of outer size==1 dummies or stride==0
+// broadcast dims (which the shim BD emitter folds into repeat_count). Such a
+// transfer is NOT subject to the per-dim 10-bit wrap-size limit.
+bool isContiguousRowMajorOrBroadcast(SmallVector<Value> sizes,
+                                     SmallVector<Value> strides);
 // Check if the volume of sizes equals the volume of the memref.
 // Return true if equal, and return false if any size value is not constant,
 // or memref shape isn't static.

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -236,13 +236,12 @@ void copyPaddingAttributes(Operation *src, Operation *dst);
 // access pattern.
 bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
                                 SmallVector<Value> memcpy_strides);
-// Check if the wraps and strides describe a shim BD that lowers to a single
-// linear stream using the wide buffer_length register: a contiguous row-major
-// body, optionally with any number of outer size==1 dummies or stride==0
-// broadcast dims (which the shim BD emitter folds into repeat_count). Such a
-// transfer is NOT subject to the per-dim 10-bit wrap-size limit.
-bool isContiguousRowMajorOrBroadcast(SmallVector<Value> sizes,
-                                     SmallVector<Value> strides);
+// True when the wraps/strides lower to a single linear shim BD: contiguous
+// row-major body, optionally preceded by outer size==1 dummies or outer
+// stride==0 (BD repeat) dims. Such a transfer is exempt from the per-dim
+// 10-bit wrap-size limit.
+bool isContiguousRowMajorOrRepeated(SmallVector<Value> sizes,
+                                    SmallVector<Value> strides);
 // Check if the volume of sizes equals the volume of the memref.
 // Return true if equal, and return false if any size value is not constant,
 // or memref shape isn't static.

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1164,16 +1164,13 @@ const int AIE2_STRIDE_UPPER_BOUND = 1048576;
 const int AIE2_DIM_COUNT = 4;
 
 bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
-  // Shim DMAs that lower to a single linear BD (contiguous row-major,
-  // optionally with outer size==1 dummies or outer stride==0 broadcasts that
-  // fold into repeat_count) use the wide buffer_length register and are not
-  // subject to the per-dim 10-bit wrap-size limit. Skip tiling for those.
-  // Mirrors mlir-aie's LinearizeContiguousBDTransfer / isContiguousBDTransfer.
+  // Linear shim BDs (contiguous row-major + optional outer dummies/repeat)
+  // use the wide buffer_length register and bypass the per-dim 10-bit limit.
   SmallVector<Value> wrap_list{dma.getLength3(), dma.getLength2(),
                                dma.getLength1(), dma.getLength0()};
   SmallVector<Value> stride_list{dma.getStride3(), dma.getStride2(),
                                  dma.getStride1(), dma.getStride0()};
-  if (air::isContiguousRowMajorOrBroadcast(wrap_list, stride_list))
+  if (air::isContiguousRowMajorOrRepeated(wrap_list, stride_list))
     return false;
   for (unsigned i = 0; i < wrap_list.size(); i++) {
     if (auto const_val = getConstantIntValue(wrap_list[i])) {

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1163,52 +1163,18 @@ const std::vector<int> AIE2_WRAP_UPPER_BOUNDS = {64, 1024, 1024, 1024};
 const int AIE2_STRIDE_UPPER_BOUND = 1048576;
 const int AIE2_DIM_COUNT = 4;
 
-// Returns true if the airrt.dma_memcpy_nd describes a contiguous row-major
-// access (innermost stride=1, every outer stride equals product of inner
-// sizes, ignoring size-1 dummy dims). Such a transfer can be emitted as a
-// linear shim BD that uses the wide buffer_length register, bypassing the
-// per-dim wrap-size limit (see mlir-aie LinearizeContiguousBDTransfer +
-// isContiguousBDTransfer, which exempt shim contiguous BDs from the 10-bit
-// dim-size limit).
-bool isContiguousAirrtDma(airrt::DmaMemcpyNdOp dma) {
-  SmallVector<Value> wraps{dma.getLength3(), dma.getLength2(),
-                           dma.getLength1(), dma.getLength0()};
-  SmallVector<Value> strides{dma.getStride3(), dma.getStride2(),
-                             dma.getStride1(), dma.getStride0()};
-  // Innermost stride must be 1.
-  auto innerStride = getConstantIntValue(strides.back());
-  if (!innerStride || *innerStride != 1)
-    return false;
-  // Each outer stride must equal the product of all inner sizes (skipping
-  // size-1 dummy dims, whose stride is irrelevant since they are never
-  // stepped).
-  uint64_t product = 1;
-  for (int i = static_cast<int>(wraps.size()) - 1; i >= 1; --i) {
-    auto curSize = getConstantIntValue(wraps[i]);
-    if (!curSize)
-      return false;
-    product *= static_cast<uint64_t>(*curSize);
-    auto prevSize = getConstantIntValue(wraps[i - 1]);
-    auto prevStride = getConstantIntValue(strides[i - 1]);
-    if (!prevSize || !prevStride)
-      return false;
-    if (*prevSize > 1 && static_cast<uint64_t>(*prevStride) != product)
-      return false;
-  }
-  return true;
-}
-
 bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
-  // Contiguous shim transfers are lowered to linear-mode BDs using the wide
-  // buffer_length register; they are not subject to the per-dim wrap-size
-  // limit. Skip tiling for those.
-  if (isContiguousAirrtDma(dma))
+  // Shim DMAs that lower to a single linear BD (contiguous row-major,
+  // optionally with outer size==1 dummies or outer stride==0 broadcasts that
+  // fold into repeat_count) use the wide buffer_length register and are not
+  // subject to the per-dim 10-bit wrap-size limit. Skip tiling for those.
+  // Mirrors mlir-aie's LinearizeContiguousBDTransfer / isContiguousBDTransfer.
+  SmallVector<Value> wrap_list{dma.getLength3(), dma.getLength2(),
+                               dma.getLength1(), dma.getLength0()};
+  SmallVector<Value> stride_list{dma.getStride3(), dma.getStride2(),
+                                 dma.getStride1(), dma.getStride0()};
+  if (air::isContiguousRowMajorOrBroadcast(wrap_list, stride_list))
     return false;
-  SmallVector<Value> wrap_list;
-  wrap_list.push_back(dma.getLength3());
-  wrap_list.push_back(dma.getLength2());
-  wrap_list.push_back(dma.getLength1());
-  wrap_list.push_back(dma.getLength0());
   for (unsigned i = 0; i < wrap_list.size(); i++) {
     if (auto const_val = getConstantIntValue(wrap_list[i])) {
       // Detected wrap that goes beyond the AIE2 hardware limit.

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1163,7 +1163,47 @@ const std::vector<int> AIE2_WRAP_UPPER_BOUNDS = {64, 1024, 1024, 1024};
 const int AIE2_STRIDE_UPPER_BOUND = 1048576;
 const int AIE2_DIM_COUNT = 4;
 
+// Returns true if the airrt.dma_memcpy_nd describes a contiguous row-major
+// access (innermost stride=1, every outer stride equals product of inner
+// sizes, ignoring size-1 dummy dims). Such a transfer can be emitted as a
+// linear shim BD that uses the wide buffer_length register, bypassing the
+// per-dim wrap-size limit (see mlir-aie LinearizeContiguousBDTransfer +
+// isContiguousBDTransfer, which exempt shim contiguous BDs from the 10-bit
+// dim-size limit).
+bool isContiguousAirrtDma(airrt::DmaMemcpyNdOp dma) {
+  SmallVector<Value> wraps{dma.getLength3(), dma.getLength2(),
+                           dma.getLength1(), dma.getLength0()};
+  SmallVector<Value> strides{dma.getStride3(), dma.getStride2(),
+                             dma.getStride1(), dma.getStride0()};
+  // Innermost stride must be 1.
+  auto innerStride = getConstantIntValue(strides.back());
+  if (!innerStride || *innerStride != 1)
+    return false;
+  // Each outer stride must equal the product of all inner sizes (skipping
+  // size-1 dummy dims, whose stride is irrelevant since they are never
+  // stepped).
+  uint64_t product = 1;
+  for (int i = static_cast<int>(wraps.size()) - 1; i >= 1; --i) {
+    auto curSize = getConstantIntValue(wraps[i]);
+    if (!curSize)
+      return false;
+    product *= static_cast<uint64_t>(*curSize);
+    auto prevSize = getConstantIntValue(wraps[i - 1]);
+    auto prevStride = getConstantIntValue(strides[i - 1]);
+    if (!prevSize || !prevStride)
+      return false;
+    if (*prevSize > 1 && static_cast<uint64_t>(*prevStride) != product)
+      return false;
+  }
+  return true;
+}
+
 bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
+  // Contiguous shim transfers are lowered to linear-mode BDs using the wide
+  // buffer_length register; they are not subject to the per-dim wrap-size
+  // limit. Skip tiling for those.
+  if (isContiguousAirrtDma(dma))
+    return false;
   SmallVector<Value> wrap_list;
   wrap_list.push_back(dma.getLength3());
   wrap_list.push_back(dma.getLength2());

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -2281,7 +2281,7 @@ static bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
     if (stepsize && *stepsize == 1)
       return true;
   }
-  unsigned stride_factor = 1;
+  uint64_t stride_factor = 1;
   for (int i = memcpy_sizes.size() - 1; i >= 0; i--) {
     auto stepsize = mlir::getConstantIntValue(memcpy_strides[i]);
     if (!stepsize)
@@ -2291,9 +2291,9 @@ static bool isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
       return false;
     if (*wrap == 1 && *stepsize == 0)
       continue; // dummy dimension.
-    if (*stepsize != stride_factor)
+    if (static_cast<uint64_t>(*stepsize) != stride_factor)
       return false;
-    stride_factor *= *wrap;
+    stride_factor *= static_cast<uint64_t>(*wrap);
   }
   return true;
 }

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1501,15 +1501,74 @@ bool air::isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
     if (stepsize && *stepsize == 1)
       return true;
   }
-  unsigned stride_factor = 1;
+  uint64_t stride_factor = 1;
   for (int i = memcpy_sizes.size() - 1; i >= 0; i--) {
     auto stepsize = mlir::getConstantIntValue(memcpy_strides[i]);
     auto wrap = mlir::getConstantIntValue(memcpy_sizes[i]);
+    // Conservative: a non-constant wrap or stride can't be proven default.
+    if (!stepsize || !wrap)
+      return false;
     if (*wrap == 1 && *stepsize == 0)
       continue; // dummy dimension.
-    if (*stepsize != stride_factor)
+    if (static_cast<uint64_t>(*stepsize) != stride_factor)
       return false;
-    stride_factor *= *wrap;
+    stride_factor *= static_cast<uint64_t>(*wrap);
+  }
+  return true;
+}
+
+// Check if the wraps and strides describe a shim BD that lowers to a single
+// linear stream using the wide buffer_length register. This is true when:
+//   - the inner (fast-varying) dims form a contiguous row-major access, and
+//   - any remaining outer dims are either size==1 dummies or stride==0
+//     broadcasts (which the shim BD emitter folds into repeat_count).
+// Such a transfer is NOT subject to the per-dim 10-bit wrap-size limit, since
+// the linear body is emitted via buffer_length and the outer stride==0 dim
+// becomes the BD repeat_count.
+//
+// Examples that return true:
+//   sizes=[1,1,1,2048] strides=[0,0,0,1]            (plain contiguous)
+//   sizes=[N,1,1,2048] strides=[0,*,*,1]            (broadcast K=2048)
+//   sizes=[N,M,K]      strides=[0,K,1]              (broadcast of contiguous
+//   body)
+// Examples that return false:
+//   sizes=[N,M,1,K]    strides=[X,K,*,1] X!=M*K     (non-contiguous outer)
+//   sizes=[N,M,K]      strides=[?,0,1]   M>1        (middle broadcast, not a
+//                                                   single linear BD)
+bool air::isContiguousRowMajorOrBroadcast(SmallVector<Value> sizes,
+                                          SmallVector<Value> strides) {
+  if (sizes.size() != strides.size())
+    return false;
+  if (sizes.empty())
+    return true;
+  // Skip outer size==1 dummies and stride==0 broadcast dims. The shim BD
+  // emitter folds these (dummies drop; broadcasts become repeat_count).
+  int firstBodyDim = 0;
+  for (; firstBodyDim < static_cast<int>(sizes.size()); ++firstBodyDim) {
+    auto sz = mlir::getConstantIntValue(sizes[firstBodyDim]);
+    auto st = mlir::getConstantIntValue(strides[firstBodyDim]);
+    if (!sz || !st)
+      return false;
+    if (*sz == 1)
+      continue; // dummy
+    if (*st == 0)
+      continue; // outer broadcast / repeat
+    break;
+  }
+  // Remaining inner dims must form a contiguous row-major linear BD. Inner
+  // dummies (size==1) are still allowed; inner broadcasts (stride==0 with
+  // size>1) are not -- they cannot fold into a single linear BD.
+  uint64_t stride_factor = 1;
+  for (int i = static_cast<int>(sizes.size()) - 1; i >= firstBodyDim; --i) {
+    auto sz = mlir::getConstantIntValue(sizes[i]);
+    auto st = mlir::getConstantIntValue(strides[i]);
+    if (!sz || !st)
+      return false;
+    if (*sz == 1)
+      continue; // inner dummy: stride irrelevant
+    if (static_cast<uint64_t>(*st) != stride_factor)
+      return false;
+    stride_factor *= static_cast<uint64_t>(*sz);
   }
   return true;
 }

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1517,47 +1517,26 @@ bool air::isDefaultDataAccessPattern(SmallVector<Value> memcpy_sizes,
   return true;
 }
 
-// Check if the wraps and strides describe a shim BD that lowers to a single
-// linear stream using the wide buffer_length register. This is true when:
-//   - the inner (fast-varying) dims form a contiguous row-major access, and
-//   - any remaining outer dims are either size==1 dummies or stride==0
-//     broadcasts (which the shim BD emitter folds into repeat_count).
-// Such a transfer is NOT subject to the per-dim 10-bit wrap-size limit, since
-// the linear body is emitted via buffer_length and the outer stride==0 dim
-// becomes the BD repeat_count.
-//
-// Examples that return true:
-//   sizes=[1,1,1,2048] strides=[0,0,0,1]            (plain contiguous)
-//   sizes=[N,1,1,2048] strides=[0,*,*,1]            (broadcast K=2048)
-//   sizes=[N,M,K]      strides=[0,K,1]              (broadcast of contiguous
-//   body)
-// Examples that return false:
-//   sizes=[N,M,1,K]    strides=[X,K,*,1] X!=M*K     (non-contiguous outer)
-//   sizes=[N,M,K]      strides=[?,0,1]   M>1        (middle broadcast, not a
-//                                                   single linear BD)
-bool air::isContiguousRowMajorOrBroadcast(SmallVector<Value> sizes,
-                                          SmallVector<Value> strides) {
+// True when the wraps/strides lower to a single linear shim BD: a contiguous
+// row-major body, optionally preceded by outer size==1 dummies or outer
+// stride==0 dims (the latter fold into the BD repeat_count). Inner stride==0
+// with size>1 is rejected -- it cannot fold into one linear BD.
+bool air::isContiguousRowMajorOrRepeated(SmallVector<Value> sizes,
+                                         SmallVector<Value> strides) {
   if (sizes.size() != strides.size())
     return false;
   if (sizes.empty())
     return true;
-  // Skip outer size==1 dummies and stride==0 broadcast dims. The shim BD
-  // emitter folds these (dummies drop; broadcasts become repeat_count).
   int firstBodyDim = 0;
   for (; firstBodyDim < static_cast<int>(sizes.size()); ++firstBodyDim) {
     auto sz = mlir::getConstantIntValue(sizes[firstBodyDim]);
     auto st = mlir::getConstantIntValue(strides[firstBodyDim]);
     if (!sz || !st)
       return false;
-    if (*sz == 1)
-      continue; // dummy
-    if (*st == 0)
-      continue; // outer broadcast / repeat
+    if (*sz == 1 || *st == 0)
+      continue;
     break;
   }
-  // Remaining inner dims must form a contiguous row-major linear BD. Inner
-  // dummies (size==1) are still allowed; inner broadcasts (stride==0 with
-  // size>1) are not -- they cannot fold into a single linear BD.
   uint64_t stride_factor = 1;
   for (int i = static_cast<int>(sizes.size()) - 1; i >= firstBodyDim; --i) {
     auto sz = mlir::getConstantIntValue(sizes[i]);
@@ -1565,7 +1544,7 @@ bool air::isContiguousRowMajorOrBroadcast(SmallVector<Value> sizes,
     if (!sz || !st)
       return false;
     if (*sz == 1)
-      continue; // inner dummy: stride irrelevant
+      continue;
     if (static_cast<uint64_t>(*st) != stride_factor)
       return false;
     stride_factor *= static_cast<uint64_t>(*sz);

--- a/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
@@ -7,21 +7,11 @@
 
 // RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
 
-// Shim BDs that describe a contiguous row-major access (innermost stride==1,
-// every outer stride == product of inner sizes, ignoring size==1 dummy dims)
-// lower to a single linear-mode BD via the wide buffer_length register and
-// are NOT subject to the per-dim 10-bit wrap-size limit. The wrap-tile pass
-// (violatesAIE2WrapLimit) must therefore skip them, even when an inner
-// dimension exceeds 1023.
-//
-// The corresponding outer stride==0 broadcast pattern (size > 1 outer dim
-// with stride 0, optionally interleaved with size==1 dummies, over a
-// contiguous inner body) is also a single linear BD: the broadcast folds
-// into the shim BD repeat_count. It too must skip wrap-tiling, regardless of
-// inner size.
+// Linear shim BDs (contiguous row-major body, optionally preceded by outer
+// size==1 dummies or outer stride==0 repeat dims) lower to a single
+// buffer_length transfer and bypass the per-dim 10-bit wrap-size limit.
 
-// Plain contiguous bf16, inner 131136 (>> 1023). Must emit a single linear
-// BD, not the (683, 192) tiled form.
+// Plain contiguous bf16, inner 131136 (>> 1023): single BD, no tiling.
 
 // CHECK-LABEL: aie.device(npu1)
 // CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])
@@ -49,9 +39,8 @@ module {
 
 // -----
 
-// Plain contiguous bf16, inner 2049. Has no even factor <= 1023, so prior
-// to the linear-BD skip this case errored out in tileIllegalWrapDim. Now it
-// passes through as a single linear BD.
+// bf16 length 2049 has no even factor <= 1023. Previously errored in
+// tileIllegalWrapDim; now passes through as a single linear BD.
 
 // CHECK-LABEL: aie.device(npu1)
 // CHECK: aie.dma_bd(%arg0 : memref<2049xbf16>, 0, 2049, [<size = 2049, stride = 1>])
@@ -79,10 +68,8 @@ module {
 
 // -----
 
-// Broadcast pattern: outermost size==8, stride==0; middle dims are size==1
-// dummies; inner stride==1 with size 2048 (> 1023). The shim BD folds the
-// outer broadcast into repeat_count and emits a single linear BD of size
-// 2048. Must NOT be tiled.
+// Outer repeat: size==8 stride==0 outer, dummy mids, inner 2048 stride==1.
+// Folds into repeat_count=7 + one linear BD of 2048. Must NOT be tiled.
 
 // CHECK-LABEL: aie.device(npu1)
 // CHECK: aie.dma_bd(%arg0 : memref<2048xbf16>, 0, 2048, [<size = 2048, stride = 1>])
@@ -112,8 +99,7 @@ module {
 
 // -----
 
-// NPU2: same plain-contiguous linearization on AIE2P device. Guards against
-// device divergence in the skip-tiling logic.
+// NPU2: same linearization on AIE2P. Guards against device divergence.
 
 // CHECK-LABEL: aie.device(npu2)
 // CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])

--- a/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
@@ -1,0 +1,140 @@
+//===- linear_shim_bd.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// Shim BDs that describe a contiguous row-major access (innermost stride==1,
+// every outer stride == product of inner sizes, ignoring size==1 dummy dims)
+// lower to a single linear-mode BD via the wide buffer_length register and
+// are NOT subject to the per-dim 10-bit wrap-size limit. The wrap-tile pass
+// (violatesAIE2WrapLimit) must therefore skip them, even when an inner
+// dimension exceeds 1023.
+//
+// The corresponding outer stride==0 broadcast pattern (size > 1 outer dim
+// with stride 0, optionally interleaved with size==1 dummies, over a
+// contiguous inner body) is also a single linear BD: the broadcast folds
+// into the shim BD repeat_count. It too must skip wrap-tiling, regardless of
+// inner size.
+
+// Plain contiguous bf16, inner 131136 (>> 1023). Must emit a single linear
+// BD, not the (683, 192) tiled form.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<131136xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c131136_i64 = arith.constant 131136 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// Plain contiguous bf16, inner 2049. Has no even factor <= 1023, so prior
+// to the linear-BD skip this case errored out in tileIllegalWrapDim. Now it
+// passes through as a single linear BD.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<2049xbf16>, 0, 2049, [<size = 2049, stride = 1>])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<2049xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2049_i64 = arith.constant 2049 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c2049_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<2049xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// Broadcast pattern: outermost size==8, stride==0; middle dims are size==1
+// dummies; inner stride==1 with size 2048 (> 1023). The shim BD folds the
+// outer broadcast into repeat_count and emits a single linear BD of size
+// 2048. Must NOT be tiled.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<2048xbf16>, 0, 2048, [<size = 2048, stride = 1>])
+// CHECK: repeat_count = 7 : i32
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<2048xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c8_i64, %c1_i64, %c1_i64, %c2048_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<2048xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// NPU2: same plain-contiguous linearization on AIE2P device. Guards against
+// device divergence in the skip-tiling logic.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<131136xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c131136_i64 = arith.constant 131136 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -7,6 +7,13 @@
 
 // RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
 
+// All test cases below use a *non-contiguous* outer dim (stride != inner
+// volume) so the shim BD cannot collapse to a single linear-mode transfer.
+// The oversized inner wrap (>= 1024) therefore exercises the alignment-aware
+// splitter in tileIllegalWrapDim. (Plain contiguous and outer-broadcast
+// patterns are covered separately in linear_shim_bd.mlir, where they are
+// expected to bypass tiling entirely.)
+
 // When tileIllegalWrapDim splits a wrap that exceeds the shim 10-bit limit
 // (1023), the new innermost size in bytes must remain a multiple of the shim
 // address granularity (4 B). For a bf16 transfer of length 131136 the only
@@ -17,7 +24,7 @@
 // yielding an inner segment of 192 * 2 B = 384 B (4-B aligned).
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 683, stride = 192>, <size = 192, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 683, stride = 192>, <size = 192, stride = 1>])
 
 module {
   aie.device(npu1) {
@@ -29,13 +36,15 @@ module {
       airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
     }
   }
-  func.func @forward(%arg0: memref<131136xbf16>) {
+  func.func @forward(%arg0: memref<262273xbf16>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
     %c131136_i64 = arith.constant 131136 : i64
+    %c131137_i64 = arith.constant 131137 : i64
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c1_i64, %c1_i64, %c131136_i64], [%c131137_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<262273xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }
@@ -48,7 +57,7 @@ module {
 // already covers the full granularity.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<131136xf32>, 0, 131136, [<size = 192, stride = 683>, <size = 683, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xf32>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 192, stride = 683>, <size = 683, stride = 1>])
 
 module {
   aie.device(npu1) {
@@ -60,13 +69,15 @@ module {
       airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
     }
   }
-  func.func @forward(%arg0: memref<131136xf32>) {
+  func.func @forward(%arg0: memref<262273xf32>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
     %c131136_i64 = arith.constant 131136 : i64
+    %c131137_i64 = arith.constant 131137 : i64
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c1_i64, %c1_i64, %c131136_i64], [%c131137_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<262273xf32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }
@@ -89,14 +100,16 @@ module {
       airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
     }
   }
-  func.func @forward(%arg0: memref<2049xbf16>) {
+  func.func @forward(%arg0: memref<4099xbf16>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
     %c2049_i64 = arith.constant 2049 : i64
+    %c2050_i64 = arith.constant 2050 : i64
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
     // expected-error @+1 {{cannot tile dim 3 of size 2049 into shim-legal chunks}}
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c2049_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<2049xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c1_i64, %c1_i64, %c2049_i64], [%c2050_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<4099xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }
@@ -110,7 +123,7 @@ module {
 // inner wrap drops to 4 (* 1 B = 4 B aligned) and the outer wrap becomes 257.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<1028xi8>, 0, 1028, [<size = 257, stride = 4>, <size = 4, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<2057xi8>, 0, 1028, [<size = 2, stride = 1029>, <size = 1, stride = 0>, <size = 257, stride = 4>, <size = 4, stride = 1>])
 
 module {
   aie.device(npu1) {
@@ -122,13 +135,15 @@ module {
       airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
     }
   }
-  func.func @forward(%arg0: memref<1028xi8>) {
+  func.func @forward(%arg0: memref<2057xi8>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
     %c1028_i64 = arith.constant 1028 : i64
+    %c1029_i64 = arith.constant 1029 : i64
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c1028_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<1028xi8>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c1_i64, %c1_i64, %c1028_i64], [%c1029_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<2057xi8>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }
@@ -140,7 +155,7 @@ module {
 // device divergence going unnoticed.
 
 // CHECK-LABEL: aie.device(npu2)
-// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 683, stride = 192>, <size = 192, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 683, stride = 192>, <size = 192, stride = 1>])
 
 module {
   aie.device(npu2) {
@@ -152,13 +167,15 @@ module {
       airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
     }
   }
-  func.func @forward(%arg0: memref<131136xbf16>) {
+  func.func @forward(%arg0: memref<262273xbf16>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
     %c131136_i64 = arith.constant 131136 : i64
+    %c131137_i64 = arith.constant 131137 : i64
     %c4_i32 = arith.constant 4 : i32
     %p = airrt.segment_load "forward_0" : i64
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c131136_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<131136xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c1_i64, %c1_i64, %c131136_i64], [%c131137_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<262273xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
     return
   }
 }

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -7,12 +7,10 @@
 
 // RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
 
-// All test cases below use a *non-contiguous* outer dim (stride != inner
-// volume) so the shim BD cannot collapse to a single linear-mode transfer.
-// The oversized inner wrap (>= 1024) therefore exercises the alignment-aware
-// splitter in tileIllegalWrapDim. (Plain contiguous and outer-broadcast
-// patterns are covered separately in linear_shim_bd.mlir, where they are
-// expected to bypass tiling entirely.)
+// All cases below use a non-contiguous outer dim so the shim BD cannot
+// collapse to a single linear transfer; the oversized inner wrap (>= 1024)
+// then exercises the alignment-aware splitter. Linear-BD cases are covered
+// in linear_shim_bd.mlir.
 
 // When tileIllegalWrapDim splits a wrap that exceeds the shim 10-bit limit
 // (1023), the new innermost size in bytes must remain a multiple of the shim


### PR DESCRIPTION
## Summary

Add `isContiguousAirrtDma()` helper that recognizes `airrt.dma_memcpy_nd` ops describing a contiguous row-major access (innermost stride=1, every outer stride equals product of inner sizes, ignoring size-1 dummy dims).

Such transfers lower to linear-mode shim BDs using the wide `buffer_length` register and are not subject to the per-dim 10-bit wrap-size limit (matching mlir-aie's `LinearizeContiguousBDTransfer` / `isContiguousBDTransfer` treatment). `violatesAIE2WrapLimit()` now returns false for those, so they are not unnecessarily tiled by the AIE2-wrap-limit splitter.

## Test plan

- [x] Full conversion lit suite passes.
- [x] A broadcast of a K=2048 vector (> 1023 wrap limit) lowers to linear `[<size=2048, stride=1>]` instead of chunked `[<size=4, stride=512>, <size=512, stride=1>]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)