### PR TITLE
[programming_examples] Add conv2d_14x14 NPU1 port

### DIFF
--- a/programming_examples/conv2d_14x14/Makefile
+++ b/programming_examples/conv2d_14x14/Makefile
@@ -2,36 +2,55 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-ifdef PEANO_INSTALL_DIR
-  BUILD_DIR := build_peano
+DEVICE ?= npu2
+
+ifeq ($(DEVICE),npu2)
+  AIE_TARGET := aie2p
+  AIE_KERNEL_DIR := aie2p
+else ifeq ($(DEVICE),npu1)
+  AIE_TARGET := aie2
+  AIE_KERNEL_DIR := aie2p
 else
-  BUILD_DIR := build_chess
+  $(error Unsupported DEVICE='$(DEVICE)'. Use DEVICE=npu1 or DEVICE=npu2)
+endif
+
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano_$(DEVICE)
+else
+  BUILD_DIR := build_chess_$(DEVICE)
 endif
 
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
+DEVICE_FLAG = --target-device $(DEVICE)
 
 AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+PEANOWRAP2_FLAGS  = -O2 -std=c++20 --target=aie2-none-unknown-elf  ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include
 
-AIE_TARGET ?= aie2p
-PEANO_FLAGS = ${PEANOWRAP2P_FLAGS}
+ifeq ($(AIE_TARGET),aie2p)
+  PEANO_FLAGS = ${PEANOWRAP2P_FLAGS}
+else
+  PEANO_FLAGS = ${PEANOWRAP2_FLAGS}
+endif
 
