### PR TITLE
[Transform] AIRHerdPlacementPass honors pre-set x_loc/y_loc attrs on herd

### DIFF
--- a/mlir/lib/Transform/AIRHerdPlacementPass.cpp
+++ b/mlir/lib/Transform/AIRHerdPlacementPass.cpp
@@ -472,6 +472,45 @@ private:
 
     std::vector<std::unique_ptr<Herd>> placedHerds;
 
+    // Honor pre-set x_loc/y_loc attributes on herds. A herd with both
+    // attributes set is treated as user-pinned: its grid cells are marked
+    // occupied so subsequent (unpinned) herds avoid them, and its
+    // attributes are preserved unchanged. This lets users express
+    // explicit per-tile placement (matching the handwritten reference
+    // patterns) and have the neighbor-aware placer route around them
+    // when picking spots for unpinned herds.
+    {
+      std::vector<std::unique_ptr<Herd>> remaining;
+      remaining.reserve(unplacedHerds.size());
+      for (auto &h : unplacedHerds) {
+        auto firstHerdOp = h->getHerdOp(0);
+        auto colAttr = firstHerdOp->getAttrOfType<IntegerAttr>(
+            xilinx::air::HerdOp::getColOffsetAttrName());
+        auto rowAttr = firstHerdOp->getAttrOfType<IntegerAttr>(
+            xilinx::air::HerdOp::getRowOffsetAttrName());
+        if (colAttr && rowAttr) {
+          int32_t pinX = static_cast<int32_t>(colAttr.getInt()) -
+                         segment->getAnchorPointCol();
+          int32_t pinY = static_cast<int32_t>(rowAttr.getInt()) -
+                         segment->getAnchorPointRow();
+          if (segment->isLegalPlacement(h, pinY, pinX)) {
+            segment->placeHerd(h, pinY, pinX);
+            h->setLocX(pinX);
+            h->setLocY(pinY);
+            placedHerds.push_back(std::move(h));
+            continue;
+          }
+          // Pre-set position is illegal (out of bounds or overlapping a
+          // previous pin); fall through to the placer.
+          firstHerdOp->emitWarning()
+              << "ignoring user-pinned x_loc/y_loc (" << pinX << ", " << pinY
+              << ") for herd because the placement is illegal";
+        }
+        remaining.push_back(std::move(h));
+      }
+      unplacedHerds = std::move(remaining);
+    }
+
     // If there are cascade or shared L1 connections, use neighbor-aware
     // placement
     if (!cascadeConnections.empty() || !sharedL1Connections.empty()) {

--- a/mlir/lib/Transform/AIRHerdPlacementPass.cpp
+++ b/mlir/lib/Transform/AIRHerdPlacementPass.cpp
@@ -464,6 +464,98 @@ private:
     return westToEast || northToSouth;
   }
 
