### PR TITLE
[programming_examples] AWQ int4 matvec examples (GEMV + GEMV+R)

### DIFF
--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -56,6 +56,12 @@ EXAMPLES = [
     },
     {
         "category": "Linear Algebra",
+        "name": "Matrix-Vector Multiplication (AWQ int4)",
+        "path": "matrix_vector_multiplication/int4_awq",
+        "datatypes": "int4 weights / bf16 activations",
+    },
+    {
+        "category": "Linear Algebra",
         "name": "AXPY",
         "path": "axpy",
         "datatypes": "bf16",

--- a/programming_examples/matrix_vector_multiplication/int4_awq/Makefile
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/Makefile
@@ -1,0 +1,106 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# int4 AWQ GEMV / GEMV+R examples (packed Q+S+Z BO).
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+OUTPUT_FORMAT ?= elf
+OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
+
+# Shapes / tiling (overridable). Defaults match the Llama Wo decode GEMV.
+M       ?= 2048
+K       ?= 2048
+GS      ?= 128
+M_TILE  ?= 8
+K_CHUNK ?= 2048
+
+AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include
+
+PY_ARGS = --m $(M) --k $(K) --gs $(GS) --m-tile $(M_TILE) --k-chunk $(K_CHUNK)
+
+all: run_packed
+
+print_packed:
+	${powershell} python3 ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
+
+print_packed_add:
+	${powershell} python3 ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
+
+compile-kernel:
+	mkdir -p $(BUILD_DIR)
+	@if [ -z "$(PEANO_INSTALL_DIR)" ]; then \
+		echo "Error: PEANO_INSTALL_DIR not set (source utils/env_setup.sh)."; \
+		exit 1; \
+	fi
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} \
+		-DDIM_M=$(M_TILE) -DDIM_K=$(K_CHUNK) -DDIM_GS=$(GS) \
+		-c ${srcdir}/mv_int4_bf16.cc -o $(BUILD_DIR)/mv_int4_bf16.o
+
+# GEMV: D = dequant(A) @ B
+run_packed: compile-kernel
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
+
+# GEMV + fused residual add (LA-style 2-tile cascade)
+run_packed_add: compile-kernel
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
+
+# ELF profile harnesses (compile module, then run XRT benchmark loop)
+build-test-packed-exe:
+	@$(MAKE) build-test-exe-impl SRC=test_packed.cpp OUT=test_packed.exe
+
+build-test-packed-add-exe:
+	@$(MAKE) build-test-exe-impl SRC=test_packed_add.cpp OUT=test_packed_add.exe
+
+profile_packed: build-test-packed-exe compile-kernel
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 ${srcdir}/matvec_int4_packed.py --compile-mode compile-only --output-format elf $(PY_ARGS)
+	cd $(BUILD_DIR) && ./test_packed.exe -e air.elf -k "main:matvec_int4_packed" \
+	  -M $(M) -K $(K) -G $(GS) -T $(M_TILE) -C $(K_CHUNK)
+
+profile_packed_add: build-test-packed-add-exe compile-kernel
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 ${srcdir}/matvec_int4_packed_add.py --compile-mode compile-only --output-format elf $(PY_ARGS)
+	cd $(BUILD_DIR) && ./test_packed_add.exe -e air.elf -k "main:matvec_int4_packed_add" \
+	  -M $(M) -K $(K) -G $(GS) -T $(M_TILE) -C $(K_CHUNK)
+
+build-test-exe-impl:
+	@GPP=$$( \
+		for bin in /usr/bin/g++-*; do \
+			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
+			if [ "$$ver" -ge 13 ] 2>/dev/null; then \
+				echo "$$ver $$bin"; \
+			fi; \
+		done | sort -nr | head -n1 | awk '{print $$2}' \
+	); \
+	if [ -z "$$GPP" ]; then \
+		echo "Error: No g++ version >= 13 found in /usr/bin."; exit 1; \
+	fi; \
+	if [ -z "$$XILINX_XRT" ]; then \
+		echo "Error: XILINX_XRT not set (source xrt/setup.sh)."; exit 1; \
+	fi; \
+	if [ -z "$(AIEOPT_DIR)" ]; then \
+		echo "Error: AIEOPT_DIR unset (source utils/env_setup.sh)."; exit 1; \
+	fi; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && $$GPP ${srcdir}/$(SRC) -o $(OUT) -std=c++23 -Wall \
+		-I$$XILINX_XRT/include -L$$XILINX_XRT/lib \
+		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
+		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed.py
@@ -1,0 +1,380 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# int4-AWQ GEMV: D[M] = dequant(A_q, A_s, A_z)[M, K] @ B[K].
+#
+# Q, S, Z are prepacked into a single L3 BO with one contiguous slab per
+# kernel-call tile:
+#     [ Q :  M_TILE * K_CHUNK/2 bytes uint8 ]
+#     [ S :  K_CHUNK/GS * M_TILE bf16        ]
+#     [ Z :  K_CHUNK/GS * M_TILE uint8       ]
+# Single packed BO collapses the per-tile shim DMA to a single BD per shim
+# channel (vs three with separate Q/S/Z channels), which is what makes the
+# inner loop's ping-pong viable without exceeding the 2-S2MM-per-tile cap.
+# The kernel slices Q, S, Z back out via pointer arithmetic — offsets are
+# 32-byte aligned for typical M_TILE/K_CHUNK/GS choices.
+
+import argparse
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import (
+    AffineConstantExpr,
+    AffineExpr,
+    AffineMap,
+    AffineSymbolExpr,
+    BF16Type,
+    IntegerAttr,
+    IntegerType,
+    MemRefType,
+    StringAttr,
+    UnitAttr,
+)
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import (
+    Channel,
+    ChannelGet,
+    ChannelPut,
+    MemorySpace,
+    T,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects.air import channel as channel_decl
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects import arith
+from air.dialects.scf import for_, yield_
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+KERNEL_OBJ_NAME = "mv_int4_bf16.o"
+
+
+def pack_inputs(A_q, A_s, A_z, M, K, GS, M_TILE, K_CHUNK, N_CORES, M_PER_LAUNCH):
+    """Pack Q+S+Z per kernel-call tile into a single contiguous L3 buffer.
+
+    Output: uint8 array shaped [total_tiles, TILE_BYTES] where total_tiles =
+    N_LAUNCHES * N_CORES * (M_PER_LAUNCH / N_CORES / M_TILE) * (K / K_CHUNK).
+    """
+    n_gpc = K_CHUNK // GS
+    q_bytes = M_TILE * (K_CHUNK // 2)
+    s_bytes = n_gpc * M_TILE * 2
+    z_bytes = n_gpc * M_TILE
+    tile_bytes = q_bytes + s_bytes + z_bytes
+
+    M_per_core_per_launch = M_PER_LAUNCH // N_CORES
+    M_div = M_per_core_per_launch // M_TILE
+    K_div = K // K_CHUNK
+    N_LAUNCHES = M // M_PER_LAUNCH
+
+    total_tiles = N_LAUNCHES * N_CORES * M_div * K_div
+    packed = np.zeros((total_tiles, tile_bytes), dtype=np.uint8)
+
+    tile_idx = 0
+    for lj in range(N_LAUNCHES):
+        for c in range(N_CORES):
+            base_row = lj * M_PER_LAUNCH + c * M_per_core_per_launch
+            for outer in range(M_div):
+                row_off = base_row + outer * M_TILE
+                for kc in range(K_div):
+                    q_col = kc * (K_CHUNK // 2)
+                    g_off = kc * n_gpc
+                    q_tile = A_q[
+                        row_off : row_off + M_TILE,
+                        q_col : q_col + (K_CHUNK // 2),
+                    ]
+                    s_tile = A_s[g_off : g_off + n_gpc, row_off : row_off + M_TILE]
+                    z_tile = A_z[g_off : g_off + n_gpc, row_off : row_off + M_TILE]
+                    p = packed[tile_idx]
+                    p[0:q_bytes] = (
+                        np.ascontiguousarray(q_tile).view(np.uint8).reshape(-1)
+                    )
+                    p[q_bytes : q_bytes + s_bytes] = (
+                        np.ascontiguousarray(s_tile).view(np.uint8).reshape(-1)
+                    )
+                    p[q_bytes + s_bytes :] = (
+                        np.ascontiguousarray(z_tile).view(np.uint8).reshape(-1)
+                    )
+                    tile_idx += 1
+    return packed
+
+
+def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=None):
+    if M_PER_LAUNCH is None:
+        M_PER_LAUNCH = M  # 1 launch by default
+
+    assert M % M_PER_LAUNCH == 0
+    assert M_PER_LAUNCH % N_CORES == 0
+    M_per_core_per_launch = M_PER_LAUNCH // N_CORES
+    assert M_per_core_per_launch % M_TILE == 0
+    M_div_m_per_core = M_per_core_per_launch // M_TILE
+    assert K % K_CHUNK == 0
+    assert K_CHUNK % GS == 0
+    K_div_k = K // K_CHUNK
+    n_groups_per_chunk = K_CHUNK // GS
+    N_LAUNCHES = M // M_PER_LAUNCH
+    total_tiles = N_LAUNCHES * N_CORES * M_div_m_per_core * K_div_k
+
+    q_bytes = M_TILE * (K_CHUNK // 2)
+    s_bytes = n_groups_per_chunk * M_TILE * 2
+    z_bytes = n_groups_per_chunk * M_TILE
+    tile_bytes = q_bytes + s_bytes + z_bytes
+
+    assert q_bytes % 32 == 0
+    assert (q_bytes + s_bytes) % 32 == 0
+
+    @module_builder
+    def build():
+        bf16_ty = BF16Type.get()
+        i8_ty = IntegerType.get_signless(8)
+
+        packed_l3 = MemRefType.get([total_tiles, tile_bytes], i8_ty)
+        B_l3 = MemRefType.get([K], bf16_ty)
+        D_l3 = MemRefType.get([M], bf16_ty)
+
+        l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+
+        packed_l2 = MemRefType.get([tile_bytes], i8_ty, memory_space=l2_ms)
+        packed_l1 = MemRefType.get([tile_bytes], i8_ty, memory_space=l1_ms)
+        B_l1 = MemRefType.get([K_CHUNK], bf16_ty, memory_space=l1_ms)
+        D_l1 = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
+
+        channel_decl("inL3", size=[N_CORES])
+        Channel("inB", size=[1, 1], broadcast_shape=[N_CORES, 1])
+        channel_decl("aL2ToL1", size=[N_CORES])
+        channel_decl("outD", size=[N_CORES])
+
+        zero_func = FuncOp("zero_vectorized_bf16", ([D_l1], []), visibility="private")
+        zero_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        zero_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        matvec_func = FuncOp(
+            "matvec_int4_bf16_packed",
+            ([packed_l1, B_l1, D_l1], []),
+            visibility="private",
+        )
+        matvec_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        matvec_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        @FuncOp.from_py_func(packed_l3, B_l3, D_l3)
+        def matvec_int4_packed(PACKED, B, D):
+            @launch(sizes=[1, N_LAUNCHES], operands=[PACKED, B, D])
+            def launch_body(li, lj, lsx, lsy, packed, b, d):
+                launch_to_off = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(M_PER_LAUNCH),
+                        )
+                    ],
+                )
+                launch_off = affine_apply(launch_to_off, [lj])
+                tiles_per_launch_per_core = M_div_m_per_core * K_div_k
+                tile_base_per_launch = arith.muli(
+                    lj,
+                    arith.ConstantOp.create_index(N_CORES * tiles_per_launch_per_core),
+                )
+
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_tile_const = arith.ConstantOp.create_index(
+                        c * tiles_per_launch_per_core
+                    )
+                    core_tile_base = arith.AddIOp(
+                        tile_base_per_launch, c_tile_const
+                    ).result
+                    # Single multi-dim BD per core covers all (outer, kc)
+                    # tiles for this launch — the inner ping-pong is on the
+                    # tile loop, kept hidden behind the multi-dim wrap.
+                    ChannelPut(
+                        "inL3",
+                        packed,
+                        indices=[c_idx],
+                        offsets=[core_tile_base, 0],
+                        sizes=[tiles_per_launch_per_core, tile_bytes],
+                        strides=[tile_bytes, 1],
+                    )
+                    c_row_const = arith.ConstantOp.create_index(
+                        c * M_per_core_per_launch
+                    )
+                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[core_launch_base],
+                        sizes=[M_per_core_per_launch],
+                        strides=[1],
+                    )
+
+                # B: replay each K-chunk across outer iters (outer-stride=0).
+                ChannelPut(
+                    "inB",
+                    b,
+                    offsets=[0, 0, 0],
+                    sizes=[M_div_m_per_core, K_div_k, K_CHUNK],
+                    strides=[0, K_CHUNK, 1],
+                )
+
+                @segment(name="seg")
+                def segment_body():
+                    for c in range(N_CORES):
+                        c_idx_s = arith.ConstantOp.create_index(c)
+                        for _ in for_(M_div_m_per_core):
+                            for _ in for_(K_div_k):
+                                l2_op = AllocOp(packed_l2, [], [])
+                                ChannelGet("inL3", l2_op, indices=[c_idx_s])
+                                ChannelPut("aL2ToL1", l2_op, indices=[c_idx_s])
+                                DeallocOp(l2_op)
+                                yield_([])
+                            yield_([])
+
+                    @herd(name="matvec_h", sizes=[N_CORES, 1])
+                    def herd_body(tx, ty, _sx, _sy):
+                        for _outer in for_(M_div_m_per_core):
+                            l1_d_op = AllocOp(D_l1, [], [])
+                            CallOp(zero_func, [l1_d_op])
+                            for _ in for_(K_div_k):
+                                l1_packed_op = AllocOp(packed_l1, [], [])
+                                l1_b_op = AllocOp(B_l1, [], [])
+                                ChannelGet("aL2ToL1", l1_packed_op, indices=[tx])
+                                ChannelGet("inB", l1_b_op, indices=[tx, ty])
+                                CallOp(
+                                    matvec_func,
+                                    [l1_packed_op, l1_b_op, l1_d_op],
+                                )
+                                DeallocOp(l1_packed_op)
+                                DeallocOp(l1_b_op)
+                                yield_([])
+                            ChannelPut("outD", l1_d_op, indices=[tx])
+                            DeallocOp(l1_d_op)
+                            yield_([])
+
+                    herd_body.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+                    herd_body.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
+                    herd_body.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+    return build()
+
+
+def cpu_reference(A_q, A_s, A_z, B):
+    M_ = A_q.shape[0]
+    K_ = B.shape[0]
+    n_groups = A_s.shape[0]
+    gs = K_ // n_groups
+    D = np.zeros(M_, dtype=np.float32)
+    Bf = B.astype(np.float32)
+    A_s_f = A_s.astype(np.float32)
+    A_z_i = A_z.astype(np.int32)
+    for r in range(M_):
+        for kk in range(K_):
+            byte = int(A_q[r, kk // 2])
+            nib = (byte & 0x0F) if (kk % 2 == 0) else ((byte >> 4) & 0x0F)
+            g = kk // gs
+            D[r] += (nib - A_z_i[g, r]) * A_s_f[g, r] * Bf[kk]
+    return D.astype(bfloat16)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="matvec_int4_packed.py",
+        description="int4-AWQ GEMV: D = dequant(A) @ B",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--gs", type=int, default=128)
+    parser.add_argument("--m-tile", type=int, default=8, dest="m_tile")
+    parser.add_argument("--k-chunk", type=int, default=2048, dest="k_chunk")
+    parser.add_argument("--n-cores", type=int, default=8, dest="n_cores")
+    parser.add_argument("--m-per-launch", type=int, default=None, dest="m_per_launch")
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="elf",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-and-run", "compile-only"],
+        default="compile-and-run",
+        dest="compile_mode",
+    )
+    args = parser.parse_args()
+
+    module = build_module(
+        args.m,
+        args.k,
+        GS=args.gs,
+        M_TILE=args.m_tile,
+        K_CHUNK=args.k_chunk,
+        N_CORES=args.n_cores,
+        M_PER_LAUNCH=args.m_per_launch,
+    )
+    if args.print_module_only:
+        print(module)
+        exit(0)
+
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            instance_name="matvec_int4_packed",
+            use_lock_race_condition_fix=False,
+            stack_size=4096,
+        )
+        backend.compile(module)
+        backend.unload()
+        exit(0)
+
+    np.random.seed(42)
+    A_q_unp = np.random.randint(0, 16, size=(args.m, args.k), dtype=np.uint8)
+    A_q = (A_q_unp[:, 0::2] | (A_q_unp[:, 1::2] << 4)).astype(np.uint8)
+    n_groups = args.k // args.gs
+    A_s = np.random.uniform(0.005, 0.02, size=(n_groups, args.m)).astype(bfloat16)
+    A_z = np.random.randint(7, 9, size=(n_groups, args.m), dtype=np.uint8)
+    B = np.random.randn(args.k).astype(bfloat16)
+
+    D_ref = cpu_reference(A_q, A_s, A_z, B)
+    m_per_launch = args.m_per_launch if args.m_per_launch is not None else args.m
+    PACKED = pack_inputs(
+        A_q,
+        A_s,
+        A_z,
+        args.m,
+        args.k,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        m_per_launch,
+    )
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="matvec_int4_packed",
+        use_lock_race_condition_fix=False,
+        stack_size=4096,
+    )
+    exit(
+        runner.run_test(
+            module,
+            inputs=[PACKED, B],
+            expected_outputs=[D_ref],
+            rtol=0.1,
+            atol=0.05,
+            min_correlation=0.999,
+        )
+    )

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
@@ -103,7 +103,10 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
         packed_l2 = MemRefType.get([tile_bytes], i8_ty, memory_space=l2_ms)
         packed_l1 = MemRefType.get([tile_bytes], i8_ty, memory_space=l1_ms)
         B_l1 = MemRefType.get([K_CHUNK], bf16_ty, memory_space=l1_ms)
