### PR TITLE
programming_examples: move output channel.get after producer scope (#1671)

### DIFF
--- a/programming_examples/attention_decode/attn_decode_npu2.py
+++ b/programming_examples/attention_decode/attn_decode_npu2.py
@@ -351,24 +351,6 @@ def build_module(
                     )
                     yield_([])
 
-                # KV cache writeback at slot pos_host for this col.
-                ChannelGet(
-                    "cL2ToL3",
-                    l3_k_cache_data,
-                    offsets=[tx_i, pos_host, launch_offset_y],
-                    sizes=[1, 1, tile_n],
-                    strides=[seq_len * n, n, 1],
-                    indices=[c_tx_i],
-                )
-                ChannelGet(
-                    "cL2ToL3",
-                    l3_v_cache_data,
-                    offsets=[tx_i, pos_host, launch_offset_y],
-                    sizes=[1, 1, tile_n],
-                    strides=[seq_len * n, n, 1],
-                    indices=[c_tx_i],
-                )
-
                 # KV cache reads for attention: pos K rows, then pos V rows.
                 # Slot pos is supplied to attn_1/attn_2 directly from the herd's
                 # local L1 c_data (K_new at row GROUP_SIZE, V_new at row
@@ -395,16 +377,6 @@ def build_module(
                         indices=[c_tx_i],
                     )
                     yield_([])
-
-                # xb output back to L3 for this col.
-                ChannelGet(
-                    "dL2ToL3",
-                    l3_xb_data,
-                    offsets=[tx_i, 0, 0],
-                    sizes=[1, GROUP_SIZE, n],
-                    strides=[GROUP_SIZE * n, n, 1],
-                    indices=[c_tx_i],
-                )
 
             @segment(name="vecmat_i8_0")
             def segment_body():
@@ -492,16 +464,6 @@ def build_module(
                             indices=[c_tx_i],
                         )
                         yield_([])
-
-                    # KV cache writeback: pull from herd then forward to L3.
-                    ChannelGet(
-                        "cL1ToL2",
-                        l2_c_bufs[tx_i].result,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                        indices=[c_tx_i],
-                    )
 
                 l1_out_data = AllocOp(l1MemrefTyC, [], [])
 
@@ -1427,9 +1389,19 @@ def build_module(
                     "attn_decode_npu2.o"
                 )
 
-                # Per-col KV cache writeback forwarding to L3.
+                # Per-col KV cache writeback: pull from herd L1, then forward
+                # to L3. The get of cL1ToL2 is placed AFTER @herd so source
+                # program order encodes producer→consumer (#1671).
                 for tx_i in range(NKV):
                     c_tx_i = arith.ConstantOp.create_index(tx_i)
+                    ChannelGet(
+                        "cL1ToL2",
+                        l2_c_bufs[tx_i].result,
+                        offsets=[],
+                        sizes=[],
+                        strides=[],
+                        indices=[c_tx_i],
+                    )
                     ChannelPut(
                         "cL2ToL3",
                         l2_c_bufs[tx_i].result,
@@ -1471,6 +1443,39 @@ def build_module(
                     DeallocOp(l2_b_bufs[tx_i])
                     DeallocOp(l2_c_bufs[tx_i])
                 DeallocOp(l1_c_data)
+
+            # Output gets at launch scope, placed AFTER @segment so source
+            # program order encodes producer→consumer (#1671).
+            for tx_i in range(NKV):
+                c_tx_i = arith.ConstantOp.create_index(tx_i)
+
+                # KV cache writeback at slot pos_host for this col.
+                ChannelGet(
+                    "cL2ToL3",
+                    l3_k_cache_data,
+                    offsets=[tx_i, pos_host, launch_offset_y],
+                    sizes=[1, 1, tile_n],
+                    strides=[seq_len * n, n, 1],
+                    indices=[c_tx_i],
+                )
+                ChannelGet(
+                    "cL2ToL3",
+                    l3_v_cache_data,
+                    offsets=[tx_i, pos_host, launch_offset_y],
+                    sizes=[1, 1, tile_n],
+                    strides=[seq_len * n, n, 1],
+                    indices=[c_tx_i],
+                )
+
+                # xb output back to L3 for this col.
+                ChannelGet(
+                    "dL2ToL3",
+                    l3_xb_data,
+                    offsets=[tx_i, 0, 0],
+                    sizes=[1, GROUP_SIZE, n],
+                    strides=[GROUP_SIZE * n, n, 1],
+                    indices=[c_tx_i],
+                )
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
@@ -43,9 +43,6 @@ def build_module():
         def launch_body(a, b, c, d):
 
             ChannelPut("ChanIn", a)
-            ChannelGet("ChanOut", b, indices=[0, 0])
-            ChannelGet("ChanOut", c, indices=[0, 1])
-            ChannelGet("ChanOut", d, indices=[0, 2])
 
             @segment(name="seg")
             def segment_body():
@@ -78,6 +75,10 @@ def build_module():
 
                     DeallocOp(image_in)
                     DeallocOp(image_out)
+
+            ChannelGet("ChanOut", b, indices=[0, 0])
+            ChannelGet("ChanOut", c, indices=[0, 1])
+            ChannelGet("ChanOut", d, indices=[0, 2])
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/broadcast_selective_capture/broadcast_selective_capture.py
+++ b/programming_examples/channel_examples/broadcast_selective_capture/broadcast_selective_capture.py
@@ -76,18 +76,6 @@ def build_module():
                     strides=[1],
                 )
 
-            # Collect output tiles from each core
-            for i in range(NUM_TILES):
-                offset = TILE_SIZE * i
-                ChannelGet(
-                    "ChanOut",
-                    l3_out,
-                    indices=[0, i],
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                )
-
             @segment(name="seg")
             def segment_body():
 
@@ -129,6 +117,18 @@ def build_module():
 
                     DeallocOp(recv_buf)
                     DeallocOp(out_buf)
+
+            # Collect output tiles from each core
+            for i in range(NUM_TILES):
+                offset = TILE_SIZE * i
+                ChannelGet(
+                    "ChanOut",
+                    l3_out,
+                    indices=[0, i],
+                    offsets=[offset],
+                    sizes=[TILE_SIZE],
+                    strides=[1],
+                )
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/channel_size/channel_size.py
+++ b/programming_examples/channel_examples/channel_size/channel_size.py
@@ -61,22 +61,6 @@ def build_module():
                         strides=[IMAGE_WIDTH, 1],
                     )
 
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
-
             # The arguments are still the input and the output
             @segment(name="seg")
             def segment_body():
@@ -120,6 +104,22 @@ def build_module():
                     # Deallocate our L1 buffers
                     DeallocOp(tile_in)
                     DeallocOp(tile_out)
+
+            # Transfer one tile of data per worker
+            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+                for w in range(IMAGE_WIDTH // TILE_WIDTH):
+                    offset0 = TILE_HEIGHT * h
+                    offset1 = TILE_WIDTH * w
+
+                    # Write data back out to the channel tile by tile
+                    ChannelGet(
+                        "ChanOut",
+                        b,
+                        indices=[h, w],
+                        offsets=[offset0, offset1],
+                        sizes=TILE_SIZE,
+                        strides=[IMAGE_WIDTH, 1],
+                    )
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
@@ -70,9 +70,6 @@ def build_module():
             # Fetch all input data into the channel
             ChannelPut("ChanIn", a)
 
-            # Push all output data out of the channel
-            ChannelGet("ChanOut", b)
-
             @segment(name="seg")
             def segment_body():
 
@@ -125,6 +122,9 @@ def build_module():
 
                     DeallocOp(image_in)
                     DeallocOp(image_out)
+
+            # Push all output data out of the channel
+            ChannelGet("ChanOut", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/hierarchical/hierarchical.py
+++ b/programming_examples/channel_examples/hierarchical/hierarchical.py
@@ -52,7 +52,6 @@ def build_module():
         def launch_body(a, b):
 
             ChannelPut("ChanInL2", a)
-            ChannelGet("ChanOutL2", b)
 
             @segment(name="seg")
             def segment_body():
@@ -60,11 +59,6 @@ def build_module():
                 ChannelGet("ChanInL2", image_in_l2)
                 ChannelPut("ChanInL1", image_in_l2)
                 DeallocOp(image_in_l2)
-
-                image_out_l2 = AllocOp(image_type_l2, [], [])
-                ChannelGet("ChanOutL1", image_out_l2)
-                ChannelPut("ChanOutL2", image_out_l2)
-                DeallocOp(image_out_l2)
 
                 @herd(name="addherd", sizes=[1, 1])
                 def herd_body(tx, ty, sx, sy):
@@ -93,6 +87,13 @@ def build_module():
 
                     DeallocOp(image_in)
                     DeallocOp(image_out)
+
+                image_out_l2 = AllocOp(image_type_l2, [], [])
+                ChannelGet("ChanOutL1", image_out_l2)
+                ChannelPut("ChanOutL2", image_out_l2)
+                DeallocOp(image_out_l2)
+
+            ChannelGet("ChanOutL2", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/worker_to_self/worker_to_self.py
+++ b/programming_examples/channel_examples/worker_to_self/worker_to_self.py
@@ -51,7 +51,6 @@ def build_module():
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
             ChannelPut("ChanIn", a)
-            ChannelGet("ChanOut", b)
 
             # The arguments are still the input and the output
             @segment(name="seg")
@@ -94,6 +93,8 @@ def build_module():
                     DeallocOp(tensor_out_l1)
 
                 DeallocOp(tensor_in_l2)
+
+            ChannelGet("ChanOut", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/channel_examples/worker_to_worker/worker_to_worker.py
+++ b/programming_examples/channel_examples/worker_to_worker/worker_to_worker.py
@@ -63,22 +63,6 @@ def build_module():
                         strides=[IMAGE_WIDTH, 1],
                     )
 
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
-
             # The arguments are still the input and the output
             @segment(name="seg")
             def segment_body():
@@ -192,6 +176,22 @@ def build_module():
                     ChannelPut("ChanOut", tile_out2, indices=[th, tw])
                     DeallocOp(tile_in2)
                     DeallocOp(tile_out2)
+
+            # Transfer one tile of data per worker
+            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
+                for w in range(IMAGE_WIDTH // TILE_WIDTH):
+                    offset0 = TILE_HEIGHT * h
+                    offset1 = TILE_WIDTH * w
+
+                    # Write data back out to the channel tile by tile
+                    ChannelGet(
+                        "ChanOut",
+                        b,
+                        indices=[h, w],
+                        offsets=[offset0, offset1],
+                        sizes=TILE_SIZE,
+                        strides=[IMAGE_WIDTH, 1],
+                    )
 
 
 if __name__ == "__main__":

--- a/programming_examples/data_transfer_transpose/channel/transpose.py
+++ b/programming_examples/data_transfer_transpose/channel/transpose.py
@@ -36,9 +36,6 @@ def build_module(m, k, dtype):
             # Put data into the channel
             ChannelPut("ChanIn", a)
 
-            # Write data back out to the channel
-            ChannelGet("ChanOut", b)
-
             @segment(name="seg")
             def segment_body():
                 @herd(name="herd", sizes=[1, 1])
@@ -60,6 +57,9 @@ def build_module(m, k, dtype):
                     ChannelPut("ChanOut", tensor_in, sizes=[1, k, m], strides=[1, 1, k])
 
                     DeallocOp(tensor_in)
+
+            # Write data back out to the channel
+            ChannelGet("ChanOut", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
+++ b/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
@@ -173,7 +173,7 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
         def matvec_int4_swiglu_rms(PACKED, RMS, D):
             @launch(sizes=[1, 1], operands=[PACKED, RMS, D])
             def launch_body(li, lj, lsx, lsy, packed, rms, d):
-                # L3-side puts: per-core PACKED slab + per-core D get.
+                # L3-side puts: per-core PACKED slab.
                 for c in range(N_CORES):
                     c_idx = arith.ConstantOp.create_index(c)
                     c_tile_const = arith.ConstantOp.create_index(c * M_div)
@@ -184,15 +184,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
                         offsets=[c_tile_const, 0],
                         sizes=[M_div, tile_bytes],
                         strides=[tile_bytes, 1],
-                    )
-                    c_d_off = arith.ConstantOp.create_index(c * half_M_per_core)
-                    ChannelGet(
-                        "outD",
-                        d,
-                        indices=[c_idx],
-                        offsets=[c_d_off],
-                        sizes=[half_M_per_core],
-                        strides=[1],
                     )
                 # RMS input broadcast: a single S2MM per compute tile, replayed
                 # once per launch (RMS input does not change across outer iters).
@@ -478,6 +469,20 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
                     herd_body.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
                     herd_body.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
                     herd_body.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                # Per-core D gets, placed AFTER @segment so source program
+                # order encodes producer→consumer (#1671).
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_d_off = arith.ConstantOp.create_index(c * half_M_per_core)
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[c_d_off],
+                        sizes=[half_M_per_core],
+                        strides=[1],
+                    )
 
     return build()
 

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu1.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu1.py
@@ -497,16 +497,6 @@ def build_module(
                         strides=[lkp * dv_tile, dv_tile, 1],
                     )
 
-                # Output get: contiguous dv_tile slice (transposed L3 layout)
-                ChannelGet(
-                    "GpOut",
-                    gp,
-                    indices=[head_offset_idx],
-                    offsets=[out_combined],
-                    sizes=[lqp * dv_tile],
-                    strides=[1],
-                )
-
             # ----------------------------------------------------------
             # Segment: unrolled over heads
             # ----------------------------------------------------------
@@ -602,36 +592,6 @@ def build_module(
                             strides=[M, dv_tile * K_mmul, dv_tile, 1],
                         )
                         yield_([])
-
-                # Output gather from ty=0 tiles
-                affine_map_col = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_size_q),
-                        )
-                    ],
-                )
-                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
-                with InsertionPoint(par_out.body):
-                    apply_off = affine_apply(
-                        affine_map_col,
-                        [par_out.induction_variables[0]],
-                    )
-                    ChannelGet(
-                        "Gp2L2",
-                        gp_l2.result,
-                        indices=[par_out.induction_variables[0], 0],
-                        offsets=[apply_off, 0],
-                        sizes=[tile_size_q, dv_tile],
-                        strides=[dv_tile, 1],
-                    )
-                    scf.InParallelOp()
-
-                # Output: L2-to-L3
-                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
 
                 # ----------------------------------------------------------
                 # Herd: [NQ, NS] — pass seg_x as operand
