### PR TITLE
[Util] Fix Windows build: replace __builtin_mul_overflow with llvm::MulOverflow

### DIFF
--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -31,6 +31,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "iostream"
@@ -324,9 +325,11 @@ air::getStaticAffineForTripCountAsInt(affine::AffineForOp for_op) {
 std::optional<int64_t> air::getStaticTripCountInRange(Operation *inner,
                                                       Operation *outer) {
   int64_t trip = 1;
+  // Use llvm::MulOverflow instead of __builtin_mul_overflow so the code
+  // builds on MSVC (the Windows CI does not provide the GCC/Clang builtin).
   auto checkedMul = [&](int64_t factor) -> bool {
     int64_t product;
-    if (__builtin_mul_overflow(trip, factor, &product))
+    if (llvm::MulOverflow(trip, factor, product))
       return false;
     trip = product;
     return true;


### PR DESCRIPTION
## Summary

PR #1647 added [`getStaticTripCountInRange`](https://github.com/Xilinx/mlir-air/blob/main/mlir/lib/Util/Util.cpp#L325) with an overflow-checked multiply using `__builtin_mul_overflow`. That builtin is GCC/Clang only — MSVC doesn't have it. The Windows CI (\"Build and Test (Windows)\") has failed on every push since #1647 was merged (commit \`945f663f\`) with:

\`\`\`
Util.cpp(329): error C3861: '__builtin_mul_overflow': identifier not found
\`\`\`

Visible in the failing run for the merge commit of #1647 itself: https://github.com/Xilinx/mlir-air/actions/runs/26865062984 — and every PR built since (e.g. mine, #1649).

## Fix

Replace with [`llvm::MulOverflow`](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/Support/MathExtras.h#L750) from \`llvm/Support/MathExtras.h\`, which forwards to \`__builtin_mul_overflow\` when available and falls back to a manual unsigned-multiply-then-check on MSVC. Drop-in replacement — only API difference is the result parameter (reference instead of pointer).

## Test plan

- [x] Linux build green (\`ninja -C build\`)
- [x] \`ninja check-air-mlir\` back to baseline (same 4 pre-existing failures unrelated to this change)
- [ ] Windows CI on this PR — that's the real signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)