-        R_full_l1 = MemRefType.get([M], bf16_ty, memory_space=l1_ms)
+        # addr_h loads only the current launch's slab of R, not all of M, so
+        # the per-outer offset arithmetic inside the herd is launch-relative
+        # (otherwise multi-launch runs read R from launch 0 every time).
+        R_full_l1 = MemRefType.get([M_per_core * N_CORES], bf16_ty, memory_space=l1_ms)
         partial_l1 = MemRefType.get([CASCADE_WIDTH], bf16_ty, memory_space=l1_ms)
         partial_slice_ty = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
         D_l1 = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
@@ -193,11 +196,13 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                     sizes=[M_div_m_per_core, K_div_k, K_CHUNK],
                     strides=[0, K_CHUNK, 1],
                 )
+                # Broadcast only the current launch's slab of R; addr_h's
+                # core_base + iter_off offset is then launch-relative.
                 ChannelPut(
                     "inR",
                     r,
-                    offsets=[0],
-                    sizes=[M],
+                    offsets=[launch_off],
+                    sizes=[M_PER_LAUNCH],
                     strides=[1],
                 )
 

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
@@ -1,0 +1,408 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# int4-AWQ GEMV + residual add: D[M] = dequant(A_q, A_s, A_z) @ B[K] + R[M].
+#
+# Mirrors the bf16 matvec_2tile_add cascade structure so the int4 design
+# is a drop-in replacement for the Llama-decode wo/wdown GEMV+residual
+# layers: two stacked herds per column connected by an intra-column
+# npu_cascade. R stays a separate L3 BO (produced by an upstream NPU op,
+# never repacked by the host).
+#   matvec_h (north): int4 matvec into a 32-lane L1 partial buffer.
+#   addr_h  (south):  receives partial via cascade, adds the matching
+#                     M_TILE slice of R, writes D.
+# AIE2P cascade flows N→S, so matvec_h pins to a higher row than addr_h.
+#
+# Q+S+Z come in as a single prepacked L3 BO (same layout as
+# matvec_int4_packed.py); the L1 receive on matvec_h stays within its
+# 2-S2MM-per-tile budget (packed + B broadcast).
+
+import argparse
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import (
+    AffineConstantExpr,
+    AffineExpr,
+    AffineMap,
+    AffineSymbolExpr,
+    BF16Type,
+    BoolAttr,
+    IntegerAttr,
+    IntegerType,
+    MemRefType,
+    StringAttr,
+    UnitAttr,
+)
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import (
+    Channel,
+    ChannelGet,
+    ChannelPut,
+    MemorySpace,
+    T,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects.air import channel as channel_decl
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.memref import AllocOp, DeallocOp, subview
+from air.dialects.memref import cast as memref_cast
+from air.dialects import arith
+from air.dialects.scf import for_, yield_
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+from matvec_int4_packed import pack_inputs
+
+KERNEL_OBJ_NAME = "mv_int4_bf16.o"
+
+CASCADE_WIDTH = 32  # AIE2P cascade payload = vector<32xbf16>
+
+
+def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=None):
+    if M_PER_LAUNCH is None:
+        M_PER_LAUNCH = M
+
+    assert M % M_PER_LAUNCH == 0
+    assert M_PER_LAUNCH % N_CORES == 0
+    M_per_core = M_PER_LAUNCH // N_CORES
+    assert M_per_core % M_TILE == 0
+    M_div_m_per_core = M_per_core // M_TILE
+    assert K % K_CHUNK == 0
+    assert K_CHUNK % GS == 0
+    K_div_k = K // K_CHUNK
+    n_groups_per_chunk = K_CHUNK // GS
+    N_LAUNCHES = M // M_PER_LAUNCH
+    total_tiles = N_LAUNCHES * N_CORES * M_div_m_per_core * K_div_k
+
+    q_bytes = M_TILE * (K_CHUNK // 2)
+    s_bytes = n_groups_per_chunk * M_TILE * 2
+    z_bytes = n_groups_per_chunk * M_TILE
+    tile_bytes = q_bytes + s_bytes + z_bytes
+    assert q_bytes % 32 == 0
+    assert (q_bytes + s_bytes) % 32 == 0
+    assert M_TILE <= CASCADE_WIDTH, "cascade payload is fixed at 32 lanes"
+
+    @module_builder
+    def build():
+        bf16_ty = BF16Type.get()
+        i8_ty = IntegerType.get_signless(8)
+
+        packed_l3 = MemRefType.get([total_tiles, tile_bytes], i8_ty)
+        B_l3 = MemRefType.get([K], bf16_ty)
+        R_l3 = MemRefType.get([M], bf16_ty)
+        D_l3 = MemRefType.get([M], bf16_ty)
+
+        l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+
+        packed_l2 = MemRefType.get([tile_bytes], i8_ty, memory_space=l2_ms)
+        packed_l1 = MemRefType.get([tile_bytes], i8_ty, memory_space=l1_ms)
+        B_l1 = MemRefType.get([K_CHUNK], bf16_ty, memory_space=l1_ms)
+        R_full_l1 = MemRefType.get([M], bf16_ty, memory_space=l1_ms)
+        partial_l1 = MemRefType.get([CASCADE_WIDTH], bf16_ty, memory_space=l1_ms)
+        partial_slice_ty = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
+        D_l1 = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
+
+        channel_decl("inL3", size=[N_CORES])
+        channel_decl("aL2ToL1", size=[N_CORES])
+        Channel("inB", size=[1, 1], broadcast_shape=[N_CORES, 1])
+        Channel("inR", size=[1, 1], broadcast_shape=[N_CORES, 1])
+        channel_decl("partial_cas", size=[N_CORES], channel_type="npu_cascade")
+        channel_decl("outD", size=[N_CORES])
+
+        zero_func = FuncOp(
+            "zero_vectorized_bf16",
+            ([partial_slice_ty], []),
+            visibility="private",
+        )
+        zero_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        zero_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        matvec_func = FuncOp(
+            "matvec_int4_bf16_packed",
+            ([packed_l1, B_l1, partial_slice_ty], []),
+            visibility="private",
+        )
+        matvec_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        matvec_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        partial_plus_r_func = FuncOp(
+            "partial_plus_r_bf16",
+            ([partial_slice_ty, R_full_l1, T.i32(), D_l1], []),
+            visibility="private",
+        )
+        partial_plus_r_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        partial_plus_r_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        @FuncOp.from_py_func(packed_l3, B_l3, R_l3, D_l3)
+        def matvec_int4_packed_add(PACKED, B, R, D):
+            @launch(sizes=[1, N_LAUNCHES], operands=[PACKED, B, R, D])
+            def launch_body(li, lj, lsx, lsy, packed, b, r, d):
+                tiles_per_launch_per_core = M_div_m_per_core * K_div_k
+                tile_base_per_launch = arith.muli(
+                    lj,
+                    arith.ConstantOp.create_index(N_CORES * tiles_per_launch_per_core),
+                )
+                launch_to_off = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(M_PER_LAUNCH),
+                        )
+                    ],
+                )
+                launch_off = affine_apply(launch_to_off, [lj])
+
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_tile_const = arith.ConstantOp.create_index(
+                        c * tiles_per_launch_per_core
+                    )
+                    core_tile_base = arith.AddIOp(
+                        tile_base_per_launch, c_tile_const
+                    ).result
+                    ChannelPut(
+                        "inL3",
+                        packed,
+                        indices=[c_idx],
+                        offsets=[core_tile_base, 0],
+                        sizes=[tiles_per_launch_per_core, tile_bytes],
+                        strides=[tile_bytes, 1],
+                    )
+                    c_row_const = arith.ConstantOp.create_index(c * M_per_core)
+                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[core_launch_base],
+                        sizes=[M_per_core],
+                        strides=[1],
+                    )
+                ChannelPut(
+                    "inB",
+                    b,
+                    offsets=[0, 0, 0],
+                    sizes=[M_div_m_per_core, K_div_k, K_CHUNK],
+                    strides=[0, K_CHUNK, 1],
+                )
+                ChannelPut(
+                    "inR",
+                    r,
+                    offsets=[0],
+                    sizes=[M],
+                    strides=[1],
+                )
+
+                @segment(name="seg")
+                def segment_body():
+                    for c in range(N_CORES):
+                        c_idx_s = arith.ConstantOp.create_index(c)
+                        for _ in for_(M_div_m_per_core):
+                            for _ in for_(K_div_k):
+                                l2_op = AllocOp(packed_l2, [], [])
+                                ChannelGet("inL3", l2_op, indices=[c_idx_s])
+                                ChannelPut("aL2ToL1", l2_op, indices=[c_idx_s])
+                                DeallocOp(l2_op)
+                                yield_([])
+                            yield_([])
+
+                    @herd(name="matvec_h", sizes=[N_CORES, 1])
+                    def matvec_herd(tx, ty, _sx, _sy):
+                        for _outer in for_(M_div_m_per_core):
+                            l1_part_op = AllocOp(partial_l1, [], [])
+                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
+                            l1_part = l1_part_op.result
+                            l1_part_slice_strided = subview(l1_part, [0], [M_TILE], [1])
+                            l1_part_slice = memref_cast(
+                                partial_slice_ty, l1_part_slice_strided
+                            )
+                            CallOp(zero_func, [l1_part_slice])
+                            for _kc in for_(K_div_k):
+                                l1_b_op = AllocOp(B_l1, [], [])
+                                ChannelGet("inB", l1_b_op, indices=[tx, ty])
+                                l1_packed_op = AllocOp(packed_l1, [], [])
+                                ChannelGet("aL2ToL1", l1_packed_op, indices=[tx])
+                                CallOp(
+                                    matvec_func,
+                                    [l1_packed_op, l1_b_op, l1_part_slice],
+                                )
+                                DeallocOp(l1_packed_op)
+                                DeallocOp(l1_b_op)
+                                yield_([])
+                            ChannelPut("partial_cas", l1_part, indices=[tx])
+                            DeallocOp(l1_part_op)
+                            yield_([])
+
+                    matvec_herd.attributes["link_with"] = StringAttr.get(
+                        KERNEL_OBJ_NAME
+                    )
+                    # matvec_h pinned NORTH of addr_h (cascade N→S on AIE2P).
+                    matvec_herd.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
+                    matvec_herd.attributes["y_loc"] = IntegerAttr.get(T.i64(), 3)
+
+                    @herd(name="addr_h", sizes=[N_CORES, 1])
+                    def addr_herd(tx, ty, _sx, _sy):
+                        M_per_core_c = arith.constant(T.i32(), M_per_core)
+                        m_c = arith.constant(T.i32(), M_TILE)
+                        tx_i32 = arith.index_cast(T.i32(), tx)
+                        core_base = arith.muli(tx_i32, M_per_core_c)
+
+                        l1_r_op = AllocOp(R_full_l1, [], [])
+                        ChannelGet("inR", l1_r_op, indices=[tx, ty])
+
+                        for outer in for_(M_div_m_per_core):
+                            l1_part_op = AllocOp(partial_l1, [], [])
+                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
+                            l1_d_op = AllocOp(D_l1, [], [])
+                            ChannelGet("partial_cas", l1_part_op, indices=[tx])
+                            l1_part_slice_strided = subview(
+                                l1_part_op.result, [0], [M_TILE], [1]
+                            )
+                            l1_part_slice = memref_cast(
+                                partial_slice_ty, l1_part_slice_strided
+                            )
+                            outer_i32 = arith.index_cast(T.i32(), outer)
+                            iter_off = arith.muli(outer_i32, m_c)
+                            offset = arith.addi(core_base, iter_off)
+                            CallOp(
+                                partial_plus_r_func,
+                                [l1_part_slice, l1_r_op, offset, l1_d_op],
+                            )
+                            ChannelPut("outD", l1_d_op, indices=[tx])
+                            DeallocOp(l1_d_op)
+                            DeallocOp(l1_part_op)
+                            yield_([])
+                        DeallocOp(l1_r_op)
+
+                    addr_herd.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+                    addr_herd.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
+                    addr_herd.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+    return build()
+
+
+def cpu_reference(A_q, A_s, A_z, B, R):
+    M_ = A_q.shape[0]
+    K_ = B.shape[0]
+    n_groups = A_s.shape[0]
+    gs = K_ // n_groups
+    D = np.zeros(M_, dtype=np.float32)
+    Bf = B.astype(np.float32)
+    A_s_f = A_s.astype(np.float32)
+    A_z_i = A_z.astype(np.int32)
+    Rf = R.astype(np.float32)
+    for r in range(M_):
+        for kk in range(K_):
+            byte = int(A_q[r, kk // 2])
+            nib = (byte & 0x0F) if (kk % 2 == 0) else ((byte >> 4) & 0x0F)
+            g = kk // gs
+            D[r] += (nib - A_z_i[g, r]) * A_s_f[g, r] * Bf[kk]
+        D[r] += Rf[r]
+    return D.astype(bfloat16)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="matvec_int4_packed_add.py",
+        description="int4-AWQ GEMV with fused residual add: D = dequant(A) @ B + R",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--gs", type=int, default=128)
+    parser.add_argument("--m-tile", type=int, default=8, dest="m_tile")
+    parser.add_argument("--k-chunk", type=int, default=2048, dest="k_chunk")
+    parser.add_argument("--n-cores", type=int, default=8, dest="n_cores")
+    parser.add_argument("--m-per-launch", type=int, default=None, dest="m_per_launch")
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["xclbin", "elf"],
+        default="elf",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-and-run", "compile-only"],
+        default="compile-and-run",
+        dest="compile_mode",
+    )
+    args = parser.parse_args()
+
+    module = build_module(
+        args.m,
+        args.k,
+        GS=args.gs,
+        M_TILE=args.m_tile,
+        K_CHUNK=args.k_chunk,
+        N_CORES=args.n_cores,
+        M_PER_LAUNCH=args.m_per_launch,
+    )
+    if args.print_module_only:
+        print(module)
+        exit(0)
+
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            instance_name="matvec_int4_packed_add",
+            use_lock_race_condition_fix=False,
+            stack_size=4096,
+        )
+        backend.compile(module)
+        backend.unload()
+        exit(0)
+
+    np.random.seed(42)
+    A_q_unp = np.random.randint(0, 16, size=(args.m, args.k), dtype=np.uint8)
+    A_q = (A_q_unp[:, 0::2] | (A_q_unp[:, 1::2] << 4)).astype(np.uint8)
+    n_groups = args.k // args.gs
+    A_s = np.random.uniform(0.005, 0.02, size=(n_groups, args.m)).astype(bfloat16)
+    A_z = np.random.randint(7, 9, size=(n_groups, args.m), dtype=np.uint8)
+    B = np.random.randn(args.k).astype(bfloat16)
+    R = np.random.randn(args.m).astype(bfloat16)
+
+    D_ref = cpu_reference(A_q, A_s, A_z, B, R)
+    m_per_launch = args.m_per_launch if args.m_per_launch is not None else args.m
+    PACKED = pack_inputs(
+        A_q,
+        A_s,
+        A_z,
+        args.m,
+        args.k,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        m_per_launch,
+    )
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="matvec_int4_packed_add",
+        use_lock_race_condition_fix=False,
+        stack_size=4096,
+    )
+    exit(
+        runner.run_test(
+            module,
+            inputs=[PACKED, B, R],
+            expected_outputs=[D_ref],
+            rtol=0.1,
+            atol=0.05,
+            min_correlation=0.999,
+        )
+    )

