### PR TITLE
[AIRToAIE] Fix packet-flow routing when herd consumes ops in non-decl order

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -268,6 +268,17 @@ simpleDMAChannelAllocation(std::vector<MemcpyBundleAsFlow> &memcpy_flows,
                            MemTileDMAAllocator &memtile_dma_alloc,
                            TileDMAAllocator &tile_dma_alloc,
                            air::CascadeAllocator &core_cascade_alloc);
+
+// Shared-MM2S packet flow ordering. Receiver mem chain + core follow
+// herd-source order; sender pkt_ids + dispatch order must too. Call
+// sortPacketShimFlowsByReceiverOrder before simpleDMAChannelAllocation,
+// reorderL3PacketPutsByFlowOrder after.
+bool isPacketShimFlow(const MemcpyBundleAsFlow &f);
+void sortPacketShimFlowsByReceiverOrder(
+    std::vector<MemcpyBundleAsFlow> &memcpy_flows, AIE::DeviceOp aie_device);
+void reorderL3PacketPutsByFlowOrder(
+    AIE::DeviceOp aie_device,
+    const std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 template <typename T>
 int foundInVector(T item, std::vector<T> vec);
 int getSCFForLoopDepth(Operation *o);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3909,6 +3909,103 @@ public:
       }
     }
 
+    // Reorder packet-switched shim sender flows by their receiver-side
+    // first-use position. When multiple packet flows demux into one tile S2MM
+    // port, the receiver consumes BD chains in FIFO arrival order; the sender
+    // (shim) emits in dispatch order. Both must match the core's lock-acquire
+    // order, which follows herd-source order. Without this sort, when a herd
+    // puts sibling channel.gets before a per-tile loop containing the main
+    // get, sender dispatch (driven by launch-decl order) and receiver mem
+    // chain / core (driven by herd-source order) disagree → packets land in
+    // wrong BD chains, wrong-buffer data, or deadlock.
+    {
+      DenseMap<Operation *, unsigned> walkPos;
+      unsigned pos = 0;
+      if (auto pm = aie_device->getParentOfType<ModuleOp>())
+        pm.walk([&](Operation *op) { walkPos[op] = pos++; });
+      else
+        aie_device.walk([&](Operation *op) { walkPos[op] = pos++; });
+      auto getReceiverFirstUsePos = [&](const air::MemcpyBundleAsFlow &f) {
+        unsigned minPos = std::numeric_limits<unsigned>::max();
+        for (int i = 0; i < f.numS2MMAllocs; ++i) {
+          if (i >= (int)f.S2MM.size())
+            break;
+          for (auto *recvOp : f.S2MM[i]) {
+            auto it = walkPos.find(recvOp);
+            if (it != walkPos.end() && it->second < minPos)
+              minPos = it->second;
+          }
+        }
+        return minPos;
+      };
+      // Sort only the eligible subset to keep the comparator strict-weak.
+      SmallVector<size_t> eligibleIdx;
+      for (size_t i = 0; i < memcpy_flows.size(); ++i) {
+        auto &f = memcpy_flows[i];
+        if (f.memcpyResourceType != "npu_dma_packet")
+          continue;
+        if (f.MM2S_memspace != air::MemorySpace::L3)
+          continue;
+        eligibleIdx.push_back(i);
+      }
+      if (eligibleIdx.size() > 1) {
+        SmallVector<air::MemcpyBundleAsFlow> eligible;
+        for (auto i : eligibleIdx)
+          eligible.push_back(std::move(memcpy_flows[i]));
+        llvm::stable_sort(eligible, [&](const air::MemcpyBundleAsFlow &a,
+                                        const air::MemcpyBundleAsFlow &b) {
+          return getReceiverFirstUsePos(a) < getReceiverFirstUsePos(b);
+        });
+        for (size_t k = 0; k < eligibleIdx.size(); ++k)
+          memcpy_flows[eligibleIdx[k]] = std::move(eligible[k]);
+      }
+
+      // Physically reorder the launch-side L3 ChannelPut ops in IR so the
+      // runtime sequence (emitted later by AIRRtToNpuPass in IR walk order)
+      // dispatches dma_start_task calls in the sorted order. The puts live
+      // in func.func @repro (outside aie.device), reached via the parent
+      // module. Track prev per block since there may be multiple launch
+      // clones (e.g. main + reset device).
+      if (auto parentModule = aie_device->getParentOfType<ModuleOp>()) {
+        DenseMap<StringAttr, SmallVector<air::ChannelPutOp>> putsByChan;
+        parentModule.walk([&](air::ChannelPutOp put) {
+          auto memrefTy = dyn_cast<BaseMemRefType>(put.getMemref().getType());
+          if (!memrefTy || !air::isL3(memrefTy))
+            return;
+          auto chan = air::getChannelDeclarationThroughSymbol(put);
+          if (!chan || chan.getChannelType().str() != "npu_dma_packet")
+            return;
+          putsByChan[chan.getSymNameAttr()].push_back(put);
+        });
+        SmallVector<air::ChannelPutOp> sortedPuts;
+        for (auto &f : memcpy_flows) {
+          if (f.memcpyResourceType != "npu_dma_packet")
+            continue;
+          if (f.MM2S_memspace != air::MemorySpace::L3)
+            continue;
+          auto chan = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op);
+          if (!chan)
+            continue;
+          auto it = putsByChan.find(chan.getSymNameAttr());
+          if (it == putsByChan.end())
+            continue;
+          for (auto put : it->second)
+            sortedPuts.push_back(put);
+        }
+        DenseMap<Block *, Operation *> prevByBlock;
+        for (auto put : sortedPuts) {
+          Block *blk = put->getBlock();
+          auto it = prevByBlock.find(blk);
+          if (it == prevByBlock.end()) {
+            prevByBlock[blk] = put;
+            continue;
+          }
+          put->moveAfter(it->second);
+          prevByBlock[blk] = put;
+        }
+      }
+    }
+
     // Step 2: Allocate tile DMA channels, shim DMA channels and shim tiles
     auto r = simpleDMAChannelAllocation(memcpy_flows, shim_dma_alloc,
                                         memtile_dma_alloc, tile_dma_alloc,

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3909,102 +3909,10 @@ public:
       }
     }
 