@@ -1129,6 +1089,36 @@ def build_module(
                         else:
                             _emit_counter_increment()
 
+                # Output gather from ty=0 tiles
+                affine_map_col = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_size_q),
+                        )
+                    ],
+                )
+                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
+                with InsertionPoint(par_out.body):
+                    apply_off = affine_apply(
+                        affine_map_col,
+                        [par_out.induction_variables[0]],
+                    )
+                    ChannelGet(
+                        "Gp2L2",
+                        gp_l2.result,
+                        indices=[par_out.induction_variables[0], 0],
+                        offsets=[apply_off, 0],
+                        sizes=[tile_size_q, dv_tile],
+                        strides=[dv_tile, 1],
+                    )
+                    scf.InParallelOp()
+
+                # Output: L2-to-L3
+                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
+
                 # Deallocs for segment-level buffers
                 for q_buf in q_saved_bufs:
                     DeallocOp(q_buf)
@@ -1145,6 +1135,16 @@ def build_module(
                 DeallocOp(gp_l2)
                 if causal:
                     DeallocOp(causal_ctr)
+
+            # Output get: contiguous dv_tile slice (transposed L3 layout)
+            ChannelGet(
+                "GpOut",
+                gp,
+                indices=[head_offset_idx],
+                offsets=[out_combined],
+                sizes=[lqp * dv_tile],
+                strides=[1],
+            )
 
 
 if __name__ == "__main__":

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
@@ -487,16 +487,6 @@ def build_module(
                         strides=[lkp * dv_tile, dv_tile, 1],
                     )
 
-                # Output get: contiguous dv_tile slice (transposed L3 layout)
-                ChannelGet(
-                    "GpOut",
-                    gp,
-                    indices=[head_offset_idx],
-                    offsets=[out_combined],
-                    sizes=[lqp * dv_tile],
-                    strides=[1],
-                )
-
             # ----------------------------------------------------------
             # Segment: unrolled over heads
             # ----------------------------------------------------------
@@ -592,36 +582,6 @@ def build_module(
                             strides=[M, dv_tile * M, dv_tile, 1],
                         )
                         yield_([])
-
-                # Output gather from ty=0 tiles
-                affine_map_col = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_size_q),
-                        )
-                    ],
-                )
-                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
-                with InsertionPoint(par_out.body):
-                    apply_off = affine_apply(
-                        affine_map_col,
-                        [par_out.induction_variables[0]],
-                    )
-                    ChannelGet(
-                        "Gp2L2",
-                        gp_l2.result,
-                        indices=[par_out.induction_variables[0], 0],
-                        offsets=[apply_off, 0],
-                        sizes=[tile_size_q, dv_tile],
-                        strides=[dv_tile, 1],
-                    )
-                    scf.InParallelOp()
-
-                # Output: L2-to-L3
-                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
 
                 # ----------------------------------------------------------
                 # Herd: [NQ, NS] — pass seg_x as operand
