### PR TITLE
[Transform] AIRSpecialize/Unroll: admit size-1 dim IV fold, reject cascade unroll

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2358,15 +2358,18 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
     }
     // Pre-fold gate. The fold inserts one new outer dim; admit at the
     // maxNumDims boundary only when canonicalize can collapse the new
-    // dim with the existing outermost, which requires (a) the memtile
-    // pass (skipZeroStride=true) and (b) some parent scf.for IV reaches
-    // the original outermost offset. Pre-canonicalize offsets are used
-    // so an IV sitting in a size-1 dim is still found. The post-fold
-    // active-dim count check below rejects fold results that did not
-    // collapse.
+    // dim with an existing dim. This requires (a) the memtile pass
+    // (skipZeroStride=true) and (b) some parent scf.for IV reaches an
+    // offset entry that is either the outermost (offset[0]) or sits in a
+    // size-1 wrap dim (which canonicalize will erase, freeing room for
+    // the new outer dim). Pre-canonicalize offsets and the original
+    // pre-canonicalize wraps are used here so an IV in a size-1 dim is
+    // still found. The post-fold active-dim count check below rejects
+    // fold results that did not actually collapse.
     bool admitBoundary = false;
     if (skipZeroStride && maxNumDims >= 0 && numActualWrapDims == maxNumDims) {
       SmallVector<Value> origOffsets = channel_op.getOffsets();
+      SmallVector<Value> origWraps = channel_op.getSizes();
       SmallVector<scf::ForOp> parentForOps;
       Operation *parent = channel_op->getParentOp();
       while (parent) {
@@ -2389,10 +2392,20 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
         }
         return false;
       };
