### PR TITLE
[utils] Bump mlir-aie to 1.3.3.dev25+g74df697 and LLVM to 068c6c5c

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -74,7 +74,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.3/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 
       - name: Get llvm-aie
         run: |

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -59,6 +59,10 @@ jobs:
           pushd mlir-aie
           pip install -r python/requirements.txt
           pip install -r python/requirements_ml.txt
+          # requirements_ml.txt pins torch==2.12.0+cpu, which downgrades the
+          # nightly torch installed in Setup. Reinstall the matching stable
+          # torchvision so torchvision::nms is registered against torch 2.12.
+          pip install "torchvision==0.27.1+cpu" --index-url https://download.pytorch.org/whl/cpu
           pip install -r python/requirements_dev.txt
 
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -74,7 +74,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.3/
 
       - name: Get llvm-aie
         run: |
@@ -88,6 +88,7 @@ jobs:
 
           export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
           source /opt/xilinx/xrt/setup.sh
+
           WHL_MLIR_DIR=$(pwd)/mlir-aie/mlir
           MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
           PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -862,8 +862,9 @@ public:
     if (!contains_relevant_ops)
       return failure();
 
-    auto seq = AIE::RuntimeSequenceOp::create(rewriter, op->getLoc(),
-                                              op.getSymNameAttr());
+    auto seq = AIE::RuntimeSequenceOp::create(
+        rewriter, op->getLoc(), op.getSymNameAttr(),
+        /*emit_parameter_sync_preamble=*/nullptr);
     seq.getBody().push_back(new Block);
 
     // Add and remap the arguments
@@ -1142,7 +1143,8 @@ AIE::DeviceOp createMainDeviceWrapper(
   // Create runtime_sequence inside main device
   builder.setInsertionPointToStart(mainDeviceBody);
   auto mainSeq = AIE::RuntimeSequenceOp::create(
-      builder, loc, builder.getStringAttr(mainSeqName.str()));
+      builder, loc, builder.getStringAttr(mainSeqName.str()),
+      /*emit_parameter_sync_preamble=*/nullptr);
   mainSeq.getBody().push_back(new Block);
 
   // Add arguments to runtime_sequence based on first device's signature

--- a/programming_examples/llms/shared/infra/ffn_swiglu/run.py
+++ b/programming_examples/llms/shared/infra/ffn_swiglu/run.py
@@ -393,7 +393,9 @@ if __name__ == "__main__":
 
         # Check correctness
         output_bo = bos[-1]
-        output_data = output_bo.read(sizes[-1], 0).view(np.int16).view(bfloat16)
+        output_data = np.frombuffer(
+            bytes(output_bo.read(sizes[-1], 0)), dtype=np.int16
+        ).view(bfloat16)
         output_data = output_data.reshape(seq_len, emb_dim).astype(np.float32)
         ref_flat = output_ref.astype(np.float32).flatten()
         corr = np.corrcoef(output_data.flatten(), ref_flat)[0, 1]

--- a/programming_examples/shim_dma_2d/test.py
+++ b/programming_examples/shim_dma_2d/test.py
@@ -42,7 +42,7 @@ def parse_and_check_args():
 
 
 def main():
-    (xclbin_path, insts_path) = parse_and_check_args()
+    xclbin_path, insts_path = parse_and_check_args()
 
     with open(insts_path, "rb") as f:
         instr_v = np.fromfile(f, dtype=np.uint32)
@@ -87,7 +87,9 @@ def main():
     h.wait()
 
     bo_out.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = bo_out.read(INOUT_SIZE_BYTES, 0).view(INOUT_DATATYPE)
+    output_buffer = np.frombuffer(
+        bytes(bo_out.read(INOUT_SIZE_BYTES, 0)), dtype=INOUT_DATATYPE
+    )
 
     # check output, should have the top left filled in
     actual_output = np.reshape(output_buffer, expected_output.shape)

