### PR TITLE
[Transform] Ping-pong labeling: honor air.disable_ping_pong opt-out attribute

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1599,6 +1599,27 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
                                   SmallVectorImpl<Operation *> *allocsOut) {
     if (forOp->hasAttr("unroll"))
       return false;
+    // User-facing opt-out: an scf.for in the candidate's region tree
+    // (including the candidate itself) carrying `air.disable_ping_pong`
+    // disables PP labeling for the enclosing candidate. Used by designs
+    // that know PP is unsafe or unprofitable for the surrounding loop
+    // -- e.g. an inner scf.for with vector iter_args, which today
+    // miscompiles under PP body duplication. Attaching the attr at the
+    // bug site (the inner loop) is more robust than attaching on the
+    // outer candidate, because compiler passes that rebuild fresh
+    // scf.for ops mostly leave pure-compute inner loops intact.
+    if (forOp->hasAttr("air.disable_ping_pong"))
+      return false;
+    bool optedOut = false;
+    forOp.getBody()->walk([&](scf::ForOp inner) -> WalkResult {
+      if (inner->hasAttr("air.disable_ping_pong")) {
+        optedOut = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (optedOut)
+      return false;
     SmallVector<Operation *> allocs;
     for (auto exec : forOp.getOps<air::ExecuteOp>()) {
       for (auto alloc : exec.getOps<memref::AllocOp>()) {

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_disable_opt_out.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_disable_opt_out.mlir
@@ -1,0 +1,148 @@
+//===- label_ping_pong_disable_opt_out.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// User-facing opt-out: an scf.for carrying the air.disable_ping_pong attr
+// in the input IR must NOT be labeled for ping-pong, regardless of any
+// other eligibility checks. Used by designs that know PP is unsafe or
+// unprofitable for a specific loop (e.g. a body that contains a nested
+// scf.for with vector iter_args, which today miscompiles through the
+// unroll + async-rewrite + AIE-lowering path).
+
+// RUN: air-opt %s -air-label-scf-for-to-ping-pong | FileCheck %s
+
+// =============================================================================
+// Case 1 (NEGATIVE): outer-loop alloc that would normally qualify for
+// ping-pong (single channel.get/iter, etc.), with air.disable_ping_pong
+// attached. Outer must NOT be labeled (no hoist_alloc, no unroll).
+// =============================================================================
+
+// CHECK-LABEL: func.func @opt_out_rejects
+// CHECK:       scf.for
+// CHECK-NOT:   hoist_alloc
+// CHECK-NOT:   } {unroll
+// CHECK:       return
+
+module {
+  air.channel @load_chan [1]
+  func.func @opt_out_rejects(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_0 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %arg10 = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            %fill = air.channel.get async [%async_token_a] @load_chan[] (%results_a[] [] []) : (memref<32x32xbf16, 2>)
+            %async_token_d = air.execute [%fill] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          } {air.disable_ping_pong}
+        }
+      }
+    }
+    return
+  }
+
+// =============================================================================
+// Case 2 (POSITIVE control): identical body to Case 1, but without
+// air.disable_ping_pong. Outer MUST be labeled (hoist_alloc + unroll=2).
+// Locks the predicate against unconditional rejection.
+// =============================================================================
+
+// CHECK-LABEL: func.func @no_opt_out_labels
+// CHECK:       scf.for
+// CHECK:       memref.alloc() {hoist_alloc = true} : memref<32x32xbf16, 2>
+// CHECK:       } {unroll = 2 : i32}
+// CHECK:       return
+
+  func.func @no_opt_out_labels(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 2 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_1 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %arg10 = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            %fill = air.channel.get async [%async_token_a] @load_chan[] (%results_a[] [] []) : (memref<32x32xbf16, 2>)
+            %async_token_d = air.execute [%fill] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+
+// =============================================================================
+// Case 3 (NEGATIVE, nested): air.disable_ping_pong sits on a NESTED scf.for
+// inside the candidate's body. The outer candidate must still NOT be labeled
+// -- the walk in isPingPongCandidate honors the attr at any depth.
+// =============================================================================
+
+// CHECK-LABEL: func.func @opt_out_on_nested_for_rejects_outer
+// CHECK:       scf.for
+// CHECK-NOT:   hoist_alloc
+// CHECK-NOT:   } {unroll
+// CHECK:       return
+
+  func.func @opt_out_on_nested_for_rejects_outer(%arg0: memref<256x1024xbf16>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg4) in (%arg6=%c1) attributes {id = 3 : i32} {
+      %1 = air.segment async {
+        %c4 = arith.constant 4 : index
+        %2 = air.herd @herd_2 async tile (%arg21, %arg22) in (%arg23=%c4, %arg24=%c4) {
+          %c0 = arith.constant 0 : index
+          %c1_h = arith.constant 1 : index
+          %c8 = arith.constant 8 : index
+          %c64 = arith.constant 64 : index
+          %c512 = arith.constant 512 : index
+          %cst0_bf16 = arith.constant 0.000000e+00 : bf16
+          %async_token_0 = air.wait_all async
+          %3 = scf.for %arg10 = %c0 to %c512 step %c64 iter_args(%arg11 = %async_token_0) -> (!air.async.token) {
+            // Outer-loop direct alloc -- candidate for PP labeling.
+            %async_token_a, %results_a = air.execute [%arg11] -> (memref<32x32xbf16, 2>) {
+              %alloc_a = memref.alloc() : memref<32x32xbf16, 2>
+              air.execute_terminator %alloc_a : memref<32x32xbf16, 2>
+            }
+            %fill = air.channel.get async [%async_token_a] @load_chan[] (%results_a[] [] []) : (memref<32x32xbf16, 2>)
+            // Nested compute loop. PP opt-out attached here.
+            %async_token_compute = air.execute [%fill] {
+              scf.for %arg12 = %c0 to %c8 step %c1_h {
+                %v = vector.transfer_read %results_a[%arg12, %c0], %cst0_bf16 {in_bounds = [true]} : memref<32x32xbf16, 2>, vector<32xbf16>
+                vector.transfer_write %v, %results_a[%arg12, %c0] {in_bounds = [true]} : vector<32xbf16>, memref<32x32xbf16, 2>
+              } {air.disable_ping_pong}
+            }
+            %async_token_d = air.execute [%async_token_compute] {
+              memref.dealloc %results_a : memref<32x32xbf16, 2>
+            }
+            scf.yield %async_token_d : !air.async.token
+          }
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

`LabelScfForLoopForPingPongPattern::isPingPongCandidate` now walks the
candidate's region and rejects PP labeling if any `scf.for` in the tree
(including the candidate itself) carries the `air.disable_ping_pong` attribute.

This is a user-facing opt-out for designs that know PP is unsafe or
unprofitable for a specific loop — most notably the case where the candidate's
body contains a nested `scf.for` with vector iter_args, which today miscompiles
through the PP unroll + async-rewrite + AIE-lowering path (odd-iteration
outputs come out as garbage on the order of ~1e7, correlation drops from ~1.0
to ~-0.01; reproduced on NPU2 with an inline AWQ int4 matvec).

## Why an opt-out attribute rather than a heuristic

A previous attempt (#1660, now closed) tried to detect the buggy IR shape
automatically by rejecting any candidate whose body contained a nested
`scf.for` with non-token iter_args. That predicate was too broad: it would
silently disable PP for any future design with surviving inner vector iter_args
at PP labeling time (e.g. a matmul that doesn't fully unroll its accumulator
reduction loop upstream), with no signal to the user.

The opt-out attribute is precise — only opted-in loops are affected — and
documents the workaround at the bug site in the user's design rather than
inside the compiler.

## Why walk the region tree

The attribute is checked on every `scf.for` in the region tree, not just on
the candidate, so designs can attach the attribute at the bug site (the inner
loop closest to the vector iter_args) rather than on the outer candidate.
This is more robust because the labeling pass runs much later than the
loop-rewriting passes (`air-dependency`, `air-fuse-alloc-dealloc`,
`canonicalize`), and attaching at the bug site survives even if upstream
transforms reshape the outer loop structure.

## Scope note

This PR is the labeling-pass check + lit test only. Preservation of the
attribute through the four `scf.for` / `scf.parallel` rewrite sites is in
**#1664**, which is a follow-up to the merged #1657 (`loop_annotation`
preservation through the same 4 sites). #1664 must land before this PR is
useful end-to-end.

## Test

`mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_disable_opt_out.mlir`
— three cases:

| Case | Setup | Expected |
|------|-------|----------|
| NEGATIVE outer | PP-eligible outer with `air.disable_ping_pong` | NOT labeled |
| POSITIVE control | Same outer, no attribute | Labeled (`hoist_alloc` + `unroll = 2`). Locks the predicate against unconditional rejection. |
| NEGATIVE nested | Attribute on a nested `scf.for` inside the candidate's body | Outer NOT labeled. Locks the walk-the-region semantics. |

## Related

- #1626 — `air-ping-pong-transform` nested-loop SSA dominance
- #1628 — labeling: skip outer `scf.for` if nested for is a candidate
- #1647 — labeling: reject loops with multi-fill candidate alloc
- #1657 — preserve `loop_annotation` through async-token rewrites (merged)
- **#1664** — preserve `air.disable_ping_pong` through the same sites (required for this PR)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>