### PR TITLE
[programming_examples] Add bf16 x bfp16ebs8 mixed-precision GEMM example

### DIFF
--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -68,6 +68,12 @@ EXAMPLES = [
     },
     {
         "category": "Linear Algebra",
+        "name": "Matrix Multiplication (bf16 x bfp16ebs8)",
+        "path": "matrix_multiplication/bf16_x_bfp16",
+        "datatypes": "bf16 activations / bfp16ebs8 weights",
+    },
+    {
+        "category": "Linear Algebra",
         "name": "AXPY",
         "path": "axpy",
         "datatypes": "bf16",

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
@@ -1,0 +1,89 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+M       ?= 64
+K       ?= 128
+N       ?= 128
+TILE_M  ?= 32
+TILE_N  ?= 32
+TILE_K_L1 ?= 128
+TILE_K_L2 ?= $(K)
+HERD_M  ?= 2
+HERD_N  ?= 4
+
+# bfp16ebs8 MMUL is Peano-only; xchesscc has no bfp16ebs8 codegen path.
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  $(error PEANO_INSTALL_DIR not set. Chess toolchain is not supported for bfp16ebs8; source utils/env_setup.sh)
+endif
+
+AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include
+
+PY_ARGS = --m $(M) --k $(K) --n $(N) \
+          --tile-m $(TILE_M) --tile-n $(TILE_N) \
+          --tile-k-l1 $(TILE_K_L1) --tile-k-l2 $(TILE_K_L2) \
+          --herd-m $(HERD_M) --herd-n $(HERD_N)
+
+all: run
+
+print:
+	${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) -p
+
+compile-kernel:
+	mkdir -p $(BUILD_DIR)
+	$(PEANO_INSTALL_DIR)/bin/clang++ $(PEANOWRAP2P_FLAGS) \
+		-DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) \
+		-c $(srcdir)/mm_bf16_x_bfp16.cc -o $(BUILD_DIR)/mm_bf16_x_bfp16.o
+
+run: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS)
+
+compile-only: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) --compile-mode compile-only
+
+# Build the C++ XRT timing harness. Mirrors bf16/Makefile:build-test-exe.
+build-test-exe:
+	@GPP=$$( \
+		for bin in /usr/bin/g++-*; do \
+			ver=$$(echo $$bin | grep -oE '[0-9]+$$'); \
+			if [ "$$ver" -ge 13 ] 2>/dev/null; then \
+				echo "$$ver $$bin"; \
+			fi; \
+		done | sort -nr | head -n1 | awk '{print $$2}' \
+	); \
+	if [ -z "$$GPP" ]; then \
+		echo "Error: No g++ version >= 13 found in /usr/bin."; \
+		exit 1; \
+	fi; \
+	if [ -z "$$XILINX_XRT" ]; then \
+		echo "Error: XILINX_XRT not set. Source xrt/setup.sh first."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(AIEOPT_DIR)" ]; then \
+		echo "Error: AIEOPT_DIR not set. Source utils/env_setup.sh first."; \
+		exit 1; \
+	fi; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && $$GPP $(srcdir)/test.cpp -o test.exe -std=c++23 -Wall \
+		-I$$XILINX_XRT/include -L$$XILINX_XRT/lib \
+		-I$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/include \
+		-L$(AIEOPT_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
+
+# End-to-end latency profile: build xclbin then run the C++ harness.
+profile: compile-kernel build-test-exe
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) \
+	    --compile-mode compile-and-xclbin
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE \
+	  -i air.insts.bin -M $(M) -K $(K) -N $(N)
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
@@ -14,10 +14,11 @@ HERD_M  ?= 2
 HERD_N  ?= 4
 
 # bfp16ebs8 MMUL is Peano-only; xchesscc has no bfp16ebs8 codegen path.
+# compile-kernel errors at recipe time if PEANO_INSTALL_DIR is unset.
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
-  $(error PEANO_INSTALL_DIR not set. Chess toolchain is not supported for bfp16ebs8; source utils/env_setup.sh)
+  BUILD_DIR := build_chess
 endif
 
 AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
