### PR TITLE
[llama32_1b] full-int4 ELF2 for decode (-48% latency, -68% weight memory)

### DIFF
--- a/programming_examples/decode_ffn_swiglu/Makefile
+++ b/programming_examples/decode_ffn_swiglu/Makefile
@@ -36,5 +36,34 @@ run:
 		--m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) \
 		--herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 
+# int4-AWQ variant: M = 2*hidden, K = emb. Reuses mv_int4_bf16.o from the
+# int4_awq examples (same M_TILE / K_CHUNK / GS macros).
+INT4_SRCDIR := $(srcdir)/../matrix_vector_multiplication/int4_awq
+INT4_M_TILE  ?= 8
+INT4_K_CHUNK ?= 2048
+INT4_GS      ?= 128
+
+AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf \
+	-Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body \
+	-DNDEBUG -I ${AIEOPT_DIR}/include
+
+compile-kernel-int4:
+	mkdir -p $(BUILD_DIR)
+	@if [ -z "$(PEANO_INSTALL_DIR)" ]; then \
+		echo "Error: PEANO_INSTALL_DIR not set (source utils/env_setup.sh)."; \
+		exit 1; \
+	fi
+	$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANOWRAP2P_FLAGS} \
+		-DDIM_M=$(INT4_M_TILE) -DDIM_K=$(INT4_K_CHUNK) -DDIM_GS=$(INT4_GS) \
+		-c $(INT4_SRCDIR)/mv_int4_bf16.cc -o $(BUILD_DIR)/mv_int4_bf16.o
+
+run_int4: compile-kernel-int4
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 ${srcdir}/matvec_int4_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) \
+		--m $(M) --k $(K) --gs $(INT4_GS) \
+		--m-tile $(INT4_M_TILE) --k-chunk $(INT4_K_CHUNK)
+
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
+++ b/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
@@ -1,0 +1,604 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# int4-AWQ FFN GEMV with weighted-RMSNorm input and fused SwiGLU output:
+#
+#   normed = rms_norm(input_vec, norm_weight)        # row 0 + row 1 of RMS
+#   raw[M]  = dequant(A_packed[M, K]) @ normed        # gate/up interleaved
+#   swiglu[M/2] = silu(raw[2i]) * raw[2i+1]
+#
+# A is the AWQ packed Q+S+Z BO (matvec_int4_packed.pack_inputs layout).
+# Single matvec herd (no cascade) — simpler than the bf16 4-cascade design
+# but stays under the AIE2P 2-S2MM/tile cap: PACKED via aL2ToL1 (1 S2MM)
+# + RMS via inRMS broadcast (1 S2MM, replayed once per launch). Gate/up
+# partials accumulate into separate L1 scratches; a final vectorized
+# SwiGLU pass emits M_per_core/2 outputs per tile.
+#
+# Reuses mv_int4_bf16.o (same kernel symbol/dim macros as stages 1, 3).
+
+import argparse
+import os
+import sys
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "matrix_vector_multiplication",
+        "int4_awq",
+    ),
+)
+
+from air.ir import (
+    AffineConstantExpr,
+    AffineExpr,
+    AffineMap,
+    AffineMapAttr,
+    AffineSymbolExpr,
+    BF16Type,
+    BoolAttr,
+    F32Type,
+    IntegerAttr,
+    IntegerType,
+    MemRefType,
+    StringAttr,
+    UnitAttr,
+    VectorType,
+)
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import (
+    Channel,
+    ChannelGet,
+    ChannelPut,
+    MemorySpace,
+    T,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects.air import channel as channel_decl
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.memref import (
+    AllocOp,
+    DeallocOp,
+    subview,
+    load as memref_load,
+    store as memref_store,
+    cast as memref_cast,
+)
+from air.dialects import arith
+from air.dialects import math as math_dialect
+from air.dialects.scf import for_, yield_
+from air.dialects.vector import (
+    transfer_read,
+    transfer_write,
+    BroadcastOp,
+    reduction as vector_reduction,
+)
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+from matvec_int4_packed import pack_inputs
+
+KERNEL_OBJ_NAME = "mv_int4_bf16.o"
+
+range_ = for_
+
+
+def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
+    """int4-AWQ fused FFN: RMSNorm → int4 GEMV → SwiGLU pair.
+
+    Output is M/2 elements (gate/up paired). M is the interleaved gate+up
+    row count (= 2 * hidden_dim). Single-launch, single-herd design.
+    """
+    assert M % 2 == 0
+    assert M % N_CORES == 0
+    M_per_core = M // N_CORES
+    assert M_per_core % M_TILE == 0
+    M_div = M_per_core // M_TILE
+    assert K == K_CHUNK, "int4 FFN: K must equal K_CHUNK (single chunk per outer)"
+    assert K % GS == 0
+    assert M_TILE % 2 == 0
+    SILU_VEC = 16
+    half_M_per_core = M_per_core // 2
+    assert (
+        half_M_per_core % SILU_VEC == 0
+    ), f"M_per_core/2 ({half_M_per_core}) must be a multiple of {SILU_VEC}"
+
+    n_gpc = K_CHUNK // GS
+    q_bytes = M_TILE * (K_CHUNK // 2)
+    s_bytes = n_gpc * M_TILE * 2
+    z_bytes = n_gpc * M_TILE
+    tile_bytes = q_bytes + s_bytes + z_bytes
+    assert q_bytes % 32 == 0
+    assert (q_bytes + s_bytes) % 32 == 0
+
+    total_tiles = N_CORES * M_div
+
+    @module_builder
+    def build():
+        bf16_ty = BF16Type.get()
+        i8_ty = IntegerType.get_signless(8)
+        f32_ty = F32Type.get()
+
+        packed_l3 = MemRefType.get([total_tiles, tile_bytes], i8_ty)
+        RMS_l3 = MemRefType.get([2, K], bf16_ty)
+        D_l3 = MemRefType.get([M // 2], bf16_ty)
+
+        l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+
+        # Allocate the partial buffer as a 32-lane (CASCADE_WIDTH-style) buffer
+        # and pass a subview-cast to the M_TILE-shaped kernel — matches the
+        # matvec_int4_packed_add layout so air-shrink-memref-sizes-by-access
+        # rewrites the kernel signature consistently across all stitched calls.
+        CASCADE_WIDTH = 32
+        packed_l2 = MemRefType.get([tile_bytes], i8_ty, memory_space=l2_ms)
+        packed_l1 = MemRefType.get([tile_bytes], i8_ty, memory_space=l1_ms)
+        rms_l1_ty = MemRefType.get([2, K], bf16_ty, memory_space=l1_ms)
+        normed_l1_ty = MemRefType.get([K], bf16_ty, memory_space=l1_ms)
+        partial_full_ty = MemRefType.get([CASCADE_WIDTH], bf16_ty, memory_space=l1_ms)
+        partial_slice_ty = MemRefType.get([M_TILE], bf16_ty, memory_space=l1_ms)
+        gate_l1_ty = MemRefType.get([half_M_per_core], bf16_ty, memory_space=l1_ms)
+        up_l1_ty = MemRefType.get([half_M_per_core], bf16_ty, memory_space=l1_ms)
+        D_l1_ty = MemRefType.get([half_M_per_core], bf16_ty, memory_space=l1_ms)
+
+        channel_decl("inL3", size=[N_CORES])
+        channel_decl("aL2ToL1", size=[N_CORES])
+        Channel("inRMS", size=[1, 1], broadcast_shape=[N_CORES, 1])
+        channel_decl("outD", size=[N_CORES])
+
+        zero_func = FuncOp(
+            "zero_vectorized_bf16",
+            ([partial_slice_ty], []),
+            visibility="private",
+        )
+        zero_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        zero_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        matvec_func = FuncOp(
+            "matvec_int4_bf16_packed",
+            ([packed_l1, normed_l1_ty, partial_slice_ty], []),
+            visibility="private",
+        )
+        matvec_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        matvec_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+        @FuncOp.from_py_func(packed_l3, RMS_l3, D_l3)
+        def matvec_int4_swiglu_rms(PACKED, RMS, D):
+            @launch(sizes=[1, 1], operands=[PACKED, RMS, D])
+            def launch_body(li, lj, lsx, lsy, packed, rms, d):
+                # L3-side puts: per-core PACKED slab + per-core D get.
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_tile_const = arith.ConstantOp.create_index(c * M_div)
+                    ChannelPut(
+                        "inL3",
+                        packed,
+                        indices=[c_idx],
+                        offsets=[c_tile_const, 0],
+                        sizes=[M_div, tile_bytes],
+                        strides=[tile_bytes, 1],
+                    )
+                    c_d_off = arith.ConstantOp.create_index(c * half_M_per_core)
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[c_d_off],
+                        sizes=[half_M_per_core],
+                        strides=[1],
+                    )
+                # RMS input broadcast: a single S2MM per compute tile, replayed
+                # once per launch (RMS input does not change across outer iters).
+                ChannelPut(
+                    "inRMS",
+                    rms,
+                    offsets=[0, 0],
+                    sizes=[2, K],
+                    strides=[K, 1],
+                )
+
+                @segment(name="seg")
+                def segment_body():
+                    # Memtile staging: M_div iters of 1 packed tile each.
+                    for c in range(N_CORES):
+                        c_idx_s = arith.ConstantOp.create_index(c)
+                        for _ in for_(M_div):
+                            l2_op = AllocOp(packed_l2, [], [])
+                            ChannelGet("inL3", l2_op, indices=[c_idx_s])
+                            ChannelPut("aL2ToL1", l2_op, indices=[c_idx_s])
+                            DeallocOp(l2_op)
+                            yield_([])
+
+                    @herd(name="matvec_h", sizes=[N_CORES, 1])
+                    def herd_body(tx, ty, _sx, _sy):
+                        c0 = arith.ConstantOp.create_index(0)
+
+                        l1_rms_op = AllocOp(rms_l1_ty, [], [])
+                        l1_normed_op = AllocOp(normed_l1_ty, [], [])
+                        l1_gate_op = AllocOp(gate_l1_ty, [], [])
+                        l1_up_op = AllocOp(up_l1_ty, [], [])
+                        l1_d_op = AllocOp(D_l1_ty, [], [])
+                        l1_rms = l1_rms_op.result
+                        l1_normed = l1_normed_op.result
+                        l1_gate = l1_gate_op.result
+                        l1_up = l1_up_op.result
+                        l1_d = l1_d_op.result
+
+                        # Single-shot S2MM: RMS input via broadcast.
+                        ChannelGet("inRMS", l1_rms, indices=[tx, ty])
+
+                        # ---- Inline RMSNorm (faithful port of bf16 stage 2) ----
+                        rms_vec_size = 16
+                        rms_vecTy_bf16 = VectorType.get([rms_vec_size], bf16_ty)
+                        rms_vecTy_f32 = VectorType.get([rms_vec_size], f32_ty)
+                        rms_identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+                        read_map_2d_rms = AffineMapAttr.get(
+                            AffineMap.get(2, 0, [AffineExpr.get_dim(1)])
+                        )
+                        rms_cst0_bf16 = arith.ConstantOp(bf16_ty, 0.0)
+                        rms_cst0_f32 = arith.ConstantOp(f32_ty, 0.0)
+                        rms_acc_ty = MemRefType.get(
+                            shape=[rms_vec_size],
+                            element_type=f32_ty,
+                            memory_space=l1_ms,
+                        )
+                        rms_tmp_ty = MemRefType.get(
+                            shape=[rms_vec_size],
+                            element_type=bf16_ty,
+                            memory_space=l1_ms,
+                        )
+                        rms_acc = AllocOp(rms_acc_ty, [], [])
+                        rms_tmp = AllocOp(rms_tmp_ty, [], [])
+                        zero_vec_f32 = BroadcastOp(rms_vecTy_f32, rms_cst0_f32)
+                        transfer_write(
+                            None,
+                            zero_vec_f32,
+                            rms_acc,
+                            [c0],
+                            rms_identity_map,
+                            [True],
+                        )
+                        c_k = arith.ConstantOp.create_index(K)
+                        c_rms_vec = arith.ConstantOp.create_index(rms_vec_size)
+                        for j in range_(0, c_k, c_rms_vec):
+                            sub_r = subview(l1_rms, [0, j], [1, rms_vec_size], [1, 1])
+                            v_x = transfer_read(
+                                rms_vecTy_bf16,
+                                sub_r,
+                                [c0, c0],
+                                read_map_2d_rms,
+                                rms_cst0_bf16,
+                                [True],
+                            )
+                            v_sq_bf16 = arith.mulf(v_x, v_x)
+                            transfer_write(
+                                None,
+                                v_sq_bf16,
+                                rms_tmp,
+                                [c0],
+                                rms_identity_map,
+                                [True],
+                            )
+                            v_sq_rd_bf16 = transfer_read(
+                                rms_vecTy_bf16,
+                                rms_tmp,
+                                [c0],
+                                rms_identity_map,
+                                rms_cst0_bf16,
+                                [True],
+                            )
+                            v_sq_f32 = arith.extf(rms_vecTy_f32, v_sq_rd_bf16)
+                            v_acc = transfer_read(
+                                rms_vecTy_f32,
+                                rms_acc,
+                                [c0],
+                                rms_identity_map,
+                                rms_cst0_f32,
+                                [True],
+                            )
+                            v_sum = arith.addf(v_acc, v_sq_f32)
+                            transfer_write(
+                                None,
+                                v_sum,
+                                rms_acc,
+                                [c0],
+                                rms_identity_map,
+                                [True],
+                            )
+                            yield_([])
+
+                        v_final_f32 = transfer_read(
+                            rms_vecTy_f32,
+                            rms_acc,
+                            [c0],
+                            rms_identity_map,
+                            rms_cst0_f32,
+                            [True],
+                        )
+                        total_sum_f32 = vector_reduction(f32_ty, "add", v_final_f32)
+                        k_f32_const = arith.ConstantOp(f32_ty, float(K))
+                        eps_f32_const = arith.ConstantOp(f32_ty, 1.0e-5)
+                        mean_f32 = arith.divf(total_sum_f32, k_f32_const)
+                        mean_eps_f32 = arith.addf(mean_f32, eps_f32_const)
+                        rstd_f32 = math_dialect.rsqrt(mean_eps_f32)
+                        rstd_bf16 = arith.truncf(bf16_ty, rstd_f32)
+                        v_rstd = BroadcastOp(rms_vecTy_bf16, rstd_bf16)
+
+                        for j in range_(0, c_k, c_rms_vec):
+                            sub_r = subview(l1_rms, [0, j], [1, rms_vec_size], [1, 1])
+                            sub_w = subview(l1_rms, [1, j], [1, rms_vec_size], [1, 1])
+                            sub_b = subview(l1_normed, [j], [rms_vec_size], [1])
+                            v_r = transfer_read(
+                                rms_vecTy_bf16,
+                                sub_r,
+                                [c0, c0],
+                                read_map_2d_rms,
+                                rms_cst0_bf16,
+                                [True],
+                            )
+                            v_w = transfer_read(
+                                rms_vecTy_bf16,
+                                sub_w,
+                                [c0, c0],
+                                read_map_2d_rms,
+                                rms_cst0_bf16,
+                                [True],
+                            )
+                            v_n = arith.mulf(v_r, v_rstd.result)
+                            v_y = arith.mulf(v_n, v_w)
+                            transfer_write(
+                                None,
+                                v_y,
+                                sub_b,
+                                [c0],
+                                rms_identity_map,
+                                [True],
+                            )
+                            yield_([])
+
+                        DeallocOp(rms_acc)
+                        DeallocOp(rms_tmp)
+
+                        # ---- Hot int4 GEMV loop: M_div outers ----
+                        # Each iter produces M_TILE partials = (M_TILE/2) (gate, up)
+                        # pairs. Deinterleave into separate gate/up scratches indexed
+                        # at outer * (M_TILE/2).
+                        pair_off_map = AffineMap.get(
+                            0,
+                            1,
+                            [
+                                AffineExpr.get_mul(
+                                    AffineSymbolExpr.get(0),
+                                    AffineConstantExpr.get(M_TILE // 2),
+                                )
+                            ],
+                        )
+                        for outer in for_(M_div):
+                            l1_partial_op = AllocOp(partial_full_ty, [], [])
+                            l1_partial_op.attributes["air.shrinkage"] = BoolAttr.get(
+                                False
+                            )
+                            l1_partial_slice_strided = subview(
+                                l1_partial_op.result, [0], [M_TILE], [1]
+                            )
+                            l1_partial_slice = memref_cast(
+                                partial_slice_ty, l1_partial_slice_strided
+                            )
+                            l1_packed_op = AllocOp(packed_l1, [], [])
+                            ChannelGet("aL2ToL1", l1_packed_op, indices=[tx])
+                            CallOp(zero_func, [l1_partial_slice])
+                            CallOp(
+                                matvec_func,
+                                [l1_packed_op, l1_normed, l1_partial_slice],
+                            )
+                            pair_off = affine_apply(pair_off_map, [outer])
+                            for i in range(M_TILE // 2):
+                                ci_g = arith.ConstantOp.create_index(2 * i)
+                                ci_u = arith.ConstantOp.create_index(2 * i + 1)
+                                v_g = memref_load(l1_partial_slice, [ci_g])
+                                v_u = memref_load(l1_partial_slice, [ci_u])
+                                pair_pos_map = AffineMap.get(
+                                    0,
+                                    1,
+                                    [
+                                        AffineExpr.get_add(
+                                            AffineSymbolExpr.get(0),
+                                            AffineConstantExpr.get(i),
+                                        )
+                                    ],
+                                )
+                                pair_pos = affine_apply(pair_pos_map, [pair_off])
+                                memref_store(v_g, l1_gate, [pair_pos])
+                                memref_store(v_u, l1_up, [pair_pos])
+                            DeallocOp(l1_packed_op)
+                            DeallocOp(l1_partial_op)
+                            yield_([])
+
+                        # ---- Vectorized SwiGLU(gate, up) → D ----
+                        vecTyOut = VectorType.get([SILU_VEC], bf16_ty)
+                        cst_half_bf16 = arith.ConstantOp(bf16_ty, 0.5)
+                        cst_one_bf16 = arith.ConstantOp(bf16_ty, 1.0)
+                        v_half_bf16 = BroadcastOp(vecTyOut, cst_half_bf16)
+                        v_one_bf16 = BroadcastOp(vecTyOut, cst_one_bf16)
+                        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+                        cst0_bf16_v = arith.ConstantOp(bf16_ty, 0.0)
+                        c_half = arith.ConstantOp.create_index(half_M_per_core)
+                        c_silu = arith.ConstantOp.create_index(SILU_VEC)
+                        for kk in for_(0, c_half, c_silu):
+                            sub_g = subview(l1_gate, [kk], [SILU_VEC], [1])
+                            sub_u = subview(l1_up, [kk], [SILU_VEC], [1])
+                            sub_out = subview(l1_d, [kk], [SILU_VEC], [1])
+                            v_g = transfer_read(
+                                vecTyOut,
+                                sub_g,
+                                [c0],
+                                identity_map,
+                                cst0_bf16_v,
+                                [True],
+                            )
+                            v_u = transfer_read(
+                                vecTyOut,
+                                sub_u,
+                                [c0],
+                                identity_map,
+                                cst0_bf16_v,
+                                [True],
+                            )
+                            v_half_g = arith.mulf(v_g, v_half_bf16.result)
+                            v_tanh = math_dialect.tanh(v_half_g)
+                            v_tanh_p1 = arith.addf(v_tanh, v_one_bf16.result)
+                            v_sig = arith.mulf(v_tanh_p1, v_half_bf16.result)
+                            v_silu = arith.mulf(v_g, v_sig)
+                            v_out = arith.mulf(v_silu, v_u)
+                            transfer_write(
+                                None,
+                                v_out,
+                                sub_out,
+                                [c0],
+                                identity_map,
+                                [True],
+                            )
+                            yield_([])
+
+                        ChannelPut("outD", l1_d, indices=[tx])
+
+                        DeallocOp(l1_rms_op)
+                        DeallocOp(l1_normed_op)
+                        DeallocOp(l1_gate_op)
+                        DeallocOp(l1_up_op)
+                        DeallocOp(l1_d_op)
+
+                    herd_body.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+                    herd_body.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
+                    herd_body.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+    return build()
+
+
+def cpu_reference(A_q, A_s, A_z, RMS_in, eps=1e-5):
+    """CPU bf16 reference: RMSNorm + int4 GEMV + SwiGLU pair. Output M/2."""
+    M_ = A_q.shape[0]
+    K_ = RMS_in.shape[1]
+    n_groups = A_s.shape[0]
+    gs = K_ // n_groups
+    x = RMS_in[0].astype(np.float32)
+    w = RMS_in[1].astype(np.float32)
+    mean_sq = float((x * x).sum()) / K_
+    rstd = 1.0 / np.sqrt(mean_sq + eps)
+    normed = ((x * rstd) * w).astype(bfloat16).astype(np.float32)
+    # Vectorized dequant: unpack nibbles, then broadcast scales/zeros per group.
+    A_q_i = A_q.astype(np.int32)
+    low = A_q_i & 0x0F
+    high = (A_q_i >> 4) & 0x0F
+    nibs = np.empty((M_, K_), dtype=np.int32)
+    nibs[:, 0::2] = low
+    nibs[:, 1::2] = high
+    s_per_kk = np.repeat(A_s.astype(np.float32), gs, axis=0)  # (K_, M_)
+    z_per_kk = np.repeat(A_z.astype(np.int32), gs, axis=0)  # (K_, M_)
+    dequant = (nibs - z_per_kk.T) * s_per_kk.T  # (M_, K_)
+    raw = dequant @ normed
+    raw_bf16 = raw.astype(bfloat16).astype(np.float32)
+    gate = raw_bf16[0::2]
+    up = raw_bf16[1::2]
+    silu = gate * 0.5 * (np.tanh(gate / 2.0) + 1.0)
+    return (silu * up).astype(bfloat16)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="matvec_int4_swiglu_rms.py",
+        description="int4-AWQ FFN GEMV with fused RMSNorm input and SwiGLU output.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=16384)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--gs", type=int, default=128)
+    parser.add_argument("--m-tile", type=int, default=8, dest="m_tile")
+    parser.add_argument("--k-chunk", type=int, default=2048, dest="k_chunk")
+    parser.add_argument("--n-cores", type=int, default=8, dest="n_cores")
+    parser.add_argument(
+        "--output-format", type=str, choices=["xclbin", "elf"], default="elf"
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-and-run", "compile-only"],
+        default="compile-and-run",
+    )
+    args = parser.parse_args()
+
+    module = build_module(
+        args.m,
+        args.k,
+        GS=args.gs,
+        M_TILE=args.m_tile,
+        K_CHUNK=args.k_chunk,
+        N_CORES=args.n_cores,
+    )
+    if args.print_module_only:
+        print(module)
+        exit(0)
+
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            instance_name="matvec_int4_swiglu_rms",
+            use_lock_race_condition_fix=False,
+            stack_size=4096,
+        )
+        backend.compile(module)
+        backend.unload()
+        exit(0)
+
+    np.random.seed(42)
+    A_q_unp = np.random.randint(0, 16, size=(args.m, args.k), dtype=np.uint8)
+    A_q = (A_q_unp[:, 0::2] | (A_q_unp[:, 1::2] << 4)).astype(np.uint8)
+    n_groups = args.k // args.gs
+    A_s = np.random.uniform(0.005, 0.02, size=(n_groups, args.m)).astype(bfloat16)
+    A_z = np.random.randint(7, 9, size=(n_groups, args.m), dtype=np.uint8)
+    input_vec = np.random.randn(args.k).astype(bfloat16)
+    norm_weight = (np.random.randn(args.k) * 0.1 + 1.0).astype(bfloat16)
+    RMS_in = np.stack([input_vec, norm_weight], axis=0).astype(bfloat16)
+
+    D_ref = cpu_reference(A_q, A_s, A_z, RMS_in)
+    PACKED = pack_inputs(
+        A_q,
+        A_s,
+        A_z,
+        args.m,
+        args.k,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        args.m,
+    )
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="matvec_int4_swiglu_rms",
+        use_lock_race_condition_fix=False,
+        stack_size=4096,
+    )
+    exit(
+        runner.run_test(
+            module,
+            inputs=[PACKED, RMS_in],
+            expected_outputs=[D_ref],
+            rtol=0.15,
+            atol=0.5,
+            min_correlation=0.99,
+        )
+    )

--- a/programming_examples/decode_ffn_swiglu/run_int4_npu2_peano.lit
+++ b/programming_examples/decode_ffn_swiglu/run_int4_npu2_peano.lit
@@ -1,0 +1,13 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_int4_npu2_peano
+// RUN: cd test_int4_npu2_peano
+// RUN: make -f %S/Makefile clean
+//
+// int4-AWQ FFN: swiglu = silu(dequant(A_interleaved) · rms_norm(B[0], B[1])).
+// Default shape: M=16384 (=2*hidden), K=2048 (=emb), M_TILE=8, K_CHUNK=2048, GS=128.
+// RUN: make -f %S/Makefile run_int4 M=16384 K=2048 INT4_M_TILE=8 INT4_K_CHUNK=2048 INT4_GS=128 OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
+++ b/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
@@ -1,0 +1,472 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""o_gemv_ffn_int4 — full-int4 ELF2 for the LLAMA decode block.
+
+3-launch ELF derived from o_gemv_ffn_int4p1_multi.py. ALL three weight
+matrices (wo, gate+up, wdown) are int4-AWQ packed BOs:
+
+  Stage 1 (matvec_int4_packed_add):  res1 = dequant(wo) @ attn_out + x_residual
+                                     into arg6[0]
+  Stage 2 (matvec_int4_swiglu_rms):  swiglu = silu(dequant(gateup) @ rms_norm(arg6)) * up
+  Stage 3 (matvec_int4_packed_add):  output = dequant(wdown) @ swiglu + arg6[0]
+
+ABI (15 args; arg0/arg7/arg12 are packed int4 BOs):
+
+    arg0:  memref<tq x tile_bytes xi8>          wo_packed         STATIC
+    arg1:  memref<emb xbf16>                    attn_out          INPUT
+    arg2:  memref<emb xbf16>                    (dead)
+    arg3:  memref<emb xbf16>                    x_residual        INPUT
+    arg4:  memref<emb xbf16>                    (dead)
+    arg5:  memref<emb xbf16>                    (dead)
+    arg6:  memref<2 x emb xbf16>                packed RMS input  STATIC
+                                                  (row 0 = res1, row 1 = ffn_norm_w)
+    arg7:  memref<tg x tile_bytes xi8>          gate/up_packed    STATIC
+                                                  (interleaved gate/up packed)
+    arg8:  memref<hidden xbf16>                 (dead)
+    arg9:  memref<hidden x emb xbf16>           (dead)
+    arg10: memref<hidden xbf16>                 (dead)
+    arg11: memref<hidden xbf16>                 swiglu            INTERMEDIATE
+    arg12: memref<td x tile_bytes xi8>          wdown_packed      STATIC
+    arg13: memref<emb xbf16>                    (dead)
+    arg14: memref<emb xbf16>                    output            OUTPUT
+
+K_CHUNK for all three int4 stages is fixed at 2048 → all three stages
+link the same mv_int4_bf16.o (DIM_K=2048, DIM_M=8). Stage 3 (K=hidden=8192)
+splits into K_div=4 inner iterations; stages 1 and 2 do a single K chunk.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "matrix_vector_multiplication",
+        "int4_awq",
+    ),
+)
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "decode_ffn_swiglu",
+    ),
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import matvec_int4_packed_add
+from matvec_int4_packed_add import build_module as build_int4_gemv_add
+import matvec_int4_swiglu_rms
+from matvec_int4_swiglu_rms import build_module as build_int4_swiglu_rms
+from matvec_int4_packed import pack_inputs
+
+from kernel_builder.stitching import (
+    _extract_between_func_and_return,
+    _extract_affine_maps,
+    _extract_private_funcs,
+    _extract_channel_decls,
+    _rename_all_with_externs,
+    _fix_launch_func_args,
+)
+from air.ir import Module, Context
+from air.backend.xrt import XRTBackend
+
+# All three stages share mv_int4_bf16.o — keep these symbols un-prefixed
+# across the stitched launches so all three calls resolve to the same .o
+# entry points.
+_EXTERNS = {
+    "@matvec_int4_bf16_packed",
+    "@zero_vectorized_bf16",
+    "@partial_plus_r_bf16",
+}
+
+
+def _packed_dims(M, K, GS, M_TILE, K_CHUNK, N_CORES, M_PER_LAUNCH):
+    n_gpc = K_CHUNK // GS
+    tile_bytes = M_TILE * (K_CHUNK // 2) + n_gpc * M_TILE * 2 + n_gpc * M_TILE
+    M_per_core_per_launch = M_PER_LAUNCH // N_CORES
+    M_div = M_per_core_per_launch // M_TILE
+    K_div = K // K_CHUNK
+    N_LAUNCHES = M // M_PER_LAUNCH
+    total_tiles = N_LAUNCHES * N_CORES * M_div * K_div
+    return total_tiles, tile_bytes
+
+
+def build_o_gemv_ffn_int4_module(
+    emb_dim=2048,
+    hidden_dim=8192,
+    gs=128,
+    m_tile=8,
+    k_chunk=2048,
+    n_cores=8,
+):
+    """Build full-int4 3-launch ELF2."""
+    assert emb_dim % k_chunk == 0 and hidden_dim % k_chunk == 0
+    # Stage 2's int4 module requires K == K_CHUNK; emb_dim must equal k_chunk.
+    assert (
+        emb_dim == k_chunk
+    ), f"Stage 2 int4 swiglu_rms requires emb_dim ({emb_dim}) == k_chunk ({k_chunk})"
+
+    matvec_int4_packed_add.KERNEL_OBJ_NAME = "mv_int4_bf16.o"
+    matvec_int4_swiglu_rms.KERNEL_OBJ_NAME = "mv_int4_bf16.o"
+
+    # Stage 1: O proj (M=emb, K=emb), int4 GEMV+R.
+    stage1 = build_int4_gemv_add(
+        emb_dim,
+        emb_dim,
+        GS=gs,
+        M_TILE=m_tile,
+        K_CHUNK=k_chunk,
+        N_CORES=n_cores,
+    )
+
+    # Stage 2: FFN gate+up + RMS + SwiGLU, int4 (M=2*hidden, K=emb).
+    stage2 = build_int4_swiglu_rms(
+        2 * hidden_dim,
+        emb_dim,
+        GS=gs,
+        M_TILE=m_tile,
+        K_CHUNK=k_chunk,
+        N_CORES=n_cores,
+    )
+
+    # Stage 3: Down proj (M=emb, K=hidden), int4 GEMV+R.
+    stage3 = build_int4_gemv_add(
+        emb_dim,
+        hidden_dim,
+        GS=gs,
+        M_TILE=m_tile,
+        K_CHUNK=k_chunk,
+        N_CORES=n_cores,
+    )
+
+    # Packed BO dims for the three int4 args.
+    tq, tile_bytes_o = _packed_dims(
+        emb_dim, emb_dim, gs, m_tile, k_chunk, n_cores, emb_dim
+    )
+    tg, tile_bytes_g = _packed_dims(
+        2 * hidden_dim, emb_dim, gs, m_tile, k_chunk, n_cores, 2 * hidden_dim
+    )
+    td, tile_bytes_d = _packed_dims(
+        emb_dim, hidden_dim, gs, m_tile, k_chunk, n_cores, emb_dim
+    )
+    assert (
+        tile_bytes_o == tile_bytes_d == tile_bytes_g
+    ), "All three int4 stages must share tile_bytes (same K_CHUNK/GS/M_TILE)"
+    tile_bytes = tile_bytes_o
+
+    def _slice(ir, prefix, arg_map, arg_aliases=None):
+        body = _extract_between_func_and_return(ir)
+        maps = _extract_affine_maps(ir)
+        chans = _extract_channel_decls(ir)
+        privs = _extract_private_funcs(ir)
+        body = _rename_all_with_externs(body, prefix, _EXTERNS)
+        maps = [_rename_all_with_externs(m, prefix, _EXTERNS) for m in maps]
+        chans = [_rename_all_with_externs(c, prefix, _EXTERNS) for c in chans]
+        privs = [_rename_all_with_externs(p, prefix, _EXTERNS) for p in privs]
+        body = _fix_launch_func_args(
+            body,
+            prefix,
+            arg_map=arg_map,
+            arg_aliases=arg_aliases,
+        )
+        return body, maps, chans, privs
+
+    # Stage 1 — matvec_int4_packed_add local (PACKED=0, B=1, R=2, D=3):
+    #   wo_packed (arg0) @ attn_out (arg1) + x_residual (arg3) → arg6[0]
+    s1_body, s1_maps, s1_chans, s1_privs = _slice(
+        str(stage1),
+        "s1",
+        arg_map={0: 0, 1: 1, 2: 3},
+        arg_aliases={3: "%arg6_row0"},
+    )
+    # Stage 2 — matvec_int4_swiglu_rms local (PACKED=0, RMS=1, D=2):
+    #   gateup_packed (arg7), packed_rms native 2D (arg6), swiglu (arg11)
+    s2_body, s2_maps, s2_chans, s2_privs = _slice(
+        str(stage2),
+        "s2",
+        arg_map={0: 7, 1: 6, 2: 11},
+    )
+    # Stage 3 — matvec_int4_packed_add local (PACKED=0, B=1, R=2, D=3):
+    #   wdown_packed (arg12) @ swiglu (arg11) + arg6[0] → output (arg14)
+    s3_body, s3_maps, s3_chans, s3_privs = _slice(
+        str(stage3),
+        "s3",
+        arg_map={0: 12, 1: 11, 3: 14},
+        arg_aliases={2: "%arg6_row0"},
+    )
+
+    # Dedup private decls by symbol identity (all three stages declare the
+    # same int4 externs; keep one copy).
+    seen = set()
+    all_privs = []
+    for p in s1_privs + s2_privs + s3_privs:
+        m = re.search(r"@(\w+)", p)
+        if m and m.group(1) not in seen:
+            seen.add(m.group(1))
+            all_privs.append(p.strip())
+
+    seen_chans = set()
+    all_chans = []
+    for c in s1_chans + s2_chans + s3_chans:
+        cs = c.strip()
+        if cs not in seen_chans:
+            seen_chans.add(cs)
+            all_chans.append(cs)
+
+    all_maps = s1_maps + s2_maps + s3_maps
+
+    combined = (
+        "\n".join(all_maps)
+        + f"""
+module {{
+{chr(10).join('  ' + c for c in all_chans)}
+{chr(10).join('  ' + p for p in all_privs)}
+  func.func @o_gemv_ffn_int4(
+    %arg0: memref<{tq}x{tile_bytes}xi8>,
+    %arg1: memref<{emb_dim}xbf16>,
+    %arg2: memref<{emb_dim}xbf16>,
+    %arg3: memref<{emb_dim}xbf16>,
+    %arg4: memref<{emb_dim}xbf16>,
+    %arg5: memref<{emb_dim}xbf16>,
+    %arg6: memref<2x{emb_dim}xbf16>,
+    %arg7: memref<{tg}x{tile_bytes}xi8>,
+    %arg8: memref<{hidden_dim}xbf16>,
+    %arg9: memref<{hidden_dim}x{emb_dim}xbf16>,
+    %arg10: memref<{hidden_dim}xbf16>,
+    %arg11: memref<{hidden_dim}xbf16>,
+    %arg12: memref<{td}x{tile_bytes}xi8>,
+    %arg13: memref<{emb_dim}xbf16>,
+    %arg14: memref<{emb_dim}xbf16>
+  ) {{
+    %arg6_row0_strided = memref.subview %arg6[0, 0] [1, {emb_dim}] [1, 1]
+        : memref<2x{emb_dim}xbf16> to memref<{emb_dim}xbf16, strided<[1]>>
+    %arg6_row0 = memref.cast %arg6_row0_strided
+        : memref<{emb_dim}xbf16, strided<[1]>> to memref<{emb_dim}xbf16>
+{s1_body}
+{s2_body}
+{s3_body}
+    return
+  }}
+}}
+"""
+    )
+    with Context() as ctx:
+        return Module.parse(combined, ctx)
+
+
+def o_gemv_ffn_int4_reference(
+    wo, attn_out, x_residual, ffn_norm_w, wgate, wup, wdown, eps=1e-5
+):
+    """CPU bf16 reference (caller dequantizes int4 weights upstream)."""
+    res1 = wo.astype(np.float32) @ attn_out.astype(np.float32) + x_residual.astype(
+        np.float32
+    )
+    rstd = 1.0 / np.sqrt((res1 * res1).mean() + eps)
+    normed = (res1 * rstd) * ffn_norm_w.astype(np.float32)
+    normed_bf16 = normed.astype(bfloat16).astype(np.float32)
+    gate = wgate.astype(np.float32) @ normed_bf16
+    up = wup.astype(np.float32) @ normed_bf16
+    swiglu = (gate * 0.5 * (np.tanh(gate / 2.0) + 1.0)) * up
+    swiglu_bf16 = swiglu.astype(bfloat16).astype(np.float32)
+    output = (wdown.astype(np.float32) @ swiglu_bf16 + res1).astype(bfloat16)
+    return output
+
+
+def _gen_int4_weights(M, K, gs, seed):
+    """uint4 packed weights + scales + zeros + dequantized bf16 (for CPU ref)."""
+    rng = np.random.default_rng(seed)
+    A_q_unp = rng.integers(0, 16, size=(M, K), dtype=np.uint8)
+    A_q = (A_q_unp[:, 0::2] | (A_q_unp[:, 1::2] << 4)).astype(np.uint8)
+    n_groups = K // gs
+    A_s = rng.uniform(0.005, 0.02, size=(n_groups, M)).astype(bfloat16)
+    A_z = rng.integers(7, 9, size=(n_groups, M), dtype=np.uint8)
+    # Vectorized dequant.
+    A_q_i = A_q.astype(np.int32)
+    low = A_q_i & 0x0F
+    high = (A_q_i >> 4) & 0x0F
+    nibs = np.empty((M, K), dtype=np.int32)
+    nibs[:, 0::2] = low
+    nibs[:, 1::2] = high
+    s_per_kk = np.repeat(A_s.astype(np.float32), gs, axis=0)
+    z_per_kk = np.repeat(A_z.astype(np.int32), gs, axis=0)
+    dequant_f32 = (nibs - z_per_kk.T) * s_per_kk.T
+    dequant_bf16 = dequant_f32.astype(bfloat16)
+    return A_q, A_s, A_z, dequant_bf16
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="o_gemv_ffn_int4_multi.py",
+        description="Full int4-AWQ ELF2 (stages 1+2+3 all int4).",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--emb-dim", type=int, default=2048)
+    parser.add_argument("--hidden-dim", type=int, default=8192)
+    parser.add_argument("--gs", type=int, default=128)
+    parser.add_argument("--m-tile", type=int, default=8, dest="m_tile")
+    parser.add_argument("--k-chunk", type=int, default=2048, dest="k_chunk")
+    parser.add_argument("--n-cores", type=int, default=8, dest="n_cores")
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-only", "compile-and-run"],
+        default="compile-and-run",
+    )
+    parser.add_argument(
+        "--output-format", type=str, choices=["xclbin", "elf"], default="elf"
+    )
+    args = parser.parse_args()
+
+    emb_dim = args.emb_dim
+    hidden_dim = args.hidden_dim
+    print(
+        f"O GEMV + FFN full-int4 3-launch: "
+        f"emb_dim={emb_dim}, hidden_dim={hidden_dim}, k_chunk={args.k_chunk}"
+    )
+
+    module = build_o_gemv_ffn_int4_module(
+        emb_dim=emb_dim,
+        hidden_dim=hidden_dim,
+        gs=args.gs,
+        m_tile=args.m_tile,
+        k_chunk=args.k_chunk,
+        n_cores=args.n_cores,
+    )
+    if args.print_module_only:
+        print(module)
+        sys.exit(0)
+
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            instance_name="o_gemv_ffn_int4",
+            use_lock_race_condition_fix=False,
+            stack_size=4096,
+        )
+        backend.compile(module)
+        backend.unload()
+        print("Compile-only done.")
+        sys.exit(0)
+
+    np.random.seed(42)
+    print("Generating int4 wo + dequantizing for CPU ref...")
+    wo_q, wo_s, wo_z, wo_bf16 = _gen_int4_weights(emb_dim, emb_dim, args.gs, 100)
+    # Stage 2 packed gate/up: rows 2i = gate[i], rows 2i+1 = up[i].
+    # Generate as ONE interleaved [2*hidden, emb] matrix, then split into
+    # gate/up bf16 references for the CPU ref.
+    print("Generating int4 gate/up (interleaved) + dequantizing for CPU ref...")
+    gu_q, gu_s, gu_z, gu_bf16 = _gen_int4_weights(2 * hidden_dim, emb_dim, args.gs, 150)
+    gate_bf16 = gu_bf16[0::2]
+    up_bf16 = gu_bf16[1::2]
+    print("Generating int4 wdown + dequantizing for CPU ref...")
+    wd_q, wd_s, wd_z, wd_bf16 = _gen_int4_weights(emb_dim, hidden_dim, args.gs, 200)
+
+    attn_out = np.random.randn(emb_dim).astype(bfloat16)
+    x_residual = np.random.randn(emb_dim).astype(bfloat16)
+    ffn_norm_w = (np.random.randn(emb_dim) * 0.1 + 1.0).astype(bfloat16)
+    packed_rms = np.empty((2, emb_dim), dtype=bfloat16)
+    packed_rms[0] = 0.0
+    packed_rms[1] = ffn_norm_w
+    swiglu_buf = np.zeros(hidden_dim, dtype=bfloat16)
+
+    wo_packed = pack_inputs(
+        wo_q,
+        wo_s,
+        wo_z,
+        emb_dim,
+        emb_dim,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        emb_dim,
+    )
+    gu_packed = pack_inputs(
+        gu_q,
+        gu_s,
+        gu_z,
+        2 * hidden_dim,
+        emb_dim,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        2 * hidden_dim,
+    )
+    wd_packed = pack_inputs(
+        wd_q,
+        wd_s,
+        wd_z,
+        emb_dim,
+        hidden_dim,
+        args.gs,
+        args.m_tile,
+        args.k_chunk,
+        args.n_cores,
+        emb_dim,
+    )
+
+    expected = o_gemv_ffn_int4_reference(
+        wo_bf16,
+        attn_out,
+        x_residual,
+        ffn_norm_w,
+        gate_bf16,
+        up_bf16,
+        wd_bf16,
+    )
+
+    z_emb = np.zeros(emb_dim, dtype=bfloat16)
+    z_hidden = np.zeros(hidden_dim, dtype=bfloat16)
+    z_hidden_emb = np.zeros((hidden_dim, emb_dim), dtype=bfloat16)
+
+    from air.backend.xrt_runner import XRTRunner
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="o_gemv_ffn_int4",
+        use_lock_race_condition_fix=False,
+        stack_size=4096,
+    )
+    sys.exit(
+        runner.run_test(
+            module,
+            inputs=[
+                wo_packed,  # arg0
+                attn_out,  # arg1
+                z_emb,  # arg2 dead
+                x_residual,  # arg3
+                z_emb,  # arg4 dead
+                z_emb,  # arg5 dead
+                packed_rms,  # arg6
+                gu_packed,  # arg7 (int4 interleaved gate/up)
+                z_hidden,  # arg8 dead
+                z_hidden_emb,  # arg9 dead
+                z_hidden,  # arg10 dead
+                swiglu_buf,  # arg11
+                wd_packed,  # arg12
+                z_emb,  # arg13 dead
+            ],
+            expected_outputs=[expected],
+            rtol=0.2,
+            atol=2.0,
+            min_correlation=0.99,
+        )
+    )