--- a/programming_examples/matrix_vector_multiplication/int4_awq/mv_int4_bf16.cc
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/mv_int4_bf16.cc
@@ -1,0 +1,118 @@
+//===- mv_int4_bf16.cc - AWQ uint4 weight x bf16 activation matvec --------===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Per-tile micro-kernels for the int4-AWQ GEMV examples:
+//   - matvec_int4_bf16_packed(packed, b, c):
+//         c[0..m] += dequant(A)[m, k] @ b[k]
+//         where dequant(A)[r, k] = (q[r, k] - z[r, g(k)]) * s_a[r, g(k)],
+//         q ∈ uint4, z ∈ uint4 (stored uint8), s_a ∈ bf16, b ∈ bf16, c ∈ bf16.
+//         The packed L1 BO contains Q, S, Z back-to-back per tile:
+//             [ Q : m * k/2 bytes uint8 (row-major) ]
+//             [ S : k/gs * m bf16                   ]
+//             [ Z : k/gs * m uint8                  ]
+//         Offsets are 32-byte aligned when m and gs are powers of two ≥ 16.
+//   - zero_vectorized_bf16(c):           c[0..m] = 0
+//   - partial_plus_r_bf16(p, r, off, d): d[0..m] = p[0..m] + r[off..off+m]
+//
+//===----------------------------------------------------------------------===//
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+#ifndef DIM_M
+#define DIM_M 8
+#endif
+#ifndef DIM_K
+#define DIM_K 2048
+#endif
+#ifndef DIM_GS
+#define DIM_GS 128
+#endif
+
+static_assert(DIM_K % DIM_GS == 0, "DIM_K must be a multiple of DIM_GS");
+
+// int4-AWQ matvec inner kernel. One accfloat accumulator per output row spans
+// the full K. Within each group we accumulate raw (w_bf16 × b) into a per-
+// group accfloat, then fold the per-group bf16 scale via a single mac with
+// the broadcast scalar — keeps the inner loop a tight load-unpack-sub-cvt-mac
+// chain and avoids the per-group acc32→bf16 plumbing that an int8-mac design
+// would impose.
+template <unsigned m, unsigned k, unsigned gs, unsigned r>
+void matvec_int4_bf16_impl(uint8_t *__restrict a_q, bfloat16 *__restrict a_s,
+                           uint8_t *__restrict a_z, bfloat16 *__restrict b,
+                           bfloat16 *__restrict c) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  static_assert(gs % r == 0, "group size must be multiple of inner vector r");
+  constexpr unsigned NSUB = gs / r;
+
+  for (unsigned row = 0; row < m; row++) {
+    aie::accum<accfloat, r> acc;
+    acc.from_vector(aie::zeros<float, r>());
+    const uint8_t *__restrict aq = a_q + row * (k / 2);
+
+    for (unsigned g = 0; g < k / gs; g++) {
+      aie::vector<int8, r> zv =
+          aie::broadcast<int8, r>((int8_t)a_z[g * m + row]);
+      bfloat16 sa = a_s[g * m + row];
+
+      aie::accum<accfloat, r> g_acc;
+      g_acc.from_vector(aie::zeros<float, r>());
+
+#pragma clang loop unroll(full)
+      for (unsigned i = 0; i < NSUB; i++) {
+        const unsigned off = (g * gs + i * r) / 2;
+        aie::vector<uint8, r / 2> packed = aie::load_v<r / 2>(aq + off);
+        aie::vector<int8, r> w_int8 =
+            packed.template cast_to<uint4>().template unpack_sign<int8>(false);
+        w_int8 = aie::sub(w_int8, zv);
+        aie::vector<bfloat16, r> w_bf16 = aie::to_float<bfloat16>(w_int8, 0);
+        aie::vector<bfloat16, r> b_vec = aie::load_v<r>(b + g * gs + i * r);
+        g_acc = aie::mac(g_acc, w_bf16, b_vec);
+      }
+
+      aie::vector<bfloat16, r> g_bf16 = g_acc.template to_vector<bfloat16>();
+      acc = aie::mac(acc, g_bf16, sa);
+    }
+
+    float s = aie::reduce_add(acc.template to_vector<float>());
+    c[row] = (bfloat16)((float)c[row] + s);
+  }
+}
+
+template <unsigned m>
+static void zero_impl(bfloat16 *__restrict c) {
+  for (unsigned i = 0; i < m; i++)
+    c[i] = (bfloat16)0.0f;
+}
+
+template <unsigned m>
+static void partial_plus_r_impl(const bfloat16 *__restrict partial,
+                                const bfloat16 *__restrict r_full, int offset,
+                                bfloat16 *__restrict d) {
+  for (unsigned i = 0; i < m; i++)
+    d[i] = (bfloat16)((float)partial[i] + (float)r_full[offset + i]);
+}
+
+extern "C" {
+
+// Packed-BO entry. The single L1 input combines Q, S, Z so the compute tile
+// stays within its 2-S2MM-channel budget when paired with the broadcast B.
+void matvec_int4_bf16_packed(uint8_t *packed, bfloat16 *b, bfloat16 *c) {
+  constexpr unsigned Q_BYTES = DIM_M * (DIM_K / 2);
+  constexpr unsigned S_BYTES = (DIM_K / DIM_GS) * DIM_M * 2;
+  uint8_t *a_q = packed;
+  bfloat16 *a_s = reinterpret_cast<bfloat16 *>(packed + Q_BYTES);
+  uint8_t *a_z = packed + Q_BYTES + S_BYTES;
+  matvec_int4_bf16_impl<DIM_M, DIM_K, DIM_GS, 32>(a_q, a_s, a_z, b, c);
+}
+
+void zero_vectorized_bf16(bfloat16 *c) { zero_impl<DIM_M>(c); }
+
+void partial_plus_r_bf16(bfloat16 *partial, bfloat16 *r_full, int offset,
+                         bfloat16 *d) {
+  partial_plus_r_impl<DIM_M>(partial, r_full, offset, d);
+}
+
+} // extern "C"