-      if (!origOffsets.empty()) {
+      // Check each (offset[i], wraps[i]) pair: an IV reach at i is
+      // admissible iff i==0 (outermost, collapses against the new outer
+      // dim directly) or wraps[i]==1 (size-1 dim erased by canonicalize,
+      // freeing slot for the new outer dim).
+      for (unsigned i = 0; i < origOffsets.size() && !admitBoundary; ++i) {
+        bool slotIsCollapsible = (i == 0);
+        if (!slotIsCollapsible && i < origWraps.size()) {
+          if (auto cw = getConstantIntValue(origWraps[i]))
+            slotIsCollapsible = (*cw == 1);
+        }
+        if (!slotIsCollapsible)
+          continue;
         for (auto pf : parentForOps) {
-          Value iv = pf.getInductionVar();
-          if (reachesIV(origOffsets[0], iv)) {
+          if (reachesIV(origOffsets[i], pf.getInductionVar())) {
             admitBoundary = true;
             break;
           }
@@ -2586,6 +2599,52 @@ struct AIRUnrollScfForIntoBDChain : public OpRewritePattern<scf::ForOp> {
       if (isa<air::AsyncTokenType>(resTy))
         resAsyncTokenCount++;
     if (resAsyncTokenCount > 1)
+      return failure();
+
+    // Reject unroll when the loop is part of a deeply-nested redundant-repeat
+    // cascade — i.e. neither this for_op's IV nor any enclosing scf.for IV
+    // (up to the herd/segment/launch boundary) appears in any contained
+    // channel op's offsets, AND the COMPOUND trip count of all such
+    // redundant enclosing loops exceeds the per-channel lock capacity
+    // (kRedundantUnrollLockLimit = 16). Unrolling such a cascade creates
+    // K identical chained channel ops; downstream air-to-aie collapses
+    // them to one BD per channel but sets the lock init count to K,
+    // breaking per-iter producer/consumer pairing. Below the threshold
+    // (e.g. a single 2- or 4-iter loop with constant offsets), the
+    // unrolled chain stays small and downstream BD/lock allocation still
+    // emits distinct BDs that pair correctly.
+    constexpr int64_t kRedundantUnrollLockLimit = 16;
+    SmallVector<Value> enclosingIVs;
+    enclosingIVs.push_back(for_op.getInductionVar());
+    int64_t compoundTrip = 1;
+    if (auto t = air::getStaticScfForTripCountAsInt(for_op))
+      compoundTrip *= *t;
+    else
+      compoundTrip = -1;
+    for (Operation *p = for_op->getParentOp(); p; p = p->getParentOp()) {
+      if (isa<air::HerdOp, air::SegmentOp, air::LaunchOp>(p))
+        break;
+      if (auto pf = dyn_cast<scf::ForOp>(p)) {
+        enclosingIVs.push_back(pf.getInductionVar());
+        if (compoundTrip > 0) {
+          if (auto t = air::getStaticScfForTripCountAsInt(pf))
+            compoundTrip *= *t;
+          else
+            compoundTrip = -1;
+        }
+      }
+    }
+    bool someIVInOffsets = false;
+    for_op.getBody()->walk([&](air::ChannelInterface chan) {
+      for (Value off : chan.getOffsets())
+        for (Value iv : enclosingIVs)
+          if (off == iv) {
+            someIVInOffsets = true;
+            return WalkResult::interrupt();
+          }
+      return WalkResult::advance();
+    });
+    if (!someIVInOffsets && compoundTrip > kRedundantUnrollLockLimit)
       return failure();
 
     // Unroll loop; preserve async tokens after unroll.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2356,16 +2356,10 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
       if (*getConstantIntValue(v) > 1)
         numActualWrapDims++;
     }
-    // Pre-fold gate. The fold inserts one new outer dim; admit at the
-    // maxNumDims boundary only when canonicalize can collapse the new
-    // dim with an existing dim. This requires (a) the memtile pass
-    // (skipZeroStride=true) and (b) some parent scf.for IV reaches an
-    // offset entry that is either the outermost (offset[0]) or sits in a
-    // size-1 wrap dim (which canonicalize will erase, freeing room for
-    // the new outer dim). Pre-canonicalize offsets and the original
-    // pre-canonicalize wraps are used here so an IV in a size-1 dim is
-    // still found. The post-fold active-dim count check below rejects
-    // fold results that did not actually collapse.
+    // Pre-fold gate. At the maxNumDims boundary, admit only when some
+    // parent IV reaches an offset that canonicalize can collapse: offset[0]
+    // (outermost) or any offset whose wrap is statically 1 (size-1 dim
+    // erased by canonicalize). Memtile pass only (skipZeroStride=true).
     bool admitBoundary = false;
     if (skipZeroStride && maxNumDims >= 0 && numActualWrapDims == maxNumDims) {
       SmallVector<Value> origOffsets = channel_op.getOffsets();
@@ -2392,24 +2386,18 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
         }
         return false;
       };
-      // Check each (offset[i], wraps[i]) pair: an IV reach at i is
-      // admissible iff i==0 (outermost, collapses against the new outer
-      // dim directly) or wraps[i]==1 (size-1 dim erased by canonicalize,
-      // freeing slot for the new outer dim).
       for (unsigned i = 0; i < origOffsets.size() && !admitBoundary; ++i) {
         bool slotIsCollapsible = (i == 0);
-        if (!slotIsCollapsible && i < origWraps.size()) {
+        if (!slotIsCollapsible && i < origWraps.size())
           if (auto cw = getConstantIntValue(origWraps[i]))
             slotIsCollapsible = (*cw == 1);
-        }
         if (!slotIsCollapsible)
           continue;
-        for (auto pf : parentForOps) {
+        for (auto pf : parentForOps)
           if (reachesIV(origOffsets[i], pf.getInductionVar())) {
             admitBoundary = true;
             break;
           }
-        }
       }
     }
     int effectiveMax = admitBoundary ? maxNumDims : (maxNumDims - 1);
@@ -2601,47 +2589,66 @@ struct AIRUnrollScfForIntoBDChain : public OpRewritePattern<scf::ForOp> {
     if (resAsyncTokenCount > 1)
       return failure();
 
-    // Reject unroll when the loop is part of a deeply-nested redundant-repeat
-    // cascade — i.e. neither this for_op's IV nor any enclosing scf.for IV
-    // (up to the herd/segment/launch boundary) appears in any contained
-    // channel op's offsets, AND the COMPOUND trip count of all such
-    // redundant enclosing loops exceeds the per-channel lock capacity
-    // (kRedundantUnrollLockLimit = 16). Unrolling such a cascade creates
-    // K identical chained channel ops; downstream air-to-aie collapses
-    // them to one BD per channel but sets the lock init count to K,
-    // breaking per-iter producer/consumer pairing. Below the threshold
-    // (e.g. a single 2- or 4-iter loop with constant offsets), the
-    // unrolled chain stays small and downstream BD/lock allocation still
-    // emits distinct BDs that pair correctly.
+    // Reject unroll of a deeply-nested redundant-repeat cascade: if no
+    // enclosing IV reaches any channel offset and the compound trip
+    // count exceeds the per-channel lock capacity, unrolling would emit
+    // K chained identical ops and downstream air-to-aie would set the
+    // lock init count to K, breaking per-iter pairing. Leaving the loop
+    // intact keeps init=1 with an implicit per-iter BD repeat.
     constexpr int64_t kRedundantUnrollLockLimit = 16;
-    SmallVector<Value> enclosingIVs;
-    enclosingIVs.push_back(for_op.getInductionVar());
-    int64_t compoundTrip = 1;
-    if (auto t = air::getStaticScfForTripCountAsInt(for_op))
-      compoundTrip *= *t;
-    else
-      compoundTrip = -1;
+    auto satMul = [](int64_t a, int64_t b) -> int64_t {
+      if (a < 0 || b < 0)
+        return -1;
+      int64_t prod;
+      if (llvm::MulOverflow(a, b, prod) || prod > kRedundantUnrollLockLimit)
+        return kRedundantUnrollLockLimit + 1;
+      return prod;
+    };
+    SmallVector<Value> enclosingIVs{for_op.getInductionVar()};
+    int64_t compoundTrip =
+        air::getStaticScfForTripCountAsInt(for_op).value_or(-1);
     for (Operation *p = for_op->getParentOp(); p; p = p->getParentOp()) {
       if (isa<air::HerdOp, air::SegmentOp, air::LaunchOp>(p))
         break;
       if (auto pf = dyn_cast<scf::ForOp>(p)) {
         enclosingIVs.push_back(pf.getInductionVar());
-        if (compoundTrip > 0) {
-          if (auto t = air::getStaticScfForTripCountAsInt(pf))
-            compoundTrip *= *t;
-          else
-            compoundTrip = -1;
-        }
+        auto t = air::getStaticScfForTripCountAsInt(pf);
+        compoundTrip = t ? satMul(compoundTrip, *t) : -1;
       }
     }
+    // True iff `v` transitively depends on some enclosing IV via its
+    // def-use chain (handles arith ops, affine.apply, index_cast,
+    // air.execute wrappers).
+    auto ivReachesValue = [&](Value v) -> bool {
+      SmallVector<Value> worklist{v};
+      llvm::SmallPtrSet<Value, 8> seen;
+      while (!worklist.empty()) {
+        Value cur = worklist.pop_back_val();
+        if (!seen.insert(cur).second)
+          continue;
+        for (Value iv : enclosingIVs)
+          if (cur == iv)
+            return true;
+        Operation *def = cur.getDefiningOp();
+        if (!def)
+          continue;
+        if (auto exec = dyn_cast<air::ExecuteOp>(def))
+          for (Operation &child : exec.getChildOps())
+            for (Value oper : child.getOperands())
+              worklist.push_back(oper);
+        else
+          for (Value oper : def->getOperands())
+            worklist.push_back(oper);
+      }
+      return false;
+    };
     bool someIVInOffsets = false;
     for_op.getBody()->walk([&](air::ChannelInterface chan) {
       for (Value off : chan.getOffsets())
-        for (Value iv : enclosingIVs)
-          if (off == iv) {
-            someIVInOffsets = true;
-            return WalkResult::interrupt();
-          }
+        if (ivReachesValue(off)) {
+          someIVInOffsets = true;
+          return WalkResult::interrupt();
+        }
       return WalkResult::advance();
     });
     if (!someIVInOffsets && compoundTrip > kRedundantUnrollLockLimit)

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
@@ -227,3 +227,121 @@ module {
     return
   }
 }
+
+// -----
+
+// =============================================================================
+// AIRUnrollScfForIntoBDChain compound-trip cascade guard.
+//
+// A scf.for whose body contains only a channel op with ALL-constant offsets
+// represents a redundant-repeat (same data sent each iteration). The unroll
+// fallback would materialize N chained identical channel ops; downstream
+// air-to-aie collapses them to one BD but sets the per-channel lock init
+// count to N, breaking per-iter producer/consumer pairing.
+//
+// When this for_op is itself nested inside one or more scf.fors that are
+// ALSO redundant (no IV from any enclosing scf.for reaches the channel
+// offsets), the compound trip count of the cascade can exceed the per-
+// channel lock capacity. The guard rejects the unroll in this case so the
+// loops survive and downstream emits a single BD with an implicit per-iter
+// repeat at init=1.
+//
+// Concretely: scf.for %g = 0..9 / scf.for %y = 0..16 enclosing a single
+// channel.put with constant offsets and the v21fold-style 4D wrap
+// <8,6272>·<98,8>·<8,784>·<8,1> = 50176 B. Compound trip = 9 * 16 = 144,
+// well above the kRedundantUnrollLockLimit = 16 threshold. Both loops must
+// be preserved.
+// =============================================================================
+
+// CHECK-LABEL: @unroll_cascade_redundant_preserved
+// CHECK:       scf.for {{.*}} = %c0{{.*}} to %c9{{.*}} step %c1{{.*}}
+// CHECK:         scf.for {{.*}} = %c0{{.*}} to %c16{{.*}} step %c1{{.*}}
+// CHECK:           air.channel.put async {{.*}} @channel_casc[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c8{{.*}}, %c98{{.*}}, %c8{{.*}}, %c8{{.*}}] [%c6272{{.*}}, %c8{{.*}}, %c784{{.*}}, %c1{{.*}}])
+// CHECK-NOT:       air.channel.put
+// CHECK:         scf.yield
+// CHECK:       scf.yield
+// CHECK:       {air.segment_end}
+
+module {
+  air.channel @channel_casc [1]
+  func.func @unroll_cascade_redundant_preserved() {
+    %0 = air.launch async () in () {
+      %1 = air.segment @seg_casc async {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c8 = arith.constant 8 : index
+        %c9 = arith.constant 9 : index
+        %c16 = arith.constant 16 : index
+        %c98 = arith.constant 98 : index
+        %c784 = arith.constant 784 : index
+        %c6272 = arith.constant 6272 : index
+        %async_token, %results = air.execute -> (memref<1x3x50176xi8, 1 : i32>) {
+          %alloc = memref.alloc() : memref<1x3x50176xi8, 1 : i32>
+          air.execute_terminator %alloc : memref<1x3x50176xi8, 1 : i32>
+        }
+        %tg = scf.for %g = %c0 to %c9 step %c1 iter_args(%arg_g = %async_token) -> (!air.async.token) {
+          %ty = scf.for %y = %c0 to %c16 step %c1 iter_args(%arg_y = %arg_g) -> (!air.async.token) {
+            %p = air.channel.put async [%arg_y] @channel_casc[] (%results[%c0, %c0, %c0, %c0] [%c8, %c98, %c8, %c8] [%c6272, %c8, %c784, %c1]) {id = 3 : i32} : (memref<1x3x50176xi8, 1 : i32>)
+            scf.yield %p : !air.async.token
+          }
+          scf.yield %ty : !air.async.token
+        }
+        %async_token_0 = air.execute {
+          memref.dealloc %results : memref<1x3x50176xi8, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// =============================================================================
+// Regression guard for AIRUnrollScfForIntoBDChain compound-trip cascade:
+// short redundant loops (compound trip <= kRedundantUnrollLockLimit = 16)
+// must still unroll. A single scf.for with trip 4 and constant offsets
+// should unroll into 4 chained puts, matching the pre-fix behavior. This
+// keeps the guard from over-rejecting workloads like gemm 29 whose small
+// non-IV-bearing inner loops legitimately need unrolling to emit distinct
+// BDs.
+// =============================================================================
+
+// CHECK-LABEL: @unroll_small_redundant_admitted
+// CHECK-NOT:   scf.for
+// CHECK:       air.channel.put async {{.*}} @channel_small[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c3{{.*}}, %c4{{.*}}, %c5{{.*}}] [%c200{{.*}}, %c50{{.*}}, %c12{{.*}}, %c1{{.*}}])
+// CHECK:       air.channel.put async {{.*}} @channel_small[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c3{{.*}}, %c4{{.*}}, %c5{{.*}}] [%c200{{.*}}, %c50{{.*}}, %c12{{.*}}, %c1{{.*}}])
+// CHECK:       air.channel.put async {{.*}} @channel_small[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c3{{.*}}, %c4{{.*}}, %c5{{.*}}] [%c200{{.*}}, %c50{{.*}}, %c12{{.*}}, %c1{{.*}}])
+// CHECK:       air.channel.put async {{.*}} @channel_small[] (%{{.*}}[%c0{{.*}}, %c0{{.*}}, %c0{{.*}}, %c0{{.*}}] [%c2{{.*}}, %c3{{.*}}, %c4{{.*}}, %c5{{.*}}] [%c200{{.*}}, %c50{{.*}}, %c12{{.*}}, %c1{{.*}}])
+// CHECK:       {air.segment_end}
+
+module {
+  air.channel @channel_small [1]
+  func.func @unroll_small_redundant_admitted() {
+    %0 = air.launch async () in () {
+      %1 = air.segment @seg_small async {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %c3 = arith.constant 3 : index
+        %c4 = arith.constant 4 : index
+        %c5 = arith.constant 5 : index
+        %c12 = arith.constant 12 : index
+        %c50 = arith.constant 50 : index
+        %c200 = arith.constant 200 : index
+        %async_token, %results = air.execute -> (memref<10000xi8, 1 : i32>) {
+          %alloc = memref.alloc() : memref<10000xi8, 1 : i32>
+          air.execute_terminator %alloc : memref<10000xi8, 1 : i32>
+        }
+        %t = scf.for %iv = %c0 to %c4 step %c1 iter_args(%arg = %async_token) -> (!air.async.token) {
+          %p = air.channel.put async [%arg] @channel_small[] (%results[%c0, %c0, %c0, %c0] [%c2, %c3, %c4, %c5] [%c200, %c50, %c12, %c1]) {id = 4 : i32} : (memref<10000xi8, 1 : i32>)
+          scf.yield %p : !air.async.token
+        }
+        %async_token_0 = air.execute {
+          memref.dealloc %results : memref<10000xi8, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/opt_memtile_dma_bds.mlir
@@ -230,28 +230,10 @@ module {
 
 // -----
 
-// =============================================================================
-// AIRUnrollScfForIntoBDChain compound-trip cascade guard.
-//
-// A scf.for whose body contains only a channel op with ALL-constant offsets
-// represents a redundant-repeat (same data sent each iteration). The unroll
-// fallback would materialize N chained identical channel ops; downstream
-// air-to-aie collapses them to one BD but sets the per-channel lock init
-// count to N, breaking per-iter producer/consumer pairing.
-//
-// When this for_op is itself nested inside one or more scf.fors that are
-// ALSO redundant (no IV from any enclosing scf.for reaches the channel
-// offsets), the compound trip count of the cascade can exceed the per-
-// channel lock capacity. The guard rejects the unroll in this case so the
-// loops survive and downstream emits a single BD with an implicit per-iter
-// repeat at init=1.
-//
-// Concretely: scf.for %g = 0..9 / scf.for %y = 0..16 enclosing a single
-// channel.put with constant offsets and the v21fold-style 4D wrap
-// <8,6272>·<98,8>·<8,784>·<8,1> = 50176 B. Compound trip = 9 * 16 = 144,
-// well above the kRedundantUnrollLockLimit = 16 threshold. Both loops must
-// be preserved.
-// =============================================================================
+// Cascade-redundant unroll guard: 9 * 16 = 144 > kRedundantUnrollLockLimit
+// (16) with all-constant channel offsets and no IV reach. Both loops must
+// be preserved so downstream emits one BD with implicit per-iter repeat
+// at init=1, instead of 144 chained identical puts at init=144.
 
 // CHECK-LABEL: @unroll_cascade_redundant_preserved
 // CHECK:       scf.for {{.*}} = %c0{{.*}} to %c9{{.*}} step %c1{{.*}}
@@ -297,15 +279,9 @@ module {
 
 // -----
 
-// =============================================================================
-// Regression guard for AIRUnrollScfForIntoBDChain compound-trip cascade:
-// short redundant loops (compound trip <= kRedundantUnrollLockLimit = 16)
-// must still unroll. A single scf.for with trip 4 and constant offsets
-// should unroll into 4 chained puts, matching the pre-fix behavior. This
-// keeps the guard from over-rejecting workloads like gemm 29 whose small
-// non-IV-bearing inner loops legitimately need unrolling to emit distinct
-// BDs.
-// =============================================================================
+// Regression guard: short redundant loop (trip 4 <= 16) still unrolls.
+// Keeps the cascade guard from over-rejecting workloads that need small
+// no-IV-in-offsets unrolls.
 
 // CHECK-LABEL: @unroll_small_redundant_admitted
 // CHECK-NOT:   scf.for


### PR DESCRIPTION
## Summary

Two related fixes in `air-opt-memtile-dma-bds` that together restore correct per-iteration producer/consumer pairing for designs where a deeply nested loop nest folds down to memtile BDs (motivating workload: `conv2d_14x14`).

### 1. `AIRSpecializeChannelWrapAndStrideInScfFor` pre-fold gate

Extend the boundary-admission discriminator to also admit when the matched IV reaches an offset position whose wrap is statically `1`. Such a slot is a size-1 dim that `canonicalize` will erase, freeing room for the new fold-introduced outer dim. Previously the gate only admitted `i == 0`, causing conv2d_14x14's L2→L1 act gather (IV at `offset[1]`, `wraps[1] == 1`) to be unnecessarily rejected. Once rejected at the pre-fold gate, the unroll fallback fires and exposes the second bug.

### 2. `AIRUnrollScfForIntoBDChain` compound-trip cascade guard

When a `scf.for` whose body contains only a channel op with all-constant offsets is nested inside another redundant `scf.for` (no IV from any enclosing `scf.for` appears in the channel offsets), unrolling materializes N chained identical channel ops. Downstream `air-to-aie` collapses them to one BD per channel but sets the per-channel lock `init` count to N, which breaks per-iter producer/consumer pairing — the consumer waits for N tokens, the paired producer (often at a different scope and rate) cannot keep up.

Reject the unroll when:
- no enclosing IV appears in the channel offsets, **AND**
- the compound trip count of all redundant enclosing `scf.for`s exceeds `kRedundantUnrollLockLimit = 16`.

Below the threshold (e.g. a single 2- or 4-iter loop) unrolling is harmless and still happens, so workloads like `29_gemm` that rely on small-trip unrolls are unaffected. At/above the threshold the loops are preserved and downstream emits a single BD with implicit per-iter repeat, keeping `init=1` lock semantics.

### End-to-end impact on conv2d_14x14 (NPU2)

The L2→L1 act gather PUT previously emitted 144 chained identical puts and `init=144` locks. With this PR it stays as a `9×16` nested scf.for around one put with `init=1` locks. NPU output becomes bit-exact with the integer-arithmetic PyTorch golden (zero mismatches).

## Tests

- `@unroll_cascade_redundant_preserved` — 9×16=144 cascade preserves both loops (conv2d_14x14 regression guard).
- `@unroll_small_redundant_admitted` — trip-4 single redundant loop still unrolls to 4 chained puts (guard against over-rejection).
- All 29 existing `AIRDependencyScheduleOpt` lit tests pass.

## Test plan

- [x] `ninja check-air-mlir` — 29/29 in `AIRDependencyScheduleOpt`
- [x] NPU2 hardware: `29_gemm`, `17_gemm`, `36_cascade`, `41_softmax`, `42_softmax_bf16`, `46_triton_matmul`, `conv2d_14x14` all PASS
- [x] conv2d_14x14 bit-exact (no atol/rtol, `np.array_equal`) when host golden uses kernel-matching rounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)