### PR TITLE
[Transform][AIRToAIE] Preserve loop_annotation through async-token rewrites

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1816,6 +1816,12 @@ struct LowerScfTokenPattern : public OpRewritePattern<scf::ForOp> {
     if (fop->hasAttr("unroll")) {
       new_fop->setAttr("unroll", fop->getAttr("unroll"));
     }
+    // Preserve user-attached loop_annotation (e.g., unroll-disable for
+    // Peano). Without this, Peano -O2 aggressively unrolls small-trip
+    // loops and blows program memory on AIE2P.
+    if (fop->hasAttr("loop_annotation")) {
+      new_fop->setAttr("loop_annotation", fop->getAttr("loop_annotation"));
+    }
 
     // use the new for op's results
     int idx = 0;

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -1244,6 +1244,11 @@ private:
     if (auto attr = loop_op->getAttrOfType<StringAttr>(
             SymbolTable::getSymbolAttrName()))
       new_loop_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
+    // Preserve user-attached loop_annotation (e.g., unroll-disable for
+    // Peano). This is dropped by default since the new loop is a fresh
+    // op with only a few hand-copied attributes.
+    if (auto attr = loop_op->getAttr("loop_annotation"))
+      new_loop_op->setAttr("loop_annotation", attr);
 
     // Splice the operations inside loop op INCLUDING the terminator
     auto &bb = new_loop_op.getBody()->getOperations();
@@ -1303,6 +1308,8 @@ private:
     if (auto attr = loop_op->getAttrOfType<StringAttr>(
             SymbolTable::getSymbolAttrName()))
       new_loop_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
+    if (auto attr = loop_op->getAttr("loop_annotation"))
+      new_loop_op->setAttr("loop_annotation", attr);
 
     // Splice the operations inside loop op
     auto &bb = new_loop_op.getBody()->getOperations();

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -801,6 +801,11 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
   if (auto attr =
           for_op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
     new_for_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
+  // Preserve loop_annotation (user code attaches it to disable Peano
+  // unrolling). Without this, Peano -O2 aggressively unrolls small-trip
+  // loops and blows program memory.
+  if (auto attr = for_op->getAttr("loop_annotation"))
+    new_for_op->setAttr("loop_annotation", attr);
   remap.map(for_op.getInductionVar(), new_for_op.getInductionVar());
   remap.map(getLoopCarriedTokenFromScfOp(for_op, "argument"),
             getLoopCarriedTokenFromScfOp(new_for_op, "argument"));

--- a/mlir/test/Conversion/AIRToAIE/lower_scf_token_preserves_loop_annotation.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_scf_token_preserves_loop_annotation.mlir
@@ -1,0 +1,42 @@
+//===- lower_scf_token_preserves_loop_annotation.mlir ----------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie='test-patterns=lower-scf-tokens' | FileCheck %s
+
+// LowerScfTokenPattern strips !air.async.token iter_args from scf.for by
+// building a fresh sync scf.for and hand-copying a few attrs. A user-attached
+// llvm.loop_annotation was dropped. Verify it survives.
+
+#loop_unroll = #llvm.loop_unroll<disable = true>
+#loop_annotation = #llvm.loop_annotation<unroll = #loop_unroll, mustProgress = true>
+
+// CHECK-DAG: #[[$LOOP_UNROLL:.*]] = #llvm.loop_unroll<disable = true>
+// CHECK-DAG: #[[$LOOP_ANNOT:.*]] = #llvm.loop_annotation<unroll = #[[$LOOP_UNROLL]], mustProgress = true>
+
+module attributes {torch.debug_module_name = "mmult"} {
+  func.func @lower_scf_token_preserves_loop_annotation(%arg0: memref<32x32xi32, 2>, %arg1: memref<32x32xi32, 2>, %arg2: memref<32x32xi32, 2>) {
+    %c1 = arith.constant 1 : index
+    air.herd @herd_0 tile (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<32x32xi32, 2>, memref<32x32xi32, 2>, memref<32x32xi32, 2> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %c32 = arith.constant 32 : index
+      %c64 = arith.constant 64 : index
+      %0 = air.wait_all async
+      // CHECK: scf.for %{{.*}} = %c0 to %c64 step %c32 {
+      // CHECK: } {loop_annotation = #[[$LOOP_ANNOT]]}
+      %1 = scf.for %arg10 = %c0 to %c64 step %c32 iter_args(%arg11 = %0) -> (!air.async.token) {
+        %asyncToken = air.execute [%arg11] {
+          linalg.matmul ins(%arg7, %arg8 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%arg9 : memref<32x32xi32, 2>)
+          air.execute_terminator
+        } {id = 1 : i32}
+        %2 = air.wait_all async [%asyncToken]
+        scf.yield %2 : !air.async.token
+      } {loop_annotation = #loop_annotation}
+      air.wait_all [%1]
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependency/preserve_loop_annotation.mlir
+++ b/mlir/test/Transform/AIRDependency/preserve_loop_annotation.mlir
@@ -1,0 +1,55 @@
+//===- preserve_loop_annotation.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+// air-dependency rewrites sync scf.for / scf.parallel that touch async ops
+// into async versions by building a fresh op with an extra !air.async.token
+// iter_arg / init_val. The fresh op was created with only sym_name copied,
+// so a user-attached llvm.loop_annotation (used to disable Peano -O2
+// unrolling) was dropped. Verify it survives.
+
+#loop_unroll = #llvm.loop_unroll<disable = true>
+#loop_annotation = #llvm.loop_annotation<unroll = #loop_unroll, mustProgress = true>
+
+// CHECK-DAG: #[[$LOOP_UNROLL:.*]] = #llvm.loop_unroll<disable = true>
+// CHECK-DAG: #[[$LOOP_ANNOT:.*]] = #llvm.loop_annotation<unroll = #[[$LOOP_UNROLL]], mustProgress = true>
+
+// CHECK-LABEL: func.func @preserve_loop_annotation_scf_for
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: } {loop_annotation = #[[$LOOP_ANNOT]]}
+func.func @preserve_loop_annotation_scf_for(%arg0: memref<4096xi32>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  scf.for %arg1 = %c0 to %c4 step %c1 {
+    %0 = arith.muli %arg1, %c32 : index
+    %1 = memref.alloc() : memref<32xi32, 2>
+    air.dma_memcpy_nd (%1[] [] [], %arg0[%0] [%c32] [%c1]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
+    memref.dealloc %1 : memref<32xi32, 2>
+  } {loop_annotation = #loop_annotation}
+  return
+}
+
+// CHECK-LABEL: func.func @preserve_loop_annotation_scf_parallel
+// CHECK: scf.parallel
+// CHECK: } {loop_annotation = #[[$LOOP_ANNOT]]}
+func.func @preserve_loop_annotation_scf_parallel(%arg0: memref<4096xi32>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  scf.parallel (%arg1) = (%c0) to (%c4) step (%c1) {
+    %0 = arith.muli %arg1, %c32 : index
+    %1 = memref.alloc() : memref<32xi32, 2>
+    air.dma_memcpy_nd (%1[] [] [], %arg0[%0] [%c32] [%c1]) {id = 2 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
+    memref.dealloc %1 : memref<32xi32, 2>
+    scf.reduce
+  } {loop_annotation = #loop_annotation}
+  return
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_preserves_loop_annotation.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_preserves_loop_annotation.mlir
@@ -1,0 +1,77 @@
+//===- hoist_preserves_loop_annotation.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-hoist-ops-not-using-ping-pong | FileCheck %s
+
+// HoistOpsNotUsingPingPongPattern (in AIRDependencyScheduleOpt.cpp) calls
+// hoistTargetOpsToNewSCFFor (in Util/Dependency.cpp). That helper creates
+// a fresh scf.for to receive the hoisted ops and only copies sym_name by
+// default, so a user-attached llvm.loop_annotation on the labeled outer
+// loop was dropped. Verify it survives on the new isolated loop too.
+
+#loop_unroll = #llvm.loop_unroll<disable = true>
+#loop_annotation = #llvm.loop_annotation<unroll = #loop_unroll, mustProgress = true>
+
+// CHECK-DAG: #[[$LOOP_UNROLL:.*]] = #llvm.loop_unroll<disable = true>
+// CHECK-DAG: #[[$LOOP_ANNOT:.*]] = #llvm.loop_annotation<unroll = #[[$LOOP_UNROLL]], mustProgress = true>
+
+// CHECK-LABEL: hoist_preserves_loop_annotation
+// The first hoisted scf.for (containing the herd) inherits loop_annotation.
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: air.herd
+// CHECK: scf.yield
+// CHECK: } {loop_annotation = #[[$LOOP_ANNOT]]}
+// The original loop (now isolated) keeps it too.
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: memref.alloc() {hoist_alloc = "true"}
+// CHECK: scf.yield
+// CHECK: {isolated = true, loop_annotation = #[[$LOOP_ANNOT]], unroll = 2 : i64}
+
+air.channel @channel_1 [1, 1]
+air.channel @channel_0 [1, 1]
+func.func @hoist_preserves_loop_annotation(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
+    %1 = air.segment async args(%arg14=%arg8, %arg15=%arg9) : memref<256x1024xbf16>, memref<1024x1024xbf16> {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c512 = arith.constant 512 : index
+      %c64 = arith.constant 64 : index
+      %30 = air.wait_all async
+      %31 = scf.for %arg20 = %c0 to %c2 step %c1_0 iter_args(%arg21 = %30) -> (!air.async.token) {
+        %async_token, %results = air.execute [%arg21] -> (memref<32x32xbf16, 1>) {
+          %alloc = memref.alloc() {hoist_alloc = "true"} : memref<32x32xbf16, 1>
+          air.execute_terminator %alloc : memref<32x32xbf16, 1>
+        }
+        %2 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
+          %5 = air.channel.put async [%arg17] @channel_0[] (%results[] [] []) : (memref<32x32xbf16, 1>)
+          scf.yield %5 : !air.async.token
+        }
+        %3 = air.herd @herd_0 async [%async_token] tile (%arg16, %arg17) in (%arg18=%c1_0, %arg19=%c1_0) {
+          %5 = air.wait_all async
+          %async_token_4, %results_5 = air.execute [%5] -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_9 = air.execute [%async_token_4] {
+            memref.dealloc %results_5 : memref<32x32xbf16, 2>
+          }
+        }
+        %4 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
+          %5 = air.channel.get async [%arg17] @channel_1[] (%results[] [] []) : (memref<32x32xbf16, 1>)
+          scf.yield %5 : !air.async.token
+        }
+        %async_token_1 = air.execute [%4, %2] {
+          memref.dealloc %results : memref<32x32xbf16, 1>
+        }
+        scf.yield %async_token_1 : !air.async.token
+      } {loop_annotation = #loop_annotation, unroll = 2}
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

Several AIR passes replace an existing `scf.for` / `scf.parallel` with a fresh
op (to add or strip the loop-carried `!air.async.token` iter_arg), hand-copy a
small set of attributes, and let the rest fall on the floor. A user-attached
`llvm.loop_annotation` — the canonical way to disable Peano `-O2` unrolling on
small-trip loops via

```mlir
#llvm.loop_annotation<unroll = <disable = true>, mustProgress = true>
```

— was one of the attrs that fell off. Without it, Peano aggressively unrolls a
row / group / subgroup loop in inline AWQ-style int4 kernels and the per-core
program memory blows past the 16 KB AIE2P budget.

## Change

Patch the four call sites that build a fresh loop and propagate
`loop_annotation` alongside the existing `sym_name` / `unroll` copies:

| File | Site | Pass surface |
|------|------|--------------|
| `mlir/lib/Conversion/AIRToAIEPass.cpp` | `LowerScfTokenPattern` | `-air-to-aie` (strips the !air.async.token iter_arg before AIE codegen) |
| `mlir/lib/Transform/AIRDependency.cpp` | `convertScfForToAsync` | `-air-dependency` (adds the token iter_arg during the initial AIR dependency build) |
| `mlir/lib/Transform/AIRDependency.cpp` | `convertScfParToAsync` | `-air-dependency` (same, parallel variant) |
| `mlir/lib/Util/Dependency.cpp` | `hoistTargetOpsToNewSCFFor` | `-air-hoist-ops-not-using-ping-pong` et al. (helper that isolates a sub-loop's body) |

## Tests

Three new lit tests, one per pass surface.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>