--- a/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_add_npu2_2048x2048_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_add_npu2_2048x2048_peano.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_int4_packed_add_npu2_2048x2048_peano
+// RUN: cd test_int4_packed_add_npu2_2048x2048_peano
+// RUN: make -f %S/Makefile clean
+//
+// int4-AWQ GEMV with fused residual add: D = dequant(A) @ B + R at M=K=2048
+// (Llama Wo decode shape; 2-tile cascade matches the bf16 matvec_2tile_add
+// reference structurally).
+// RUN: make -f %S/Makefile run_packed_add M=2048 K=2048 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_npu2_2048x2048_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_npu2_2048x2048_peano.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_int4_packed_npu2_2048x2048_peano
+// RUN: cd test_int4_packed_npu2_2048x2048_peano
+// RUN: make -f %S/Makefile clean
+//
+// int4-AWQ GEMV: D = dequant(A) @ B at M=K=2048 (Llama Wo decode shape).
+// RUN: make -f %S/Makefile run_packed M=2048 K=2048 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_npu2_2048x8192_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/run_packed_npu2_2048x8192_peano.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_int4_packed_npu2_2048x8192_peano
+// RUN: cd test_int4_packed_npu2_2048x8192_peano
+// RUN: make -f %S/Makefile clean
+//
+// int4-AWQ GEMV at M=2048, K=8192 (Llama wdown decode shape). Exercises
+// the multi-kc inner loop (K_div_k = K/K_CHUNK = 4) so the tile loop has
+// trip count > 1 inside the launch.
+// RUN: make -f %S/Makefile run_packed M=2048 K=8192 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_vector_multiplication/int4_awq/test_packed.cpp
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/test_packed.cpp
@@ -10,9 +10,11 @@
 // Per-tile PACKED layout (uint8): [ Q | S(bf16) | Z(uint8) ].
 
 #include "cxxopts.hpp"
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <iostream>
 #include <limits>
