### PR TITLE
[ci] llama32_1b: install verify Python deps + add compile-only test

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -153,6 +153,10 @@ jobs:
           (
             export HF_TOKEN="${{ secrets.HF_TOKEN }}"
             export LIT_OPTS="$LIT_OPTS --filter llama32_1b/run_npu2_verify"
+            # Install verify's Python dependencies (safetensors, transformers,
+            # torch, huggingface_hub) on top of the mlir-air base environment.
+            # Scoped to this sub-shell so it does not affect other test steps.
+            pip install -r ../programming_examples/llama32_1b/requirements.txt
             ninja check-programming-examples-peano || ninja check-programming-examples-peano
           )
 

--- a/programming_examples/llama32_1b/llama32_1b_inference.py
+++ b/programming_examples/llama32_1b/llama32_1b_inference.py
@@ -888,6 +888,9 @@ def build_session(args) -> Session:
         compile_decode_kernels(decode_cache, config)
 
     if args.compile_only:
+        # Stable end-of-compile marker for CI (run_npu2_compile.lit FileCheck).
+        # Do not change without also updating the lit CHECK line.
+        print("\nCompilation passed.")
         sys.exit(0)
 
     if args.run_only:

--- a/programming_examples/llama32_1b/run_npu2_compile.lit
+++ b/programming_examples/llama32_1b/run_npu2_compile.lit
@@ -1,0 +1,27 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// LLAMA-3.2-1B compile-only smoke test: builds every prefill + decode kernel
+// ELF through the AIR -> AIE -> aiecc -> Peano pipeline. No NPU dispatch and
+// no HuggingFace weight download — this is the signal that fork PR CI can
+// always give us (it does not require `hf_token`, so unlike `run_npu2_verify`
+// it is not skipped when HF_TOKEN is unset).
+//
+// Pairs with run_npu2_verify.lit (end-to-end correctness gate against HF
+// bf16, gated by hf_token) — together they cover "does it still compile?"
+// without secrets and "does it still produce correct output?" with secrets.
+//
+// Gated on ryzen_ai_npu2 because the example hardcodes the AIE2P target
+// throughout its kernel builders (kernel_builder/external_kernels.py uses
+// --target=aie2p-none-unknown-elf, gemm_builder.py uses arch="aie2p");
+// running this on a non-NPU2 context would compile artifacts that cannot
+// be exercised on the host runner. The actual compile does not touch the
+// NPU device, so any NPU2-capable runner is sufficient.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_compile
+// RUN: cd test_peano_compile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Compilation passed.


### PR DESCRIPTION
Follow-up to #1636 (already merged into `llama-verify`). Three small changes to make CI actually exercise the verify gate and give every fork PR a real signal on the compile path.

## Summary

| File | Change |
|---|---|
| `.github/workflows/buildAndTestRyzenAI.yml` | +4 lines: `pip install -r programming_examples/llama32_1b/requirements.txt` inside the HF_TOKEN sub-shell. Without this the dispatched verify run fails with `ModuleNotFoundError: No module named 'safetensors'` before reaching any HF auth or model download. Scoped to the sub-shell so it does not affect other test steps. |
| `programming_examples/llama32_1b/run_npu2_compile.lit` | **new** (+27 lines): compile-only smoke test that builds every prefill + decode kernel ELF through the AIR→AIE→aiecc→Peano pipeline and FileChecks the explicit `Compilation passed.` marker. `REQUIRES: ryzen_ai_npu2, peano` only (no `hf_token`), so unlike `run_npu2_verify.lit` it is **not** skipped on fork-originated PR CI where GitHub does not expose repository secrets. Every PR gets a real PASS/FAIL signal on the compile path. |
| `programming_examples/llama32_1b/llama32_1b_inference.py` | +3 lines: print an explicit `Compilation passed.` marker at the end of the `--compile-only` path. Stable, documented end-of-compile marker for the new lit test; inline comment ties it to the lit `CHECK` line so future edits don't silently break CI. |

**Scope:** 3 files, +34 lines.

## Why each piece

### CI dependency install
The dispatched verify run on `llama-verify` failed today ([run 26767696534](https://github.com/Xilinx/mlir-air/actions/runs/26767696534/job/78898489604)) — the workflow change from #1636 successfully exposes `HF_TOKEN` to the gated step (`HF_TOKEN found in environment; hf_token feature enabled.` confirmed in the log), but `verify_runner.py` then fails at import:

```
File ".../verify/verify_runner.py", line 83, in _load_weights
ModuleNotFoundError: No module named 'safetensors'
```

The runner's `air-venv` doesn't have the example's Python deps. Adding the pip install inside the same sub-shell where HF_TOKEN is exported keeps the install cost localized to the one step that needs it.

### Compile-only smoke test
`run_npu2_verify.lit` is gated by `REQUIRES: hf_token` and skips on every fork PR (GitHub doesn't expose secrets to fork-originated CI). Without a second test, fork PRs get **no signal** on whether the llama32_1b example still builds. The new `run_npu2_compile.lit` fills that gap.

|  | fork PR auto CI (no secret) | maintainer dispatch / post-merge main |
|---|---|---|
| `run_npu2_compile.lit` | ✅ real PASS/FAIL | ✅ real PASS/FAIL |
| `run_npu2_verify.lit` | UNSUPPORTED (skip) | ✅ real HF-bf16 parity gate |

### Stable compile marker
The smoke test FileChecks `Compilation passed.` — printed at exactly one site in `llama32_1b_inference.py`'s `--compile-only` exit, with an inline comment marking it load-bearing for CI. Less fragile than relying on incidental log lines.

## Test plan

- [x] Local: `lit -v --filter llama32_1b/run_npu2_compile build/programming_examples/` → `PASS` in ~140 s (with `HF_TOKEN` deliberately unset to mirror the fork-PR condition)
- [x] Local: `make verify` PASS 2/2 prompts (post-cleanup)
- [ ] CI side: pending maintainer `workflow_dispatch` against `llama-verify` to confirm the pip install path lets the verify run progress past the import error and exercise the HF-gated test end-to-end