@@ -1119,6 +1079,36 @@ def build_module(
                         else:
                             _emit_counter_increment()
 
+                # Output gather from ty=0 tiles
+                affine_map_col = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_size_q),
+                        )
+                    ],
+                )
+                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
+                with InsertionPoint(par_out.body):
+                    apply_off = affine_apply(
+                        affine_map_col,
+                        [par_out.induction_variables[0]],
+                    )
+                    ChannelGet(
+                        "Gp2L2",
+                        gp_l2.result,
+                        indices=[par_out.induction_variables[0], 0],
+                        offsets=[apply_off, 0],
+                        sizes=[tile_size_q, dv_tile],
+                        strides=[dv_tile, 1],
+                    )
+                    scf.InParallelOp()
+
+                # Output: L2-to-L3
+                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
+
                 # Deallocs for segment-level buffers
                 for q_buf in q_saved_bufs:
                     DeallocOp(q_buf)
@@ -1135,6 +1125,27 @@ def build_module(
                 DeallocOp(gp_l2)
                 if causal:
                     DeallocOp(causal_ctr)
+
+            # Output gets: one per head in the unroll group, placed after the
+            # producing @segment so source order encodes producer→consumer.
+            for head_local in range(num_heads_per_unroll):
+                if head_local == 0:
+                    head_idx = head_base
+                else:
+                    head_idx = affine_apply(affine_map_plus1, [head_base])
+                head_out_off = affine_apply(affine_map_head_out_dv, [head_idx, lz])
+                head_offset_idx = ConstantOp(index_type, head_local)
+                out_combined = affine_apply(
+                    affine_map_add, [head_out_off, out_launch_off]
+                )
+                ChannelGet(
+                    "GpOut",
+                    gp,
+                    indices=[head_offset_idx],
+                    offsets=[out_combined],
+                    sizes=[lqp * dv_tile],
+                    strides=[1],
+                )
 
 
 if __name__ == "__main__":

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_seqfirst.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_seqfirst.py
@@ -484,18 +484,6 @@ def build_module(
                         strides=[lkp * emb_dim_v, emb_dim_v, 1],
                     )
 
-                # Output get: SEQ-FIRST 2D memref [lq, num_heads*dv]
-                # 2D offsets: [row=out_launch_row, col=out_col_off]
-                emb_dim_out = num_heads * dv
-                ChannelGet(
-                    "GpOut",
-                    gp,
-                    indices=[head_offset_idx],
-                    offsets=[out_launch_row, out_col_off],
-                    sizes=[lqp, dv_tile],
-                    strides=[emb_dim_out, 1],
-                )
-
             # ----------------------------------------------------------
             # Segment: unrolled over heads
             # ----------------------------------------------------------
@@ -591,36 +579,6 @@ def build_module(
                             strides=[M, dv_tile * M, dv_tile, 1],
                         )
                         yield_([])
-
-                # Output gather from ty=0 tiles
-                affine_map_col = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_size_q),
-                        )
-                    ],
-                )
-                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
-                with InsertionPoint(par_out.body):
-                    apply_off = affine_apply(
-                        affine_map_col,
-                        [par_out.induction_variables[0]],
-                    )
-                    ChannelGet(
-                        "Gp2L2",
-                        gp_l2.result,
-                        indices=[par_out.induction_variables[0], 0],
-                        offsets=[apply_off, 0],
-                        sizes=[tile_size_q, dv_tile],
-                        strides=[dv_tile, 1],
-                    )
-                    scf.InParallelOp()
-
-                # Output: L2-to-L3
-                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
 
                 # ----------------------------------------------------------
                 # Herd: [NQ, NS] — pass seg_x as operand
