### PR TITLE
[AIRRtToNpu] Recognize stride-0 outer replay dims as still-contiguous

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1181,7 +1181,11 @@ bool isContiguousAirrtDma(airrt::DmaMemcpyNdOp dma) {
     return false;
   // Each outer stride must equal the product of all inner sizes (skipping
   // size-1 dummy dims, whose stride is irrelevant since they are never
-  // stepped).
+  // stepped). An outer dim with stride=0 is a pure replay (broadcast-like
+  // transfers e.g. shim->compute broadcasts of a B vector replayed each
+  // outer iter) — the underlying data layout is still contiguous, so it
+  // qualifies for linear-mode BD lowering (the inner contiguous block is
+  // sent once per replay tick via the wide buffer_length register).
   uint64_t product = 1;
   for (int i = static_cast<int>(wraps.size()) - 1; i >= 1; --i) {
     auto curSize = getConstantIntValue(wraps[i]);
@@ -1192,7 +1196,8 @@ bool isContiguousAirrtDma(airrt::DmaMemcpyNdOp dma) {
     auto prevStride = getConstantIntValue(strides[i - 1]);
     if (!prevSize || !prevStride)
       return false;
-    if (*prevSize > 1 && static_cast<uint64_t>(*prevStride) != product)
+    if (*prevSize > 1 && static_cast<uint64_t>(*prevStride) != product &&
+        *prevStride != 0)
       return false;
   }
   return true;

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1163,7 +1163,47 @@ const std::vector<int> AIE2_WRAP_UPPER_BOUNDS = {64, 1024, 1024, 1024};
 const int AIE2_STRIDE_UPPER_BOUND = 1048576;
 const int AIE2_DIM_COUNT = 4;
 
+// Returns true if the airrt.dma_memcpy_nd describes a contiguous row-major
+// access (innermost stride=1, every outer stride equals product of inner
+// sizes, ignoring size-1 dummy dims). Such a transfer can be emitted as a
+// linear shim BD that uses the wide buffer_length register, bypassing the
+// per-dim wrap-size limit (see mlir-aie LinearizeContiguousBDTransfer +
+// isContiguousBDTransfer, which exempt shim contiguous BDs from the 10-bit
+// dim-size limit).
+bool isContiguousAirrtDma(airrt::DmaMemcpyNdOp dma) {
+  SmallVector<Value> wraps{dma.getLength3(), dma.getLength2(),
+                           dma.getLength1(), dma.getLength0()};
+  SmallVector<Value> strides{dma.getStride3(), dma.getStride2(),
+                             dma.getStride1(), dma.getStride0()};
+  // Innermost stride must be 1.
+  auto innerStride = getConstantIntValue(strides.back());
+  if (!innerStride || *innerStride != 1)
+    return false;
+  // Each outer stride must equal the product of all inner sizes (skipping
+  // size-1 dummy dims, whose stride is irrelevant since they are never
+  // stepped).
+  uint64_t product = 1;
+  for (int i = static_cast<int>(wraps.size()) - 1; i >= 1; --i) {
+    auto curSize = getConstantIntValue(wraps[i]);
+    if (!curSize)
+      return false;
+    product *= static_cast<uint64_t>(*curSize);
+    auto prevSize = getConstantIntValue(wraps[i - 1]);
+    auto prevStride = getConstantIntValue(strides[i - 1]);
+    if (!prevSize || !prevStride)
+      return false;
+    if (*prevSize > 1 && static_cast<uint64_t>(*prevStride) != product)
+      return false;
+  }
+  return true;
+}
+
 bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
+  // Contiguous shim transfers are lowered to linear-mode BDs using the wide
+  // buffer_length register; they are not subject to the per-dim wrap-size
+  // limit. Skip tiling for those.
+  if (isContiguousAirrtDma(dma))
+    return false;
   SmallVector<Value> wrap_list;
   wrap_list.push_back(dma.getLength3());
   wrap_list.push_back(dma.getLength2());


### PR DESCRIPTION
## Summary

**⚠️ Stacked on #1627** — base contains that PR's commit. Rebase to `main` after #1627 lands.

Extends `isContiguousAirrtDma` (added in #1627) to accept `*prevStride == 0` on outer dims. A stride-0 outer dim is a pure replay (broadcast-like transfers e.g. shim → compute broadcasts of a B vector replayed each outer iter) — the underlying inner block is still contiguous and qualifies for linear-mode BD via the wide `buffer_length` register.

Without this, replay patterns like `sizes=[N, K] strides=[0, 1]` with K > 1023 still get chunked by the wrap-limit splitter even though the data layout is contiguous.

## Test plan

- [ ] Extend the lit test added in #1627 with a stride-0 outer-dim case to lock the behavior in.
- [ ] A broadcast `air.channel.put` with `sizes=[N, K] strides=[0, 1]` produces a linear-mode shim BD instead of getting chunked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)