--- a/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
+++ b/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
@@ -3,8 +3,8 @@
 
 """o_gemv_ffn_int4 — full-int4 ELF2 for the LLAMA decode block.
 
-3-launch ELF derived from o_gemv_ffn_int4p1_multi.py. ALL three weight
-matrices (wo, gate+up, wdown) are int4-AWQ packed BOs:
+3-launch ELF derived from the bf16 baseline o_gemv_ffn_multi.py. ALL three
+weight matrices (wo, gate+up, wdown) are int4-AWQ packed BOs:
 
   Stage 1 (matvec_int4_packed_add):  res1 = dequant(wo) @ attn_out + x_residual
                                      into arg6[0]

--- a/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
+++ b/programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py
@@ -227,12 +227,13 @@ def build_o_gemv_ffn_int4_module(
 
     all_maps = s1_maps + s2_maps + s3_maps
 
-    combined = (
-        "\n".join(all_maps)
-        + f"""
+    maps_block = "\n".join(all_maps)
+    chans_block = "\n".join("  " + c for c in all_chans)
+    privs_block = "\n".join("  " + p for p in all_privs)
+    combined = f"""{maps_block}
 module {{
-{chr(10).join('  ' + c for c in all_chans)}
-{chr(10).join('  ' + p for p in all_privs)}
+{chans_block}
+{privs_block}
   func.func @o_gemv_ffn_int4(
     %arg0: memref<{tq}x{tile_bytes}xi8>,
     %arg1: memref<{emb_dim}xbf16>,
@@ -261,7 +262,6 @@ module {{
   }}
 }}
 """