@@ -36,6 +37,11 @@ print:
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
+	@if [ -z "$(PEANO_INSTALL_DIR)" ]; then \
+		echo "Error: PEANO_INSTALL_DIR not set. Chess toolchain is not"\
+		     "supported for bfp16ebs8; source utils/env_setup.sh."; \
+		exit 1; \
+	fi
 	$(PEANO_INSTALL_DIR)/bin/clang++ $(PEANOWRAP2P_FLAGS) \
 		-DDIM_M=$(TILE_M) -DDIM_N=$(TILE_N) -DDIM_K=$(TILE_K_L1) \
 		-c $(srcdir)/mm_bf16_x_bfp16.cc -o $(BUILD_DIR)/mm_bf16_x_bfp16.o

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
@@ -1,0 +1,659 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# bf16 A x bfp16ebs8 B -> bf16 C mixed-precision GEMM on NPU2.
+# B is uint8 at the AIR boundary (no MLIR bfp16ebs8 element type) and the
+# kernel reinterprets via aie::block_vector<bfp16ebs8>.
+
+import argparse
+import sys
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import (
+    AffineConstantExpr,
+    AffineExpr,
+    AffineMap,
+    AffineSymbolExpr,
+    BF16Type,
+    F32Type,
+    IntegerAttr,
+    IntegerType,
+    MemRefType,
+    ShapedType,
+    StridedLayoutAttr,
+    StringAttr,
+    UnitAttr,
+)
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import (
+    MemorySpace,
+    T,
+    dma_memcpy_nd,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects.func import CallOp, FuncOp
+from air.dialects.memref import AllocOp, DeallocOp, subview
+from air.dialects.scf import for_, yield_
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+KERNEL_OBJ_NAME = "mm_bf16_x_bfp16.o"
+BFP16_BLOCK = 8
+BFP16_BYTES_PER_BLOCK = 9
+
+
+def bfp_tile_bytes(tile_n, tile_k_l1):
+    nelem = tile_n * tile_k_l1
+    assert nelem % BFP16_BLOCK == 0
+    return (nelem // BFP16_BLOCK) * BFP16_BYTES_PER_BLOCK
+
+
+def _bf16_block_to_bfp16ebs8(block_f32):
+    """Reference per-block scalar packer; use pack_b_bfp16ebs8 in production."""
+    assert block_f32.shape == (BFP16_BLOCK,)
+    bits = np.frombuffer(block_f32.astype(np.float32).tobytes(), dtype=np.uint32).copy()
+    sign = (bits & 0x80000000) != 0
+    exp = (bits >> 23) & 0xFF
+    mant_explicit = (bits & 0x007FFFFF) | np.where(exp != 0, 0x00800000, 0).astype(
+        np.uint32
+    )
+    max_exp = int(exp.max())
+    signed_mant = np.where(
+        sign, (~mant_explicit + 1) & 0xFFFFFFFF, mant_explicit
+    ).astype(np.int64)
+    base = (signed_mant.astype(np.int64) >> (23 - 7 + 1)).astype(np.int64)
+    shift = max_exp - exp.astype(np.int64)
+    aligned = np.where(shift >= 32, np.where(sign, -1, 0), base >> shift).astype(
+        np.int8
+    )
+    out = np.empty(BFP16_BYTES_PER_BLOCK, dtype=np.uint8)
+    out[0] = np.uint8(max_exp)
+    out[1:] = aligned.view(np.uint8)
+    return out
+
+
+def pack_b_bfp16ebs8(B_bf16, tile_n, tile_k_l1):
+    """[K, N] bf16 -> [N/tile_n, K/tile_k_l1, tile_bytes] uint8 (3D BO).
+
+    Vectorized over all blocks at once. Each 9-byte record packs 8
+    K-contiguous elements for one N row (B is consumed transposed).
+    """
+    K, N = B_bf16.shape
+    r = s = t = 8
+    assert tile_n % t == 0 and tile_k_l1 % s == 0
+    assert K % tile_k_l1 == 0 and N % tile_n == 0
+    Nb = N // tile_n
+    Kb = K // tile_k_l1
+    NB_in = tile_n // t  # n MMUL sub-tiles per tile_n
+    KB_in = tile_k_l1 // s  # k MMUL sub-tiles per tile_k_l1
+    n_blocks_total = Nb * Kb * NB_in * KB_in  # one MMUL sub-block per row of output
+
+    # Permute B into per-block 8-element views: [Nb, Kb, NB_in, KB_in, t, s].
+    # sub[..., n_i, k_i] = B[kb * tile_k_l1 + kbi * s + k_i, nb * tile_n + nbi * t + n_i]
+    Bf = B_bf16.astype(np.float32)
+    Bv = Bf.reshape(Kb, KB_in, s, Nb, NB_in, t)  # [Kb, KB_in, s, Nb, NB_in, t]
+    Bv = np.transpose(Bv, (3, 0, 4, 1, 5, 2))  # [Nb, Kb, NB_in, KB_in, t, s]
+    # Each (block_idx, n_i) line of 8 elements gets one bfp16ebs8 9-byte record.
+    blocks = np.ascontiguousarray(Bv).reshape(n_blocks_total * t, s)  # [n_records, 8]
+
+    # Vectorized bit math (same per-element logic as the scalar reference).
+    bits = blocks.view(np.uint32)  # reinterpret f32 bits
+    sign = (bits & 0x80000000) != 0  # [n_records, 8] bool
+    exp = ((bits >> 23) & 0xFF).astype(np.int32)  # [n_records, 8]
+    mant_explicit = (bits & 0x007FFFFF) | np.where(
+        exp != 0, np.uint32(0x00800000), np.uint32(0)
+    )
+    max_exp = exp.max(axis=1, keepdims=True)  # [n_records, 1] shared exp per block
+    signed_mant = np.where(
+        sign, (~mant_explicit + np.uint32(1)) & np.uint32(0xFFFFFFFF), mant_explicit
+    ).astype(np.int64)
+    base = signed_mant >> (23 - 7 + 1)  # 24-bit -> 8-bit-with-sign
+    shift = (max_exp - exp).astype(np.int64)  # [n_records, 8] >= 0
+    big_shift = shift >= 32
+    aligned = np.where(
+        big_shift, np.where(sign, -1, 0), base >> np.minimum(shift, 31)
+    ).astype(np.int8)
+
+    # Interleave [shared_exp, m0..m7] per record into 9-byte stride.
+    records = np.empty((n_blocks_total * t, BFP16_BYTES_PER_BLOCK), dtype=np.uint8)
+    records[:, 0] = max_exp.flatten().astype(np.uint8)
+    records[:, 1:] = aligned.view(np.uint8)
+
+    # Reassemble: per tile we have NB_in * KB_in * t records, each 9 bytes.
+    tb = bfp_tile_bytes(tile_n, tile_k_l1)
+    out = records.reshape(Nb, Kb, NB_in * KB_in * t * BFP16_BYTES_PER_BLOCK)
+    assert out.shape[2] == tb
+    return out
+
+
+def cpu_reference_from_bfp_packed(B_packed, A_bf16, m, k, n, tile_n, tile_k_l1):
+    r = s = t = 8
+    NB_in = tile_n // t
+    KB_in = tile_k_l1 // s
+    Bf = np.zeros((k, n), dtype=np.float32)
+    for nb in range(n // tile_n):
+        for kb in range(k // tile_k_l1):
+            cursor = 0
+            for nbi in range(NB_in):
+                for kbi in range(KB_in):
+                    n0 = nb * tile_n + nbi * t
+                    k0 = kb * tile_k_l1 + kbi * s
+                    sub_T = np.zeros((t, s), dtype=np.float32)
+                    for n_i in range(t):
+                        block = B_packed[
+                            nb, kb, cursor : cursor + BFP16_BYTES_PER_BLOCK
+                        ]
+                        cursor += BFP16_BYTES_PER_BLOCK
+                        shared_exp = int(block[0])
+                        mults = (
+                            (1.0 * (1 << (shared_exp - 127)))
+                            if shared_exp >= 127
+                            else (1.0 / (1 << (127 - shared_exp)))
+                        ) / 64.0
+                        mants = block[1:].view(np.int8).astype(np.int32)
+                        sub_T[n_i, :] = mants.astype(np.float32) * mults
+                    Bf[k0 : k0 + s, n0 : n0 + t] = sub_T.T
+    C = A_bf16.astype(np.float32) @ Bf
+    return C.astype(bfloat16)
+
+
+@module_builder
+def build_module(
+    m,
+    k,
+    n,
+    tile_m,
+    tile_k_l2,
+    tile_k_l1,
+    tile_n,
+    herd_m,
+    herd_n,
+):
+    """bf16 A x bfp16ebs8 B mixed-precision GEMM with f32 L1 accumulator."""
+    r, s, t = 8, 8, 8
+    assert m % (tile_m * herd_m) == 0
+    assert n % (tile_n * herd_n) == 0
+    assert k % tile_k_l2 == 0
+    assert tile_k_l2 % tile_k_l1 == 0
+    assert tile_m % (2 * r) == 0
+    assert tile_n % (2 * t) == 0
+    assert tile_k_l1 % s == 0
+
+    tile_bytes = bfp_tile_bytes(tile_n, tile_k_l1)
+    N_div = n // tile_n
+    K_div = k // tile_k_l1
+
+    bf16_ty = BF16Type.get()
+    f32_ty = F32Type.get()
+    u8_ty = IntegerType.get_signless(8)
+
+    # L3 (caller-facing)
+    A_l3_ty = MemRefType.get([m, k], bf16_ty)
+    B_l3_ty = MemRefType.get([N_div, K_div, tile_bytes], u8_ty)
+    C_l3_ty = MemRefType.get([m, n], bf16_ty)
+
+    # L1 MMUL block layouts. C is N-outer M-inner so the L1->L2 drain DMA
+    # fits in the AIE2P 3-dim BD step limit.
+    l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l1_size = [1, 1, tile_m // r, tile_k_l1 // s, r, s]
+    b_l1_size = [tile_bytes]
+    c_l1_size = [1, 1, tile_n // t, tile_m // r, r, t]
+    c_herd_l1_size = [herd_m, herd_n, tile_n // t, tile_m // r, r, t]
+
+    l1MemrefTyA = MemRefType.get(a_l1_size, bf16_ty, memory_space=l1_ms)
+    l1MemrefTyB = MemRefType.get(b_l1_size, u8_ty, memory_space=l1_ms)
+    c_subview_layout = StridedLayoutAttr.get(
+        ShapedType.get_dynamic_size(),
+        [
+            tile_m * tile_n * herd_n,
+            tile_m * tile_n,
+            tile_m * t,  # n_b stride: skip full M-block column = tile_m * t
+            r * t,  # m_b stride: skip one M-block = r * t
+            t,  # m_i stride: skip one row within block
+            1,  # n_i stride
+        ],
+    )
+    l1MemrefTyC = MemRefType.get(
+        c_l1_size, f32_ty, memory_space=l1_ms, layout=c_subview_layout
+    )
+    l1MemrefTyCHerd = MemRefType.get(c_herd_l1_size, f32_ty, memory_space=l1_ms)
+    c_drain_l1_size = [herd_m, herd_n, tile_n // t, tile_m // r, r, t]
+    l1MemrefTyCDrainHerd = MemRefType.get(c_drain_l1_size, bf16_ty, memory_space=l1_ms)
+
+    # External funcs: matmul (block-layout I/O) + f32->bf16 row-major drain
+    # operating on the flattened tile (length tile_m*tile_n).
+    matmul_func = FuncOp(
+        "matmul_bf16_x_bfp16_packed_f32",
+        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
+        visibility="private",
+    )
+    matmul_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+    matmul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+    # CallOp(zero_func) over linalg.fill: kernel writes contiguously, avoids
+    # affine-codegen edge cases on the strided 6D subview.
+    zero_func = FuncOp(
+        "zero_vectorized_f32_mn",
+        ([l1MemrefTyC], []),
+        visibility="private",
+    )
+    zero_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+    zero_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+    # The drain kernel reads/writes flat tile_m*tile_n elements; pass per-PE
+    # subviews from the segment-level buffers.
+    drain_acc_ty = MemRefType.get(
+        c_l1_size, f32_ty, memory_space=l1_ms, layout=c_subview_layout
+    )
+    drain_dst_layout = StridedLayoutAttr.get(
+        ShapedType.get_dynamic_size(),
+        [
+            tile_m * tile_n * herd_n,
+            tile_m * tile_n,
+            tile_n * r,
+            r * t,
+            t,
+            1,
+        ],
+    )
+    drain_dst_ty = MemRefType.get(
+        c_l1_size, bf16_ty, memory_space=l1_ms, layout=drain_dst_layout
+    )
+    f32_to_bf16_func = FuncOp(
+        "f32_to_bf16_mn",
+        ([drain_acc_ty, drain_dst_ty], []),
+        visibility="private",
+    )
+    f32_to_bf16_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+    f32_to_bf16_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+    @FuncOp.from_py_func(A_l3_ty, B_l3_ty, C_l3_ty)
+    def matmul_bf16_x_bfp16(arg0, arg1, arg2):
+        launch_size = [m // tile_m // herd_m, n // tile_n // herd_n]
+
+        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
+        def launch_body(
+            launch_ivx,
+            launch_ivy,
+            launch_sizex,
+            launch_sizey,
+            l3_a_data,
+            l3_b_data,
+            l3_c_data,
+        ):
+            @segment(
+                name="matmul_seg",
+                operands=[launch_ivx, launch_ivy, l3_a_data, l3_b_data, l3_c_data],
+            )
+            def segment_body(
+                launch_ivx_s,
+                launch_ivy_s,
+                l3_a_data_s,
+                l3_b_data_s,
+                l3_c_data_s,
+            ):
+                k_per_l2 = tile_k_l2 // tile_k_l1
+                a_size_l2 = [herd_m, 1, tile_m, tile_k_l2]
+                b_size_l2 = [1, herd_n, k_per_l2, tile_bytes]
+                c_size_l2 = [herd_m, herd_n, tile_m, tile_n]
+                l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+                l2MemrefTyA = MemRefType.get(a_size_l2, bf16_ty, memory_space=l2_ms)
+                l2MemrefTyB = MemRefType.get(b_size_l2, u8_ty, memory_space=l2_ms)
+                l2MemrefTyC = MemRefType.get(c_size_l2, bf16_ty, memory_space=l2_ms)
+
+                l2_a_data = AllocOp(l2MemrefTyA, [], [])
+                l2_b_data = AllocOp(l2MemrefTyB, [], [])
+                l2_c_data = AllocOp(l2MemrefTyC, [], [])
+                # Segment-shared L1_C f32 accumulator persists across the
+                # three herd invocations; drain holds the bf16-narrowed result.
+                l1_c_data = AllocOp(l1MemrefTyCHerd, [], [])
+                l1_c_drain = AllocOp(l1MemrefTyCDrainHerd, [], [])
+
+                launch_ix_map = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_m * herd_m),
+                        )
+                    ],
+                )
+                launch_iy_map = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_n * herd_n),
+                        )
+                    ],
+                )
+                launch_offset_x = affine_apply(launch_ix_map, [launch_ivx_s])
+                launch_offset_y = affine_apply(launch_iy_map, [launch_ivy_s])
+
+                n_outer_off_map = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(herd_n),
+                        )
+                    ],
+                )
+                n_outer_off = affine_apply(n_outer_off_map, [launch_ivy_s])
+
+                # ---- Herd #1: zero-init L1 C f32 (segment-shared).
+                @herd(
+                    name="herd_0",
+                    sizes=[herd_m, herd_n],
+                    operands=[l1_c_data],
+                )
+                def herd_init(_tx, _ty, _sx, _sy, _l1_c):
+                    l1_c_subview = subview(
+                        _l1_c,
+                        offsets=[_tx, _ty, 0, 0, 0, 0],
+                        sizes=[1, 1, tile_n // t, tile_m // r, r, t],
+                        strides=[1, 1, 1, 1, 1, 1],
+                    )
+                    CallOp(zero_func, [l1_c_subview])
+
+                # ---- Segment-level K-l2 loop (matches bf16).
+                for i in for_(0, k // tile_k_l2):
+                    reduction_l2_iv_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(tile_k_l2),
+                            )
+                        ],
+                    )
+                    reduction_offset = affine_apply(reduction_l2_iv_map, [i])
+                    # K-l2 chunk offset in B (in units of K-l1 tile slots).
+                    k_l2_b_off_map = AffineMap.get(
+                        0,
+                        1,
+                        [
+                            AffineExpr.get_mul(
+                                AffineSymbolExpr.get(0),
+                                AffineConstantExpr.get(k_per_l2),
+                            )
+                        ],
+                    )
+                    k_l2_b_off = affine_apply(k_l2_b_off_map, [i])
+                    dma_memcpy_nd(
+                        l2_a_data,
+                        l3_a_data_s,
+                        src_offsets=[0, 0, launch_offset_x, reduction_offset],
+                        src_sizes=[herd_m, 1, tile_m, tile_k_l2],
+                        src_strides=[k * tile_m, tile_k_l2, k, 1],
+                    )
+                    dma_memcpy_nd(
+                        l2_b_data,
+                        l3_b_data_s,
+                        src_offsets=[0, n_outer_off, k_l2_b_off, 0],
+                        src_sizes=[1, herd_n, k_per_l2, tile_bytes],
+                        src_strides=[
+                            K_div * tile_bytes,
+                            K_div * tile_bytes,
+                            tile_bytes,
+                            1,
+                        ],
+                    )
+
+                    # ---- Herd #2: compute (K-l1 loop inside).
+                    @herd(
+                        name="herd_0",
+                        sizes=[herd_m, herd_n],
+                        operands=[l1_c_data, l2_a_data, l2_b_data],
+                    )
+                    def herd_compute(
+                        _tx,
+                        _ty,
+                        _sx,
+                        _sy,
+                        _l1_c,
+                        _l2_a,
+                        _l2_b,
+                    ):
+                        _l1_a = AllocOp(l1MemrefTyA, [], [])
+                        _l1_b = AllocOp(l1MemrefTyB, [], [])
+                        for j in for_(0, k_per_l2):
+                            reduction_l1_iv_map = AffineMap.get(
+                                0,
+                                1,
+                                [
+                                    AffineExpr.get_mul(
+                                        AffineSymbolExpr.get(0),
+                                        AffineConstantExpr.get(tile_k_l1),
+                                    )
+                                ],
+                            )
+                            reduction_l1_offset = affine_apply(reduction_l1_iv_map, [j])
+                            dma_memcpy_nd(
+                                _l1_a,
+                                _l2_a,
+                                src_offsets=[_tx, 0, 0, 0, 0, reduction_l1_offset],
+                                src_sizes=[
+                                    1,
+                                    1,
+                                    tile_m // r,
+                                    tile_k_l1 // s,
+                                    r,
+                                    s,
+                                ],
+                                src_strides=[
+                                    tile_m * tile_k_l2,
+                                    tile_m * tile_k_l2,
+                                    tile_k_l2 * r,
+                                    s,
+                                    tile_k_l2,
+                                    1,
+                                ],
+                            )
+                            # L2->L1 B: per-PE per-K-l1-chunk byte tile.
+                            dma_memcpy_nd(
+                                _l1_b,
+                                _l2_b,
+                                src_offsets=[0, _ty, j, 0],
+                                src_sizes=[1, 1, 1, tile_bytes],
+                                src_strides=[
+                                    herd_n * k_per_l2 * tile_bytes,
+                                    k_per_l2 * tile_bytes,
+                                    tile_bytes,
+                                    1,
+                                ],
+                            )
+                            l1_c_subview = subview(
+                                _l1_c,
+                                offsets=[_tx, _ty, 0, 0, 0, 0],
+                                sizes=[
+                                    1,
+                                    1,
+                                    tile_n // t,
+                                    tile_m // r,
+                                    r,
+                                    t,
+                                ],
+                                strides=[1, 1, 1, 1, 1, 1],
+                            )
+                            CallOp(matmul_func, [_l1_a, _l1_b, l1_c_subview])
+                            yield_([])
+
+                        DeallocOp(_l1_a)
+                        DeallocOp(_l1_b)
+
+                    yield_([])
+
+                # ---- Herd #3: drain f32 L1 C -> bf16 L1 C drain -> L2.
+                @herd(
+                    name="herd_0",
+                    sizes=[herd_m, herd_n],
+                    operands=[l1_c_data, l1_c_drain, l2_c_data],
+                )
+                def herd_drain(
+                    _tx,
+                    _ty,
+                    _sx,
+                    _sy,
+                    _l1_c,
+                    _l1_c_drain,
+                    _l2_c,
+                ):
+                    l1_c_acc_sv = subview(
+                        _l1_c,
+                        offsets=[_tx, _ty, 0, 0, 0, 0],
+                        sizes=[1, 1, tile_n // t, tile_m // r, r, t],
+                        strides=[1, 1, 1, 1, 1, 1],
+                    )
+                    l1_c_drain_sv = subview(
+                        _l1_c_drain,
+                        offsets=[_tx, _ty, 0, 0, 0, 0],
+                        sizes=[1, 1, tile_n // t, tile_m // r, r, t],
+                        strides=[1, 1, 1, 1, 1, 1],
+                    )
+                    CallOp(f32_to_bf16_func, [l1_c_acc_sv, l1_c_drain_sv])
+                    # L1 (block) -> L2 (row-major), 6D src permute matches bf16.
+                    dma_memcpy_nd(
+                        _l2_c,
+                        _l1_c_drain,
+                        dst_offsets=[_tx, _ty, 0, 0],
+                        dst_sizes=[1, 1, tile_m, tile_n],
+                        dst_strides=[
+                            herd_n * tile_m * tile_n,
+                            tile_m * tile_n,
+                            tile_n,
+                            1,
+                        ],
+                        src_offsets=[_tx, _ty, 0, 0, 0, 0],
+                        src_sizes=[
+                            1,
+                            1,
+                            tile_m // r,
+                            r,
+                            tile_n // t,
+                            t,
+                        ],
+                        # 6D src strides chosen so the BD optimizer collapses
+                        # (m_b, m_i) into a single dim, fitting AIE2P 3-dim BDs.
+                        src_strides=[
+                            herd_n * tile_m * tile_n,
+                            tile_m * tile_n,
+                            r * t,  # m_b: skip one M-block
+                            t,  # m_i: next row within block
+                            tile_m * t,  # n_b: skip one M-block column
+                            1,  # n_i
+                        ],
+                    )
+
+                dma_memcpy_nd(
+                    l3_c_data_s,
+                    l2_c_data,
+                    dst_offsets=[launch_offset_x, launch_offset_y],
+                    dst_sizes=[herd_m * tile_m, herd_n * tile_n],
+                    dst_strides=[n, 1],
+                    src_offsets=[0, 0, 0, 0],
+                    src_sizes=[herd_m, tile_m, herd_n, tile_n],
+                    src_strides=[
+                        tile_m * herd_n * tile_n,
+                        tile_n,
+                        tile_m * tile_n,
+                        1,
+                    ],
+                )
+
+                DeallocOp(l2_a_data)
+                DeallocOp(l2_b_data)
+                DeallocOp(l2_c_data)
+                DeallocOp(l1_c_data)
+                DeallocOp(l1_c_drain)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=64)
+    parser.add_argument("--k", type=int, default=128)
+    parser.add_argument("--n", type=int, default=128)
+    parser.add_argument("--tile-m", type=int, default=32, dest="tile_m")
+    parser.add_argument("--tile-k-l2", type=int, default=128, dest="tile_k_l2")
+    parser.add_argument("--tile-k-l1", type=int, default=128, dest="tile_k_l1")
+    parser.add_argument("--tile-n", type=int, default=32, dest="tile_n")
+    parser.add_argument("--herd-m", type=int, default=2, dest="herd_m")
+    parser.add_argument("--herd-n", type=int, default=4, dest="herd_n")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument(
+        "--compile-mode",
+        choices=["compile-and-run", "compile-only", "compile-and-xclbin"],
+        default="compile-and-run",
+        dest="compile_mode",
+    )
+    args = parser.parse_args()
+
+    module = build_module(
+        args.m,
+        args.k,
+        args.n,
+        args.tile_m,
+        args.tile_k_l2,
+        args.tile_k_l1,
+        args.tile_n,
+        args.herd_m,
+        args.herd_n,
+    )
+    if args.print_module_only:
+        print(module)
+        sys.exit(0)
+
+    np.random.seed(42)
+    A = (np.random.randn(args.m, args.k) * (1.0 / np.sqrt(args.k))).astype(bfloat16)
+    B = (np.random.randn(args.k, args.n) * (1.0 / np.sqrt(args.k))).astype(bfloat16)
+
+    B_packed = pack_b_bfp16ebs8(B, args.tile_n, args.tile_k_l1)
+    C_ref = cpu_reference_from_bfp_packed(
+        B_packed, A, args.m, args.k, args.n, args.tile_n, args.tile_k_l1
+    )
+
+    # runtime_loop_tiling_sizes=[2,2] keeps the runtime DMA loop within the
+    # ~4-task shim BD pool at large launch axes.
+    common_kwargs = dict(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format="xclbin",
+        stack_size=2048,
+        runtime_loop_tiling_sizes=[2, 2],
+        instance_name="matmul_bf16_x_bfp16",
+    )
+
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(**common_kwargs)
+        backend.compile(module)
+        backend.unload()
+        sys.exit(0)
+
+    if args.compile_mode == "compile-and-xclbin":
+        backend = XRTBackend(**common_kwargs)
+        backend.compile(module)
+        backend.unload()
+        sys.exit(0)
+
+    runner = XRTRunner(**common_kwargs)
+    sys.exit(
+        runner.run_test(
+            module,
+            inputs=[A, B_packed],
+            expected_outputs=[C_ref],
+            rtol=0.1,
+            atol=0.05,
+            max_mismatch_percentage=0.05,
+            min_correlation=0.999,
+        )
+    )

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/mm_bf16_x_bfp16.cc
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/mm_bf16_x_bfp16.cc
@@ -1,0 +1,142 @@
+//===- mm_bf16_x_bfp16.cc - bf16 A x bfp16ebs8 B -> bf16 C kernel ---------===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Mixed-precision GEMM micro-kernel: bf16 activations × bfp16ebs8 weights,
+// f32 L1 accumulator, bf16 store-out. Targets AIE2P `mac_8x8_8x8T` BFP MMUL.
+// B is uint8 at the AIR boundary (no MLIR bfp16ebs8 element type) and the
+// kernel reinterprets via `aie::block_vector<bfp16ebs8>`.
+//
+//===----------------------------------------------------------------------===//
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+#ifndef DIM_M
+#define DIM_M 64
+#endif
+#ifndef DIM_K
+#define DIM_K 64
+#endif
+#ifndef DIM_N
+#define DIM_N 64
+#endif
+
+constexpr aie::rounding_mode round_mode = aie::rounding_mode::conv_even;
+
+// C is N-outer M-inner [n_b][m_b][r][t] (instead of the more natural M-outer)
+// so the L1->L2 drain DMA fits in the AIE2P 3-dim BD step limit.
+template <unsigned rowA, unsigned colA, unsigned colB, unsigned r, unsigned s,
+          unsigned t>
+static void matmul_vectorized_2x2_bfp16_bf16_f32(const bfloat16 *__restrict pA,
+                                                 const bfp16ebs8 *__restrict pB,
+                                                 float *__restrict pC) {
+  const unsigned sizeA = r * s;
+  const unsigned sizeB = s * t;
+  const unsigned sizeC = r * t;
+
+  for (unsigned j = 0; j < colB; j += 2) {
+    float *__restrict pC1 = pC + (j * rowA) * sizeC;
+    float *__restrict pC2 = pC + ((j + 1) * rowA) * sizeC;
+
+    for (unsigned z = 0; z < rowA; z += 2) {
+      const bfloat16 *__restrict pA1 = pA + (z * colA) * sizeA;
+      const bfloat16 *__restrict pA2 = pA + ((z + 1) * colA) * sizeA;
+
+      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pB1bfp16(pB);
+      aie::block_vector_input_buffer_stream<bfp16ebs8, 64> pB2bfp16(pB);
+      pB1bfp16.seek(j * colA);
+      pB2bfp16.seek((j + 1) * colA);
+
+      aie::vector<bfloat16, sizeA> A0;
+      aie::vector<bfloat16, sizeA> A1;
+      aie::block_vector<bfp16ebs8, sizeB> B0;
+      aie::block_vector<bfp16ebs8, sizeB> B1;
+
+      aie::accum<accfloat, sizeC> accC00(aie::load_v<sizeC>(pC1));
+      aie::accum<accfloat, sizeC> accC10(aie::load_v<sizeC>(pC1 + sizeC));
+      aie::accum<accfloat, sizeC> accC01(aie::load_v<sizeC>(pC2));
+      aie::accum<accfloat, sizeC> accC11(aie::load_v<sizeC>(pC2 + sizeC));
+
+      aie::accum<accfloat, 64> accA0;
+      aie::accum<accfloat, 64> accA1;
+
+      // Indexed loads avoid VLD_x_pstm_nrm_imm_pseudo Peano backend bug at
+      // small tiles; no perf impact at larger tiles.
+      for (unsigned i = 0; i < colA; ++i) {
+        A0 = aie::load_v<sizeA>(pA1 + i * sizeA);
+        A1 = aie::load_v<sizeA>(pA2 + i * sizeA);
+
+        accA0 = A0;
+        accA1 = mul_elem_64(A1, concat(broadcast_one_to_v32bfloat16(),
+                                       broadcast_one_to_v32bfloat16()));
+
+        B0 = pB1bfp16.pop();
+        B1 = pB2bfp16.pop();
+
+        accC00 = mac_8x8_8x8T(accA0.to_vector<bfp16ebs8>(), B0, accC00);
+        accC01 = mac_8x8_8x8T(accA0.to_vector<bfp16ebs8>(), B1, accC01);
+        accC10 = mac_8x8_8x8T(accA1.to_vector<bfp16ebs8>(), B0, accC10);
+        accC11 = mac_8x8_8x8T(accA1.to_vector<bfp16ebs8>(), B1, accC11);
+      }
+
+      aie::store_v(pC1, accC00.template to_vector<float>());
+      aie::store_v(pC1 + sizeC, accC10.template to_vector<float>());
+      pC1 += 2 * sizeC;
+      aie::store_v(pC2, accC01.template to_vector<float>());
+      aie::store_v(pC2 + sizeC, accC11.template to_vector<float>());
+      pC2 += 2 * sizeC;
+    }
+  }
+}
+
+template <unsigned m_tile, unsigned n_tile>
+static void zero_mn_f32_impl(float *__restrict c) {
+  constexpr unsigned VW = 16;
+  constexpr unsigned NTOT = m_tile * n_tile;
+  static_assert(NTOT % VW == 0,
+                "m_tile*n_tile must be a multiple of f32 vector width");
+  aie::vector<float, VW> zv = aie::zeros<float, VW>();
+  for (unsigned i = 0; i < NTOT; i += VW)
+    aie::store_v(c + i, zv);
+}
+
+template <unsigned m_tile, unsigned n_tile>
+static void f32_to_bf16_mn_impl(const float *__restrict src,
+                                bfloat16 *__restrict dst) {
+  constexpr unsigned VW = 16;
+  constexpr unsigned NTOT = m_tile * n_tile;
+  static_assert(NTOT % VW == 0, "m_tile*n_tile must be a multiple of VW");
+  for (unsigned i = 0; i < NTOT; i += VW) {
+    aie::vector<float, VW> v = aie::load_v<VW>(src + i);
+    aie::vector<bfloat16, VW> vb;
+    for (unsigned j = 0; j < VW; j++)
+      vb[j] = (bfloat16)v[j];
+    aie::store_v(dst + i, vb);
+  }
+}
+
+extern "C" {
+
+void matmul_bf16_x_bfp16_packed_f32(bfloat16 *pA, uint8_t *pB_bytes,
+                                    float *pC) {
+  constexpr int r = 8, s = 8, t = 8;
+  constexpr int m = DIM_M, k = DIM_K, n = DIM_N;
+  static_assert(m % (2 * r) == 0, "DIM_M must be multiple of 16 (2x mmul m)");
+  static_assert(n % (2 * t) == 0, "DIM_N must be multiple of 16 (2x mmul n)");
+  static_assert(k % s == 0, "DIM_K must be multiple of 8 (mmul k)");
+  ::aie::set_rounding(round_mode);
+  const bfp16ebs8 *pB = reinterpret_cast<const bfp16ebs8 *>(pB_bytes);
+  matmul_vectorized_2x2_bfp16_bf16_f32<m / r, k / s, n / t, r, s, t>(pA, pB,
+                                                                     pC);
+}
+
+void zero_vectorized_f32_mn(float *pC) { zero_mn_f32_impl<DIM_M, DIM_N>(pC); }
+
+void f32_to_bf16_mn(float *src, bfloat16 *dst) {
+  ::aie::set_rounding(round_mode);
+  f32_to_bf16_mn_impl<DIM_M, DIM_N>(src, dst);
+}
+
+} // extern "C"

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/run_packed_npu2_llama_qproj_peano.lit
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/run_packed_npu2_llama_qproj_peano.lit
@@ -1,0 +1,13 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_bf16_x_bfp16_npu2_llama_qproj_peano
+// RUN: cd test_bf16_x_bfp16_npu2_llama_qproj_peano
+// RUN: make -f %S/Makefile clean
+//
+// Llama-3.2-1B Q-projection scale: A[2048,2048] @ B[2048,2048], 8x4 herd,
+// 64x64 tile, full-K single segment iter.
+// RUN: make -f %S/Makefile run M=2048 K=2048 N=2048 TILE_M=64 TILE_N=64 TILE_K_L1=128 TILE_K_L2=2048 HERD_M=8 HERD_N=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/run_packed_npu2_small_peano.lit
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/run_packed_npu2_small_peano.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_bf16_x_bfp16_npu2_small_peano
+// RUN: cd test_bf16_x_bfp16_npu2_small_peano
+// RUN: make -f %S/Makefile clean
+//
+// bf16 A x bfp16ebs8 B -> bf16 C mixed-precision GEMM smoke: single PE,
+// 64x64x64 tile, no K loop. Smallest config that exercises the full
+// AIR -> AIE pipeline with the bfp16ebs8 type-pun across the AIR boundary.
+// RUN: make -f %S/Makefile run M=64 K=64 N=64 TILE_M=64 TILE_K_L1=64 TILE_N=64 HERD_M=1 HERD_N=1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/test.cpp
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/test.cpp
@@ -1,0 +1,194 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "cxxopts.hpp"
+#include <bits/stdc++.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <stdfloat>
+
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+using A_DATATYPE = std::bfloat16_t;
+using B_DATATYPE = uint8_t; // bfp16ebs8 weights transported as raw bytes
+using C_DATATYPE = std::bfloat16_t;
+
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>())("size_m,M", "Matrix size M",
+                                     cxxopts::value<int>())(
+      "size_n,N", "Matrix size N", cxxopts::value<int>())(
+      "size_k,K", "Matrix size K", cxxopts::value<int>());
+}
+
+static inline std::bfloat16_t random_bfloat16_t() {
+  return std::bfloat16_t(0.5f * (float)rand() / (float)(RAND_MAX));
+}
+
+int main(int argc, const char *argv[]) {
+
+  cxxopts::Options options("Allowed options");
+  cxxopts::ParseResult vm;
+  add_default_options(options);
+  test_utils::parse_options(argc, argv, options, vm);
+  int verbosity = vm["verbosity"].as<int>();
+
+  int M = vm["size_m"].as<int>();
+  int K = vm["size_k"].as<int>();
+  int N = vm["size_n"].as<int>();
+
+  // bfp16ebs8 packs 8 elements into 9 bytes; K*N must be a multiple of 8.
+  if ((K * N) % 8 != 0) {
+    std::cerr << "error: K*N must be a multiple of 8 (bfp16ebs8 block size)\n";
+    return 1;
+  }
+
+  int A_VOLUME = M * K;
+  int B_VOLUME_BYTES = (K * N) * 9 / 8;
+  int C_VOLUME = M * N;
+
+  int A_SIZE = A_VOLUME * sizeof(A_DATATYPE);
+  int B_SIZE = B_VOLUME_BYTES;
+  int C_SIZE = C_VOLUME * sizeof(C_DATATYPE);
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node, verbosity](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 if (verbosity >= 1) {
+                                   std::cout << "Name: " << name << std::endl;
+                                 }
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_a =
+      xrt::bo(device, A_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_b =
+      xrt::bo(device, B_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_c =
+      xrt::bo(device, C_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
+  for (int i = 0; i < A_VOLUME; i++)
+    bufA[i] = random_bfloat16_t();
+  B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
+  for (int i = 0; i < B_VOLUME_BYTES; i++)
+    bufB[i] = (uint8_t)(rand() & 0xff);
+  C_DATATYPE *bufC = bo_c.map<C_DATATYPE *>();
+  std::memset(bufC, 0, C_SIZE);
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned n_iterations = 20;
+  unsigned n_warmup_iterations = 10;
+  unsigned num_iter = n_iterations + n_warmup_iterations;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+
+  float macs = 2.0 * float(M) * float(K) * float(N);
+
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+
+    if (verbosity >= 1) {
+      std::cout << "Running Kernel.\n";
+    }
+    auto start = std::chrono::high_resolution_clock::now();
+    unsigned int opcode = 3;
+    auto run = kernel(opcode, bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+    bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    if (iter < n_warmup_iterations) {
+      continue;
+    }
+
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+  }
+
+  std::cout << std::endl
+            << "Avg NPU matmul time: " << npu_time_total / n_iterations << "us."
+            << std::endl;
+  std::cout << "Avg NPU gflops: "
+            << macs / (1000 * npu_time_total / n_iterations) << std::endl;
+
+  std::cout << std::endl
+            << "Min NPU matmul time: " << npu_time_min << "us." << std::endl;
+  std::cout << "Max NPU gflops: " << macs / (1000 * npu_time_min) << std::endl;
+
+  std::cout << std::endl
+            << "Max NPU matmul time: " << npu_time_max << "us." << std::endl;
+  std::cout << "Min NPU gflops: " << macs / (1000 * npu_time_max) << std::endl;
+
+  return 0;
+}

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/test.cpp
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/test.cpp
@@ -89,15 +89,19 @@ int main(int argc, const char *argv[]) {
   std::string Node = vm["kernel"].as<std::string>();
 
   auto xkernels = xclbin.get_kernels();
-  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
-                               [Node, verbosity](xrt::xclbin::kernel &k) {
-                                 auto name = k.get_name();
-                                 if (verbosity >= 1) {
-                                   std::cout << "Name: " << name << std::endl;
-                                 }
-                                 return name.rfind(Node, 0) == 0;
-                               });
-  auto kernelName = xkernel.get_name();
+  auto it = std::find_if(xkernels.begin(), xkernels.end(),
+                         [Node, verbosity](xrt::xclbin::kernel &k) {
+                           auto name = k.get_name();
+                           if (verbosity >= 1) {
+                             std::cout << "Name: " << name << std::endl;
+                           }
+                           return name.rfind(Node, 0) == 0;
+                         });
+  if (it == xkernels.end()) {
+    std::cerr << "error: kernel '" << Node << "' not found in xclbin\n";
+    return 1;
+  }
+  auto kernelName = it->get_name();
 
   if (verbosity >= 1)
     std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
@@ -113,7 +117,7 @@ int main(int argc, const char *argv[]) {
     std::cout << "Getting handle to kernel:" << kernelName << "\n";
   auto kernel = xrt::kernel(context, kernelName);
 
-  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(instr_v[0]),
                           XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
   auto bo_a =
       xrt::bo(device, A_SIZE, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
@@ -135,7 +139,7 @@ int main(int argc, const char *argv[]) {
   std::memset(bufC, 0, C_SIZE);
 
   void *bufInstr = bo_instr.map<void *>();
-  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(instr_v[0]));
 
   bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);


### PR DESCRIPTION
## Summary

- Adds `programming_examples/matrix_multiplication/bf16_x_bfp16/`: bf16 A x bfp16ebs8 B -> bf16 C mixed-precision GEMM on NPU2, with f32 L1 accumulator.
- Uses AIE2P \`mac_8x8_8x8T\` BFP MMUL via an external Peano kernel. The bfp16ebs8 type is not a first-class MLIR element type, so B is transported as \`uint8\` at the AIR boundary and the kernel reinterprets via \`aie::block_vector<bfp16ebs8>\`.
- AIR builder mirrors the bf16 baseline's 3-herd structure (zero-init / compute / drain) so the segment-shared L1_C f32 accumulator persists across K-l2 staging without bf16 truncation between K chunks.
- Includes a vectorized \`pack_b_bfp16ebs8\` host packer + CPU reference, a C++ XRT timing harness (mirrors \`bf16/test.cpp\`), and two lit tests (small smoke + Q-proj scale).

## Measured perf (Strix Point NPU2, 8x4 herd, 2048x2048x2048, tile 64x64, tile_k_l1=128)

| | Latency | Throughput |
|---|---|---|
| Avg | 3163 us | 5431 GFLOPS |
| Min | 3142 us | 5468 GFLOPS |
| Max | 3189 us | 5387 GFLOPS |

Correlation vs f32 CPU reference: 0.999976.

## Test plan

- [x] \`make run M=64 K=64 N=64 TILE_M=64 TILE_K_L1=64 TILE_N=64 HERD_M=1 HERD_N=1\` (small smoke) -> PASS, correlation 0.999975
- [x] \`make run M=2048 K=2048 N=2048 TILE_M=64 TILE_N=64 TILE_K_L1=128 TILE_K_L2=2048 HERD_M=8 HERD_N=4\` (Q-proj scale) -> PASS, correlation 0.999976
- [x] \`make profile\` at Q-proj scale -> 5.43 TFLOPS avg / 5.47 TFLOPS min
- [x] \`clang-format-17\` clean on \`mm_bf16_x_bfp16.cc\` and \`test.cpp\`
- [x] \`black\` (26.5.1) clean on \`matmul_bf16_x_bfp16.py\` and \`generate_readme.py\`
- [ ] \`lit -sv programming_examples/matrix_multiplication/bf16_x_bfp16/\` covers both .lit files in CI

## Notes

- Kernel uses indexed loads \`pA + i*sizeA\` instead of post-increment \`pA += sizeA\` to work around a Peano \`VLD_x_pstm_nrm_imm_pseudo\` backend crash at small tiles (e.g. 16x16). Same crash fires in mlir-aie's reference \`aie_kernels/aie2p/mm_bfp_mixed.cc\` at the same tile sizes. No perf impact at 64x64.
- Per-PE L1 footprint at 64x64 tile_k_l1=128: ~49 KB (L1_A bf16 16 KB + L1_B bfp16 9 KB + L1_C f32 16 KB + L1_C drain bf16 8 KB), fits in NPU2's 64 KB L1.
- Chess toolchain is intentionally not supported (no bfp16ebs8 codegen path); Makefile errors if \`PEANO_INSTALL_DIR\` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)