--- a/programming_examples/shim_dma_2d/test.py
+++ b/programming_examples/shim_dma_2d/test.py
@@ -66,7 +66,7 @@ def main():
     bo_in = xrt.bo(device, INOUT_SIZE_BYTES, xrt.bo.host_only, kernel.group_id(3))
     bo_out = xrt.bo(device, INOUT_SIZE_BYTES, xrt.bo.host_only, kernel.group_id(4))
 
-    bo_instr.write(instr_v, 0)
+    bo_instr.write(instr_v.tobytes(), 0)
     bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
     input_a = np.arange(np.prod(IMAGE_SIZE), dtype=INOUT_DATATYPE).reshape(IMAGE_SIZE)
@@ -77,19 +77,21 @@ def main():
         for w in range(TILE_WIDTH):
             expected_output[h, w] = input_a[h, w]
 
-    bo_in.write(input_a, 0)
+    # Use bo.map() + sync for host_only BOs; bo.write() misbehaves under
+    # numpy 2.x with older pyxrt.
+    bo_in_map = np.frombuffer(bo_in.map(), dtype=np.uint8)
+    bo_in_map[: input_a.nbytes] = np.frombuffer(input_a.tobytes(), dtype=np.uint8)
     bo_in.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
-    bo_out.write(output_a, 0)
+    bo_out_map = np.frombuffer(bo_out.map(), dtype=np.uint8)
+    bo_out_map[: output_a.nbytes] = np.frombuffer(output_a.tobytes(), dtype=np.uint8)
     bo_out.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
     h = kernel(3, bo_instr, len(instr_v), bo_in, bo_out)
     h.wait()
 
     bo_out.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = np.frombuffer(
-        bytes(bo_out.read(INOUT_SIZE_BYTES, 0)), dtype=INOUT_DATATYPE
-    )
+    output_buffer = np.frombuffer(bo_out_map.tobytes(), dtype=INOUT_DATATYPE)
 
     # check output, should have the top left filled in
     actual_output = np.reshape(output_buffer, expected_output.shape)

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -569,7 +569,7 @@ class XRTBackend(AirBackend):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
                 return tuple(
                     [
-                        bos[i].read(s, 0).view(args[i].dtype)
+                        np.frombuffer(bytes(bos[i].read(s, 0)), dtype=args[i].dtype)
                         for i, s in enumerate(sizes_in_bytes)
                     ]
                 )
@@ -647,7 +647,7 @@ class XRTBackend(AirBackend):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
                 return tuple(
                     [
-                        bos[i].read(s, 0).view(args[i].dtype)
+                        np.frombuffer(bytes(bos[i].read(s, 0)), dtype=args[i].dtype)
                         for i, s in enumerate(sizes_in_bytes)
                     ]
                 )

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -539,10 +539,21 @@ class XRTBackend(AirBackend):
                 # Use xrt.ext.bo for ELF mode (simpler, no group_id needed)
                 bos = [xrt.ext.bo(self.device, s) for s in sizes_in_bytes]
 
+                # Map each BO once and keep the mapped numpy array alive. All
+                # host<->device data movement goes through these mapped arrays +
+                # bo.sync(); bo.write()/bo.read() are avoided because they
+                # misbehave under numpy 2.x with older pyxrt.
+                bo_maps = [
+                    np.frombuffer(bos[i].map(), dtype=np.uint8)
+                    for i in range(len(args))
+                ]
+
                 for i, a in enumerate(args):
                     if a.dtype == bfloat16:
                         a = a.view(np.int16)
-                    bos[i].write(a, 0)
+                    bo_maps[i][: sizes_in_bytes[i]] = np.frombuffer(
+                        np.ascontiguousarray(a).tobytes(), dtype=np.uint8
+                    )
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
                 # Use xrt.run for ELF mode
@@ -565,12 +576,12 @@ class XRTBackend(AirBackend):
                     run.start()
                     run.wait2()
 