-KERNEL_SRC = ${AIEOPT_DIR}/include/aie_kernels/aie2p/conv2dk14.cc
+# The aie2p source compiles for both aie2 and aie2p targets; on aie2 the
+# mmul<8,8,8> specialization is emulated via two mmul<4,8,8> macs.
+KERNEL_SRC = ${AIEOPT_DIR}/include/aie_kernels/$(AIE_KERNEL_DIR)/conv2dk14.cc
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG) -p
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
 
 profile: compile-kernel build-test-exe
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG)
-	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
+	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin --device $(DEVICE)
 
 build-test-exe:
 	@GPP=$$( \

--- a/programming_examples/conv2d_14x14/conv2d_14x14.py
+++ b/programming_examples/conv2d_14x14/conv2d_14x14.py
@@ -3,16 +3,21 @@
 
 """mlir-air port of upstream mlir-aie programming_examples/ml/conv2d_14x14.
 
-Full-size 8x4 herd (32 cores) executing 9 oc-groups x 16 y-rows x 4 xb-blocks
-of 14x14 stride-14 conv on 896x896 input, 4 in-channels, 1152 out-channels,
-uint8 act / int8 wts / int8 out.
+Targets both NPU2 (Strix, 8x4 herd, 32 cores) and NPU1 (Phoenix, 4x4 herd,
+16 cores). On NPU1 each column processes twice as many oc-groups (18 vs 9)
+to keep total work identical at 72 oc-groups across CO=1152.
+
+Both paths execute 14x14 stride-14 conv on 896x896 input, 4 in-channels,
+1152 out-channels, uint8 act / int8 wts / int8 out.
 
 Design highlights:
   * L2 act buffer holds a full 14-row image-band per memtile (50176 B each,
     4 memtiles); producer L3->L2 uses a 4D scatter wrap matching upstream's
     [<14,56>,<64,784>,<56,1>], and consumer L2->L1 gathers via the same
     [<2,6272>,<98,8>,<8,784>,<8,1>] window the kernel expects.
-  * L1 weights are streamed direct L3->L1 with a 4D shim BD per col.
+  * L1 weights are streamed direct L3->L1 with a 4D shim BD per col. The
+    per-col weight slab is NUM_G * 12544 bytes (=112896 for npu2, =225792
+    for npu1).
   * L2->L3 output drain is a flat 65536-B/col S2MM per g iter; host
     reorders the kernel's [oc=2,nt=2,nt8=8,oc8=8] byte order into
     upstream-host-major [nt=2,nt8=8,oc=2,oc8=8] before comparing.
@@ -75,7 +80,16 @@ def _add_mul_map(c):
 
 
 @module_builder
-def build_module():
+def build_module(n_cols=8, num_g=9):
+    """Build the AIR module for an n_cols x 4 herd processing num_g oc-groups
+    per column. n_cols * num_g must equal 72 (total oc-groups across CO=1152
+    with 16 OC per group). For NPU2 use (8, 9); for NPU1 use (4, 18)."""
+    assert (
+        n_cols * num_g == 72
+    ), f"Expected n_cols * num_g == 72, got {n_cols} * {num_g} = {n_cols * num_g}"
+    wts_per_col = num_g * 12544  # bytes per col in the L3 weight slab
+    out_per_col = num_g * 65536  # bytes per col in the L3 output slab
+
     i8 = T.i8()
     i32 = T.i32()
     l2_attr = IntegerAttr.get(i32, MemorySpace.L2)
@@ -83,12 +97,12 @@ def build_module():
 
     # L3 (host) memref types
     memrefTyI = MemRefType.get([4, 802816], i8)
-    memrefTyW = MemRefType.get([8, 112896], i8)
-    memrefTyO = MemRefType.get([8, 589824], i8)
+    memrefTyW = MemRefType.get([n_cols, wts_per_col], i8)
+    memrefTyO = MemRefType.get([n_cols, out_per_col], i8)
 
     # L2 (memtile)
     l2ActTy = MemRefType.get([4, 14, 3584], i8, memory_space=l2_attr)
-    l2OutTy = MemRefType.get([8, 4, 64, 256], i8, memory_space=l2_attr)
+    l2OutTy = MemRefType.get([n_cols, 4, 64, 256], i8, memory_space=l2_attr)
 
     # L1 (compute tile)
     l1InTy = MemRefType.get([12544], i8, memory_space=l1_attr)
@@ -113,10 +127,10 @@ def build_module():
                 l2_act = AllocOp(l2ActTy, [], [])
                 l2_out = AllocOp(l2OutTy, [], [])
 
-                # L3->L2 act fill (9 oc-groups x 16 y-rows of the 4D scatter
-                # wrap matching upstream's [<14,56>,<64,784>,<56,1>]).
+                # L3->L2 act fill (num_g oc-groups x 16 y-rows of the 4D
+                # scatter wrap matching upstream's [<14,56>,<64,784>,<56,1>]).
                 mul14 = _mul_const_map(14)
-                for _gp in range_(0, 9):
+                for _gp in range_(0, num_g):
                     for yp in range_(0, 16):
                         y_off = affine_apply(mul14, [yp])
                         dma_memcpy_nd(
@@ -134,7 +148,7 @@ def build_module():
 
                 @herd(
                     name="conv2dk14_herd",
-                    sizes=[8, 4],
+                    sizes=[n_cols, 4],
                     operands=[l3_W_s, l2_act, l2_out],
                 )
                 def herd_body(tx, ty, _sx, _sy, _l3_W, _l2_act, _l2_out):
@@ -150,7 +164,7 @@ def build_module():
                     mul12544 = _mul_const_map(12544)
                     y4_plus_xb = _add_mul_map(4)
 
-                    for g in range_(0, 9):
+                    for g in range_(0, num_g):
                         g_off = affine_apply(mul12544, [g])
 
                         # L3->L1 wts (per oc-group, per col=tx).
@@ -159,7 +173,7 @@ def build_module():
                             _l3_W,
                             src_offsets=[tx, g_off],
                             src_sizes=[1, 12544],
-                            src_strides=[112896, 1],
+                            src_strides=[wts_per_col, 1],
                         )
 
                         for y in range_(0, 16):
@@ -220,16 +234,16 @@ def build_module():
                 # reorders the per-call [oc, nt, nt8, oc8] byte order into
                 # spatial [nt, nt8, oc, oc8] before comparing.
                 mul65536 = _mul_const_map(65536)
-                for g in range_(0, 9):
+                for g in range_(0, num_g):
                     gg_off = affine_apply(mul65536, [g])
                     dma_memcpy_nd(
                         l3_O_s,
                         l2_out,
                         dst_offsets=[0, gg_off],
-                        dst_sizes=[8, 65536],
-                        dst_strides=[589824, 1],
+                        dst_sizes=[n_cols, 65536],
+                        dst_strides=[out_per_col, 1],
                         src_offsets=[0, 0, 0, 0],
-                        src_sizes=[8, 4, 64, 256],
+                        src_sizes=[n_cols, 4, 64, 256],
                         src_strides=[65536, 16384, 256, 1],
                     )
                     yield_([])
@@ -246,16 +260,21 @@ CO = 1152
 KSZ = 14
 WIDTH_OUT = WIDTH // KSZ  # 64
 HEIGHT_OUT = HEIGHT // KSZ  # 64
-NUM_G = 9  # oc-groups
 CLIP_MIN, CLIP_MAX = -128, 127
 
+# (n_cols, num_g) per target device. n_cols * num_g must == 72.
+DEVICE_LAYOUTS = {
+    "npu2": (8, 9),
+    "npu1": (4, 18),
+}
 
-def build_inputs_and_golden():
+
+def build_inputs_and_golden(n_cols, num_g):
     """Generate the inputs and the byte-permuted golden expected by the NPU
     output layout.
 
     The NPU writes 4,718,592 raw bytes laid out as
-        [col=8][g=9][row=4][yxb=64][oc=2][nt=2][nt8=8][oc8=8]
+        [col=n_cols][g=num_g][row=4][yxb=64][oc=2][nt=2][nt8=8][oc8=8]
     where each 256-B call's inner [oc, nt, nt8, oc8] is the kernel-write
     order. The host-expected layout (which matches PyTorch's (CO, HOUT,
     WOUT)) is [nt, nt8, oc, oc8]; we permute the golden's bytes here so
