### PR TITLE
[ci] bump pinned mlir-aie wheel to 1.3.2.dev94+g24e0c2f

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=eaa62484f4381e20a44b0c16570c9ceedc56996e
-DEV_COUNT=82
+export HASH=24e0c2ff020316948e8c81f9822f0648e437a525
+DEV_COUNT=94
 WHEEL_VERSION=1.3.2.dev$DEV_COUNT+g${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary

Bumps the pinned mlir-aie wheel from `1.3.2.dev82+geaa6248` to `1.3.2.dev94+g24e0c2f` (mlir-aie hash `eaa6248` → `24e0c2f`, 12 upstream commits).

Highlights in the bump range:
- Sort MemTile ObjectFifos by buffer size and spill to least-used neighbor (Xilinx/mlir-aie#3116)
- Asymmetric consumer element type in ObjectFifo (Xilinx/mlir-aie#3117)
- Use DMA hardware repeat for single-buffer ObjectFifos with `repeat_count` (Xilinx/mlir-aie#3115)
- NPU2 support for `tiling_exploration` per_tile and tile_group examples (Xilinx/mlir-aie#3107)
- Resolve JIT compiler tools portably (Xilinx/mlir-aie#3111)
- Port MobileNet to the IRON API (Xilinx/mlir-aie#3059)

LLVM pin (`utils/clone-llvm.sh`) already matches mlir-aie@`24e0c2f` (`ea2f5081` / `DATETIME=2026051220`) — no LLVM bump needed.

## Test plan

- [ ] CI builds wheels against the new mlir-aie release at `latest-wheels-3`
- [ ] `check-air-mlir` and `check-air-python` pass
- [ ] Ryzen AI e2e suite passes against the new wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)