### PR TITLE
[AIRToAIE] Offset intra-device packet flow IDs past shim flow IDs per device

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -3311,13 +3312,13 @@ public:
   }
 
   AIE::PacketFlowOp
-  createPacketFlowOp(OpBuilder &builder, int &flowID, Value source,
+  createPacketFlowOp(OpBuilder &builder, int flowID, Value source,
                      xilinx::AIE::WireBundle sourceBundle,
                      uint32_t sourceChannel, Value dest,
                      xilinx::AIE::WireBundle destBundle, uint32_t destChannel,
                      mlir::BoolAttr keep_pkt_header = nullptr) {
     AIE::PacketFlowOp pktFlow = AIE::PacketFlowOp::create(
-        builder, builder.getUnknownLoc(), flowID++, keep_pkt_header, nullptr);
+        builder, builder.getUnknownLoc(), flowID, keep_pkt_header, nullptr);
     Region &r_pktFlow = pktFlow.getPorts();
     Block *b_pktFlow = builder.createBlock(&r_pktFlow);
     builder.setInsertionPointToStart(b_pktFlow);
@@ -3329,6 +3330,27 @@ public:
     return pktFlow;
   }
 
+  // Assign a pkt_id for a shim (or trace) packet flow: monotonic global
+  // counter, skipping any id already claimed by an intra-device flow in this
+  // device. Records the assignment in claimedPacketIDs.
+  int assignShimPacketID() {
+    while (claimedPacketIDs.count(nextGlobalShimPacketID))
+      ++nextGlobalShimPacketID;
+    int id = nextGlobalShimPacketID++;
+    claimedPacketIDs.insert(id);
+    return id;
+  }
+
+  // Assign a pkt_id for an intra-device packet flow: lowest pkt_id not yet
+  // claimed in this device. Records the assignment in claimedPacketIDs.
+  int assignIntraDevicePacketID() {
+    int id = 0;
+    while (claimedPacketIDs.count(id))
+      ++id;
+    claimedPacketIDs.insert(id);
+    return id;
+  }
+
   // This method generates broadcast packet flow if found multiple flows with
   // the same source. TODO: packet flows sharing source do not always mean
   // broadcast.
@@ -3337,7 +3359,7 @@ public:
                                     xilinx::AIE::WireBundle sourceBundle,
                                     uint32_t sourceChannel, mlir::Value dest,
                                     xilinx::AIE::WireBundle destBundle,
