### PR TITLE
[Transform][AIRToAIE] Preserve air.disable_ping_pong attr through async-token rewrites

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -1822,6 +1822,12 @@ struct LowerScfTokenPattern : public OpRewritePattern<scf::ForOp> {
     if (fop->hasAttr("loop_annotation")) {
       new_fop->setAttr("loop_annotation", fop->getAttr("loop_annotation"));
     }
+    // Preserve the user-facing ping-pong opt-out so labeling later in
+    // the pipeline still sees it.
+    if (fop->hasAttr("air.disable_ping_pong")) {
+      new_fop->setAttr("air.disable_ping_pong",
+                       fop->getAttr("air.disable_ping_pong"));
+    }
 
     // use the new for op's results
     int idx = 0;

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -1249,6 +1249,10 @@ private:
     // op with only a few hand-copied attributes.
     if (auto attr = loop_op->getAttr("loop_annotation"))
       new_loop_op->setAttr("loop_annotation", attr);
+    // Preserve the user-facing ping-pong opt-out so labeling later still
+    // sees it.
+    if (auto attr = loop_op->getAttr("air.disable_ping_pong"))
+      new_loop_op->setAttr("air.disable_ping_pong", attr);
 
     // Splice the operations inside loop op INCLUDING the terminator
     auto &bb = new_loop_op.getBody()->getOperations();
@@ -1310,6 +1314,8 @@ private:
       new_loop_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
     if (auto attr = loop_op->getAttr("loop_annotation"))
       new_loop_op->setAttr("loop_annotation", attr);
+    if (auto attr = loop_op->getAttr("air.disable_ping_pong"))
+      new_loop_op->setAttr("air.disable_ping_pong", attr);
 
     // Splice the operations inside loop op
     auto &bb = new_loop_op.getBody()->getOperations();

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -806,6 +806,10 @@ scf::ForOp hoistTargetOpsToNewSCFFor(PatternRewriter &rewriter,
   // loops and blows program memory.
   if (auto attr = for_op->getAttr("loop_annotation"))
     new_for_op->setAttr("loop_annotation", attr);
+  // Preserve the user-facing ping-pong opt-out so labeling later still
+  // sees it.
+  if (auto attr = for_op->getAttr("air.disable_ping_pong"))
+    new_for_op->setAttr("air.disable_ping_pong", attr);
   remap.map(for_op.getInductionVar(), new_for_op.getInductionVar());
   remap.map(getLoopCarriedTokenFromScfOp(for_op, "argument"),
             getLoopCarriedTokenFromScfOp(new_for_op, "argument"));

--- a/mlir/test/Conversion/AIRToAIE/lower_scf_token_preserves_disable_ping_pong_attr.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_scf_token_preserves_disable_ping_pong_attr.mlir
@@ -1,0 +1,36 @@
+//===- lower_scf_token_preserves_disable_ping_pong_attr.mlir ---*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie='test-patterns=lower-scf-tokens' | FileCheck %s
+
+// LowerScfTokenPattern strips !air.async.token iter_args from scf.for by
+// building a fresh sync scf.for. The user-facing ping-pong opt-out attr
+// `air.disable_ping_pong` must survive that rewrite.
+
+module attributes {torch.debug_module_name = "mmult"} {
+  func.func @lower_scf_token_preserves_disable_ping_pong_attr(%arg0: memref<32x32xi32, 2>, %arg1: memref<32x32xi32, 2>, %arg2: memref<32x32xi32, 2>) {
+    %c1 = arith.constant 1 : index
+    air.herd @herd_0 tile (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<32x32xi32, 2>, memref<32x32xi32, 2>, memref<32x32xi32, 2> attributes {id = 1 : i32} {
+      %c0 = arith.constant 0 : index
+      %c32 = arith.constant 32 : index
+      %c64 = arith.constant 64 : index
+      %0 = air.wait_all async
+      // CHECK: scf.for %{{.*}} = %c0 to %c64 step %c32 {
+      // CHECK: } {air.disable_ping_pong}
+      %1 = scf.for %arg10 = %c0 to %c64 step %c32 iter_args(%arg11 = %0) -> (!air.async.token) {
+        %asyncToken = air.execute [%arg11] {
+          linalg.matmul ins(%arg7, %arg8 : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs(%arg9 : memref<32x32xi32, 2>)
+          air.execute_terminator
+        } {id = 1 : i32}
+        %2 = air.wait_all async [%asyncToken]
+        scf.yield %2 : !air.async.token
+      } {air.disable_ping_pong}
+      air.wait_all [%1]
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependency/preserve_disable_ping_pong_attr.mlir
+++ b/mlir/test/Transform/AIRDependency/preserve_disable_ping_pong_attr.mlir
@@ -1,0 +1,48 @@
+//===- preserve_disable_ping_pong_attr.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-dependency | FileCheck %s
+
+// air-dependency rewrites sync scf.for / scf.parallel that touch async ops
+// into async versions by building a fresh op. The user-facing ping-pong
+// opt-out attr `air.disable_ping_pong` must survive that rewrite so the
+// labeling pass running much later in the pipeline still sees it.
+
+// CHECK-LABEL: func.func @preserve_disable_ping_pong_scf_for
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: } {air.disable_ping_pong}
+func.func @preserve_disable_ping_pong_scf_for(%arg0: memref<4096xi32>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  scf.for %arg1 = %c0 to %c4 step %c1 {
+    %0 = arith.muli %arg1, %c32 : index
+    %1 = memref.alloc() : memref<32xi32, 2>
+    air.dma_memcpy_nd (%1[] [] [], %arg0[%0] [%c32] [%c1]) {id = 1 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
+    memref.dealloc %1 : memref<32xi32, 2>
+  } {air.disable_ping_pong}
+  return
+}
+
+// CHECK-LABEL: func.func @preserve_disable_ping_pong_scf_parallel
+// CHECK: scf.parallel
+// CHECK: } {air.disable_ping_pong}
+func.func @preserve_disable_ping_pong_scf_parallel(%arg0: memref<4096xi32>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  scf.parallel (%arg1) = (%c0) to (%c4) step (%c1) {
+    %0 = arith.muli %arg1, %c32 : index
+    %1 = memref.alloc() : memref<32xi32, 2>
+    air.dma_memcpy_nd (%1[] [] [], %arg0[%0] [%c32] [%c1]) {id = 2 : i32} : (memref<32xi32, 2>, memref<4096xi32>)
+    memref.dealloc %1 : memref<32xi32, 2>
+    scf.reduce
+  } {air.disable_ping_pong}
+  return
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_preserves_disable_ping_pong_attr.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/hoist_preserves_disable_ping_pong_attr.mlir
@@ -1,0 +1,70 @@
+//===- hoist_preserves_disable_ping_pong_attr.mlir -------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-hoist-ops-not-using-ping-pong | FileCheck %s
+
+// hoistTargetOpsToNewSCFFor (in Util/Dependency.cpp) creates a fresh
+// scf.for to receive the hoisted ops. The user-facing ping-pong opt-out
+// attr `air.disable_ping_pong` must survive that rewrite on both the
+// hoisted half and the isolated original.
+
+// CHECK-LABEL: hoist_preserves_disable_ping_pong_attr
+// First hoisted scf.for (containing the herd) inherits the attr.
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: air.herd
+// CHECK: scf.yield
+// CHECK: } {air.disable_ping_pong}
+// Original loop (now isolated) keeps it too.
+// CHECK: scf.for {{.*}} iter_args
+// CHECK: memref.alloc() {hoist_alloc = "true"}
+// CHECK: scf.yield
+// CHECK: {air.disable_ping_pong, isolated = true, unroll = 2 : i64}
+
+air.channel @channel_1 [1, 1]
+air.channel @channel_0 [1, 1]
+func.func @hoist_preserves_disable_ping_pong_attr(%arg0: memref<256x1024xbf16>, %arg1: memref<1024x1024xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg4, %arg5) in (%arg6=%c1, %arg7=%c1) args(%arg8=%arg0, %arg9=%arg1) : memref<256x1024xbf16>, memref<1024x1024xbf16> attributes {id = 7 : i32} {
+    %1 = air.segment async args(%arg14=%arg8, %arg15=%arg9) : memref<256x1024xbf16>, memref<1024x1024xbf16> {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c512 = arith.constant 512 : index
+      %c64 = arith.constant 64 : index
+      %30 = air.wait_all async
+      %31 = scf.for %arg20 = %c0 to %c2 step %c1_0 iter_args(%arg21 = %30) -> (!air.async.token) {
+        %async_token, %results = air.execute [%arg21] -> (memref<32x32xbf16, 1>) {
+          %alloc = memref.alloc() {hoist_alloc = "true"} : memref<32x32xbf16, 1>
+          air.execute_terminator %alloc : memref<32x32xbf16, 1>
+        }
+        %2 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
+          %5 = air.channel.put async [%arg17] @channel_0[] (%results[] [] []) : (memref<32x32xbf16, 1>)
+          scf.yield %5 : !air.async.token
+        }
+        %3 = air.herd @herd_0 async [%async_token] tile (%arg16, %arg17) in (%arg18=%c1_0, %arg19=%c1_0) {
+          %5 = air.wait_all async
+          %async_token_4, %results_5 = air.execute [%5] -> (memref<32x32xbf16, 2>) {
+            %alloc = memref.alloc() : memref<32x32xbf16, 2>
+            air.execute_terminator %alloc : memref<32x32xbf16, 2>
+          }
+          %async_token_9 = air.execute [%async_token_4] {
+            memref.dealloc %results_5 : memref<32x32xbf16, 2>
+          }
+        }
+        %4 = scf.for %arg16 = %c0 to %c512 step %c64 iter_args(%arg17 = %async_token) -> (!air.async.token) {
+          %5 = air.channel.get async [%arg17] @channel_1[] (%results[] [] []) : (memref<32x32xbf16, 1>)
+          scf.yield %5 : !air.async.token
+        }
+        %async_token_1 = air.execute [%4, %2] {
+          memref.dealloc %results : memref<32x32xbf16, 1>
+        }
+        scf.yield %async_token_1 : !air.async.token
+      } {air.disable_ping_pong, unroll = 2}
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

Follow-up to #1657 (merged), which preserved `llvm.loop_annotation` through
the four `scf.for` / `scf.parallel` rewrite sites that hand-copy a small set
of attributes when building a fresh op. The user-facing PP opt-out attribute
`air.disable_ping_pong` (consumed by `LabelScfForLoopForPingPongPattern`, see
#1662) needs the same preservation: the labeling pass runs much later than
the rewriting passes, so if the rewrites drop the attr, the opt-out is
silently ignored.

## Change

Patch the same four call sites that #1657 touched, propagating
`air.disable_ping_pong` alongside `loop_annotation`:

| File | Site | Pass surface |
|------|------|--------------|
| `mlir/lib/Conversion/AIRToAIEPass.cpp` | `LowerScfTokenPattern` | `-air-to-aie` |
| `mlir/lib/Transform/AIRDependency.cpp` | `convertScfForToAsync` | `-air-dependency` |
| `mlir/lib/Transform/AIRDependency.cpp` | `convertScfParToAsync` | `-air-dependency` |
| `mlir/lib/Util/Dependency.cpp` | `hoistTargetOpsToNewSCFFor` | `-air-hoist-ops-not-using-ping-pong` |

## Tests

Three new lit tests (mirror the structure of the three #1657 tests, one per
pass surface):

- `mlir/test/Transform/AIRDependency/preserve_disable_ping_pong_attr.mlir`
- `mlir/test/Transform/AIRDependencyScheduleOpt/hoist_preserves_disable_ping_pong_attr.mlir`
- `mlir/test/Conversion/AIRToAIE/lower_scf_token_preserves_disable_ping_pong_attr.mlir`

All three pass under `air-opt | FileCheck`.

## Related

- #1657 — preserved `loop_annotation` (merged); same 4 call sites
- #1662 — labeling-pass check that consumes the attribute

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>