-    )
     with Context() as ctx:
         return Module.parse(combined, ctx)
 

--- a/programming_examples/llama32_1b/multi_launch_builder/test_o_gemv_ffn.cpp
+++ b/programming_examples/llama32_1b/multi_launch_builder/test_o_gemv_ffn.cpp
@@ -1,0 +1,168 @@
+//===- test_o_gemv_ffn.cpp ------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+// XRT (ELF) profiling harness for the 15-arg LLAMA decode ELF2 op
+// (matvec_2tile_add + matvec_swiglu_rms + matvec_2tile_add fused via
+// arg6-row0 subview routing). Works for both the bf16 baseline
+// (o_gemv_ffn) and the full int4 variant (o_gemv_ffn_int4) — size
+// the three weight BOs from the CLI.
+
+#include "cxxopts.hpp"
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+#include <limits>
+#include <stdfloat>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+
+using DT_BF16 = std::bfloat16_t;
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("ELF2 (o_gemv_ffn) Profiling");
+  options.add_options()("help,h", "produce help message")(
+      "elf,e", "elf path", cxxopts::value<std::string>())(
+      "kernel,k", "kernel <kernel>:<instance>", cxxopts::value<std::string>())(
+      "verbosity,v", "verbosity", cxxopts::value<int>()->default_value("0"))(
+      "emb", "embedding dim", cxxopts::value<int>()->default_value("2048"))(
+      "hidden", "hidden dim", cxxopts::value<int>()->default_value("8192"))(
+      "w0_bytes", "arg0 wo bytes", cxxopts::value<size_t>())(
+      "w7_bytes", "arg7 gate+up bytes", cxxopts::value<size_t>())(
+      "w12_bytes", "arg12 wdown bytes", cxxopts::value<size_t>())(
+      "iterations", "timed iters", cxxopts::value<int>()->default_value("50"))(
+      "warmup", "warmup iters", cxxopts::value<int>()->default_value("20"));
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+  int emb = vm["emb"].as<int>();
+  int hidden = vm["hidden"].as<int>();
+  size_t w0_bytes = vm["w0_bytes"].as<size_t>();
+  size_t w7_bytes = vm["w7_bytes"].as<size_t>();
+  size_t w12_bytes = vm["w12_bytes"].as<size_t>();
+  size_t emb_bytes = (size_t)emb * sizeof(DT_BF16);
+  size_t hidden_bytes = (size_t)hidden * sizeof(DT_BF16);
+  size_t rms_bytes = (size_t)2 * emb_bytes;
+  size_t dead_he_bytes = (size_t)hidden * emb * sizeof(DT_BF16);
+
+  srand(time(NULL));
+  auto device = xrt::device(0);
+  xrt::elf ctx_elf{vm["elf"].as<std::string>()};
+  xrt::hw_context context(device, ctx_elf);
+  auto kernel = xrt::ext::kernel(context, vm["kernel"].as<std::string>());
+
+  // 15 args (see o_gemv_ffn_int4_multi.py docstring for ABI).
+  xrt::bo bo0 = xrt::ext::bo{device, w0_bytes};      // wo
+  xrt::bo bo1 = xrt::ext::bo{device, emb_bytes};     // attn_out
+  xrt::bo bo2 = xrt::ext::bo{device, emb_bytes};     // dead
+  xrt::bo bo3 = xrt::ext::bo{device, emb_bytes};     // x_residual
+  xrt::bo bo4 = xrt::ext::bo{device, emb_bytes};     // dead
+  xrt::bo bo5 = xrt::ext::bo{device, emb_bytes};     // dead
+  xrt::bo bo6 = xrt::ext::bo{device, rms_bytes};     // rms input [2, emb]
+  xrt::bo bo7 = xrt::ext::bo{device, w7_bytes};      // gate+up
+  xrt::bo bo8 = xrt::ext::bo{device, hidden_bytes};  // dead
+  xrt::bo bo9 = xrt::ext::bo{device, dead_he_bytes}; // dead [hidden, emb]
+  xrt::bo bo10 = xrt::ext::bo{device, hidden_bytes}; // dead
+  xrt::bo bo11 = xrt::ext::bo{device, hidden_bytes}; // swiglu
+  xrt::bo bo12 = xrt::ext::bo{device, w12_bytes};    // wdown
+  xrt::bo bo13 = xrt::ext::bo{device, emb_bytes};    // dead
+  xrt::bo bo14 = xrt::ext::bo{device, emb_bytes};    // output
+
+  // Fill weight + activation BOs with bounded random values so timing
+  // isn't disturbed by NaN/Inf, but content is irrelevant for timing.
+  auto fill_u8 = [](xrt::bo &bo, size_t bytes) {
+    uint8_t *p = bo.map<uint8_t *>();
+    for (size_t i = 0; i < bytes; i++)
+      p[i] = (uint8_t)(rand() & 0xFF);
+  };
+  auto fill_bf16 = [](xrt::bo &bo, size_t bytes) {
+    DT_BF16 *p = bo.map<DT_BF16 *>();
+    size_t n = bytes / sizeof(DT_BF16);
+    for (size_t i = 0; i < n; i++)
+      p[i] = DT_BF16(0.01f * (float)rand() / RAND_MAX);
+  };
+  fill_u8(bo0, w0_bytes);
+  fill_bf16(bo1, emb_bytes);
+  fill_bf16(bo3, emb_bytes);
+  fill_bf16(bo6, rms_bytes);
+  fill_u8(bo7, w7_bytes);
+  fill_u8(bo12, w12_bytes);
+  memset(bo2.map<uint8_t *>(), 0, emb_bytes);
+  memset(bo4.map<uint8_t *>(), 0, emb_bytes);
+  memset(bo5.map<uint8_t *>(), 0, emb_bytes);
+  memset(bo8.map<uint8_t *>(), 0, hidden_bytes);
+  memset(bo9.map<uint8_t *>(), 0, dead_he_bytes);
+  memset(bo10.map<uint8_t *>(), 0, hidden_bytes);
+  memset(bo11.map<uint8_t *>(), 0, hidden_bytes);
+  memset(bo13.map<uint8_t *>(), 0, emb_bytes);
+  memset(bo14.map<uint8_t *>(), 0, emb_bytes);
+
+  for (xrt::bo *b : {&bo0, &bo1, &bo2, &bo3, &bo4, &bo5, &bo6, &bo7, &bo8, &bo9,
+                     &bo10, &bo11, &bo12, &bo13, &bo14})
+    b->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iter = vm["iterations"].as<int>();
+  unsigned n_warm = vm["warmup"].as<int>();
+  unsigned total = n_iter + n_warm;
+  float t_total = 0, t_min = std::numeric_limits<float>::max(), t_max = 0;
+
+  std::cout << "ELF2 (o_gemv_ffn) Benchmark\n"
+            << "  emb=" << emb << " hidden=" << hidden << " w0=" << w0_bytes
+            << "B"
+            << " w7=" << w7_bytes << "B"
+            << " w12=" << w12_bytes << "B\n";
+
+  for (unsigned i = 0; i < total; i++) {
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo0);
+    run.set_arg(1, bo1);
+    run.set_arg(2, bo2);
+    run.set_arg(3, bo3);
+    run.set_arg(4, bo4);
+    run.set_arg(5, bo5);
+    run.set_arg(6, bo6);
+    run.set_arg(7, bo7);
+    run.set_arg(8, bo8);
+    run.set_arg(9, bo9);
+    run.set_arg(10, bo10);
+    run.set_arg(11, bo11);
+    run.set_arg(12, bo12);
+    run.set_arg(13, bo13);
+    run.set_arg(14, bo14);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    run.start();
+    run.wait2();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    bo14.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    if (i < n_warm)
+      continue;
+    float dt =
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    t_total += dt;
+    t_min = std::min(t_min, dt);
+    t_max = std::max(t_max, dt);
+  }
+
+  // GEMV+R MACs: wo (emb*emb), gate+up (2*hidden*emb), wdown (emb*hidden).
+  float macs =
+      2.0f * ((float)emb * emb + 2.0f * hidden * emb + (float)emb * hidden);
+  std::cout << "\nAvg NPU time: " << t_total / n_iter << " us\n";
+  std::cout << "Avg gflops:   " << macs / (1000.0f * t_total / n_iter) << "\n";
+  std::cout << "Min NPU time: " << t_min << " us  (max gflops "
+            << macs / (1000.0f * t_min) << ")\n";
+  std::cout << "Max NPU time: " << t_max << " us\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary

