### PR TITLE
[Transform] LabelScfForLoopForPingPong: dedup channel.gets in mutually-exclusive affine.if branches

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1631,7 +1631,14 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
 
     // Reject if any candidate alloc has >1 channel.get/iter, or if any
     // intervening loop has a non-static trip count (can't bound the count).
+    //
+    // Channel.gets inside mutually-exclusive `affine.if` branches (introduced
+    // by air-specialize-dma-broadcast for index-dispatched broadcasts) all
+    // read into the same alloc but only ONE runs per iter. Group those into
+    // a single occurrence using the enclosing top-level affine.if as a
+    // discriminator, so we don't reject just because there are N branches.
     llvm::DenseSet<Value> seenOnce;
+    llvm::DenseSet<std::pair<Value, Operation *>> seenInAffineIf;
     bool reject = false;
     forOp.getBody()->walk<WalkOrder::PreOrder>(
         [&](Operation *op) -> WalkResult {
@@ -1644,7 +1651,23 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
           if (it == aliasToCanonical.end())
             return WalkResult::advance();
           auto trip = air::getStaticTripCountInRange(op, forOp.getOperation());
-          if (!trip || *trip > 1 || !seenOnce.insert(it->second).second) {
+          if (!trip || *trip > 1) {
+            reject = true;
+            return WalkResult::interrupt();
+          }
+          // Find the outermost affine.if between op and forOp.
+          Operation *topIf = nullptr;
+          for (Operation *p = op->getParentOp();
+               p && p != forOp.getOperation(); p = p->getParentOp()) {
+            if (isa<mlir::affine::AffineIfOp>(p))
+              topIf = p;
+          }
+          if (topIf) {
+            // Multiple gets to the same alloc inside the same affine.if
+            // chain are mutually-exclusive branches; dedup by (alloc, topIf).
+            if (!seenInAffineIf.insert({it->second, topIf}).second)
+              return WalkResult::advance();
+          } else if (!seenOnce.insert(it->second).second) {
             reject = true;
             return WalkResult::interrupt();
           }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1632,13 +1632,16 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
     // Reject if any candidate alloc has >1 channel.get/iter, or if any
     // intervening loop has a non-static trip count (can't bound the count).
     //
-    // Channel.gets inside mutually-exclusive `affine.if` branches (introduced
-    // by air-specialize-dma-broadcast for index-dispatched broadcasts) all
-    // read into the same alloc but only ONE runs per iter. Group those into
-    // a single occurrence using the enclosing top-level affine.if as a
-    // discriminator, so we don't reject just because there are N branches.
-    llvm::DenseSet<Value> seenOnce;
-    llvm::DenseSet<std::pair<Value, Operation *>> seenInAffineIf;
+    // Channel.gets dispatched by `air-specialize-dma-broadcast` into a chain
+    // of `affine.if` branches all read into the same alloc but only ONE runs
+    // per iter — which is safe for ping-pong. To distinguish that case from
+    // genuinely unsafe multi-fill, check mutual exclusivity directly: two
+    // gets to the same alloc are safe iff they share a common `affine.if`
+    // ancestor where they sit in different regions (then-vs-else). Any other
+    // arrangement — siblings under separate top-level affine.ifs, two gets
+    // in the same `then`/`else` block of one ladder, gets entirely outside
+    // any affine.if — implies both can execute in the same iter, so reject.
+    llvm::SmallDenseMap<Value, SmallVector<Operation *>, 4> getsByAlloc;
     bool reject = false;
     forOp.getBody()->walk<WalkOrder::PreOrder>(
         [&](Operation *op) -> WalkResult {
@@ -1655,26 +1658,43 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
             reject = true;
             return WalkResult::interrupt();
           }
-          // Find the outermost affine.if between op and forOp.
-          Operation *topIf = nullptr;
-          for (Operation *p = op->getParentOp(); p && p != forOp.getOperation();
-               p = p->getParentOp()) {
-            if (isa<mlir::affine::AffineIfOp>(p))
-              topIf = p;
-          }
-          if (topIf) {
-            // Multiple gets to the same alloc inside the same affine.if
-            // chain are mutually-exclusive branches; dedup by (alloc, topIf).
-            if (!seenInAffineIf.insert({it->second, topIf}).second)
-              return WalkResult::advance();
-          } else if (!seenOnce.insert(it->second).second) {
-            reject = true;
-            return WalkResult::interrupt();
-          }
+          getsByAlloc[it->second].push_back(op);
           return WalkResult::advance();
         });
     if (reject)
       return false;
+
+    // For each op, collect the (affine.if, region) chain that encloses it,
+    // stopping at forOp's body.
+    auto getAffineIfPath = [&](Operation *op) {
+      SmallVector<std::pair<Operation *, Region *>, 4> path;
+      for (Region *r = op->getParentRegion();
+           r && r->getParentOp() && r->getParentOp() != forOp.getOperation();
+           r = r->getParentOp()->getParentRegion()) {
+        if (isa<mlir::affine::AffineIfOp>(r->getParentOp()))
+          path.emplace_back(r->getParentOp(), r);
+      }
+      return path;
+    };
+    // Two ops are mutually exclusive at runtime iff some common affine.if
+    // ancestor places them in different regions (one in `then`, the other
+    // in `else`).
+    auto areMutuallyExclusive = [&](Operation *a, Operation *b) {
+      auto pa = getAffineIfPath(a);
+      auto pb = getAffineIfPath(b);
+      for (auto &[aIf, aReg] : pa)
+        for (auto &[bIf, bReg] : pb)
+          if (aIf == bIf && aReg != bReg)
+            return true;
+      return false;
+    };
+    for (auto &kv : getsByAlloc) {
+      auto &gets = kv.second;
+      for (size_t i = 0; i < gets.size(); ++i)
+        for (size_t j = i + 1; j < gets.size(); ++j)
+          if (!areMutuallyExclusive(gets[i], gets[j]))
+            return false;
+    }
 
     if (allocsOut)
       *allocsOut = std::move(allocs);

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1657,8 +1657,8 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
           }
           // Find the outermost affine.if between op and forOp.
           Operation *topIf = nullptr;
-          for (Operation *p = op->getParentOp();
-               p && p != forOp.getOperation(); p = p->getParentOp()) {
+          for (Operation *p = op->getParentOp(); p && p != forOp.getOperation();
+               p = p->getParentOp()) {
             if (isa<mlir::affine::AffineIfOp>(p))
               topIf = p;
           }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_multifill_alloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_multifill_alloc.mlir
@@ -165,3 +165,80 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// Case 4 (positive): channel.gets inside mutually-exclusive `affine.if`
+// branches (the IR shape produced by `air-specialize-dma-broadcast` for
+// index-dispatched broadcasts) all write to the SAME outer-loop alloc, but
+// only ONE branch runs per outer iter. Pre-fix the multifill predicate
+// counted these as N gets and rejected the loop. Post-fix: dedup by the
+// outermost `affine.if` between the get and the for, so the chain registers
+// as a single per-iter occurrence and the loop is labeled.
+// =============================================================================
+
+// CHECK-LABEL: func.func @affine_if_broadcast_branches_eligible
+// CHECK:       scf.for
+// CHECK:       memref.alloc() {hoist_alloc = true} : memref<32x32xbf16, 2>
+// CHECK:       } {unroll = 2 : i32}
+
+#set_a = affine_set<()[s0] : (s0 == 0)>
+#set_b = affine_set<()[s0] : (s0 - 1 == 0)>
+#set_c = affine_set<()[s0] : (s0 - 2 == 0)>
+
+module {
+  air.channel @chA [1, 1] {broadcast_shape = [1, 4]}
+  air.channel @chB [1, 1] {broadcast_shape = [1, 4]}
+  air.channel @chC [1, 1] {broadcast_shape = [1, 4]}
+  air.channel @chD [1, 1] {broadcast_shape = [1, 4]}
+
+  func.func @affine_if_broadcast_branches_eligible(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%col, %row) in (%cs=%c4, %rs=%c4) {
+          %c0 = arith.constant 0 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %iv = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            // N=4 mutually-exclusive affine.if branches dispatch on the herd
+            // column index. Each branch reads via a distinct channel into the
+            // same alloc. Only one branch runs per iter, so this is logically
+            // a single get-per-iter, not 4.
+            %g = affine.if #set_a()[%col] -> !air.async.token {
+              %ga = air.channel.get async [%async_token_a] @chA[] (%results_a[] [] []) {id = 1 : i32} : (memref<32x32xbf16, 2>)
+              affine.yield %ga : !air.async.token
+            } else {
+              %gb = affine.if #set_b()[%col] -> !air.async.token {
+                %gbb = air.channel.get async [%async_token_a] @chB[] (%results_a[] [] []) {id = 2 : i32} : (memref<32x32xbf16, 2>)
+                affine.yield %gbb : !air.async.token
+              } else {
+                %gc = affine.if #set_c()[%col] -> !air.async.token {
+                  %gcc = air.channel.get async [%async_token_a] @chC[] (%results_a[] [] []) {id = 3 : i32} : (memref<32x32xbf16, 2>)
+                  affine.yield %gcc : !air.async.token
+                } else {
+                  %gd = air.channel.get async [%async_token_a] @chD[] (%results_a[] [] []) {id = 4 : i32} : (memref<32x32xbf16, 2>)
+                  affine.yield %gd : !air.async.token
+                }
+                affine.yield %gc : !air.async.token
+              }
+              affine.yield %gb : !air.async.token
+            }
+            %async_token_d = air.execute [%g] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_multifill_alloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_multifill_alloc.mlir
@@ -242,3 +242,126 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// Case 5 (negative): two SIBLING top-level `affine.if`s, each independently
+// gating its own `air.channel.get` into the same outer-loop alloc. The two
+// affine.ifs are NOT mutually exclusive (no common affine.if ancestor places
+// them in different regions), so both gets can execute in the same iter ->
+// genuine multi-fill -> reject. Guards against the dedup over-broadening.
+// =============================================================================
+
+// CHECK-LABEL: func.func @sibling_affine_ifs_rejected
+// CHECK:       scf.for
+// CHECK-NOT:   hoist_alloc
+// CHECK-NOT:   } {unroll
+// CHECK:       return
+
+#set_x = affine_set<()[s0] : (s0 == 0)>
+#set_y = affine_set<()[s0] : (s0 - 1 == 0)>
+
+module {
+  air.channel @chX [1, 1]
+  air.channel @chY [1, 1]
+
+  func.func @sibling_affine_ifs_rejected(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%col, %row) in (%cs=%c4, %rs=%c4) {
+          %c0 = arith.constant 0 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %iv = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            // Two TOP-LEVEL affine.ifs back-to-back. Their predicates may
+            // both evaluate true in the same iter; nothing makes them
+            // mutually exclusive. Must reject.
+            %g1 = affine.if #set_x()[%col] -> !air.async.token {
+              %gx = air.channel.get async [%async_token_a] @chX[] (%results_a[] [] []) {id = 1 : i32} : (memref<32x32xbf16, 2>)
+              affine.yield %gx : !air.async.token
+            } else {
+              affine.yield %async_token_a : !air.async.token
+            }
+            %g2 = affine.if #set_y()[%col] -> !air.async.token {
+              %gy = air.channel.get async [%g1] @chY[] (%results_a[] [] []) {id = 2 : i32} : (memref<32x32xbf16, 2>)
+              affine.yield %gy : !air.async.token
+            } else {
+              affine.yield %g1 : !air.async.token
+            }
+            %async_token_d = air.execute [%g2] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// =============================================================================
+// Case 6 (negative): two gets to the same alloc inside the same `then`
+// block of a single affine.if. Both run when the predicate is true ->
+// genuine multi-fill in that branch -> reject. Guards against per-(alloc,
+// topIf) dedup ignoring within-branch multiplicity.
+// =============================================================================
+
+// CHECK-LABEL: func.func @same_branch_two_gets_rejected
+// CHECK:       scf.for
+// CHECK-NOT:   hoist_alloc
+// CHECK-NOT:   } {unroll
+// CHECK:       return
+
+#set_p = affine_set<()[s0] : (s0 == 0)>
+
+module {
+  air.channel @chP [1, 1]
+  air.channel @chQ [1, 1]
+
+  func.func @same_branch_two_gets_rejected(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%col, %row) in (%cs=%c4, %rs=%c4) {
+          %c0 = arith.constant 0 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %iv = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            // ONE affine.if whose `then` body contains TWO sequential gets
+            // to the same alloc. They are NOT mutually exclusive (both run
+            // when the predicate is true).
+            %g = affine.if #set_p()[%col] -> !air.async.token {
+              %gp = air.channel.get async [%async_token_a] @chP[] (%results_a[] [] []) {id = 1 : i32} : (memref<32x32xbf16, 2>)
+              %gq = air.channel.get async [%gp] @chQ[] (%results_a[] [] []) {id = 2 : i32} : (memref<32x32xbf16, 2>)
+              affine.yield %gq : !air.async.token
+            } else {
+              affine.yield %async_token_a : !air.async.token
+            }
+            %async_token_d = air.execute [%g] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/test/airrunner/matmul/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul/run_makefile_airrunner.lit
@@ -5,6 +5,7 @@
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run | FileCheck %s
-// Updated post-#1647: K-tiled L1 fills no longer ping-pong'd (multi-fill
-// of the same alloc per outer iter is unsafe; see PR description).
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 1225.6us
+// Updated post-#1659: ping-pong restored for K-tiled L1 fills dispatched via
+// mutually-exclusive affine.if broadcast branches (only one branch fires per
+// outer iter, so multi-fill of the same alloc is safe).
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 1127.23us

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -6,6 +6,7 @@
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run | FileCheck %s
-// Updated post-#1647: K-tiled L1 fills no longer ping-pong'd (multi-fill
-// of the same alloc per outer iter is unsafe; see PR description).
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 429.52us
+// Updated post-#1659: ping-pong restored for K-tiled L1 fills dispatched via
+// mutually-exclusive affine.if broadcast branches (only one branch fires per
+// outer iter, so multi-fill of the same alloc is safe).
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 423.808us


### PR DESCRIPTION
## Summary

`air-specialize-dma-broadcast` lowers an index-dispatched broadcast into a chain of N `affine.if` branches, each calling `air.channel.get` on the SAME alloc. Only one branch actually runs per iteration. The pre-existing predicate in `LabelScfForLoopForPingPongPattern` counted these as N gets and rejected the loop for ping-pong labeling, even though logically there is only ONE get per iter.

This PR dedups by `(alloc, outermost affine.if between op and forOp)`: gets that share a common enclosing `affine.if` chain are mutually-exclusive branches and contribute a single occurrence to the per-iter count.

This unlocks ping-pong on the L1 act buffer for broadcast-distributed designs (observed ~12% steady-state speedup on a 4×8 conv2dk14_32core port: 1.30 ms → 1.14 ms / iter).

## Test plan

- [x] New positive test `@affine_if_broadcast_branches_eligible` in `label_ping_pong_multifill_alloc.mlir`: scf.for with 4 mutually-exclusive `affine.if` branches each reading via a distinct channel into the same alloc; post-fix the loop is labeled (`hoist_alloc=true`, `unroll=2`).
- [x] Existing `@multifill_outer_loop` and `@multifill_via_execute_yield` still REJECT inner-for multi-fill — regression guard against over-labeling.
- [x] Existing `@singlefill_outer_loop` still labels the simple single-get-per-iter case.
- [x] Full `mlir/test/Transform/` lit suite passes (210/210).
- [x] Independently verified the new positive test fails if the fix is reverted.