### PR TITLE
[test] Add `--` separator before host args in airhost lit tests

### DIFF
--- a/test/airhost/07_mb_beef_maker/run.lit
+++ b/test/airhost/07_mb_beef_maker/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/09_mb_hsa_herd_lock/run.lit
+++ b/test/airhost/09_mb_hsa_herd_lock/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/10_mb_shim_dma_to_tile_dma/run.lit
+++ b/test/airhost/10_mb_shim_dma_to_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/11_mb_shim_dma_from_tile_dma/run.lit
+++ b/test/airhost/11_mb_shim_dma_from_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/12_dual_channel_shim_dma/run.lit
+++ b/test/airhost/12_dual_channel_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/13_mb_add_one/run.lit
+++ b/test/airhost/13_mb_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/14_multi_shim_dma/run.lit
+++ b/test/airhost/14_multi_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/15_dual_mb_dual_herd_add_one/run.lit
+++ b/test/airhost/15_dual_mb_dual_herd_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/16_multi_shim_dma_all_channels/run.lit
+++ b/test/airhost/16_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/18_2d_tile_dma_transpose/run.lit
+++ b/test/airhost/18_2d_tile_dma_transpose/run.lit
@@ -8,5 +8,5 @@
 
 // Expected to fail unless mlir-aie pull #55 is merged
 // XFAIL: *
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/26_air_beefmaker_extfn/run.lit
+++ b/test/airhost/26_air_beefmaker_extfn/run.lit
@@ -10,5 +10,5 @@
 // XFAIL: *
 // RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-to-aie="output-prefix=./ row-offset=2 col-offset=7" -o /dev/null
-// RUN: aiecc.py --no-xbridge aie.segment_0.mlir %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py --no-xbridge aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/273_barrier_add_two/run.lit
+++ b/test/airhost/273_barrier_add_two/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/274_segment_column_reset_test/run.lit
+++ b/test/airhost/274_segment_column_reset_test/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/275_segment_shim_reset_test/run.lit
+++ b/test/airhost/275_segment_shim_reset_test/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/290_mb_matrix_add_ddr/run.lit
+++ b/test/airhost/290_mb_matrix_add_ddr/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/29_mb_matrix_add/run.lit
+++ b/test/airhost/29_mb_matrix_add/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/30_2d_mb_shim_dma/run.lit
+++ b/test/airhost/30_2d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/31_3d_mb_shim_dma/run.lit
+++ b/test/airhost/31_3d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/32_4d_mb_shim_dma/run.lit
+++ b/test/airhost/32_4d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/36_4d_mb_multi_shim_dma_all_channels/run.lit
+++ b/test/airhost/36_4d_mb_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/37_4d_mb_multi_shim_dma_broadcast/run.lit
+++ b/test/airhost/37_4d_mb_multi_shim_dma_broadcast/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/38_4d_mb_shim_dma_channel_stress/run.lit
+++ b/test/airhost/38_4d_mb_shim_dma_channel_stress/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf


### PR DESCRIPTION
Follow-on to Xilinx/mlir-aie#3066, which makes aiecc reject unknown command-line arguments before `--` instead of silently forwarding them to the host compiler.

The `%airhost_libs%` substitution expands to a list that includes `-Wl,--whole-archive`, `-Wl,-R...`, `-Wl,-rpath,...`, and `-Wl,--no-whole-archive` — flags aiecc has never recognized, but which were absorbed by its legacy `cl::Sink` and passed through to clang. Once #3066 lands, `cl::ParseCommandLineOptions` will hard-error on those `-Wl,...` tokens.

Insert `--` immediately after the input MLIR on each `aiecc.py` RUN line so the host flags, `%airhost_libs%`, host source, and `-o` are captured into `hostExtraArgs` and forwarded verbatim to the host compiler. This mirrors the style used by the parent PR's `test/aiecc/cpp_host_compile.mlir` update.