### PR TITLE
utils: bump mlir-aie wheel pin to 1.3.2.dev101+ge094875

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=24e0c2ff020316948e8c81f9822f0648e437a525
-DEV_COUNT=94
+export HASH=e094875d61e891c692bd2120e761909e4e4273fd
+DEV_COUNT=101
 WHEEL_VERSION=1.3.2.dev$DEV_COUNT+g${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then


### PR DESCRIPTION
## Summary
- Bumps `utils/clone-mlir-aie.sh` pinned wheel from `1.3.2.dev94+g24e0c2f` to `1.3.2.dev101+ge094875` — latest cp312-compatible wheel in `latest-wheels-3`.
- `MLIR_PYTHON_EXTRAS_SHORTHASH` left at `a736a7d` (verified unchanged in mlir-aie `python/requirements.txt` at the new HEAD).

## Test plan
- [x] `build-mlir-air-using-wheels.sh` — clean wheel-based build succeeds.
- [x] `ninja check-air-mlir` — 403/403 tracked tests pass, no regressions from the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)