@@ -1118,6 +1076,36 @@ def build_module(
                         else:
                             _emit_counter_increment()
 
+                # Output gather from ty=0 tiles
+                affine_map_col = AffineMap.get(
+                    0,
+                    1,
+                    [
+                        AffineExpr.get_mul(
+                            AffineSymbolExpr.get(0),
+                            AffineConstantExpr.get(tile_size_q),
+                        )
+                    ],
+                )
+                par_out = scf.ForallOp(lower_bounds=[0], upper_bounds=[NQ], steps=[1])
+                with InsertionPoint(par_out.body):
+                    apply_off = affine_apply(
+                        affine_map_col,
+                        [par_out.induction_variables[0]],
+                    )
+                    ChannelGet(
+                        "Gp2L2",
+                        gp_l2.result,
+                        indices=[par_out.induction_variables[0], 0],
+                        offsets=[apply_off, 0],
+                        sizes=[tile_size_q, dv_tile],
+                        strides=[dv_tile, 1],
+                    )
+                    scf.InParallelOp()
+
+                # Output: L2-to-L3
+                ChannelPut("GpOut", gp_l2.result, indices=[seg_x])
+
                 # Deallocs for segment-level buffers
                 for q_buf in q_saved_bufs:
                     DeallocOp(q_buf)
@@ -1134,6 +1122,26 @@ def build_module(
                 DeallocOp(gp_l2)
                 if causal:
                     DeallocOp(causal_ctr)
+
+            # Output gets: one per head in the unroll group, placed after the
+            # producing @segment so source order encodes producer→consumer.
+            emb_dim_out = num_heads * dv
+            for head_local in range(num_heads_per_unroll):
+                if head_local == 0:
+                    head_idx = head_base
+                else:
+                    head_idx = affine_apply(affine_map_plus1, [head_base])
+                head_out_off = affine_apply(affine_map_head_out_dv, [head_idx, lz])
+                head_offset_idx = ConstantOp(index_type, head_local)
+                out_col_off = head_out_off
+                ChannelGet(
+                    "GpOut",
+                    gp,
+                    indices=[head_offset_idx],
+                    offsets=[out_launch_row, out_col_off],
+                    sizes=[lqp, dv_tile],
+                    strides=[emb_dim_out, 1],
+                )
 
 
 if __name__ == "__main__":

--- a/programming_examples/llama2_mha/mha.py
+++ b/programming_examples/llama2_mha/mha.py
@@ -261,22 +261,6 @@ def build_module(
                 )
                 yield_([])
 
-            ChannelGet(
-                "cL2ToL3",
-                l3_k_cache_data,
-                offsets=[pos_host, launch_offset_y],
-                sizes=[1, tile_n],
-                strides=[n, 1],
-            )
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_v_cache_data,
-                offsets=[pos_host, launch_offset_y],
-                sizes=[1, tile_n],
-                strides=[n, 1],
-            )
-
             # Launch 2 runtime
 
             for i in range_(0, pos_host + 1):
@@ -297,14 +281,6 @@ def build_module(
                     strides=[n, 1],
                 )
                 yield_([])
-
-            ChannelGet(
-                "dL2ToL3",
-                l3_xb_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
 
             @segment(name="vecmat_i8_0")
             def segment_body():
@@ -385,14 +361,6 @@ def build_module(
                         )
                         yield_([])
                     yield_([])
-
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
 
                 l1_out_data = AllocOp(l1MemrefTyC, [], [])
 
@@ -658,6 +626,14 @@ def build_module(
 
                 herd_body_0.attributes["link_with"] = StringAttr.get("mha.o")
 
+                ChannelGet(
+                    "cL1ToL2",
+                    l2_c_data,
+                    offsets=[],
+                    sizes=[],
+                    strides=[],
+                )
+
                 ChannelPut(
                     "cL2ToL3",
                     l2_c_data,
@@ -692,6 +668,30 @@ def build_module(
                 DeallocOp(l2_a_data)
                 DeallocOp(l2_b_data)
                 DeallocOp(l2_c_data)
+
+            ChannelGet(
+                "cL2ToL3",
+                l3_k_cache_data,
+                offsets=[pos_host, launch_offset_y],
+                sizes=[1, tile_n],
+                strides=[n, 1],
+            )
+
+            ChannelGet(
+                "cL2ToL3",
+                l3_v_cache_data,
+                offsets=[pos_host, launch_offset_y],
+                sizes=[1, tile_n],
+                strides=[n, 1],
+            )
+
+            ChannelGet(
+                "dL2ToL3",
+                l3_xb_data,
+                offsets=[],
+                sizes=[],
+                strides=[],
+            )
 
 
 if __name__ == "__main__":

--- a/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
@@ -55,21 +55,6 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                         strides=[image_width, 1],
                     )
 
-            # Transfer one tile of data per worker
-            for h in range(image_height // tile_height):
-                for w in range(image_width // tile_width):
-                    offset0 = tile_height * h
-                    offset1 = tile_width * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        format_name("ChanOut", h, w),
-                        b,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
-
             # The arguments are still the input and the output
             @segment(name="seg")
             def segment_body():
@@ -123,6 +108,21 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                             # Deallocate our L1 buffers
                             DeallocOp(tile_in)
                             DeallocOp(tile_out)
+
+            # Transfer one tile of data per worker
+            for h in range(image_height // tile_height):
+                for w in range(image_width // tile_width):
+                    offset0 = tile_height * h
+                    offset1 = tile_width * w
+
+                    # Write data back out to the channel tile by tile
+                    ChannelGet(
+                        format_name("ChanOut", h, w),
+                        b,
+                        offsets=[offset0, offset1],
+                        sizes=tile_size,
+                        strides=[image_width, 1],
+                    )
 
 
 if __name__ == "__main__":

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/multi_launch_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/multi_launch_channel.py
@@ -56,15 +56,6 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                         strides=[image_width, 1],
                     )
 
-                    # Write one tile of data into the output
-                    ChannelGet(
-                        format_name("ChanOut", h, w),
-                        b,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
-
                     # The arguments are still the input and the output
                     @segment(name=format_name("segment", h, w))
                     def segment_body():
@@ -114,6 +105,15 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                             # Deallocate our L1 buffers
                             DeallocOp(tile_in)
                             DeallocOp(tile_out)
+
+                    # Write one tile of data into the output
+                    ChannelGet(
+                        format_name("ChanOut", h, w),
+                        b,
+                        offsets=[offset0, offset1],
+                        sizes=tile_size,
+                        strides=[image_width, 1],
+                    )
 
 
 if __name__ == "__main__":

--- a/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
+++ b/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
@@ -50,15 +50,6 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                         sizes=tile_size,
                         strides=[image_width, 1],
                     )
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
                     yield_([])
                 yield_([])
 
@@ -117,6 +108,23 @@ def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
                         DeallocOp(tile_out)
 
                         yield_([])
+
+            # Write data back out to the channel tile by tile
+            for offset0 in range_(
+                0, tile_height * (image_height // tile_height), tile_height
+            ):
+                for offset1 in range_(
+                    0, tile_width * (image_width // tile_width), tile_width
+                ):
+                    ChannelGet(
+                        "ChanOut",
+                        b,
+                        offsets=[offset0, offset1],
+                        sizes=tile_size,
+                        strides=[image_width, 1],
+                    )
+                    yield_([])
+                yield_([])
 
 
 if __name__ == "__main__":

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_2tile_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_2tile_add.py
@@ -135,14 +135,6 @@ def build_module(M, K, m=8, k=512, n_cores=8):
                         sizes=[M_div_m_per_core, K_div_k, m, k],
                         strides=[m * K, k, K, 1],
                     )
-                    ChannelGet(
-                        "outD",
-                        d,
-                        indices=[c_col],
-                        offsets=[i * M_per_core],
-                        sizes=[M_per_core],
-                        strides=[1],
-                    )
                 # B: replay the same K-chunk stream per outer iter
                 # (outer-dim stride=0). R: broadcast the full vector
                 # once and reuse via per-iter offset inside addr_h.
@@ -260,6 +252,19 @@ def build_module(M, K, m=8, k=512, n_cores=8):
                     addr_herd.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
                     addr_herd.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
                     addr_herd.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                # Per-core D gets, placed AFTER @segment so source program
+                # order encodes producer→consumer (#1671).
+                for i in range(n_cores):
+                    c_col = arith.ConstantOp.create_index(i)
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_col],
+                        offsets=[i * M_per_core],
+                        sizes=[M_per_core],
+                        strides=[1],
+                    )
 
     return build()
 

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed.py
@@ -201,18 +201,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                         sizes=[tiles_per_launch_per_core, tile_bytes],
                         strides=[tile_bytes, 1],
                     )
-                    c_row_const = arith.ConstantOp.create_index(
-                        c * M_per_core_per_launch
-                    )
-                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
-                    ChannelGet(
-                        "outD",
-                        d,
-                        indices=[c_idx],
-                        offsets=[core_launch_base],
-                        sizes=[M_per_core_per_launch],
-                        strides=[1],
-                    )
 
                 # B: replay each K-chunk across outer iters (outer-stride=0).
                 ChannelPut(
@@ -260,6 +248,23 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                     herd_body.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
                     herd_body.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
                     herd_body.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                # Per-core D gets, placed AFTER @segment so source program
+                # order encodes producer→consumer (#1671).
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_row_const = arith.ConstantOp.create_index(
+                        c * M_per_core_per_launch
+                    )
+                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[core_launch_base],
+                        sizes=[M_per_core_per_launch],
+                        strides=[1],
+                    )
 
     return build()
 

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
@@ -179,16 +179,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                         sizes=[tiles_per_launch_per_core, tile_bytes],
                         strides=[tile_bytes, 1],
                     )
-                    c_row_const = arith.ConstantOp.create_index(c * M_per_core)
-                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
-                    ChannelGet(
-                        "outD",
-                        d,
-                        indices=[c_idx],
-                        offsets=[core_launch_base],
-                        sizes=[M_per_core],
-                        strides=[1],
-                    )
                 ChannelPut(
                     "inB",
                     b,
@@ -290,6 +280,21 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                     addr_herd.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
                     addr_herd.attributes["x_loc"] = IntegerAttr.get(T.i64(), 0)
                     addr_herd.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                # Per-core D gets, placed AFTER @segment so source program
+                # order encodes producer→consumer (#1671).
+                for c in range(N_CORES):
+                    c_idx = arith.ConstantOp.create_index(c)
+                    c_row_const = arith.ConstantOp.create_index(c * M_per_core)
+                    core_launch_base = arith.AddIOp(launch_off, c_row_const).result
+                    ChannelGet(
+                        "outD",
+                        d,
+                        indices=[c_idx],
+                        offsets=[core_launch_base],
+                        sizes=[M_per_core],
+                        strides=[1],
+                    )
 
     return build()
 

--- a/programming_examples/multi_segment/multi_segment_channel/multi_segment.py
+++ b/programming_examples/multi_segment/multi_segment_channel/multi_segment.py
@@ -45,8 +45,6 @@ def build_module():
         def launch_body(a, b, c, d):
             ChannelPut("ChanInA", a)
             ChannelPut("ChanInB", b)
-            ChannelGet("ChanOutC", c)
-            ChannelGet("ChanOutD", d)
 
             @segment(name="seg1")
             def segment_body():
@@ -70,6 +68,8 @@ def build_module():
                     DeallocOp(image_in_a)
                     DeallocOp(image_out_a)
 
+            ChannelGet("ChanOutC", c)
+
             @segment(name="seg2")
             def segment_body():
 
@@ -91,6 +91,8 @@ def build_module():
 
                     DeallocOp(image_in_b)
                     DeallocOp(image_out_b)
+
+            ChannelGet("ChanOutD", d)
 
 
 if __name__ == "__main__":

--- a/programming_examples/passthrough/passthrough_channel/passthrough_channel.py
+++ b/programming_examples/passthrough/passthrough_channel/passthrough_channel.py
@@ -42,7 +42,6 @@ def build_module(vector_size, num_subvectors):
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
             ChannelPut("ChanIn", a)
-            ChannelGet("ChanOut", b)
 
             @segment(name="seg")
             def segment_body():
@@ -72,6 +71,8 @@ def build_module(vector_size, num_subvectors):
                         DeallocOp(tensor_in)
                         DeallocOp(tensor_out)
                         yield_([])
+
+            ChannelGet("ChanOut", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py
+++ b/programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py
@@ -47,7 +47,6 @@ def build_module(vector_size, num_subvectors):
         @launch(operands=[arg0, arg1])
         def launch_body(a, b):
             ChannelPut("ChanIn", a)
-            ChannelGet("ChanOut", b)
 
             @segment(name="seg")
             def segment_body():
@@ -74,6 +73,8 @@ def build_module(vector_size, num_subvectors):
                         DeallocOp(tensor_in)
                         DeallocOp(tensor_out)
                         yield_([])
+
+            ChannelGet("ChanOut", b)
 
 
 if __name__ == "__main__":

--- a/programming_examples/segment_unroll/segment_unroll.py
+++ b/programming_examples/segment_unroll/segment_unroll.py
@@ -71,7 +71,7 @@ def build_module():
 
         @launch(operands=[input_buf, output_buf])
         def launch_body(a, b):
-            # Put/Get on each subchannel at launch level
+            # Put on each subchannel at launch level
             # Each unrolled segment instance reads from its own subchannel
             chunk_size = VECTOR_LEN // SEGMENT_SIZE_X
             for sx in range(SEGMENT_SIZE_X):
@@ -87,15 +87,6 @@ def build_module():
                     ChannelPut(
                         "ChanIn",
                         a,
-                        indices=[sx_idx, sy_idx],
-                        offsets=[offset_idx],
-                        sizes=[size_idx],
-                        strides=[stride_idx],
-                    )
-                    # Get a portion of output from each subchannel
-                    ChannelGet(
-                        "ChanOut",
-                        b,
                         indices=[sx_idx, sy_idx],
                         offsets=[offset_idx],
                         sizes=[size_idx],
@@ -128,6 +119,25 @@ def build_module():
 
                     DeallocOp(tile_in)
                     DeallocOp(tile_out)
+
+            # Get on each subchannel at launch level (after producer @segment)
+            for sx in range(SEGMENT_SIZE_X):
+                for sy in range(SEGMENT_SIZE_Y):
+                    offset = sx * chunk_size
+                    sx_idx = arith.constant(T.index(), sx)
+                    sy_idx = arith.constant(T.index(), sy)
+                    offset_idx = arith.constant(T.index(), offset)
+                    size_idx = arith.constant(T.index(), chunk_size)
+                    stride_idx = arith.constant(T.index(), 1)
+                    # Get a portion of output from each subchannel
+                    ChannelGet(
+                        "ChanOut",
+                        b,
+                        indices=[sx_idx, sy_idx],
+                        offsets=[offset_idx],
+                        sizes=[size_idx],
+                        strides=[stride_idx],
+                    )
 
 
 if __name__ == "__main__":

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -113,13 +113,6 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                 sizes=[k, tile_n],
                 strides=[n, 1],
             )
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
 
             @segment(name="vecmat_i8_0")
             def segment_body():
@@ -192,15 +185,6 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                     )
                     yield_([])
 
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
                 @herd(name="herd_0", sizes=[1, 1])
                 def herd_body(_tx, _ty, _sx, _sy):
 
@@ -250,6 +234,15 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
 
                 herd_body.attributes["link_with"] = StringAttr.get("vm.o")
 
+                l2_c_data = AllocOp(l2MemrefTyC, [], [])
+                ChannelGet(
+                    "cL1ToL2",
+                    l2_c_data,
+                    offsets=[],
+                    sizes=[],
+                    strides=[],
+                )
+
                 ChannelPut(
                     "cL2ToL3",
                     l2_c_data,
@@ -260,6 +253,14 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                 DeallocOp(l2_a_data)
                 DeallocOp(l2_b_data)
                 DeallocOp(l2_c_data)
+
+            ChannelGet(
+                "cL2ToL3",
+                l3_c_data,
+                offsets=[launch_offset_y],
+                sizes=[tile_n],
+                strides=[1],
+            )
 
 
 if __name__ == "__main__":

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -151,13 +151,6 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_o
                 sizes=[k // bs, tile_n],
                 strides=[n, 1],
             )
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
 
             @segment(name="vecmat_i8_0")
             def segment_body():
@@ -302,15 +295,6 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_o
                     )
                     yield_([])
 
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
                 @herd(name="herd_0", sizes=[1, 1])
                 def herd_body(_tx, _ty, _sx, _sy):
 
@@ -378,6 +362,15 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_o
 
                 herd_body.attributes["link_with"] = StringAttr.get("vm.o")
 
+                l2_c_data = AllocOp(l2MemrefTyC, [], [])
+                ChannelGet(
+                    "cL1ToL2",
+                    l2_c_data,
+                    offsets=[],
+                    sizes=[],
+                    strides=[],
+                )
+
                 ChannelPut(
                     "cL2ToL3",
                     l2_c_data,
@@ -390,6 +383,14 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_o
                 DeallocOp(l2_b_data)
                 DeallocOp(l2_b_scale)
                 DeallocOp(l2_c_data)
+
+            ChannelGet(
+                "cL2ToL3",
+                l3_c_data,
+                offsets=[launch_offset_y],
+                sizes=[tile_n],
+                strides=[1],
+            )
 
 
 if __name__ == "__main__":

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -118,13 +118,6 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                 sizes=[k, tile_n],
                 strides=[n, 1],
             )
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
 
             @segment(name="vecmat_i8_0")
             def segment_body():
@@ -209,15 +202,6 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                     )
                     yield_([])
 
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
                 @herd(name="herd_0", sizes=[1, 1])
                 def herd_body(_tx, _ty, _sx, _sy):
 
@@ -267,6 +251,15 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
 
                 herd_body.attributes["link_with"] = StringAttr.get("vm.o")
 
+                l2_c_data = AllocOp(l2MemrefTyC, [], [])
+                ChannelGet(
+                    "cL1ToL2",
+                    l2_c_data,
+                    offsets=[],
+                    sizes=[],
+                    strides=[],
+                )
+
                 ChannelPut(
                     "cL2ToL3",
                     l2_c_data,
@@ -277,6 +270,14 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
                 DeallocOp(l2_a_data)
                 DeallocOp(l2_b_data)
                 DeallocOp(l2_c_data)
+
+            ChannelGet(
+                "cL2ToL3",
+                l3_c_data,
+                offsets=[launch_offset_y],
+                sizes=[tile_n],
+                strides=[1],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1671. At each scope, moves the matching `ChannelGet` for an output channel to *after* the `@segment` / `@herd` whose body contains the producing `ChannelPut`. This makes the source program order itself a valid synchronous program (under infinite-FIFO channel semantics, where `put` enqueues, `get` blocks if empty, and `segment`/`herd` are blocking dispatch+join), independent of the async normalization the `air-dependency` pass performs later.

Python helpers correctly continue to emit synchronous IR by design (`async_token=None`); this PR is purely a program-order fix in the example sources, no behavior change once the pass pipeline runs.

## Scope: 27 files (npu1 + npu2)

### Batches 1–7: npu1-runnable subset (20 files)

#### Launch-body get-before-segment (17 files)

- `programming_examples/passthrough/passthrough_channel/passthrough_channel.py`
- `programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py`
- `programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py`
- `programming_examples/channel_examples/worker_to_self/worker_to_self.py`
- `programming_examples/channel_examples/worker_to_worker/worker_to_worker.py`
- `programming_examples/channel_examples/broadcast/single_herd/broadcast.py`
- `programming_examples/channel_examples/channel_size/channel_size.py`
- `programming_examples/channel_examples/broadcast_selective_capture/broadcast_selective_capture.py`
- `programming_examples/channel_examples/hierarchical/hierarchical.py` *(also segment-level)*
- `programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py`
- `programming_examples/matrix_scalar_add/multi_launch_channel/multi_launch_channel.py` *(XFAIL upstream)*
- `programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py`
- `programming_examples/multi_segment/multi_segment_channel/multi_segment.py` *(XFAIL upstream)*
- `programming_examples/data_transfer_transpose/channel/transpose.py`
- `programming_examples/segment_unroll/segment_unroll.py`
- `programming_examples/vector_matrix_multiplication/{bf16,i8,block_quantized_i8}/single_core/single_core.py` *(also segment-level)*
- `programming_examples/llama2_mha/mha.py` *(peano lit XFAIL upstream; also segment-level)*
- `programming_examples/flash_attention/kernel_fusion_based/attn_npu1.py` *(also segment-level)*

#### Segment-body get-before-herd (5 files, all in the above list)

- `channel_examples/hierarchical/hierarchical.py`
- `vector_matrix_multiplication/{bf16,i8,block_quantized_i8}/single_core/single_core.py`
- `llama2_mha/mha.py`
- `flash_attention/kernel_fusion_based/attn_npu1.py`

### Batch 8: npu2-only follow-up (7 files)

All seven files were initially deferred because the npu1 dev machine couldn't exercise them; all are now verified `PASS!` on `/dev/accel0` (NPU2 / AIE2P, peano).

| File | Edit level | Post-edit correlation |
|---|---|---|
| `flash_attention/kernel_fusion_based/attn_npu2.py` | launch + segment | 0.997371 |
| `flash_attention/kernel_fusion_based/attn_npu2_seqfirst.py` | launch + segment | 0.997459 |
| `attention_decode/attn_decode_npu2.py` | launch + segment | 0.963059 |
| `decode_ffn_swiglu/matvec_int4_swiglu_rms.py` | launch | 0.999917 |
| `matrix_vector_multiplication/bf16_cascade/matvec_2tile_add.py` | launch | 0.999994 |
| `matrix_vector_multiplication/int4_awq/matvec_int4_packed.py` | launch | 0.999997 |
| `matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py` | launch | 0.999993 |

**npu2 shape difference worth flagging:** the trailing single-`ChannelGet` placement that works in the npu1 batches (e.g. `attn_npu1.py`, where `num_heads_per_unroll = 1` so the surrounding `for` loop runs once) is **not** sufficient on npu2. With `num_heads_per_unroll = 2` (or `N_CORES > 1` unrolled), the producing `@segment` emits multiple channel-bundle entries per launch iter; a single trailing `get` triggers

```
'airrt.dma_memcpy_nd' op failed to specialize channel bundle indices
```

inside `air-opt-shim-dma-bds`. The npu2 fix uses a fresh per-iter `for head_local in range(num_heads_per_unroll)` (or `for c in range(N_CORES)`) loop **after** `@segment`, recomputing the per-iter offsets so the unroll factor of gets matches the unroll factor of puts.

## Test plan

- [x] **17 npu1-runnable examples**: baseline + post-edit `make run` on /dev/accel0 (npu1), both report `PASS!`.
- [x] **3 npu1 XFAIL examples** (`multi_launch_channel`, `multi_segment_channel`, `llama2_mha`): no `.lit` files modified; their pre-existing `XFAIL: *` annotations are untouched. Post-edit IR build via `make print` succeeds; pre-existing failure modes unchanged.
- [x] **7 npu2-only examples**: baseline + post-edit `make run` on /dev/accel0 (npu2), both report `PASS!` with matching output correlation (see table above).
- [x] **Post-edit AST re-audit**: 0 remaining launch-body-get-before-segment or segment-body-get-before-herd patterns across the full programming_examples tree.
- [ ] CI on npu1 + npu2 lit (`run_npu1_*.lit`, `run_npu2_*.lit`, default `run_makefile_*.lit`) — to be run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