@@ -295,11 +314,9 @@ def build_inputs_and_golden():
     # matches.
 
     # Weights need to be reshaped to OIYX -> OYXIO8 grouped form so the
-    # 8x112896 buffer matches what the kernel reads. Upstream uses
-    # DataShaper.reorder_mat("OYXIO8", "OIYX"). We replicate by computing
-    # the expected (8, 112896) byte buffer via numpy: each col holds CO//8
-    # = 144 oc-groups of 12544 B each. 8 cols * 9 oc_per_col_group * 12544
-    # = 903168 B total = 8 * 112896.
+    # (n_cols, num_g*12544) buffer matches what the kernel reads. Upstream
+    # uses DataShaper.reorder_mat("OYXIO8", "OIYX"). Total CO//8 = 144
+    # oc-groups packed contiguously then split across n_cols columns.
     wts_np = int_weight.data.numpy().astype(np.int8)  # (CO, CI, KSZ, KSZ)
     # OYXIO8 layout: split CO into (CO//8, 8). Source label "OIYX" means
     # axes (CO, CI, Y, X) which is what we have. Target label "OYXIO8"
@@ -311,41 +328,29 @@ def build_inputs_and_golden():
     co_outer = CO // 8
     wts_split = wts_np.reshape(co_outer, 8, CI, KSZ, KSZ)
     wts_oyxio8 = np.transpose(wts_split, (0, 3, 4, 2, 1))  # (co_outer, Y, X, CI, 8)
-    # Pack into (8 cols, 112896 bytes per col). 8 cols * 144 oc-groups per
-    # col * 12544 B per oc-group. Each oc-group = (Y*X*CI*8) = 14*14*4*8 =
-    # 6272... wait, an oc-group spans 8 output channels. Volume per oc-
-    # group = KSZ*KSZ*CI*8 = 14*14*4*8 = 6272 bytes (= int8 elements).
-    # But the kernel reads 12544 B per oc-group. The 12544 B includes
-    # something else (likely 2x for stride or duplication). Upstream test
-    # uses a single concatenated wts buffer total 8 * 112896 = 903168 B
-    # which is exactly CO * CI * KSZ * KSZ * 1 byte (since int8) = 1152 *
-    # 4 * 14 * 14 = 903168. So the (8, 112896) layout simply packs the
-    # entire weight set into the 8-col shim arrangement.
+    # Per-col block: num_g oc-groups (kernel calls), 12544 B each (= 2
+    # CO//8 slices). Each CO//8 slice = KSZ*KSZ*CI*8 = 6272 B. Total
+    # buffer = CO * CI * KSZ * KSZ = 903168 B = n_cols * (num_g * 12544).
     in2 = wts_oyxio8.tobytes()