-                                    uint32_t destChannel, int &flowID) {
+                                    uint32_t destChannel, int flowID) {
     AIE::PacketFlowOp packetFlowOp = nullptr;
     aie_device.walk([&](AIE::PacketFlowOp pktFlowOp) {
       auto pktSrcOp = getPacketSourceOpInPacketFlowOp(pktFlowOp, source);
@@ -3393,62 +3415,14 @@ public:
       return AIE::PacketFlowOp(); // Only air.channel_interface ops support
                                   // packet-flow routing.
 
-    // Convert a flow map from Operation pointers to channel symbol names.
-    // This is necessary because air.channel declarations are duplicated
-    // under aie.device op and its parent module op, requiring symbol-based
-    // matching.
-    auto buildFlowIdMap =
-        [](const SetVector<Operation *> &fmap) -> std::vector<std::string> {
-      std::vector<std::string> result;
-      for (auto op : fmap) {
-        auto flowChanOp = dyn_cast_if_present<air::ChannelOp>(op);
-        if (!flowChanOp) {
-          result.push_back("");
-          continue;
-        }
-        result.push_back(flowChanOp.getSymName().str());
-      }
-      return result;
-    };
-
-    // Search both flow maps by channel name. Channel names are unique symbols,
-    // so each channel appears in exactly one map. We search the shim (device-
-    // host) map first, then the intra-device map.
-    //
-    // Note: we cannot reliably determine which map to search from the memcpy
-    // op alone, because ChannelPutOp::getDstMemref() and ChannelGetOp::
-    // getSrcMemref() return nullptr by design (the other end of a channel op
-    // is implicit via the channel symbol). Searching both maps directly is
-    // simpler and always correct.
-    std::string chanName = chanIfOp.getChanName().str();
-
-    // Shim map first. Shim flow IDs are the position within the global shim
-    // map, unmodified.
-    {
-      auto flowStrings = buildFlowIdMap(shimFlowOpToFlowIdMap);
-      auto it = llvm::find(flowStrings, chanName);
-      if (it != flowStrings.end()) {
-        int flowID = std::distance(flowStrings.begin(), it);
-        return findPacketFlowOp(source, sourceBundle, sourceChannel,
-                                /*checkFlowID=*/true, flowID);
-      }
-    }
-    // Intra-device map: IDs were emitted with an offset of
-    // intraDeviceFlowIDBase (= globalShimFlowID + 1 at the time the device
-    // was processed) so they do not collide with shim IDs. Apply the same
-    // offset at lookup.
-    {
-      auto flowStrings = buildFlowIdMap(intraDeviceFlowOpToFlowIdMap);
-      auto it = llvm::find(flowStrings, chanName);
-      if (it != flowStrings.end()) {
-        int flowID =
-            intraDeviceFlowIDBase + std::distance(flowStrings.begin(), it);
-        return findPacketFlowOp(source, sourceBundle, sourceChannel,
-                                /*checkFlowID=*/true, flowID);
-      }
-    }
-
-    return AIE::PacketFlowOp();
+    // packetIDForChannelName stores the pkt_id assigned at flow-creation time,
+    // keyed by air.channel symbol name. Symbol names are stable across the
+    // aie.device / parent module duplication of air.channel decls.
+    auto it = packetIDForChannelName.find(chanIfOp.getChanName().str());
+    if (it == packetIDForChannelName.end())
+      return AIE::PacketFlowOp();
+    return findPacketFlowOp(source, sourceBundle, sourceChannel,
+                            /*checkFlowID=*/true, it->second);
   }
 
   /// Query an existing packet flow operation from the runtime function.
@@ -4154,17 +4128,18 @@ public:
 
     // Step 4: Connect flows.
     //
-    // Packet flows are assigned pkt_ids in two passes to prevent collisions
-    // between shim and intra-device flows whose physical routes may share
-    // switchboxes. With two independent 0-based counters, the first shim
-    // flow (e.g. shim->compute) and the first intra-device flow (e.g.
-    // memtile->compute) both got pkt_id=0 -> switchbox arbiters could not
-    // disambiguate where the routes crossed -> silent mis-routing.
+    // Packet flows are assigned pkt_ids in two passes so that within one
+    // device, no two packet flows share a pkt_id. (Pre-fix: shim and intra-
+    // device flows ran independent 0-based counters, the first of each got
+    // pkt_id=0, and switchbox arbiters silently mis-routed where their
+    // physical routes crossed.) Each air.channel symbol maps to exactly one
+    // pkt_id, recorded in packetIDForChannelName for broadcast reuse and for
+    // lookup by getExistingPacketFlowOpFromDevice.
     //
-    // Pass 1: shim packet flows. Claims pkt_ids [base..globalShimFlowID].
-    // Pass 2: intra-device packet flows. Offset by globalShimFlowID + 1 so
-    //         within a device every packet flow has a unique pkt_id.
-    // Pass 3: stream and cascade flows (no pkt_id involved).
+    //   Pass 1: shim packet flows (assignShimPacketID -- monotonic global).
+    //   Pass 2: intra-device packet flows (assignIntraDevicePacketID --
+    //           lowest gap in claimedPacketIDs).
+    //   Pass 3: stream and cascade flows (no pkt_id involved).
     auto isInvalidAlloc = [&](air::MemcpyBundleAsFlow &f, int i) {
       if (!f.MM2S_alloc.getDmaTile() || !f.S2MM_alloc[i].getDmaTile()) {
         LLVM_DEBUG(llvm::dbgs()
@@ -4178,6 +4153,28 @@ public:
       return f.MM2S_alloc.getDmaTile().isShimNOCorPLTile() ||
              f.S2MM_alloc[i].getDmaTile().isShimNOCorPLTile();
     };
+    // The flow-op key for packetIDForChannelName is the air.channel symbol
+    // name. air.channel decls are duplicated under aie.device and its parent
+    // module, so symbol name is the stable identifier across both contexts.
+    auto getChannelName = [](air::MemcpyBundleAsFlow &f) -> std::string {
+      if (auto chanOp = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op))
+        return chanOp.getSymName().str();
+      return {};
+    };
+    // Assign or reuse a pkt_id for a packet flow. air.channel-rooted flows
+    // dedupe by symbol name (broadcast: one source -> multiple receivers
+    // share a pkt_id). Non-channel packet flows get a fresh id per call.
+    auto assignOrLookupPacketID = [&](air::MemcpyBundleAsFlow &f,
+                                      bool isShim) -> int {
+      std::string chanName = getChannelName(f);
+      if (chanName.empty())
+        return isShim ? assignShimPacketID() : assignIntraDevicePacketID();
+      auto [it, inserted] = packetIDForChannelName.try_emplace(chanName, -1);
+      if (inserted)
+        it->second =
+            isShim ? assignShimPacketID() : assignIntraDevicePacketID();
+      return it->second;
+    };
 
     // Pass 1: shim packet flows.
     for (auto &f : memcpy_flows) {
@@ -4188,41 +4185,28 @@ public:
           continue;
         if (!isShimFlowAt(f, i))
           continue;
-        // Device-host flows use global shim flow ID.
-        shimFlowOpToFlowIdMap.insert(f.air_flow_op);
-        auto it = llvm::find(shimFlowOpToFlowIdMap, f.air_flow_op);
-        int flowID = std::distance(shimFlowOpToFlowIdMap.begin(), it);
-        auto pktFlowOp = getPacketFlowOp(
+        int flowID = assignOrLookupPacketID(f, /*isShim=*/true);
+        getPacketFlowOp(
             aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
             AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
             f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
             (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
-        globalShimFlowID = std::max(globalShimFlowID, flowID);
-        // Store flow ID in matching MM2S shim alloc for labeling phase.
-        // Use the packet flow op's actual ID, not the mutated flowID
-        // (createPacketFlowOp post-increments flowID by reference).
-        int storedFlowID = pktFlowOp ? pktFlowOp.getID() : flowID;
+        // Backlink: the host runtime keys packet identification on
+        // (shim tile, pkt_id), so the matching MM2S shim alloc carries the id.
         for (auto &sa : shim_dma_alloc.mm2s_allocs) {
           if (sa.getDmaTile().getOperation() ==
                   f.MM2S_alloc.getDmaTile().getOperation() &&
               sa.dma_channel == f.MM2S_alloc.dma_channel &&
               sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
               sa.dma_id == f.MM2S_alloc.dma_id) {
-            sa.packet_flow_id = storedFlowID;
+            sa.packet_flow_id = flowID;
             break;
           }
         }
       }
     }
 
-    // After all shim flows for this device are placed, lock in the offset
-    // that subsequent intra-device flows must use to stay unique within the
-    // device. globalShimFlowID is post-incremented by createPacketFlowOp so
-    // it already equals (highest shim pkt_id placed so far) + 1, which is
-    // exactly the first non-colliding pkt_id for intra-device flows.
-    intraDeviceFlowIDBase = globalShimFlowID;
-
-    // Pass 2: intra-device packet flows (offset by intraDeviceFlowIDBase).
+    // Pass 2: intra-device packet flows.
     for (auto &f : memcpy_flows) {
       if (f.memcpyResourceType != "npu_dma_packet")
         continue;
@@ -4231,16 +4215,12 @@ public:
           continue;
         if (isShimFlowAt(f, i))
           continue;
-        intraDeviceFlowOpToFlowIdMap.insert(f.air_flow_op);
-        auto it = llvm::find(intraDeviceFlowOpToFlowIdMap, f.air_flow_op);
-        int flowID = intraDeviceFlowIDBase +
-                     std::distance(intraDeviceFlowOpToFlowIdMap.begin(), it);
+        int flowID = assignOrLookupPacketID(f, /*isShim=*/false);
         getPacketFlowOp(
             aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
             AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
             f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
             (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
-        intraDeviceFlowID = std::max(intraDeviceFlowID, flowID);
       }
     }
 
@@ -6510,9 +6490,12 @@ public:
 
         builder.setInsertionPoint(device.getBody()->getTerminator());
         auto keep_pkt_header = builder.getBoolAttr(true);
-        // Trace flows go to shim tiles, so use global shim flow ID
+        // Trace packets terminate at shim DMA -> draw from the shim id pool.
+        // assignShimPacketID skips ids already claimed by intra-device flows
+        // placed earlier in this device (latent collision: pre-redesign trace
+        // could reuse an id from the device's intra-device pass).
         (void)createPacketFlowOp(
-            builder, globalShimFlowID, srcTile, AIE::WireBundle::Trace, 0,
+            builder, assignShimPacketID(), srcTile, AIE::WireBundle::Trace, 0,
             destTile, AIE::WireBundle::DMA, destChan, keep_pkt_header);
       }
     }
@@ -6711,11 +6694,11 @@ public:
         continue;
       seen.insert(device);
 
-      // Reset per-device flow tracking for segment unroll.
-      // Each isolated device can reuse packet IDs starting from 0.
-      intraDeviceFlowID = 0;
-      intraDeviceFlowOpToFlowIdMap.clear();
-      intraDeviceFlowIDBase = 0;
+      // Reset per-device packet-flow tracking for segment unroll. Each
+      // isolated device assigns its own pkt_ids; shim ids are drawn from a
+      // global counter (nextGlobalShimPacketID) for cross-device uniqueness.
+      packetIDForChannelName.clear();
+      claimedPacketIDs.clear();
 
       // The shim tile allocation is not unified for dma and channel lowering
       // so we disallow a mix of dma and channel ops.
@@ -6948,25 +6931,23 @@ public:
     }
   }
 
-  // Intra-device flow ID tracking (reset per device for segment unroll)
-  // These flows are between tiles within the same device and can safely
-  // reuse packet IDs across isolated devices.
-  int intraDeviceFlowID = 0;
-  SetVector<Operation *>
-      intraDeviceFlowOpToFlowIdMap; // Ordered set for intra-device flows
-  // Offset added to intra-device packet flow IDs within a device so they do
-  // not collide with shim packet flow IDs assigned in the same device. Set
-  // to globalShimFlowID after all shim flows for the device are placed
-  // (globalShimFlowID is post-incremented, so it equals the next free
-  // non-shim pkt_id); reset to 0 per device.
-  int intraDeviceFlowIDBase = 0;
-
-  // Device-host (shim) flow ID tracking (persists globally across devices)
-  // These flows involve shim tiles and require globally unique IDs since
-  // all devices share the host interface/NoC.
-  int globalShimFlowID = 0;
-  SetVector<Operation *>
-      shimFlowOpToFlowIdMap; // Ordered set for device-host flows
+  // Packet-flow id tracking.
+  //
+  // Per-device (reset each device):
+  //   packetIDForChannelName: air.channel symbol -> assigned pkt_id. Drives
+  //     reuse for broadcast (one source, many receivers) and lookup from
+  //     downstream lowering. Keyed by symbol name because air.channel decls
+  //     are duplicated under aie.device and its parent module.
+  //   claimedPacketIDs: pkt_ids already assigned in this device. Drives gap-
+  //     finding for intra-device flows and skip-on-collision for trace/shim.
+  //
+  // Global (persists across devices):
+  //   nextGlobalShimPacketID: monotonic source for shim (and trace) pkt_ids.
+  //     Shim flows require global uniqueness because the host runtime keys
+  //     packet identification on (shim tile, pkt_id).
+  llvm::StringMap<int> packetIDForChannelName;
+  llvm::SmallSet<int, 32> claimedPacketIDs;
+  int nextGlobalShimPacketID = 0;
 
 private:
   // Collapses the innermost `numDims` dimensions of a MemRef `val` into a

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3422,12 +3422,27 @@ public:
     // simpler and always correct.
     std::string chanName = chanIfOp.getChanName().str();
 
-    for (const auto &flowMap : {std::cref(shimFlowOpToFlowIdMap),
-                                std::cref(intraDeviceFlowOpToFlowIdMap)}) {
-      auto flowStrings = buildFlowIdMap(flowMap.get());
+    // Shim map first. Shim flow IDs are the position within the global shim
+    // map, unmodified.
+    {
+      auto flowStrings = buildFlowIdMap(shimFlowOpToFlowIdMap);
       auto it = llvm::find(flowStrings, chanName);
       if (it != flowStrings.end()) {
         int flowID = std::distance(flowStrings.begin(), it);
+        return findPacketFlowOp(source, sourceBundle, sourceChannel,
+                                /*checkFlowID=*/true, flowID);
+      }
+    }
+    // Intra-device map: IDs were emitted with an offset of
+    // intraDeviceFlowIDBase (= globalShimFlowID + 1 at the time the device
+    // was processed) so they do not collide with shim IDs. Apply the same
+    // offset at lookup.
+    {
+      auto flowStrings = buildFlowIdMap(intraDeviceFlowOpToFlowIdMap);
+      auto it = llvm::find(flowStrings, chanName);
+      if (it != flowStrings.end()) {
+        int flowID =
+            intraDeviceFlowIDBase + std::distance(flowStrings.begin(), it);
         return findPacketFlowOp(source, sourceBundle, sourceChannel,
                                 /*checkFlowID=*/true, flowID);
       }
@@ -4137,80 +4152,118 @@ public:
     // ping-pong deadlock.
     tile_dma_alloc.sortMemcpyOps(dma_memcpy_ops);
 
-    // Step 4: Connect flows
-    for (auto &f : memcpy_flows) {
-      for (int i = 0; i < f.numS2MMAllocs; i++) {
-        // Skip if either MM2S or S2MM tile allocation is invalid
-        if (!f.MM2S_alloc.getDmaTile() || !f.S2MM_alloc[i].getDmaTile()) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "AIRToAIE: skipping memcpy flow due to invalid DMA "
-                        "tile allocation (MM2S or S2MM tile is null)\n");
-          continue;
-        }
-        // Determine if this is a device-host flow (involves shim tiles)
-        bool isShimFlow = f.MM2S_alloc.getDmaTile().isShimNOCorPLTile() ||
-                          f.S2MM_alloc[i].getDmaTile().isShimNOCorPLTile();
+    // Step 4: Connect flows.
+    //
+    // Packet flows are assigned pkt_ids in two passes to prevent collisions
+    // between shim and intra-device flows whose physical routes may share
+    // switchboxes. With two independent 0-based counters, the first shim
+    // flow (e.g. shim->compute) and the first intra-device flow (e.g.
+    // memtile->compute) both got pkt_id=0 -> switchbox arbiters could not
+    // disambiguate where the routes crossed -> silent mis-routing.
+    //
+    // Pass 1: shim packet flows. Claims pkt_ids [base..globalShimFlowID].
+    // Pass 2: intra-device packet flows. Offset by globalShimFlowID + 1 so
+    //         within a device every packet flow has a unique pkt_id.
+    // Pass 3: stream and cascade flows (no pkt_id involved).
+    auto isInvalidAlloc = [&](air::MemcpyBundleAsFlow &f, int i) {
+      if (!f.MM2S_alloc.getDmaTile() || !f.S2MM_alloc[i].getDmaTile()) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "AIRToAIE: skipping memcpy flow due to invalid DMA "
+                      "tile allocation (MM2S or S2MM tile is null)\n");
+        return true;
+      }
+      return false;
+    };
+    auto isShimFlowAt = [&](air::MemcpyBundleAsFlow &f, int i) {
+      return f.MM2S_alloc.getDmaTile().isShimNOCorPLTile() ||
+             f.S2MM_alloc[i].getDmaTile().isShimNOCorPLTile();
+    };
 
-        if (f.memcpyResourceType == "npu_dma_packet") {
-          // Use appropriate flow map based on whether flow involves shim tiles
-          if (isShimFlow) {
-            // Device-host flows use global shim flow ID
-            shimFlowOpToFlowIdMap.insert(f.air_flow_op);
-            auto it = llvm::find(shimFlowOpToFlowIdMap, f.air_flow_op);
-            int flowID = std::distance(shimFlowOpToFlowIdMap.begin(), it);
-            auto pktFlowOp = getPacketFlowOp(
-                aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.MM2S_alloc.dma_channel.channel,
-                f.S2MM_alloc[i].getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
-            // Update global shim flow ID following the local packet assignment.
-            globalShimFlowID = std::max(globalShimFlowID, flowID);
-            // Store flow ID in matching MM2S shim alloc for labeling phase.
-            // Use the packet flow op's actual ID, not the mutated flowID
-            // (createPacketFlowOp post-increments flowID by reference).
-            int storedFlowID = pktFlowOp ? pktFlowOp.getID() : flowID;
-            for (auto &sa : shim_dma_alloc.mm2s_allocs) {
-              if (sa.getDmaTile().getOperation() ==
-                      f.MM2S_alloc.getDmaTile().getOperation() &&
-                  sa.dma_channel == f.MM2S_alloc.dma_channel &&
-                  sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
-                  sa.dma_id == f.MM2S_alloc.dma_id) {
-                sa.packet_flow_id = storedFlowID;
-                break;
-              }
-            }
-          } else {
-            // Intra-device flows use per-device flow ID (can restart from 0)
-            intraDeviceFlowOpToFlowIdMap.insert(f.air_flow_op);
-            auto it = llvm::find(intraDeviceFlowOpToFlowIdMap, f.air_flow_op);
-            int flowID =
-                std::distance(intraDeviceFlowOpToFlowIdMap.begin(), it);
-            getPacketFlowOp(aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-                            AIE::WireBundle::DMA,
-                            (uint32_t)f.MM2S_alloc.dma_channel.channel,
-                            f.S2MM_alloc[i].getDmaTile()->getResult(0),
-                            AIE::WireBundle::DMA,
-                            (uint32_t)f.S2MM_alloc[i].dma_channel.channel,
-                            flowID);
-            // Update intra-device flow ID following the local packet
-            // assignment.
-            intraDeviceFlowID = std::max(intraDeviceFlowID, flowID);
+    // Pass 1: shim packet flows.
+    for (auto &f : memcpy_flows) {
+      if (f.memcpyResourceType != "npu_dma_packet")
+        continue;
+      for (int i = 0; i < f.numS2MMAllocs; i++) {
+        if (isInvalidAlloc(f, i))
+          continue;
+        if (!isShimFlowAt(f, i))
+          continue;
+        // Device-host flows use global shim flow ID.
+        shimFlowOpToFlowIdMap.insert(f.air_flow_op);
+        auto it = llvm::find(shimFlowOpToFlowIdMap, f.air_flow_op);
+        int flowID = std::distance(shimFlowOpToFlowIdMap.begin(), it);
+        auto pktFlowOp = getPacketFlowOp(
+            aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
+            AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
+            f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
+            (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+        globalShimFlowID = std::max(globalShimFlowID, flowID);
+        // Store flow ID in matching MM2S shim alloc for labeling phase.
+        // Use the packet flow op's actual ID, not the mutated flowID
+        // (createPacketFlowOp post-increments flowID by reference).
+        int storedFlowID = pktFlowOp ? pktFlowOp.getID() : flowID;
+        for (auto &sa : shim_dma_alloc.mm2s_allocs) {
+          if (sa.getDmaTile().getOperation() ==
+                  f.MM2S_alloc.getDmaTile().getOperation() &&
+              sa.dma_channel == f.MM2S_alloc.dma_channel &&
+              sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
+              sa.dma_id == f.MM2S_alloc.dma_id) {
+            sa.packet_flow_id = storedFlowID;
+            break;
           }
-        } else if (f.memcpyResourceType == "npu_dma_stream")
+        }
+      }
+    }
+
+    // After all shim flows for this device are placed, lock in the offset
+    // that subsequent intra-device flows must use to stay unique within the
+    // device. globalShimFlowID is post-incremented by createPacketFlowOp so
+    // it already equals (highest shim pkt_id placed so far) + 1, which is
+    // exactly the first non-colliding pkt_id for intra-device flows.
+    intraDeviceFlowIDBase = globalShimFlowID;
+
+    // Pass 2: intra-device packet flows (offset by intraDeviceFlowIDBase).
+    for (auto &f : memcpy_flows) {
+      if (f.memcpyResourceType != "npu_dma_packet")
+        continue;
+      for (int i = 0; i < f.numS2MMAllocs; i++) {
+        if (isInvalidAlloc(f, i))
+          continue;
+        if (isShimFlowAt(f, i))
+          continue;
+        intraDeviceFlowOpToFlowIdMap.insert(f.air_flow_op);
+        auto it = llvm::find(intraDeviceFlowOpToFlowIdMap, f.air_flow_op);
+        int flowID = intraDeviceFlowIDBase +
+                     std::distance(intraDeviceFlowOpToFlowIdMap.begin(), it);
+        getPacketFlowOp(
+            aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
+            AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
+            f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
+            (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+        intraDeviceFlowID = std::max(intraDeviceFlowID, flowID);
+      }
+    }
+
+    // Pass 3: stream and cascade flows.
+    for (auto &f : memcpy_flows) {
+      if (f.memcpyResourceType != "npu_dma_stream" &&
+          f.memcpyResourceType != "npu_cascade")
+        continue;
+      for (int i = 0; i < f.numS2MMAllocs; i++) {
+        if (isInvalidAlloc(f, i))
+          continue;
+        if (f.memcpyResourceType == "npu_dma_stream")
           getFlowOp(
               aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
               AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
               f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
               (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
-        else if (f.memcpyResourceType == "npu_cascade") {
+        else
           getCascadeFlowOp(
               aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
               AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
               f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
               (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
-        }
       }
     }
     return success();
@@ -6662,6 +6715,7 @@ public:
       // Each isolated device can reuse packet IDs starting from 0.
       intraDeviceFlowID = 0;
       intraDeviceFlowOpToFlowIdMap.clear();
+      intraDeviceFlowIDBase = 0;
 
       // The shim tile allocation is not unified for dma and channel lowering
       // so we disallow a mix of dma and channel ops.
@@ -6900,6 +6954,12 @@ public:
   int intraDeviceFlowID = 0;
   SetVector<Operation *>
       intraDeviceFlowOpToFlowIdMap; // Ordered set for intra-device flows
+  // Offset added to intra-device packet flow IDs within a device so they do
+  // not collide with shim packet flow IDs assigned in the same device. Set
+  // to globalShimFlowID after all shim flows for the device are placed
+  // (globalShimFlowID is post-incremented, so it equals the next free
+  // non-shim pkt_id); reset to 0 per device.
+  int intraDeviceFlowIDBase = 0;
 
   // Device-host (shim) flow ID tracking (persists globally across devices)
   // These flows involve shim tiles and require globally unique IDs since

--- a/mlir/test/Conversion/AIRToAIE/packet_id_shim_vs_intra_device.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_id_shim_vs_intra_device.mlir
@@ -1,0 +1,167 @@
+//===- packet_id_shim_vs_intra_device.mlir ---------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Regression: shim packet flows and intra-device (memtile-to-compute,
+// compute-to-compute) packet flows used independent 0-based pkt_id counters
+// inside one device. The first shim packet flow and the first intra-device
+// packet flow both got pkt_id = 0; where their physical routes crossed at a
+// switchbox, the arbiter could not disambiguate them and packets silently
+// mis-routed. The fix assigns shim packet flows first, then offsets
+// intra-device packet flow IDs so every packet flow within a device carries
+// a unique pkt_id.
+//
+// Each case below uses `--split-input-file` so the per-device pkt_id counter
+// resets between cases. The regression invariants pinned per device are:
+//   (1) Each `aie.packet_flow(N)` value appears AT MOST ONCE per device
+//       (no two flows share an ID).
+//   (2) The pkt_id on intra-device `aie.dma_bd` ops is strictly greater
+//       than every shim pkt_id used in the same device.
+
+// RUN: air-opt %s --split-input-file -air-to-aie='row-offset=2 col-offset=0 device=npu2' 2>&1 | FileCheck %s
+
+// =============================================================================
+// Case 1: one shim packet flow (L3 -> L2) coexists with one intra-device
+// packet flow (L2 -> L1). Pre-fix: both packet_flow ops got id 0
+// (collision). Post-fix: distinct.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @case1_seg
+// Two distinct packet_flow declarations. The intra-device one MUST NOT also
+// be packet_flow(0) -- that was the pre-fix collision.
+// CHECK-COUNT-1: aie.packet_flow(0) {
+// CHECK-NOT:     aie.packet_flow(0) {
+// CHECK:         aie.packet_flow({{[1-9][0-9]*}}) {
+//
+// The intra-device flow's receiver-side dma_bd carries the assigned pkt_id.
+// It MUST be non-zero (would-be collision with the shim flow's pkt_id 0).
+// CHECK:     aie.dma_bd{{.*}}pkt_id = {{[1-9][0-9]*}}
+
+module {
+  air.channel @l3_to_l2 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @l2_to_l1 [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case1_shim_and_intra(%arg0: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%in0=%arg0) : memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      // L3-side put: drives the shim MM2S packet flow.
+      %put_l3 = air.channel.put async @l3_to_l2[%c0, %c0] (%in0[] [] []) {id = 1 : i32} : (memref<64xbf16>)
+
+      %seg = air.segment @case1_seg async [%put_l3] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+        // L2 staging buffer (memtile, memory_space = 1).
+        %async_l2, %buf_l2 = air.execute -> (memref<64xbf16, 1>) {
+          %alloc = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %alloc : memref<64xbf16, 1>
+        }
+        %get_l2 = air.channel.get async [%async_l2] @l3_to_l2[%c1_seg, %c1_seg] (%buf_l2[] [] []) {id = 2 : i32} : (memref<64xbf16, 1>)
+        // L2-side put: drives the intra-device (memtile -> compute) packet
+        // flow. Pre-fix this got pkt_id = 0 (same as the shim flow above).
+        %put_l2 = air.channel.put async [%get_l2] @l2_to_l1[%c1_seg, %c1_seg] (%buf_l2[] [] []) {id = 3 : i32} : (memref<64xbf16, 1>)
+
+        %herd = air.herd @case1_herd async [%put_l2] tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          %async_l1, %buf_l1 = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_l1 = air.channel.get async [%async_l1] @l2_to_l1[%hc0, %hc0] (%buf_l1[] [] []) {id = 4 : i32} : (memref<64xbf16, 2>)
+          %dealloc_l1 = air.execute [%get_l1] {
+            memref.dealloc %buf_l1 : memref<64xbf16, 2>
+          }
+        }
+        %dealloc_l2 = air.execute [%put_l2] {
+          memref.dealloc %buf_l2 : memref<64xbf16, 1>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// =============================================================================
+// Case 2: two shim packet flows + two intra-device packet flows. Shim flows
+// claim two distinct pkt_ids (0 and 1). Pre-fix the intra-device flows
+// reused 0 and 1 (double collision). Post-fix the intra-device flows must
+// claim pkt_ids strictly greater than every shim pkt_id in the device.
+// Validates the offset scales with the count of shim flows.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @case2_seg
+// Each shim pkt_id appears exactly once -- intra-device must NOT reuse them.
+// CHECK-COUNT-1: aie.packet_flow(0) {
+// CHECK-NOT:     aie.packet_flow(0) {
+// CHECK-COUNT-1: aie.packet_flow(1) {
+// CHECK-NOT:     aie.packet_flow(1) {
+//
+// And there must be exactly two more packet_flow ops with distinct IDs
+// strictly greater than 1.
+// CHECK-COUNT-2: aie.packet_flow({{[2-9][0-9]*}}) {
+//
+// The intra-device dma_bd ops both carry pkt_ids >= 2.
+// CHECK-COUNT-2: aie.dma_bd{{.*}}pkt_id = {{[2-9][0-9]*}}
+
+module {
+  air.channel @l3_to_l2_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @l3_to_l2_b [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @l2_to_l1_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @l2_to_l1_b [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case2_two_shim_two_intra(%arg0: memref<64xbf16>, %arg1: memref<64xbf16>) {
+    %0 = air.launch async () in () args(%in_a=%arg0, %in_b=%arg1) : memref<64xbf16>, memref<64xbf16> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %put_a = air.channel.put async @l3_to_l2_a[%c0, %c0] (%in_a[] [] []) {id = 1 : i32} : (memref<64xbf16>)
+      %put_b = air.channel.put async @l3_to_l2_b[%c0, %c0] (%in_b[] [] []) {id = 2 : i32} : (memref<64xbf16>)
+
+      %seg = air.segment @case2_seg async [%put_a, %put_b] attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+
+        %async_l2a, %buf_l2a = air.execute -> (memref<64xbf16, 1>) {
+          %alloc = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %alloc : memref<64xbf16, 1>
+        }
+        %get_l2a = air.channel.get async [%async_l2a] @l3_to_l2_a[%c1_seg, %c1_seg] (%buf_l2a[] [] []) {id = 3 : i32} : (memref<64xbf16, 1>)
+        %put_l2a = air.channel.put async [%get_l2a] @l2_to_l1_a[%c1_seg, %c1_seg] (%buf_l2a[] [] []) {id = 4 : i32} : (memref<64xbf16, 1>)
+
+        %async_l2b, %buf_l2b = air.execute -> (memref<64xbf16, 1>) {
+          %alloc = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %alloc : memref<64xbf16, 1>
+        }
+        %get_l2b = air.channel.get async [%async_l2b] @l3_to_l2_b[%c1_seg, %c1_seg] (%buf_l2b[] [] []) {id = 5 : i32} : (memref<64xbf16, 1>)
+        %put_l2b = air.channel.put async [%get_l2b] @l2_to_l1_b[%c1_seg, %c1_seg] (%buf_l2b[] [] []) {id = 6 : i32} : (memref<64xbf16, 1>)
+
+        %herd = air.herd @case2_herd async [%put_l2a, %put_l2b] tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          %async_l1a, %buf_l1a = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_l1a = air.channel.get async [%async_l1a] @l2_to_l1_a[%hc0, %hc0] (%buf_l1a[] [] []) {id = 7 : i32} : (memref<64xbf16, 2>)
+          %async_l1b, %buf_l1b = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_l1b = air.channel.get async [%async_l1b] @l2_to_l1_b[%hc0, %hc0] (%buf_l1b[] [] []) {id = 8 : i32} : (memref<64xbf16, 2>)
+          %dealloc_l1a = air.execute [%get_l1a] {
+            memref.dealloc %buf_l1a : memref<64xbf16, 2>
+          }
+          %dealloc_l1b = air.execute [%get_l1b] {
+            memref.dealloc %buf_l1b : memref<64xbf16, 2>
+          }
+        }
+        %dealloc_l2a = air.execute [%put_l2a] {
+          memref.dealloc %buf_l2a : memref<64xbf16, 1>
+        }
+        %dealloc_l2b = air.execute [%put_l2b] {
+          memref.dealloc %buf_l2b : memref<64xbf16, 1>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_id_shim_vs_intra_device.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_id_shim_vs_intra_device.mlir
@@ -165,3 +165,54 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// Case 3: intra-device-only device (no shim packet flow). Pins the redesign
+// invariant: when no shim flow in this device has claimed pkt_id 0, an
+// intra-device flow may take it. The lowest-gap assignment in
+// assignIntraDevicePacketID is what makes this possible -- prior schemes
+// that offset intra-device pkt_ids past a global shim counter would have
+// wasted pkt_id 0 in this device once any other device had placed a shim
+// flow.
+// =============================================================================
+
+// CHECK-LABEL: aie.device(npu2) @case3_seg
+// The single packet flow in this device is intra-device (L2->L1) and must
+// be allowed to take pkt_id 0.
+// CHECK-COUNT-1: aie.packet_flow(0) {
+// CHECK-NOT:     aie.packet_flow(0) {
+
+module {
+  air.channel @l2_to_l1_only [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @case3_intra_only() {
+    %0 = air.launch async () in () attributes {id = 1 : i32} {
+      %seg = air.segment @case3_seg async attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c1_seg = arith.constant 1 : index
+        %async_l2, %buf_l2 = air.execute -> (memref<64xbf16, 1>) {
+          %alloc = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %alloc : memref<64xbf16, 1>
+        }
+        %put_l2 = air.channel.put async [%async_l2] @l2_to_l1_only[%c1_seg, %c1_seg] (%buf_l2[] [] []) {id = 1 : i32} : (memref<64xbf16, 1>)
+
+        %herd = air.herd @case3_herd async [%put_l2] tile (%tx, %ty) in (%htx=%c1_seg, %hty=%c1_seg) attributes {id = 3 : i32} {
+          %hc0 = arith.constant 0 : index
+          %async_l1, %buf_l1 = air.execute -> (memref<64xbf16, 2>) {
+            %alloc = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %alloc : memref<64xbf16, 2>
+          }
+          %get_l1 = air.channel.get async [%async_l1] @l2_to_l1_only[%hc0, %hc0] (%buf_l1[] [] []) {id = 2 : i32} : (memref<64xbf16, 2>)
+          %dealloc_l1 = air.execute [%get_l1] {
+            memref.dealloc %buf_l1 : memref<64xbf16, 2>
+          }
+        }
+        %dealloc_l2 = air.execute [%put_l2] {
+          memref.dealloc %buf_l2 : memref<64xbf16, 1>
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

Two-commit PR. The first commit fixes a silent mis-routing bug caused by
two independent 0-based `pkt_id` counters; the second replaces the
positional id scheme that produced the bug with a per-channel id map so
the data model can't reproduce it.

### Commit 1: shim vs. intra-device collision fix

Shim packet flows and intra-device packet flows used independent 0-based
`pkt_id` counters within one device. The first shim packet flow (e.g.
L3->L1) and the first intra-device packet flow (e.g. memtile->compute)
both got `pkt_id = 0`; where their physical routes crossed at a
switchbox, the arbiter could not disambiguate them and packets silently
mis-routed. The original fix introduces a two-pass placement so
intra-device flows are offset past the highest shim `pkt_id` claimed in
the device.

### Commit 2: positional id scheme replaced with per-op id map

The first commit corrects the symptom but keeps the data model that
produced it: shim and intra-device flow ops are tracked in two
`SetVector`s and `pkt_id` is re-derived at lookup time via
`std::distance`. That's what made the original 0-vs-0 collision easy to
miss, and it leaves `intraDeviceFlowID` written-only after the fix.

Commit 2 replaces the per-device state with:
- `packetIDForChannelName` --- `air.channel` symbol -> assigned `pkt_id`.
- `claimedPacketIDs` --- pkt_ids already in use in this device.

`assignShimPacketID()` and `assignIntraDevicePacketID()` are the two
allocators; the latter picks the lowest unclaimed id, the former draws
from a monotonic global counter (shim ids stay globally unique for the
host runtime contract) and skips any id already claimed by an
intra-device flow in this device. `createPacketFlowOp` /
`getPacketFlowOp` lose their `int &flowID` post-increment (source of
the off-by-one confusion) and now take id by value. The
`buildFlowIdMap` helper is deleted; `getExistingPacketFlowOpFromDevice`
becomes a one-line map lookup.

Side effects:
- `intraDeviceFlowID` (dead after commit 1) is removed.
- `createTracePacketFlow` now uses `assignShimPacketID`, closing a
  latent collision between trace and intra-device pkt_ids in one device
  (commit 1 did not address this).
- An intra-device-only device may now claim `pkt_id 0`; the prior
  offset scheme reserved low ids globally for shim use.

## Test plan

- [x] Lit regression `packet_id_shim_vs_intra_device.mlir`:
  - Case 1 --- one shim + one intra-device flow (pre-commit-1 both got `pkt_id = 0`).
  - Case 2 --- two of each (pre-commit-1 the intra-device flows reused `pkt_id`s `0` and `1`).
  - Case 3 (new in commit 2) --- intra-device-only device pinned to take `pkt_id 0`.
  - All pinned with `CHECK-COUNT-1 + CHECK-NOT` to fail on future re-collision.
- [x] `ninja check-air-mlir` AIRToAIE conversion suite: 65/65 pass.
- [x] Full `ninja check-air-mlir`: same 5 pre-existing failures as base PR (none related to packet flow id placement).

Co-authored with Claude Code.
