### PR TITLE
[llama32_1b_int4] Wire int4 verify lit into CI: drop HF_TOKEN dep + broaden filter

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -143,16 +143,18 @@ jobs:
           ninja check-programming-examples-peano || ninja check-programming-examples-peano
 
           # Programming examples set 1b: hf_token-gated tests only.
-          # Scoped LIT --filter pattern matches only the lit files that need a
-          # Hugging Face token (currently just
-          # programming_examples/llms/llama32_1b/run_npu2_verify.lit). HF_TOKEN is
-          # exported in a sub-shell so it is visible only to this single ninja
-          # invocation — the main check-programming-examples-peano step above
-          # never sees the token. Extend the regex when new hf_token tests are
-          # added.
+          # Scoped LIT --filter pattern matches any verify lit under
+          # programming_examples/llms/llama32_1b{,_int4}/ — currently just the
+          # bf16 baseline's run_npu2_verify.lit (int4 + bfp16 verify lits got
+          # un-gated when verify_adapter switched to building the HF reference
+          # from the AMD AWQ checkpoint's config); kept here so future
+          # hf_token-requiring verify lits under either dir don't silently
+          # skip. HF_TOKEN is exported in a sub-shell so it's visible only to
+          # this single ninja invocation — the main check-programming-examples-peano
+          # step above never sees the token.
           (
             export HF_TOKEN="${{ secrets.HF_TOKEN }}"
-            export LIT_OPTS="$LIT_OPTS --filter llama32_1b/run_npu2_verify"
+            export LIT_OPTS="$LIT_OPTS --filter llms/llama32_1b.*/run_npu2_verify"
             # Install verify's Python dependencies (safetensors, transformers,
             # torch, huggingface_hub) on top of the mlir-air base environment.
             # Scoped to this sub-shell so it does not affect other test steps.

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -136,6 +136,13 @@ jobs:
           # Chess tests disabled to reduce CI time. Uncomment to re-enable:
           # ninja check-air-e2e-chess
 
+          # Install verify's Python dependencies (safetensors, transformers,
+          # torch, huggingface_hub). Required by both the main and gated
+          # `check-programming-examples-peano` invocations below: the int4
+          # verify lit is ungated and runs in the main step, while the bf16
+          # baseline's verify lit runs in the gated sub-shell.
+          pip install -r ../programming_examples/llms/llama32_1b/requirements.txt
+
           # Programming examples set 1: peano tests (retry once on failure for flaky NPU tests).
           # HF_TOKEN is NOT set here — REQUIRES: hf_token tests skip cleanly as
           # UNSUPPORTED in this step. They are exercised in the targeted step below,
@@ -145,9 +152,7 @@ jobs:
           # Programming examples set 1b: hf_token-gated tests only.
           # Scoped LIT --filter pattern matches any verify lit under
           # programming_examples/llms/llama32_1b{,_int4}/ — currently just the
-          # bf16 baseline's run_npu2_verify.lit (int4 + bfp16 verify lits got
-          # un-gated when verify_adapter switched to building the HF reference
-          # from the AMD AWQ checkpoint's config); kept here so future
+          # bf16 baseline's run_npu2_verify.lit; kept here so future
           # hf_token-requiring verify lits under either dir don't silently
           # skip. HF_TOKEN is exported in a sub-shell so it's visible only to
           # this single ninja invocation — the main check-programming-examples-peano
@@ -155,10 +160,6 @@ jobs:
           (
             export HF_TOKEN="${{ secrets.HF_TOKEN }}"
             export LIT_OPTS="$LIT_OPTS --filter llms/llama32_1b.*/run_npu2_verify"
-            # Install verify's Python dependencies (safetensors, transformers,
-            # torch, huggingface_hub) on top of the mlir-air base environment.
-            # Scoped to this sub-shell so it does not affect other test steps.
-            pip install -r ../programming_examples/llms/llama32_1b/requirements.txt
             ninja check-programming-examples-peano || ninja check-programming-examples-peano
           )
 

--- a/programming_examples/llms/llama32_1b/llama32_1b_weights.py
+++ b/programming_examples/llms/llama32_1b/llama32_1b_weights.py
@@ -155,19 +155,28 @@ def _resolve_safetensor_files(model_path: str) -> List[str]:
     from huggingface_hub import snapshot_download
     from huggingface_hub.errors import LocalEntryNotFoundError
 
+    pattern_glob = "*.safetensors"
     try:
         local_dir = snapshot_download(
             model_path,
             allow_patterns=["*.safetensors", "*.json"],
             local_files_only=True,
         )
+        # local_files_only=True returns whatever subset of allow_patterns is
+        # already cached; it does NOT raise when some files match. A persistent
+        # CI runner that previously did `AutoConfig.from_pretrained` will have
+        # config.json cached but no safetensors. Force the network branch
+        # when no .safetensors are actually present.
+        if not glob_module.glob(os.path.join(local_dir, pattern_glob)):
+            raise LocalEntryNotFoundError(
+                f"local cache for {model_path} has no .safetensors"
+            )
     except LocalEntryNotFoundError:
         local_dir = snapshot_download(
             model_path,
             allow_patterns=["*.safetensors", "*.json"],
         )
-    pattern = os.path.join(local_dir, "*.safetensors")
-    files = sorted(glob_module.glob(pattern))
+    files = sorted(glob_module.glob(os.path.join(local_dir, pattern_glob)))
     if not files:
         raise FileNotFoundError(
             f"No .safetensors files found after downloading {model_path}"

--- a/programming_examples/llms/llama32_1b_int4/requirements.txt
+++ b/programming_examples/llms/llama32_1b_int4/requirements.txt
@@ -13,12 +13,9 @@
 # upstream meta-llama base model via `make verify` (HF AutoTokenizer
 # fetches the gated tokenizer).
 
-# Weight loading (AWQ qweight/qzeros/scales). hf_xet is required because
-# the AMD AWQ checkpoint is stored on HF's Xet/CAS backend; without it
-# huggingface_hub silently skips the Xet-backed .safetensors blob.
+# Weight loading (AWQ qweight/qzeros/scales)
 safetensors
 huggingface_hub
-hf_xet
 
 # Tokenizer + HF vanilla bf16 reference for `make verify`
 transformers

--- a/programming_examples/llms/llama32_1b_int4/requirements.txt
+++ b/programming_examples/llms/llama32_1b_int4/requirements.txt
@@ -13,9 +13,12 @@
 # upstream meta-llama base model via `make verify` (HF AutoTokenizer
 # fetches the gated tokenizer).
 
-# Weight loading (AWQ qweight/qzeros/scales)
+# Weight loading (AWQ qweight/qzeros/scales). hf_xet is required because
+# the AMD AWQ checkpoint is stored on HF's Xet/CAS backend; without it
+# huggingface_hub silently skips the Xet-backed .safetensors blob.
 safetensors
 huggingface_hub
+hf_xet
 
 # Tokenizer + HF vanilla bf16 reference for `make verify`
 transformers

--- a/programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit
@@ -3,14 +3,12 @@
 //
 // LLAMA-3.2-1B int4-AWQ verify gate: top-K token-level inclusion check
 // via the shared verify/ framework. NPU (bf16 prefill on dequantized
-// AWQ + int4 decode) vs HF bf16 reference, 2 prompts × 32 greedy tokens,
-// k=5. Mirrors the bf16 sibling's run_npu2_verify.lit so both Llama
-// examples gate on identical methodology.
+// AWQ + int4 decode) vs HF bf16 reference (built from the AMD AWQ
+// checkpoint's config + AWQ-dequant weights — no upstream meta-llama
+// download). 2 prompts × 32 greedy tokens, k=5. Mirrors the bf16
+// sibling's run_npu2_verify.lit methodology.
 //
-// Requires HF_TOKEN to fetch the upstream tokenizer behind the AWQ
-// checkpoint (gated).
-//
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/llama32_1b_int4/run_npu2_verify_prefill_bfp16.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_verify_prefill_bfp16.lit
@@ -4,12 +4,11 @@
 // LLAMA-3.2-1B bfp16 prefill verify gate: top-K token-level inclusion
 // check on the bfp16 prefill backend. Mirrors run_npu2_verify.lit's
 // methodology but exercises the bfp16 stitchers in isolation (prefill
-// only; decode is unaffected by --prefill-dtype).
+// only; decode is unaffected by --prefill-dtype). HF reference is built
+// from the AMD AWQ checkpoint's config + AWQ-dequant weights (no
+// upstream meta-llama download), so the lit is un-gated.
 //
-// Requires HF_TOKEN to fetch the upstream tokenizer behind the AWQ
-// checkpoint (gated).
-//
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_peano_verify_prefill_bfp16
 // RUN: cd test_peano_verify_prefill_bfp16

--- a/programming_examples/llms/llama32_1b_int4/verify_adapter.py
+++ b/programming_examples/llms/llama32_1b_int4/verify_adapter.py
@@ -7,12 +7,12 @@ Wraps the production `llama32_1b_int4_inference` driver into a Runner for
 the shared verify framework. Mirrors `llama32_1b/verify_adapter.py` but
 loads AWQ weights (`load_weights_awq`) and uses the int4 decode kernels.
 
-HF reference uses the meta-llama Llama-3.2-1B-Instruct architecture with
-AWQ-dequantized weights patched in over the bf16 originals (see
-`build_hf_model`). That isolates the verify gate to NPU drift only, vs
-the looser "quant_error + NPU_drift" comparison you'd get by using the
-un-quantized meta-llama weights as reference. No autoawq dep — we use
-our own `awq_repacker.dequant_to_bf16`.
+HF reference is built from the AMD AWQ checkpoint's config alone (no
+weight download) with AWQ-dequantized weights patched in. That isolates
+the verify gate to NPU drift only — both sides see exactly the same bf16
+tensor values for every Linear weight — and keeps the verify path
+ungated (no HF_TOKEN needed). No autoawq dep — we use our own
+`awq_repacker.dequant_to_bf16`.
 """
 
 from __future__ import annotations
@@ -49,10 +49,9 @@ from llama32_1b_prefill import (
 )  # noqa: E402
 from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
 
-# Default AWQ checkpoint exposed by AMD; un-gated, no HF_TOKEN required to
-# fetch the AWQ weights themselves. The tokenizer behind it (the upstream
-# meta-llama/Llama-3.2-1B-Instruct tokenizer) IS gated, so `make verify`
-# still needs HF_TOKEN.
+# Default AWQ checkpoint exposed by AMD; un-gated, no HF_TOKEN needed.
+# `build_hf_model` reuses this checkpoint's config to construct the HF
+# reference architecture, so the entire verify path is ungated.
 _DEFAULT_AWQ_MODEL = "amd/Llama-3.2-1B-Instruct-awq-uint4-asym-g128-bf16-lmhead"
 
 MODEL_CHOICES = {
@@ -65,15 +64,10 @@ def resolve_model(model_choice_or_id: str) -> str:
     return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
 
 
-# HF reference architecture (vanilla meta-llama). The Linear weights are
-# replaced with our AWQ-dequant copies inside `build_hf_model`, so the
-# gate measures NPU drift only — both sides see identical bf16 values
-# for every weight.
-_HF_REF_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
-
-
 def hf_reference(npu_model_name: str) -> str:
-    return _HF_REF_MODEL
+    """HF reference model name; same as the AWQ checkpoint so the
+    tokenizer and HF arch config are loaded from a single ungated repo."""
+    return npu_model_name
 
 
 def build_config():
@@ -94,29 +88,29 @@ def _get_or_load_weights(model_name: str, config):
 
 
 def build_hf_model(npu_model_name: str, hf_ref_model: str, config):
-    """Construct the HF reference model: meta-llama architecture + the
-    AWQ-dequantized weights from the AMD checkpoint patched in over the
-    bf16 originals. Tightens the verify gate from
-    (quant_error + NPU_drift) down to (NPU_drift) since both sides see
-    exactly the same bf16 tensor values for every Linear weight.
+    """Construct an HF reference model with AWQ-dequantized weights.
 
-    The trick: load weights once via `load_weights_awq` (which already
-    produces bf16 dequant copies on each LayerWeights field). Then walk
-    each HF Linear and overwrite `.weight.data` with the dequant. HF
-    stores Linear weights as (out_features, in_features) but our dequant
-    is (in_features, out_features), hence the `.T.contiguous()`.
+    Load the architecture config from the AMD AWQ checkpoint (ungated),
+    construct an empty LlamaForCausalLM from that config, then overwrite
+    every Linear and layernorm with the AWQ-dequant bf16 from
+    `load_weights_awq`. No remote weight download — only the config.json
+    is fetched, which is already cached by the prefill driver's run.
 
-    Layernorms, embed_tokens and lm_head in the AMD checkpoint are
-    un-quantized bf16 and we copy them straight through.
+    Tightens the verify gate from (quant_error + NPU_drift) down to
+    (NPU_drift) since both sides see exactly the same bf16 tensor values.
+    HF stores Linear weights as (out_features, in_features) but our
+    dequant is (in_features, out_features), hence the transpose.
     """
     import torch
-    from transformers import AutoModelForCausalLM
+    from transformers import AutoConfig, LlamaForCausalLM
 
     weights = _get_or_load_weights(npu_model_name, config)
-    print(f"[verify_adapter] loading HF arch from {hf_ref_model}...")
-    model = AutoModelForCausalLM.from_pretrained(
-        hf_ref_model, torch_dtype=torch.bfloat16
-    )
+    print(f"[verify_adapter] building HF arch from {hf_ref_model} config...")
+    hf_cfg = AutoConfig.from_pretrained(hf_ref_model)
+    if hasattr(hf_cfg, "quantization_config"):
+        delattr(hf_cfg, "quantization_config")
+    hf_cfg.torch_dtype = torch.bfloat16
+    model = LlamaForCausalLM(hf_cfg).to(torch.bfloat16)
 
     def _to_bf16_tensor(arr):
         # numpy bfloat16 -> torch bfloat16 via int16 bit-reinterpret. The


### PR DESCRIPTION
## Summary

`programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit` was silently never executed in CI:

1. **Filter regex miss**: [buildAndTestRyzenAI.yml:155](.github/workflows/buildAndTestRyzenAI.yml#L155) scopes the hf_token sub-shell to `--filter llama32_1b/run_npu2_verify`. That regex matches only `llms/llama32_1b/run_npu2_verify.lit` (the bf16 baseline); the int4 path `llms/llama32_1b_int4/run_npu2_verify.lit` has an extra `_int4/` segment and doesn't match.
2. **Gated REQUIRES**: int4 lit had `REQUIRES: hf_token`. Without HF_TOKEN exported (which the main unfiltered step deliberately doesn't do), lit skipped it as UNSUPPORTED.

Net result: the int4 e2e verify gate ran on neither the main step nor the gated sub-shell.

## Changes

1. **Drop the HF_TOKEN dep** in [verify_adapter.py](programming_examples/llms/llama32_1b_int4/verify_adapter.py). `build_hf_model` previously did `AutoModelForCausalLM.from_pretrained(\"meta-llama/Llama-3.2-1B-Instruct\")` to get the bf16 architecture, then patched in AWQ-dequant weights. Switch to loading the architecture **config** from the AMD AWQ checkpoint (`AutoConfig.from_pretrained`) and constructing an empty `LlamaForCausalLM(hf_cfg)` from it — only `config.json` is fetched (and is already cached by the prefill driver's run). All Linear / layernorm / embed tensors are then overwritten with the AWQ-dequant bf16 the runner already loads, same as before. The gate still measures NPU drift only (both sides see identical bf16 weight values); the path is now ungated.
2. **Drop `REQUIRES: hf_token`** from [run_npu2_verify.lit](programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit) so it runs in the main `check-programming-examples-peano` step.
3. **Broaden the CI sub-shell filter** from `llama32_1b/run_npu2_verify` to `llms/llama32_1b.*/run_npu2_verify` so any future HF_TOKEN-requiring verify lit under either `llms/llama32_1b/` or `llms/llama32_1b_int4/` is caught (belt-and-suspenders). The bf16 baseline lit still routes through the sub-shell unchanged.

## Dependency

Depends on **[#1666](https://github.com/Xilinx/mlir-air/pull/1666)** to land first — that PR fixes the underlying int4 NPU decode kernel bug (`mv_int4_bf16.o` poisoned by int4 GEMM prefill produces NaN/Inf Q). Without #1666, turning on the int4 verify gate would make CI fail loudly instead of silently skipping.

## Test plan

- [x] `make verify` (no HF_TOKEN, fresh build): `[verify] Summary: {'n_layer_records': 0, 'topk_passed': 2, 'topk_failed': 0}` → `[verify] PASS`.
- [x] verify_adapter loads HF reference via `LlamaForCausalLM(AutoConfig.from_pretrained(AWQ))` — no `meta-llama` network round-trip.
- [ ] CI: full `buildAndTestRyzenAI.yml` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)