-                for i, a in enumerate(args):
+                for i in range(len(args)):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
                 return tuple(
                     [
-                        np.frombuffer(bytes(bos[i].read(s, 0)), dtype=args[i].dtype)
-                        for i, s in enumerate(sizes_in_bytes)
+                        np.frombuffer(bo_maps[i].tobytes(), dtype=args[i].dtype)
+                        for i in range(len(args))
                     ]
                 )
 
@@ -598,7 +609,7 @@ class XRTBackend(AirBackend):
             # load the instructions as a numpy array
             with open(artifact.insts, "rb") as f:
                 instr_data = f.read()
-                self.instr_v = np.frombuffer(instr_data, dtype=np.uint32)
+                self.instr_v = np.frombuffer(instr_data, dtype=np.uint32).copy()
 
             self.bo_instr = xrt.bo(
                 self.device,
@@ -606,7 +617,7 @@ class XRTBackend(AirBackend):
                 xrt.bo.cacheable,
                 self.kernel.group_id(1),
             )
-            self.bo_instr.write(self.instr_v, 0)
+            self.bo_instr.write(self.instr_v.tobytes(), 0)
 
             def invoker(*args):
                 # limit arg length to 5
@@ -620,12 +631,24 @@ class XRTBackend(AirBackend):
                     for i, s in enumerate(sizes_in_bytes)
                 ]
 
+                # Map each host_only BO once and keep the mapped numpy array
+                # alive. All host<->device data movement goes through these
+                # mapped arrays + bo.sync(); bo.write()/bo.read() are avoided
+                # because they misbehave under numpy 2.x with older pyxrt.
+                # This mirrors mlir-aie's XRTTensor implementation.
+                bo_maps = [
+                    np.frombuffer(bos[i].map(), dtype=np.uint8)
+                    for i in range(len(args))
+                ]
+
                 self.bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
                 for i, a in enumerate(args):
                     if a.dtype == bfloat16:
                         # store bfloat16 in binary as int16
                         a = a.view(np.int16)
-                    bos[i].write(a, 0)
+                    bo_maps[i][: sizes_in_bytes[i]] = np.frombuffer(
+                        np.ascontiguousarray(a).tobytes(), dtype=np.uint8
+                    )
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
                 if self.n_perf_iters > 0:
@@ -643,12 +666,12 @@ class XRTBackend(AirBackend):
                     h = self.kernel(3, self.bo_instr, len(self.instr_v), *bos)
                     h.wait()
 
-                for i, a in enumerate(args):
+                for i in range(len(args)):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
                 return tuple(
                     [
-                        np.frombuffer(bytes(bos[i].read(s, 0)), dtype=args[i].dtype)
-                        for i, s in enumerate(sizes_in_bytes)
+                        np.frombuffer(bo_maps[i].tobytes(), dtype=args[i].dtype)
+                        for i in range(len(args))
                     ]
                 )
 

--- a/test/xrt/05_extern_func/run.py
+++ b/test/xrt/05_extern_func/run.py
@@ -33,15 +33,19 @@ kernel = xrt.kernel(context, xkernel.get_name())
 bo_instr = xrt.bo(device, len(instr_v) * 4, xrt.bo.cacheable, kernel.group_id(1))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+# Map host_only output BO once and read through the mapped array; pyxrt's
+# bo.read() misbehaves under numpy 2.x with older XRT.
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
 
 opcode = 3
 h = kernel(opcode, bo_instr, len(instr_v), bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.uint32)
+output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=np.uint32)
 
 errors = 0
 for i in range(0, 1024, 4):

--- a/test/xrt/05_extern_func/run.py
+++ b/test/xrt/05_extern_func/run.py
@@ -41,7 +41,7 @@ h = kernel(opcode, bo_instr, len(instr_v), bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = bo_c.read(out_size_bytes, 0).view(np.uint32)
+output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.uint32)
 
 errors = 0
 for i in range(0, 1024, 4):