Full-int4 sibling of the 3-launch `o_gemv_ffn` ELF that landed in #1631. All three weight matrices (wo, gate+up, wdown) become AWQ-packed int4 BOs while preserving the arg6-row0 subview-routed residual that lets the post-attention residual feed both the FFN RMSNorm and the down-proj residual without a host copy or intermediate launch.

Stages of `o_gemv_ffn_int4` (15-arg ABI matches the bf16 baseline so the caller can pass dead args as zero placeholders):

1. `matvec_int4_packed_add`: `res1 = dequant(wo) @ attn_out + x_residual` into `arg6[0]`
2. `matvec_int4_swiglu_rms`: `swiglu = silu(dequant(gateup) @ rms_norm(arg6)) * up`
3. `matvec_int4_packed_add`: `output = dequant(wdown) @ swiglu + arg6[0]`

All three stages link a single `mv_int4_bf16.o` (`K_CHUNK=2048, M_TILE=8`).

### New fused module

`matvec_int4_swiglu_rms` keeps the RMSNorm + GEMV + SwiGLU fusion of the bf16 variant but consumes AWQ-packed weights. A single matvec herd stays under the AIE2P 2-S2MM-per-tile budget by routing `PACKED` via `aL2ToL1` and `RMS` via the `inRMS` broadcast (replayed once per launch).

