### PR TITLE
[ci] bump pinned mlir-aie wheel to 1.3.2.dev82+geaa6248, drop cp310

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -233,7 +233,9 @@ jobs:
             pip -q download --no-deps --platform manylinux_2_35_x86_64 "mlir_aie${NO_RTTI_UNDERSCORE}==${MLIR_AIE_VERSION}" \
               -f "$MLIR_AIE_WHEELS_URL"
             unzip -q mlir_aie*.whl
-            export MLIR_AIE_INSTALL_PATH=$PWD/mlir_aie${NO_RTTI_UNDERSCORE}
+            # Both RTTI and no-RTTI wheels extract to a `mlir_aie/` package
+            # directory (only the wheel filename differs).
+            export MLIR_AIE_INSTALL_PATH=$PWD/mlir_aie
 
             export MLIR_AIR_SOURCE_DIR=$PWD
             export WHEELHOUSE_DIR=$PWD/wheelhouse
@@ -407,7 +409,9 @@ jobs:
           rm -rf "$MLIR_AIE_EXTRACT"
           mkdir -p /c/tmp/airwhls
           python -m zipfile -e mlir_aie*.whl /c/tmp/airwhls
-          mv "/c/tmp/airwhls/mlir_aie${NO_RTTI_UNDERSCORE}" "$MLIR_AIE_EXTRACT"
+          # Both RTTI and no-RTTI wheels extract to a `mlir_aie/` package
+          # directory (only the wheel filename differs).
+          mv /c/tmp/airwhls/mlir_aie "$MLIR_AIE_EXTRACT"
 
       - name: Build wheel
         shell: bash

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -137,12 +137,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.10"
-            ENABLE_RTTI: OFF
-
           - python_version: "3.11"
             ENABLE_RTTI: ON
 
@@ -220,11 +214,9 @@ jobs:
 
             NO_RTTI=""
             NO_RTTI_UNDERSCORE=""
-            NO_RTTI_DOT=""
             if [ x"$ENABLE_RTTI" == x"OFF" ]; then
               NO_RTTI="-no-rtti"
               NO_RTTI_UNDERSCORE="_no_rtti"
-              NO_RTTI_DOT=".no.rtti"
               MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2"
             else
               MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/"
@@ -238,10 +230,10 @@ jobs:
             export MLIR_INSTALL_ABS_PATH=$PWD/mlir$NO_RTTI_UNDERSCORE
 
             export MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
-            pip -q download --no-deps --platform manylinux_2_35_x86_64 "mlir_aie==${MLIR_AIE_VERSION}${NO_RTTI_DOT}" \
+            pip -q download --no-deps --platform manylinux_2_35_x86_64 "mlir_aie${NO_RTTI_UNDERSCORE}==${MLIR_AIE_VERSION}" \
               -f "$MLIR_AIE_WHEELS_URL"
             unzip -q mlir_aie*.whl
-            export MLIR_AIE_INSTALL_PATH=$PWD/mlir_aie
+            export MLIR_AIE_INSTALL_PATH=$PWD/mlir_aie${NO_RTTI_UNDERSCORE}
 
             export MLIR_AIR_SOURCE_DIR=$PWD
             export WHEELHOUSE_DIR=$PWD/wheelhouse
@@ -288,8 +280,8 @@ jobs:
             ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
-            **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
-            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.14)
+            **Pinned mlir_aie:** `${{ matrix.ENABLE_RTTI == 'ON' && 'mlir_aie' || 'mlir_aie_no_rtti' }}==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}`
+            **Platforms:** Linux x86_64 (Python 3.11–3.14), Windows AMD64 (Python 3.11–3.14)
 
             ### Installation
 
@@ -331,12 +323,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.10"
-            ENABLE_RTTI: OFF
-
           - python_version: "3.11"
             ENABLE_RTTI: ON
 
@@ -404,9 +390,9 @@ jobs:
       - name: Get mlir-aie
         shell: bash
         run: |
-          NO_RTTI_DOT=""
+          NO_RTTI_UNDERSCORE=""
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
-            NO_RTTI_DOT=".no.rtti"
+            NO_RTTI_UNDERSCORE="_no_rtti"
             MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2"
           else
             MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/"
@@ -414,14 +400,14 @@ jobs:
 
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip -q download --no-deps --platform win_amd64 \
-            "mlir_aie==${MLIR_AIE_VERSION}${NO_RTTI_DOT}" \
+            "mlir_aie${NO_RTTI_UNDERSCORE}==${MLIR_AIE_VERSION}" \
             -f "$MLIR_AIE_WHEELS_URL"
           # Extract to a short path alongside MLIR
           MLIR_AIE_EXTRACT=/c/tmp/airwhls/a
           rm -rf "$MLIR_AIE_EXTRACT"
           mkdir -p /c/tmp/airwhls
           python -m zipfile -e mlir_aie*.whl /c/tmp/airwhls
-          mv /c/tmp/airwhls/mlir_aie "$MLIR_AIE_EXTRACT"
+          mv "/c/tmp/airwhls/mlir_aie${NO_RTTI_UNDERSCORE}" "$MLIR_AIE_EXTRACT"
 
       - name: Build wheel
         shell: bash