-    in2_arr = np.frombuffer(in2, dtype=np.int8).reshape(8, 112896)
+    in2_arr = np.frombuffer(in2, dtype=np.int8).reshape(n_cols, num_g * 12544)
 
     # Construct the byte-permuted golden expected at the L3 output.
     # NPU raw bytes (4,718,592) reshape as
-    #   (col=8, g=9, row=4, yxb=64, 2, 2, 8, 8) - last 4 dims are kernel
-    #   write order [oc, nt, nt8, oc8].
-    # diff_v21fold_correct.py transposes to spatial order and reshapes;
-    # we invert it to permute the golden into NPU-byte order.
+    #   (col=n_cols, g=num_g, row=4, yxb=64, 2, 2, 8, 8) - last 4 dims
+    #   are the kernel write order [oc, nt, nt8, oc8].
     #
     # Spatial layout from golden: (CO=1152, HOUT=64, WOUT=64).
-    # Co-group decomposition: CO = 8 cols * 9 g * 16 oc-per-group =
-    #   col*9*16 + g*16 + oc_in_group, where oc_in_group = oc*8 + oc8.
+    # Co-group decomposition: CO = n_cols * num_g * 16 oc-per-group =
+    #   col*num_g*16 + g*16 + oc_in_group, where oc_in_group = oc*8 + oc8.
     # Output decomposition: HOUT = 4 rows * 16 y = row*16 + y. WOUT =
     #   4 xb * 16 (nt*8 + nt8) = xb*16 + nt*8 + nt8.
-    g_arr = golden_int.reshape(8, 9, 2, 8, 4, 16, 4, 2, 8)
-    # axes: (col=8, g=9, oc=2, oc8=8, row=4, y=16, xb=4, nt=2, nt8=8)
-    # Target raw byte order: (col, g, row, yxb=y*4+xb, oc, nt, nt8, oc8)
-    # where the inner 4 dims (oc, nt, nt8, oc8) are the kernel write
-    # order. yxb interleaves (y, xb).
+    g_arr = golden_int.reshape(n_cols, num_g, 2, 8, 4, 16, 4, 2, 8)
+    # axes: (col, g, oc=2, oc8=8, row=4, y=16, xb=4, nt=2, nt8=8)
     g_arr = np.transpose(g_arr, (0, 1, 4, 5, 6, 2, 7, 8, 3))
-    # now: (col=8, g=9, row=4, y=16, xb=4, oc=2, nt=2, nt8=8, oc8=8)
-    g_arr = g_arr.reshape(8, 9, 4, 16 * 4, 2, 2, 8, 8)
+    # now: (col, g, row=4, y=16, xb=4, oc=2, nt=2, nt8=8, oc8=8)
+    g_arr = g_arr.reshape(n_cols, num_g, 4, 16 * 4, 2, 2, 8, 8)
     # (col, g, row, yxb=64, oc, nt, nt8, oc8) - matches NPU byte layout.
-    expected_out_npu = g_arr.reshape(8, 589824).astype(np.int8)
+    expected_out_npu = g_arr.reshape(n_cols, num_g * 65536).astype(np.int8)
 
     return in1, in2_arr, expected_out_npu
 