### Files

- `programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py` — new standalone fused FFN module
- `programming_examples/decode_ffn_swiglu/Makefile` — `run_int4` target + `compile-kernel-int4`
- `programming_examples/decode_ffn_swiglu/run_int4_npu2_peano.lit` — lit test for the standalone
- `programming_examples/llama32_1b/multi_launch_builder/o_gemv_ffn_int4_multi.py` — full int4 3-launch stitcher
- `programming_examples/llama32_1b/multi_launch_builder/test_o_gemv_ffn.cpp` — XRT timing harness (works for both bf16 and int4 ELF2 — size the three weight BOs from the CLI)

### NPU2 measurements

`emb=2048, hidden=8192`, 20 warmup + 50 timed iters via `test_o_gemv_ffn.exe`:

| Variant         | Avg latency | Min        | Avg GFLOPS | Weight memory |
| --------------- | ----------- | ---------- | ---------- | ------------- |
| bf16 baseline   | 2599 µs     | 2590 µs    | 42.0       | 110 MB        |
| full int4       | 1350 µs     | 1345 µs    | 80.8       | 28 MB         |

**1.93× speedup, -48% latency, -68% weight memory.**

End-to-end correctness on NPU2: 0.999831 correlation vs bf16 reference (`rtol=0.2, atol=2.0`). Standalone `matvec_int4_swiglu_rms` (M=16384, K=2048): 0.999917.

## Test plan

- [x] Standalone `matvec_int4_swiglu_rms` passes on NPU2 (correlation 0.999917)
- [x] Stitched `o_gemv_ffn_int4` passes on NPU2 (correlation 0.999831)
- [x] bf16 ELF2 still compiles and profiles via the new shared harness
- [x] `compile-kernel-int4` Makefile target builds `mv_int4_bf16.o` against the int4_awq source tree
- [ ] `lit` test (`run_int4_npu2_peano.lit`) — runs via `ninja check-air-e2e-peano`

🤖 Generated with [Claude Code](https://claude.com/claude-code)