### PR TITLE
[Transform] Ping-pong labeling: skip outer scf.for if nested for is a candidate

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1581,85 +1581,73 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
                                     std::string omitMemorySpace)
       : OpRewritePattern(ctx), omitMemorySpace(omitMemorySpace) {}
 
-  // Helper: does `forOp` have a direct child air.execute containing a
-  // memref.alloc that matches the omitMemorySpace filter? (Same predicate
-  // used in matchAndRewrite below; factored out so we can ask the question
-  // for descendants without recursing into the rewriter.)
-  static bool hasLabelableAllocChild(scf::ForOp forOp,
-                                     StringRef omitMemorySpace) {
+  // Single predicate shared between the rewriter's main check and the
+  // nested-loop suppression below. A loop is a ping-pong labeling candidate
+  // iff:
+  //   - it is not already labeled (no "unroll" attr), and
+  //   - it has at least one direct-child air.execute containing memref.alloc,
+  //     and
+  //   - if omitMemorySpace is set, none of those allocs live in that space
+  //     (matches the original "skip if any alloc matches omit" semantics).
+  // `allocsOut`, if non-null, is populated with the matched alloc ops when
+  // the loop is a candidate, so callers can avoid re-walking.
+  static bool isPingPongCandidate(scf::ForOp forOp, StringRef omitMemorySpace,
+                                  SmallVectorImpl<Operation *> *allocsOut) {
+    if (forOp->hasAttr("unroll"))
+      return false;
+    SmallVector<Operation *> allocs;
     for (auto exec : forOp.getOps<air::ExecuteOp>()) {
       for (auto alloc : exec.getOps<memref::AllocOp>()) {
         auto ty = llvm::cast<MemRefType>(alloc.getType());
-        if (omitMemorySpace.empty())
-          return true;
-        if (omitMemorySpace == "L1" && air::isL1(ty))
-          continue;
-        if (omitMemorySpace == "L2" && air::isL2(ty))
-          continue;
-        return true;
+        if (!omitMemorySpace.empty()) {
+          if (omitMemorySpace == "L1" && air::isL1(ty))
+            return false;
+          if (omitMemorySpace == "L2" && air::isL2(ty))
+            return false;
+        }
+        allocs.push_back(alloc.getOperation());
       }
     }
-    return false;
+    if (allocs.empty())
+      return false;
+    if (allocsOut)
+      *allocsOut = std::move(allocs);
+    return true;
   }
 
   LogicalResult matchAndRewrite(scf::ForOp for_op,
                                 PatternRewriter &rewriter) const override {
 
-    // Check if the loop has been labelled
-    if (for_op->hasAttr("unroll"))
-      return failure();
-
-    // Check if the loop has child air.execute event containing memref.alloc
     SmallVector<Operation *> alloc_ops;
-    for (auto child_exec : for_op.getOps<air::ExecuteOp>()) {
-      for (auto child_alloc : child_exec.getOps<memref::AllocOp>()) {
-        alloc_ops.push_back(child_alloc.getOperation());
-      }
-    }
-    if (alloc_ops.empty())
+    if (!isPingPongCandidate(for_op, omitMemorySpace, &alloc_ops))
       return failure();
 
-    // Check if we should skip this loop based on memory space
-    if (!omitMemorySpace.empty()) {
-      bool shouldSkip = false;
-      for (auto op : alloc_ops) {
-        auto alloc_op = dyn_cast_if_present<memref::AllocOp>(op);
-        if (!alloc_op)
-          continue;
-        auto memref_type = llvm::cast<MemRefType>(alloc_op.getType());
-
-        // Check if this alloc's memory space matches the omit criteria
-        if ((omitMemorySpace == "L1" && air::isL1(memref_type)) ||
-            (omitMemorySpace == "L2" && air::isL2(memref_type))) {
-          shouldSkip = true;
-          break;
-        }
-      }
-      if (shouldSkip)
-        return failure();
-    }
-
-    // Skip outer loop if any nested scf.for is itself a labeling candidate
-    // (already labeled, or has a direct air.execute alloc child that matches
-    // the omitMemorySpace filter). This avoids cascading pingpong unrolls in
-    // nested loops, e.g. matvec-add where the outer M-loop has a per-iter
+    // Skip outer loop if any nested scf.for in the same async scope is itself
+    // a labeling candidate (or already labeled). This avoids cascading
+    // pingpong unrolls, e.g. matvec-add where the outer M-loop has a per-iter
     // partial alloc and the inner K-loop has per-iter A/B allocs: labeling
     // both would expand the inner body 2x for the outer pingpong AND 2x for
     // the inner pingpong, producing 4 buffer instances for A/B instead of 2.
-    // Only the deepest qualifying loop in any nest gets labeled.
-    //
-    // This rule fires only when a nested for loop has its own alloc-children
-    // (or unroll attr). If the nested for has no allocs, the outer remains a
-    // candidate. Sibling for loops at the same depth are labeled independently.
+    // Only the deepest qualifying loop in any nest gets labeled. Sibling fors
+    // at the same depth are labeled independently. Nested loops inside an
+    // air.herd / air.segment / air.launch are in a different scope and do not
+    // count, so the walk stops at those boundaries.
     bool hasLabelableNestedFor = false;
-    for_op.getBody()->walk([&](scf::ForOp innerFor) {
-      if (innerFor == for_op)
-        return WalkResult::advance();
-      if (innerFor->hasAttr("unroll") ||
-          hasLabelableAllocChild(innerFor, omitMemorySpace))
-        hasLabelableNestedFor = true;
-      return WalkResult::advance();
-    });
+    for_op.getBody()->walk<WalkOrder::PreOrder>(
+        [&](Operation *op) -> WalkResult {
+          if (isa<air::HerdOp, air::SegmentOp, air::LaunchOp>(op))
+            return WalkResult::skip();
+          auto innerFor = dyn_cast<scf::ForOp>(op);
+          if (!innerFor)
+            return WalkResult::advance();
+          if (innerFor->hasAttr("unroll") ||
+              isPingPongCandidate(innerFor, omitMemorySpace,
+                                  /*allocsOut=*/nullptr)) {
+            hasLabelableNestedFor = true;
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
     if (hasLabelableNestedFor)
       return failure();
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1581,6 +1581,27 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
                                     std::string omitMemorySpace)
       : OpRewritePattern(ctx), omitMemorySpace(omitMemorySpace) {}
 
+  // Helper: does `forOp` have a direct child air.execute containing a
+  // memref.alloc that matches the omitMemorySpace filter? (Same predicate
+  // used in matchAndRewrite below; factored out so we can ask the question
+  // for descendants without recursing into the rewriter.)
+  static bool hasLabelableAllocChild(scf::ForOp forOp,
+                                     StringRef omitMemorySpace) {
+    for (auto exec : forOp.getOps<air::ExecuteOp>()) {
+      for (auto alloc : exec.getOps<memref::AllocOp>()) {
+        auto ty = llvm::cast<MemRefType>(alloc.getType());
+        if (omitMemorySpace.empty())
+          return true;
+        if (omitMemorySpace == "L1" && air::isL1(ty))
+          continue;
+        if (omitMemorySpace == "L2" && air::isL2(ty))
+          continue;
+        return true;
+      }
+    }
+    return false;
+  }
+
   LogicalResult matchAndRewrite(scf::ForOp for_op,
                                 PatternRewriter &rewriter) const override {
 
@@ -1617,6 +1638,30 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
       if (shouldSkip)
         return failure();
     }
+
+    // Skip outer loop if any nested scf.for is itself a labeling candidate
+    // (already labeled, or has a direct air.execute alloc child that matches
+    // the omitMemorySpace filter). This avoids cascading pingpong unrolls in
+    // nested loops, e.g. matvec-add where the outer M-loop has a per-iter
+    // partial alloc and the inner K-loop has per-iter A/B allocs: labeling
+    // both would expand the inner body 2x for the outer pingpong AND 2x for
+    // the inner pingpong, producing 4 buffer instances for A/B instead of 2.
+    // Only the deepest qualifying loop in any nest gets labeled.
+    //
+    // This rule fires only when a nested for loop has its own alloc-children
+    // (or unroll attr). If the nested for has no allocs, the outer remains a
+    // candidate. Sibling for loops at the same depth are labeled independently.
+    bool hasLabelableNestedFor = false;
+    for_op.getBody()->walk([&](scf::ForOp innerFor) {
+      if (innerFor == for_op)
+        return WalkResult::advance();
+      if (innerFor->hasAttr("unroll") ||
+          hasLabelableAllocChild(innerFor, omitMemorySpace))
+        hasLabelableNestedFor = true;
+      return WalkResult::advance();
+    });
+    if (hasLabelableNestedFor)
+      return failure();
 
     // Label the scf.for loop and all its child memref.allocs
     int unroll_factor = 2; // Unroll factor hardened as 2. TODO: add support for

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
@@ -87,6 +87,12 @@ module {
 // be labeled; otherwise cascading pingpong unrolls would create 2x2 = 4
 // buffer instances for A/B instead of the intended 2.
 
+// Both allocs are L1 (memspace 2). Under DEFAULT (no omit) the outer loop is
+// a candidate and the inner is too, so the outer is suppressed and only the
+// inner gets labeled. Under OMIT_L2 the omit filter doesn't reject either
+// alloc, so the result is the same as DEFAULT. Under OMIT_L1 both loops are
+// filtered out and neither is labeled.
+
 // DEFAULT-LABEL: func.func @test_nested
 // DEFAULT: scf.for {{.*}} iter_args
 // DEFAULT-NOT: } {unroll
@@ -94,7 +100,18 @@ module {
 // DEFAULT:     memref.alloc() {hoist_alloc = true} : memref<32x32xbf16, 2>
 // DEFAULT:   } {unroll = 2 : i32}
 // DEFAULT-NOT: } {unroll
-// CHECK: }
+
+// OMIT_L2-LABEL: func.func @test_nested
+// OMIT_L2: scf.for {{.*}} iter_args
+// OMIT_L2-NOT: } {unroll
+// OMIT_L2:   scf.for {{.*}} iter_args
+// OMIT_L2:     memref.alloc() {hoist_alloc = true} : memref<32x32xbf16, 2>
+// OMIT_L2:   } {unroll = 2 : i32}
+// OMIT_L2-NOT: } {unroll
+
+// OMIT_L1-LABEL: func.func @test_nested
+// OMIT_L1-NOT: hoist_alloc
+// OMIT_L1-NOT: unroll
 
 module {
   func.func @test_nested(%arg0: memref<256x1024xbf16>) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_loops.mlir
@@ -78,3 +78,62 @@ module {
     return
   }
 }
+
+// -----
+
+// Nested for loops where both the outer and inner have direct memref.alloc
+// children (the matvec-add pattern: outer M-loop allocs a partial buffer,
+// inner K-loop allocs A/B chunks). Only the innermost qualifying loop should
+// be labeled; otherwise cascading pingpong unrolls would create 2x2 = 4
+// buffer instances for A/B instead of the intended 2.
+
+// DEFAULT-LABEL: func.func @test_nested
+// DEFAULT: scf.for {{.*}} iter_args
+// DEFAULT-NOT: } {unroll
+// DEFAULT:   scf.for {{.*}} iter_args
+// DEFAULT:     memref.alloc() {hoist_alloc = true} : memref<32x32xbf16, 2>
+// DEFAULT:   } {unroll = 2 : i32}
+// DEFAULT-NOT: } {unroll
+// CHECK: }
+
+module {
+  func.func @test_nested(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 7 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %c4_a = arith.constant 4 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %arg10 = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            // outer-loop direct alloc (partial-like)
+            %async_token_outer, %results_outer = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_p = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_p : memref<32x32xbf16, 2>
+            }
+            %inner = scf.for %arg12 = %c0 to %c4_a step %c1_h iter_args(%arg13 = %async_token_outer) -> (!air.async.token) {
+              // inner-loop direct alloc (A-chunk-like)
+              %async_token_inner, %results_inner = air.execute [%arg13] -> (memref<32x32xbf16, 2>) {
+                %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+                air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+              }
+              %async_token_d = air.execute [%async_token_inner] {
+                memref.dealloc %results_inner : memref<32x32xbf16, 2>
+              }
+              scf.yield %async_token_d : !air.async.token
+            }
+            %async_token_outer_d = air.execute [%inner] {
+              memref.dealloc %results_outer : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_outer_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

`LabelScfForLoopForPingPongPattern` labels any `scf.for` that has a direct `air.execute` alloc child. It had no nesting check, so for matvec-like loop nests where outer and inner both have alloc children, both got labeled and the downstream ping-pong transform produced a 4-buffer chain instead of 2, breaking the lock-init protocol and racing at runtime (1/8 .. 7/8 cols passing non-deterministically on a representative 2-tile cascade design).

Fix: after the existing alloc-child check, walk the loop body for nested `scf.for` ops; if any has its own labelable alloc-child (or already carries `unroll`), skip the outer. Only the deepest qualifying loop in each nest gets labeled. Sibling inners are labeled independently. Refactors the alloc-check predicate into a static helper `hasLabelableAllocChild`.

Handles four nesting patterns:
- **Simple nested** `for outer { alloc_a; for inner { alloc_b } }` → only inner labeled. Outer's alloc lifetime is fully within one iter, double-buffering it adds nothing.
- **Sibling inners with allocs**: outer skipped; both inners labeled independently.
- **Imperfect nest** (one inner has allocs, sibling has none): outer skipped if any descendant is labelable.
- **Pathological** (outer has alloc, no inner has allocs): outer is the only candidate, labeled.

Adds `test_nested` lit case. Existing `label_ping_pong_loops.mlir` tests unchanged.

## Test plan

- [ ] Full transform lit suite passes (208 tests).
- [ ] An e2e design with the nested-alloc pattern becomes deterministic 8/8 (was racy 1/8 ↔ 7/8 before this fix due to the 4-buffer chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)