@@ -361,14 +366,25 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target-device",
+        type=str,
+        choices=sorted(DEVICE_LAYOUTS.keys()),
+        default="npu2",
+        dest="target_device",
+        help="Target NPU device. npu2: 8x4 herd, 9 oc-groups/col. "
+        "npu1: 4x4 herd, 18 oc-groups/col. Same total work.",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    n_cols, num_g = DEVICE_LAYOUTS[args.target_device]
+
+    mlir_module = build_module(n_cols=n_cols, num_g=num_g)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
-    in1, in2, expected_out = build_inputs_and_golden()
+    in1, in2, expected_out = build_inputs_and_golden(n_cols, num_g)
 
     runner = XRTRunner(
         verbose=args.verbose,
@@ -376,7 +392,7 @@ if __name__ == "__main__":
         output_format=args.output_format,
         instance_name="conv2dk14_test",
         lower_linalg_to_func="conv2dk14.o",
-        target_device="npu2",
+        target_device=args.target_device,
     )
     exit(
         runner.run_test(

--- a/programming_examples/conv2d_14x14/conv2d_14x14.py
+++ b/programming_examples/conv2d_14x14/conv2d_14x14.py
@@ -16,7 +16,7 @@ Design highlights:
     [<14,56>,<64,784>,<56,1>], and consumer L2->L1 gathers via the same
     [<2,6272>,<98,8>,<8,784>,<8,1>] window the kernel expects.
   * L1 weights are streamed direct L3->L1 with a 4D shim BD per col. The
-    per-col weight slab is NUM_G * 12544 bytes (=112896 for npu2, =225792
+    per-col weight slab is num_g * 12544 bytes (=112896 for npu2, =225792
     for npu1).
   * L2->L3 output drain is a flat 65536-B/col S2MM per g iter; host
     reorders the kernel's [oc=2,nt=2,nt8=8,oc8=8] byte order into
@@ -316,7 +316,9 @@ def build_inputs_and_golden(n_cols, num_g):
     # Weights need to be reshaped to OIYX -> OYXIO8 grouped form so the
     # (n_cols, num_g*12544) buffer matches what the kernel reads. Upstream
     # uses DataShaper.reorder_mat("OYXIO8", "OIYX"). Total CO//8 = 144
-    # oc-groups packed contiguously then split across n_cols columns.
+    # 8-OC blocks packed contiguously and then split across n_cols columns;
+    # the kernel consumes them in pairs (one "oc-group" / kernel call =
+    # 16 OC = two CO//8 blocks = 12544 bytes).
     wts_np = int_weight.data.numpy().astype(np.int8)  # (CO, CI, KSZ, KSZ)
     # OYXIO8 layout: split CO into (CO//8, 8). Source label "OIYX" means
     # axes (CO, CI, Y, X) which is what we have. Target label "OYXIO8"

--- a/programming_examples/conv2d_14x14/run_npu1_makefile_peano.lit
+++ b/programming_examples/conv2d_14x14/run_npu1_makefile_peano.lit
@@ -5,6 +5,6 @@
 //
 // RUN: mkdir -p test_npu1_peano
 // RUN: cd test_npu1_peano
-// RUN: make -f %S/Makefile DEVICE=npu1 clean
-// RUN: make -f %S/Makefile DEVICE=npu1 run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile DEVICE=npu1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR clean
+// RUN: make -f %S/Makefile DEVICE=npu1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR run | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/conv2d_14x14/run_npu1_makefile_peano.lit
+++ b/programming_examples/conv2d_14x14/run_npu1_makefile_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// RUN: mkdir -p test_npu1_peano
+// RUN: cd test_npu1_peano
+// RUN: make -f %S/Makefile DEVICE=npu1 clean
+// RUN: make -f %S/Makefile DEVICE=npu1 run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/conv2d_14x14/test.cpp
+++ b/programming_examples/conv2d_14x14/test.cpp
@@ -155,8 +155,8 @@ int main(int argc, const char *argv[]) {
 
   // KSZxKSZ stride-KSZ conv: per output = KSZ*KSZ*CI MACs;
   //   outputs = (H/KSZ) * (W/KSZ) * CO; *2 for mul+add per MAC.
-  double macs = 2.0 * double(KSZ) * double(KSZ) * double(CI) *
-                double(H / KSZ) * double(W / KSZ) * double(CO);
+  double macs = 2.0 * double(KSZ) * double(KSZ) * double(CI) * double(H / KSZ) *
+                double(W / KSZ) * double(CO);
 
   for (unsigned iter = 0; iter < num_iter; iter++) {
     auto start = std::chrono::high_resolution_clock::now();

--- a/programming_examples/conv2d_14x14/test.cpp
+++ b/programming_examples/conv2d_14x14/test.cpp
@@ -40,13 +40,17 @@ using IN_DATATYPE =
 using WT_DATATYPE = int8_t;  // i8 weights
 using OUT_DATATYPE = int8_t; // i8 outputs
 
+// Problem dims (fixed by the design; see conv2d_14x14.py).
+constexpr int CI = 4;
+constexpr int CO = 1152;
+constexpr int H = 896;
+constexpr int W = 896;
+constexpr int KSZ = 14;
+
 // Total buffer sizes (device-independent: same on npu2 and npu1).
-//   IN  = CI * H * W                     = 4 * 896 * 896 = 3,211,264 B
-//   WT  = CO * CI * KSZ * KSZ            = 1152 * 4 * 14 * 14 = 903,168 B
-//   OUT = CO * (H/KSZ) * (W/KSZ)         = 1152 * 64 * 64 = 4,718,592 B
-constexpr int IN_VOLUME = 3211264;
-constexpr int WT_VOLUME = 903168;
-constexpr int OUT_VOLUME = 4718592;
+constexpr int IN_VOLUME = CI * H * W;                  // 3,211,264 B
+constexpr int WT_VOLUME = CO * CI * KSZ * KSZ;         // 903,168 B
+constexpr int OUT_VOLUME = CO * (H / KSZ) * (W / KSZ); // 4,718,592 B
 
 void add_default_options(cxxopts::Options &options) {
   options.add_options()("help,h", "produce help message")(
@@ -149,9 +153,10 @@ int main(int argc, const char *argv[]) {
   float npu_time_min = std::numeric_limits<float>::max();
   float npu_time_max = 0;
 
-  // 14x14 stride-14 conv, 4 in-chan, 1152 out-chan over 896x896:
-  //   per output: 14*14*4 MACs; outputs: 64*64*1152
-  double macs = 2.0 * 14.0 * 14.0 * 4.0 * 64.0 * 64.0 * 1152.0;
+  // KSZxKSZ stride-KSZ conv: per output = KSZ*KSZ*CI MACs;
+  //   outputs = (H/KSZ) * (W/KSZ) * CO; *2 for mul+add per MAC.
+  double macs = 2.0 * double(KSZ) * double(KSZ) * double(CI) *
+                double(H / KSZ) * double(W / KSZ) * double(CO);
 
   for (unsigned iter = 0; iter < num_iter; iter++) {
     auto start = std::chrono::high_resolution_clock::now();

--- a/programming_examples/conv2d_14x14/test.cpp
+++ b/programming_examples/conv2d_14x14/test.cpp
@@ -11,6 +11,12 @@
 // which uses bit-exact np.array_equal on i8). This harness only measures
 // steady-state NPU latency over an xclbin/insts pair that the Python flow
 // has already produced.
+//
+// Works for both the npu2 (8x4 herd) and npu1 (4x4 herd) builds: the
+// total IN/WT/OUT buffer sizes are device-independent because the same
+// total work (CO=1152, H=W=896) is partitioned across either 8 cols * 9
+// oc-groups or 4 cols * 18 oc-groups. The --device flag is purely
+// informational and prints the herd layout.
 
 #include "cxxopts.hpp"
 #include <bits/stdc++.h>
@@ -34,17 +40,13 @@ using IN_DATATYPE =
 using WT_DATATYPE = int8_t;  // i8 weights
 using OUT_DATATYPE = int8_t; // i8 outputs
 
-// Problem dims fixed by the design (see conv2d_14x14.py / CONV_IR).
-constexpr int IN_COLS = 4;
-constexpr int IN_BYTES_PER_COL = 802816;
-constexpr int WT_COLS = 8;
-constexpr int WT_BYTES_PER_COL = 112896;
-constexpr int OUT_COLS = 8;
-constexpr int OUT_BYTES_PER_COL = 589824;
-
-constexpr int IN_VOLUME = IN_COLS * IN_BYTES_PER_COL;    // 3,211,264
-constexpr int WT_VOLUME = WT_COLS * WT_BYTES_PER_COL;    // 903,168
-constexpr int OUT_VOLUME = OUT_COLS * OUT_BYTES_PER_COL; // 4,718,592
+// Total buffer sizes (device-independent: same on npu2 and npu1).
+//   IN  = CI * H * W                     = 4 * 896 * 896 = 3,211,264 B
+//   WT  = CO * CI * KSZ * KSZ            = 1152 * 4 * 14 * 14 = 903,168 B
+//   OUT = CO * (H/KSZ) * (W/KSZ)         = 1152 * 64 * 64 = 4,718,592 B
+constexpr int IN_VOLUME = 3211264;
+constexpr int WT_VOLUME = 903168;
+constexpr int OUT_VOLUME = 4718592;
 
 void add_default_options(cxxopts::Options &options) {
   options.add_options()("help,h", "produce help message")(
@@ -59,7 +61,11 @@ void add_default_options(cxxopts::Options &options) {
       "iters", "number of timed iterations",
       cxxopts::value<int>()->default_value("20"))(
       "warmup", "number of warmup iterations",
-      cxxopts::value<int>()->default_value("10"));
+      cxxopts::value<int>()->default_value("10"))(
+      "device,d",
+      "target device label (npu1 or npu2) - informational only; total BO "
+      "sizes are identical on both",
+      cxxopts::value<std::string>()->default_value("npu2"));
 }
 
 int main(int argc, const char *argv[]) {
@@ -68,6 +74,18 @@ int main(int argc, const char *argv[]) {
   add_default_options(options);
   test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
+
+  const std::string device_label = vm["device"].as<std::string>();
+  if (device_label != "npu1" && device_label != "npu2") {
+    std::cerr << "Unknown --device '" << device_label
+              << "' (expected npu1 or npu2)\n";
+    return 1;
+  }
+  const int n_cols = (device_label == "npu1") ? 4 : 8;
+  const int num_g = (device_label == "npu1") ? 18 : 9;
+  if (verbosity >= 0)
+    std::cout << "Device: " << device_label << " (" << n_cols
+              << " cols x 4 rows, " << num_g << " oc-groups per col)\n";
 
   srand(0);
 


### PR DESCRIPTION
## Summary
- Extends the recently-landed conv2d_14x14 example (#1663) to also target NPU1 (Phoenix) alongside NPU2 (Strix). New `--target-device {npu1,npu2}` flag in `conv2d_14x14.py` and `DEVICE ?= npu2` switch in the Makefile.
- NPU2 keeps the 8x4 herd / 9 oc-groups-per-col layout; NPU1 uses a 4x4 herd / 18 oc-groups-per-col layout. The invariant `n_cols * num_g == 72` keeps total work, golden, and host buffer volumes bit-exact across devices, so the existing `XRTRunner` `np.array_equal` check still gates correctness end-to-end on either NPU.
- The aie2p `conv2dk14.cc` kernel source is reused for the aie2 build: `aie::mmul<8,8,8,uint8,int8>` is supported on AIE2 via the emulated specialization in `aie_api/detail/aie2/mmul_8_8.hpp` (two `mmul<4,8,8>` macs per call), so the same source compiles with peano under either `--target=aie2` or `--target=aie2p`.
- The C++ profile harness (`test.cpp`) works on both devices unchanged since IN/WT/OUT total volumes are device-independent; a new `--device` flag prints the active herd layout for clarity.
- New `run_npu1_makefile_peano.lit` gates CI on `ryzen_ai_npu1` + `peano`.

## Test plan
- [x] `make DEVICE=npu2 run` still passes (`build_module` IR for npu2 is byte-for-byte identical to the pre-change output).
- [x] `make DEVICE=npu1 run` passes on local NPU1 Phoenix (`PASS!`).
- [x] `make DEVICE=npu1 profile` runs cleanly on local NPU1: ~11.3 ms avg / ~654 GOps avg, 689 GOps peak.
- [ ] CI: `run_npu1_makefile_peano.lit` (gated on `ryzen_ai_npu1` + `peano`) and existing `run_npu2_makefile_peano.lit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)