@@ -75,9 +77,25 @@ int main(int argc, const char *argv[]) {
   xrt::bo bo_d = xrt::ext::bo{device, D_SIZE};
 
   {
-    uint8_t *p = bo_packed.map<uint8_t *>();
-    for (size_t i = 0; i < PACKED_SIZE; i++)
-      p[i] = (uint8_t)(rand() & 0xFF);
+    // Fill each per-tile slab as valid AWQ data so the profile loop runs
+    // on inputs that the kernel can actually process (random bytes in the
+    // S region would produce bf16 NaN/Inf which destabilizes timing).
+    uint8_t *base = bo_packed.map<uint8_t *>();
+    for (size_t t = 0; t < n_tiles_total; t++) {
+      uint8_t *p = base + t * TILE_BYTES;
+      // Q: any uint8 pattern is a valid pair of uint4 nibbles.
+      for (size_t i = 0; i < Q_BYTES; i++)
+        p[i] = (uint8_t)(rand() & 0xFF);
+      // S: bf16 in [0.005, 0.02] (matches the Python correctness reference).
+      DT_BF16 *s = reinterpret_cast<DT_BF16 *>(p + Q_BYTES);
+      size_t s_elems = S_BYTES / sizeof(DT_BF16);
+      for (size_t i = 0; i < s_elems; i++)
+        s[i] = DT_BF16(0.005f + 0.015f * ((float)rand() / RAND_MAX));
+      // Z: uint4 (stored uint8) in [7, 9), per Python reference.
+      uint8_t *z = p + Q_BYTES + S_BYTES;
+      for (size_t i = 0; i < Z_BYTES; i++)
+        z[i] = (uint8_t)(7 + (rand() & 1));
+    }
   }
   {
     DT_BF16 *p = bo_b.map<DT_BF16 *>();

--- a/programming_examples/matrix_vector_multiplication/int4_awq/test_packed.cpp
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/test_packed.cpp
@@ -1,0 +1,134 @@
+//===- test_packed.cpp ----------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+// XRT (ELF) profiling harness for int4-AWQ GEMV with prepacked Q+S+Z BO.
+//   D[M] = sum_k (q[r, k] - z[g(k), r]) * s[g(k), r] * B[k]
+// 3-arg kernel: (PACKED, B, D), order matches matvec_int4_packed.py.
+//
+// Per-tile PACKED layout (uint8): [ Q | S(bf16) | Z(uint8) ].
+
+#include "cxxopts.hpp"
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <limits>
+#include <stdfloat>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+
+using DT_BF16 = std::bfloat16_t;
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("int4-AWQ GEMV ELF Profiling (packed)");
+  options.add_options()("help,h", "produce help message")(
+      "elf,e", "elf path", cxxopts::value<std::string>())(
+      "kernel,k", "kernel <kernel>:<instance>", cxxopts::value<std::string>())(
+      "verbosity,v", "verbosity", cxxopts::value<int>()->default_value("0"))(
+      "size_m,M", "rows M", cxxopts::value<int>()->default_value("2048"))(
+      "size_k,K", "reduction K", cxxopts::value<int>()->default_value("2048"))(
+      "group_size,G", "AWQ group size",
+      cxxopts::value<int>()->default_value("128"))(
+      "tile_m,T", "M_TILE", cxxopts::value<int>()->default_value("8"))(
+      "k_chunk,C", "K_CHUNK", cxxopts::value<int>()->default_value("2048"))(
+      "iterations", "timed iters", cxxopts::value<int>()->default_value("20"))(
+      "warmup", "warmup iters", cxxopts::value<int>()->default_value("10"));
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+  int M = vm["size_m"].as<int>();
+  int K = vm["size_k"].as<int>();
+  int GS = vm["group_size"].as<int>();
+  int M_TILE = vm["tile_m"].as<int>();
+  int K_CHUNK = vm["k_chunk"].as<int>();
+  int n_gpc = K_CHUNK / GS;
+
+  size_t Q_BYTES = (size_t)M_TILE * (K_CHUNK / 2);
+  size_t S_BYTES = (size_t)n_gpc * M_TILE * sizeof(DT_BF16);
+  size_t Z_BYTES = (size_t)n_gpc * M_TILE;
+  size_t TILE_BYTES = Q_BYTES + S_BYTES + Z_BYTES;
+  size_t n_tiles_total = ((size_t)M / M_TILE) * (K / K_CHUNK);
+  size_t PACKED_SIZE = n_tiles_total * TILE_BYTES;
+  size_t B_SIZE = (size_t)K * sizeof(DT_BF16);
+  size_t D_SIZE = (size_t)M * sizeof(DT_BF16);
+
+  srand(time(NULL));
+
+  auto device = xrt::device(0);
+  xrt::elf ctx_elf{vm["elf"].as<std::string>()};
+  xrt::hw_context context(device, ctx_elf);
+  auto kernel = xrt::ext::kernel(context, vm["kernel"].as<std::string>());
+
+  xrt::bo bo_packed = xrt::ext::bo{device, PACKED_SIZE};
+  xrt::bo bo_b = xrt::ext::bo{device, B_SIZE};
+  xrt::bo bo_d = xrt::ext::bo{device, D_SIZE};
+
+  {
+    uint8_t *p = bo_packed.map<uint8_t *>();
+    for (size_t i = 0; i < PACKED_SIZE; i++)
+      p[i] = (uint8_t)(rand() & 0xFF);
+  }
+  {
+    DT_BF16 *p = bo_b.map<DT_BF16 *>();
+    for (size_t i = 0; i < (size_t)K; i++)
+      p[i] = DT_BF16(4.0f * (float)rand() / RAND_MAX);
+  }
+  {
+    DT_BF16 *p = bo_d.map<DT_BF16 *>();
+    memset(p, 0, D_SIZE);
+  }
+
+  bo_packed.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_d.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iter = vm["iterations"].as<int>();
+  unsigned n_warm = vm["warmup"].as<int>();
+  unsigned total = n_iter + n_warm;
+  float t_total = 0, t_min = std::numeric_limits<float>::max(), t_max = 0;
+  float macs = 2.0f * (float)M * (float)K;
+
+  std::cout << "int4-AWQ GEMV Benchmark (ELF, packed)\n"
+            << "  M=" << M << " K=" << K << " GS=" << GS << " M_TILE=" << M_TILE
+            << " K_CHUNK=" << K_CHUNK << " TILE_BYTES=" << TILE_BYTES
+            << " n_tiles=" << n_tiles_total << " PACKED=" << PACKED_SIZE
+            << " B\n";
+
+  for (unsigned i = 0; i < total; i++) {
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo_packed);
+    run.set_arg(1, bo_b);
+    run.set_arg(2, bo_d);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    run.start();
+    run.wait2();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    bo_d.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    if (i < n_warm)
+      continue;
+    float dt =
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    t_total += dt;
+    t_min = std::min(t_min, dt);
+    t_max = std::max(t_max, dt);
+  }
+
+  std::cout << "\nAvg NPU time: " << t_total / n_iter << " us\n";
+  std::cout << "Avg gflops:   " << macs / (1000.0f * t_total / n_iter) << "\n";
+  std::cout << "Min NPU time: " << t_min << " us  (max gflops "
+            << macs / (1000.0f * t_min) << ")\n";
+  std::cout << "Max NPU time: " << t_max << " us  (min gflops "
+            << macs / (1000.0f * t_max) << ")\n";
+  return 0;
+}