@@ -489,8 +475,8 @@ jobs:
             ## MLIR-AIR Wheels (${{ matrix.ENABLE_RTTI == 'ON' && 'RTTI' || 'no-RTTI' }})
 
             **Latest commit:** `${{ needs.get-air-project-commit.outputs.AIR_PROJECT_COMMIT }}`
-            **Pinned mlir_aie:** `${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}${{ matrix.ENABLE_RTTI == 'ON' && '' || '.no.rtti' }}`
-            **Platforms:** Linux x86_64 (Python 3.10–3.14), Windows AMD64 (Python 3.10–3.14)
+            **Pinned mlir_aie:** `${{ matrix.ENABLE_RTTI == 'ON' && 'mlir_aie' || 'mlir_aie_no_rtti' }}==${{ needs.get-air-project-commit.outputs.MLIR_AIE_VERSION }}`
+            **Platforms:** Linux x86_64 (Python 3.11–3.14), Windows AMD64 (Python 3.11–3.14)
 
             ### Installation
 

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,9 +14,9 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=886d9325f1b087d2c1180aece51d53384b698a46
-DATETIME=2026052005
-WHEEL_VERSION=0.0.1.$DATETIME+${HASH:0:7}
+export HASH=eaa62484f4381e20a44b0c16570c9ceedc56996e
+DEV_COUNT=82
+WHEEL_VERSION=1.3.2.dev$DEV_COUNT+g${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -321,11 +321,11 @@ def get_extras_require():
     # mlir_aie + Peano; users targeting other backends skip the extra.
     mlir_aie_version = os.getenv("MLIR_AIE_VERSION", "")
     if mlir_aie_version:
-        no_rtti_dot = "" if check_env("ENABLE_RTTI", 1) else ".no.rtti"
+        mlir_aie_pkg = "mlir_aie" if check_env("ENABLE_RTTI", 1) else "mlir_aie_no_rtti"
         # mlir_aie is pinned to the version this AIR wheel was built and
         # tested against. llvm-aie (Peano) tracks nightly — no pin.
         extras["aie"] = [
-            f"mlir_aie=={mlir_aie_version}{no_rtti_dot}",
+            f"{mlir_aie_pkg}=={mlir_aie_version}",
             "llvm-aie",
         ]
     return extras
@@ -343,7 +343,7 @@ setup(
     },
     zip_safe=False,
     packages=find_packages(exclude=["wheelhouse", "mlir-air"]),
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=parse_requirements(Path(__file__).parent / "requirements.txt"),
     extras_require=get_extras_require(),
 )


### PR DESCRIPTION
## Summary

- Bumps the pinned mlir-aie commit from `886d932` (2026-05-20) to `eaa6248` (2026-05-29) — picks up the latest wheel from `latest-wheels-3` / `latest-wheels-no-rtti-2`.
- Adapts to two upstream-side changes in mlir-aie's wheel publishing.
- Drops cp310 from the wheel build matrix to match upstream (mlir-aie no longer publishes cp310 wheels for `dev82+geaa6248`).

## Upstream changes this PR adapts to

**1. Wheel version format**

Old: `mlir_aie-0.0.1.<DATETIME>+<sha7>-...whl`
New: `mlir_aie-1.3.2.dev<N>+g<sha7>-...whl` (git-describe style)

`utils/clone-mlir-aie.sh` updated to emit `1.3.2.dev82+geaa6248` from `--get-wheel-version`.

**2. no-RTTI variant — package rename**

Old: `mlir_aie==<version>.no.rtti`
New: `mlir_aie_no_rtti==<version>` (package renamed; no version suffix)

Updated:
- `.github/workflows/buildAIRWheels.yml` (Linux + Windows wheel jobs) — install line now uses `mlir_aie${NO_RTTI_UNDERSCORE}==${MLIR_AIE_VERSION}`; the extracted folder path follows the same pattern. The unused `NO_RTTI_DOT` variable is removed.
- `utils/mlir_air_wheels/setup.py` — `extras["aie"]` dependency switched from version-suffix to package-name rename.

## cp310 deprecation

`latest-wheels-3` and `latest-wheels-no-rtti-2` do not include cp310 wheels for `dev82+geaa6248` (only cp311–cp314). To keep CI green:
- Dropped `python_version: "3.10"` matrix entries from Linux and Windows wheel builds in `buildAIRWheels.yml`.
- Bumped `python_requires` to `>=3.11` in `setup.py`.
- Updated release-notes string from `Python 3.10–3.14` to `Python 3.11–3.14`.

The `buildAndTestRyzenAI.yml` workflow is unchanged — it runs on self-hosted runners (`amd8845hs`, `amdhx370`) with system Python, mirroring mlir-aie's own RyzenAI workflow. The shared runner already uses Python ≥3.11 since mlir-aie's own CI installs the same wheels.

## What's unchanged

- `MLIR_PYTHON_EXTRAS_SHORTHASH` stays at `a736a7d` (mlir-aie@eaa6248 still pins this).
- Pinned LLVM in `clone-llvm.sh` stays at `ea2f50817` / `2026051220` (mlir-aie@eaa6248 still builds against this LLVM).

## Test plan

- [ ] `buildAIRWheels` workflow passes for cp311/cp312/cp313/cp314 (RTTI and no-RTTI).
- [ ] `buildAndTest` (Linux source build) passes.
- [ ] `buildAndTestWindows` passes.
- [ ] `buildAndTestRyzenAI` passes on both runner types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)