### PR TITLE
[ci] Pin llvm-aie to last-good nightly (2026062301) to unblock CI

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Get llvm-aie
         run: |
           source air-venv/bin/activate
-          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1056). Revert once fixed upstream.
+          python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       - name: Build and test mlir-air
         run: |

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -52,7 +52,7 @@ export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # Install llvm-aie
 # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1056). Revert once fixed upstream.
-python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+python3 -m pip install --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"
 

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -51,7 +51,8 @@ export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
 export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # Install llvm-aie
-python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+# Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1056). Revert once fixed upstream.
+python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"
 


### PR DESCRIPTION
## Summary

Pins `llvm-aie` (Peano) to the last-known-good nightly `21.0.0.2026062301+cb664e8c` at every install site to restore CI.

The 2026-06-24 nightly (`fdf257de`) miscompiles `int->float->int` at `-O2` on AIE2: the argument-defining load is scheduled into the soft-float call's delay slots, so the callee reads a stale argument register → silent wrong answer (all-zeros output instead of `input + 1`).

Root cause, bisect, and fix tracked in Xilinx/llvm-aie#1056. mlir-aie applied the same pin in Xilinx/mlir-aie#3221.

This is a temporary stopgap; will be reverted once the upstream codegen fix lands in a new peano nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)