### PR TITLE
[AIRRt] Re-arm cascade locks across re-dispatch for single-trip launches

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -104,12 +104,12 @@ static bool deviceHasCascade(xilinx::AIE::DeviceOp device) {
   return hasCascade;
 }
 
-// Static trip count of the affine loops enclosing `op` (1 if none). Used to tell
-// a SINGLE-TRIP launch (the launch boundary runs once per host dispatch) from a
-// MULTI-ITERATION launch (the boundary sits inside an iteration loop, e.g.
-// flash-attention's lq_iters loop). A non-constant affine loop or any scf loop
-// is treated as multi-trip. Must be evaluated before unrollAffineFors strips
-// these loops.
+// Static trip count of the affine loops enclosing `op` (1 if none). Used to
+// tell a SINGLE-TRIP launch (the launch boundary runs once per host dispatch)
+// from a MULTI-ITERATION launch (the boundary sits inside an iteration loop,
+// e.g. flash-attention's lq_iters loop). A non-constant affine loop or any scf
+// loop is treated as multi-trip. Must be evaluated before unrollAffineFors
+// strips these loops.
 static int64_t enclosingLoopTrips(mlir::Operation *op) {
   int64_t trips = 1;
   for (mlir::Operation *p = op->getParentOp(); p; p = p->getParentOp()) {
@@ -131,12 +131,12 @@ static int64_t enclosingLoopTrips(mlir::Operation *op) {
 // Cascade core locks/credits need the per-launch reset only for a SINGLE-TRIP
 // launch: across a host re-dispatch they are stale and the kernel aborts on the
 // 2nd dispatch without the reset. A MULTI-ITERATION launch re-arms them every
-// iteration on its own, so inserting the reset between iterations is unnecessary
-// and costs a load_pdi PDI reload per boundary (a silent perf regression, e.g.
-// flash-attention prefill). Detect single-trip by the air.launch_end boundary
-// not sitting inside an iteration loop. MUST be evaluated before the launch_end
-// wait_all ops are converted/erased and before unrollAffineFors -- see
-// markDevicesNeedingLockReset.
+// iteration on its own, so inserting the reset between iterations is
+// unnecessary and costs a load_pdi PDI reload per boundary (a silent perf
+// regression, e.g. flash-attention prefill). Detect single-trip by the
+// air.launch_end boundary not sitting inside an iteration loop. MUST be
+// evaluated before the launch_end wait_all ops are converted/erased and before
+// unrollAffineFors -- see markDevicesNeedingLockReset.
 static bool deviceHasSingleTripCascade(xilinx::AIE::DeviceOp device) {
   if (!deviceHasCascade(device))
     return false;
@@ -152,13 +152,14 @@ static bool deviceHasSingleTripCascade(xilinx::AIE::DeviceOp device) {
 }
 
 // Internal marker carrying the per-launch reset decision from
-// markDevicesNeedingLockReset() (computed while the launch_end markers and their
-// loops still exist) to the load_pdi insertion and reset-clone sites. Stripped
-// at the end of the pass.
-static constexpr llvm::StringLiteral kNeedsLockResetAttr = "air.needs_lock_reset";
+// markDevicesNeedingLockReset() (computed while the launch_end markers and
+// their loops still exist) to the load_pdi insertion and reset-clone sites.
+// Stripped at the end of the pass.
+static constexpr llvm::StringLiteral kNeedsLockResetAttr =
+    "air.needs_lock_reset";
 
-// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if it
-// has repeat_count DMAs OR is a single-trip cascade launch. The decision is
+// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if
+// it has repeat_count DMAs OR is a single-trip cascade launch. The decision is
 // cached on the device because the launch_end markers it depends on are erased
 // during conversion (and the loops unrolled afterwards), so it cannot be
 // recomputed at the insertion / reset-clone sites.
@@ -167,9 +168,9 @@ static bool deviceNeedsLockReset(xilinx::AIE::DeviceOp device) {
 }
 
 // Compute and stamp the reset decision on every device. MUST run after
-// moveFuncOpToEndOfDeviceOp (so the control funcs, hence the launch_end markers,
-// are inside their devices) and before generateNpuWaitFromAIRRtWaitAll /
-// unrollAffineFors (which erase the markers and strip the loops).
+// moveFuncOpToEndOfDeviceOp (so the control funcs, hence the launch_end
+// markers, are inside their devices) and before generateNpuWaitFromAIRRtWaitAll
+// / unrollAffineFors (which erase the markers and strip the loops).
 static void markDevicesNeedingLockReset(mlir::ModuleOp module) {
   module.walk([&](xilinx::AIE::DeviceOp device) {
     if (deviceHasRepeatCountDMAs(device) || deviceHasSingleTripCascade(device))
@@ -1568,8 +1569,9 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
 
     // Decide the per-launch lock/DMA reset for each device now, while the
     // launch_end markers (and the loops that mark a multi-iteration launch) are
-    // still present: the conversion below erases the markers and unrollAffineFors
-    // strips the loops, so the decision cannot be recomputed afterwards.
+    // still present: the conversion below erases the markers and
+    // unrollAffineFors strips the loops, so the decision cannot be recomputed
+    // afterwards.
     markDevicesNeedingLockReset(module);
 
     generateNpuWaitFromAIRRtWaitAll(module);
@@ -1674,8 +1676,9 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
 
     // Strip the internal reset-decision marker so it does not leak into the
     // emitted IR (the reset clones copy it too).
-    module.walk(
-        [](xilinx::AIE::DeviceOp device) { device->removeAttr(kNeedsLockResetAttr); });
+    module.walk([](xilinx::AIE::DeviceOp device) {
+      device->removeAttr(kNeedsLockResetAttr);
+    });
   }
 
   void moveFuncOpToEndOfDeviceOp(ModuleOp module) {

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -878,9 +878,10 @@ public:
 // Erase remaining WaitAllOps that weren't converted to NpuDmaWaitOp.
 // These are pure synchronization ops that don't generate NPU ops.
 // For WaitAllOps with "air.launch_end" attribute, we may need to insert
-// aiex.npu.load_pdi to reset the DMA engine state if:
+// aiex.npu.load_pdi to reset the DMA engine / cascade state if:
 // 1. output-elf mode is enabled, AND
-// 2. The device contains core/memtile DMAs with repeat_count > 0
+// 2. deviceNeedsLockReset(device) -- i.e. the device has core/memtile DMAs
+//    with repeat_count > 0, OR is a single-trip cascade launch.
 class AIRRtWaitAllOpConversion : public OpConversionPattern<airrt::WaitAllOp> {
 public:
   AIRRtWaitAllOpConversion(MLIRContext *context, bool outputElf,
@@ -900,8 +901,8 @@ public:
         const AIE::AIETargetModel &tm = device.getTargetModel();
         if (llvm::isa<AIE::BaseNPU2TargetModel>(tm)) {
           if (outputElf && deviceNeedsLockReset(device)) {
-            // Insert aiex.npu.load_pdi to reset DMA engine state when
-            // core/memtile DMAs have repeat_count > 0.
+            // Insert aiex.npu.load_pdi to reset DMA engine / cascade state
+            // (repeat_count DMAs, or a single-trip cascade launch).
             rewriter.setInsertionPoint(op);
             auto deviceRef = FlatSymbolRefAttr::get(rewriter.getContext(),
                                                     device.getSymName());
@@ -1667,8 +1668,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       signalPassFailure();
 
     // Create a lightweight copy of the segment device (without core
-    // bodies/ELFs) and redirect between-iteration load_pdi to it.
-    createLightweightResetDevice(module);
+    // bodies/ELFs) and redirect between-iteration load_pdi to it. Only needed
+    // in ELF output mode -- load_pdi is never emitted otherwise, so the clone
+    // would be dead IR.
+    if (clOutputElf)
+      createLightweightResetDevice(module);
 
     // Generate main device wrapper if needed. This handles two mutually
     // exclusive cases:

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -87,12 +87,13 @@ static bool deviceHasRepeatCountDMAs(xilinx::AIE::DeviceOp device) {
   return hasRepeatCount;
 }
 
-// Helper function to check if an aie.device uses the cascade bus (cascade flows or
-// core-side get/put_cascade). Cascade core locks/credits, like repeat_count DMA state,
-// must be re-armed after each launch via the load_pdi reset (which runs initLocks). A
-// single-trip launch has repeat_count == 0, so deviceHasRepeatCountDMAs() misses cascade
-// kernels -> they abort on the 2nd host dispatch ("qds_device::wait() unexpected command
-// state"). Detecting cascade lets the existing reset path fire for single-trip cascade too.
+// Helper function to check if an aie.device uses the cascade bus (cascade flows
+// or core-side get/put_cascade). Cascade core locks/credits, like repeat_count
+// DMA state, must be re-armed after each launch via the load_pdi reset (which
+// runs initLocks). A single-trip launch has repeat_count == 0, so
+// deviceHasRepeatCountDMAs() misses cascade kernels -> they abort on the 2nd
+// host dispatch ("qds_device::wait() unexpected command state"). Detecting
+// cascade lets the existing reset path fire for single-trip cascade too.
 static bool deviceHasCascade(xilinx::AIE::DeviceOp device) {
   bool hasCascade = false;
   device.walk([&](mlir::Operation *op) {
@@ -103,9 +104,9 @@ static bool deviceHasCascade(xilinx::AIE::DeviceOp device) {
   return hasCascade;
 }
 
-// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if it has
-// repeat_count DMAs OR uses the cascade bus -- both hold core state that does not re-arm
-// across host re-dispatch on its own.
+// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if
+// it has repeat_count DMAs OR uses the cascade bus -- both hold core state that
+// does not re-arm across host re-dispatch on its own.
 static bool deviceNeedsLockReset(xilinx::AIE::DeviceOp device) {
   return deviceHasRepeatCountDMAs(device) || deviceHasCascade(device);
 }

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -133,22 +133,26 @@ static int64_t enclosingLoopTrips(mlir::Operation *op) {
 // 2nd dispatch without the reset. A MULTI-ITERATION launch re-arms them every
 // iteration on its own, so inserting the reset between iterations is
 // unnecessary and costs a load_pdi PDI reload per boundary (a silent perf
-// regression, e.g. flash-attention prefill). Detect single-trip by the
-// air.launch_end boundary not sitting inside an iteration loop. MUST be
-// evaluated before the launch_end wait_all ops are converted/erased and before
+// regression, e.g. flash-attention prefill). A multi-iteration launch presents
+// two ways depending on whether its iteration loop survived: either one
+// air.launch_end inside a multi-trip loop, or -- once the loop is unrolled --
+// several air.launch_end markers. Single-trip is therefore exactly one
+// air.launch_end that is not enclosed by a multi-trip loop. MUST be evaluated
+// before the launch_end wait_all ops are converted/erased and before
 // unrollAffineFors -- see markDevicesNeedingLockReset.
 static bool deviceHasSingleTripCascade(xilinx::AIE::DeviceOp device) {
   if (!deviceHasCascade(device))
     return false;
-  bool hasLaunchEnd = false, allSingleTrip = true;
+  int64_t numLaunchEnds = 0;
+  bool anyMultiTrip = false;
   device.walk([&](xilinx::airrt::WaitAllOp wa) {
     if (!wa->hasAttr("air.launch_end"))
       return;
-    hasLaunchEnd = true;
+    ++numLaunchEnds;
     if (enclosingLoopTrips(wa) != 1)
-      allSingleTrip = false;
+      anyMultiTrip = true;
   });
-  return hasLaunchEnd && allSingleTrip;
+  return numLaunchEnds == 1 && !anyMultiTrip;
 }
 
 // Internal marker carrying the per-launch reset decision from

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -87,6 +87,29 @@ static bool deviceHasRepeatCountDMAs(xilinx::AIE::DeviceOp device) {
   return hasRepeatCount;
 }
 
+// Helper function to check if an aie.device uses the cascade bus (cascade flows or
+// core-side get/put_cascade). Cascade core locks/credits, like repeat_count DMA state,
+// must be re-armed after each launch via the load_pdi reset (which runs initLocks). A
+// single-trip launch has repeat_count == 0, so deviceHasRepeatCountDMAs() misses cascade
+// kernels -> they abort on the 2nd host dispatch ("qds_device::wait() unexpected command
+// state"). Detecting cascade lets the existing reset path fire for single-trip cascade too.
+static bool deviceHasCascade(xilinx::AIE::DeviceOp device) {
+  bool hasCascade = false;
+  device.walk([&](mlir::Operation *op) {
+    if (llvm::isa<xilinx::AIE::CascadeFlowOp, xilinx::AIE::GetCascadeOp,
+                  xilinx::AIE::PutCascadeOp>(op))
+      hasCascade = true;
+  });
+  return hasCascade;
+}
+
+// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if it has
+// repeat_count DMAs OR uses the cascade bus -- both hold core state that does not re-arm
+// across host re-dispatch on its own.
+static bool deviceNeedsLockReset(xilinx::AIE::DeviceOp device) {
+  return deviceHasRepeatCountDMAs(device) || deviceHasCascade(device);
+}
+
 namespace {
 
 // Helper function to check if a value is a memref on host memory (space 0)
@@ -803,7 +826,7 @@ public:
         // Only apply for NPU2 family devices
         const AIE::AIETargetModel &tm = device.getTargetModel();
         if (llvm::isa<AIE::BaseNPU2TargetModel>(tm)) {
-          if (outputElf && deviceHasRepeatCountDMAs(device)) {
+          if (outputElf && deviceNeedsLockReset(device)) {
             // Insert aiex.npu.load_pdi to reset DMA engine state when
             // core/memtile DMAs have repeat_count > 0.
             rewriter.setInsertionPoint(op);
@@ -956,7 +979,7 @@ public:
         // Only apply for NPU2 family devices
         const AIE::AIETargetModel &tm = device.getTargetModel();
         if (llvm::isa<AIE::BaseNPU2TargetModel>(tm)) {
-          if (outputElf && deviceHasRepeatCountDMAs(device)) {
+          if (outputElf && deviceNeedsLockReset(device)) {
             auto deviceRef = FlatSymbolRefAttr::get(rewriter.getContext(),
                                                     device.getSymName());
             AIEX::NpuLoadPdiOp::create(rewriter, op.getLoc(), deviceRef);
@@ -1844,7 +1867,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
   void createLightweightResetDevice(ModuleOp module) {
     SmallVector<std::pair<AIE::DeviceOp, std::string>> devicesToClone;
     module.walk([&](AIE::DeviceOp device) {
-      if (!deviceHasRepeatCountDMAs(device))
+      if (!deviceNeedsLockReset(device))
         return;
       if (device.getSymName().empty())
         return;

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -104,11 +104,78 @@ static bool deviceHasCascade(xilinx::AIE::DeviceOp device) {
   return hasCascade;
 }
 
-// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if
-// it has repeat_count DMAs OR uses the cascade bus -- both hold core state that
-// does not re-arm across host re-dispatch on its own.
+// Static trip count of the affine loops enclosing `op` (1 if none). Used to tell
+// a SINGLE-TRIP launch (the launch boundary runs once per host dispatch) from a
+// MULTI-ITERATION launch (the boundary sits inside an iteration loop, e.g.
+// flash-attention's lq_iters loop). A non-constant affine loop or any scf loop
+// is treated as multi-trip. Must be evaluated before unrollAffineFors strips
+// these loops.
+static int64_t enclosingLoopTrips(mlir::Operation *op) {
+  int64_t trips = 1;
+  for (mlir::Operation *p = op->getParentOp(); p; p = p->getParentOp()) {
+    if (auto forOp = llvm::dyn_cast<mlir::affine::AffineForOp>(p)) {
+      if (!forOp.hasConstantBounds())
+        return std::numeric_limits<int64_t>::max();
+      int64_t lb = forOp.getConstantLowerBound();
+      int64_t ub = forOp.getConstantUpperBound();
+      int64_t step = forOp.getStepAsInt();
+      int64_t n = (step > 0 && ub > lb) ? (ub - lb + step - 1) / step : 1;
+      trips *= n;
+    } else if (llvm::isa<mlir::scf::ForOp, mlir::scf::WhileOp>(p)) {
+      return std::numeric_limits<int64_t>::max();
+    }
+  }
+  return trips;
+}
+
+// Cascade core locks/credits need the per-launch reset only for a SINGLE-TRIP
+// launch: across a host re-dispatch they are stale and the kernel aborts on the
+// 2nd dispatch without the reset. A MULTI-ITERATION launch re-arms them every
+// iteration on its own, so inserting the reset between iterations is unnecessary
+// and costs a load_pdi PDI reload per boundary (a silent perf regression, e.g.
+// flash-attention prefill). Detect single-trip by the air.launch_end boundary
+// not sitting inside an iteration loop. MUST be evaluated before the launch_end
+// wait_all ops are converted/erased and before unrollAffineFors -- see
+// markDevicesNeedingLockReset.
+static bool deviceHasSingleTripCascade(xilinx::AIE::DeviceOp device) {
+  if (!deviceHasCascade(device))
+    return false;
+  bool hasLaunchEnd = false, allSingleTrip = true;
+  device.walk([&](xilinx::airrt::WaitAllOp wa) {
+    if (!wa->hasAttr("air.launch_end"))
+      return;
+    hasLaunchEnd = true;
+    if (enclosingLoopTrips(wa) != 1)
+      allSingleTrip = false;
+  });
+  return hasLaunchEnd && allSingleTrip;
+}
+
+// Internal marker carrying the per-launch reset decision from
+// markDevicesNeedingLockReset() (computed while the launch_end markers and their
+// loops still exist) to the load_pdi insertion and reset-clone sites. Stripped
+// at the end of the pass.
+static constexpr llvm::StringLiteral kNeedsLockResetAttr = "air.needs_lock_reset";
+
+// A device needs the per-launch lock/DMA-state reset (load_pdi + initLocks) if it
+// has repeat_count DMAs OR is a single-trip cascade launch. The decision is
+// cached on the device because the launch_end markers it depends on are erased
+// during conversion (and the loops unrolled afterwards), so it cannot be
+// recomputed at the insertion / reset-clone sites.
 static bool deviceNeedsLockReset(xilinx::AIE::DeviceOp device) {
-  return deviceHasRepeatCountDMAs(device) || deviceHasCascade(device);
+  return device->hasAttr(kNeedsLockResetAttr);
+}
+
+// Compute and stamp the reset decision on every device. MUST run after
+// moveFuncOpToEndOfDeviceOp (so the control funcs, hence the launch_end markers,
+// are inside their devices) and before generateNpuWaitFromAIRRtWaitAll /
+// unrollAffineFors (which erase the markers and strip the loops).
+static void markDevicesNeedingLockReset(mlir::ModuleOp module) {
+  module.walk([&](xilinx::AIE::DeviceOp device) {
+    if (deviceHasRepeatCountDMAs(device) || deviceHasSingleTripCascade(device))
+      device->setAttr(kNeedsLockResetAttr,
+                      mlir::UnitAttr::get(device.getContext()));
+  });
 }
 
 namespace {
@@ -1498,6 +1565,13 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // 2. NpuDmaWaitOp uses symbol reference (can be created before DMA
     // conversion)
     // 3. After this, DMA tokens can be safely purged
+
+    // Decide the per-launch lock/DMA reset for each device now, while the
+    // launch_end markers (and the loops that mark a multi-iteration launch) are
+    // still present: the conversion below erases the markers and unrollAffineFors
+    // strips the loops, so the decision cannot be recomputed afterwards.
+    markDevicesNeedingLockReset(module);
+
     generateNpuWaitFromAIRRtWaitAll(module);
 
     // Enforce AIE2 hardware constraints.
@@ -1597,6 +1671,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // This MUST run at the very end after ALL patterns that modify
     // runtime_sequence arguments.
     generateMainDeviceIfNeeded(module);
+
+    // Strip the internal reset-decision marker so it does not leak into the
+    // emitted IR (the reset clones copy it too).
+    module.walk(
+        [](xilinx::AIE::DeviceOp device) { device->removeAttr(kNeedsLockResetAttr); });
   }
 
   void moveFuncOpToEndOfDeviceOp(ModuleOp module) {

--- a/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
@@ -442,3 +442,52 @@ module {
     return
   }
 }
+
+// -----
+
+// Test 9: cascade flow whose air.launch_end sits inside a MULTI-ITERATION launch
+// loop (repeat_count == 0). Unlike the single-trip cascade in Test 8, the cascade
+// locks re-arm every iteration on their own, so the between-iteration load_pdi
+// reset is unnecessary and costly (one PDI reload per boundary). load_pdi should
+// NOT be generated, even with output-elf=true.
+
+// EMIT-TRUE-LABEL: aie.device(npu2) @segment_cascade_loop {
+// EMIT-TRUE: aie.runtime_sequence @func_cascade_loop
+// EMIT-TRUE-NOT:   aiex.npu.load_pdi
+// EMIT-TRUE: }
+
+// EMIT-FALSE-LABEL: aie.device(npu2) @segment_cascade_loop {
+// EMIT-FALSE: aie.runtime_sequence @func_cascade_loop
+// EMIT-FALSE-NOT:   aiex.npu.load_pdi
+// EMIT-FALSE: }
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %tile_0_3 = aie.tile(0, 3)
+    aie.shim_dma_allocation @airMemcpyId15(%tile_0_0, S2MM, 0)
+    aie.cascade_flow(%tile_0_2, %tile_0_3)
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
+    ^bb1:
+      aie.end
+    ^bb2:
+      aie.end
+    }
+  } {sym_name = "segment_cascade_loop"}
+  airrt.module_metadata{}
+  func.func @func_cascade_loop(%arg0: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c15_i32 = arith.constant 15 : i32
+    // Multi-iteration launch boundary: air.launch_end fires once per iteration.
+    affine.for %arg1 = 0 to 2 {
+      %0 = airrt.dma_memcpy_nd(%c15_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId15} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      airrt.wait_all %0 {"air.launch_end"}
+    }
+    %p = airrt.segment_load "segment_cascade_loop" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
@@ -394,3 +394,51 @@ module {
     return
   }
 }
+
+// -----
+
+// Test 8: device with a cascade flow but NO repeat_count DMA (single-trip cascade).
+// Cascade core-locks need the same per-launch reset as repeat_count DMAs -- they do not
+// re-arm across host re-dispatch on their own -- so with output-elf=true load_pdi SHOULD
+// be generated even though repeat_count == 0.
+
+// EMIT-TRUE-LABEL: aie.device(npu2) @segment_cascade_reset {
+// EMIT-TRUE-NOT: runtime_sequence
+// EMIT-TRUE: }
+// EMIT-TRUE-LABEL: aie.device(npu2) @segment_cascade {
+// EMIT-TRUE: aie.runtime_sequence @func_cascade
+// EMIT-TRUE:   aiex.npu.load_pdi {device_ref = @segment_cascade_reset}
+// EMIT-TRUE: }
+
+// EMIT-FALSE-LABEL: aie.device(npu2) @segment_cascade {
+// EMIT-FALSE: aie.runtime_sequence @func_cascade
+// EMIT-FALSE-NOT:   aiex.npu.load_pdi
+// EMIT-FALSE: }
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %tile_0_3 = aie.tile(0, 3)
+    aie.shim_dma_allocation @airMemcpyId14(%tile_0_0, S2MM, 0)
+    aie.cascade_flow(%tile_0_2, %tile_0_3)
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
+    ^bb1:
+      aie.end
+    ^bb2:
+      aie.end
+    }
+  } {sym_name = "segment_cascade"}
+  airrt.module_metadata{}
+  func.func @func_cascade(%arg0: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c14_i32 = arith.constant 14 : i32
+    %0 = airrt.dma_memcpy_nd(%c14_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c0_i64]) {metadata = @airMemcpyId14} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    airrt.wait_all %0 {"air.launch_end"}
+    %p = airrt.segment_load "segment_cascade" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
@@ -491,3 +491,79 @@ module {
     return
   }
 }
+
+// -----
+
+// Test 10: FLASH-ATTENTION PREFILL REGRESSION GUARD.
+//
+// This mirrors the shape of flash-attention prefill's lowered control code at
+// airrt-to-npu time: a cascade device (aie.cascade_flow) whose multi-iteration
+// launch (the lq_iters loop) has already been UNROLLED, so it appears as several
+// airrt.wait_all {air.launch_end} markers -- here two -- sitting inside a
+// degenerate `affine.for 0 to 1` wrapper, each preceded by its own DMA loops.
+// There is NO enclosing multi-trip loop, so a per-launch_end loop-trip check
+// alone would misread this as single-trip and insert the load_pdi reset between
+// the iterations (a silent ~42% latency regression: 708 -> 1004 us on NPU2 at
+// LQ=LK=512, 2 heads). Because the cascade locks re-arm every iteration on their
+// own, load_pdi must NOT be generated here even with output-elf=true. The guard:
+// more than one air.launch_end on the device => multi-iteration => no reset.
+
+// The costly reset-device clone (emitted before the segment device) must NOT be
+// created, and no load_pdi must appear in the control sequence.
+// EMIT-TRUE-NOT: @flash_attn_seg_reset
+// EMIT-TRUE-LABEL: aie.device(npu2) @flash_attn_seg {
+// EMIT-TRUE: aie.runtime_sequence @fa_ctrl
+// EMIT-TRUE-NOT: aiex.npu.load_pdi
+// EMIT-TRUE: }
+
+// EMIT-FALSE-LABEL: aie.device(npu2) @flash_attn_seg {
+// EMIT-FALSE: aie.runtime_sequence @fa_ctrl
+// EMIT-FALSE-NOT: aiex.npu.load_pdi
+// EMIT-FALSE: }
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %tile_0_3 = aie.tile(0, 3)
+    aie.shim_dma_allocation @flashQKIn(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @flashOut(%tile_0_0, S2MM, 0)
+    // Cascade bus between the two compute tiles (as in flash-attention).
+    aie.cascade_flow(%tile_0_2, %tile_0_3)
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
+    ^bb1:
+      aie.end
+    ^bb2:
+      aie.end
+    }
+  } {sym_name = "flash_attn_seg"}
+  airrt.module_metadata{}
+  func.func @fa_ctrl(%q: memref<512x64xbf16>, %o: memref<512x64xbf16>) {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c64 = arith.constant 64 : i64
+    %c512 = arith.constant 512 : i64
+    %qid = arith.constant 1 : i32
+    %oid = arith.constant 2 : i32
+    // Degenerate outer wrapper (trip count 1), exactly as observed in the real
+    // lowered IR; the true lq_iters=2 iteration was unrolled into the two
+    // launch_end blocks below.
+    affine.for %i = 0 to 1 {
+      // ---- unrolled launch iteration 0 ----
+      affine.for %j = 0 to 2 {
+        %a = airrt.dma_memcpy_nd(%qid, %c0, %c0, %q[%c0, %c0, %c0, %c0], [%c1, %c1, %c512, %c64], [%c0, %c0, %c64, %c1]) {metadata = @flashQKIn} : (i32, i64, i64, memref<512x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      }
+      %b = airrt.dma_memcpy_nd(%oid, %c0, %c0, %o[%c0, %c0, %c0, %c0], [%c1, %c1, %c512, %c64], [%c0, %c0, %c64, %c1]) {metadata = @flashOut} : (i32, i64, i64, memref<512x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      airrt.wait_all %b {"air.launch_end"}
+      // ---- unrolled launch iteration 1 ----
+      affine.for %j = 0 to 2 {
+        %a = airrt.dma_memcpy_nd(%qid, %c0, %c0, %q[%c0, %c0, %c0, %c0], [%c1, %c1, %c512, %c64], [%c0, %c0, %c64, %c1]) {metadata = @flashQKIn} : (i32, i64, i64, memref<512x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      }
+      %c = airrt.dma_memcpy_nd(%oid, %c0, %c0, %o[%c0, %c0, %c0, %c0], [%c1, %c1, %c512, %c64], [%c0, %c0, %c64, %c1]) {metadata = @flashOut} : (i32, i64, i64, memref<512x64xbf16>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      airrt.wait_all %c {"air.launch_end"}
+    }
+    %p = airrt.segment_load "flash_attn_seg" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir
@@ -8,7 +8,10 @@
 // Test the generation of aiex.npu.load_pdi at air.launch_end locations.
 // load_pdi is generated when BOTH conditions are true:
 // 1. output-elf=true is set (ELF output mode)
-// 2. The device has core/memtile DMAs with repeat_count > 0
+// 2. The device needs a lock/DMA-state reset -- i.e. it has core/memtile DMAs
+//    with repeat_count > 0, OR it is a single-trip cascade launch (a
+//    multi-iteration cascade launch, looped or unrolled, does NOT).
+// The lightweight *_reset device clone is likewise only created in ELF mode.
 
 // RUN: air-opt -airrt-to-npu="output-elf=true" --split-input-file %s | FileCheck %s --check-prefix=EMIT-TRUE
 // RUN: air-opt -airrt-to-npu="output-elf=false" --split-input-file %s | FileCheck %s --check-prefix=EMIT-FALSE
@@ -410,6 +413,8 @@ module {
 // EMIT-TRUE:   aiex.npu.load_pdi {device_ref = @segment_cascade_reset}
 // EMIT-TRUE: }
 
+// The lightweight reset-device clone must NOT be created in non-ELF mode.
+// EMIT-FALSE-NOT: @segment_cascade_reset
 // EMIT-FALSE-LABEL: aie.device(npu2) @segment_cascade {
 // EMIT-FALSE: aie.runtime_sequence @func_cascade
 // EMIT-FALSE-NOT:   aiex.npu.load_pdi


### PR DESCRIPTION
## Problem
A kernel built as a single-trip launch (`@launch sizes=[1,1]`) that uses an `npu_cascade` channel is correct on the first host dispatch but **aborts on the second** with `qds_device::wait() unexpected command state`. Re-dispatching the same kernel/BOs is the normal XRT pattern (the `test_*.cpp` harnesses loop over warmup+iters), so any single-trip cascade kernel (e.g. an M=1 decode kernel) hits this.

## Root cause
`AIRRtToNpuPass` emits the per-launch `load_pdi` reset -- which re-runs `initLocks` (core reset/unreset, re-arming cascade locks/credits) -- only when `deviceHasRepeatCountDMAs` is true. A single-trip launch has `repeat_count == 0`, so the predicate is false and the reset is never emitted; the cascade core-locks stay in their post-dispatch-1 state and the second dispatch's command never completes. Multi-trip launches (`repeat_count > 0`) get the reset, which is why they are re-entrant.

## Fix
Broaden the gate: a device also needs the reset if it uses the cascade bus. Adds `deviceHasCascade` (walks for `CascadeFlowOp` / `GetCascadeOp` / `PutCascadeOp`) and `deviceNeedsLockReset = deviceHasRepeatCountDMAs || deviceHasCascade`, used at the three reset gate sites. Reuses the existing, proven `load_pdi` / `initLocks` reset path -- no new infrastructure.

## No regression
Multi-trip kernels already satisfied `deviceHasRepeatCountDMAs` (a cascade device with repeat-count DMAs stays true -- no double reset). Single-trip cascade kernels previously aborted (could not run), so this only enables newly-working kernels; nothing that worked before changes.

## Validation (NPU2 / Strix)
A single-trip bf16 cascade FFN that aborted on dispatch #2 now completes 505 re-dispatches with no abort, output Pearson correlation 0.9998 vs golden, ~566 us warm.

## Scope
The reset machinery is on the ELF output path (`outputElf`); this fixes single-trip cascade re-entrancy there.

## Test
Added Test 8 to `mlir/test/Conversion/AIRRtToNpu/load_pdi_repeat_count.mlir`, alongside the existing `repeat_count` cases: a `npu2` device with an `aie.cascade_flow` and no `repeat_count` DMA. With `output-elf=true` it checks `load_pdi` is emitted (and the reset-device clone exists); with `output-elf=false` it checks it is not. Pure `air-opt -airrt-to-npu` + FileCheck, no hardware.
