### PR TITLE
[programming_examples/dequant_awq] Add --direct-codegen flag for inline-MLIR kernel body

### DIFF
--- a/programming_examples/dequant_awq/Makefile
+++ b/programming_examples/dequant_awq/Makefile
@@ -15,6 +15,12 @@ DEVICE ?= npu2
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# DIRECT_CODEGEN_FLAG: pass --direct-codegen to emit the per-tile dequant
+# body as inline MLIR ops instead of calling dequant.o. AIE2P only.
+#   make run                                # extern .o (default)
+#   make run DIRECT_CODEGEN_FLAG=--direct-codegen   # inline MLIR
+DIRECT_CODEGEN_FLAG ?=
+
 N ?= 1024
 GROUP_SIZE ?= 128
 HERD_N ?= 4
@@ -40,9 +46,12 @@ PY_ARGS = --device $(DEVICE) --n $(N) --group-size $(GROUP_SIZE) --herd-n $(HERD
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
+	${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS) $(DIRECT_CODEGEN_FLAG)
 
+# Build dequant.o for the extern path. No-op when --direct-codegen is set
+# (the inline path has no external kernel object).
 compile-kernel:
+ifeq ($(DIRECT_CODEGEN_FLAG),)
 	mkdir -p $(BUILD_DIR)
 	@if [ -n "$(PEANO_INSTALL_DIR)" ]; then \
 		$(PEANO_INSTALL_DIR)/bin/clang++ ${PEANO_FLAGS} \
@@ -55,12 +64,17 @@ compile-kernel:
 		echo "Error: Neither PEANO_INSTALL_DIR nor xchesscc_wrapper found."; \
 		exit 1; \
 	fi
+else
+	@echo "DIRECT_CODEGEN_FLAG set: skipping dequant.o build (inline path)."
+endif
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
+ifeq ($(DIRECT_CODEGEN_FLAG),)
 	cp $(BUILD_DIR)/dequant.o $(BUILD_DIR)/air_project/dequant.o
+endif
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
+		${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
 
 # ELF profile harness (compile module ELF, then run XRT benchmark loop)
 build-test-dequant-exe:
@@ -71,9 +85,11 @@ ifeq ($(DEVICE),npu1)
 	$(error `make profile` requires DEVICE=npu2: the ELF profile harness compiles with --output-format=elf, which is only supported on npu2 and later. Use `make run` for npu1 correctness.)
 endif
 	mkdir -p $(BUILD_DIR)/air_project
+ifeq ($(DIRECT_CODEGEN_FLAG),)
 	cp $(BUILD_DIR)/dequant.o $(BUILD_DIR)/air_project/dequant.o
+endif
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/dequant_awq.py --compile-mode compile-only --output-format elf $(PY_ARGS)
+		${powershell} python3 ${srcdir}/dequant_awq.py --compile-mode compile-only --output-format elf $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
 	cd $(BUILD_DIR) && ./test_dequant.exe -e air.elf -k "main:dequant" \
 		-N $(N) -G $(GROUP_SIZE) -H $(HERD_N)
 

--- a/programming_examples/dequant_awq/dequant_awq.py
+++ b/programming_examples/dequant_awq/dequant_awq.py
@@ -395,14 +395,13 @@ if __name__ == "__main__":
             (float(int4_vals[i]) - float(zeros[g])) * float(scales[g])
         )
 
-    instance_name = "dequant_inline" if args.direct_codegen else "dequant"
-
+    # ELF kernel resolves as main:<instance_name>; must match @dequant.
     if args.compile_mode == "compile-and-run":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_pingpong=True,
             output_format=args.output_format,
-            instance_name=instance_name,
+            instance_name="dequant",
             target_device=args.device,
         )
         exit(

--- a/programming_examples/dequant_awq/dequant_awq.py
+++ b/programming_examples/dequant_awq/dequant_awq.py
@@ -14,6 +14,19 @@ and matrix_multiplication/int4_awq), keeping each compute tile within its
 to a fully vectorized inner loop in dequant.cc.
 
 Uses a 1xHERD_N AIE herd splitting N across compute tiles.
