### PR TITLE
[CI] Disable llama32_1b_int4 verify: OOM on amdhx370 runner

### DIFF
--- a/programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 // download). 2 prompts × 32 greedy tokens, k=5. Mirrors the bf16
 // sibling's run_npu2_verify.lit methodology.
 //
-// REQUIRES: ryzen_ai_npu2, peano
+// REQUIRES: false
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify


### PR DESCRIPTION
AWQ quantisation loads the full bf16 model before converting to int4. Running alongside other LLM verify tests on the amdhx370 runner exhausts RAM and triggers the OOM killer (exit 137).