### PR TITLE
[programming_examples] bf16_x_bfp16: opt out K-l1 fill loop from ping-pong

### DIFF
--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
@@ -18,6 +18,8 @@ from air.ir import (
     AffineSymbolExpr,
     BF16Type,
     F32Type,
+    IndexType,
+    InsertionPoint,
     IntegerAttr,
     IntegerType,
     MemRefType,
@@ -36,11 +38,34 @@ from air.dialects.air import (
     module_builder,
     segment,
 )
+from air.dialects.arith import constant
 from air.dialects.func import CallOp, FuncOp
 from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.scf import for_, yield_
+from air.dialects.scf import ForOp, for_, yield_
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
+
+
+def for_disable_pp(start, stop=None, step=None):
+    """`for_` variant that tags the underlying scf.for with
+    `air.disable_ping_pong`. The K-l1 fill loop's L1 budget can't absorb
+    the ping-pong unroll's 2x buffer copies on AIE2P (74 KiB > 64 KiB)."""
+    if step is None:
+        step = 1
+    if stop is None:
+        stop = start
+        start = 0
+    params = [start, stop, step]
+    for i, p in enumerate(params):
+        if isinstance(p, int):
+            p = constant(IndexType.get(), p)
+        params[i] = p
+    start, stop, step = params
+    for_op = ForOp(start, stop, step, None)
+    for_op.operation.attributes["air.disable_ping_pong"] = UnitAttr.get()
+    with InsertionPoint(for_op.body):
+        yield for_op.induction_variable
+
 
 KERNEL_OBJ_NAME = "mm_bf16_x_bfp16.o"
 BFP16_BLOCK = 8
@@ -426,7 +451,7 @@ def build_module(
                     ):
                         _l1_a = AllocOp(l1MemrefTyA, [], [])
                         _l1_b = AllocOp(l1MemrefTyB, [], [])
-                        for j in for_(0, k_per_l2):
+                        for j in for_disable_pp(0, k_per_l2):
                             reduction_l1_iv_map = AffineMap.get(
                                 0,
                                 1,

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
@@ -18,7 +18,6 @@ from air.ir import (
     AffineSymbolExpr,
     BF16Type,
     F32Type,
-    IndexType,
     InsertionPoint,
     IntegerAttr,
     IntegerType,
@@ -38,7 +37,7 @@ from air.dialects.air import (
     module_builder,
     segment,
 )
-from air.dialects.arith import constant
+from air.dialects import arith
 from air.dialects.func import CallOp, FuncOp
 from air.dialects.memref import AllocOp, DeallocOp, subview
 from air.dialects.scf import ForOp, for_, yield_
@@ -58,10 +57,9 @@ def for_disable_pp(start, stop=None, step=None):
     params = [start, stop, step]
     for i, p in enumerate(params):
         if isinstance(p, int):
-            p = constant(IndexType.get(), p)
-        params[i] = p
+            params[i] = arith.ConstantOp.create_index(p)
     start, stop, step = params
-    for_op = ForOp(start, stop, step, None)
+    for_op = ForOp(start, stop, step, [])
     for_op.operation.attributes["air.disable_ping_pong"] = UnitAttr.get()
     with InsertionPoint(for_op.body):
         yield for_op.induction_variable


### PR DESCRIPTION
## Summary
- Re-enabling ping-pong on the bf16_x_bfp16 K-l1 fill loop (via PR #1659's affine.if dedup) overflows AIE2P L1 (74 KiB > 64 KiB) and breaks aiecc compile on `matrix_multiplication/bf16_x_bfp16/run_packed_npu2_llama_qproj_peano.lit`.
- Opt this specific loop out with the `air.disable_ping_pong` attribute introduced in PR #1662. Restores the pre-PR-#1659 schedule for just this loop; other designs that benefit from the dedup are untouched.
- Wraps `for_` in a small `for_disable_pp` helper that builds the underlying `ForOp` and tags it before nesting the body, since the existing `for_` generator doesn't expose the op handle.

## Background
PR #1659 (`LabelScfForLoopForPingPongPattern` dedup) recognised that `air-specialize-dma-broadcast`'s mutually-exclusive affine.if chain dispatches only one channel.get per iter, and stopped over-counting it as multi-fill. That correctly re-enabled ping-pong on a previously-rejected family of loops. The bf16_x_bfp16 example was authored against the pre-PR-#1659 behaviour where this K-l1 loop was implicitly NOT ping-ponged; with the dedup landed, ping-pong's 2x unroll doubles `_l1_a` (16 KiB) and `_l1_b` (9 KiB) and pushes the tile past its 64 KiB budget:

```
buf4 16K  buf3 16K  buf0 16K  buf2 9K  buf1 9K  buf5 8K   total 74 KiB
'aie.tile' op allocated buffers exceeded available memory
```

## Test plan
On NPU2 (Strix, amdhx370), `M=K=N=2048`, `TILE_M=TILE_N=64`, `TILE_K_L1=128`, `TILE_K_L2=2048`, `HERD_M=8`, `HERD_N=4`:
- [x] `make run` compiles cleanly, correlation `0.999976` (threshold `0.999`), PASS!
- [x] `make profile` mean kernel time `3138.7 us` (range 3127-3151) vs pre-PR-#1659 baseline `3156.7 us` (range 3132-3202); delta within intra-build noise.
- [x] `black --check` clean.
- [ ] CI: `Build and Test with AIE tools on Ryzen AI / amdhx370`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)