+
+Two codegen paths share the same DMA / packed L1 layout / output shape:
+
+  * Default: the inner kernel body is a CallOp to a hand-written C++
+    kernel (dequant.cc, compiled to dequant.o) that the linker resolves.
+
+  * --direct-codegen (AIE2P only): the inner body is authored as standard
+    arith/vector/memref ops and lowered through mlir-aie's VectorToAIEVec
+    + AIEVecToLLVM pipeline to the AIE2P unpack.I512.I8.I4 intrinsic, the
+    magic-number sitofp i16->bf16 sequence, and native bf16 mul. No
+    external .o is needed. The inner subgroup processes R=64 nibbles per
+    iteration (the natural width of llvm.aie2p.unpack.I512.I8.I4), so
+    group_size must be a multiple of 64 in this mode.
 """
 
 import argparse
@@ -23,10 +36,24 @@ from ml_dtypes import bfloat16
 from air.ir import *
 from air.dialects.affine import apply as affine_apply
 from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects import arith
+from air.dialects.memref import AllocOp, DeallocOp, load as memref_load
+from air.dialects.vector import (
+    transfer_read,
+    transfer_write,
+    BroadcastOp,
+    bitcast as v_bitcast,
+)
 from air.dialects.func import FuncOp, CallOp
+from air.dialects.scf import for_, yield_
 from air.backend.xrt_runner import XRTRunner, type_mapper
 from air.backend.xrt import XRTBackend
+
+range_ = for_
+
+# Inner subgroup width (nibbles per iteration) for --direct-codegen.
+# Must match the byte-packed source size of llvm.aie2p.unpack.I512.I8.I4.
+R_SUB = 64
 
 
 def packed_tile_bytes(n_tile, group_size):
@@ -42,15 +69,107 @@ def packed_tile_bytes(n_tile, group_size):
     return q_bytes, s_bytes, z_bytes, tile_bytes
 
 
+def _emit_inline_dequant_body(
+    l1_packed, l1_out, n_tile, group_size, q_bytes, s_bytes, ng_tile, nsub_per_group
+):
+    """Per-tile int4 -> bf16 dequant authored as standard MLIR ops.
+
+    Reads Q+S+Z out of l1_packed and writes n_tile bf16 results into l1_out.
+    Lowerings (all in upstream mlir-aie):
+      * vector.transfer_read + vector.bitcast + arith.extui (int4 path)
+        -> aievec.unpack -> llvm.aie2p.unpack.I512.I8.I4
+      * arith.extsi (i8 -> i16) + arith.sitofp (i16 -> bf16) -> magic-number
+        aievec sequence (UPS + acc-add + cast + sub + SRS)
+      * arith.subi (i8) and arith.mulf (bf16, native v32/v64) lower via
+        existing aievec patterns.
+    """
+    i8_type = IntegerType.get_signless(8)
+    i16_ty = IntegerType.get_signless(16)
+    bf16_type = type_mapper(bfloat16)
+
+    vec_i8 = VectorType.get([R_SUB // 2], i8_type)
+    vec_i4 = VectorType.get([R_SUB], IntegerType.get_signless(4))
+    vec_i8_unpacked = VectorType.get([R_SUB], i8_type)
+    vec_bf16 = VectorType.get([R_SUB], bf16_type)
+    id_map = AffineMapAttr.get(AffineMap.get_identity(1))
+    c0_i8 = arith.ConstantOp(i8_type, 0)
+
+    # Unroll the per-group loop in Python so each group's z offset and
+    # scale offset stay constants. Wrapping it in an scf.for triggers loop
+    # strength reduction that rewrites the loop IV in element units and
+    # then reuses the same IV for the z/s offsets, silently corrupting
+    # them.
+    for g_py in range(ng_tile):
+        # Scalar zero point: byte at q_bytes + s_bytes + g_py.
+        z_off = arith.ConstantOp.create_index(q_bytes + s_bytes + g_py)
+        z_byte = memref_load(l1_packed, [z_off])
+        zv = BroadcastOp(vec_i8_unpacked, z_byte)
+
+        # Scalar bf16 scale: 2 bytes at q_bytes + g_py*2, reassembled as
+        # i16 then bitcast to bf16.
+        s_off_lo = arith.ConstantOp.create_index(q_bytes + g_py * 2)
+        s_off_hi = arith.ConstantOp.create_index(q_bytes + g_py * 2 + 1)
+        s_lo_i8 = memref_load(l1_packed, [s_off_lo])
+        s_hi_i8 = memref_load(l1_packed, [s_off_hi])
+        s_lo_i16 = arith.extui(i16_ty, s_lo_i8)
+        s_hi_i16 = arith.extui(i16_ty, s_hi_i8)
+        s_hi_shifted = arith.shli(s_hi_i16, arith.ConstantOp(i16_ty, 8))
+        s_bits = arith.ori(s_lo_i16, s_hi_shifted)
+        sv = arith.bitcast(bf16_type, s_bits)
+        sv_vec = BroadcastOp(vec_bf16, sv)
+
+        # Inner subgroup loop stays as scf.for since its IV only feeds
+        # element offsets (no scalar metadata loads keyed on it).
+        c_rs = arith.ConstantOp.create_index(R_SUB)
+        g_base_elems = arith.ConstantOp.create_index(g_py * group_size)
+        for i in range_(0, nsub_per_group):
+            sub_off_elems = arith.addi(
+                g_base_elems,
+                arith.muli(i, c_rs),
+            )
+            sub_off_bytes = arith.divui(
+                sub_off_elems,
+                arith.ConstantOp.create_index(2),
+            )
+
+            pk_i8 = transfer_read(
+                vec_i8, l1_packed, [sub_off_bytes], id_map, c0_i8, [True]
+            )
+            # Canonical int4 unpack: bitcast to i4 vec then zero-extend to
+            # i8. The mlir-aie LowerExtUIOfBitcastI4ToUnpackPattern rewrites
+            # to aievec.unpack on the byte-packed source.
+            pk_i4 = v_bitcast(vec_i4, pk_i8)
+            w_i8 = arith.extui(vec_i8_unpacked, pk_i4)
+
+            wmz_i8 = arith.subi(w_i8, zv)
+
+            # int8 -> int16 -> bf16. LowerVectorSIToFPI16BF16AIE2pPattern
+            # picks up the i16 -> bf16 sitofp at v16/v32 widths and lowers
+            # via the magic-number trick (UPS + accfloat add/sub + SRS).
+            wmz_i16 = arith.extsi(VectorType.get([R_SUB], i16_ty), wmz_i8)
+            wmz_bf16 = arith.sitofp(vec_bf16, wmz_i16)
+
+            out_bf16 = arith.mulf(wmz_bf16, sv_vec)
+
+            transfer_write(None, out_bf16, l1_out, [sub_off_elems], id_map, [True])
+            yield_([])
+
+
 @module_builder
-def build_module(n, group_size, herd_n):
+def build_module(n, group_size, herd_n, direct_codegen=False):
     bf16_type = type_mapper(bfloat16)
     u8_type = IntegerType.get_signless(8)
 
     assert n % herd_n == 0, "n must be divisible by herd_n"
     n_tile = n // herd_n
     assert n_tile % group_size == 0, "n_tile must be divisible by group_size"
-    _, _, _, tile_bytes = packed_tile_bytes(n_tile, group_size)
+    if direct_codegen:
+        assert (
+            group_size % R_SUB == 0
+        ), f"--direct-codegen requires group_size multiple of {R_SUB}"
+    q_bytes, s_bytes, z_bytes, tile_bytes = packed_tile_bytes(n_tile, group_size)
+    ng_tile = n_tile // group_size
+    nsub_per_group = group_size // R_SUB if direct_codegen else 0
 
     # L3 types: packed weights+scales+zeros laid out per-tile, dequantized output
     l3_packed_ty = MemRefType.get([herd_n, tile_bytes], u8_type)
@@ -61,14 +180,22 @@ def build_module(n, group_size, herd_n):
     l1_packed_ty = MemRefType.get([tile_bytes], u8_type, memory_space=l1_space)
     l1_out_ty = MemRefType.get([n_tile], bf16_type, memory_space=l1_space)
 
-    # External kernel
-    dequant_func = FuncOp(
-        "dequant_int4_bf16",
-        ([l1_packed_ty, l1_out_ty], []),
-        visibility="private",
-    )
-    dequant_func.attributes["link_with"] = StringAttr.get("dequant.o")
-    dequant_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    # External kernel decl (only declared in the extern path; aircc only
+    # links dequant.o when a private @dequant_int4_bf16 FuncOp is present
+    # with `link_with = "dequant.o"`).
+    dequant_func = None
+    if not direct_codegen:
+        dequant_func = FuncOp(
+            "dequant_int4_bf16",
+            ([l1_packed_ty, l1_out_ty], []),
+            visibility="private",
+        )
+        dequant_func.attributes["link_with"] = StringAttr.get("dequant.o")
+        dequant_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+    herd_kwargs = {"name": "dequant_herd", "sizes": [1, herd_n]}
+    if not direct_codegen:
+        herd_kwargs["link_with"] = "dequant.o"
 
     @FuncOp.from_py_func(l3_packed_ty, l3_out_ty)
     def dequant(arg_packed, arg_out):
@@ -76,12 +203,7 @@ def build_module(n, group_size, herd_n):
         def launch_body(l_packed, l_out):
             @segment(name="seg", operands=[l_packed, l_out])
             def segment_body(s_packed, s_out):
-                @herd(
-                    name="dequant_herd",
-                    sizes=[1, herd_n],
-                    operands=[s_packed, s_out],
-                    link_with="dequant.o",
-                )
+                @herd(operands=[s_packed, s_out], **herd_kwargs)
                 def herd_body(_tx, _ty, _sx, _sy, h_packed, h_out):
                     l1_packed = AllocOp(l1_packed_ty, [], [])
                     l1_out = AllocOp(l1_out_ty, [], [])
@@ -95,7 +217,19 @@ def build_module(n, group_size, herd_n):
                         src_strides=[tile_bytes, 1],
                     )
 
-                    CallOp(dequant_func, [l1_packed, l1_out])
+                    if direct_codegen:
+                        _emit_inline_dequant_body(
+                            l1_packed,
+                            l1_out,
+                            n_tile,
+                            group_size,
+                            q_bytes,
+                            s_bytes,
+                            ng_tile,
+                            nsub_per_group,
+                        )
+                    else:
+                        CallOp(dequant_func, [l1_packed, l1_out])
 
                     # Each tile writes a contiguous output slice
                     # [_ty * n_tile : (_ty + 1) * n_tile].
@@ -150,7 +284,7 @@ if __name__ == "__main__":
     HERD_N = 4
 
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="dequant_awq.py",
         description="AWQ-style int4 to bf16 dequantization example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -191,6 +325,17 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--direct-codegen",
+        action="store_true",
+        dest="direct_codegen",
+        help=(
+            "Emit the per-tile dequant body as inline standard MLIR ops "
+            "(arith/vector/memref) instead of a CallOp to the hand-written "
+            "dequant.o kernel. AIE2P only; requires group_size multiple of "
+            f"{R_SUB}."
+        ),
+    )
     args = parser.parse_args()
 
     if args.n <= 0:
@@ -201,11 +346,23 @@ if __name__ == "__main__":
         parser.error("herd_n must be positive")
     if args.n % 2 != 0:
         parser.error("N must be even (2 int4 values per byte)")
-    # The vectorized kernel's inner loop processes 32 nibbles per iteration
-    # (see GROUP_SIZE static_assert in dequant.cc). Catch the mismatch here
-    # with a clear message instead of failing at C++ compile time.
-    if args.group_size % 32 != 0:
-        parser.error("group_size must be a multiple of 32 (kernel inner vector width)")
+    if args.direct_codegen:
+        if args.group_size % R_SUB != 0:
+            parser.error(
+                f"--direct-codegen requires group_size multiple of {R_SUB} "
+                f"(inline subgroup width)"
+            )
+        if args.device == "npu1":
+            parser.error("--direct-codegen is AIE2P only (no npu1 support)")
+    else:
+        # The hand-written kernel's inner loop processes 32 nibbles per
+        # iteration (see GROUP_SIZE static_assert in dequant.cc). Catch
+        # the mismatch here with a clear message instead of failing at
+        # C++ compile time.
+        if args.group_size % 32 != 0:
+            parser.error(
+                "group_size must be a multiple of 32 (kernel inner vector width)"
+            )
     if args.n % args.group_size != 0:
         parser.error("N must be divisible by group_size")
     if args.n % args.herd_n != 0:
@@ -215,7 +372,9 @@ if __name__ == "__main__":
     if args.device == "npu1" and args.output_format == "elf":
         parser.error("--output-format=elf is not supported on npu1; use xclbin")
 
-    mlir_module = build_module(args.n, args.group_size, args.herd_n)
+    mlir_module = build_module(
+        args.n, args.group_size, args.herd_n, direct_codegen=args.direct_codegen
+    )
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -236,12 +395,14 @@ if __name__ == "__main__":
             (float(int4_vals[i]) - float(zeros[g])) * float(scales[g])
         )
 
+    instance_name = "dequant_inline" if args.direct_codegen else "dequant"
+
     if args.compile_mode == "compile-and-run":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_pingpong=True,
             output_format=args.output_format,
-            instance_name="dequant",
+            instance_name=instance_name,
             target_device=args.device,
         )
         exit(

--- a/programming_examples/dequant_awq/run_makefile_peano_elf.lit
+++ b/programming_examples/dequant_awq/run_makefile_peano_elf.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// ELF output_format with the extern .o kernel path.
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR OUTPUT_FORMAT=elf | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/dequant_awq/run_makefile_peano_elf_inline.lit
+++ b/programming_examples/dequant_awq/run_makefile_peano_elf_inline.lit
@@ -1,0 +1,14 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// ELF output_format with --direct-codegen. Exercises the
+// main:<instance_name> kernel-symbol path that xclbin output_format
+// doesn't go through.
+//
+// RUN: mkdir -p test_peano_elf_inline
+// RUN: cd test_peano_elf_inline
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR OUTPUT_FORMAT=elf DIRECT_CODEGEN_FLAG=--direct-codegen | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/dequant_awq/run_makefile_peano_inline.lit
+++ b/programming_examples/dequant_awq/run_makefile_peano_inline.lit
@@ -1,0 +1,18 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// Inline-MLIR (--direct-codegen) variant of dequant_awq: the per-tile
+// int4 -> bf16 dequant body is authored as standard arith/vector/memref
+// ops (vector.transfer_read, vector.bitcast + arith.extui for the int4
+// unpack, arith.subi, arith.sitofp, arith.mulf) and lowered through
+// mlir-aie's VectorToAIEVec + AIEVecToLLVM pipeline to the AIE2P
+// unpack.I512.I8.I4 intrinsic, magic-number sitofp sequence, and native
+// bf16 mul. No external .o.
+//
+// RUN: mkdir -p test_peano_inline
+// RUN: cd test_peano_inline
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DIRECT_CODEGEN_FLAG=--direct-codegen | FileCheck %s
+// CHECK: PASS!


### PR DESCRIPTION
## Summary

`dequant_awq.py` previously had a single codegen path: a `CallOp` to a
hand-written C++ kernel (`dequant.cc` → `dequant.o`) that the linker resolves.
Add a `--direct-codegen` flag that selects an alternative path: emit the
per-tile dequant body as inline standard arith/vector/memref ops, lowered
through mlir-aie's `VectorToAIEVec` + `AIEVecToLLVM` pipeline to the AIE2P
`unpack.I512.I8.I4` intrinsic, the magic-number `sitofp i16->bf16` sequence,
and native bf16 mul. No external `.o` is needed in this mode.

Matches the `--direct-codegen` convention in
[`programming_examples/matrix_multiplication/bf16/run.py`](../tree/main/programming_examples/matrix_multiplication/bf16/run.py):
`action_store_true`, default off (preserves the existing behavior for current users).

## Change

### `dequant_awq.py`

- New `--direct-codegen` flag.
- `build_module(n, group_size, herd_n, direct_codegen=False)` takes the flag.
- New helper `_emit_inline_dequant_body(...)` containing the inline MLIR body.
  Called from the herd body when `direct_codegen=True`; otherwise the existing
  `CallOp(dequant_func, ...)` path runs unchanged.
- Mode-specific validation: inline requires `group_size % 64 == 0` (subgroup
  width = `llvm.aie2p.unpack.I512.I8.I4`) and AIE2P (no `npu1`).
- `instance_name` switches between `"dequant"` and `"dequant_inline"`.

### `Makefile`

- New `DIRECT_CODEGEN_FLAG ?=` knob:
  ```
  make run                                            # extern (default)
  make run DIRECT_CODEGEN_FLAG=--direct-codegen       # inline
  ```
- `compile-kernel` is a no-op when the flag is set (the inline path has no
  external `.o`).
- `run` / `profile` conditionally `cp` the `.o`.

### Lit tests

| File | Mode | Temp dir |
|------|------|----------|
| `run_makefile_peano.lit` (existing, unchanged) | extern | `test_peano/` |
| `run_makefile_peano_inline.lit` (new) | inline (`DIRECT_CODEGEN_FLAG=--direct-codegen`) | `test_peano_inline/` |

Both invoke the same `make run` target; the inline lit just passes the new
flag. Separate temp dirs so the two tests can run concurrently without
artifact collision.

## Verification

Tested on NPU2 (Strix / AIE2P), N=1024, GS=128, HERD_N=4:

| Mode | Result |
|------|--------|
| `make run` (extern) | `PASS!` |
| `make run DIRECT_CODEGEN_FLAG=--direct-codegen` (inline) | `PASS!` |

Print-only output confirms the IR diff:
- Extern: `call @dequant_int4_bf16` + `link_with = "dequant.o"`
- Inline: `vector.bitcast` / `arith.mulf` + no extern decl

The `npu1` path (third lit test, unchanged) uses the extern default and is
not regressed.

## Dependency

The inline path depends on the mlir-aie lowerings in
[Xilinx/mlir-aie#3145](https://github.com/Xilinx/mlir-aie/pull/3145):
- `aievec.unpack` byte-packed int4 → int8
- `extui(bitcast i8→i4)` → `aievec.unpack` rewriter
- magic-number `sitofp i16→bf16`
- `aievec.cast` across acc bank → `llvm.bitcast`

The default (extern) path does **not** depend on those and works on current
main.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>