-    // Reorder packet-switched shim sender flows by their receiver-side
-    // first-use position. When multiple packet flows demux into one tile S2MM
-    // port, the receiver consumes BD chains in FIFO arrival order; the sender
-    // (shim) emits in dispatch order. Both must match the core's lock-acquire
-    // order, which follows herd-source order. Without this sort, when a herd
-    // puts sibling channel.gets before a per-tile loop containing the main
-    // get, sender dispatch (driven by launch-decl order) and receiver mem
-    // chain / core (driven by herd-source order) disagree → packets land in
-    // wrong BD chains, wrong-buffer data, or deadlock.
-    {
-      DenseMap<Operation *, unsigned> walkPos;
-      unsigned pos = 0;
-      if (auto pm = aie_device->getParentOfType<ModuleOp>())
-        pm.walk([&](Operation *op) { walkPos[op] = pos++; });
-      else
-        aie_device.walk([&](Operation *op) { walkPos[op] = pos++; });
-      auto getReceiverFirstUsePos = [&](const air::MemcpyBundleAsFlow &f) {
-        unsigned minPos = std::numeric_limits<unsigned>::max();
-        for (int i = 0; i < f.numS2MMAllocs; ++i) {
-          if (i >= (int)f.S2MM.size())
-            break;
-          for (auto *recvOp : f.S2MM[i]) {
-            auto it = walkPos.find(recvOp);
-            if (it != walkPos.end() && it->second < minPos)
-              minPos = it->second;
-          }
-        }
-        return minPos;
-      };
-      // Sort only the eligible subset to keep the comparator strict-weak.
-      SmallVector<size_t> eligibleIdx;
-      for (size_t i = 0; i < memcpy_flows.size(); ++i) {
-        auto &f = memcpy_flows[i];
-        if (f.memcpyResourceType != "npu_dma_packet")
-          continue;
-        if (f.MM2S_memspace != air::MemorySpace::L3)
-          continue;
-        eligibleIdx.push_back(i);
-      }
-      if (eligibleIdx.size() > 1) {
-        SmallVector<air::MemcpyBundleAsFlow> eligible;
-        for (auto i : eligibleIdx)
-          eligible.push_back(std::move(memcpy_flows[i]));
-        llvm::stable_sort(eligible, [&](const air::MemcpyBundleAsFlow &a,
-                                        const air::MemcpyBundleAsFlow &b) {
-          return getReceiverFirstUsePos(a) < getReceiverFirstUsePos(b);
-        });
-        for (size_t k = 0; k < eligibleIdx.size(); ++k)
-          memcpy_flows[eligibleIdx[k]] = std::move(eligible[k]);
-      }
-
-      // Physically reorder the launch-side L3 ChannelPut ops in IR so the
-      // runtime sequence (emitted later by AIRRtToNpuPass in IR walk order)
-      // dispatches dma_start_task calls in the sorted order. The puts live
-      // in func.func @repro (outside aie.device), reached via the parent
-      // module. Track prev per block since there may be multiple launch
-      // clones (e.g. main + reset device).
-      if (auto parentModule = aie_device->getParentOfType<ModuleOp>()) {
-        DenseMap<StringAttr, SmallVector<air::ChannelPutOp>> putsByChan;
-        parentModule.walk([&](air::ChannelPutOp put) {
-          auto memrefTy = dyn_cast<BaseMemRefType>(put.getMemref().getType());
-          if (!memrefTy || !air::isL3(memrefTy))
-            return;
-          auto chan = air::getChannelDeclarationThroughSymbol(put);
-          if (!chan || chan.getChannelType().str() != "npu_dma_packet")
-            return;
-          putsByChan[chan.getSymNameAttr()].push_back(put);
-        });
-        SmallVector<air::ChannelPutOp> sortedPuts;
-        for (auto &f : memcpy_flows) {
-          if (f.memcpyResourceType != "npu_dma_packet")
-            continue;
-          if (f.MM2S_memspace != air::MemorySpace::L3)
-            continue;
-          auto chan = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op);
-          if (!chan)
-            continue;
-          auto it = putsByChan.find(chan.getSymNameAttr());
-          if (it == putsByChan.end())
-            continue;
-          for (auto put : it->second)
-            sortedPuts.push_back(put);
-        }
-        DenseMap<Block *, Operation *> prevByBlock;
-        for (auto put : sortedPuts) {
-          Block *blk = put->getBlock();
-          auto it = prevByBlock.find(blk);
-          if (it == prevByBlock.end()) {
-            prevByBlock[blk] = put;
-            continue;
-          }
-          put->moveAfter(it->second);
-          prevByBlock[blk] = put;
-        }
-      }
-    }
+    // Align shared-MM2S packet pkt_ids and launch-side L3 put IR order with
+    // the receiver mem chain (herd-source order). See helper docs.
+    air::sortPacketShimFlowsByReceiverOrder(memcpy_flows, aie_device);
+    air::reorderL3PacketPutsByFlowOrder(aie_device, memcpy_flows);
 
     // Step 2: Allocate tile DMA channels, shim DMA channels and shim tiles
     auto r = simpleDMAChannelAllocation(memcpy_flows, shim_dma_alloc,

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1590,6 +1590,103 @@ air::MemcpyBundleAsFlow::MemcpyBundleAsFlow(air::ChannelOp chan) {
 
 namespace xilinx {
 
+bool air::isPacketShimFlow(const air::MemcpyBundleAsFlow &f) {
+  return f.memcpyResourceType == "npu_dma_packet" &&
+         f.MM2S_memspace == air::MemorySpace::L3;
+}
+
+void air::sortPacketShimFlowsByReceiverOrder(
+    std::vector<air::MemcpyBundleAsFlow> &memcpy_flows,
+    AIE::DeviceOp aie_device) {
+  // Sort only the eligible subset to keep the comparator strict-weak --
+  // a partial comparator over the full vector breaks transitivity for n>=3.
+  SmallVector<size_t> eligibleIdx;
+  for (size_t i = 0; i < memcpy_flows.size(); ++i)
+    if (isPacketShimFlow(memcpy_flows[i]))
+      eligibleIdx.push_back(i);
+  if (eligibleIdx.size() < 2)
+    return;
+
+  DenseMap<Operation *, unsigned> walkPos;
+  unsigned pos = 0;
+  Operation *root = aie_device->getParentOfType<ModuleOp>();
+  if (!root)
+    root = aie_device;
+  root->walk([&](Operation *op) { walkPos[op] = pos++; });
+
+  auto firstUsePos = [&](const air::MemcpyBundleAsFlow &f) {
+    unsigned minPos = std::numeric_limits<unsigned>::max();
+    for (int i = 0; i < f.numS2MMAllocs && i < (int)f.S2MM.size(); ++i)
+      for (auto *recvOp : f.S2MM[i]) {
+        auto it = walkPos.find(recvOp);
+        if (it != walkPos.end() && it->second < minPos)
+          minPos = it->second;
+      }
+    return minPos;
+  };
+
+  SmallVector<air::MemcpyBundleAsFlow> eligible;
+  eligible.reserve(eligibleIdx.size());
+  for (auto i : eligibleIdx)
+    eligible.push_back(std::move(memcpy_flows[i]));
+  llvm::stable_sort(eligible, [&](const air::MemcpyBundleAsFlow &a,
+                                  const air::MemcpyBundleAsFlow &b) {
+    return firstUsePos(a) < firstUsePos(b);
+  });
+  for (size_t k = 0; k < eligibleIdx.size(); ++k)
+    memcpy_flows[eligibleIdx[k]] = std::move(eligible[k]);
+}
+
+void air::reorderL3PacketPutsByFlowOrder(
+    AIE::DeviceOp aie_device,
+    const std::vector<air::MemcpyBundleAsFlow> &memcpy_flows) {
+  // L3 puts live in the launch's func.func outside aie.device, reached via
+  // the parent module. AIRRtToNpuPass emits dma_start_task in IR walk order
+  // of these puts, so IR order must match flow order.
+  auto parentModule = aie_device->getParentOfType<ModuleOp>();
+  if (!parentModule)
+    return;
+
+  DenseMap<StringAttr, SmallVector<air::ChannelPutOp>> putsByChan;
+  parentModule.walk([&](air::ChannelPutOp put) {
+    auto memrefTy = dyn_cast<BaseMemRefType>(put.getMemref().getType());
+    if (!memrefTy || !air::isL3(memrefTy))
+      return;
+    auto chan = air::getChannelDeclarationThroughSymbol(put);
+    if (!chan || chan.getChannelType().str() != "npu_dma_packet")
+      return;
+    putsByChan[chan.getSymNameAttr()].push_back(put);
+  });
+
+  SmallVector<air::ChannelPutOp> sortedPuts;
+  for (auto &f : memcpy_flows) {
+    if (!isPacketShimFlow(f))
+      continue;
+    auto chan = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op);
+    if (!chan)
+      continue;
+    auto it = putsByChan.find(chan.getSymNameAttr());
+    if (it == putsByChan.end())
+      continue;
+    for (auto put : it->second)
+      sortedPuts.push_back(put);
+  }
+
+  // Per-block prev anchors handle launch clones (e.g. main + lightweight
+  // reset device for load_pdi); each clone gets its own moveAfter chain.
+  DenseMap<Block *, Operation *> prevByBlock;
+  for (auto put : sortedPuts) {
+    Block *blk = put->getBlock();
+    auto it = prevByBlock.find(blk);
+    if (it == prevByBlock.end()) {
+      prevByBlock[blk] = put;
+      continue;
+    }
+    put->moveAfter(it->second);
+    prevByBlock[blk] = put;
+  }
+}
+
 // AIR channel to AIE flow scheduling strategy 1: round robin
 // Problem: no awareness wrt channel put and get pattern, leading to deadlocks
 LogicalResult air::simpleDMAChannelAllocation(

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1595,16 +1595,46 @@ bool air::isPacketShimFlow(const air::MemcpyBundleAsFlow &f) {
          f.MM2S_memspace == air::MemorySpace::L3;
 }
 
+// Identify the unique parent core (== receiver tile) of a flow's S2MM
+// receivers. Returns null if there isn't exactly one. Reordering across
+// flows that target distinct receiver tiles is unsafe -- the bug we fix
+// only manifests when N flows demux into a single tile's S2MM port.
+static AIE::CoreOp uniqueReceiverCore(const air::MemcpyBundleAsFlow &f) {
+  AIE::CoreOp uniq = nullptr;
+  for (int i = 0; i < f.numS2MMAllocs && i < (int)f.S2MM.size(); ++i)
+    for (auto *recvOp : f.S2MM[i]) {
+      auto c = recvOp->getParentOfType<AIE::CoreOp>();
+      if (!c)
+        return nullptr;
+      if (!uniq)
+        uniq = c;
+      else if (uniq != c)
+        return nullptr;
+    }
+  return uniq;
+}
+
 void air::sortPacketShimFlowsByReceiverOrder(
     std::vector<air::MemcpyBundleAsFlow> &memcpy_flows,
     AIE::DeviceOp aie_device) {
-  // Sort only the eligible subset to keep the comparator strict-weak --
-  // a partial comparator over the full vector breaks transitivity for n>=3.
-  SmallVector<size_t> eligibleIdx;
-  for (size_t i = 0; i < memcpy_flows.size(); ++i)
-    if (isPacketShimFlow(memcpy_flows[i]))
-      eligibleIdx.push_back(i);
-  if (eligibleIdx.size() < 2)
+  // Group eligible flows by receiver core. Only reorder within groups of
+  // >=2 flows that share a single core -- that's the bug pattern (N flows
+  // demuxing into one tile S2MM port). Reordering across cores would
+  // disturb routing for unrelated flows (dual-herd, multi-column, etc.).
+  llvm::MapVector<AIE::CoreOp, SmallVector<size_t>> groupByCore;
+  for (size_t i = 0; i < memcpy_flows.size(); ++i) {
+    if (!isPacketShimFlow(memcpy_flows[i]))
+      continue;
+    if (auto core = uniqueReceiverCore(memcpy_flows[i]))
+      groupByCore[core].push_back(i);
+  }
+  bool anyGroup = false;
+  for (auto &kv : groupByCore)
+    if (kv.second.size() >= 2) {
+      anyGroup = true;
+      break;
+    }
+  if (!anyGroup)
     return;
 
   DenseMap<Operation *, unsigned> walkPos;
@@ -1625,16 +1655,23 @@ void air::sortPacketShimFlowsByReceiverOrder(
     return minPos;
   };
 
-  SmallVector<air::MemcpyBundleAsFlow> eligible;
-  eligible.reserve(eligibleIdx.size());
-  for (auto i : eligibleIdx)
-    eligible.push_back(std::move(memcpy_flows[i]));
-  llvm::stable_sort(eligible, [&](const air::MemcpyBundleAsFlow &a,
-                                  const air::MemcpyBundleAsFlow &b) {
-    return firstUsePos(a) < firstUsePos(b);
-  });
-  for (size_t k = 0; k < eligibleIdx.size(); ++k)
-    memcpy_flows[eligibleIdx[k]] = std::move(eligible[k]);
+  // Sort each group's subset in place (stable_sort on the subset keeps
+  // the comparator strict-weak).
+  for (auto &kv : groupByCore) {
+    auto &idx = kv.second;
+    if (idx.size() < 2)
+      continue;
+    SmallVector<air::MemcpyBundleAsFlow> group;
+    group.reserve(idx.size());
+    for (auto i : idx)
+      group.push_back(std::move(memcpy_flows[i]));
+    llvm::stable_sort(group, [&](const air::MemcpyBundleAsFlow &a,
+                                 const air::MemcpyBundleAsFlow &b) {
+      return firstUsePos(a) < firstUsePos(b);
+    });
+    for (size_t k = 0; k < idx.size(); ++k)
+      memcpy_flows[idx[k]] = std::move(group[k]);
+  }
 }
 
 void air::reorderL3PacketPutsByFlowOrder(

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
@@ -241,3 +241,82 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// Case 4: launch interleaves packet PUTs (in0, in1) with unrelated
+// non-packet GETs (out0, out1). Herd consumes in1 BEFORE in0 (which is in
+// an scf.for). This is the HW-failure shape from repro_packet_demux: an
+// unrelated dma sits between the two same-metadata packet puts. The
+// reorder must skip past the unrelated gets and still place the packet
+// puts in pkt_id order.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @seg
+// CHECK-DAG: aie.packet_flow(0)
+// CHECK-DAG: aie.packet_flow(1)
+// CHECK:     aie.shim_dma_allocation @air_in1(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_in0(%{{.*}}, MM2S, 0)
+
+// in1 must precede in0 in the launch; the unrelated out0 / out1 gets are
+// not constrained but must continue to coexist with the puts.
+// CHECK-LABEL: func.func @case4_interleaved_non_packet
+// CHECK:       air.channel.put{{.*}}@in1{{.*}}pkt_id = 0
+// CHECK:       air.channel.put{{.*}}@in0{{.*}}pkt_id = 1
+// CHECK-NOT:   air.channel.put{{.*}}@in0{{.*}}pkt_id = 0
+// CHECK-NOT:   air.channel.put{{.*}}@in1{{.*}}pkt_id = 1
+
+module {
+  air.channel @in0 [1] {channel_type = "npu_dma_packet"}
+  air.channel @out0 [1]
+  air.channel @in1 [1] {channel_type = "npu_dma_packet"}
+  air.channel @out1 [1]
+  func.func @case4_interleaved_non_packet(%arg0: memref<8x16xi32>, %arg1: memref<16xi32>, %arg2: memref<128xi32>, %arg3: memref<16xi32>) {
+    air.launch () in () args(%a0=%arg0, %a1=%arg1, %a2=%arg2, %a3=%arg3) : memref<8x16xi32>, memref<16xi32>, memref<128xi32>, memref<16xi32> {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %c8 = arith.constant 8 : index
+      %c128 = arith.constant 128 : index
+      air.channel.put @in0[] (%a0[%c0, %c0] [%c8, %c16] [%c16, %c1]) : (memref<8x16xi32>)
+      air.channel.get @out0[] (%a2[%c0] [%c128] [%c1]) : (memref<128xi32>)
+      air.channel.put @in1[] (%a1[] [] []) : (memref<16xi32>)
+      air.channel.get @out1[] (%a3[] [] []) : (memref<16xi32>)
+      air.segment @seg {
+        %c1_0 = arith.constant 1 : index
+        air.herd @herd_h tile (%tx, %ty) in (%htx=%c1_0, %hty=%c1_0) attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+          %bi1 = memref.alloc() : memref<16xi32, 2>
+          %bo1 = memref.alloc() : memref<16xi32, 2>
+          air.channel.get @in1[] (%bi1[] [] []) : (memref<16xi32, 2>)
+          %c0_h = arith.constant 0 : index
+          %c8_h = arith.constant 8 : index
+          %c1_h = arith.constant 1 : index
+          scf.for %tile = %c0_h to %c8_h step %c1_h {
+            %li = memref.alloc() : memref<16xi32, 2>
+            %lo = memref.alloc() : memref<16xi32, 2>
+            air.channel.get @in0[] (%li[] [] []) : (memref<16xi32, 2>)
+            %c0_t = arith.constant 0 : index
+            %c1_t = arith.constant 1 : index
+            %c16_t = arith.constant 16 : index
+            scf.for %i = %c0_t to %c16_t step %c1_t {
+              %v = memref.load %li[%i] : memref<16xi32, 2>
+              memref.store %v, %lo[%i] : memref<16xi32, 2>
+            }
+            air.channel.put @out0[] (%lo[] [] []) : (memref<16xi32, 2>)
+            memref.dealloc %li : memref<16xi32, 2>
+            memref.dealloc %lo : memref<16xi32, 2>
+          }
+          scf.for %i = %c0_h to %c8_h step %c1_h {
+            %v = memref.load %bi1[%c0_h] : memref<16xi32, 2>
+            memref.store %v, %bo1[%c0_h] : memref<16xi32, 2>
+          }
+          air.channel.put @out1[] (%bo1[] [] []) : (memref<16xi32, 2>)
+          memref.dealloc %bi1 : memref<16xi32, 2>
+          memref.dealloc %bo1 : memref<16xi32, 2>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
@@ -320,3 +320,62 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// Case 5: two herds, each with its own packet input. Each flow has a unique
+// receiver core, so they are NOT a shared-port demux group -- the reorder
+// must be a no-op. Regression for dual_herd_packet_switch where over-eager
+// reordering corrupted pkt_id assignment across independent herds.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @dual_seg
+// CHECK-DAG: aie.packet_flow(0)
+// CHECK-DAG: aie.packet_flow(1)
+// CHECK:     aie.shim_dma_allocation @air_in_a(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_in_b(%{{.*}}, MM2S, 0)
+
+// Launch puts must retain their original declaration order -- no reorder.
+// CHECK-LABEL: func.func @case5_dual_herd_independent
+// CHECK:       air.channel.put{{.*}}@in_a{{.*}}pkt_id = 0
+// CHECK-NEXT:  air.channel.put{{.*}}@in_b{{.*}}pkt_id = 1
+
+module {
+  air.channel @in_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @in_b [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case5_dual_herd_independent(%arg0: memref<64xbf16>, %arg1: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%a=%arg0, %b=%arg1) : memref<64xbf16>, memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %put_a = air.channel.put async @in_a[%c0, %c0] (%a[] [] []) {id = 1 : i32} : (memref<64xbf16>)
+      %put_b = air.channel.put async @in_b[%c0, %c0] (%b[] [] []) {id = 2 : i32} : (memref<64xbf16>)
+      %seg = air.segment @dual_seg async [%put_a, %put_b] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1 = arith.constant 1 : index
+        %herd_a = air.herd @herd_a async tile (%tx, %ty) in (%htx=%c1, %hty=%c1) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          %async_a, %buf_a = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_a = air.channel.get async [%async_a] @in_a[%hc0, %hc0] (%buf_a[] [] []) {id = 3 : i32} : (memref<64xbf16, 2>)
+          %dealloc_a = air.execute [%get_a] {
+            memref.dealloc %buf_a : memref<64xbf16, 2>
+          }
+        }
+        %herd_b = air.herd @herd_b async tile (%tx, %ty) in (%htx=%c1, %hty=%c1) attributes {id = 4 : i32} {
+          %hc0 = arith.constant 0 : index
+          %async_b, %buf_b = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_b = air.channel.get async [%async_b] @in_b[%hc0, %hc0] (%buf_b[] [] []) {id = 4 : i32} : (memref<64xbf16, 2>)
+          %dealloc_b = air.execute [%get_b] {
+            memref.dealloc %buf_b : memref<64xbf16, 2>
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
@@ -1,0 +1,243 @@
+//===- shim_pkt_herd_order_mismatch.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression: when multiple dma_packet shim flows demux into one tile S2MM
+// port, the three orderings — shim sender BD task queue (= packet arrival
+// FIFO at the receiver), receiver mem BD chain, and core lock-acquire
+// sequence — must all match. Receiver and core both follow herd-source
+// order; sender pkt_id and BD task dispatch followed launch-decl IR walk
+// order. When those diverged (sibling channel.get placed before the
+// dominant get in the herd), packets landed in the wrong BD chain →
+// wrong-buffer data or core deadlock.
+//
+// air-to-aie must reorder packet shim flows by their receiver-side
+// first-use position so that pkt_id assignment, shim alloc list order,
+// the L3 launch puts' IR positions, and the receiver mem BD chain all
+// agree with the herd's natural consumption order.
+//
+// Each module below is compiled independently via --split-input-file so
+// pkt_id counters reset between cases.
+
+// RUN: air-opt %s --split-input-file -air-to-aie='row-offset=2 col-offset=0 device=npu2' 2>&1 | FileCheck %s
+
+// =============================================================================
+// Case 1: two packet flows, herd source order is the REVERSE of launch-decl
+// order. chan_sib (declared second in launch) is consumed FIRST in herd.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @basic_seg
+
+// Two packet flows must be emitted, with distinct IDs.
+// CHECK-DAG: aie.packet_flow(0)
+// CHECK-DAG: aie.packet_flow(1)
+
+// Shim alloc list order reflects the sort: chan_sib must appear BEFORE
+// chan_loop. This drives downstream BD ordering on the same physical
+// MM2S channel.
+// CHECK:     aie.shim_dma_allocation @air_chan_sib(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_loop(%{{.*}}, MM2S, 0)
+
+// The launch puts must be physically reordered so chan_sib's put appears
+// FIRST in the IR (this drives AIRRtToNpuPass's dma_start_task dispatch
+// order). Each put must carry the matching pkt_id.
+// CHECK-LABEL: func.func @case1_reverse_order
+// CHECK:       air.channel.put{{.*}}@chan_sib{{.*}}pkt_id = 0
+// CHECK-NEXT:  air.channel.put{{.*}}@chan_loop{{.*}}pkt_id = 1
+
+// Negative checks: the pre-fix pkt_id assignment (driven by launch-decl
+// order) must NOT be emitted in this case, and chan_loop's put must not
+// precede chan_sib's put in the IR.
+// CHECK-NOT:   air.channel.put{{.*}}@chan_loop{{.*}}pkt_id = 0
+// CHECK-NOT:   air.channel.put{{.*}}@chan_sib{{.*}}pkt_id = 1
+
+module {
+  air.channel @chan_loop [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @chan_sib [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case1_reverse_order(%arg0: memref<64xbf16>, %arg1: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%in_loop=%arg0, %in_sib=%arg1) : memref<64xbf16>, memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      // Launch-decl order: chan_loop first, chan_sib second.
+      %put_loop = air.channel.put async @chan_loop[%c0, %c0] (%in_loop[] [] []) {id = 1 : i32} : (memref<64xbf16>)
+      %put_sib = air.channel.put async @chan_sib[%c0, %c0] (%in_sib[] [] []) {id = 2 : i32} : (memref<64xbf16>)
+
+      %seg = air.segment @basic_seg async [%put_loop, %put_sib] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+        %herd = air.herd @basic_herd async tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          // Herd-source order: chan_sib first (the "sibling" get), then
+          // chan_loop. Reverse of launch-decl order.
+          %async_sib, %buf_sib = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_sib = air.channel.get async [%async_sib] @chan_sib[%hc0, %hc0] (%buf_sib[] [] []) {id = 3 : i32} : (memref<64xbf16, 2>)
+
+          %async_loop, %buf_loop = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_loop = air.channel.get async [%async_loop] @chan_loop[%hc0, %hc0] (%buf_loop[] [] []) {id = 4 : i32} : (memref<64xbf16, 2>)
+
+          %dealloc_sib = air.execute [%get_sib] {
+            memref.dealloc %buf_sib : memref<64xbf16, 2>
+          }
+          %dealloc_loop = air.execute [%get_loop] {
+            memref.dealloc %buf_loop : memref<64xbf16, 2>
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// =============================================================================
+// Case 2: three packet flows; herd source order differs from launch-decl
+// order. This exercises the strict-weak-ordering requirement of the
+// comparator — a partial comparator that mixes comparable + incomparable
+// pairs broke transitivity for n>=3 in an earlier attempt at the fix.
+//
+// Launch-decl: [chan_a, chan_b, chan_c]
+// Herd-source: [chan_b, chan_c, chan_a]
+// Expected pkt_id assignment after sort: chan_b=0, chan_c=1, chan_a=2.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @three_seg
+// CHECK-DAG: aie.packet_flow(0)
+// CHECK-DAG: aie.packet_flow(1)
+// CHECK-DAG: aie.packet_flow(2)
+
+// CHECK:     aie.shim_dma_allocation @air_chan_b(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_c(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_a(%{{.*}}, MM2S, 0)
+
+// CHECK-LABEL: func.func @case2_three_flows
+// CHECK:       air.channel.put{{.*}}@chan_b{{.*}}pkt_id = 0
+// CHECK-NEXT:  air.channel.put{{.*}}@chan_c{{.*}}pkt_id = 1
+// CHECK-NEXT:  air.channel.put{{.*}}@chan_a{{.*}}pkt_id = 2
+
+module {
+  air.channel @chan_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @chan_b [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @chan_c [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case2_three_flows(%arg0: memref<64xbf16>, %arg1: memref<64xbf16>, %arg2: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%in_a=%arg0, %in_b=%arg1, %in_c=%arg2) : memref<64xbf16>, memref<64xbf16>, memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      // Launch-decl order: a, b, c.
+      %put_a = air.channel.put async @chan_a[%c0, %c0] (%in_a[] [] []) {id = 1 : i32} : (memref<64xbf16>)
+      %put_b = air.channel.put async @chan_b[%c0, %c0] (%in_b[] [] []) {id = 2 : i32} : (memref<64xbf16>)
+      %put_c = air.channel.put async @chan_c[%c0, %c0] (%in_c[] [] []) {id = 3 : i32} : (memref<64xbf16>)
+
+      %seg = air.segment @three_seg async [%put_a, %put_b, %put_c] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+        %herd = air.herd @three_herd async tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          // Herd-source order: b, c, a (intentionally reordered).
+          %async_b, %buf_b = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_b = air.channel.get async [%async_b] @chan_b[%hc0, %hc0] (%buf_b[] [] []) {id = 4 : i32} : (memref<64xbf16, 2>)
+
+          %async_c, %buf_c = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_c = air.channel.get async [%async_c] @chan_c[%hc0, %hc0] (%buf_c[] [] []) {id = 5 : i32} : (memref<64xbf16, 2>)
+
+          %async_a, %buf_a = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_a = air.channel.get async [%async_a] @chan_a[%hc0, %hc0] (%buf_a[] [] []) {id = 6 : i32} : (memref<64xbf16, 2>)
+
+          %dealloc_b = air.execute [%get_b] { memref.dealloc %buf_b : memref<64xbf16, 2> }
+          %dealloc_c = air.execute [%get_c] { memref.dealloc %buf_c : memref<64xbf16, 2> }
+          %dealloc_a = air.execute [%get_a] { memref.dealloc %buf_a : memref<64xbf16, 2> }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// =============================================================================
+// Case 3: the actual HW failure shape from repro_packet_demux. The dominant
+// channel chan_loop2 has a multi-iter scf.for around its get inside the
+// herd, chan_sib2 has a single get BEFORE the loop. Receiver mem chain
+// ends up with two distinct dma_start tasks (single + repeat) on the same
+// S2MM port; the FIRST task must match the FIRST-arriving packets.
+//
+// With the fix: chan_sib2 (early in herd) gets pkt_id=0, chan_loop2 gets
+// pkt_id=1; sender dispatches chan_sib2's 1 packet first, then chan_loop2's
+// N packets — matches receiver mem chain task order.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @forloop_seg
+// CHECK-DAG: aie.packet_flow(0)
+// CHECK-DAG: aie.packet_flow(1)
+
+// CHECK:     aie.shim_dma_allocation @air_chan_sib2(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_loop2(%{{.*}}, MM2S, 0)
+
+// CHECK-LABEL: func.func @case3_scf_for_pattern
+// CHECK:       air.channel.put{{.*}}@chan_sib2{{.*}}pkt_id = 0
+// CHECK-NEXT:  air.channel.put{{.*}}@chan_loop2{{.*}}pkt_id = 1
+
+module {
+  air.channel @chan_loop2 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @chan_sib2 [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case3_scf_for_pattern(%arg0: memref<256xbf16>, %arg1: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%in_loop=%arg0, %in_sib=%arg1) : memref<256xbf16>, memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      // Launch-decl order: chan_loop2 first (driven by the dominant input
+      // being declared first as is natural), chan_sib2 second.
+      %put_loop = air.channel.put async @chan_loop2[%c0, %c0] (%in_loop[] [] []) {id = 1 : i32} : (memref<256xbf16>)
+      %put_sib = air.channel.put async @chan_sib2[%c0, %c0] (%in_sib[] [] []) {id = 2 : i32} : (memref<64xbf16>)
+
+      %seg = air.segment @forloop_seg async [%put_loop, %put_sib] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+        %herd = air.herd @forloop_herd async tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          %hc1 = arith.constant 1 : index
+          %hc4 = arith.constant 4 : index
+          // chan_sib2's get BEFORE the scf.for — the trigger for the bug.
+          %async_sib, %buf_sib = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_sib = air.channel.get async [%async_sib] @chan_sib2[%hc0, %hc0] (%buf_sib[] [] []) {id = 3 : i32} : (memref<64xbf16, 2>)
+
+          // chan_loop2's get INSIDE an scf.for — the dominant per-tile get.
+          %loop_token = scf.for %it = %hc0 to %hc4 step %hc1 iter_args(%tok = %get_sib) -> (!air.async.token) {
+            %async_loop, %buf_loop = air.execute -> (memref<64xbf16, 2>) {
+              %alloc = memref.alloc() : memref<64xbf16, 2>
+              air.execute_terminator %alloc : memref<64xbf16, 2>
+            }
+            %get_loop = air.channel.get async [%async_loop, %tok] @chan_loop2[%hc0, %hc0] (%buf_loop[] [] []) {id = 4 : i32} : (memref<64xbf16, 2>)
+            %dealloc_loop = air.execute [%get_loop] {
+              memref.dealloc %buf_loop : memref<64xbf16, 2>
+            }
+            scf.yield %dealloc_loop : !air.async.token
+          }
+
+          %dealloc_sib = air.execute [%loop_token] {
+            memref.dealloc %buf_sib : memref<64xbf16, 2>
+          }
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

- When multiple `npu_dma_packet` shim flows demux into one tile S2MM port, three orderings must agree: shim sender BD task queue (= packet arrival FIFO at the receiver), receiver mem BD chain, and core lock-acquire sequence. The mem chain and core both follow herd-source walk order; the sender's pkt_id (and the downstream `dma_start_task` dispatch order) was driven by launch-decl IR walk order. When the herd placed sibling `channel.get` ops **before** a per-tile loop containing the dominant get, the launch-decl order diverged from herd-source order, packets landed in the wrong receiver BD chain, and L1 buffers were filled with the wrong data (or the core deadlocked on an unsatisfied lock).
- Fix in `placeDMAChannelsAndRouteFlows` (`mlir/lib/Conversion/AIRToAIEPass.cpp`): stable-sort the eligible subset (`npu_dma_packet` shim sender flows) of `memcpy_flows` by their receiver-side first-use position **before** `simpleDMAChannelAllocation` runs, propagating a consistent order through tile/shim alloc lists, `shimFlowOpToFlowIdMap` (pkt_id assignment), and receiver mem-chain construction. Then physically `moveAfter` the launch-side L3 `ChannelPut` ops in IR so `AIRRtToNpuPass` emits `dma_start_task` calls in the same order. Per-block prev tracking handles transient launch clones (main + reset device).
- The sort uses a partial filter so only the eligible subset is reordered; non-packet and non-shim flows keep their absolute positions. Sorting only the subset (instead of `stable_sort` with a partial comparator over the whole vector) keeps the comparator strict-weak — important for n>=3 shared packet flows where mixing comparable + incomparable pairs in a partial comparator broke transitivity.

## Repro

Minimal reproducer (no compute, pure data movement) added in the working tree as `programming_examples/llama32_1b/multi_launch_builder/repro_packet_demux.py`. Topology: N packet flows from one shim col MM2S into one tile DMA in port, with a herd that consumes them and puts the data back through stream channels.

| n_channels | BEFORE_LOOP | Before fix | After fix |
|---|---|---|---|
| 2 | 0 (sibling get *after* loop) | PASS | PASS |
| 2 | 1 (sibling get *before* loop) | **FAIL (wrong data)** | PASS |
| 3 | 0 | PASS | PASS |
| 3 | 1 | **FAIL (wrong data)** | PASS |
| 4 | 0 | PASS | PASS |
| 4 | 1 | **FAIL (wrong data)** | PASS |

Circuit-switched variant of the same repro passes both before and after — confirming the bug is specific to the shared-packet-port demux path.

## Test plan

- [x] `ninja check-air-mlir` — 390 passed, 1 pre-existing failure unchanged (`Transform/AIRTransform/AIRBufferize/air_transform_payload.mlir` fails on `main` too, not introduced by this change)
- [x] `repro_packet_demux.py --n-channels {2,3,4} --multidim-loop` with BEFORE_LOOP={0,1} on NPU2 hardware — all 6 variants PASS
- [x] Circuit-switched variant (same topology, no `channel_type`) — both BEFORE_LOOP values PASS, no regression
- [x] `clang-format-17` clean
- [x] Compiles with no new warnings