--- a/programming_examples/matrix_vector_multiplication/int4_awq/test_packed_add.cpp
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/test_packed_add.cpp
@@ -7,9 +7,11 @@
 // 4-arg kernel: (PACKED, B, R, D), order matches matvec_int4_packed_add.py.
 
 #include "cxxopts.hpp"
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <iostream>
 #include <limits>
@@ -74,9 +76,25 @@ int main(int argc, const char *argv[]) {
   xrt::bo bo_d = xrt::ext::bo{device, D_SIZE};
 
   {
-    uint8_t *p = bo_packed.map<uint8_t *>();
-    for (size_t i = 0; i < PACKED_SIZE; i++)
-      p[i] = (uint8_t)(rand() & 0xFF);
+    // Fill each per-tile slab as valid AWQ data so the profile loop runs
+    // on inputs that the kernel can actually process (random bytes in the
+    // S region would produce bf16 NaN/Inf which destabilizes timing).
+    uint8_t *base = bo_packed.map<uint8_t *>();
+    for (size_t t = 0; t < n_tiles_total; t++) {
+      uint8_t *p = base + t * TILE_BYTES;
+      // Q: any uint8 pattern is a valid pair of uint4 nibbles.
+      for (size_t i = 0; i < Q_BYTES; i++)
+        p[i] = (uint8_t)(rand() & 0xFF);
+      // S: bf16 in [0.005, 0.02] (matches the Python correctness reference).
+      DT_BF16 *s = reinterpret_cast<DT_BF16 *>(p + Q_BYTES);
+      size_t s_elems = S_BYTES / sizeof(DT_BF16);
+      for (size_t i = 0; i < s_elems; i++)
+        s[i] = DT_BF16(0.005f + 0.015f * ((float)rand() / RAND_MAX));
+      // Z: uint4 (stored uint8) in [7, 9), per Python reference.
+      uint8_t *z = p + Q_BYTES + S_BYTES;
+      for (size_t i = 0; i < Z_BYTES; i++)
+        z[i] = (uint8_t)(7 + (rand() & 1));
+    }
   }
   {
     DT_BF16 *p = bo_b.map<DT_BF16 *>();

--- a/programming_examples/matrix_vector_multiplication/int4_awq/test_packed_add.cpp
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/test_packed_add.cpp
@@ -1,0 +1,140 @@
+//===- test_packed_add.cpp ------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+// XRT (ELF) profiling harness for int4-AWQ GEMV + fused residual add.
+// 4-arg kernel: (PACKED, B, R, D), order matches matvec_int4_packed_add.py.
+
+#include "cxxopts.hpp"
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <limits>
+#include <stdfloat>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+
+using DT_BF16 = std::bfloat16_t;
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("int4-AWQ GEMV+Add ELF Profiling (packed)");
+  options.add_options()("help,h", "produce help message")(
+      "elf,e", "elf path", cxxopts::value<std::string>())(
+      "kernel,k", "kernel <kernel>:<instance>", cxxopts::value<std::string>())(
+      "verbosity,v", "verbosity", cxxopts::value<int>()->default_value("0"))(
+      "size_m,M", "rows M", cxxopts::value<int>()->default_value("2048"))(
+      "size_k,K", "reduction K", cxxopts::value<int>()->default_value("2048"))(
+      "group_size,G", "AWQ group size",
+      cxxopts::value<int>()->default_value("128"))(
+      "tile_m,T", "M_TILE", cxxopts::value<int>()->default_value("8"))(
+      "k_chunk,C", "K_CHUNK", cxxopts::value<int>()->default_value("2048"))(
+      "iterations", "timed iters", cxxopts::value<int>()->default_value("20"))(
+      "warmup", "warmup iters", cxxopts::value<int>()->default_value("10"));
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+  int M = vm["size_m"].as<int>();
+  int K = vm["size_k"].as<int>();
+  int GS = vm["group_size"].as<int>();
+  int M_TILE = vm["tile_m"].as<int>();
+  int K_CHUNK = vm["k_chunk"].as<int>();
+  int n_gpc = K_CHUNK / GS;
+
+  size_t Q_BYTES = (size_t)M_TILE * (K_CHUNK / 2);
+  size_t S_BYTES = (size_t)n_gpc * M_TILE * sizeof(DT_BF16);
+  size_t Z_BYTES = (size_t)n_gpc * M_TILE;
+  size_t TILE_BYTES = Q_BYTES + S_BYTES + Z_BYTES;
+  size_t n_tiles_total = ((size_t)M / M_TILE) * (K / K_CHUNK);
+  size_t PACKED_SIZE = n_tiles_total * TILE_BYTES;
+  size_t B_SIZE = (size_t)K * sizeof(DT_BF16);
+  size_t R_SIZE = (size_t)M * sizeof(DT_BF16);
+  size_t D_SIZE = (size_t)M * sizeof(DT_BF16);
+
+  srand(time(NULL));
+
+  auto device = xrt::device(0);
+  xrt::elf ctx_elf{vm["elf"].as<std::string>()};
+  xrt::hw_context context(device, ctx_elf);
+  auto kernel = xrt::ext::kernel(context, vm["kernel"].as<std::string>());
+
+  xrt::bo bo_packed = xrt::ext::bo{device, PACKED_SIZE};
+  xrt::bo bo_b = xrt::ext::bo{device, B_SIZE};
+  xrt::bo bo_r = xrt::ext::bo{device, R_SIZE};
+  xrt::bo bo_d = xrt::ext::bo{device, D_SIZE};
+
+  {
+    uint8_t *p = bo_packed.map<uint8_t *>();
+    for (size_t i = 0; i < PACKED_SIZE; i++)
+      p[i] = (uint8_t)(rand() & 0xFF);
+  }
+  {
+    DT_BF16 *p = bo_b.map<DT_BF16 *>();
+    for (size_t i = 0; i < (size_t)K; i++)
+      p[i] = DT_BF16(4.0f * (float)rand() / RAND_MAX);
+  }
+  {
+    DT_BF16 *p = bo_r.map<DT_BF16 *>();
+    for (size_t i = 0; i < (size_t)M; i++)
+      p[i] = DT_BF16(4.0f * (float)rand() / RAND_MAX);
+  }
+  {
+    DT_BF16 *p = bo_d.map<DT_BF16 *>();
+    memset(p, 0, D_SIZE);
+  }
+
+  bo_packed.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_r.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_d.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iter = vm["iterations"].as<int>();
+  unsigned n_warm = vm["warmup"].as<int>();
+  unsigned total = n_iter + n_warm;
+  float t_total = 0, t_min = std::numeric_limits<float>::max(), t_max = 0;
+  float macs = 2.0f * (float)M * (float)K;
+
+  std::cout << "int4-AWQ GEMV+Add Benchmark (ELF, packed cascade)\n"
+            << "  M=" << M << " K=" << K << " GS=" << GS << " M_TILE=" << M_TILE
+            << " K_CHUNK=" << K_CHUNK << " TILE_BYTES=" << TILE_BYTES
+            << " n_tiles=" << n_tiles_total << " PACKED=" << PACKED_SIZE
+            << " B\n";
+
+  for (unsigned i = 0; i < total; i++) {
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo_packed);
+    run.set_arg(1, bo_b);
+    run.set_arg(2, bo_r);
+    run.set_arg(3, bo_d);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    run.start();
+    run.wait2();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    bo_d.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    if (i < n_warm)
+      continue;
+    float dt =
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    t_total += dt;
+    t_min = std::min(t_min, dt);
+    t_max = std::max(t_max, dt);
+  }
+
+  std::cout << "\nAvg NPU time: " << t_total / n_iter << " us\n";
+  std::cout << "Avg gflops:   " << macs / (1000.0f * t_total / n_iter) << "\n";
+  std::cout << "Min NPU time: " << t_min << " us  (max gflops "
+            << macs / (1000.0f * t_min) << ")\n";
+  std::cout << "Max NPU time: " << t_max << " us  (min gflops "
+            << macs / (1000.0f * t_max) << ")\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add `matrix_vector_multiplication/int4_awq/` with two NPU2 designs matching the bf16 `matvec_2tile_add` reference structurally:
  - `matvec_int4_packed` &mdash; `D = dequant(A_q, A_s, A_z) @ B`
  - `matvec_int4_packed_add` &mdash; `D = dequant(A_q, A_s, A_z) @ B + R` (2-tile cascade)
- Q+S+Z prepacked into a single L3 BO &rarr; one shim BD per channel per tile, keeping the compute tile within its 2-S2MM budget when paired with the broadcast B input. R stays a separate L3 BO so it can be produced/consumed by other NPU operators in a decode pipeline without host repacking.
- Adds an int4_awq row to `programming_examples/generate_readme.py`.

## Design notes
- **Packed BO layout (per kernel-call tile)**: `[ Q : M_TILE*K_CHUNK/2 bytes uint8 | S : K_CHUNK/GS*M_TILE bf16 | Z : K_CHUNK/GS*M_TILE uint8 ]`. Internal offsets are 32-byte aligned for the M_TILE/K_CHUNK/GS values used; the kernel slices Q, S, Z out via pointer arithmetic.
- **Why packed**: when Q/S/Z were on separate L3 BOs multiplexed onto one shim channel, the per-channel BD chain expanded 3&times; with every inner-loop ping-pong slot &mdash; deadlocks on the 2-S2MM compute-tile cap once outer or kc trip count went past 1. Packing collapses that to one BO and unblocks ping-pong without exceeding S2MM channels.
- **Kernel (`mv_int4_bf16.cc`)**: one accfloat accumulator per output row spans the full K; within each group, accumulate raw `(w_bf16 * b)` into a per-group accfloat then fold the per-group scale via a single mac with the broadcast scalar. Keeps the inner loop a tight load&rarr;unpack&rarr;sub&rarr;cvt&rarr;mac chain and avoids the per-group acc32&rarr;bf16 plumbing that an int8-mac design would impose.
- **GEMV+R 2-tile cascade**: mirrors `matvec_2tile_add.py`'s `matvec_h` (north) + `addr_h` (south) split with the cascade flowing N&rarr;S on AIE2P. Re-uses the existing `zero_vectorized_bf16` / `partial_plus_r_bf16` helpers.

## Measurements (NPU2, Peano, full Llama Wo shape M=K=2048)
| Design | Total min | Total avg |
|---|---|---|
| `matvec_int4_packed` (GEMV only) | ~170 us | ~172 us |
| `matvec_int4_packed_add` (GEMV+R, 2-tile cascade) | ~206 us | ~208 us |
| bf16 `matvec_2tile_add` reference (GEMV+R) | ~286 us | ~329 us |

## Test plan
- [x] `make run_packed M=2048 K=2048` &mdash; PASS, correlation 0.999997
- [x] `make run_packed_add M=2048 K=2048` &mdash; PASS, correlation 0.999993
- [x] `make run_packed M=2048 K=8192` &mdash; PASS, correlation 0.999994 (wdown shape, exercises K-inner-loop trip > 1)
- [x] `make profile_packed` reproduces ~170us min
- [x] `make profile_packed_add` reproduces ~206us min
- [x] Lit tests (3) auto-discovered by `programming_examples` CTest; all require `ryzen_ai_npu2, peano`
- [x] `clang-format-17` and `black` clean
- [x] bf16 LA reference (`matvec_2tile_add`) still PASS after this change (untouched here)

\xF0\x9F\xA4\x96 Generated with [Claude Code](https://claude.com/claude-code)