+  // Read the (x_loc, y_loc) pin off a Herd by inspecting every wrapped
+  // air.herd op. Returns std::nullopt if no pin is set. If sibling ops
+  // (multiple HerdOps sharing one symbolic name) carry mismatched pins
+  // an op-error is emitted on the second op and std::nullopt is returned.
+  // Coordinates are kept in int64_t to match the IntegerAttr width.
+  std::optional<std::pair<int64_t, int64_t>>
+  getHerdPin(const std::unique_ptr<Herd> &h) {
+    std::optional<std::pair<int64_t, int64_t>> pin;
+    for (air::HerdOp op : h->getHerdOps()) {
+      auto col = op.getColOffset();
+      auto row = op.getRowOffset();
+      if (!col || !row) {
+        if (pin) {
+          op->emitOpError("disagrees with sibling air.herd '")
+              << h->getName(0)
+              << "': one carries x_loc/y_loc, another does not";
+          return std::nullopt;
+        }
+        continue;
+      }
+      std::pair<int64_t, int64_t> here{static_cast<int64_t>(*col),
+                                       static_cast<int64_t>(*row)};
+      if (pin && *pin != here) {
+        op->emitOpError("disagrees with sibling air.herd '")
+            << h->getName(0) << "': x_loc/y_loc (" << here.first << ", "
+            << here.second << ") vs (" << pin->first << ", " << pin->second
+            << ")";
+        return std::nullopt;
+      }
+      pin = here;
+    }
+    return pin;
+  }
+
+  // Pre-place any user-pinned herds (those with both x_loc and y_loc set)
+  // before the placer runs. Pinned herds are moved from `unplaced` to
+  // `placed` and their cells marked occupied so subsequent placement
+  // routes around them. If a pin is illegal (out of segment bounds or
+  // overlapping an already-pinned cell), a warning is emitted naming the
+  // herd, the original physical coordinates, and the segment extent, and
+  // the herd falls through to the regular placer.
+  void extractPinnedHerds(std::unique_ptr<Segment> &segment,
+                          std::vector<std::unique_ptr<Herd>> &unplaced,
+                          std::vector<std::unique_ptr<Herd>> &placed) {
+    std::vector<std::unique_ptr<Herd>> remaining;
+    remaining.reserve(unplaced.size());
+    const int32_t anchorCol = segment->getAnchorPointCol();
+    const int32_t anchorRow = segment->getAnchorPointRow();
+    const int32_t segCols = segment->getNumCols();
+    const int32_t segRows = segment->getNumRows();
+    for (auto &h : unplaced) {
+      auto pin = getHerdPin(h);
+      if (!pin) {
+        remaining.push_back(std::move(h));
+        continue;
+      }
+      const int64_t physX = pin->first;
+      const int64_t physY = pin->second;
+      const int64_t relX = physX - anchorCol;
+      const int64_t relY = physY - anchorRow;
+
+      // Bounds check before narrowing so out-of-range pins are reported
+      // distinctly from overlaps with already-placed pins.
+      auto reportIllegal = [&](StringRef reason) {
+        h->getHerdOp(0)->emitWarning()
+            << "ignoring user-pinned x_loc/y_loc (" << physX << ", " << physY
+            << ") on air.herd '" << h->getName(0) << "': " << reason
+            << " (segment anchor (" << anchorCol << ", " << anchorRow
+            << "), extent " << segCols << "x" << segRows << "); "
+            << "falling back to automatic placement";
+      };
+      if (relX < 0 || relY < 0 || relX + h->getNumCols() > segCols ||
+          relY + h->getNumRows() > segRows) {
+        reportIllegal("position is outside the segment");
+        remaining.push_back(std::move(h));
+        continue;
+      }
+      const int32_t pinX = static_cast<int32_t>(relX);
+      const int32_t pinY = static_cast<int32_t>(relY);
+      if (!segment->isLegalPlacement(h, pinY, pinX)) {
+        reportIllegal("position overlaps a previously-pinned herd");
+        remaining.push_back(std::move(h));
+        continue;
+      }
+      segment->placeHerd(h, pinY, pinX);
+      h->setLocX(pinX);
+      h->setLocY(pinY);
+      placed.push_back(std::move(h));
+    }
+    unplaced = std::move(remaining);
+  }
+
   void placeHerdsInSegment(
       std::vector<std::unique_ptr<Herd>> &unplacedHerds,
       std::unique_ptr<Segment> &segment,
@@ -472,44 +564,13 @@ private:
 
     std::vector<std::unique_ptr<Herd>> placedHerds;
 
-    // Honor pre-set x_loc/y_loc attributes on herds. A herd with both
-    // attributes set is treated as user-pinned: its grid cells are marked
-    // occupied so subsequent (unpinned) herds avoid them, and its
-    // attributes are preserved unchanged. This lets users express
-    // explicit per-tile placement (matching the handwritten reference
-    // patterns) and have the neighbor-aware placer route around them
-    // when picking spots for unpinned herds.
-    {
-      std::vector<std::unique_ptr<Herd>> remaining;
-      remaining.reserve(unplacedHerds.size());
-      for (auto &h : unplacedHerds) {
-        auto firstHerdOp = h->getHerdOp(0);
-        auto colAttr = firstHerdOp->getAttrOfType<IntegerAttr>(
-            xilinx::air::HerdOp::getColOffsetAttrName());
-        auto rowAttr = firstHerdOp->getAttrOfType<IntegerAttr>(
-            xilinx::air::HerdOp::getRowOffsetAttrName());
-        if (colAttr && rowAttr) {
-          int32_t pinX = static_cast<int32_t>(colAttr.getInt()) -
-                         segment->getAnchorPointCol();
-          int32_t pinY = static_cast<int32_t>(rowAttr.getInt()) -
-                         segment->getAnchorPointRow();
-          if (segment->isLegalPlacement(h, pinY, pinX)) {
-            segment->placeHerd(h, pinY, pinX);
-            h->setLocX(pinX);
-            h->setLocY(pinY);
-            placedHerds.push_back(std::move(h));
-            continue;
-          }
-          // Pre-set position is illegal (out of bounds or overlapping a
-          // previous pin); fall through to the placer.
-          firstHerdOp->emitWarning()
-              << "ignoring user-pinned x_loc/y_loc (" << pinX << ", " << pinY
-              << ") for herd because the placement is illegal";
-        }
-        remaining.push_back(std::move(h));
-      }
-      unplacedHerds = std::move(remaining);
-    }
+    // Honor pre-set x_loc/y_loc attributes on herds: pinned herds are
+    // claimed first so the neighbor-aware placer routes unpinned herds
+    // around them. (The func-level path in runOnOperation() takes the
+    // opposite stance and skips pinned herds entirely, on the assumption
+    // that they live outside the placement region; segment-scoped pins
+    // here are inside, so we reserve their cells.)
+    extractPinnedHerds(segment, unplacedHerds, placedHerds);
 
     // If there are cascade or shared L1 connections, use neighbor-aware
     // placement

--- a/mlir/test/Transform/AIRHerdPlacement/pinned_herd.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/pinned_herd.mlir
@@ -1,0 +1,77 @@
+//===- pinned_herd.mlir ----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -split-input-file -verify-diagnostics \
+// RUN:   -air-place-herds='num-rows=4 num-cols=4 row-anchor=2 col-anchor=0' \
+// RUN:   | FileCheck %s
+
+// Herds carrying both x_loc and y_loc are pinned: their cells are reserved
+// before automatic placement runs, so unpinned siblings route around them.
+
+// CHECK-LABEL: @pin_honored
+// CHECK: air.herd @pinned
+// CHECK-SAME: x_loc = 2 : i64
+// CHECK-SAME: y_loc = 4 : i64
+// CHECK: air.herd @unpinned
+// CHECK-SAME: x_loc = 0 : i64
+// CHECK-SAME: y_loc = 2 : i64
+func.func @pin_honored() {
+  air.segment @seg {
+    %c1 = arith.constant 1 : index
+    // Pinned at physical (x=2, y=4). Segment anchor is (col=0, row=2)
+    // and the segment is 4x4, so seg-relative (col=2, row=2) is legal.
+    air.herd @pinned tile (%t0, %t1) in (%s0=%c1, %s1=%c1) attributes {x_loc = 2 : i64, y_loc = 4 : i64} {
+    }
+    air.herd @unpinned tile (%t0, %t1) in (%s0=%c1, %s1=%c1) {
+    }
+  }
+  return
+}
+
+// -----
+
+// Pinning outside the segment extent warns (naming the herd, the original
+// physical coordinates, and the segment bounds) and falls back to the
+// regular placer.
+
+// CHECK-LABEL: @pin_out_of_bounds
+// CHECK: air.herd @oob
+// CHECK-SAME: x_loc = 0 : i64
+// CHECK-SAME: y_loc = 2 : i64
+func.func @pin_out_of_bounds() {
+  air.segment @seg {
+    %c1 = arith.constant 1 : index
+    // expected-warning @below {{ignoring user-pinned x_loc/y_loc (10, 2) on air.herd 'oob': position is outside the segment (segment anchor (0, 2), extent 4x4)}}
+    air.herd @oob tile (%t0, %t1) in (%s0=%c1, %s1=%c1) attributes {x_loc = 10 : i64, y_loc = 2 : i64} {
+    }
+  }
+  return
+}
+
+// -----
+
+// Two herds pinned to the same cell: first wins, second warns about the
+// overlap and falls through to the placer (which picks the next free cell).
+
+// CHECK-LABEL: @pin_overlap
+// CHECK: air.herd @first
+// CHECK-SAME: x_loc = 0 : i64
+// CHECK-SAME: y_loc = 2 : i64
+// CHECK: air.herd @second
+// CHECK-SAME: x_loc = 1 : i64
+// CHECK-SAME: y_loc = 2 : i64
+func.func @pin_overlap() {
+  air.segment @seg {
+    %c1 = arith.constant 1 : index
+    air.herd @first tile (%t0, %t1) in (%s0=%c1, %s1=%c1) attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+    }
+    // expected-warning @below {{ignoring user-pinned x_loc/y_loc (0, 2) on air.herd 'second': position overlaps a previously-pinned herd}}
+    air.herd @second tile (%t0, %t1) in (%s0=%c1, %s1=%c1) attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

A herd carrying both `x_loc` and `y_loc` attributes is treated as user-pinned: the placer converts those to segment-relative coords, checks legality, places there, and marks the cells occupied so subsequent unpinned herds avoid them. If the requested position is illegal (OOB or overlap), emit a warning and fall back to the normal placer.

This is needed by cascade designs where the producer herd must be on a higher row than the consumer (cascade flows N→S on AIE2/AIE2P) — the builder pins explicitly and the placer must honor it for the cascade lowering to find a valid direction.

## Test plan

- [x] Existing placement lit tests untouched.
- [x] A test with two herds — one pinned to a specific (col, row), one unpinned — verifies the pinned herd lands at the requested location and the unpinned herd avoided those cells.
- [x] A cascade design with `matvec_h y_loc=3` / `addr_h y_loc=2` produces cascade direction N→S consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)