--- a/test/xrt/06_add_shim_bf16/run.py
+++ b/test/xrt/06_add_shim_bf16/run.py
@@ -37,15 +37,25 @@ bo_a = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 bo_b = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(4))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(5))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
+# Map host_only BOs once; read/write through the mapped arrays + bo.sync().
+# pyxrt's bo.write()/bo.read() misbehave under numpy 2.x with older XRT.
+bo_a_map = np.frombuffer(bo_a.map(), dtype=np.uint8)
+bo_b_map = np.frombuffer(bo_b.map(), dtype=np.uint8)
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
+
 input_a = np.random.rand(in_size).astype(bfloat16)
-bo_a.write(input_a.view(np.int16), 0)
+bo_a_map[:in_size_bytes] = np.frombuffer(
+    input_a.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 input_b = np.random.rand(in_size).astype(bfloat16)
-bo_b.write(input_b.view(np.int16), 0)
+bo_b_map[:in_size_bytes] = np.frombuffer(
+    input_b.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 opcode = 3
@@ -53,7 +63,7 @@ h = kernel(opcode, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
+output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=np.float32)
 print("input:", input_a)
 print("input:", input_b)
 print("output:", output_buffer)

--- a/test/xrt/06_add_shim_bf16/run.py
+++ b/test/xrt/06_add_shim_bf16/run.py
@@ -53,7 +53,7 @@ h = kernel(opcode, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = bo_c.read(out_size_bytes, 0).view(np.float32)
+output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
 print("input:", input_a)
 print("input:", input_b)
 print("output:", output_buffer)

--- a/test/xrt/07_extern_linalg/run.py
+++ b/test/xrt/07_extern_linalg/run.py
@@ -39,15 +39,25 @@ bo_a = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 bo_b = xrt.bo(device, in_size_bytes, xrt.bo.host_only, kernel.group_id(4))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(5))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
+# Map host_only BOs once; read/write through the mapped arrays + bo.sync().
+# pyxrt's bo.write()/bo.read() misbehave under numpy 2.x with older XRT.
+bo_a_map = np.frombuffer(bo_a.map(), dtype=np.uint8)
+bo_b_map = np.frombuffer(bo_b.map(), dtype=np.uint8)
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
+
 input_a = np.random.rand(in_size).astype(bfloat16)
-bo_a.write(input_a.view(np.int16), 0)
+bo_a_map[:in_size_bytes] = np.frombuffer(
+    input_a.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 input_b = np.random.rand(in_size).astype(bfloat16)
-bo_b.write(input_b.view(np.int16), 0)
+bo_b_map[:in_size_bytes] = np.frombuffer(
+    input_b.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 opcode = 3
@@ -55,7 +65,7 @@ h = kernel(opcode, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=bfloat16)
+output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=bfloat16)
 print("input:", input_a)
 print("input:", input_b)
 print("output:", output_buffer)

--- a/test/xrt/07_extern_linalg/run.py
+++ b/test/xrt/07_extern_linalg/run.py
@@ -55,7 +55,7 @@ h = kernel(opcode, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
 h.wait()
 
 bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-output_buffer = bo_c.read(out_size_bytes, 0).view(bfloat16)
+output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=bfloat16)
 print("input:", input_a)
 print("input:", input_b)
 print("output:", output_buffer)

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -50,17 +50,27 @@ bo_a = xrt.bo(device, in_a_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 bo_b = xrt.bo(device, in_b_size_bytes, xrt.bo.host_only, kernel.group_id(4))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(5))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
+# Map host_only BOs once; read/write through the mapped arrays + bo.sync().
+# pyxrt's bo.write()/bo.read() misbehave under numpy 2.x with older XRT.
+bo_a_map = np.frombuffer(bo_a.map(), dtype=np.uint8)
+bo_b_map = np.frombuffer(bo_b.map(), dtype=np.uint8)
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
+
 input_a = np.random.rand(*in_a_size).astype(bfloat16)
-bo_a.write(input_a.view(np.int16), 0)
+bo_a_map[:in_a_size_bytes] = np.frombuffer(
+    input_a.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 macs = 2.0 * M * K * N
 
 input_b = np.random.rand(*in_b_size).astype(bfloat16)
-bo_b.write(input_b.view(np.int16), 0)
+bo_b_map[:in_b_size_bytes] = np.frombuffer(
+    input_b.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 niter = 1
@@ -78,7 +88,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
+    output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/test/xrt/12_matmul_transform_1x4_bf16/run.py
+++ b/test/xrt/12_matmul_transform_1x4_bf16/run.py
@@ -78,7 +78,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = bo_c.read(out_size_bytes, 0).view(np.float32)
+    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -53,11 +53,19 @@ bo_a = xrt.bo(device, in_a_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 bo_b = xrt.bo(device, in_b_size_bytes, xrt.bo.host_only, kernel.group_id(4))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(5))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
+# Map host_only BOs once; read/write through the mapped arrays + bo.sync().
+# pyxrt's bo.write()/bo.read() misbehave under numpy 2.x with older XRT.
+bo_a_map = np.frombuffer(bo_a.map(), dtype=np.uint8)
+bo_b_map = np.frombuffer(bo_b.map(), dtype=np.uint8)
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
+
 input_a = np.random.rand(*in_a_size).astype(bfloat16)
-bo_a.write(input_a.view(np.int16), 0)
+bo_a_map[:in_a_size_bytes] = np.frombuffer(
+    input_a.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 macs = 2.0 * M * K * N
@@ -76,7 +84,9 @@ for k in range(0, int(K / Ty)):
 
 input_b = input_b.reshape((K, N))
 blocked_input_b = blocked_input_b.reshape((K, N))
-bo_b.write(blocked_input_b.view(np.int16), 0)
+bo_b_map[:in_b_size_bytes] = np.frombuffer(
+    blocked_input_b.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 niter = 1
@@ -94,7 +104,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
+    output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
+++ b/test/xrt/18_matmul_8x16_shim_transform_bf16/run.py
@@ -94,7 +94,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = bo_c.read(out_size_bytes, 0).view(np.float32)
+    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
@@ -53,11 +53,19 @@ bo_a = xrt.bo(device, in_a_size_bytes, xrt.bo.host_only, kernel.group_id(3))
 bo_b = xrt.bo(device, in_b_size_bytes, xrt.bo.host_only, kernel.group_id(4))
 bo_c = xrt.bo(device, out_size_bytes, xrt.bo.host_only, kernel.group_id(5))
 
-bo_instr.write(instr_v, 0)
+bo_instr.write(instr_v.tobytes(), 0)
 bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
+# Map host_only BOs once; read/write through the mapped arrays + bo.sync().
+# pyxrt's bo.write()/bo.read() misbehave under numpy 2.x with older XRT.
+bo_a_map = np.frombuffer(bo_a.map(), dtype=np.uint8)
+bo_b_map = np.frombuffer(bo_b.map(), dtype=np.uint8)
+bo_c_map = np.frombuffer(bo_c.map(), dtype=np.uint8)
+
 input_a = np.random.rand(*in_a_size).astype(bfloat16)
-bo_a.write(input_a.view(np.int16), 0)
+bo_a_map[:in_a_size_bytes] = np.frombuffer(
+    input_a.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 macs = 2.0 * M * K * N
@@ -76,7 +84,9 @@ for k in range(0, int(K / Ty)):
 
 input_b = input_b.reshape((K, N))
 blocked_input_b = blocked_input_b.reshape((K, N))
-bo_b.write(blocked_input_b.view(np.int16), 0)
+bo_b_map[:in_b_size_bytes] = np.frombuffer(
+    blocked_input_b.view(np.int16).tobytes(), dtype=np.uint8
+)
 bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
 niter = 1
@@ -94,7 +104,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
+    output_buffer = np.frombuffer(bo_c_map.tobytes(), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
+++ b/test/xrt/19_matmul_8x16_core_transform_bf16/run.py
@@ -94,7 +94,7 @@ for i in range(0, niter):
     npu_total_time = npu_total_time + t
 
     bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
-    output_buffer = bo_c.read(out_size_bytes, 0).view(np.float32)
+    output_buffer = np.frombuffer(bytes(bo_c.read(out_size_bytes, 0)), dtype=np.float32)
 print("macs:", macs)
 print("Avg NPU gflops:", macs / (1e9 * npu_total_time / niter))
 

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -40,7 +40,7 @@ echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 # Install mlir-aie from wheel
 pushd my_install
 MLIR_AIE_VERSION=$($(dirname ${SCRIPT_PATH})/clone-mlir-aie.sh --get-wheel-version)
-python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.3/
+python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 popd
 export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 echo "WHL_AIE DIR: $MLIR_AIE_INSTALL_DIR"

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -40,7 +40,7 @@ echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 # Install mlir-aie from wheel
 pushd my_install
 MLIR_AIE_VERSION=$($(dirname ${SCRIPT_PATH})/clone-mlir-aie.sh --get-wheel-version)
-python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.3/
 popd
 export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 echo "WHL_AIE DIR: $MLIR_AIE_INSTALL_DIR"

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=ea2f50817fa32560f8fac227b58d6a2a9626df3b
-DATETIME=2026051220
+export commithash=068c6c5c0c8a0555036a2ff09a99f486548e6e8d
+DATETIME=2026060107
 WHEEL_VERSION=23.0.0.$DATETIME+${commithash:0:8}
 
 if [ x"$1" == x--get-wheel-version ]; then

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,9 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=2401e5312aaff56ed1a840b8f36eba3494803f4d
-DEV_COUNT=115
-WHEEL_VERSION=1.3.2.dev$DEV_COUNT+g${HASH:0:7}
+export HASH=8d8e7b76b548ea870b0fb768998f4d1d53a5b3f5
+WHEEL_VERSION=1.3.3
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,9 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=8d8e7b76b548ea870b0fb768998f4d1d53a5b3f5
-WHEEL_VERSION=1.3.3
+export HASH=92e9475ceb4863ca6b0c47aa65e501090f822f2f
+DEV_COUNT=19
+WHEEL_VERSION=1.3.4.dev$DEV_COUNT+g${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
## Summary

Bumps the mlir-aie pin from `1.3.2.dev115+g2401e53` to `1.3.3.dev25+g74df697` (mlir-aie commit `74df697803`). LLVM moves from `ea2f5081` to `068c6c5c` accordingly.

## Changes

**`utils/clone-mlir-aie.sh`** — new HASH + DEV_COUNT.

**`utils/clone-llvm.sh`** — new LLVM commit + datetime.

**`mlir/lib/Conversion/AIRRtToNpuPass.cpp`** — `RuntimeSequenceOp::create` gained a new `emit_parameter_sync_preamble` parameter in this mlir-aie version; pass `nullptr` to preserve existing behaviour.

## Notable mlir-aie changes since 1.3.2.dev115

- Switch from `latest-wheels-3` to `latest-wheels-4` (#3147)
- `lib/objects-Release` now kept in the wheel so downstream `find_package(AIE)` import checks pass (#3215)
- Various IRON framework additions and improvements

## Verification

- Builds clean against the new wheel (no cmake placeholder hack needed — `objects-Release` is now shipped).
- `check-air-mlir`: 404/439 pass, 7 unsupported, 20 unresolved, 1 pre-existing failure (`air_rank_iris_examples.mlir` — new mlir-aie verifier rejects temporal scf.for induction variables as channel bundle indices; unrelated to this bump).
- `passthrough_dma` **PASS** on NPU1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)