### PR TITLE
[programming_examples/llms] NPU2 LLMs (3/3): Qwen2.5-3B + Qwen3-4B

### DIFF
--- a/programming_examples/llms/qwen25_3b/.gitignore
+++ b/programming_examples/llms/qwen25_3b/.gitignore
@@ -4,7 +4,6 @@ build_chess/
 __pycache__/
 *.pyc
 kernel_cache/
-verify_kernel_cache/
 air_project/
 .debug/
 .pytest_cache/

--- a/programming_examples/llms/qwen25_3b/.gitignore
+++ b/programming_examples/llms/qwen25_3b/.gitignore
@@ -1,0 +1,32 @@
+# Build / kernel cache artifacts
+build_peano/
+build_chess/
+__pycache__/
+*.pyc
+kernel_cache/
+verify_kernel_cache/
+air_project/
+.debug/
+.pytest_cache/
+
+# Stray artifacts from running scripts outside build_*/ (xrt.py + external_kernels.py
+# write these to CWD by design — `make compile/run/verify` cd into BUILD_DIR first,
+# but ad-hoc `python3 verify/verify_runner.py` from this dir will leak them here).
+air.mlir
+air.elf
+air.xclbin
+air.insts.bin
+*.o
+
+# Local-only experimental and ad-hoc test directories
+test_swiglu/
+test_swiglu_llama/
+test_swiglu_2048/
+flash_attn_issue/
+
+# Dev-only docs and artifacts (kept locally for development reference;
+# excluded from upstream PR to keep the example focused).
+docs/development_progress/
+docs/report/
+docs/issues/
+test_hf_model/

--- a/programming_examples/llms/qwen25_3b/ARCHITECTURE.md
+++ b/programming_examples/llms/qwen25_3b/ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# Qwen2.5-3B BF16 Inference — Architecture
+
+Companion to [README.md](README.md). Built kernel-first on the shared LLM infra
+(`../shared/`, `../verify/`) and the `../qwen25_1_5b/` sibling. Largest Qwen2.5
+model: 36 layers, hidden=11008. head_dim=128 → head-first FlashAttention;
+SwiGLU and the decode Down GEMV both run on NPU.
+
+## Model Config
+
+36 layers, emb_dim=2048, n_heads=16, head_dim=128, n_kv_heads=2 (GQA group=8),
+q_dim=2048 (square O), kv_dim=256, hidden_dim=11008, vocab_size=151936, BF16,
+rope_theta=1000000, eps=1e-6, tied embeddings, **QKV bias** (no QK-norm).
+
+Topology: **Qwen2.5** (QKV bias fused into the attention-input ELF; SwiGLU on
+NPU; decode Down on NPU). head_dim=128 → head-first FA.
+
+## Per-Layer Kernel Sequence
+
+**Prefill — 6 NPU ELFs/layer:**
+
+```
+x ─[NPU elf:rms_qkv_bias_rope]   FUSED, 1 ELF
+      { RMSNorm + Q/K/V GEMM + bias-add(Q,K,V) + RoPE-Q + RoPE-K }   → q_roped, k_roped, v
+  ─[NPU elf:flash_attn]   npu_fa_headfirst (head-first, hd=128)
+      (HOST) seq→head transpose → NPU FA → (HOST) head→seq transpose → attn_out[seq,2048]
+  ─[NPU elf:o_res_norm]   { O GEMM (square 2048×2048) + Add + RMSNorm }
+  ─[NPU elf:gate]{Gate GEMM} → [NPU elf:up]{Up GEMM}
+  ─[NPU elf:swiglu]       { SwiGLU }   (NPU SwiGLU, tile_n=4096)
+  ─[NPU elf:down_add]     { Down GEMM (launch 0) + Add } → layer_out[seq,2048]
+once: (HOST) final RMSNorm → [NPU elf:lm_head_gemv] (19 partitions ×8192, vocab 151936)
+```
+
+Prefill is 6 NPU dispatches/layer: `rms_qkv_bias_rope`, `flash_attn`,
+`o_res_norm`, `gate`, `up`, `swiglu`+`down_add`.
+
+**Decode — 5 NPU ELFs/layer (+ lm_head once/token):**
+
+```
+x ─[NPU elf:rms_qkv_bias_rope_gemv]   FUSED, 1 ELF
+      { RMSNorm + Q/K/V GEMV + bias(Q,K,V) + RoPE-Q/K }   (RoPE LUT per-position, NOT static)
+  (HOST) KV-cache write → (HOST) decode_attention_cpu
+  ─[NPU elf:o_gemv]{O} → (HOST) Add + RMSNorm
+  ─[NPU elf:gate_gemv] → [NPU elf:up_gemv] → (HOST) SwiGLU
+  ─[NPU elf:down_gemv]{Down}   ← MOVED TO NPU (omit_pingpong=all + dedicated down_mv.o)
+  → (HOST) Add → layer_out[2048]
+once: (HOST) final RMSNorm → [NPU elf:lm_head_gemv]
+```
+
+## NPU vs CPU Mapping
+
+**On NPU (all heavy compute):** every GEMM / GEMV (Q/K/V, O, Gate, Up, Down,
+LM-head), RMSNorm, **QKV bias-add**, RoPE, prefill FlashAttention, **prefill
+SwiGLU** (standalone NPU ELF). **Decode Down GEMV (K=11008) is on NPU** — moved
+CPU→NPU with `omit_pingpong=all` + a dedicated `down_mv.o`, the +16% decode win.
+All four decode projections are NPU GEMV ELFs.
+
+**On CPU (cheap glue + one transpose, evidence-backed):**
+- **Head-first FA seq↔head transpose** (prefill, hd=128): BF16 DMA stride-1
+  requirement + seq-first `dk_chunks>1` upstream FA bug.
+- **Decode attention** (single token): NPU FA launch overhead > compute.
+- **Decode residual Add / FFN RMSNorm / SwiGLU** (M=1): dispatch > compute.
+- **Final RMSNorm / KV-cache write / embed lookup**: single-row dispatch >
+  compute.
+
+Decode cannot reach the lean fused `o_gemv_ffn` 2-ELF cascade: `matvec_2tile_add`
+is numerically correct only at K÷512, and hidden=11008 is not a multiple of 512
+→ decode stays at 5 standalone GEMV ELFs (with Down on NPU).
+
+## Runtime Flow
+
+```
+build_session → prepare_runtime()   ← one-time, OUTSIDE timed region
+  · load weights, transpose decode GEMV weights, tag per-layer index
+  · preload_prefill_weights → static weight BOs; preload decode + LM-head BOs
+  ↓
+run_once():  prefill (36 layers × 6 ELFs + final RMSNorm + LM-head)   ← TTFT clock
+  ↓
+generate() decode loop:  per token 36 layers × 5 ELFs + LM-head GEMV  ← TPOT clock
+```
+
+`static_input_indices` + per-layer `bo_key` skip every timed weight write. RoPE
+LUT position-dependent → NON-static.
+
+## Key Design Patterns / Deltas
+
+- **QKV bias fused into `rms_qkv_bias_rope`** — the Qwen2.5 delta.
+- **head_dim=128 → head-first FlashAttention** + host seq↔head transposes.
+- **Square O-projection** (q_dim=emb_dim=2048).
+- **Prefill SwiGLU on NPU as a standalone ELF** (tile_n=4096).
+- **Decode Down GEMV on NPU** (K=11008) — the model-specific decode delta
+  (qwen25_1_5b keeps it on a generic GEMV ELF; here it needed a dedicated
+  `down_mv.o` + `omit_pingpong=all`).
+- **Non-aligned dims (hidden=11008, kv_dim=256)** → per-shape GEMM tile configs;
+  `down_add` Down must be launch 0.
+- **Deepest model** (36 layers, tied with qwen3_4b).
+- **Multi-launch ELF + text-based MLIR stitching** (shared infra).

--- a/programming_examples/llms/qwen25_3b/Makefile
+++ b/programming_examples/llms/qwen25_3b/Makefile
@@ -1,0 +1,93 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-3B BF16 Inference on NPU2 (MLIR-AIR)
+#
+# Quick start:
+#   make compile        — Compile all kernels (cached to disk)
+#   make run            — Run inference: NPU prefill + NPU decode
+#   make profile        — Run with per-kernel profiling breakdown
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Build directory
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+# Configurable parameters
+N_TOKENS ?= 1000
+PROMPT   ?= What is the capital of France?
+MODEL    ?= instruct
+
+.PHONY: help compile run profile chat verify verify-full diagnosis all clean
+
+help:
+	@echo "============================================================"
+	@echo " Qwen2.5-3B Inference on NPU2 (MLIR-AIR)"
+	@echo "============================================================"
+	@echo ""
+	@echo "Quick start:"
+	@echo "  make compile          Compile all kernels (one-time, cached)"
+	@echo "  make run              Run inference ($(N_TOKENS) tokens)"
+	@echo "  make chat             Interactive chat REPL (streaming output)"
+	@echo "  make profile          Run with profiling breakdown"
+	@echo ""
+	@echo "More targets:"
+	@echo "  make verify           Top-k token-level inclusion gate vs HF bf16 (2 prompts × 32 tokens, k=5) — fast CI gate"
+	@echo "  make verify-full      Same as above but runs the full prompt set (longer, exhaustive)"
+	@echo "  make diagnosis        Per-layer ffn_out cosine + max_abs vs HF bf16 (single prompt, informational)"
+	@echo ""
+	@echo "Maintenance:"
+	@echo "  make clean            Remove all build artifacts and verify reports"
+
+## Compile all kernels
+compile:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py --compile-only
+
+## Run unified inference
+run:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
+
+## Run with detailed profiling breakdown
+profile:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
+
+## Interactive chat
+chat:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
+
+all: compile profile
+
+VERIFY_RUNNER = $(srcdir)/../verify/verify_runner.py
+RUNNER_ADAPTER = qwen25_3b.verify_adapter
+
+## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
+verify:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL) --max-prompts 2
+
+## Full-sweep variant of `make verify`.
+verify-full:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL)
+
+## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
+diagnosis:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
+
+## Remove all build artifacts and verify reports
+clean:
+	rm -r $(BUILD_DIR) 2>/dev/null || true
+	rm -rf $(srcdir)/../verify/reports
+	@echo "Build directory and verify/reports/ removed. Run 'make compile' to rebuild."

--- a/programming_examples/llms/qwen25_3b/README.md
+++ b/programming_examples/llms/qwen25_3b/README.md
@@ -1,0 +1,85 @@
+# Qwen2.5-3B BF16 Inference on AMD NPU2 (MLIR-AIR)
+
+End-to-end Qwen2.5-3B (3B parameter, BF16) inference running on AMD NPU2 (AIE2P)
+hardware via MLIR-AIR. Supports both prefill (seq_len=2048) and autoregressive
+decode with a KV cache. Built kernel-first on the shared LLM infrastructure
+(`../shared/`, `../verify/`) and the `../qwen25_1_5b/` sibling (same Qwen2.5
+family); the Qwen2.5-3B-specific deltas (emb=2048, q_dim=2048 → square O-proj,
+hidden=11008, 36 layers — the deepest in this set) are handled in the prefill /
+decode block runners.
+
+## Performance
+
+Measured on NPU2 (AIE2P), `make profile N_TOKENS=32`, 2026-06-28.
+
+| Phase | Measured | Notes |
+|-------|----------|-------|
+| Prefill / TTFT (2048 tokens) | **4.24 s wall** | head_dim=128 → host head-first FA seq↔head transpose included in wall; NPU-kernel time ~3.46 s |
+| Decode / TPOT (steady-state) | **3.5 tok/s** | 36 layers, NPU-compute-bound; decode Down GEMV moved onto NPU |
+
+## Model Config
+
+36 layers, emb_dim=2048, n_heads=16, head_dim=128, n_kv_heads=2 (GQA group=8),
+q_dim=2048 (square O), kv_dim=256, hidden_dim=11008, vocab_size=151936, BF16,
+rope_theta=1000000, eps=1e-6, tied embeddings (lm_head = embed_tokens),
+**QKV bias** (q/k/v projection bias — the key Qwen2.5 delta vs Llama/Qwen3;
+there is NO QK-norm).
+
+## Prerequisites
+
+1. **MLIR-AIR base environment** — AMD NPU2 hardware, Peano compiler, the
+   project's standard env: `source utils/env_setup.sh ...`
+
+2. **Extra Python packages** (on top of the base):
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Installs `safetensors`, `huggingface_hub`, `transformers`, and `torch`
+   (used by `make verify` for the HuggingFace bf16 reference comparison).
+
+3. **HuggingFace model access** (one-time):
+   - Qwen2.5-3B is openly licensed: https://huggingface.co/Qwen/Qwen2.5-3B
+   - Weights are auto-downloaded on the first `make run` and cached under
+     `~/.cache/huggingface/hub/`.
+
+## Quick Start
+
+```bash
+# One-time: compile all kernels (cached to disk)
+make compile
+
+# Run inference (instruct model by default; up to 1000 tokens, stops early on EOT)
+make run
+
+# Custom prompt / token budget
+make run PROMPT="How does photosynthesis work?" N_TOKENS=64
+
+# Run with profiling breakdown (per-kernel + per-phase)
+make profile
+
+# Top-k token-level correctness gate (NPU bf16 vs HF transformers bf16,
+# 2 prompts × 32 greedy tokens, k=5) — the production-readiness gate
+make verify
+
+# Per-layer cosine diagnosis lens (informational, single prompt)
+make diagnosis
+```
+
+## Verification
+
+`make verify` is the PASS/FAIL gate: it greedily decodes 32 tokens on the NPU
+and on HF transformers (bf16) for each prompt and checks that every NPU token is
+in HF's top-5 set at that position. Current status: **PASS, exit 0, 2/2 prompts**.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `qwen25_3b_inference.py` | Unified prefill + decode driver (`prepare_runtime` does all one-time init outside the timed region) |
+| `qwen25_3b_prefill.py` | Prefill kernel builders + `run_transformer_block_qwen25` + `preload_prefill_weights` |
+| `qwen25_3b_decode.py` | Decode kernel builders + `run_decode_block` (KV cache) |
+| `qwen25_3b_weights.py` | Weight loading from HuggingFace safetensors (incl. QKV bias, tied lm_head) |
+| `qwen25_3b_cpu_helpers.py` | NumPy helpers shared by production + verify: `rms_norm`, `attention_reference`, `softmax` |
+| `verify_adapter.py` | Hooks this model's prefill/decode into the shared `../verify/` subsystem |
+| `Makefile` | compile / run / profile / chat / verify / verify-full / diagnosis / clean |
+| `ARCHITECTURE.md` | Per-layer kernel sequence, NPU/CPU mapping, runtime flow, deltas |

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_cpu_helpers.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_cpu_helpers.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Small NumPy CPU helpers for Qwen2.5-3B production prefill/decode + verify.
+
+Mirrors llama32_1b_cpu_helpers.py. Qwen2.5 has QKV bias (no QK-norm).
+Kept helpers: rms_norm, attention_reference, softmax. Bias is applied on the
+host around the bias-free NPU GEMMs (see prefill/decode), exploiting RoPE
+linearity, so no dedicated bias helper is needed here.
+"""
+
+import numpy as np
+
+
+def rms_norm(x, weight, eps=1e-6):
+    """RMS norm; Qwen2.5 uses eps=1e-6 (rms_norm_eps)."""
+    x = np.asarray(x, dtype=np.float32)
+    weight = np.asarray(weight, dtype=np.float32)
+    rms = np.sqrt(np.mean(x * x, axis=-1, keepdims=True) + eps)
+    return (x / rms) * weight
+
+
+def softmax(x, axis=-1):
+    x = np.asarray(x, dtype=np.float32)
+    x_max = np.max(x, axis=axis, keepdims=True)
+    exp_x = np.exp(x - x_max)
+    return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
+
+
+def attention_reference(q, k, v, n_heads, n_kv_heads):
+    """GQA attention with causal mask (F32). q/k already RoPE'd (and bias-added)."""
+    q = np.asarray(q, dtype=np.float32)
+    k = np.asarray(k, dtype=np.float32)
+    v = np.asarray(v, dtype=np.float32)
+    seq_len = q.shape[0]
+    head_dim = q.shape[1] // n_heads
+    group_size = n_heads // n_kv_heads
+    q = q.reshape(seq_len, n_heads, head_dim).transpose(1, 0, 2)
+    k = k.reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+    v = v.reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+    scale = 1.0 / np.sqrt(head_dim)
+    causal_mask = np.triu(np.full((seq_len, seq_len), -np.inf, dtype=np.float32), k=1)
+    out_heads = np.empty((n_heads, seq_len, head_dim), dtype=np.float32)
+    for h in range(n_heads):
+        kv_idx = h // group_size
+        scores = q[h] @ k[kv_idx].T * scale + causal_mask
+        probs = softmax(scores, axis=-1)
+        out_heads[h] = probs @ v[kv_idx]
+    return out_heads.transpose(1, 0, 2).reshape(seq_len, n_heads * head_dim)

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_cpu_helpers.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_cpu_helpers.py
@@ -4,9 +4,9 @@
 """Small NumPy CPU helpers for Qwen2.5-3B production prefill/decode + verify.
 
 Mirrors llama32_1b_cpu_helpers.py. Qwen2.5 has QKV bias (no QK-norm).
-Kept helpers: rms_norm, attention_reference, softmax. Bias is applied on the
-host around the bias-free NPU GEMMs (see prefill/decode), exploiting RoPE
-linearity, so no dedicated bias helper is needed here.
+Kept helpers: rms_norm, attention_reference, softmax. QKV bias is fused into
+the NPU rms_qkv_bias_rope ELF on-device (see prefill/decode), so no dedicated
+host bias helper is needed here.
 """
 
 import numpy as np

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
@@ -6,13 +6,12 @@
 Single-token autoregressive generation with KV cache. Mirrors the Phase-2
 prefill (qwen25_3b_prefill.py) deltas, applied to the M=1 GEMV path:
 
-  1. QKV BIAS on host (Qwen2 family, attention_bias=True; NOT QK-norm — that
-     is Qwen3). After the Q/K/V GEMV projection, a per-channel bias is added on
-     the HOST: q=(q_dim,)+bq, k=(kv_dim,)+bk, v=(kv_dim,)+bv, BEFORE RoPE for
-     q/k (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention; V is
-     bias-added and used directly). RoPE linearity is irrelevant here — we just
-     do the cheap single-token elementwise add between the (bias-free) GEMV
-     and the standalone RoPE ELFs.
+  1. QKV BIAS fused on-device (Qwen2 family, attention_bias=True; NOT QK-norm —
+     that is Qwen3). The rms_qkv_bias_rope_gemv ELF adds the per-channel bias
+     (bq/bk/bv passed as static ELF args, indices 9/10/11) after the Q/K/V GEMV
+     and BEFORE RoPE for q/k (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) ->
+     attention; V is bias-added and used directly). RMSNorm + Q/K/V GEMV +
+     bias-add + RoPE(Q,K) are all fused into that one ELF.
 
   2. Dims: emb=2048, q_dim=2048 (16*128), kv_dim=256 (2*128),
      hidden=11008, head_dim=128. o_proj is SQUARE (q_dim==emb_dim==2048).

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
@@ -1,0 +1,504 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen2.5-3B Decode on MLIR-AIR (NPU2).
+
+Single-token autoregressive generation with KV cache. Mirrors the Phase-2
+prefill (qwen25_3b_prefill.py) deltas, applied to the M=1 GEMV path:
+
+  1. QKV BIAS on host (Qwen2 family, attention_bias=True; NOT QK-norm — that
+     is Qwen3). After the Q/K/V GEMV projection, a per-channel bias is added on
+     the HOST: q=(q_dim,)+bq, k=(kv_dim,)+bk, v=(kv_dim,)+bv, BEFORE RoPE for
+     q/k (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention; V is
+     bias-added and used directly). RoPE linearity is irrelevant here — we just
+     do the cheap single-token elementwise add between the (bias-free) GEMV
+     and the standalone RoPE ELFs.
+
+  2. Dims: emb=2048, q_dim=2048 (16*128), kv_dim=256 (2*128),
+     hidden=11008, head_dim=128. o_proj is SQUARE (q_dim==emb_dim==2048).
+     The fused llama/qwen3 `o_gemv_ffn` ELF stitches O-GEMV + SwiGLU +
+     Down-GEMV via the cascade `matvec_2tile_add` / `matvec_swiglu_rms`
+     builders, whose K-chunk requires K % 512 == 0 — which qwen2.5's K=11008
+     (Down) does NOT satisfy. Rather than re-derive cascade
+     tile params for non-512 K, decode uses STANDALONE per-projection GEMV ELFs
+     (the plain `matvec` builder, 3-arg A@B) for O / Gate / Up / Down, exactly
+     the (kernel, shape, tile) configs Phase 1 verified PASS, and does the
+     residual add / FFN RMSNorm / SwiGLU on the host (single-token, cheap,
+     exact). This trades a few extra XRT dispatches for guaranteed correctness;
+     Phase 5 can fuse later.
+
+  3. LM-head vocab = 151936. Per-partition GEMV broadcasts the K=emb input
+     vector with a push_queue repeat_count ~= n_part/32 - 1, capped at [0:255]
+     → n_part <= 8192. Use 19 partitions × 8192 (19*8192 = 155648 >= 151936;
+     last partition zero-padded, logits truncated to vocab on host). Same as
+     Qwen3-0.6B (shared vocab 151936).
+
+Decode attention is CPU (decode_attention_cpu); single-token attention is
+trivial on host (head_dim=128 FA risk is irrelevant at M=1).
+
+Phase-1-verified decode GEMV tile configs (see docs phase1_kernels.md):
+  Q/O   2048×2048 : tile_m=8  m_input=8  herd_m=8
+  K/V   256×2048  : tile_m=8  m_input=8  herd_m=8
+  Gate/Up 11008×2048 : tile_m=8 m_input=8 herd_m=8
+  Down  2048×11008 : tile_m=2  m_input=1  herd_m=8  (NPU standalone ELF; needs
+        omit_pingpong=all + its own down_mv.o)
+
+O / Gate / Up / Down ALL run on NPU as standalone GEMV ELFs. The residual add /
+FFN RMSNorm / SwiGLU stay on host (single-token, cheap, exact). Down (K=11008)
+compiles + runs on NPU once ping-pong is disabled.
+
+MEASURED (2026-06-27): with O/Gate/Up/Down on NPU, the residual + FFN RMSNorm +
+SwiGLU left on host are ~0.045ms/layer of M=1 numpy (microbench at emb=2048/
+hidden=11008). Moving them to a standalone NPU ELF would add a ~0.7-1.4ms
+dispatch per op to replace ~0.02ms numpy — a large regression — and folding into
+the GEMV epilogue is the matvec_swiglu_rms cascade that overflows L1 here. Glue
+stays on host by design; the decode cost is now the NPU GEMVs (real compute).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_PROG_EXAMPLES = str(Path(__file__).resolve().parent.parent.parent)
+if _PROG_EXAMPLES not in sys.path:
+    sys.path.insert(0, _PROG_EXAMPLES)
+_LLMS_DIR = str(Path(__file__).resolve().parent.parent)
+if _LLMS_DIR not in sys.path:
+    sys.path.insert(0, _LLMS_DIR)
+
+from qwen25_3b_weights import LlamaConfig
+from qwen25_3b_cpu_helpers import rms_norm
+
+
+# LM-head decode partitioning. vocab=151936. Per-partition GEMV broadcasts the
+# K=emb_dim input vector with a push_queue repeat_count ~= n_part/32 - 1, capped
+# at [0:255] → n_part <= 8192. 19 * 8192 = 155648 >= 151936; the final partition
+# carries zero-padded rows (logits truncated to vocab on host).
+_LM_N_PARTITIONS = 19
+_LM_N_PART = 8192  # % 64 == 0; n_part/32 - 1 = 255 (at the repeat-count limit)
+
+# Phase-1-verified decode GEMV tile configs (tile_m, m_input, herd_m).
+_GEMV_QO = (8, 8, 8)        # 2048×2048 (Q proj, O proj)
+_GEMV_KV = (8, 8, 8)        # 256×2048 (K proj, V proj)
+_GEMV_GATEUP = (8, 8, 8)    # 11008×2048 (Gate proj, Up proj)
+_GEMV_DOWN = (2, 1, 8)      # 2048×11008 (Down proj; K=11008 → L1-bound m_input=1)
+
+# Down GEMV runs on NPU as a standalone matvec ELF. The standalone builder stages
+# A in L2 (not L1) and streams B L3→L1, so K=11008 compiles + runs (verified
+# standalone: M=2048 K=11008 tile_m=2/m_input=1/herd_m=8, bit-identical to f32
+# ref). Only the *fused* cascade (matvec_swiglu_rms, which double-buffers the full
+# K in L1) overflows 64 KB L1 — so the FFN glue stays on host by design.
+
+
+# ---------------------------------------------------------------------------
+# Builder 1 (FUSED): RMSNorm + Q/K/V GEMV + bias-add(Q,K,V) + RoPE(Q,K), M=1.
+#   One ELF (RMSNorm+QKV+bias+RoPE) for the decode attention-input stage.
+# ---------------------------------------------------------------------------
+
+
+def build_rms_qkv_bias_rope_gemv_module(emb_dim, q_dim, kv_dim, config, eps=1e-6):
+    from shared.builders.rms_qkv_bias_rope_multi import (
+        build_rms_qkv_bias_rope_gemv_module as _build,
+    )
+
+    q_tm, q_mi, q_hm = _GEMV_QO
+    return _build(
+        emb_dim, q_dim, kv_dim,
+        config.n_heads, config.n_kv_heads, config.head_dim,
+        tile_m=q_tm, m_input=q_mi, herd_m=q_hm, eps=eps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder 3: standalone single-projection GEMV ELF (plain matvec, A@B).
+#   Used for O / Gate / Up / Down — the residual / RMSNorm / SwiGLU around
+#   them is done on the host (single token, cheap, exact). Avoids the cascade
+#   builders' K % 512 == 0 requirement which qwen2.5 dims violate.
+# ---------------------------------------------------------------------------
+
+
+def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="mv.o"):
+    """Standalone GEMV ELF: C[m] = A[m,k] @ B[k]. 3-arg func.
+
+    Func args: %arg0 A (m,k)  %arg1 B (k,)  %arg2 C (m,)
+
+    The raw `matvec` builder names its func @matvec_bf16; for ELF output the
+    backend's instance_name must match the module's func name (else the loaded
+    kernel symbol `main:<instance_name>` is not found). We stitch the single
+    GEMV slice through stitch_elf so the public func is renamed to `name`,
+    matching the per-projection instance_name in the backend kwargs.
+    """
+    _mv_dir = os.path.join(
+        _PROG_EXAMPLES, "matrix_vector_multiplication", "bf16"
+    )
+    if _mv_dir not in sys.path:
+        sys.path.insert(0, _mv_dir)
+    from matvec import build_module as build_gemv
+    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+
+    gemv_ir = str(build_gemv(m, k, tile_m, m_input, herd_m, bfloat16, bfloat16, link_with=link_with))
+    base_args = [
+        FuncArg("%arg0", f"memref<{m}x{k}xbf16>"),
+        FuncArg("%arg1", f"memref<{k}xbf16>"),
+        FuncArg("%arg2", f"memref<{m}xbf16>"),
+    ]
+    # GEMV func args: {0: weight (MxK), 1: input (K,), 2: output (M,)}.
+    slices = [
+        KernelSlice(
+            gemv_ir, "g", {0: 0, 1: 1, 2: 2},
+            extern_syms={"@matvec_vectorized_bf16_bf16", "@linalg_fill_bf16"},
+        )
+    ]
+    return stitch_elf(name, base_args, slices)
+
+
+# ---------------------------------------------------------------------------
+# Builder 4: LM-head GEMV (19 partitions, n_part=8192 for vocab 151936).
+# ---------------------------------------------------------------------------
+
+
+def build_lm_head_gemv_qwen_module(emb_dim):
+    from shared.builders.lm_head_gemv_multi import build_lm_head_gemv_module
+
+    return build_lm_head_gemv_module(
+        emb_dim=emb_dim,
+        n_partitions=_LM_N_PARTITIONS,
+        n_part=_LM_N_PART,
+        tile_m=8,
+        m_input=4,
+        herd_m=8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend kwargs
+# ---------------------------------------------------------------------------
+
+
+def _rms_qkv_bias_rope_gemv_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "rms_qkv_bias_rope_gemv",
+    }
+
+
+def _gemv_backend(verbose=False, name="gemv", omit_pingpong=False):
+    bk = {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": name,
+    }
+    # Large-K GEMV (Down, K=11008): the B vector is 22 KB; ping-pong would
+    # double-buffer it (4×22 KB = 88 KB > 64 KB L1) and AIE allocation fails.
+    # Disable ping-pong so the standalone Down ELF fits L1 (same reason OGF
+    # turns ping-pong off for its K=8192 down). K=2048 GEMVs keep ping-pong.
+    if omit_pingpong:
+        bk["omit_pingpong"] = "all"
+    return bk
+
+
+def _lm_gemv_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "lm_head_gemv",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Decode kernel compilation
+# ---------------------------------------------------------------------------
+
+
+def compile_decode_kernels(cache, config, verbose=False):
+    """Compile the Qwen2.5 decode kernels."""
+    from shared.infra.external_kernels import compile_mv, compile_rope
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    print(f"\n{'='*60}\nCompiling Qwen2.5 decode kernels...\n{'='*60}\n")
+
+    # External .o: GEMV (mv.o), RoPE (rope.o).
+    compile_mv()
+    compile_rope()
+
+    print("\n--- rms_qkv_bias_rope_gemv (FUSED: RMSNorm+QKV+bias+RoPE, M=1) ---")
+    cache.compile_and_cache(
+        "rms_qkv_bias_rope_gemv",
+        build_rms_qkv_bias_rope_gemv_module(emb_dim, q_dim, kv_dim, config, eps=1e-6),
+        _rms_qkv_bias_rope_gemv_backend(verbose),
+    )
+
+    # Standalone projection GEMVs. O proj is SQUARE (M=emb, K=q_dim=emb).
+    print(f"\n--- o_gemv (O proj GEMV, {emb_dim}x{q_dim}) ---")
+    o_tm, o_mi, o_hm = _GEMV_QO
+    cache.compile_and_cache(
+        "o_gemv", build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
+        _gemv_backend(verbose, "o_gemv"),
+    )
+    print(f"\n--- gate_gemv (Gate proj GEMV, {hidden_dim}x{emb_dim}) ---")
+    g_tm, g_mi, g_hm = _GEMV_GATEUP
+    cache.compile_and_cache(
+        "gate_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
+        _gemv_backend(verbose, "gate_gemv"),
+    )
+    print(f"\n--- up_gemv (Up proj GEMV, {hidden_dim}x{emb_dim}) ---")
+    cache.compile_and_cache(
+        "up_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
+        _gemv_backend(verbose, "up_gemv"),
+    )
+    # Down proj GEMV (M=emb=2048, K=hidden=11008). The STANDALONE matvec stages
+    # A in L2 and streams B L3→L1, so K=11008 compiles + runs (unlike the fused
+    # cascade, which double-buffers full-K in L1 and overflows). tile_m=2 m_input=1.
+    # Down needs tile_m=2 (K=11008 L2 budget), but the shared mv.o is built with
+    # DIM_M_OUTPUT=8 for o/gate/up. linalg_fill_bf16 zeros DIM_M_OUTPUT rows, so
+    # down must link its own mv.o (DIM_M_OUTPUT=tile_m=2) → down_mv.o.
+    d_tm, d_mi, d_hm = _GEMV_DOWN
+    compile_mv(tile_m=d_tm)            # writes mv.o with DIM_M_OUTPUT=d_tm
+    import shutil as _shutil
+    _shutil.copy2("mv.o", "down_mv.o")
+    compile_mv()                       # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
+    print(f"\n--- down_gemv (Down proj GEMV, {emb_dim}x{hidden_dim}) ---")
+    cache.compile_and_cache(
+        "down_gemv",
+        build_gemv_module(emb_dim, hidden_dim, d_tm, d_mi, d_hm,
+                          name="down_gemv", link_with="down_mv.o"),
+        _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
+    )
+
+    print(f"\n--- lm_head_gemv ({_LM_N_PARTITIONS}-partition, vocab 151936) ---")
+    cache.compile_and_cache(
+        "lm_head_gemv",
+        build_lm_head_gemv_qwen_module(emb_dim),
+        _lm_gemv_backend(verbose),
+    )
+
+    cache._save_manifest()
+    print(f"\nAll {len(cache.artifacts)} decode kernels compiled.")
+
+
+# ---------------------------------------------------------------------------
+# CPU decode attention (with KV cache)
+# ---------------------------------------------------------------------------
+
+
+def decode_attention_cpu(q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim):
+    """Single-query GQA attention with KV cache.
+
+    Args:
+        q: (q_dim,) — RoPE'd (and bias-added) query vector for the current token.
+        k_cache: (n_kv_heads, max_seq, head_dim) — cached keys (after bias+RoPE).
+        v_cache: (n_kv_heads, max_seq, head_dim) — cached values (after bias).
+        current_pos: current token position (0-indexed).
+    Returns:
+        attn_out: (q_dim,) bfloat16.
+    """
+    group_size = n_heads // n_kv_heads
+    scale = 1.0 / np.sqrt(head_dim)
+    seq_len = current_pos + 1
+
+    q_heads = q.astype(np.float32).reshape(n_heads, head_dim)
+    k_cached = k_cache[:, :seq_len, :].astype(np.float32)
+    v_cached = v_cache[:, :seq_len, :].astype(np.float32)
+
+    out = np.zeros((n_heads, head_dim), dtype=np.float32)
+    for h in range(n_heads):
+        kv_h = h // group_size
+        scores = (q_heads[h] @ k_cached[kv_h].T) * scale
+        probs = np.exp(scores - scores.max())
+        probs = probs / probs.sum()
+        out[h] = probs @ v_cached[kv_h]
+
+    return out.reshape(-1).astype(bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# Single decode transformer block
+# ---------------------------------------------------------------------------
+
+
+def _fused_bias_rope_gemv_call(cache, lw, config, lut_q, lut_k, suffix, x_in, verbose=False):
+    """Issue one rms_qkv_bias_rope_gemv ELF call (fused decode attention-input).
+
+    Used by BOTH _preload_decode_weights and run_decode_block. Single owner of
+    the fused arg layout. output_indices=[14,17,18] -> v_b, q_roped, k_roped.
+    RoPE LUTs (15,16) are position-dependent → NOT static.
+    """
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    args = [
+        np.ascontiguousarray(x_in).astype(bfloat16).reshape(emb_dim),       # 0 x_in
+        lw.attn_norm.reshape(emb_dim).astype(bfloat16),                     # 1 norm_w (static)
+        np.zeros(emb_dim, dtype=bfloat16),                                  # 2 normed (inter)
+        lw._wq_t,                                                           # 3 wq (static)
+        np.zeros(q_dim, dtype=bfloat16),                                    # 4 q (inter)
+        lw._wk_t,                                                           # 5 wk (static)
+        np.zeros(kv_dim, dtype=bfloat16),                                   # 6 k (inter)
+        lw._wv_t,                                                           # 7 wv (static)
+        np.zeros(kv_dim, dtype=bfloat16),                                   # 8 v (inter)
+        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),                  # 9 bq (static)
+        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),                 # 10 bk (static)
+        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),                 # 11 bv (static)
+        np.zeros(q_dim, dtype=bfloat16),                                    # 12 q_b (inter)
+        np.zeros(kv_dim, dtype=bfloat16),                                   # 13 k_b (inter)
+        np.zeros(kv_dim, dtype=bfloat16),                                   # 14 v_b (inter/out)
+        np.ascontiguousarray(lut_q).astype(bfloat16),                      # 15 lut_q (NON-static)
+        np.ascontiguousarray(lut_k).astype(bfloat16),                      # 16 lut_k (NON-static)
+        np.zeros(q_dim, dtype=bfloat16),                                    # 17 q_roped (inter/out)
+        np.zeros(kv_dim, dtype=bfloat16),                                   # 18 k_roped (inter/out)
+    ]
+    return cache.load_and_run(
+        "rms_qkv_bias_rope_gemv",
+        _rms_qkv_bias_rope_gemv_backend(verbose),
+        *args,
+        output_indices=[14, 17, 18],
+        static_input_indices={1, 3, 5, 7, 9, 10, 11},
+        intermediate_indices={2, 4, 6, 8, 12, 13, 14, 17, 18},
+        bo_key=f"rms_qkv_bias_rope_gemv{suffix}" if suffix else None,
+    )
+
+
+def run_decode_block(
+    x_bf16,
+    layer_weights,
+    cache,
+    config,
+    k_cache_layer,
+    v_cache_layer,
+    current_pos,
+    rope_lut_bf16,
+    verbose=False,
+):
+    """Run one Qwen2.5 transformer block for a single decode token.
+
+    Stages: rms_qkv_bias_rope_gemv (NPU, fused RMSNorm+QKV+bias+RoPE)
+    -> KV-cache write -> CPU attention -> O GEMV (NPU) -> residual (host)
+    -> FFN RMSNorm (host) -> Gate/Up GEMV (NPU) -> SwiGLU (host)
+    -> Down GEMV (NPU) -> FFN residual (host).
+    """
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    layer_idx = getattr(layer_weights, "_layer_idx", None)
+    _suffix = f"_L{layer_idx}" if layer_idx is not None else None
+    inter = {}
+
+    x_in = x_bf16.flatten().astype(bfloat16)
+
+    # RoPE LUT for the current single position.
+    rope_lut_pos = rope_lut_bf16[current_pos : current_pos + 1]  # (1, head_dim)
+    lut_q = np.tile(rope_lut_pos, (n_heads, 1)).flatten().astype(bfloat16)
+    lut_k = np.tile(rope_lut_pos, (n_kv_heads, 1)).flatten().astype(bfloat16)
+
+    # --- Stages A-C (FUSED): one ELF = RMSNorm + Q/K/V GEMV + bias(Q,K,V)
+    # + RoPE(Q,K). Output: v (bias-only), q_roped, k_roped. ---
+    res = _fused_bias_rope_gemv_call(
+        cache, layer_weights, config, lut_q, lut_k, _suffix, x_in, verbose
+    )
+    v = res[14].astype(bfloat16)
+    q_roped = res[17].astype(bfloat16)
+    k_roped = res[18].astype(bfloat16)
+    inter["v"] = v
+    inter["q_roped"] = q_roped
+    inter["k_roped"] = k_roped
+
+    # --- Update KV cache (K after bias+RoPE, V after bias) ---
+    k_cache_layer[:, current_pos, :] = k_roped.reshape(n_kv_heads, head_dim)
+    v_cache_layer[:, current_pos, :] = v.reshape(n_kv_heads, head_dim)
+
+    # --- CPU attention ---
+    with cache.profiler.time_cpu("decode_attention_cpu"):
+        attn_out = decode_attention_cpu(
+            q_roped, k_cache_layer, v_cache_layer, current_pos,
+            n_heads, n_kv_heads, head_dim,
+        )
+    inter["attn_out"] = attn_out
+
+    # --- Stage E: O proj GEMV + residual + FFN (RMSNorm/SwiGLU on host) ---
+    ro = cache.load_and_run(
+        "o_gemv",
+        _gemv_backend(verbose, "o_gemv"),
+        layer_weights._wo_t,                        # arg0 wo (static) (emb, q_dim)
+        np.ascontiguousarray(attn_out),             # arg1 attn_out (q_dim,)
+        np.zeros(emb_dim, dtype=bfloat16),          # arg2 proj (emb,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"o_gemv{_suffix}" if _suffix else None,
+    )
+    proj = ro[2].astype(np.float32)
+
+    # residual 1 (host)
+    res1 = proj + x_in.astype(np.float32)
+    inter["res1"] = res1.astype(bfloat16)
+
+    # FFN RMSNorm (host, eps=1e-6)
+    normed2 = rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6).reshape(emb_dim).astype(bfloat16)
+
+    rg = cache.load_and_run(
+        "gate_gemv",
+        _gemv_backend(verbose, "gate_gemv"),
+        layer_weights._wgate_t,                     # arg0 w_gate (static) (hidden, emb)
+        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 gate (hidden,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"gate_gemv{_suffix}" if _suffix else None,
+    )
+    gate = rg[2].astype(np.float32)
+    ru = cache.load_and_run(
+        "up_gemv",
+        _gemv_backend(verbose, "up_gemv"),
+        layer_weights._wup_t,                       # arg0 w_up (static) (hidden, emb)
+        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 up (hidden,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"up_gemv{_suffix}" if _suffix else None,
+    )
+    up = ru[2].astype(np.float32)
+    # SwiGLU (host)
+    swig = ((gate / (1.0 + np.exp(-gate))) * up).astype(bfloat16)
+    # Down projection: M=emb=2048, K=hidden=11008. The STANDALONE matvec builder
+    # stages A in L2 and streams B L3→L1, so K=11008 compiles + runs (verified
+    # bit-identical to f32 ref). Runs on NPU as its own standalone down_gemv ELF.
+    rd = cache.load_and_run(
+        "down_gemv",
+        _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
+        layer_weights._wdown_t,                     # arg0 w_down (static) (emb, hidden)
+        np.ascontiguousarray(swig),                 # arg1 swig (hidden,)
+        np.zeros(emb_dim, dtype=bfloat16),          # arg2 down (emb,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"down_gemv{_suffix}" if _suffix else None,
+    )
+    down = rd[2].astype(np.float32)
+
+    out = (down + res1).astype(bfloat16)
+    inter["ffn_out"] = out
+    return out, inter

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_decode.py
@@ -71,7 +71,6 @@ if _LLMS_DIR not in sys.path:
 from qwen25_3b_weights import LlamaConfig
 from qwen25_3b_cpu_helpers import rms_norm
 
-
 # LM-head decode partitioning. vocab=151936. Per-partition GEMV broadcasts the
 # K=emb_dim input vector with a push_queue repeat_count ~= n_part/32 - 1, capped
 # at [0:255] → n_part <= 8192. 19 * 8192 = 155648 >= 151936; the final partition
@@ -80,10 +79,10 @@ _LM_N_PARTITIONS = 19
 _LM_N_PART = 8192  # % 64 == 0; n_part/32 - 1 = 255 (at the repeat-count limit)
 
 # Phase-1-verified decode GEMV tile configs (tile_m, m_input, herd_m).
-_GEMV_QO = (8, 8, 8)        # 2048×2048 (Q proj, O proj)
-_GEMV_KV = (8, 8, 8)        # 256×2048 (K proj, V proj)
-_GEMV_GATEUP = (8, 8, 8)    # 11008×2048 (Gate proj, Up proj)
-_GEMV_DOWN = (2, 1, 8)      # 2048×11008 (Down proj; K=11008 → L1-bound m_input=1)
+_GEMV_QO = (8, 8, 8)  # 2048×2048 (Q proj, O proj)
+_GEMV_KV = (8, 8, 8)  # 256×2048 (K proj, V proj)
+_GEMV_GATEUP = (8, 8, 8)  # 11008×2048 (Gate proj, Up proj)
+_GEMV_DOWN = (2, 1, 8)  # 2048×11008 (Down proj; K=11008 → L1-bound m_input=1)
 
 # Down GEMV runs on NPU as a standalone matvec ELF. The standalone builder stages
 # A in L2 (not L1) and streams B L3→L1, so K=11008 compiles + runs (verified
@@ -105,9 +104,16 @@ def build_rms_qkv_bias_rope_gemv_module(emb_dim, q_dim, kv_dim, config, eps=1e-6
 
     q_tm, q_mi, q_hm = _GEMV_QO
     return _build(
-        emb_dim, q_dim, kv_dim,
-        config.n_heads, config.n_kv_heads, config.head_dim,
-        tile_m=q_tm, m_input=q_mi, herd_m=q_hm, eps=eps,
+        emb_dim,
+        q_dim,
+        kv_dim,
+        config.n_heads,
+        config.n_kv_heads,
+        config.head_dim,
+        tile_m=q_tm,
+        m_input=q_mi,
+        herd_m=q_hm,
+        eps=eps,
     )
 
 
@@ -130,15 +136,17 @@ def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="m
     GEMV slice through stitch_elf so the public func is renamed to `name`,
     matching the per-projection instance_name in the backend kwargs.
     """
-    _mv_dir = os.path.join(
-        _PROG_EXAMPLES, "matrix_vector_multiplication", "bf16"
-    )
+    _mv_dir = os.path.join(_PROG_EXAMPLES, "matrix_vector_multiplication", "bf16")
     if _mv_dir not in sys.path:
         sys.path.insert(0, _mv_dir)
     from matvec import build_module as build_gemv
     from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
 
-    gemv_ir = str(build_gemv(m, k, tile_m, m_input, herd_m, bfloat16, bfloat16, link_with=link_with))
+    gemv_ir = str(
+        build_gemv(
+            m, k, tile_m, m_input, herd_m, bfloat16, bfloat16, link_with=link_with
+        )
+    )
     base_args = [
         FuncArg("%arg0", f"memref<{m}x{k}xbf16>"),
         FuncArg("%arg1", f"memref<{k}xbf16>"),
@@ -147,7 +155,9 @@ def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="m
     # GEMV func args: {0: weight (MxK), 1: input (K,), 2: output (M,)}.
     slices = [
         KernelSlice(
-            gemv_ir, "g", {0: 0, 1: 1, 2: 2},
+            gemv_ir,
+            "g",
+            {0: 0, 1: 1, 2: 2},
             extern_syms={"@matvec_vectorized_bf16_bf16", "@linalg_fill_bf16"},
         )
     ]
@@ -245,18 +255,21 @@ def compile_decode_kernels(cache, config, verbose=False):
     print(f"\n--- o_gemv (O proj GEMV, {emb_dim}x{q_dim}) ---")
     o_tm, o_mi, o_hm = _GEMV_QO
     cache.compile_and_cache(
-        "o_gemv", build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
+        "o_gemv",
+        build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
         _gemv_backend(verbose, "o_gemv"),
     )
     print(f"\n--- gate_gemv (Gate proj GEMV, {hidden_dim}x{emb_dim}) ---")
     g_tm, g_mi, g_hm = _GEMV_GATEUP
     cache.compile_and_cache(
-        "gate_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
+        "gate_gemv",
+        build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
         _gemv_backend(verbose, "gate_gemv"),
     )
     print(f"\n--- up_gemv (Up proj GEMV, {hidden_dim}x{emb_dim}) ---")
     cache.compile_and_cache(
-        "up_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
+        "up_gemv",
+        build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
         _gemv_backend(verbose, "up_gemv"),
     )
     # Down proj GEMV (M=emb=2048, K=hidden=11008). The STANDALONE matvec stages
@@ -266,15 +279,23 @@ def compile_decode_kernels(cache, config, verbose=False):
     # DIM_M_OUTPUT=8 for o/gate/up. linalg_fill_bf16 zeros DIM_M_OUTPUT rows, so
     # down must link its own mv.o (DIM_M_OUTPUT=tile_m=2) → down_mv.o.
     d_tm, d_mi, d_hm = _GEMV_DOWN
-    compile_mv(tile_m=d_tm)            # writes mv.o with DIM_M_OUTPUT=d_tm
+    compile_mv(tile_m=d_tm)  # writes mv.o with DIM_M_OUTPUT=d_tm
     import shutil as _shutil
+
     _shutil.copy2("mv.o", "down_mv.o")
-    compile_mv()                       # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
+    compile_mv()  # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
     print(f"\n--- down_gemv (Down proj GEMV, {emb_dim}x{hidden_dim}) ---")
     cache.compile_and_cache(
         "down_gemv",
-        build_gemv_module(emb_dim, hidden_dim, d_tm, d_mi, d_hm,
-                          name="down_gemv", link_with="down_mv.o"),
+        build_gemv_module(
+            emb_dim,
+            hidden_dim,
+            d_tm,
+            d_mi,
+            d_hm,
+            name="down_gemv",
+            link_with="down_mv.o",
+        ),
         _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
     )
 
@@ -294,7 +315,9 @@ def compile_decode_kernels(cache, config, verbose=False):
 # ---------------------------------------------------------------------------
 
 
-def decode_attention_cpu(q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim):
+def decode_attention_cpu(
+    q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim
+):
     """Single-query GQA attention with KV cache.
 
     Args:
@@ -329,7 +352,9 @@ def decode_attention_cpu(q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, 
 # ---------------------------------------------------------------------------
 
 
-def _fused_bias_rope_gemv_call(cache, lw, config, lut_q, lut_k, suffix, x_in, verbose=False):
+def _fused_bias_rope_gemv_call(
+    cache, lw, config, lut_q, lut_k, suffix, x_in, verbose=False
+):
     """Issue one rms_qkv_bias_rope_gemv ELF call (fused decode attention-input).
 
     Used by BOTH _preload_decode_weights and run_decode_block. Single owner of
@@ -343,25 +368,25 @@ def _fused_bias_rope_gemv_call(cache, lw, config, lut_q, lut_k, suffix, x_in, ve
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
     args = [
-        np.ascontiguousarray(x_in).astype(bfloat16).reshape(emb_dim),       # 0 x_in
-        lw.attn_norm.reshape(emb_dim).astype(bfloat16),                     # 1 norm_w (static)
-        np.zeros(emb_dim, dtype=bfloat16),                                  # 2 normed (inter)
-        lw._wq_t,                                                           # 3 wq (static)
-        np.zeros(q_dim, dtype=bfloat16),                                    # 4 q (inter)
-        lw._wk_t,                                                           # 5 wk (static)
-        np.zeros(kv_dim, dtype=bfloat16),                                   # 6 k (inter)
-        lw._wv_t,                                                           # 7 wv (static)
-        np.zeros(kv_dim, dtype=bfloat16),                                   # 8 v (inter)
-        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),                  # 9 bq (static)
-        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),                 # 10 bk (static)
-        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),                 # 11 bv (static)
-        np.zeros(q_dim, dtype=bfloat16),                                    # 12 q_b (inter)
-        np.zeros(kv_dim, dtype=bfloat16),                                   # 13 k_b (inter)
-        np.zeros(kv_dim, dtype=bfloat16),                                   # 14 v_b (inter/out)
-        np.ascontiguousarray(lut_q).astype(bfloat16),                      # 15 lut_q (NON-static)
-        np.ascontiguousarray(lut_k).astype(bfloat16),                      # 16 lut_k (NON-static)
-        np.zeros(q_dim, dtype=bfloat16),                                    # 17 q_roped (inter/out)
-        np.zeros(kv_dim, dtype=bfloat16),                                   # 18 k_roped (inter/out)
+        np.ascontiguousarray(x_in).astype(bfloat16).reshape(emb_dim),  # 0 x_in
+        lw.attn_norm.reshape(emb_dim).astype(bfloat16),  # 1 norm_w (static)
+        np.zeros(emb_dim, dtype=bfloat16),  # 2 normed (inter)
+        lw._wq_t,  # 3 wq (static)
+        np.zeros(q_dim, dtype=bfloat16),  # 4 q (inter)
+        lw._wk_t,  # 5 wk (static)
+        np.zeros(kv_dim, dtype=bfloat16),  # 6 k (inter)
+        lw._wv_t,  # 7 wv (static)
+        np.zeros(kv_dim, dtype=bfloat16),  # 8 v (inter)
+        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),  # 9 bq (static)
+        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),  # 10 bk (static)
+        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),  # 11 bv (static)
+        np.zeros(q_dim, dtype=bfloat16),  # 12 q_b (inter)
+        np.zeros(kv_dim, dtype=bfloat16),  # 13 k_b (inter)
+        np.zeros(kv_dim, dtype=bfloat16),  # 14 v_b (inter/out)
+        np.ascontiguousarray(lut_q).astype(bfloat16),  # 15 lut_q (NON-static)
+        np.ascontiguousarray(lut_k).astype(bfloat16),  # 16 lut_k (NON-static)
+        np.zeros(q_dim, dtype=bfloat16),  # 17 q_roped (inter/out)
+        np.zeros(kv_dim, dtype=bfloat16),  # 18 k_roped (inter/out)
     ]
     return cache.load_and_run(
         "rms_qkv_bias_rope_gemv",
@@ -430,8 +455,13 @@ def run_decode_block(
     # --- CPU attention ---
     with cache.profiler.time_cpu("decode_attention_cpu"):
         attn_out = decode_attention_cpu(
-            q_roped, k_cache_layer, v_cache_layer, current_pos,
-            n_heads, n_kv_heads, head_dim,
+            q_roped,
+            k_cache_layer,
+            v_cache_layer,
+            current_pos,
+            n_heads,
+            n_kv_heads,
+            head_dim,
         )
     inter["attn_out"] = attn_out
 
@@ -439,9 +469,9 @@ def run_decode_block(
     ro = cache.load_and_run(
         "o_gemv",
         _gemv_backend(verbose, "o_gemv"),
-        layer_weights._wo_t,                        # arg0 wo (static) (emb, q_dim)
-        np.ascontiguousarray(attn_out),             # arg1 attn_out (q_dim,)
-        np.zeros(emb_dim, dtype=bfloat16),          # arg2 proj (emb,)
+        layer_weights._wo_t,  # arg0 wo (static) (emb, q_dim)
+        np.ascontiguousarray(attn_out),  # arg1 attn_out (q_dim,)
+        np.zeros(emb_dim, dtype=bfloat16),  # arg2 proj (emb,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -454,14 +484,18 @@ def run_decode_block(
     inter["res1"] = res1.astype(bfloat16)
 
     # FFN RMSNorm (host, eps=1e-6)
-    normed2 = rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6).reshape(emb_dim).astype(bfloat16)
+    normed2 = (
+        rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6)
+        .reshape(emb_dim)
+        .astype(bfloat16)
+    )
 
     rg = cache.load_and_run(
         "gate_gemv",
         _gemv_backend(verbose, "gate_gemv"),
-        layer_weights._wgate_t,                     # arg0 w_gate (static) (hidden, emb)
-        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
-        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 gate (hidden,)
+        layer_weights._wgate_t,  # arg0 w_gate (static) (hidden, emb)
+        np.ascontiguousarray(normed2),  # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),  # arg2 gate (hidden,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -471,9 +505,9 @@ def run_decode_block(
     ru = cache.load_and_run(
         "up_gemv",
         _gemv_backend(verbose, "up_gemv"),
-        layer_weights._wup_t,                       # arg0 w_up (static) (hidden, emb)
-        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
-        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 up (hidden,)
+        layer_weights._wup_t,  # arg0 w_up (static) (hidden, emb)
+        np.ascontiguousarray(normed2),  # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),  # arg2 up (hidden,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -488,9 +522,9 @@ def run_decode_block(
     rd = cache.load_and_run(
         "down_gemv",
         _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
-        layer_weights._wdown_t,                     # arg0 w_down (static) (emb, hidden)
-        np.ascontiguousarray(swig),                 # arg1 swig (hidden,)
-        np.zeros(emb_dim, dtype=bfloat16),          # arg2 down (emb,)
+        layer_weights._wdown_t,  # arg0 w_down (static) (emb, hidden)
+        np.ascontiguousarray(swig),  # arg1 swig (hidden,)
+        np.zeros(emb_dim, dtype=bfloat16),  # arg2 down (emb,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
@@ -4,9 +4,9 @@
 """Qwen2.5-3B BF16 Inference on MLIR-AIR (NPU2).
 
 Unified driver: NPU prefill (36 layers) + NPU decode (KV cache) + NPU LM-head.
-Direct re-parameterization of qwen25_1_5b_inference.py (same Qwen2.5 deltas:
-QKV bias on host, NO QK-norm, eps=1e-6, tied embeddings, vocab=151936 LM-head
-per-partition). 3B dims: emb=q_dim=2048 (square O), kv_dim=256, hidden=11008,
+Qwen2.5 deltas: QKV bias fused into the NPU rms_qkv_bias_rope ELF (on-device,
+not host-added), NO QK-norm, eps=1e-6, tied embeddings, vocab=151936 LM-head
+per-partition. 3B dims: emb=q_dim=2048 (square O), kv_dim=256, hidden=11008,
 head_dim=128, 36 layers.
 
 Usage:

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
@@ -1,0 +1,613 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen2.5-3B BF16 Inference on MLIR-AIR (NPU2).
+
+Unified driver: NPU prefill (36 layers) + NPU decode (KV cache) + NPU LM-head.
+Direct re-parameterization of qwen25_1_5b_inference.py (same Qwen2.5 deltas:
+QKV bias on host, NO QK-norm, eps=1e-6, tied embeddings, vocab=151936 LM-head
+per-partition). 3B dims: emb=q_dim=2048 (square O), kv_dim=256, hidden=11008,
+head_dim=128, 36 layers.
+
+Usage:
+    cd build_peano
+    python3 ../qwen25_3b_inference.py --compile-only
+    python3 ../qwen25_3b_inference.py --run-only --n-tokens 32 --prompt "..."
+    python3 ../qwen25_3b_inference.py --run-only --n-tokens 32 --profile
+"""
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from qwen25_3b_weights import LlamaConfig, load_weights, generate_rope_lut
+from qwen25_3b_cpu_helpers import rms_norm
+from shared.infra.cache import KernelCache, Profiler
+from qwen25_3b_prefill import (
+    compile_all_kernels,
+    run_transformer_block_qwen25,
+    preload_prefill_weights,
+)
+from qwen25_3b_decode import (
+    compile_decode_kernels,
+    run_decode_block,
+    _gemv_backend,
+    _lm_gemv_backend,
+    _LM_N_PARTITIONS,
+    _LM_N_PART,
+    _GEMV_QO,
+    _GEMV_GATEUP,
+    _GEMV_DOWN,
+)
+import qwen25_3b_decode as _decode_mod
+
+EPS = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Streaming-decode helpers (BPE-safe incremental output)
+# ---------------------------------------------------------------------------
+
+
+class _StreamState:
+    def __init__(self) -> None:
+        self.printed_len: int = 0
+
+
+def _delta_text(tokenizer: Any, ids: list, state: _StreamState) -> str:
+    decoded = tokenizer.decode(ids, skip_special_tokens=True)
+    delta = decoded[state.printed_len :]
+    state.printed_len = len(decoded)
+    return delta
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    config: Any
+    seq_len: int
+    weights: Any
+    tokenizer: Any
+    prefill_cache: Any
+    decode_cache: Any
+    rope_lut_bf16: np.ndarray
+    model_variant: str
+
+
+# ---------------------------------------------------------------------------
+# Runtime preparation
+# ---------------------------------------------------------------------------
+
+
+def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16):
+    """One-time runtime init: transpose decode GEMV weights, tag layer idx,
+    pre-load prefill + decode + LM-head BOs."""
+    print(f"\n{'='*60}")
+    print("Preparing runtime (one-time init, outside profiling scope)...")
+    print(f"{'='*60}")
+    t0 = time.time()
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    # 1. Pre-transpose decode GEMV weights. GEMV expects W[out, in]; HF/our
+    #    loader stores projections as (in, out) (y = x @ W), so transpose.
+    if not hasattr(weights, "_decode_weights_transposed"):
+        print("  Pre-transposing weights for decode GEMV...")
+        for lw in weights.layers:
+            lw._wq_t = np.ascontiguousarray(lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T)    # (q_dim, emb)
+            lw._wk_t = np.ascontiguousarray(lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
+            lw._wv_t = np.ascontiguousarray(lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
+            lw._wo_t = np.ascontiguousarray(lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T)    # (emb, q_dim)
+            lw._wgate_t = np.ascontiguousarray(lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T)  # (hidden, emb)
+            lw._wup_t = np.ascontiguousarray(lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T)      # (hidden, emb)
+            lw._wdown_t = np.ascontiguousarray(lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T)  # (emb, hidden)
+        weights._decode_weights_transposed = True
+
+    # 2. Tag layer index for per-layer BO isolation.
+    for i, lw in enumerate(weights.layers):
+        lw._layer_idx = i
+
+    # 3. Pre-load prefill block weights into per-layer BOs (skipped on the real
+    #    prefill pass via static_input_indices).
+    preload_prefill_weights(weights, config, prefill_cache, seq_len, rope_lut_bf16)
+
+    # 4. Pre-load decode weights into per-layer BOs + LM-head GEMV.
+    _preload_decode_weights(decode_cache, weights, config)
+
+    t_prep = time.time() - t0
+    print(f"  Runtime prepared in {t_prep:.1f}s")
+    prefill_cache.profiler.preprocessing_s = t_prep
+    decode_cache.profiler.preprocessing_s = t_prep
+
+
+def _preload_decode_weights(decode_cache, weights, config):
+    """Pre-load all decode block weights into per-layer BOs (skipped on
+    subsequent calls via static_input_indices)."""
+    if hasattr(weights, "_decode_weights_preloaded_to_bos"):
+        return
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    vocab_size = weights.lm_head.shape[0]
+
+    print("  Pre-loading decode weights into per-layer BOs...")
+    _was = decode_cache.profiler.enabled
+    decode_cache.profiler.enabled = False
+
+    lut_q_dummy = np.zeros(n_heads * head_dim, dtype=bfloat16)
+    lut_k_dummy = np.zeros(n_kv_heads * head_dim, dtype=bfloat16)
+
+    for li in range(config.n_layers):
+        lw = weights.layers[li]
+
+        # One fused ELF: RMSNorm + Q/K/V GEMV + bias-add + RoPE.
+        _decode_mod._fused_bias_rope_gemv_call(
+            decode_cache, lw, config, lut_q_dummy, lut_k_dummy,
+            f"_L{li}", np.zeros(emb_dim, dtype=bfloat16),
+        )
+
+        # o_gemv: weight static {0}.
+        decode_cache.load_and_run(
+            "o_gemv", _gemv_backend(False, "o_gemv"),
+            lw._wo_t, np.zeros(q_dim, dtype=bfloat16),
+            np.zeros(emb_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"o_gemv_L{li}",
+        )
+        # gate_gemv / up_gemv: weight static {0}.
+        decode_cache.load_and_run(
+            "gate_gemv", _gemv_backend(False, "gate_gemv"),
+            lw._wgate_t, np.zeros(emb_dim, dtype=bfloat16),
+            np.zeros(hidden_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"gate_gemv_L{li}",
+        )
+        decode_cache.load_and_run(
+            "up_gemv", _gemv_backend(False, "up_gemv"),
+            lw._wup_t, np.zeros(emb_dim, dtype=bfloat16),
+            np.zeros(hidden_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"up_gemv_L{li}",
+        )
+        # down_gemv: M=emb=2048, K=hidden=11008. Standalone GEMV ELF on NPU
+        # (the fused cascade overflowed L1, the standalone does not). weight
+        # static {0}.
+        decode_cache.load_and_run(
+            "down_gemv", _gemv_backend(False, "down_gemv", omit_pingpong=True),
+            lw._wdown_t, np.zeros(hidden_dim, dtype=bfloat16),
+            np.zeros(emb_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"down_gemv_L{li}",
+        )
+
+    # LM-head GEMV weights (19 partitions, n_part=8192).
+    weights._lm_weight_parts_gemv = []
+    for p in range(_LM_N_PARTITIONS):
+        n_start = p * _LM_N_PART
+        n_end = min(n_start + _LM_N_PART, vocab_size)
+        w = np.zeros((_LM_N_PART, emb_dim), dtype=bfloat16)
+        if n_end > n_start:
+            w[: n_end - n_start, :] = np.ascontiguousarray(
+                weights.lm_head[n_start:n_end, :]
+            ).astype(bfloat16)
+        weights._lm_weight_parts_gemv.append(w)
+
+    lm_inputs = [np.zeros(emb_dim, dtype=bfloat16)]
+    for p in range(_LM_N_PARTITIONS):
+        lm_inputs.append(weights._lm_weight_parts_gemv[p])
+        lm_inputs.append(np.zeros(_LM_N_PART, dtype=bfloat16))
+    decode_cache.load_and_run(
+        "lm_head_gemv",
+        _lm_gemv_backend(),
+        *lm_inputs,
+        output_indices=[2 + 2 * p for p in range(_LM_N_PARTITIONS)],
+        static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+    )
+
+    decode_cache.profiler.enabled = _was
+    weights._decode_weights_preloaded_to_bos = True
+    print(f"  Pre-loaded {config.n_layers} decode layers + LM Head.")
+
+
+# ---------------------------------------------------------------------------
+# NPU LM-head (19-partition GEMV) — shared by prefill end + decode.
+# ---------------------------------------------------------------------------
+
+
+def _run_lm_head(decode_cache, weights, x_normed_bf16, vocab_size):
+    lm_inputs = [x_normed_bf16.flatten().astype(bfloat16)]
+    out_idx = []
+    for p in range(_LM_N_PARTITIONS):
+        lm_inputs.append(weights._lm_weight_parts_gemv[p])
+        lm_inputs.append(np.zeros(_LM_N_PART, dtype=bfloat16))
+        out_idx.append(2 + 2 * p)
+    res = decode_cache.load_and_run(
+        "lm_head_gemv",
+        _lm_gemv_backend(),
+        *lm_inputs,
+        output_indices=out_idx,
+        static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+    )
+    logits = np.zeros(vocab_size, dtype=np.float32)
+    for p in range(_LM_N_PARTITIONS):
+        n_start = p * _LM_N_PART
+        n_end = min(n_start + _LM_N_PART, vocab_size)
+        logits[n_start:n_end] = res[2 + 2 * p][: n_end - n_start].astype(np.float32)
+    return logits
+
+
+# ---------------------------------------------------------------------------
+# NPU Prefill with KV cache extraction
+# ---------------------------------------------------------------------------
+
+
+def run_npu_prefill(
+    token_ids,
+    weights,
+    config,
+    prefill_cache,
+    decode_cache,
+    rope_lut_bf16,
+    max_seq,
+    tokenizer,
+    cpu_attn=True,
+    profile=False,
+    quiet=False,
+):
+    """Run NPU prefill (36 Qwen2.5 layers) and extract KV cache.
+
+    Returns: (prefill_token, logits_row, k_cache, v_cache, prompt_len).
+    K cache stores k_roped (AFTER bias AND RoPE); V stores bias-added projection.
+    """
+    seq_len = len(token_ids)
+    emb_dim = config.emb_dim
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    vocab_size = weights.lm_head.shape[0]
+
+    k_cache = np.zeros((config.n_layers, n_kv_heads, max_seq, head_dim), dtype=bfloat16)
+    v_cache = np.zeros((config.n_layers, n_kv_heads, max_seq, head_dim), dtype=bfloat16)
+
+    with prefill_cache.profiler.time_cpu("embed_lookup"):
+        x_bf16 = weights.embed_table[token_ids].astype(np.float32).astype(bfloat16)
+
+    if not quiet:
+        print(f"Running NPU prefill ({config.n_layers} layers, seq_len={seq_len})...")
+    t_start = time.time()
+
+    for layer_idx in range(config.n_layers):
+        t0 = prefill_cache.profiler.start_layer()
+        x_bf16, inter = run_transformer_block_qwen25(
+            x_bf16,
+            weights.layers[layer_idx],
+            rope_lut_bf16,
+            config,
+            prefill_cache,
+            layer_idx=layer_idx,
+            cpu_attn=cpu_attn,
+            verbose=profile,
+        )
+        with prefill_cache.profiler.time_cpu("kv_cache_extract"):
+            k_roped = inter["k_roped"]
+            v_biased = inter["v"]
+            k_cache[layer_idx, :, :seq_len, :] = (
+                k_roped.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+            )
+            v_cache[layer_idx, :, :seq_len, :] = (
+                v_biased.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+            )
+        prefill_cache.profiler.end_layer(layer_idx, t0)
+
+    # Final RMSNorm (eps=1e-6) on the prediction-position row + NPU LM-head.
+    prompt_len = len([t for t in token_ids if t != tokenizer.eos_token_id])
+    pred_pos = prompt_len - 1
+    with prefill_cache.profiler.time_cpu("final_rms_norm"):
+        last_hidden = np.asarray(x_bf16, dtype=np.float32)[pred_pos : pred_pos + 1]
+        last_normed = rms_norm(last_hidden, weights.final_norm, eps=EPS).flatten().astype(bfloat16)
+
+    logits_row = _run_lm_head(decode_cache, weights, last_normed, vocab_size)
+    prefill_token = int(np.argmax(logits_row))
+
+    t_prefill = time.time() - t_start
+    if not quiet:
+        print(f"NPU prefill done in {t_prefill:.2f}s. First token: {prefill_token}")
+    return prefill_token, logits_row, k_cache, v_cache, prompt_len
+
+
+# ---------------------------------------------------------------------------
+# Single decode step
+# ---------------------------------------------------------------------------
+
+
+def run_npu_decode_step(
+    x_decode_bf16, weights, config, decode_cache, rope_lut_bf16, k_cache, v_cache, current_pos
+):
+    """Run one NPU decode step: 36 blocks + final RMSNorm + LM-head."""
+    vocab_size = weights.lm_head.shape[0]
+    x = x_decode_bf16.copy()
+    for layer_idx in range(config.n_layers):
+        t0 = decode_cache.profiler.start_layer()
+        x, _ = run_decode_block(
+            x,
+            weights.layers[layer_idx],
+            decode_cache,
+            config,
+            k_cache[layer_idx],
+            v_cache[layer_idx],
+            current_pos,
+            rope_lut_bf16,
+        )
+        decode_cache.profiler.end_layer(layer_idx, t0)
+
+    with decode_cache.profiler.time_cpu("final_rms_norm"):
+        x_normed = rms_norm(
+            x.astype(np.float32).reshape(1, config.emb_dim), weights.final_norm, eps=EPS
+        )
+    logits = _run_lm_head(decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size)
+    next_token = int(np.argmax(logits))
+    return next_token, logits
+
+
+# ---------------------------------------------------------------------------
+# Full generation
+# ---------------------------------------------------------------------------
+
+
+def generate(
+    prompt_tokens,
+    weights,
+    config,
+    prefill_cache,
+    decode_cache,
+    rope_lut_bf16,
+    tokenizer,
+    n_tokens=10,
+    profile=False,
+    cpu_attn=True,
+    on_token=None,
+    ttft_start=None,
+):
+    seq_len = len(prompt_tokens)
+    max_seq = seq_len + n_tokens
+    streaming = on_token is not None
+    if ttft_start is None:
+        ttft_start = time.perf_counter()
+
+    if not streaming:
+        print(f"\n{'='*60}")
+        print(f"Qwen2.5 Inference: prompt_len={seq_len}, n_tokens={n_tokens}")
+        print(f"{'='*60}\n")
+
+    prefill_token, _logits, k_cache, v_cache, prompt_len = run_npu_prefill(
+        prompt_tokens, weights, config, prefill_cache, decode_cache,
+        rope_lut_bf16, max_seq, tokenizer=tokenizer, cpu_attn=cpu_attn,
+        profile=profile, quiet=True,
+    )
+
+    ttft = time.perf_counter() - ttft_start
+    if not streaming:
+        print(f"Time to first token (TTFT): {ttft:.2f}s. First token: {prefill_token}")
+
+    generated_tokens = [prefill_token]
+    current_pos = prompt_len
+    x_decode = weights.embed_table[prefill_token].astype(bfloat16)
+
+    stream_state = _StreamState() if streaming else None
+    if streaming:
+        on_token(prefill_token, _delta_text(tokenizer, generated_tokens, stream_state))
+
+    if not streaming:
+        print(f"\nDecoding {n_tokens} tokens...")
+    t_dec = time.time()
+
+    eos_ids = {tokenizer.eos_token_id}
+    eot = tokenizer.convert_tokens_to_ids("<|im_end|>")
+    if isinstance(eot, int) and eot >= 0:
+        eos_ids.add(eot)
+
+    for _ in range(n_tokens):
+        next_token, _ = run_npu_decode_step(
+            x_decode, weights, config, decode_cache, rope_lut_bf16,
+            k_cache, v_cache, current_pos,
+        )
+        generated_tokens.append(next_token)
+        current_pos += 1
+        with decode_cache.profiler.time_cpu("embed_lookup"):
+            x_decode = weights.embed_table[next_token].astype(bfloat16)
+        if streaming:
+            on_token(next_token, _delta_text(tokenizer, generated_tokens, stream_state))
+        if next_token in eos_ids:
+            break
+
+    t_decode = time.time() - t_dec
+    n_gen = len(generated_tokens) - 1
+    if not streaming and n_gen > 0:
+        print(f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)")
+
+    if prefill_cache.profiler.enabled:
+        print(f"\n{'='*60}\nPREFILL detail")
+        prefill_cache.profiler.report()
+    if decode_cache.profiler.enabled:
+        print(f"\n{'='*60}\nDECODE detail")
+        decode_cache.profiler.report()
+
+    return generated_tokens
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+MODEL_CHOICES = {"base": "Qwen/Qwen2.5-3B", "instruct": "Qwen/Qwen2.5-3B-Instruct"}
+
+
+def build_session(args) -> Session:
+    config = LlamaConfig()
+    seq_len = 2048
+
+    prefill_cache = KernelCache(
+        "prefill_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+    )
+    decode_cache = KernelCache(
+        "decode_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+    )
+
+    if not args.run_only:
+        print("Compiling prefill kernels...")
+        compile_all_kernels(prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn)
+        print("\nCompiling decode kernels...")
+        compile_decode_kernels(decode_cache, config, verbose=args.verbose)
+
+    if args.compile_only:
+        print("\nCompilation passed.")
+        sys.exit(0)
+
+    if args.run_only:
+        prefill_cache.load_manifest()
+        decode_cache.load_manifest()
+
+    model_id = MODEL_CHOICES.get(args.model, args.model)
+    print(f"\nLoading weights ({model_id})...")
+    weights = load_weights(model_id, config=config)
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    rope_lut_bf16 = generate_rope_lut(config=config, seq_len=seq_len + args.n_tokens).astype(bfloat16)
+
+    prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16)
+
+    return Session(
+        config=config, seq_len=seq_len, weights=weights, tokenizer=tokenizer,
+        prefill_cache=prefill_cache, decode_cache=decode_cache,
+        rope_lut_bf16=rope_lut_bf16, model_variant=args.model,
+    )
+
+
+def _tokenize_prompt(session: Session, prompt_text: str) -> list:
+    if session.model_variant == "instruct":
+        messages = [{"role": "user", "content": prompt_text}]
+        chat_text = session.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        return session.tokenizer.encode(chat_text)
+    return session.tokenizer.encode(prompt_text)
+
+
+def run_once(session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None):
+    ttft_start = time.perf_counter()
+    with session.prefill_cache.profiler.time_cpu("tokenize"):
+        tokens = _tokenize_prompt(session, prompt_text)
+    prompt_len_actual = len(tokens)
+    with session.prefill_cache.profiler.time_cpu("eos_pad"):
+        if len(tokens) < session.seq_len:
+            tokens = tokens + [session.tokenizer.eos_token_id] * (session.seq_len - len(tokens))
+    generated = generate(
+        tokens, session.weights, session.config, session.prefill_cache,
+        session.decode_cache, session.rope_lut_bf16, tokenizer=session.tokenizer,
+        n_tokens=n_tokens, profile=profile, cpu_attn=cpu_attn, on_token=on_token,
+        ttft_start=ttft_start,
+    )
+    return generated, prompt_len_actual
+
+
+def _print_one_shot_output(session, prompt_text, generated, prompt_len_actual):
+    print(f"\n{'='*60}")
+    if session.model_variant == "instruct":
+        response = session.tokenizer.decode(generated, skip_special_tokens=True).strip()
+        print(f"Q: {prompt_text}")
+        print(f"A: {response}")
+    else:
+        prompt_tokens = _tokenize_prompt(session, prompt_text)
+        all_tokens = prompt_tokens[:prompt_len_actual] + generated
+        print("Generated text:")
+        print(session.tokenizer.decode(all_tokens))
+
+
+def repl_loop(session, args):
+    print("\nInteractive mode — Ctrl-D or /quit to exit.\n")
+
+    def _cb(_tid, delta):
+        sys.stdout.write(delta)
+        sys.stdout.flush()
+
+    while True:
+        try:
+            prompt = input("Prompt> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if not prompt:
+            continue
+        if prompt in ("/quit", "/exit"):
+            return
+        sys.stdout.write("\nResponse: ")
+        sys.stdout.flush()
+        try:
+            run_once(session, prompt, n_tokens=args.n_tokens, profile=False,
+                     cpu_attn=args.cpu_attn, on_token=_cb)
+        except KeyboardInterrupt:
+            print("\n[interrupted]")
+            continue
+        print("\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Qwen2.5-3B Inference (NPU)")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--run-only", action="store_true")
+    parser.add_argument("--n-tokens", type=int, default=10)
+    parser.add_argument("--profile", action="store_true")
+    # Default: NPU head-first FlashAttention. Pass --cpu-attn to fall back to
+    # the FP32 host attention reference.
+    parser.add_argument("--cpu-attn", action="store_true", default=False)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--prompt", type=str, default="What is the capital of France?")
+    parser.add_argument("--model", type=str, choices=["base", "instruct"], default="instruct")
+    parser.add_argument("--interactive", action="store_true")
+    args = parser.parse_args()
+
+    if args.interactive:
+        if args.compile_only:
+            parser.error("--interactive cannot be combined with --compile-only")
+        if not args.run_only:
+            parser.error("--interactive requires --run-only")
+        args.profile = False
+
+    session = build_session(args)
+
+    if args.interactive:
+        repl_loop(session, args)
+    else:
+        generated, plen = run_once(
+            session, args.prompt, n_tokens=args.n_tokens, profile=args.profile,
+            cpu_attn=args.cpu_attn,
+        )
+        _print_one_shot_output(session, args.prompt, generated, plen)

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_inference.py
@@ -92,7 +92,9 @@ class Session:
 # ---------------------------------------------------------------------------
 
 
-def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16):
+def prepare_runtime(
+    prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16
+):
     """One-time runtime init: transpose decode GEMV weights, tag layer idx,
     pre-load prefill + decode + LM-head BOs."""
     print(f"\n{'='*60}")
@@ -113,13 +115,27 @@ def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_
     if not hasattr(weights, "_decode_weights_transposed"):
         print("  Pre-transposing weights for decode GEMV...")
         for lw in weights.layers:
-            lw._wq_t = np.ascontiguousarray(lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T)    # (q_dim, emb)
-            lw._wk_t = np.ascontiguousarray(lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
-            lw._wv_t = np.ascontiguousarray(lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
-            lw._wo_t = np.ascontiguousarray(lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T)    # (emb, q_dim)
-            lw._wgate_t = np.ascontiguousarray(lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T)  # (hidden, emb)
-            lw._wup_t = np.ascontiguousarray(lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T)      # (hidden, emb)
-            lw._wdown_t = np.ascontiguousarray(lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T)  # (emb, hidden)
+            lw._wq_t = np.ascontiguousarray(
+                lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T
+            )  # (q_dim, emb)
+            lw._wk_t = np.ascontiguousarray(
+                lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T
+            )  # (kv_dim, emb)
+            lw._wv_t = np.ascontiguousarray(
+                lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T
+            )  # (kv_dim, emb)
+            lw._wo_t = np.ascontiguousarray(
+                lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T
+            )  # (emb, q_dim)
+            lw._wgate_t = np.ascontiguousarray(
+                lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T
+            )  # (hidden, emb)
+            lw._wup_t = np.ascontiguousarray(
+                lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T
+            )  # (hidden, emb)
+            lw._wdown_t = np.ascontiguousarray(
+                lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T
+            )  # (emb, hidden)
         weights._decode_weights_transposed = True
 
     # 2. Tag layer index for per-layer BO isolation.
@@ -166,41 +182,62 @@ def _preload_decode_weights(decode_cache, weights, config):
 
         # One fused ELF: RMSNorm + Q/K/V GEMV + bias-add + RoPE.
         _decode_mod._fused_bias_rope_gemv_call(
-            decode_cache, lw, config, lut_q_dummy, lut_k_dummy,
-            f"_L{li}", np.zeros(emb_dim, dtype=bfloat16),
+            decode_cache,
+            lw,
+            config,
+            lut_q_dummy,
+            lut_k_dummy,
+            f"_L{li}",
+            np.zeros(emb_dim, dtype=bfloat16),
         )
 
         # o_gemv: weight static {0}.
         decode_cache.load_and_run(
-            "o_gemv", _gemv_backend(False, "o_gemv"),
-            lw._wo_t, np.zeros(q_dim, dtype=bfloat16),
+            "o_gemv",
+            _gemv_backend(False, "o_gemv"),
+            lw._wo_t,
+            np.zeros(q_dim, dtype=bfloat16),
             np.zeros(emb_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"o_gemv_L{li}",
         )
         # gate_gemv / up_gemv: weight static {0}.
         decode_cache.load_and_run(
-            "gate_gemv", _gemv_backend(False, "gate_gemv"),
-            lw._wgate_t, np.zeros(emb_dim, dtype=bfloat16),
+            "gate_gemv",
+            _gemv_backend(False, "gate_gemv"),
+            lw._wgate_t,
+            np.zeros(emb_dim, dtype=bfloat16),
             np.zeros(hidden_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"gate_gemv_L{li}",
         )
         decode_cache.load_and_run(
-            "up_gemv", _gemv_backend(False, "up_gemv"),
-            lw._wup_t, np.zeros(emb_dim, dtype=bfloat16),
+            "up_gemv",
+            _gemv_backend(False, "up_gemv"),
+            lw._wup_t,
+            np.zeros(emb_dim, dtype=bfloat16),
             np.zeros(hidden_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"up_gemv_L{li}",
         )
         # down_gemv: M=emb=2048, K=hidden=11008. Standalone GEMV ELF on NPU
         # (the fused cascade overflowed L1, the standalone does not). weight
         # static {0}.
         decode_cache.load_and_run(
-            "down_gemv", _gemv_backend(False, "down_gemv", omit_pingpong=True),
-            lw._wdown_t, np.zeros(hidden_dim, dtype=bfloat16),
+            "down_gemv",
+            _gemv_backend(False, "down_gemv", omit_pingpong=True),
+            lw._wdown_t,
+            np.zeros(hidden_dim, dtype=bfloat16),
             np.zeros(emb_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"down_gemv_L{li}",
         )
 
@@ -317,10 +354,14 @@ def run_npu_prefill(
             k_roped = inter["k_roped"]
             v_biased = inter["v"]
             k_cache[layer_idx, :, :seq_len, :] = (
-                k_roped.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+                k_roped.astype(bfloat16)
+                .reshape(seq_len, n_kv_heads, head_dim)
+                .transpose(1, 0, 2)
             )
             v_cache[layer_idx, :, :seq_len, :] = (
-                v_biased.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+                v_biased.astype(bfloat16)
+                .reshape(seq_len, n_kv_heads, head_dim)
+                .transpose(1, 0, 2)
             )
         prefill_cache.profiler.end_layer(layer_idx, t0)
 
@@ -329,7 +370,11 @@ def run_npu_prefill(
     pred_pos = prompt_len - 1
     with prefill_cache.profiler.time_cpu("final_rms_norm"):
         last_hidden = np.asarray(x_bf16, dtype=np.float32)[pred_pos : pred_pos + 1]
-        last_normed = rms_norm(last_hidden, weights.final_norm, eps=EPS).flatten().astype(bfloat16)
+        last_normed = (
+            rms_norm(last_hidden, weights.final_norm, eps=EPS)
+            .flatten()
+            .astype(bfloat16)
+        )
 
     logits_row = _run_lm_head(decode_cache, weights, last_normed, vocab_size)
     prefill_token = int(np.argmax(logits_row))
@@ -346,7 +391,14 @@ def run_npu_prefill(
 
 
 def run_npu_decode_step(
-    x_decode_bf16, weights, config, decode_cache, rope_lut_bf16, k_cache, v_cache, current_pos
+    x_decode_bf16,
+    weights,
+    config,
+    decode_cache,
+    rope_lut_bf16,
+    k_cache,
+    v_cache,
+    current_pos,
 ):
     """Run one NPU decode step: 36 blocks + final RMSNorm + LM-head."""
     vocab_size = weights.lm_head.shape[0]
@@ -369,7 +421,9 @@ def run_npu_decode_step(
         x_normed = rms_norm(
             x.astype(np.float32).reshape(1, config.emb_dim), weights.final_norm, eps=EPS
         )
-    logits = _run_lm_head(decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size)
+    logits = _run_lm_head(
+        decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size
+    )
     next_token = int(np.argmax(logits))
     return next_token, logits
 
@@ -405,9 +459,17 @@ def generate(
         print(f"{'='*60}\n")
 
     prefill_token, _logits, k_cache, v_cache, prompt_len = run_npu_prefill(
-        prompt_tokens, weights, config, prefill_cache, decode_cache,
-        rope_lut_bf16, max_seq, tokenizer=tokenizer, cpu_attn=cpu_attn,
-        profile=profile, quiet=True,
+        prompt_tokens,
+        weights,
+        config,
+        prefill_cache,
+        decode_cache,
+        rope_lut_bf16,
+        max_seq,
+        tokenizer=tokenizer,
+        cpu_attn=cpu_attn,
+        profile=profile,
+        quiet=True,
     )
 
     ttft = time.perf_counter() - ttft_start
@@ -433,8 +495,14 @@ def generate(
 
     for _ in range(n_tokens):
         next_token, _ = run_npu_decode_step(
-            x_decode, weights, config, decode_cache, rope_lut_bf16,
-            k_cache, v_cache, current_pos,
+            x_decode,
+            weights,
+            config,
+            decode_cache,
+            rope_lut_bf16,
+            k_cache,
+            v_cache,
+            current_pos,
         )
         generated_tokens.append(next_token)
         current_pos += 1
@@ -448,7 +516,9 @@ def generate(
     t_decode = time.time() - t_dec
     n_gen = len(generated_tokens) - 1
     if not streaming and n_gen > 0:
-        print(f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)")
+        print(
+            f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)"
+        )
 
     if prefill_cache.profiler.enabled:
         print(f"\n{'='*60}\nPREFILL detail")
@@ -472,15 +542,21 @@ def build_session(args) -> Session:
     seq_len = 2048
 
     prefill_cache = KernelCache(
-        "prefill_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+        "prefill_kernel_cache",
+        verbose=args.verbose,
+        profiler=Profiler(enabled=args.profile),
     )
     decode_cache = KernelCache(
-        "decode_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+        "decode_kernel_cache",
+        verbose=args.verbose,
+        profiler=Profiler(enabled=args.profile),
     )
 
     if not args.run_only:
         print("Compiling prefill kernels...")
-        compile_all_kernels(prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn)
+        compile_all_kernels(
+            prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn
+        )
         print("\nCompiling decode kernels...")
         compile_decode_kernels(decode_cache, config, verbose=args.verbose)
 
@@ -500,14 +576,23 @@ def build_session(args) -> Session:
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-    rope_lut_bf16 = generate_rope_lut(config=config, seq_len=seq_len + args.n_tokens).astype(bfloat16)
+    rope_lut_bf16 = generate_rope_lut(
+        config=config, seq_len=seq_len + args.n_tokens
+    ).astype(bfloat16)
 
-    prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16)
+    prepare_runtime(
+        prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16
+    )
 
     return Session(
-        config=config, seq_len=seq_len, weights=weights, tokenizer=tokenizer,
-        prefill_cache=prefill_cache, decode_cache=decode_cache,
-        rope_lut_bf16=rope_lut_bf16, model_variant=args.model,
+        config=config,
+        seq_len=seq_len,
+        weights=weights,
+        tokenizer=tokenizer,
+        prefill_cache=prefill_cache,
+        decode_cache=decode_cache,
+        rope_lut_bf16=rope_lut_bf16,
+        model_variant=args.model,
     )
 
 
@@ -521,18 +606,30 @@ def _tokenize_prompt(session: Session, prompt_text: str) -> list:
     return session.tokenizer.encode(prompt_text)
 
 
-def run_once(session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None):
+def run_once(
+    session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None
+):
     ttft_start = time.perf_counter()
     with session.prefill_cache.profiler.time_cpu("tokenize"):
         tokens = _tokenize_prompt(session, prompt_text)
     prompt_len_actual = len(tokens)
     with session.prefill_cache.profiler.time_cpu("eos_pad"):
         if len(tokens) < session.seq_len:
-            tokens = tokens + [session.tokenizer.eos_token_id] * (session.seq_len - len(tokens))
+            tokens = tokens + [session.tokenizer.eos_token_id] * (
+                session.seq_len - len(tokens)
+            )
     generated = generate(
-        tokens, session.weights, session.config, session.prefill_cache,
-        session.decode_cache, session.rope_lut_bf16, tokenizer=session.tokenizer,
-        n_tokens=n_tokens, profile=profile, cpu_attn=cpu_attn, on_token=on_token,
+        tokens,
+        session.weights,
+        session.config,
+        session.prefill_cache,
+        session.decode_cache,
+        session.rope_lut_bf16,
+        tokenizer=session.tokenizer,
+        n_tokens=n_tokens,
+        profile=profile,
+        cpu_attn=cpu_attn,
+        on_token=on_token,
         ttft_start=ttft_start,
     )
     return generated, prompt_len_actual
@@ -571,8 +668,14 @@ def repl_loop(session, args):
         sys.stdout.write("\nResponse: ")
         sys.stdout.flush()
         try:
-            run_once(session, prompt, n_tokens=args.n_tokens, profile=False,
-                     cpu_attn=args.cpu_attn, on_token=_cb)
+            run_once(
+                session,
+                prompt,
+                n_tokens=args.n_tokens,
+                profile=False,
+                cpu_attn=args.cpu_attn,
+                on_token=_cb,
+            )
         except KeyboardInterrupt:
             print("\n[interrupted]")
             continue
@@ -590,7 +693,9 @@ if __name__ == "__main__":
     parser.add_argument("--cpu-attn", action="store_true", default=False)
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("--prompt", type=str, default="What is the capital of France?")
-    parser.add_argument("--model", type=str, choices=["base", "instruct"], default="instruct")
+    parser.add_argument(
+        "--model", type=str, choices=["base", "instruct"], default="instruct"
+    )
     parser.add_argument("--interactive", action="store_true")
     args = parser.parse_args()
 
@@ -607,7 +712,10 @@ if __name__ == "__main__":
         repl_loop(session, args)
     else:
         generated, plen = run_once(
-            session, args.prompt, n_tokens=args.n_tokens, profile=args.profile,
+            session,
+            args.prompt,
+            n_tokens=args.n_tokens,
+            profile=args.profile,
             cpu_attn=args.cpu_attn,
         )
         _print_one_shot_output(session, args.prompt, generated, plen)

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
@@ -54,7 +54,6 @@ if _LLMS_DIR not in sys.path:
 from qwen25_3b_weights import LlamaConfig
 from qwen25_3b_cpu_helpers import attention_reference
 
-
 # ---------------------------------------------------------------------------
 # Generic per-GEMM spec + IR builder. Supports the three bf16-out methods the
 # Qwen2.5 GEMMs resolve to (fused-cast / drain / direct), each picking its own
@@ -72,9 +71,9 @@ def _gemm_spec(m, k, n, precision):
         from kernel_registry.registry_lookup import gemm_config
 
         cfg = gemm_config(m, k, n, "bf16", "low")
-        assert cfg["method"] == "direct", (
-            f"expected direct for low-prec {m}x{k}x{n}, got {cfg['method']}"
-        )
+        assert (
+            cfg["method"] == "direct"
+        ), f"expected direct for low-prec {m}x{k}x{n}, got {cfg['method']}"
         tile = cfg["tile"]
         return {
             "method": "direct",
@@ -93,13 +92,29 @@ def _gemm_spec(m, k, n, precision):
 def _build_gemm_ir(m, k, n, spec, herd_m=8, herd_n=4):
     """Build the lowered IR for one GEMM by its method spec."""
     method = spec["method"]
-    tm, k2, k1, tn = spec["tile_m"], spec["tile_k_l2"], spec["tile_k_l1"], spec["tile_n"]
+    tm, k2, k1, tn = (
+        spec["tile_m"],
+        spec["tile_k_l2"],
+        spec["tile_k_l1"],
+        spec["tile_n"],
+    )
     if method == "direct":
         from matrix_multiplication.bf16_in_bf16_out.run import build_module_lowered
 
         return str(
             build_module_lowered(
-                m, k, n, tm, k2, k1, tn, herd_m, herd_n, bfloat16, bfloat16, arch="aie2p"
+                m,
+                k,
+                n,
+                tm,
+                k2,
+                k1,
+                tn,
+                herd_m,
+                herd_n,
+                bfloat16,
+                bfloat16,
+                arch="aie2p",
             )
         )
     from shared.builders.gemm_builder import _build_gemm_module
@@ -215,14 +230,22 @@ def _build_residual_add_2d_ir(seq_len, emb_dim):
                 @segment(name="radd_seg", operands=[proj_flat, xres_flat, out_flat])
                 def add_seg(s_proj, s_xres, s_out):
                     row_map = AffineMap.get(
-                        0, 2,
-                        [AffineExpr.get_add(
-                            AffineExpr.get_mul(AffineSymbolExpr.get(0),
-                                               AffineConstantExpr.get(rows_per_pe)),
-                            AffineSymbolExpr.get(1))],
+                        0,
+                        2,
+                        [
+                            AffineExpr.get_add(
+                                AffineExpr.get_mul(
+                                    AffineSymbolExpr.get(0),
+                                    AffineConstantExpr.get(rows_per_pe),
+                                ),
+                                AffineSymbolExpr.get(1),
+                            )
+                        ],
                     )
 
-                    @herd(name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out])
+                    @herd(
+                        name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out]
+                    )
                     def add_body(_tx, _ty, _sx, _sy, h_proj, h_xres, h_out):
                         l1_p = AllocOp(l1_ty, [], [])
                         l1_x = AllocOp(l1_ty, [], [])
@@ -232,17 +255,46 @@ def _build_residual_add_2d_ir(seq_len, emb_dim):
                         for iv in range_(0, rows_per_pe, 1):
                             r = affine_apply(row_map, [_tx, iv])
                             off = arith.muli(r, arith.ConstantOp.create_index(emb_dim))
-                            dma_memcpy_nd(l1_p, h_proj, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
-                            dma_memcpy_nd(l1_x, h_xres, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            dma_memcpy_nd(
+                                l1_p,
+                                h_proj,
+                                src_offsets=[off],
+                                src_sizes=[emb_dim],
+                                src_strides=[1],
+                            )
+                            dma_memcpy_nd(
+                                l1_x,
+                                h_xres,
+                                src_offsets=[off],
+                                src_sizes=[emb_dim],
+                                src_strides=[1],
+                            )
                             for j in range_(0, emb_dim, 16):
                                 sp = subview(l1_p.result, [j], [16], [1])
                                 sx = subview(l1_x.result, [j], [16], [1])
                                 so = subview(l1_o.result, [j], [16], [1])
-                                vp = transfer_read(vec_ty, sp, [c0], identity_map, cst0, [True])
-                                vx = transfer_read(vec_ty, sx, [c0], identity_map, cst0, [True])
-                                transfer_write(None, arith.addf(vp, vx), so, [c0], identity_map, [True])
+                                vp = transfer_read(
+                                    vec_ty, sp, [c0], identity_map, cst0, [True]
+                                )
+                                vx = transfer_read(
+                                    vec_ty, sx, [c0], identity_map, cst0, [True]
+                                )
+                                transfer_write(
+                                    None,
+                                    arith.addf(vp, vx),
+                                    so,
+                                    [c0],
+                                    identity_map,
+                                    [True],
+                                )
                                 yield_([])
-                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[off], dst_sizes=[emb_dim], dst_strides=[1])
+                            dma_memcpy_nd(
+                                h_out,
+                                l1_o,
+                                dst_offsets=[off],
+                                dst_sizes=[emb_dim],
+                                dst_strides=[1],
+                            )
                             yield_([])
                         DeallocOp(l1_p)
                         DeallocOp(l1_x)
@@ -267,11 +319,15 @@ def build_o_res_norm_module(seq_len, emb_dim, o_herd_m=8, o_herd_n=4):
       [+ f32 C-scratch tail for the fused-cast O GEMM]
     """
     from shared.infra.stitching import (
-        _wrap_ir_in_launch, stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+        _wrap_ir_in_launch,
+        stitch_elf,
+        KernelSlice,
+        FuncArg,
+        alloc_gemm_scratch,
     )
     from weighted_rms_norm.weighted_rms_norm import build_module as build_rms
 
-    o_spec = _gemm_spec(seq_len, emb_dim, emb_dim, "high")   # fused-cast _m64
+    o_spec = _gemm_spec(seq_len, emb_dim, emb_dim, "high")  # fused-cast _m64
     print(f"  [o_res_norm] O GEMM method={o_spec['method']} (tn={o_spec['tile_n']})")
 
     print(f"  [1/3] O GEMM ({o_spec['method']})  {seq_len}x{emb_dim}x{emb_dim}...")
@@ -279,31 +335,44 @@ def build_o_res_norm_module(seq_len, emb_dim, o_herd_m=8, o_herd_n=4):
     print("  [2/3] Residual Add...")
     res_add_ir = _build_residual_add_2d_ir(seq_len, emb_dim)
     print("  [3/3] FFN RMSNorm...")
-    rms_ir = _wrap_ir_in_launch(str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8)))
+    rms_ir = _wrap_ir_in_launch(
+        str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8))
+    )
 
     scratch_args, scratch_for = alloc_gemm_scratch(
-        [(o_spec, seq_len, emb_dim)], base_arg_count=7,
+        [(o_spec, seq_len, emb_dim)],
+        base_arg_count=7,
     )
 
     def _amap(i, w, o, sc):
         return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
 
     base_args = [
-        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),   # attn_out
-        FuncArg("%arg1", f"memref<{emb_dim}x{emb_dim}xbf16>"),   # wo
-        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),   # proj
-        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),   # x_resid
-        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),   # res1 (out)
-        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),             # ffn_norm
-        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),   # normed2 (out)
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),  # attn_out
+        FuncArg("%arg1", f"memref<{emb_dim}x{emb_dim}xbf16>"),  # wo
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),  # proj
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),  # x_resid
+        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),  # res1 (out)
+        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),  # ffn_norm
+        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),  # normed2 (out)
     ]
     slices = [
-        KernelSlice(o_ir, "og", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(o_spec)),
+        KernelSlice(
+            o_ir,
+            "og",
+            _amap(0, 1, 2, scratch_for[0]),
+            extern_syms=_gemm_externs(o_spec),
+        ),
         KernelSlice(res_add_ir, "ra", {0: 2, 1: 3, 2: 4}, private_from=False),
         KernelSlice(rms_ir, "rm", {0: 4, 1: 5, 2: 6}, private_from=False),
     ]
-    module = stitch_elf("o_res_norm", base_args, slices, scratch_args=scratch_args,
-                        debug_dump_path="/tmp/debug_o_res_norm_3b.mlir")
+    module = stitch_elf(
+        "o_res_norm",
+        base_args,
+        slices,
+        scratch_args=scratch_args,
+        debug_dump_path="/tmp/debug_o_res_norm_3b.mlir",
+    )
     print(f"  o_res_norm module: {len(str(module).splitlines())} lines, parsed OK")
     return module, scratch_for
 
@@ -321,15 +390,24 @@ def build_gate_module(seq_len, emb_dim, hidden_dim, gate_herd_m=8, gate_herd_n=4
       %arg0 normed2 (seq,emb)  %arg1 w_gate (emb,hid)  %arg2 gate (seq,hid) <- OUT
     """
     from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+
     g_spec = _gemm_spec(seq_len, emb_dim, hidden_dim, "low")  # direct
-    print(f"  [gate] Gate GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})...")
-    gate_ir = _build_gemm_ir(seq_len, emb_dim, hidden_dim, g_spec, gate_herd_m, gate_herd_n)
+    print(
+        f"  [gate] Gate GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})..."
+    )
+    gate_ir = _build_gemm_ir(
+        seq_len, emb_dim, hidden_dim, g_spec, gate_herd_m, gate_herd_n
+    )
     base_args = [
-        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),     # normed2
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),  # normed2
         FuncArg("%arg1", f"memref<{emb_dim}x{hidden_dim}xbf16>"),  # w_gate
         FuncArg("%arg2", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # gate (out)
     ]
-    slices = [KernelSlice(gate_ir, "gg", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec))]
+    slices = [
+        KernelSlice(
+            gate_ir, "gg", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec)
+        )
+    ]
     module = stitch_elf("gate", base_args, slices)
     print(f"  gate module: {len(str(module).splitlines())} lines, parsed OK")
     return module
@@ -345,15 +423,20 @@ def build_up_module(seq_len, emb_dim, hidden_dim, up_herd_m=8, up_herd_n=4):
       %arg0 normed2 (seq,emb)  %arg1 w_up (emb,hid)  %arg2 up (seq,hid) <- OUT
     """
     from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+
     g_spec = _gemm_spec(seq_len, emb_dim, hidden_dim, "low")  # direct
-    print(f"  [up] Up GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})...")
+    print(
+        f"  [up] Up GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})..."
+    )
     up_ir = _build_gemm_ir(seq_len, emb_dim, hidden_dim, g_spec, up_herd_m, up_herd_n)
     base_args = [
-        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),     # normed2
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),  # normed2
         FuncArg("%arg1", f"memref<{emb_dim}x{hidden_dim}xbf16>"),  # w_up
         FuncArg("%arg2", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # up (out)
     ]
-    slices = [KernelSlice(up_ir, "ug", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec))]
+    slices = [
+        KernelSlice(up_ir, "ug", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec))
+    ]
     module = stitch_elf("up", base_args, slices)
     print(f"  up module: {len(str(module).splitlines())} lines, parsed OK")
     return module
@@ -384,9 +467,12 @@ def _swiglu_tile_n(seq_len, hidden_dim, herd_x=8):
 def build_swiglu_module(seq_len, hidden_dim, herd_x=8, herd_y=1):
     """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (seq x hidden)."""
     from silu_and_mul.silu_and_mul import build_module_2d as build_swiglu
+
     tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
-    print(f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
-          f"iters={seq_len * hidden_dim // (tile_n * herd_x)})...")
+    print(
+        f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
+        f"iters={seq_len * hidden_dim // (tile_n * herd_x)})..."
+    )
     module = build_swiglu(seq_len, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
     print(f"  swiglu module: {len(str(module).splitlines())} lines, parsed OK")
     return module
@@ -433,7 +519,8 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                 @segment(name="dadd_seg", operands=[down_flat, res_flat, l_out])
                 def add_seg(s_down, s_res, s_out):
                     offset_map = AffineMap.get(
-                        0, 3,
+                        0,
+                        3,
                         [
                             AffineExpr.get_add(
                                 AffineSymbolExpr.get(0),
@@ -451,7 +538,9 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                         ],
                     )
 
-                    @herd(name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out])
+                    @herd(
+                        name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out]
+                    )
                     def add_body(_tx, _ty, _sx, _sy, h_down, h_res, h_out):
                         l1_d = AllocOp(l1_ty, [], [])
                         l1_r = AllocOp(l1_ty, [], [])
@@ -460,17 +549,46 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                         cst0 = arith.ConstantOp(xrt_dtype, 0.0)
                         for loop_iv in range_(0, chunk_size, tile_n):
                             offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
-                            dma_memcpy_nd(l1_d, h_down, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
-                            dma_memcpy_nd(l1_r, h_res, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            dma_memcpy_nd(
+                                l1_d,
+                                h_down,
+                                src_offsets=[offset],
+                                src_sizes=[tile_n],
+                                src_strides=[1],
+                            )
+                            dma_memcpy_nd(
+                                l1_r,
+                                h_res,
+                                src_offsets=[offset],
+                                src_sizes=[tile_n],
+                                src_strides=[1],
+                            )
                             for j in range_(0, tile_n, 16):
                                 sd = subview(l1_d.result, [j], [16], [1])
                                 sr = subview(l1_r.result, [j], [16], [1])
                                 so = subview(l1_o.result, [j], [16], [1])
-                                vd = transfer_read(vec_ty, sd, [c0], identity_map, cst0, [True])
-                                vr = transfer_read(vec_ty, sr, [c0], identity_map, cst0, [True])
-                                transfer_write(None, arith.addf(vd, vr), so, [c0], identity_map, [True])
+                                vd = transfer_read(
+                                    vec_ty, sd, [c0], identity_map, cst0, [True]
+                                )
+                                vr = transfer_read(
+                                    vec_ty, sr, [c0], identity_map, cst0, [True]
+                                )
+                                transfer_write(
+                                    None,
+                                    arith.addf(vd, vr),
+                                    so,
+                                    [c0],
+                                    identity_map,
+                                    [True],
+                                )
                                 yield_([])
-                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[offset], dst_sizes=[tile_n], dst_strides=[1])
+                            dma_memcpy_nd(
+                                h_out,
+                                l1_o,
+                                dst_offsets=[offset],
+                                dst_sizes=[tile_n],
+                                dst_strides=[1],
+                            )
                             yield_([])
                         DeallocOp(l1_d)
                         DeallocOp(l1_r)
@@ -488,18 +606,27 @@ def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd
       [+ f32 C-scratch tail for the fused-cast Down]
     """
     from shared.infra.stitching import (
-        stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+        stitch_elf,
+        KernelSlice,
+        FuncArg,
+        alloc_gemm_scratch,
     )
+
     n_total = seq_len * emb_dim
     d_spec = _gemm_spec(seq_len, hidden_dim, emb_dim, "high")  # fused-cast _m64
-    print(f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
-          f"(tn={d_spec['tile_n']})...")
-    down_ir = _build_gemm_ir(seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n)
+    print(
+        f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
+        f"(tn={d_spec['tile_n']})..."
+    )
+    down_ir = _build_gemm_ir(
+        seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n
+    )
     print("  [down_add] FFN Add (2D -> 1D)...")
     ffn_add_ir = _build_down_add_2d_to_1d_ir(seq_len, emb_dim)
 
     scratch_args, scratch_for = alloc_gemm_scratch(
-        [(d_spec, seq_len, emb_dim)], base_arg_count=5,
+        [(d_spec, seq_len, emb_dim)],
+        base_arg_count=5,
     )
 
     def _amap(i, w, o, sc):
@@ -508,16 +635,27 @@ def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd
     base_args = [
         FuncArg("%arg0", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # swiglu
         FuncArg("%arg1", f"memref<{hidden_dim}x{emb_dim}xbf16>"),  # w_down
-        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),     # down
-        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),     # res1
-        FuncArg("%arg4", f"memref<{n_total}xbf16>"),              # output
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),  # down
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),  # res1
+        FuncArg("%arg4", f"memref<{n_total}xbf16>"),  # output
     ]
     slices = [
-        KernelSlice(down_ir, "dg", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(d_spec), private_from=True),
+        KernelSlice(
+            down_ir,
+            "dg",
+            _amap(0, 1, 2, scratch_for[0]),
+            extern_syms=_gemm_externs(d_spec),
+            private_from=True,
+        ),
         KernelSlice(ffn_add_ir, "fa", {0: 2, 1: 3, 2: 4}, private_from=False),
     ]
-    module = stitch_elf("down_add", base_args, slices, scratch_args=scratch_args,
-                        debug_dump_path="/tmp/debug_down_add_3b.mlir")
+    module = stitch_elf(
+        "down_add",
+        base_args,
+        slices,
+        scratch_args=scratch_args,
+        debug_dump_path="/tmp/debug_down_add_3b.mlir",
+    )
     print(f"  down_add module: {len(str(module).splitlines())} lines, parsed OK")
     return module, scratch_for
 
@@ -594,9 +732,9 @@ def _down_add_backend(verbose=False):
 # Set by compile_all_kernels so the block runner knows scratch-arg indices.
 # Gate/Up are direct-codegen (bf16-out, no f32 scratch), so each is its own ELF
 # with no scratch args.
-_FUSED_SCRATCH_FOR = None     # rms_qkv_bias_rope (Q/K/V): Q fused-cast → [19, None, None]
-_ORES_SCRATCH_FOR = None     # o_res_norm (O): fused-cast → [7]
-_DOWN_SCRATCH_FOR = None     # down_add (Down): fused-cast → [5]
+_FUSED_SCRATCH_FOR = None  # rms_qkv_bias_rope (Q/K/V): Q fused-cast → [19, None, None]
+_ORES_SCRATCH_FOR = None  # o_res_norm (O): fused-cast → [7]
+_DOWN_SCRATCH_FOR = None  # down_add (Down): fused-cast → [5]
 
 
 def _resolve_scratch_for():
@@ -612,22 +750,32 @@ def _resolve_scratch_for():
         out = []
         for s in specs:
             if s["needs_f32_scratch"]:
-                out.append(nxt); nxt += 1
+                out.append(nxt)
+                nxt += 1
             else:
                 out.append(None)
         return out
 
-    _FUSED_SCRATCH_FOR = _alloc([
-        _gemm_spec(seq, cfg.emb_dim, q_dim, "high"),
-        _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
-        _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
-    ], 19)
-    _ORES_SCRATCH_FOR = _alloc([
-        _gemm_spec(seq, cfg.emb_dim, cfg.emb_dim, "high"),
-    ], 7)
-    _DOWN_SCRATCH_FOR = _alloc([
-        _gemm_spec(seq, cfg.hidden_dim, cfg.emb_dim, "high"),
-    ], 5)
+    _FUSED_SCRATCH_FOR = _alloc(
+        [
+            _gemm_spec(seq, cfg.emb_dim, q_dim, "high"),
+            _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
+            _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
+        ],
+        19,
+    )
+    _ORES_SCRATCH_FOR = _alloc(
+        [
+            _gemm_spec(seq, cfg.emb_dim, cfg.emb_dim, "high"),
+        ],
+        7,
+    )
+    _DOWN_SCRATCH_FOR = _alloc(
+        [
+            _gemm_spec(seq, cfg.hidden_dim, cfg.emb_dim, "high"),
+        ],
+        5,
+    )
     return _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR
 
 
@@ -641,7 +789,9 @@ def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
 
-    print(f"\n{'='*60}\nCompiling Qwen2.5-3B prefill kernels (seq_len={seq_len})...\n{'='*60}\n")
+    print(
+        f"\n{'='*60}\nCompiling Qwen2.5-3B prefill kernels (seq_len={seq_len})...\n{'='*60}\n"
+    )
 
     from shared.infra.external_kernels import compile_gemm_mm, compile_rope
 
@@ -649,10 +799,15 @@ def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
     #   _m32 drain    tile_n=64  (K/V projections)
     #   _m64 fused    tile_n=128 (Q, O, Down projections)
     # Gate/Up direct-codegen needs NO external .o. rope.o for head_dim=128.
-    compile_gemm_mm(tile_m=32, tile_n=64, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o")
-    compile_gemm_mm(tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o")
+    compile_gemm_mm(
+        tile_m=32, tile_n=64, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o"
+    )
+    compile_gemm_mm(
+        tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o"
+    )
     compile_rope()
     from shared.infra.external_kernels import compile_silu_and_mul
+
     compile_silu_and_mul()  # silu_and_mul.o for the standalone NPU SwiGLU ELF
 
     print("\n--- rms_qkv_bias_rope (FUSED: RMSNorm+QKV+bias+RoPE) ---")
@@ -668,16 +823,19 @@ def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
     cache.compile_and_cache("o_res_norm", ores_mod, _o_res_norm_backend(verbose))
 
     print("\n--- gate (Gate GEMM, direct) ---")
-    cache.compile_and_cache("gate", build_gate_module(seq_len, emb_dim, hidden_dim),
-                            _gate_backend(verbose))
+    cache.compile_and_cache(
+        "gate", build_gate_module(seq_len, emb_dim, hidden_dim), _gate_backend(verbose)
+    )
 
     print("\n--- up (Up GEMM, direct) ---")
-    cache.compile_and_cache("up", build_up_module(seq_len, emb_dim, hidden_dim),
-                            _up_backend(verbose))
+    cache.compile_and_cache(
+        "up", build_up_module(seq_len, emb_dim, hidden_dim), _up_backend(verbose)
+    )
 
     print("\n--- swiglu (NPU SwiGLU: silu(gate)*up) ---")
-    cache.compile_and_cache("swiglu", build_swiglu_module(seq_len, hidden_dim),
-                            _swiglu_backend(verbose))
+    cache.compile_and_cache(
+        "swiglu", build_swiglu_module(seq_len, hidden_dim), _swiglu_backend(verbose)
+    )
 
     print("\n--- down_add (Down GEMM [launch 0] + FFN Add) ---")
     down_mod, down_scratch = build_down_add_module(seq_len, emb_dim, hidden_dim)
@@ -720,25 +878,25 @@ def _fused_bias_rope_call(
     kv_dim = n_kv_heads * head_dim
 
     args = [
-        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 x_in
-        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),          # 1 norm_w (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                       # 2 normed (inter)
-        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),          # 3 wq (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 4 q (inter)
-        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),         # 5 wk (static)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 6 k (inter)
-        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),         # 7 wv (static)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 8 v (inter)
-        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),                  # 9 bq (static)
-        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),                 # 10 bk (static)
-        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),                 # 11 bv (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 12 q_b (inter)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 13 k_b (inter)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 14 v_b (inter/out)
-        lut_q,                                                             # 15 lut_q (static)
-        lut_k,                                                             # 16 lut_k (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 17 q_roped (inter/out)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 18 k_roped (inter/out)
+        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),  # 0 x_in
+        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),  # 1 norm_w (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 normed (inter)
+        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),  # 3 wq (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 4 q (inter)
+        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),  # 5 wk (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 6 k (inter)
+        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),  # 7 wv (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 8 v (inter)
+        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),  # 9 bq (static)
+        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),  # 10 bk (static)
+        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),  # 11 bv (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 12 q_b (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 13 k_b (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 14 v_b (inter/out)
+        lut_q,  # 15 lut_q (static)
+        lut_k,  # 16 lut_k (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 17 q_roped (inter/out)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 18 k_roped (inter/out)
     ]
     inter = {2, 4, 6, 8, 12, 13, 14, 17, 18}
     nxt = 19
@@ -781,8 +939,7 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
     ores_scratch = _ORES_SCRATCH_FOR
     down_scratch = _DOWN_SCRATCH_FOR
-    if (ores_scratch is None or down_scratch is None
-            or _FUSED_SCRATCH_FOR is None):
+    if ores_scratch is None or down_scratch is None or _FUSED_SCRATCH_FOR is None:
         ores_scratch, down_scratch = _resolve_scratch_for()
 
     print("Pre-loading prefill block weights (per-layer BOs)...")
@@ -797,19 +954,29 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
         # One fused ELF: RMSNorm + Q/K/V GEMM + bias-add + RoPE.
         _fused_bias_rope_call(
-            cache, lw, config, seq_len, lut_q, lut_k, layer_idx,
+            cache,
+            lw,
+            config,
+            seq_len,
+            lut_q,
+            lut_k,
+            layer_idx,
             np.zeros((seq_len, emb_dim), dtype=bfloat16),
         )
 
         # o_res_norm: static {1,5}. Outputs res1 (arg4), normed2 (arg6).
         ores_args = [
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 attn_out
-            np.asarray(lw.wo, dtype=bfloat16).reshape(emb_dim, emb_dim),           # 1 wo (static)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 3 x_resid
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
-            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(emb_dim),              # 5 ffn_norm (static)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 0 attn_out
+            np.asarray(lw.wo, dtype=bfloat16).reshape(
+                emb_dim, emb_dim
+            ),  # 1 wo (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 proj (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 3 x_resid
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 4 res1 (out)
+            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(
+                emb_dim
+            ),  # 5 ffn_norm (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 6 normed2 (out)
         ]
         ores_inter = set()
         for sc, cols in zip(ores_scratch, (emb_dim,)):
@@ -817,7 +984,9 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
                 ores_inter.add(sc)
         cache.load_and_run(
-            "o_res_norm", _o_res_norm_backend(), *ores_args,
+            "o_res_norm",
+            _o_res_norm_backend(),
+            *ores_args,
             output_indices=[4, 6],
             static_input_indices={1, 5},
             intermediate_indices={2, 4, 6} | ores_inter,
@@ -826,31 +995,44 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
         # gate: static {1}. Output gate (arg2).
         gate_args = [
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
-            np.asarray(lw.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_gate (static)
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 0 normed2
+            np.asarray(lw.w_gate, dtype=bfloat16).reshape(
+                emb_dim, hidden_dim
+            ),  # 1 w_gate (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 gate (out)
         ]
         cache.load_and_run(
-            "gate", _gate_backend(), *gate_args,
-            output_indices=[2], static_input_indices={1}, intermediate_indices={2},
+            "gate",
+            _gate_backend(),
+            *gate_args,
+            output_indices=[2],
+            static_input_indices={1},
+            intermediate_indices={2},
             bo_key=f"gate_L{layer_idx}",
         )
 
         # up: static {1}. Output up (arg2).
         up_args = [
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
-            np.asarray(lw.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),      # 1 w_up (static)
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 0 normed2
+            np.asarray(lw.w_up, dtype=bfloat16).reshape(
+                emb_dim, hidden_dim
+            ),  # 1 w_up (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 up (out)
         ]
         cache.load_and_run(
-            "up", _up_backend(), *up_args,
-            output_indices=[2], static_input_indices={1}, intermediate_indices={2},
+            "up",
+            _up_backend(),
+            *up_args,
+            output_indices=[2],
+            static_input_indices={1},
+            intermediate_indices={2},
             bo_key=f"up_L{layer_idx}",
         )
 
         # SwiGLU: NPU ELF (no static weights — only warms the per-layer BO set).
         cache.load_and_run(
-            "swiglu", _swiglu_backend(),
+            "swiglu",
+            _swiglu_backend(),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
@@ -873,7 +1055,9 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
                 down_inter.add(sc)
         cache.load_and_run(
-            "down_add", _down_add_backend(), *down_args,
+            "down_add",
+            _down_add_backend(),
+            *down_args,
             output_indices=[4],
             static_input_indices={1},
             intermediate_indices={2, 4} | down_inter,
@@ -920,8 +1104,15 @@ def run_transformer_block_qwen25(
     # ---- Stages A-C (FUSED): one ELF = RMSNorm + Q/K/V GEMM + bias(Q,K,V)
     # + RoPE(Q,K). Output: v (bias-only), q_roped, k_roped. ----
     res = _fused_bias_rope_call(
-        cache, layer_weights, config, seq_len, lut_q, lut_k, layer_idx,
-        x_bf16, verbose=verbose,
+        cache,
+        layer_weights,
+        config,
+        seq_len,
+        lut_q,
+        lut_k,
+        layer_idx,
+        x_bf16,
+        verbose=verbose,
     )
     v = res[14].reshape(seq_len, kv_dim)
     q_roped = res[17].reshape(seq_len, q_dim)
@@ -968,13 +1159,17 @@ def run_transformer_block_qwen25(
 
     # ELF A1: o_res_norm → res1 (arg4) + normed2 (arg6).
     ores_args = [
-        np.asarray(attn_out, dtype=bfloat16).reshape(seq_len, emb_dim),        # 0 attn_out
-        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(emb_dim, emb_dim),  # 1 wo (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
-        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),          # 3 x_resid
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
-        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(emb_dim),   # 5 ffn_norm (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+        np.asarray(attn_out, dtype=bfloat16).reshape(seq_len, emb_dim),  # 0 attn_out
+        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(
+            emb_dim, emb_dim
+        ),  # 1 wo (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 proj (inter)
+        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),  # 3 x_resid
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 4 res1 (out)
+        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(
+            emb_dim
+        ),  # 5 ffn_norm (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 6 normed2 (out)
     ]
     ores_inter = set()
     for sc, cols in zip(ores_scratch, (emb_dim,)):
@@ -997,9 +1192,11 @@ def run_transformer_block_qwen25(
     gate_res = cache.load_and_run(
         "gate",
         _gate_backend(verbose),
-        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 normed2
-        np.asarray(layer_weights.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),  # 1 w_gate (static)
-        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),  # 0 normed2
+        np.asarray(layer_weights.w_gate, dtype=bfloat16).reshape(
+            emb_dim, hidden_dim
+        ),  # 1 w_gate (static)
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 gate (out)
         output_indices=[2],
         static_input_indices={1},
         intermediate_indices={2},
@@ -1011,9 +1208,11 @@ def run_transformer_block_qwen25(
     up_res = cache.load_and_run(
         "up",
         _up_backend(verbose),
-        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 normed2
-        np.asarray(layer_weights.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_up (static)
-        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),  # 0 normed2
+        np.asarray(layer_weights.w_up, dtype=bfloat16).reshape(
+            emb_dim, hidden_dim
+        ),  # 1 w_up (static)
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 up (out)
         output_indices=[2],
         static_input_indices={1},
         intermediate_indices={2},
@@ -1025,9 +1224,9 @@ def run_transformer_block_qwen25(
     sw_res = cache.load_and_run(
         "swiglu",
         _swiglu_backend(verbose),
-        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),   # 0 gate
-        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),     # 1 up
-        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                 # 2 swiglu (out)
+        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 0 gate
+        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 1 up
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 swiglu (out)
         output_indices=[2],
         intermediate_indices={2},
         bo_key=f"swiglu_L{layer_idx}",
@@ -1036,11 +1235,13 @@ def run_transformer_block_qwen25(
 
     # ELF B: down_add → output (arg4). Down GEMM is launch 0 (K=hidden NaN fix).
     down_args = [
-        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),       # 0 swiglu
-        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),  # 1 w_down (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
-        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),            # 3 res1
-        np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 0 swiglu
+        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(
+            hidden_dim, emb_dim
+        ),  # 1 w_down (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 down (inter)
+        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),  # 3 res1
+        np.zeros(n_total, dtype=bfloat16),  # 4 output (out)
     ]
     down_inter = set()
     for sc, cols in zip(down_scratch, (emb_dim,)):

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
@@ -1,0 +1,1060 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen2.5-3B Prefill on MLIR-AIR (NPU2) — single-block (Phase 2) path.
+
+Direct re-parameterization of qwen25_1_5b (SAME architecture family: Qwen2.5
+QKV bias, NO QK-norm, eps=1e-6, tied embeddings; head_dim=128 cpu_attn prefill).
+The o_ffn tail is SPLIT into FIVE NPU ELFs + 1 host op (o_res_norm, gate, up,
+HOST SwiGLU, down_add) because at this hidden size the merged tail overflows L2,
+and the Down GEMM (K=hidden, NON-512-aligned) must be launch 0 of its ELF — see
+build_down_add_module.
+
+Qwen2.5 deltas vs LLAMA-3.2:
+
+  1. QKV bias (attention_bias=True, the Qwen2 family). After the Q/K/V
+     projection GEMM, a per-channel bias is added on the HOST, AFTER the GEMM
+     and BEFORE RoPE (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention;
+     V is bias-added and used directly). NO QK-norm (that is Qwen3).
+
+  2. Dims (3B): emb=2048, q_dim=2048 (16 heads x 128), kv_dim=256
+     (2 heads x 128), hidden=11008, head_dim=128. o_proj is SQUARE
+     (q_dim==emb_dim==2048).
+
+emb=q_dim=2048 is 1024-aligned (Q/O/Down N=2048 -> stock tile_n=128 herd_n=4).
+The non-aligned dim is hidden=11008=256*43 (Gate/Up N=11008 -> tile_n=64;
+Down K=11008 -> tile_k_l2=256). Every GEMM is driven straight from
+gemm_registry_config, with the Down-launch-0 split layered on top.
+
+Registry-selected methods (seq=2048):
+    Q/O    (2048x2048)   -> fused-cast (mm_m64.o, tile_n=128) — needs f32 scratch
+    K/V    (2048x256)    -> drain      (mm_m32.o, tile_n=64)
+    Gate/Up(2048x11008)  -> direct (low-precision, tile_n=64, tile_k_l2=128)
+    Down   (11008x2048)  -> fused-cast (mm_m64.o, tile_n=128, launch 0)
+
+Attention uses the CPU fallback (cpu_attn=True). head_dim=128 -> FA hang risk,
+so prefill never uses NPU FlashAttention (mirrors qwen3_0_6b).
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+# Add programming_examples/ and llms/ to path for shared.* + registry imports.
+_PROG_EXAMPLES = str(Path(__file__).resolve().parent.parent.parent)
+if _PROG_EXAMPLES not in sys.path:
+    sys.path.insert(0, _PROG_EXAMPLES)
+_LLMS_DIR = str(Path(__file__).resolve().parent.parent)
+if _LLMS_DIR not in sys.path:
+    sys.path.insert(0, _LLMS_DIR)
+
+from qwen25_3b_weights import LlamaConfig
+from qwen25_3b_cpu_helpers import attention_reference
+
+
+# ---------------------------------------------------------------------------
+# Generic per-GEMM spec + IR builder. Supports the three bf16-out methods the
+# Qwen2.5 GEMMs resolve to (fused-cast / drain / direct), each picking its own
+# registry tiles. NO padding — registry tile_n aligns with the real dims.
+# ---------------------------------------------------------------------------
+
+
+def _gemm_spec(m, k, n, precision):
+    """Registry config for one GEMM. precision: 'high' or 'low'."""
+    from shared.builders.gemm_builder import gemm_registry_config
+
+    if precision == "low":
+        # 'low' best is 'direct' for the Gate/Up shape; synthesize a spec since
+        # gemm_registry_config's high tier does not know the direct method.
+        from kernel_registry.registry_lookup import gemm_config
+
+        cfg = gemm_config(m, k, n, "bf16", "low")
+        assert cfg["method"] == "direct", (
+            f"expected direct for low-prec {m}x{k}x{n}, got {cfg['method']}"
+        )
+        tile = cfg["tile"]
+        return {
+            "method": "direct",
+            "tile_m": tile["tile_m"],
+            "tile_k_l2": tile["tile_k_l2"],
+            "tile_k_l1": tile["tile_k_l1"],
+            "tile_n": tile["tile_n"],
+            "n_launches": 1,
+            "needs_f32_scratch": False,
+            "sym_suffix": "",
+            "build_kwargs": {},
+        }
+    return gemm_registry_config(m, k, n, "bf16", "high")
+
+
+def _build_gemm_ir(m, k, n, spec, herd_m=8, herd_n=4):
+    """Build the lowered IR for one GEMM by its method spec."""
+    method = spec["method"]
+    tm, k2, k1, tn = spec["tile_m"], spec["tile_k_l2"], spec["tile_k_l1"], spec["tile_n"]
+    if method == "direct":
+        from matrix_multiplication.bf16_in_bf16_out.run import build_module_lowered
+
+        return str(
+            build_module_lowered(
+                m, k, n, tm, k2, k1, tn, herd_m, herd_n, bfloat16, bfloat16, arch="aie2p"
+            )
+        )
+    from shared.builders.gemm_builder import _build_gemm_module
+
+    return str(
+        _build_gemm_module(
+            m, k, n, tm, k2, k1, tn, herd_m, herd_n, **dict(spec["build_kwargs"])
+        )
+    )
+
+
+def _gemm_externs(spec):
+    """Extern symbols a GEMM slice contributes (empty for direct-codegen)."""
+    if spec["method"] == "direct":
+        return set()  # fully lowered, no external mm.o call
+    sfx = spec["sym_suffix"]
+    return {
+        "@matmul_bf16",
+        "@op_has_no_registered_library_name" + sfx,
+        "@zero_f32_mn" + sfx,
+        "@f32_to_bf16_mn" + sfx,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Builder 1 (FUSED): RMSNorm + Q/K/V GEMM + bias-add(Q,K,V) + RoPE(Q,K).
+#   One ELF replaces rms_qkv + host bias-add + rope_q + rope_k. NO N-padding
+#   (registry tile_n aligns). Q is fused-cast (needs an f32 C-scratch); K/V drain.
+# ---------------------------------------------------------------------------
+
+
+def build_rms_qkv_bias_rope_module(seq_len, config):
+    from shared.builders.rms_qkv_bias_rope_multi import (
+        build_rms_qkv_bias_rope_module as _build,
+    )
+
+    q_dim = config.n_heads * config.head_dim
+    kv_dim = config.n_kv_heads * config.head_dim
+
+    def _spec_fn(m, k, n):
+        return _gemm_spec(m, k, n, "high")
+
+    return _build(
+        seq_len,
+        config.emb_dim,
+        q_dim,
+        kv_dim,
+        config.n_heads,
+        config.n_kv_heads,
+        config.head_dim,
+        q_pad=q_dim,
+        kv_pad=kv_dim,
+        gemm_spec_fn=_spec_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder 3: O proj (SQUARE) + Residual + FFN, SPLIT into multiple ELFs.
+#
+#   Why split? The Down GEMM (K=hidden, NON-512-aligned) produces ALL-NaN when
+#   it is NOT the first launch of a stitched ELF (the 0.5B K=4864 bug). Remedy:
+#   keep the offending GEMM as its own XRT call so it is always launch 0.
+#
+#   The O+FFN tail is FIVE ELFs (L2/L1/BD limits; see per-builder docstrings):
+#     o_res_norm : O(fused-cast) + Residual + FFN-RMSNorm -> res1, normed2
+#     gate       : Gate(direct) alone -> gate
+#     up         : Up(direct) alone   -> up
+#     swiglu     : NPU silu(gate)*up  -> swiglu
+#     down_add   : Down(fused-cast, launch 0) + FFN-Add -> output (seq*emb,)
+# ---------------------------------------------------------------------------
+
+
+def _build_residual_add_2d_ir(seq_len, emb_dim):
+    """Residual add: proj(seq,emb) + x_resid(seq,emb) -> res1(seq,emb) 2D.
+
+    res1 is kept 2D so downstream slices read it without expand_shape.
+    """
+    from air.ir import MemRefType, IntegerAttr, AffineMap, AffineExpr
+    from air.ir import AffineSymbolExpr, AffineConstantExpr, AffineMapAttr, VectorType
+    from air.dialects.air import module_builder, launch, segment, herd, dma_memcpy_nd
+    from air.dialects.air import MemorySpace, T
+    from air.dialects.affine import apply as affine_apply
+    from air.dialects import arith
+    from air.dialects.memref import AllocOp, DeallocOp, subview
+    from air.dialects.vector import transfer_read, transfer_write
+    from air.dialects.func import FuncOp
+    from air.dialects.scf import for_ as range_, yield_
+    from air.backend.xrt_runner import type_mapper
+
+    n_total = seq_len * emb_dim
+
+    @module_builder
+    def _build():
+        from air.dialects.memref import collapse_shape as memref_collapse_shape
+
+        xrt_dtype = type_mapper(bfloat16)
+        twod_ty = MemRefType.get([seq_len, emb_dim], xrt_dtype)
+        flat_ty = MemRefType.get([n_total], xrt_dtype)
+        rows_per_pe = seq_len // 8
+        l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l1_ty = MemRefType.get([emb_dim], xrt_dtype, memory_space=l1_space)
+        vec_ty = VectorType.get([16], xrt_dtype)
+        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+
+        @FuncOp.from_py_func(twod_ty, twod_ty, twod_ty)
+        def res_add(proj_2d, xres_2d, out_2d):
+            @launch(operands=[proj_2d, xres_2d, out_2d])
+            def add_launch(l_proj, l_xres, l_out):
+                proj_flat = memref_collapse_shape(flat_ty, l_proj, [[0, 1]])
+                xres_flat = memref_collapse_shape(flat_ty, l_xres, [[0, 1]])
+                out_flat = memref_collapse_shape(flat_ty, l_out, [[0, 1]])
+
+                @segment(name="radd_seg", operands=[proj_flat, xres_flat, out_flat])
+                def add_seg(s_proj, s_xres, s_out):
+                    row_map = AffineMap.get(
+                        0, 2,
+                        [AffineExpr.get_add(
+                            AffineExpr.get_mul(AffineSymbolExpr.get(0),
+                                               AffineConstantExpr.get(rows_per_pe)),
+                            AffineSymbolExpr.get(1))],
+                    )
+
+                    @herd(name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out])
+                    def add_body(_tx, _ty, _sx, _sy, h_proj, h_xres, h_out):
+                        l1_p = AllocOp(l1_ty, [], [])
+                        l1_x = AllocOp(l1_ty, [], [])
+                        l1_o = AllocOp(l1_ty, [], [])
+                        c0 = arith.ConstantOp.create_index(0)
+                        cst0 = arith.ConstantOp(xrt_dtype, 0.0)
+                        for iv in range_(0, rows_per_pe, 1):
+                            r = affine_apply(row_map, [_tx, iv])
+                            off = arith.muli(r, arith.ConstantOp.create_index(emb_dim))
+                            dma_memcpy_nd(l1_p, h_proj, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            dma_memcpy_nd(l1_x, h_xres, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            for j in range_(0, emb_dim, 16):
+                                sp = subview(l1_p.result, [j], [16], [1])
+                                sx = subview(l1_x.result, [j], [16], [1])
+                                so = subview(l1_o.result, [j], [16], [1])
+                                vp = transfer_read(vec_ty, sp, [c0], identity_map, cst0, [True])
+                                vx = transfer_read(vec_ty, sx, [c0], identity_map, cst0, [True])
+                                transfer_write(None, arith.addf(vp, vx), so, [c0], identity_map, [True])
+                                yield_([])
+                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[off], dst_sizes=[emb_dim], dst_strides=[1])
+                            yield_([])
+                        DeallocOp(l1_p)
+                        DeallocOp(l1_x)
+                        DeallocOp(l1_o)
+
+    return str(_build())
+
+
+def build_o_res_norm_module(seq_len, emb_dim, o_herd_m=8, o_herd_n=4):
+    """ELF A1: O(fused-cast) + Residual + FFN-RMSNorm.
+
+    The 0.5B single o_ffn_head merge (O fused-cast + Gate/Up direct + SwiGLU)
+    overflows L2 MemTiles at hidden=8960: the fused-cast O f32 C-scratch and the
+    two direct Gate/Up f32 L2 staging buffers (1x4x64x128xf32 = 128 KB each, 8
+    columns) cannot co-reside. So the O+FFN tail is split into o_res_norm, gate,
+    up, HOST SwiGLU, down_add. This ELF holds only the fused-cast O scratch.
+
+    Func args:
+      %arg0 attn_out (seq,emb)  %arg1 wo (emb,emb)  %arg2 proj (seq,emb)
+      %arg3 x_resid (seq,emb)   %arg4 res1 (seq,emb)   <- OUTPUT (feeds down_add)
+      %arg5 ffn_norm (emb,)     %arg6 normed2 (seq,emb) <- OUTPUT (feeds gate_up)
+      [+ f32 C-scratch tail for the fused-cast O GEMM]
+    """
+    from shared.infra.stitching import (
+        _wrap_ir_in_launch, stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+    )
+    from weighted_rms_norm.weighted_rms_norm import build_module as build_rms
+
+    o_spec = _gemm_spec(seq_len, emb_dim, emb_dim, "high")   # fused-cast _m64
+    print(f"  [o_res_norm] O GEMM method={o_spec['method']} (tn={o_spec['tile_n']})")
+
+    print(f"  [1/3] O GEMM ({o_spec['method']})  {seq_len}x{emb_dim}x{emb_dim}...")
+    o_ir = _build_gemm_ir(seq_len, emb_dim, emb_dim, o_spec, o_herd_m, o_herd_n)
+    print("  [2/3] Residual Add...")
+    res_add_ir = _build_residual_add_2d_ir(seq_len, emb_dim)
+    print("  [3/3] FFN RMSNorm...")
+    rms_ir = _wrap_ir_in_launch(str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8)))
+
+    scratch_args, scratch_for = alloc_gemm_scratch(
+        [(o_spec, seq_len, emb_dim)], base_arg_count=7,
+    )
+
+    def _amap(i, w, o, sc):
+        return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
+
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),   # attn_out
+        FuncArg("%arg1", f"memref<{emb_dim}x{emb_dim}xbf16>"),   # wo
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),   # proj
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),   # x_resid
+        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),   # res1 (out)
+        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),             # ffn_norm
+        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),   # normed2 (out)
+    ]
+    slices = [
+        KernelSlice(o_ir, "og", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(o_spec)),
+        KernelSlice(res_add_ir, "ra", {0: 2, 1: 3, 2: 4}, private_from=False),
+        KernelSlice(rms_ir, "rm", {0: 4, 1: 5, 2: 6}, private_from=False),
+    ]
+    module = stitch_elf("o_res_norm", base_args, slices, scratch_args=scratch_args,
+                        debug_dump_path="/tmp/debug_o_res_norm_3b.mlir")
+    print(f"  o_res_norm module: {len(str(module).splitlines())} lines, parsed OK")
+    return module, scratch_for
+
+
+def build_gate_module(seq_len, emb_dim, hidden_dim, gate_herd_m=8, gate_herd_n=4):
+    """ELF A2: Gate(direct) alone.
+
+    Even isolated from O's fused-cast scratch, the TWO direct Gate/Up GEMMs
+    cannot co-reside in one ELF: each direct codegen GEMM stages its full f32
+    output (1x4x64x128xf32 = 128 KB per column × 8) in L2, and two of them
+    overflow the MemTiles. So Gate and Up are each their own ELF; SwiGLU is fused
+    onto Up. (Standalone, one direct GEMM fits — Phase-1 verified.)
+
+    Func args:
+      %arg0 normed2 (seq,emb)  %arg1 w_gate (emb,hid)  %arg2 gate (seq,hid) <- OUT
+    """
+    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+    g_spec = _gemm_spec(seq_len, emb_dim, hidden_dim, "low")  # direct
+    print(f"  [gate] Gate GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})...")
+    gate_ir = _build_gemm_ir(seq_len, emb_dim, hidden_dim, g_spec, gate_herd_m, gate_herd_n)
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),     # normed2
+        FuncArg("%arg1", f"memref<{emb_dim}x{hidden_dim}xbf16>"),  # w_gate
+        FuncArg("%arg2", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # gate (out)
+    ]
+    slices = [KernelSlice(gate_ir, "gg", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec))]
+    module = stitch_elf("gate", base_args, slices)
+    print(f"  gate module: {len(str(module).splitlines())} lines, parsed OK")
+    return module
+
+
+def build_up_module(seq_len, emb_dim, hidden_dim, up_herd_m=8, up_herd_n=4):
+    """ELF A3: Up(direct) alone.
+
+    A single direct GEMM at N=8960 already saturates the L2 MemTiles (its f32
+    staging is 128 KB/column), so even Up+SwiGLU overflow — SwiGLU is its own ELF.
+
+    Func args:
+      %arg0 normed2 (seq,emb)  %arg1 w_up (emb,hid)  %arg2 up (seq,hid) <- OUT
+    """
+    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+    g_spec = _gemm_spec(seq_len, emb_dim, hidden_dim, "low")  # direct
+    print(f"  [up] Up GEMM ({g_spec['method']}) {seq_len}x{emb_dim}x{hidden_dim} (tn={g_spec['tile_n']})...")
+    up_ir = _build_gemm_ir(seq_len, emb_dim, hidden_dim, g_spec, up_herd_m, up_herd_n)
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{emb_dim}xbf16>"),     # normed2
+        FuncArg("%arg1", f"memref<{emb_dim}x{hidden_dim}xbf16>"),  # w_up
+        FuncArg("%arg2", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # up (out)
+    ]
+    slices = [KernelSlice(up_ir, "ug", {0: 0, 1: 1, 2: 2}, extern_syms=_gemm_externs(g_spec))]
+    module = stitch_elf("up", base_args, slices)
+    print(f"  up module: {len(str(module).splitlines())} lines, parsed OK")
+    return module
+
+
+# NPU SwiGLU (silu_and_mul.build_module_2d) compiles at hidden=11008 once tile_n
+# is in the BD/L1 sweet spot. Failure horns:
+#   - tile_n too large (>= ~7168) -> 3 L1 buffers overflow per-core L1
+#   - tile_n too small (<= ~2048)  -> the chunk loop unrolls into >1k shim DMA
+#     tasks and exhausts the buffer-descriptor pool
+# Compiling band tile_n in ~[3584, 5120]. Verified standalone on NPU2:
+# mean_rel_L1=1.02e-2 (registry SwiGLU tier).
+
+# Largest compiling tile_n per hidden (fewest loop iters), from a compile sweep.
+_SWIGLU_TILE_N = {8960: 5120, 9728: 4864, 11008: 4096}
+
+
+def _swiglu_tile_n(seq_len, hidden_dim, herd_x=8):
+    if hidden_dim in _SWIGLU_TILE_N:
+        return _SWIGLU_TILE_N[hidden_dim]
+    half = (seq_len * hidden_dim) // herd_x
+    for t in range(5120, 1024, -64):
+        if half % t == 0:
+            return t
+    raise RuntimeError(f"No SwiGLU tile_n for seq={seq_len} hidden={hidden_dim}")
+
+
+def build_swiglu_module(seq_len, hidden_dim, herd_x=8, herd_y=1):
+    """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (seq x hidden)."""
+    from silu_and_mul.silu_and_mul import build_module_2d as build_swiglu
+    tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
+    print(f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
+          f"iters={seq_len * hidden_dim // (tile_n * herd_x)})...")
+    module = build_swiglu(seq_len, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
+    print(f"  swiglu module: {len(str(module).splitlines())} lines, parsed OK")
+    return module
+
+
+def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
+    """Eltwise add: down(seq,emb) + res1(seq,emb) -> output(seq*emb,)."""
+    from air.ir import MemRefType, IntegerAttr, AffineMap, AffineExpr
+    from air.ir import AffineSymbolExpr, AffineConstantExpr, AffineMapAttr, VectorType
+    from air.dialects.air import module_builder, launch, segment, herd, dma_memcpy_nd
+    from air.dialects.air import MemorySpace, T
+    from air.dialects.affine import apply as affine_apply
+    from air.dialects import arith
+    from air.dialects.memref import AllocOp, DeallocOp, subview
+    from air.dialects.vector import transfer_read, transfer_write
+    from air.dialects.func import FuncOp
+    from air.dialects.scf import for_ as range_, yield_
+    from air.backend.xrt_runner import type_mapper
+
+    n_total = seq_len * emb_dim
+
+    @module_builder
+    def _build():
+        from air.dialects.memref import collapse_shape as memref_collapse_shape
+
+        xrt_dtype = type_mapper(bfloat16)
+        twod_ty = MemRefType.get([seq_len, emb_dim], xrt_dtype)
+        out_1d_ty = MemRefType.get([n_total], xrt_dtype)
+        total_tiles = 8
+        chunk_size = n_total // total_tiles
+        tile_n = emb_dim
+        l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l1_ty = MemRefType.get([tile_n], xrt_dtype, memory_space=l1_space)
+        vec_ty = VectorType.get([16], xrt_dtype)
+        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+
+        @FuncOp.from_py_func(twod_ty, twod_ty, out_1d_ty)
+        def down_add(down_2d, res_2d, out_1d):
+            @launch(operands=[down_2d, res_2d, out_1d])
+            def add_launch(l_down, l_res, l_out):
+                down_flat = memref_collapse_shape(out_1d_ty, l_down, [[0, 1]])
+                res_flat = memref_collapse_shape(out_1d_ty, l_res, [[0, 1]])
+
+                @segment(name="dadd_seg", operands=[down_flat, res_flat, l_out])
+                def add_seg(s_down, s_res, s_out):
+                    offset_map = AffineMap.get(
+                        0, 3,
+                        [
+                            AffineExpr.get_add(
+                                AffineSymbolExpr.get(0),
+                                AffineExpr.get_mul(
+                                    AffineExpr.get_add(
+                                        AffineExpr.get_mul(
+                                            AffineSymbolExpr.get(1),
+                                            AffineConstantExpr.get(1),
+                                        ),
+                                        AffineSymbolExpr.get(2),
+                                    ),
+                                    AffineConstantExpr.get(chunk_size),
+                                ),
+                            )
+                        ],
+                    )
+
+                    @herd(name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out])
+                    def add_body(_tx, _ty, _sx, _sy, h_down, h_res, h_out):
+                        l1_d = AllocOp(l1_ty, [], [])
+                        l1_r = AllocOp(l1_ty, [], [])
+                        l1_o = AllocOp(l1_ty, [], [])
+                        c0 = arith.ConstantOp.create_index(0)
+                        cst0 = arith.ConstantOp(xrt_dtype, 0.0)
+                        for loop_iv in range_(0, chunk_size, tile_n):
+                            offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
+                            dma_memcpy_nd(l1_d, h_down, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            dma_memcpy_nd(l1_r, h_res, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            for j in range_(0, tile_n, 16):
+                                sd = subview(l1_d.result, [j], [16], [1])
+                                sr = subview(l1_r.result, [j], [16], [1])
+                                so = subview(l1_o.result, [j], [16], [1])
+                                vd = transfer_read(vec_ty, sd, [c0], identity_map, cst0, [True])
+                                vr = transfer_read(vec_ty, sr, [c0], identity_map, cst0, [True])
+                                transfer_write(None, arith.addf(vd, vr), so, [c0], identity_map, [True])
+                                yield_([])
+                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[offset], dst_sizes=[tile_n], dst_strides=[1])
+                            yield_([])
+                        DeallocOp(l1_d)
+                        DeallocOp(l1_r)
+                        DeallocOp(l1_o)
+
+    return str(_build())
+
+
+def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd_n=4):
+    """ELF B: Down(fused-cast, launch 0) + FFN-Add.
+
+    Func args:
+      %arg0 swiglu (seq,hid)  %arg1 w_down (hid,emb)  %arg2 down (seq,emb)
+      %arg3 res1 (seq,emb)    %arg4 output (seq*emb,)
+      [+ f32 C-scratch tail for the fused-cast Down]
+    """
+    from shared.infra.stitching import (
+        stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+    )
+    n_total = seq_len * emb_dim
+    d_spec = _gemm_spec(seq_len, hidden_dim, emb_dim, "high")  # fused-cast _m64
+    print(f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
+          f"(tn={d_spec['tile_n']})...")
+    down_ir = _build_gemm_ir(seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n)
+    print("  [down_add] FFN Add (2D -> 1D)...")
+    ffn_add_ir = _build_down_add_2d_to_1d_ir(seq_len, emb_dim)
+
+    scratch_args, scratch_for = alloc_gemm_scratch(
+        [(d_spec, seq_len, emb_dim)], base_arg_count=5,
+    )
+
+    def _amap(i, w, o, sc):
+        return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
+
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # swiglu
+        FuncArg("%arg1", f"memref<{hidden_dim}x{emb_dim}xbf16>"),  # w_down
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),     # down
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),     # res1
+        FuncArg("%arg4", f"memref<{n_total}xbf16>"),              # output
+    ]
+    slices = [
+        KernelSlice(down_ir, "dg", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(d_spec), private_from=True),
+        KernelSlice(ffn_add_ir, "fa", {0: 2, 1: 3, 2: 4}, private_from=False),
+    ]
+    module = stitch_elf("down_add", base_args, slices, scratch_args=scratch_args,
+                        debug_dump_path="/tmp/debug_down_add_3b.mlir")
+    print(f"  down_add module: {len(str(module).splitlines())} lines, parsed OK")
+    return module, scratch_for
+
+
+# ---------------------------------------------------------------------------
+# Backend kwargs
+# ---------------------------------------------------------------------------
+
+
+def _rms_qkv_bias_rope_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "rms_qkv_bias_rope",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _o_res_norm_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "o_res_norm",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _gate_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "gate",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _up_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "up",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _swiglu_backend(verbose=False):
+    # ELF symbol name must match the top func name in build_module_2d.
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "silu_and_mul_2d",
+    }
+
+
+def _down_add_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "down_add",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Compilation
+# ---------------------------------------------------------------------------
+
+# Set by compile_all_kernels so the block runner knows scratch-arg indices.
+# Gate/Up are direct-codegen (bf16-out, no f32 scratch), so each is its own ELF
+# with no scratch args.
+_FUSED_SCRATCH_FOR = None     # rms_qkv_bias_rope (Q/K/V): Q fused-cast → [19, None, None]
+_ORES_SCRATCH_FOR = None     # o_res_norm (O): fused-cast → [7]
+_DOWN_SCRATCH_FOR = None     # down_add (Down): fused-cast → [5]
+
+
+def _resolve_scratch_for():
+    """Recompute scratch_for lists from the registry (for --run-only path)."""
+    global _FUSED_SCRATCH_FOR, _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR
+    cfg = LlamaConfig()
+    seq = 2048
+    q_dim = cfg.n_heads * cfg.head_dim
+    kv_dim = cfg.n_kv_heads * cfg.head_dim
+
+    def _alloc(specs, base):
+        nxt = base
+        out = []
+        for s in specs:
+            if s["needs_f32_scratch"]:
+                out.append(nxt); nxt += 1
+            else:
+                out.append(None)
+        return out
+
+    _FUSED_SCRATCH_FOR = _alloc([
+        _gemm_spec(seq, cfg.emb_dim, q_dim, "high"),
+        _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
+        _gemm_spec(seq, cfg.emb_dim, kv_dim, "high"),
+    ], 19)
+    _ORES_SCRATCH_FOR = _alloc([
+        _gemm_spec(seq, cfg.emb_dim, cfg.emb_dim, "high"),
+    ], 7)
+    _DOWN_SCRATCH_FOR = _alloc([
+        _gemm_spec(seq, cfg.hidden_dim, cfg.emb_dim, "high"),
+    ], 5)
+    return _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR
+
+
+def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
+    global _FUSED_SCRATCH_FOR, _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    print(f"\n{'='*60}\nCompiling Qwen2.5-3B prefill kernels (seq_len={seq_len})...\n{'='*60}\n")
+
+    from shared.infra.external_kernels import compile_gemm_mm, compile_rope
+
+    # mm.o variants for the external GEMMs:
+    #   _m32 drain    tile_n=64  (K/V projections)
+    #   _m64 fused    tile_n=128 (Q, O, Down projections)
+    # Gate/Up direct-codegen needs NO external .o. rope.o for head_dim=128.
+    compile_gemm_mm(tile_m=32, tile_n=64, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o")
+    compile_gemm_mm(tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o")
+    compile_rope()
+    from shared.infra.external_kernels import compile_silu_and_mul
+    compile_silu_and_mul()  # silu_and_mul.o for the standalone NPU SwiGLU ELF
+
+    print("\n--- rms_qkv_bias_rope (FUSED: RMSNorm+QKV+bias+RoPE) ---")
+    fused_mod, fused_scratch = build_rms_qkv_bias_rope_module(seq_len, config)
+    _FUSED_SCRATCH_FOR = fused_scratch
+    cache.compile_and_cache(
+        "rms_qkv_bias_rope", fused_mod, _rms_qkv_bias_rope_backend(verbose)
+    )
+
+    print("\n--- o_res_norm (O proj + Residual + FFN RMSNorm) ---")
+    ores_mod, ores_scratch = build_o_res_norm_module(seq_len, emb_dim)
+    _ORES_SCRATCH_FOR = ores_scratch
+    cache.compile_and_cache("o_res_norm", ores_mod, _o_res_norm_backend(verbose))
+
+    print("\n--- gate (Gate GEMM, direct) ---")
+    cache.compile_and_cache("gate", build_gate_module(seq_len, emb_dim, hidden_dim),
+                            _gate_backend(verbose))
+
+    print("\n--- up (Up GEMM, direct) ---")
+    cache.compile_and_cache("up", build_up_module(seq_len, emb_dim, hidden_dim),
+                            _up_backend(verbose))
+
+    print("\n--- swiglu (NPU SwiGLU: silu(gate)*up) ---")
+    cache.compile_and_cache("swiglu", build_swiglu_module(seq_len, hidden_dim),
+                            _swiglu_backend(verbose))
+
+    print("\n--- down_add (Down GEMM [launch 0] + FFN Add) ---")
+    down_mod, down_scratch = build_down_add_module(seq_len, emb_dim, hidden_dim)
+    _DOWN_SCRATCH_FOR = down_scratch
+    cache.compile_and_cache("down_add", down_mod, _down_add_backend(verbose))
+
+    # Flash Attention (head-first, head_dim=128). Skip if using CPU fallback.
+    if not cpu_attn:
+        print("\n--- flash_attn (head-first FA, head_dim=128) ---")
+        from shared.infra.fa_headfirst import compile_headfirst_fa
+
+        compile_headfirst_fa(cache, seq_len, n_heads, n_kv_heads, head_dim, verbose)
+    else:
+        print("\n--- Skipping flash_attn (CPU attention fallback) ---")
+
+    cache._save_manifest()
+    print(f"\nAll {len(cache.artifacts)} kernels compiled to {cache.cache_dir}/")
+
+
+# ---------------------------------------------------------------------------
+# Pre-load prefill weights into per-layer BOs (one-time warmup)
+# ---------------------------------------------------------------------------
+
+
+def _fused_bias_rope_call(
+    cache, lw, config, seq_len, lut_q, lut_k, layer_idx, x_in, verbose=False
+):
+    """Issue one rms_qkv_bias_rope ELF call (fused prefill attention-input).
+
+    Used by BOTH preload_prefill_weights (warmup, x_in zeroed) and the block
+    runner. Single owner of the fused arg layout. NO N-padding. Q is fused-cast
+    (f32 C-scratch tail, tracked by _FUSED_SCRATCH_FOR). output_indices=
+    [14,17,18] -> v_b, q_roped, k_roped.
+    """
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    args = [
+        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 x_in
+        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),          # 1 norm_w (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                       # 2 normed (inter)
+        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),          # 3 wq (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 4 q (inter)
+        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),         # 5 wk (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 6 k (inter)
+        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),         # 7 wv (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 8 v (inter)
+        np.asarray(lw.bq, dtype=bfloat16).reshape(q_dim),                  # 9 bq (static)
+        np.asarray(lw.bk, dtype=bfloat16).reshape(kv_dim),                 # 10 bk (static)
+        np.asarray(lw.bv, dtype=bfloat16).reshape(kv_dim),                 # 11 bv (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 12 q_b (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 13 k_b (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 14 v_b (inter/out)
+        lut_q,                                                             # 15 lut_q (static)
+        lut_k,                                                             # 16 lut_k (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                         # 17 q_roped (inter/out)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                        # 18 k_roped (inter/out)
+    ]
+    inter = {2, 4, 6, 8, 12, 13, 14, 17, 18}
+    nxt = 19
+    for sc, cols in zip(_FUSED_SCRATCH_FOR or [], (q_dim, kv_dim, kv_dim)):
+        if sc is not None:
+            args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            inter.add(nxt)
+            nxt += 1
+    return cache.load_and_run(
+        "rms_qkv_bias_rope",
+        _rms_qkv_bias_rope_backend(verbose),
+        *args,
+        output_indices=[14, 17, 18],
+        static_input_indices={1, 3, 5, 7, 9, 10, 11, 15, 16},
+        intermediate_indices=inter,
+        bo_key=f"rms_qkv_bias_rope_L{layer_idx}",
+    )
+
+
+def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
+    """Pre-load all prefill block weights into per-layer BOs once.
+
+    The warmup call layout MUST match ``run_transformer_block_qwen25`` exactly
+    (same arg count, static/intermediate indices, bo_key). Qwen2.5-3B has SIX
+    prefill ELFs: rms_qkv_bias_rope (fused), o_res_norm, gate, up, swiglu,
+    down_add (the O+FFN tail split because the K=hidden Down GEMM must be launch
+    0; see build_down_add_module).
+    """
+    if hasattr(weights, "_prefill_weights_preloaded"):
+        return
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    n_total = seq_len * emb_dim
+
+    ores_scratch = _ORES_SCRATCH_FOR
+    down_scratch = _DOWN_SCRATCH_FOR
+    if (ores_scratch is None or down_scratch is None
+            or _FUSED_SCRATCH_FOR is None):
+        ores_scratch, down_scratch = _resolve_scratch_for()
+
+    print("Pre-loading prefill block weights (per-layer BOs)...")
+    profiler_enabled = cache.profiler.enabled
+    cache.profiler.enabled = False
+
+    lut_q = np.repeat(rope_lut_bf16[:seq_len], n_heads, axis=0).flatten()
+    lut_k = np.repeat(rope_lut_bf16[:seq_len], n_kv_heads, axis=0).flatten()
+
+    for layer_idx in range(config.n_layers):
+        lw = weights.layers[layer_idx]
+
+        # One fused ELF: RMSNorm + Q/K/V GEMM + bias-add + RoPE.
+        _fused_bias_rope_call(
+            cache, lw, config, seq_len, lut_q, lut_k, layer_idx,
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),
+        )
+
+        # o_res_norm: static {1,5}. Outputs res1 (arg4), normed2 (arg6).
+        ores_args = [
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 attn_out
+            np.asarray(lw.wo, dtype=bfloat16).reshape(emb_dim, emb_dim),           # 1 wo (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 3 x_resid
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
+            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(emb_dim),              # 5 ffn_norm (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+        ]
+        ores_inter = set()
+        for sc, cols in zip(ores_scratch, (emb_dim,)):
+            if sc is not None:
+                ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+                ores_inter.add(sc)
+        cache.load_and_run(
+            "o_res_norm", _o_res_norm_backend(), *ores_args,
+            output_indices=[4, 6],
+            static_input_indices={1, 5},
+            intermediate_indices={2, 4, 6} | ores_inter,
+            bo_key=f"o_res_norm_L{layer_idx}",
+        )
+
+        # gate: static {1}. Output gate (arg2).
+        gate_args = [
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
+            np.asarray(lw.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_gate (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+        ]
+        cache.load_and_run(
+            "gate", _gate_backend(), *gate_args,
+            output_indices=[2], static_input_indices={1}, intermediate_indices={2},
+            bo_key=f"gate_L{layer_idx}",
+        )
+
+        # up: static {1}. Output up (arg2).
+        up_args = [
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
+            np.asarray(lw.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),      # 1 w_up (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+        ]
+        cache.load_and_run(
+            "up", _up_backend(), *up_args,
+            output_indices=[2], static_input_indices={1}, intermediate_indices={2},
+            bo_key=f"up_L{layer_idx}",
+        )
+
+        # SwiGLU: NPU ELF (no static weights — only warms the per-layer BO set).
+        cache.load_and_run(
+            "swiglu", _swiglu_backend(),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            output_indices=[2],
+            intermediate_indices={2},
+            bo_key=f"swiglu_L{layer_idx}",
+        )
+
+        # down_add: static {1}.
+        down_args = [
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.asarray(lw.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),
+            np.zeros(n_total, dtype=bfloat16),
+        ]
+        down_inter = set()
+        for sc, cols in zip(down_scratch, (emb_dim,)):
+            if sc is not None:
+                down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+                down_inter.add(sc)
+        cache.load_and_run(
+            "down_add", _down_add_backend(), *down_args,
+            output_indices=[4],
+            static_input_indices={1},
+            intermediate_indices={2, 4} | down_inter,
+            bo_key=f"down_add_L{layer_idx}",
+        )
+
+    cache.profiler.enabled = profiler_enabled
+    weights._prefill_weights_preloaded = True
+    print(f"  Pre-loaded {config.n_layers} prefill layers.")
+
+
+# ---------------------------------------------------------------------------
+# Single transformer block
+# ---------------------------------------------------------------------------
+
+
+def run_transformer_block_qwen25(
+    x_bf16,
+    layer_weights,
+    rope_lut_bf16,
+    config,
+    cache,
+    layer_idx=0,
+    cpu_attn=True,
+    verbose=False,
+):
+    """Run one Qwen2.5-3B transformer block on NPU (kernels pre-compiled)."""
+    seq_len = x_bf16.shape[0]
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    n_total = seq_len * emb_dim
+
+    inter = {}
+
+    # RoPE LUTs (seq-first, repeated per head).
+    lut_q = np.repeat(rope_lut_bf16[:seq_len], n_heads, axis=0).flatten()
+    lut_k = np.repeat(rope_lut_bf16[:seq_len], n_kv_heads, axis=0).flatten()
+
+    # ---- Stages A-C (FUSED): one ELF = RMSNorm + Q/K/V GEMM + bias(Q,K,V)
+    # + RoPE(Q,K). Output: v (bias-only), q_roped, k_roped. ----
+    res = _fused_bias_rope_call(
+        cache, layer_weights, config, seq_len, lut_q, lut_k, layer_idx,
+        x_bf16, verbose=verbose,
+    )
+    v = res[14].reshape(seq_len, kv_dim)
+    q_roped = res[17].reshape(seq_len, q_dim)
+    k_roped = res[18].reshape(seq_len, kv_dim)
+    inter["v"] = v
+    inter["q_roped"] = q_roped
+    inter["k_roped"] = k_roped
+
+    # ---- Stage D: GQA attention ----
+    if cpu_attn:
+        # HOST cpu fallback (FP32 causal GQA reference).
+        with cache.profiler.time_cpu("prefill_cpu_attention"):
+            attn_out = attention_reference(
+                q_roped.astype(np.float32),
+                k_roped.astype(np.float32),
+                v.astype(np.float32),
+                n_heads,
+                n_kv_heads,
+            ).astype(bfloat16)
+    else:
+        # NPU head-first FlashAttention (head_dim=128). q_roped/k_roped are
+        # post-bias post-RoPE seq-first; v is the post-bias raw V projection
+        # seq-first. Real (un-padded) dims — Qwen2.5-3B does not N-pad.
+        from shared.infra.fa_headfirst import npu_fa_headfirst
+
+        attn_out = npu_fa_headfirst(
+            cache,
+            np.ascontiguousarray(q_roped),
+            np.ascontiguousarray(k_roped),
+            np.ascontiguousarray(v),
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            seq_len,
+            verbose=verbose,
+        )
+    inter["attn_out"] = attn_out
+
+    # ---- Stage E: O proj + Residual + FFN ----
+    ores_scratch = _ORES_SCRATCH_FOR
+    down_scratch = _DOWN_SCRATCH_FOR
+    if ores_scratch is None or down_scratch is None:
+        ores_scratch, down_scratch = _resolve_scratch_for()
+
+    # ELF A1: o_res_norm → res1 (arg4) + normed2 (arg6).
+    ores_args = [
+        np.asarray(attn_out, dtype=bfloat16).reshape(seq_len, emb_dim),        # 0 attn_out
+        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(emb_dim, emb_dim),  # 1 wo (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
+        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),          # 3 x_resid
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
+        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(emb_dim),   # 5 ffn_norm (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+    ]
+    ores_inter = set()
+    for sc, cols in zip(ores_scratch, (emb_dim,)):
+        if sc is not None:
+            ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            ores_inter.add(sc)
+    ores_res = cache.load_and_run(
+        "o_res_norm",
+        _o_res_norm_backend(verbose),
+        *ores_args,
+        output_indices=[4, 6],
+        static_input_indices={1, 5},
+        intermediate_indices={2, 4, 6} | ores_inter,
+        bo_key=f"o_res_norm_L{layer_idx}",
+    )
+    res1 = ores_res[4].reshape(seq_len, emb_dim)
+    normed2 = ores_res[6].reshape(seq_len, emb_dim)
+
+    # ELF A2: gate → gate (arg2).
+    gate_res = cache.load_and_run(
+        "gate",
+        _gate_backend(verbose),
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 normed2
+        np.asarray(layer_weights.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),  # 1 w_gate (static)
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+        output_indices=[2],
+        static_input_indices={1},
+        intermediate_indices={2},
+        bo_key=f"gate_L{layer_idx}",
+    )
+    gate = gate_res[2].reshape(seq_len, hidden_dim)
+
+    # ELF A3: up → up (arg2).
+    up_res = cache.load_and_run(
+        "up",
+        _up_backend(verbose),
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),         # 0 normed2
+        np.asarray(layer_weights.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_up (static)
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+        output_indices=[2],
+        static_input_indices={1},
+        intermediate_indices={2},
+        bo_key=f"up_L{layer_idx}",
+    )
+    up = up_res[2].reshape(seq_len, hidden_dim)
+
+    # ELF A4: swiglu (NPU silu(gate)*up).
+    sw_res = cache.load_and_run(
+        "swiglu",
+        _swiglu_backend(verbose),
+        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),   # 0 gate
+        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),     # 1 up
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                 # 2 swiglu (out)
+        output_indices=[2],
+        intermediate_indices={2},
+        bo_key=f"swiglu_L{layer_idx}",
+    )
+    swiglu = sw_res[2].reshape(seq_len, hidden_dim)
+
+    # ELF B: down_add → output (arg4). Down GEMM is launch 0 (K=hidden NaN fix).
+    down_args = [
+        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),       # 0 swiglu
+        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),  # 1 w_down (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
+        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),            # 3 res1
+        np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+    ]
+    down_inter = set()
+    for sc, cols in zip(down_scratch, (emb_dim,)):
+        if sc is not None:
+            down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            down_inter.add(sc)
+    down_res = cache.load_and_run(
+        "down_add",
+        _down_add_backend(verbose),
+        *down_args,
+        output_indices=[4],
+        static_input_indices={1},
+        intermediate_indices={2, 4} | down_inter,
+        bo_key=f"down_add_L{layer_idx}",
+    )
+    output_bf16 = down_res[4].reshape(seq_len, emb_dim)
+    inter["ffn_out"] = output_bf16
+    return output_bf16, inter

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
@@ -12,10 +12,11 @@ build_down_add_module.
 
 Qwen2.5 deltas vs LLAMA-3.2:
 
-  1. QKV bias (attention_bias=True, the Qwen2 family). After the Q/K/V
-     projection GEMM, a per-channel bias is added on the HOST, AFTER the GEMM
-     and BEFORE RoPE (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention;
-     V is bias-added and used directly). NO QK-norm (that is Qwen3).
+  1. QKV bias (attention_bias=True, the Qwen2 family). The per-channel bias is
+     fused into the rms_qkv_bias_rope ELF on-device (bq/bk/bv passed as static
+     ELF args), applied AFTER the Q/K/V projection and BEFORE RoPE (HF Qwen2
+     order: proj -> +bias -> RoPE(Q,K) -> attention; V is bias-added and used
+     directly). NO QK-norm (that is Qwen3).
 
   2. Dims (3B): emb=2048, q_dim=2048 (16 heads x 128), kv_dim=256
      (2 heads x 128), hidden=11008, head_dim=128. o_proj is SQUARE

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
@@ -5,10 +5,11 @@
 
 Mirrors llama32_1b_weights.py with Qwen2.5 deltas:
   - QKV bias (attention_bias / Qwen2 family): q_proj.bias (q_dim,),
-    k_proj.bias (kv_dim,), v_proj.bias (kv_dim,). Applied on HOST around the
-    bias-free NPU kernels (RoPE linearity: RoPE(q+bq)=RoPE(q)+RoPE(bq)).
+    k_proj.bias (kv_dim,), v_proj.bias (kv_dim,). The bias is FUSED into the
+    NPU rms_qkv_bias_rope ELF on-device (passed as static ELF args), not
+    added on the host.
   - No QK-norm (that is Qwen3).
-  - Non-aligned dims: emb=896, hidden=4864, kv_dim=128 (2*64). head_dim=64.
+  - Dims (3B): emb=2048, hidden=11008, kv_dim=256 (2*128), head_dim=128.
   - Tied embeddings.
 
 Weight convention: HF (out,in); our GEMM y=x@W → transpose to (in,out).
@@ -31,7 +32,7 @@ class LlamaConfig:
     emb_dim: int = 2048
     n_heads: int = 16
     head_dim: int = 128
-    n_kv_heads: int = 2  # GQA: 7 Q heads per KV head
+    n_kv_heads: int = 2  # GQA: 8 Q heads per KV head (16 heads / 2 kv)
     hidden_dim: int = 11008
     vocab_size: int = 151936
     rope_base: float = 1000000.0

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
@@ -96,15 +96,23 @@ def _resolve_safetensor_files(model_path: str) -> List[str]:
     pattern_glob = "*.safetensors"
     try:
         local_dir = snapshot_download(
-            model_path, allow_patterns=["*.safetensors", "*.json"], local_files_only=True
+            model_path,
+            allow_patterns=["*.safetensors", "*.json"],
+            local_files_only=True,
         )
         if not glob_module.glob(os.path.join(local_dir, pattern_glob)):
-            raise LocalEntryNotFoundError(f"local cache for {model_path} has no .safetensors")
+            raise LocalEntryNotFoundError(
+                f"local cache for {model_path} has no .safetensors"
+            )
     except LocalEntryNotFoundError:
-        local_dir = snapshot_download(model_path, allow_patterns=["*.safetensors", "*.json"])
+        local_dir = snapshot_download(
+            model_path, allow_patterns=["*.safetensors", "*.json"]
+        )
     files = sorted(glob_module.glob(os.path.join(local_dir, pattern_glob)))
     if not files:
-        raise FileNotFoundError(f"No .safetensors files found after downloading {model_path}")
+        raise FileNotFoundError(
+            f"No .safetensors files found after downloading {model_path}"
+        )
     return files
 
 
@@ -115,7 +123,9 @@ def _load_tensor(file_handle, key: str, dtype) -> np.ndarray:
     return tensor.astype(dtype)
 
 
-def load_weights(model_name_or_path: str, dtype=bfloat16, config: Optional[LlamaConfig] = None) -> LlamaWeights:
+def load_weights(
+    model_name_or_path: str, dtype=bfloat16, config: Optional[LlamaConfig] = None
+) -> LlamaWeights:
     from safetensors import safe_open
 
     if config is None:
@@ -152,9 +162,18 @@ def load_weights(model_name_or_path: str, dtype=bfloat16, config: Optional[Llama
             layer_tensors[field_name] = tensor
 
         layer = LayerWeights(**layer_tensors)
-        assert layer.wq.shape == (config.emb_dim, qd), f"L{layer_idx} wq {layer.wq.shape}"
-        assert layer.wk.shape == (config.emb_dim, kvd), f"L{layer_idx} wk {layer.wk.shape}"
-        assert layer.wo.shape == (qd, config.emb_dim), f"L{layer_idx} wo {layer.wo.shape}"
+        assert layer.wq.shape == (
+            config.emb_dim,
+            qd,
+        ), f"L{layer_idx} wq {layer.wq.shape}"
+        assert layer.wk.shape == (
+            config.emb_dim,
+            kvd,
+        ), f"L{layer_idx} wk {layer.wk.shape}"
+        assert layer.wo.shape == (
+            qd,
+            config.emb_dim,
+        ), f"L{layer_idx} wo {layer.wo.shape}"
         assert layer.bq.shape == (qd,), f"L{layer_idx} bq {layer.bq.shape}"
         assert layer.bk.shape == (kvd,), f"L{layer_idx} bk {layer.bk.shape}"
         assert layer.bv.shape == (kvd,), f"L{layer_idx} bv {layer.bv.shape}"
@@ -174,10 +193,14 @@ def load_weights(model_name_or_path: str, dtype=bfloat16, config: Optional[Llama
         print("  Tied embeddings: reusing embed_table as lm_head.")
         lm_head = embed_table
 
-    return LlamaWeights(embed_table=embed_table, layers=layers, final_norm=final_norm, lm_head=lm_head)
+    return LlamaWeights(
+        embed_table=embed_table, layers=layers, final_norm=final_norm, lm_head=lm_head
+    )
 
 
-def generate_rope_lut(config: Optional[LlamaConfig] = None, seq_len: int = 2048, dtype=bfloat16) -> np.ndarray:
+def generate_rope_lut(
+    config: Optional[LlamaConfig] = None, seq_len: int = 2048, dtype=bfloat16
+) -> np.ndarray:
     if config is None:
         config = LlamaConfig()
     head_dim = config.head_dim
@@ -195,12 +218,17 @@ def generate_rope_lut(config: Optional[LlamaConfig] = None, seq_len: int = 2048,
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("model_path", type=str)
     args = parser.parse_args()
     config = LlamaConfig()
     w = load_weights(args.model_path, config=config)
     L0 = w.layers[0]
-    print(f"embed {w.embed_table.shape} final_norm {w.final_norm.shape} lm_head {w.lm_head.shape}")
-    print(f"L0 wq {L0.wq.shape} wk {L0.wk.shape} wo {L0.wo.shape} bq {L0.bq.shape} bk {L0.bk.shape}")
+    print(
+        f"embed {w.embed_table.shape} final_norm {w.final_norm.shape} lm_head {w.lm_head.shape}"
+    )
+    print(
+        f"L0 wq {L0.wq.shape} wk {L0.wk.shape} wo {L0.wo.shape} bq {L0.bq.shape} bk {L0.bk.shape}"
+    )
     print(f"{len(w.layers)} layers loaded.")

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_weights.py
@@ -1,0 +1,205 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen2.5-3B Weight Loader
+
+Mirrors llama32_1b_weights.py with Qwen2.5 deltas:
+  - QKV bias (attention_bias / Qwen2 family): q_proj.bias (q_dim,),
+    k_proj.bias (kv_dim,), v_proj.bias (kv_dim,). Applied on HOST around the
+    bias-free NPU kernels (RoPE linearity: RoPE(q+bq)=RoPE(q)+RoPE(bq)).
+  - No QK-norm (that is Qwen3).
+  - Non-aligned dims: emb=896, hidden=4864, kv_dim=128 (2*64). head_dim=64.
+  - Tied embeddings.
+
+Weight convention: HF (out,in); our GEMM y=x@W → transpose to (in,out).
+"""
+
+import os
+import glob as glob_module
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+
+@dataclass
+class LlamaConfig:
+    """Qwen2.5-3B hyperparameters (named LlamaConfig for downstream reuse)."""
+
+    n_layers: int = 36
+    emb_dim: int = 2048
+    n_heads: int = 16
+    head_dim: int = 128
+    n_kv_heads: int = 2  # GQA: 7 Q heads per KV head
+    hidden_dim: int = 11008
+    vocab_size: int = 151936
+    rope_base: float = 1000000.0
+    qkv_bias: bool = True
+    qk_norm: bool = False
+    tie_word_embeddings: bool = True
+    dtype: np.dtype = bfloat16
+
+
+@dataclass
+class LayerWeights:
+    attn_norm: np.ndarray  # (emb_dim,)
+    wq: np.ndarray  # (emb_dim, n_heads*head_dim)
+    wk: np.ndarray  # (emb_dim, n_kv_heads*head_dim)
+    wv: np.ndarray  # (emb_dim, n_kv_heads*head_dim)
+    wo: np.ndarray  # (n_heads*head_dim, emb_dim)
+    ffn_norm: np.ndarray  # (emb_dim,)
+    w_gate: np.ndarray  # (emb_dim, hidden_dim)
+    w_up: np.ndarray  # (emb_dim, hidden_dim)
+    w_down: np.ndarray  # (hidden_dim, emb_dim)
+    bq: np.ndarray  # (n_heads*head_dim,)   QKV bias
+    bk: np.ndarray  # (n_kv_heads*head_dim,)
+    bv: np.ndarray  # (n_kv_heads*head_dim,)
+
+
+@dataclass
+class LlamaWeights:
+    embed_table: np.ndarray
+    layers: List[LayerWeights] = field(default_factory=list)
+    final_norm: np.ndarray = None
+    lm_head: np.ndarray = None
+
+
+# (field, needs_transpose). Biases are 1-D (no transpose).
+_HF_LAYER_MAP = {
+    "input_layernorm.weight": ("attn_norm", False),
+    "self_attn.q_proj.weight": ("wq", True),
+    "self_attn.k_proj.weight": ("wk", True),
+    "self_attn.v_proj.weight": ("wv", True),
+    "self_attn.o_proj.weight": ("wo", True),
+    "self_attn.q_proj.bias": ("bq", False),
+    "self_attn.k_proj.bias": ("bk", False),
+    "self_attn.v_proj.bias": ("bv", False),
+    "post_attention_layernorm.weight": ("ffn_norm", False),
+    "mlp.gate_proj.weight": ("w_gate", True),
+    "mlp.up_proj.weight": ("w_up", True),
+    "mlp.down_proj.weight": ("w_down", True),
+}
+
+
+def _resolve_safetensor_files(model_path: str) -> List[str]:
+    if os.path.isdir(model_path):
+        files = sorted(glob_module.glob(os.path.join(model_path, "*.safetensors")))
+        if not files:
+            raise FileNotFoundError(f"No .safetensors files found in {model_path}")
+        return files
+
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    pattern_glob = "*.safetensors"
+    try:
+        local_dir = snapshot_download(
+            model_path, allow_patterns=["*.safetensors", "*.json"], local_files_only=True
+        )
+        if not glob_module.glob(os.path.join(local_dir, pattern_glob)):
+            raise LocalEntryNotFoundError(f"local cache for {model_path} has no .safetensors")
+    except LocalEntryNotFoundError:
+        local_dir = snapshot_download(model_path, allow_patterns=["*.safetensors", "*.json"])
+    files = sorted(glob_module.glob(os.path.join(local_dir, pattern_glob)))
+    if not files:
+        raise FileNotFoundError(f"No .safetensors files found after downloading {model_path}")
+    return files
+
+
+def _load_tensor(file_handle, key: str, dtype) -> np.ndarray:
+    tensor = file_handle.get_tensor(key)
+    if hasattr(tensor, "numpy"):
+        tensor = tensor.numpy()
+    return tensor.astype(dtype)
+
+
+def load_weights(model_name_or_path: str, dtype=bfloat16, config: Optional[LlamaConfig] = None) -> LlamaWeights:
+    from safetensors import safe_open
+
+    if config is None:
+        config = LlamaConfig()
+
+    safetensor_files = _resolve_safetensor_files(model_name_or_path)
+    key_to_file = {}
+    for filepath in safetensor_files:
+        with safe_open(filepath, framework="numpy") as f:
+            for key in f.keys():
+                key_to_file[key] = filepath
+
+    embed_key = "model.embed_tokens.weight"
+    if embed_key not in key_to_file:
+        raise KeyError(f"Missing weight: {embed_key}")
+    with safe_open(key_to_file[embed_key], framework="numpy") as f:
+        embed_table = _load_tensor(f, embed_key, dtype)
+    assert embed_table.shape == (config.vocab_size, config.emb_dim), embed_table.shape
+
+    qd = config.n_heads * config.head_dim
+    kvd = config.n_kv_heads * config.head_dim
+
+    layers = []
+    for layer_idx in range(config.n_layers):
+        layer_tensors = {}
+        for hf_suffix, (field_name, needs_transpose) in _HF_LAYER_MAP.items():
+            hf_key = f"model.layers.{layer_idx}.{hf_suffix}"
+            if hf_key not in key_to_file:
+                raise KeyError(f"Missing weight for layer {layer_idx}: {hf_key}")
+            with safe_open(key_to_file[hf_key], framework="numpy") as f:
+                tensor = _load_tensor(f, hf_key, dtype)
+            if needs_transpose:
+                tensor = np.ascontiguousarray(tensor.T)
+            layer_tensors[field_name] = tensor
+
+        layer = LayerWeights(**layer_tensors)
+        assert layer.wq.shape == (config.emb_dim, qd), f"L{layer_idx} wq {layer.wq.shape}"
+        assert layer.wk.shape == (config.emb_dim, kvd), f"L{layer_idx} wk {layer.wk.shape}"
+        assert layer.wo.shape == (qd, config.emb_dim), f"L{layer_idx} wo {layer.wo.shape}"
+        assert layer.bq.shape == (qd,), f"L{layer_idx} bq {layer.bq.shape}"
+        assert layer.bk.shape == (kvd,), f"L{layer_idx} bk {layer.bk.shape}"
+        assert layer.bv.shape == (kvd,), f"L{layer_idx} bv {layer.bv.shape}"
+        layers.append(layer)
+
+    norm_key = "model.norm.weight"
+    with safe_open(key_to_file[norm_key], framework="numpy") as f:
+        final_norm = _load_tensor(f, norm_key, dtype)
+    assert final_norm.shape == (config.emb_dim,)
+
+    lm_head_key = "lm_head.weight"
+    if lm_head_key in key_to_file:
+        with safe_open(key_to_file[lm_head_key], framework="numpy") as f:
+            lm_head = _load_tensor(f, lm_head_key, dtype)
+        assert lm_head.shape == (config.vocab_size, config.emb_dim)
+    else:
+        print("  Tied embeddings: reusing embed_table as lm_head.")
+        lm_head = embed_table
+
+    return LlamaWeights(embed_table=embed_table, layers=layers, final_norm=final_norm, lm_head=lm_head)
+
+
+def generate_rope_lut(config: Optional[LlamaConfig] = None, seq_len: int = 2048, dtype=bfloat16) -> np.ndarray:
+    if config is None:
+        config = LlamaConfig()
+    head_dim = config.head_dim
+    half = head_dim // 2
+    theta = config.rope_base
+    dim_indices = np.arange(0, head_dim, 2, dtype=np.float64)
+    inv_freq = 1.0 / (theta ** (dim_indices / head_dim))
+    positions = np.arange(seq_len, dtype=np.float64)
+    angles = np.outer(positions, inv_freq)
+    lut = np.empty((seq_len, head_dim), dtype=np.float64)
+    lut[:, :half] = np.cos(angles)
+    lut[:, half:] = np.sin(angles)
+    return lut.astype(dtype)
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_path", type=str)
+    args = parser.parse_args()
+    config = LlamaConfig()
+    w = load_weights(args.model_path, config=config)
+    L0 = w.layers[0]
+    print(f"embed {w.embed_table.shape} final_norm {w.final_norm.shape} lm_head {w.lm_head.shape}")
+    print(f"L0 wq {L0.wq.shape} wk {L0.wk.shape} wo {L0.wo.shape} bq {L0.bq.shape} bk {L0.bk.shape}")
+    print(f"{len(w.layers)} layers loaded.")

--- a/programming_examples/llms/qwen25_3b/requirements.txt
+++ b/programming_examples/llms/qwen25_3b/requirements.txt
@@ -1,4 +1,4 @@
-# Additional Python packages for the LLAMA-3.2-1B example.
+# Additional Python packages for the Qwen2.5-3B example.
 #
 # These are *on top of* the mlir-air base environment (which already
 # provides numpy, ml_dtypes, filelock, pyxrt, etc.).
@@ -6,13 +6,14 @@
 # Install with:
 #     pip install -r requirements.txt
 #
-# After this, you still need a one-time HuggingFace setup:
-#   1. Accept Meta's license at:
-#        https://huggingface.co/meta-llama/Llama-3.2-1B
-#        https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
-#   2. Create a read token at https://huggingface.co/settings/tokens
-#   3. `huggingface-cli login`  (or export HF_TOKEN=<token>)
-# See README.md / docs/usage.md for details.
+# Qwen2.5-3B is openly licensed; no license acceptance is needed. Weights
+# download from the public HuggingFace repos on first use:
+#        https://huggingface.co/Qwen/Qwen2.5-3B
+#        https://huggingface.co/Qwen/Qwen2.5-3B-Instruct
+# For gated/private mirrors or to avoid rate limits, optionally authenticate:
+#   1. Create a read token at https://huggingface.co/settings/tokens
+#   2. `huggingface-cli login`  (or export HF_TOKEN=<token>)
+# See README.md for details.
 
 # Weight loading
 safetensors

--- a/programming_examples/llms/qwen25_3b/requirements.txt
+++ b/programming_examples/llms/qwen25_3b/requirements.txt
@@ -1,0 +1,23 @@
+# Additional Python packages for the LLAMA-3.2-1B example.
+#
+# These are *on top of* the mlir-air base environment (which already
+# provides numpy, ml_dtypes, filelock, pyxrt, etc.).
+#
+# Install with:
+#     pip install -r requirements.txt
+#
+# After this, you still need a one-time HuggingFace setup:
+#   1. Accept Meta's license at:
+#        https://huggingface.co/meta-llama/Llama-3.2-1B
+#        https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
+#   2. Create a read token at https://huggingface.co/settings/tokens
+#   3. `huggingface-cli login`  (or export HF_TOKEN=<token>)
+# See README.md / docs/usage.md for details.
+
+# Weight loading
+safetensors
+huggingface_hub
+
+# Tokenizer (chat template) and HuggingFace reference model (used by `make verify`)
+transformers
+torch

--- a/programming_examples/llms/qwen25_3b/run_npu2_compile.lit
+++ b/programming_examples/llms/qwen25_3b/run_npu2_compile.lit
@@ -1,0 +1,20 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B compile-only smoke test: builds every prefill + decode kernel ELF
+// through the AIR -> AIE -> aiecc -> Peano pipeline. No NPU dispatch, no
+// HuggingFace download.
+//
+// NOT CI-triggered by design: the filename OMITS "peano", so the CI peano
+// suite (`lit --filter "peano"`) does not collect it — llama32_1b's compile
+// lit is the bf16 prefill/decode CI signal; this example shares the same
+// shared/builders + shared/infra assembly. Run on demand:
+//   lit -v programming_examples/llms/qwen25_3b/run_npu2_compile.lit
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_compile
+// RUN: cd test_peano_compile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Compilation passed.

--- a/programming_examples/llms/qwen25_3b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_3b/run_npu2_verify.lit
@@ -1,0 +1,17 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B verify gate: top-k token-level inclusion check, NPU vs HF bf16,
+// 2 prompts × 32 greedy tokens, k=5 (fast CI gate; use `make verify-full` for
+// the full sweep locally). Exercises the full production prefill + decode path
+// through the verify subsystem (verify/verify_runner.py).
+//
+// Skips cleanly when HF_TOKEN is unset (model downloads require it).
+//
+// REQUIRES: ryzen_ai_npu2, peano, hf_token
+//
+// RUN: mkdir -p test_peano_verify
+// RUN: cd test_peano_verify
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: [verify] PASS

--- a/programming_examples/llms/qwen25_3b/verify_adapter.py
+++ b/programming_examples/llms/qwen25_3b/verify_adapter.py
@@ -70,7 +70,9 @@ def build_config():
     return LlamaConfig()
 
 
-def build_runner(model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False):
+def build_runner(
+    model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False
+):
     weights = load_weights(model_name, config=config)
     return NpuRunner(
         weights=weights,
@@ -87,7 +89,9 @@ class NpuRunner:
 
     name = "npu_bf16"
 
-    def __init__(self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False):
+    def __init__(
+        self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False
+    ):
         self.weights = weights
         self.config = config
         self.max_seq = max_seq
@@ -96,16 +100,25 @@ class NpuRunner:
         self.lite_mode = lite_mode
         self._tokenizer = tokenizer
 
-        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(bfloat16)
+        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(
+            bfloat16
+        )
 
         _cache_root = _THIS_DIR / "verify_kernel_cache"
         self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
-        compile_prefill_kernels(self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn)
+        compile_prefill_kernels(
+            self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn
+        )
         self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
         compile_decode_kernels(self.decode_cache, config)
 
         prepare_runtime(
-            self.prefill_cache, self.decode_cache, weights, config, max_seq, self.rope_lut_bf16
+            self.prefill_cache,
+            self.decode_cache,
+            weights,
+            config,
+            max_seq,
+            self.rope_lut_bf16,
         )
 
         self.k_cache = None
@@ -118,9 +131,17 @@ class NpuRunner:
         else:
             padded = list(prompt_tokens)[: self.max_seq]
         prefill_token, logits_row, k_cache, v_cache, prompt_len = run_npu_prefill(
-            padded, self.weights, self.config, self.prefill_cache, self.decode_cache,
-            self.rope_lut_bf16, self.max_seq, tokenizer=self._tokenizer,
-            cpu_attn=self.cpu_attn, profile=False, quiet=True,
+            padded,
+            self.weights,
+            self.config,
+            self.prefill_cache,
+            self.decode_cache,
+            self.rope_lut_bf16,
+            self.max_seq,
+            tokenizer=self._tokenizer,
+            cpu_attn=self.cpu_attn,
+            profile=False,
+            quiet=True,
         )
         self.k_cache = k_cache
         self.v_cache = v_cache
@@ -146,8 +167,14 @@ class NpuRunner:
         layer_intermediates = []
         for li in range(cfg.n_layers):
             x, ints = run_prefill_block(
-                x, self.weights.layers[li], self.rope_lut_bf16, cfg,
-                self.prefill_cache, layer_idx=li, cpu_attn=self.cpu_attn, verbose=False,
+                x,
+                self.weights.layers[li],
+                self.rope_lut_bf16,
+                cfg,
+                self.prefill_cache,
+                layer_idx=li,
+                cpu_attn=self.cpu_attn,
+                verbose=False,
             )
             fo_full = np.asarray(ints["ffn_out"])
             layer_intermediates.append({"ffn_out": fo_full[:prompt_len]})
@@ -165,7 +192,13 @@ class NpuRunner:
     def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
         x = self.weights.embed_table[input_token].astype(bfloat16)
         next_token, logits = run_npu_decode_step(
-            x, self.weights, self.config, self.decode_cache, self.rope_lut_bf16,
-            self.k_cache, self.v_cache, current_pos,
+            x,
+            self.weights,
+            self.config,
+            self.decode_cache,
+            self.rope_lut_bf16,
+            self.k_cache,
+            self.v_cache,
+            current_pos,
         )
         return DecodeStepRecord(lm_head_logits=logits, top1_token=next_token)

--- a/programming_examples/llms/qwen25_3b/verify_adapter.py
+++ b/programming_examples/llms/qwen25_3b/verify_adapter.py
@@ -104,12 +104,16 @@ class NpuRunner:
             bfloat16
         )
 
-        _cache_root = _THIS_DIR / "verify_kernel_cache"
-        self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
+        _cache_root = _THIS_DIR / "build_peano"
+        self.prefill_cache = KernelCache(
+            str(_cache_root / "prefill_kernel_cache"), verbose=False
+        )
         compile_prefill_kernels(
             self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn
         )
-        self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
+        self.decode_cache = KernelCache(
+            str(_cache_root / "decode_kernel_cache"), verbose=False
+        )
         compile_decode_kernels(self.decode_cache, config)
 
         prepare_runtime(

--- a/programming_examples/llms/qwen25_3b/verify_adapter.py
+++ b/programming_examples/llms/qwen25_3b/verify_adapter.py
@@ -92,7 +92,7 @@ class NpuRunner:
         self.config = config
         self.max_seq = max_seq
         self.npu_attn = npu_attn
-        self.cpu_attn = not npu_attn  # Qwen2.5 prefill attention is CPU.
+        self.cpu_attn = not npu_attn  # NPU FlashAttention by default (npu_attn=True).
         self.lite_mode = lite_mode
         self._tokenizer = tokenizer
 

--- a/programming_examples/llms/qwen25_3b/verify_adapter.py
+++ b/programming_examples/llms/qwen25_3b/verify_adapter.py
@@ -1,0 +1,171 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Verify adapter for the bf16 Qwen2.5-3B example.
+
+Wraps the production `qwen25_3b_inference` driver into a Runner that
+satisfies `verify/runners/base.Runner`. The shared verify framework
+imports this via `--runner=qwen25_3b.verify_adapter`.
+
+Qwen2.5-3B has separate base ("Qwen/Qwen2.5-3B") and instruct
+("Qwen/Qwen2.5-3B-Instruct") checkpoints; DEFAULT_MODEL is instruct.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LLMS_DIR = _THIS_DIR.parent
+_VERIFY = _LLMS_DIR / "verify"
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_THIS_DIR)):
+    while _p in sys.path:
+        sys.path.remove(_p)
+    sys.path.insert(0, _p)
+
+from shared.infra.cache import KernelCache  # noqa: E402
+from qwen25_3b_prefill import (  # noqa: E402
+    compile_all_kernels as compile_prefill_kernels,
+    run_transformer_block_qwen25 as run_prefill_block,
+)
+from qwen25_3b_decode import compile_decode_kernels  # noqa: E402
+from qwen25_3b_inference import (  # noqa: E402
+    prepare_runtime,
+    run_npu_prefill,
+    run_npu_decode_step,
+)
+from qwen25_3b_weights import (  # noqa: E402
+    LlamaConfig,
+    load_weights,
+    generate_rope_lut,
+)
+from qwen25_3b_cpu_helpers import rms_norm  # noqa: E402
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+
+# Qwen2.5 has distinct base + instruct checkpoints.
+MODEL_CHOICES = {
+    "base": "Qwen/Qwen2.5-3B",
+    "instruct": "Qwen/Qwen2.5-3B-Instruct",
+}
+DEFAULT_MODEL = "instruct"
+
+EPS = 1e-6
+
+
+def resolve_model(model_choice_or_id: str) -> str:
+    return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
+
+
+def hf_reference(npu_model_name: str) -> str:
+    """bf16 baseline is its own reference (NPU bf16 vs HF bf16)."""
+    return npu_model_name
+
+
+def build_config():
+    return LlamaConfig()
+
+
+def build_runner(model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False):
+    weights = load_weights(model_name, config=config)
+    return NpuRunner(
+        weights=weights,
+        config=config,
+        max_seq=max_seq,
+        tokenizer=tokenizer,
+        npu_attn=npu_attn,
+        lite_mode=lite_mode,
+    )
+
+
+class NpuRunner:
+    """Adapter over the bf16 production NPU prefill + decode functions."""
+
+    name = "npu_bf16"
+
+    def __init__(self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False):
+        self.weights = weights
+        self.config = config
+        self.max_seq = max_seq
+        self.npu_attn = npu_attn
+        self.cpu_attn = not npu_attn  # Qwen2.5 prefill attention is CPU.
+        self.lite_mode = lite_mode
+        self._tokenizer = tokenizer
+
+        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(bfloat16)
+
+        _cache_root = _THIS_DIR / "verify_kernel_cache"
+        self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
+        compile_prefill_kernels(self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn)
+        self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
+        compile_decode_kernels(self.decode_cache, config)
+
+        prepare_runtime(
+            self.prefill_cache, self.decode_cache, weights, config, max_seq, self.rope_lut_bf16
+        )
+
+        self.k_cache = None
+        self.v_cache = None
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        eos = self._tokenizer.eos_token_id
+        if len(prompt_tokens) < self.max_seq:
+            padded = list(prompt_tokens) + [eos] * (self.max_seq - len(prompt_tokens))
+        else:
+            padded = list(prompt_tokens)[: self.max_seq]
+        prefill_token, logits_row, k_cache, v_cache, prompt_len = run_npu_prefill(
+            padded, self.weights, self.config, self.prefill_cache, self.decode_cache,
+            self.rope_lut_bf16, self.max_seq, tokenizer=self._tokenizer,
+            cpu_attn=self.cpu_attn, profile=False, quiet=True,
+        )
+        self.k_cache = k_cache
+        self.v_cache = v_cache
+
+        if self.lite_mode:
+            empty = np.empty((0,), dtype=np.float32)
+            return PrefillRecord(
+                layer_intermediates=[],
+                final_hidden_normed=empty,
+                logits_at_pred=logits_row,
+                top1_token=prefill_token,
+            )
+
+        # Diagnosis-only: re-run the prefill layer loop capturing per-layer
+        # ffn_out + final post-norm hidden state.
+        cfg = self.config
+        if len(prompt_tokens) < self.max_seq:
+            pad = np.zeros(self.max_seq - len(prompt_tokens), dtype=prompt_tokens.dtype)
+            padded_diag = np.concatenate([prompt_tokens, pad])
+        else:
+            padded_diag = prompt_tokens[: self.max_seq]
+        x = self.weights.embed_table[padded_diag].astype(np.float32).astype(bfloat16)
+        layer_intermediates = []
+        for li in range(cfg.n_layers):
+            x, ints = run_prefill_block(
+                x, self.weights.layers[li], self.rope_lut_bf16, cfg,
+                self.prefill_cache, layer_idx=li, cpu_attn=self.cpu_attn, verbose=False,
+            )
+            fo_full = np.asarray(ints["ffn_out"])
+            layer_intermediates.append({"ffn_out": fo_full[:prompt_len]})
+
+        x_full_f32 = np.asarray(x, dtype=np.float32)[:prompt_len]
+        x_full_normed = rms_norm(x_full_f32, self.weights.final_norm, eps=EPS)
+
+        return PrefillRecord(
+            layer_intermediates=layer_intermediates,
+            final_hidden_normed=x_full_normed.astype(np.float32),
+            logits_at_pred=logits_row,
+            top1_token=prefill_token,
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        x = self.weights.embed_table[input_token].astype(bfloat16)
+        next_token, logits = run_npu_decode_step(
+            x, self.weights, self.config, self.decode_cache, self.rope_lut_bf16,
+            self.k_cache, self.v_cache, current_pos,
+        )
+        return DecodeStepRecord(lm_head_logits=logits, top1_token=next_token)

--- a/programming_examples/llms/qwen3_4b/.gitignore
+++ b/programming_examples/llms/qwen3_4b/.gitignore
@@ -4,7 +4,6 @@ build_chess/
 __pycache__/
 *.pyc
 kernel_cache/
-verify_kernel_cache/
 air_project/
 .debug/
 .pytest_cache/

--- a/programming_examples/llms/qwen3_4b/.gitignore
+++ b/programming_examples/llms/qwen3_4b/.gitignore
@@ -1,0 +1,32 @@
+# Build / kernel cache artifacts
+build_peano/
+build_chess/
+__pycache__/
+*.pyc
+kernel_cache/
+verify_kernel_cache/
+air_project/
+.debug/
+.pytest_cache/
+
+# Stray artifacts from running scripts outside build_*/ (xrt.py + external_kernels.py
+# write these to CWD by design — `make compile/run/verify` cd into BUILD_DIR first,
+# but ad-hoc `python3 verify/verify_runner.py` from this dir will leak them here).
+air.mlir
+air.elf
+air.xclbin
+air.insts.bin
+*.o
+
+# Local-only experimental and ad-hoc test directories
+test_swiglu/
+test_swiglu_llama/
+test_swiglu_2048/
+flash_attn_issue/
+
+# Dev-only docs and artifacts (kept locally for development reference;
+# excluded from upstream PR to keep the example focused).
+docs/development_progress/
+docs/report/
+docs/issues/
+test_hf_model/

--- a/programming_examples/llms/qwen3_4b/ARCHITECTURE.md
+++ b/programming_examples/llms/qwen3_4b/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# Qwen3-4B BF16 Inference — Architecture
+
+Companion to [README.md](README.md). Built kernel-first on the shared LLM infra
+(`../shared/`, `../verify/`) and the `../qwen3_0_6b/` (Qwen3 QK-norm + decoupled
+O) + `../qwen25_3b/` (large-hidden un-merge) exemplars. The widest+deepest model
+in the set: 36 layers, q_dim=4096, hidden=9728. Its prefill has the most NPU
+ELFs/layer (**7**) of any model here.
+
+## Model Config
+
+36 layers, emb_dim=2560, n_heads=32, head_dim=128, n_kv_heads=8 (GQA group=4),
+q_dim=4096 (decoupled, ≠ emb), kv_dim=1024, hidden_dim=9728, vocab_size=151936,
+BF16, rope_theta=1000000, eps=1e-6, tied embeddings, **per-head QK-norm** (no
+bias).
+
+Topology: **Qwen3, SwiGLU on NPU, O+FFN un-merged** (hidden=9728 large/non-1024
+→ separate gate/up/down ELFs; SwiGLU is its own NPU ELF). Gate/Up use the
+registry **fused-cast high-precision** GEMM (tile_k_l2=64 keeps the f32-out
+B-tile DMA stride within the AIE limit at N=9728 → 5528 GFLOP/s, mean_rel_L1
+9.8e-3). head_dim=128 → head-first FlashAttention.
+
+## Per-Layer Kernel Sequence
+
+**Prefill — 7 NPU ELFs/layer:**
+
+```
+x ─[NPU elf:rms_qkv_qknorm_rope]   FUSED, 8 launches, 1 ELF
+      { RMSNorm + Q/K/V GEMM + QK-norm(Q) + QK-norm(K) + RoPE-Q + RoPE-K }
+      QK-norm = per-head RMSNorm over head_dim=128, eps=1e-6
+      → q_roped[seq,4096], k_roped[seq,1024], v[seq,1024]
+  ─[NPU elf:flash_attn]   npu_fa_headfirst (head-first, dv_chunks=2, hd=128)
+      (HOST) seq→head transpose → NPU FA → (HOST) head→seq transpose → attn_out[seq,4096]
+  ─[NPU elf:o_res_norm]   { O GEMM (decoupled 4096→2560) + Add + RMSNorm }
+  ─[NPU elf:gate]{Gate GEMM} → [NPU elf:up]{Up GEMM}
+  ─[NPU elf:swiglu]       { SwiGLU }   (NPU SwiGLU, tile_n=4864)
+  ─[NPU elf:down_add]     { Down GEMM (K=9728, launch 0) + Add } → layer_out[seq,2560]
+once: (HOST) final RMSNorm → [NPU elf:lm_head_gemv] (19 partitions ×8192, vocab 151936)
+```
+
+Prefill is 7 NPU dispatches/layer: `rms_qkv_qknorm_rope`, `flash_attn`,
+`o_res_norm`, `gate`, `up`, `swiglu`, `down_add` — the most of any model here,
+because hidden=9728 forces a full O+FFN un-merge AND SwiGLU is its own ELF.
+
+**Decode — 5 NPU ELFs/layer (+ lm_head once/token):**
+
+```
+x ─[NPU elf:rms_qkv_qknorm_rope_gemv]   FUSED, 1 ELF
+      { RMSNorm + Q/K/V GEMV + QK-norm(Q,K) + RoPE-Q/K }   (RoPE LUT per-position, NOT static)
+  (HOST) KV-cache write → (HOST) decode_attention_cpu
+  ─[NPU elf:o_gemv]{O} → (HOST) Add + RMSNorm
+  ─[NPU elf:gate_gemv] → [NPU elf:up_gemv] → (HOST) SwiGLU
+  ─[NPU elf:down_gemv]{Down}   ← MOVED TO NPU (omit_pingpong=all + dedicated down_mv.o, m_input=2)
+  → (HOST) Add → layer_out[2560]
+once: (HOST) final RMSNorm → [NPU elf:lm_head_gemv]
+```
+
+## NPU vs CPU Mapping
+
+**On NPU (all heavy compute):** every GEMM / GEMV (Q/K/V, O, Gate, Up, Down,
+LM-head), RMSNorm, **per-head QK-norm**, RoPE, prefill FlashAttention, **prefill
+SwiGLU** (standalone NPU ELF, tile_n=4864 — moved CPU→NPU; together with the
+Gate/Up fused-cast switch, prefill TTFT 12.0s→5.45s). **Decode Down GEMV (K=9728) is on NPU** (dedicated
+`down_mv.o`, `m_input=2` to keep the push_queue repeat ≤255). All four decode
+projections are NPU GEMV ELFs.
+
+**On CPU (cheap glue + one transpose, evidence-backed):**
+- **Head-first FA seq↔head transpose** (prefill, hd=128): BF16 DMA stride-1
+  requirement + seq-first `dk_chunks>1` upstream FA bug.
+- **Decode attention** (single token): NPU FA launch overhead > compute.
+- **Decode residual Add / FFN RMSNorm / SwiGLU** (M=1): dispatch > compute.
+- **Final RMSNorm / KV-cache write / embed lookup**: single-row dispatch >
+  compute.
+
+Decode cannot reach the lean fused 2-ELF cascade: emb=2560 (≥ 2560) needs
+n_cascade ≥ 5 cascade stages, but each stage needs one **core row** and the
+device has only **4 core rows** → n_cascade ≤ 4 ceiling. So decode stays at 5
+standalone GEMV ELFs. Decode is NPU-compute-bound anyway.
+
+## Runtime Flow
+
+```
+build_session → prepare_runtime()   ← one-time (~18 s), OUTSIDE timed region
+  · load weights, transpose decode GEMV weights, tag per-layer index
+  · preload_prefill_weights → static weight BOs; preload decode + LM-head BOs
+  ↓
+run_once():  prefill (36 layers × 7 ELFs + final RMSNorm + LM-head)   ← TTFT clock
+  ↓
+generate() decode loop:  per token 36 layers × 5 ELFs + LM-head GEMV  ← TPOT clock
+```
+
+`static_input_indices` + per-layer `bo_key` skip every timed weight write
+(profile: 0 weight bytes on prefill, 0.0 MB/call on decode). RoPE LUT
+position-dependent → NON-static.
+
+## Key Design Patterns / Deltas
+
+- **Per-head QK-norm fused into `rms_qkv_qknorm_rope`** — the Qwen3 delta.
+- **Decoupled O-projection** (q_dim=4096 ≠ emb=2560) → O GEMM is 4096→2560, the
+  largest non-square O in the set.
+- **7-ELF prefill** — the most of any model here: hidden=9728 forces a full
+  O+FFN un-merge (separate gate/up/down ELFs), plus SwiGLU is its own NPU ELF.
+  Gate/Up DO fuse-cast (high-prec) at N=9728 by using tile_k_l2=64, which keeps
+  the f32-out B-tile DMA stride under the AIE `[1:1048576]` limit (tile_k_l2≥128
+  would overflow it).
+- **head_dim=128 → head-first FlashAttention** (dv_chunks=2) + host transposes.
+- **Decode Down GEMV on NPU** (dedicated `down_mv.o`, m_input=2).
+- **emb=2560=512×5**, **hidden=9728=512×19** → 512-aligned (not 1024); proj N
+  divisible by 4·TILE_N=512 → stock TILE_N=128 HERD_N=4 placement.
+- **Multi-launch ELF + text-based MLIR stitching** (shared infra).

--- a/programming_examples/llms/qwen3_4b/Makefile
+++ b/programming_examples/llms/qwen3_4b/Makefile
@@ -1,0 +1,93 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen3-4B BF16 Inference on NPU2 (MLIR-AIR)
+#
+# Quick start:
+#   make compile        — Compile all kernels (cached to disk)
+#   make run            — Run inference: NPU prefill + NPU decode
+#   make profile        — Run with per-kernel profiling breakdown
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Build directory
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+# Configurable parameters
+N_TOKENS ?= 1000
+PROMPT   ?= What is the capital of France?
+MODEL    ?= instruct
+
+.PHONY: help compile run profile chat verify verify-full diagnosis all clean
+
+help:
+	@echo "============================================================"
+	@echo " Qwen3-4B Inference on NPU2 (MLIR-AIR)"
+	@echo "============================================================"
+	@echo ""
+	@echo "Quick start:"
+	@echo "  make compile          Compile all kernels (one-time, cached)"
+	@echo "  make run              Run inference ($(N_TOKENS) tokens)"
+	@echo "  make chat             Interactive chat REPL (streaming output)"
+	@echo "  make profile          Run with profiling breakdown"
+	@echo ""
+	@echo "More targets:"
+	@echo "  make verify           Top-k token-level inclusion gate vs HF bf16 (2 prompts × 32 tokens, k=5) — fast CI gate"
+	@echo "  make verify-full      Same as above but runs the full prompt set (longer, exhaustive)"
+	@echo "  make diagnosis        Per-layer ffn_out cosine + max_abs vs HF bf16 (single prompt, informational)"
+	@echo ""
+	@echo "Maintenance:"
+	@echo "  make clean            Remove all build artifacts and verify reports"
+
+## Compile all kernels
+compile:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py --compile-only
+
+## Run unified inference
+run:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
+
+## Run with detailed profiling breakdown
+profile:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
+
+## Interactive chat
+chat:
+	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
+
+all: compile profile
+
+VERIFY_RUNNER = $(srcdir)/../verify/verify_runner.py
+RUNNER_ADAPTER = qwen3_4b.verify_adapter
+
+## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
+verify:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL) --max-prompts 2
+
+## Full-sweep variant of `make verify`.
+verify-full:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL)
+
+## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
+diagnosis:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
+
+## Remove all build artifacts and verify reports
+clean:
+	rm -r $(BUILD_DIR) 2>/dev/null || true
+	rm -rf $(srcdir)/../verify/reports
+	@echo "Build directory and verify/reports/ removed. Run 'make compile' to rebuild."

--- a/programming_examples/llms/qwen3_4b/README.md
+++ b/programming_examples/llms/qwen3_4b/README.md
@@ -1,0 +1,86 @@
+# Qwen3-4B BF16 Inference on AMD NPU2 (MLIR-AIR)
+
+End-to-end Qwen3-4B (4B parameter, BF16) inference running on AMD NPU2 (AIE2P)
+hardware via MLIR-AIR. Supports both prefill (seq_len=2048) and autoregressive
+decode with a KV cache. Built kernel-first on the shared LLM infrastructure
+(`../shared/`, `../verify/`) and the `../qwen3_0_6b/` (Qwen3 per-head QK-norm +
+decoupled O) and `../qwen25_3b/` (large-hidden un-merge) exemplars; the
+Qwen3-4B-specific deltas (emb=2560, q_dim=4096 decoupled, hidden=9728, 36 layers
+— the widest+deepest in this set) are handled in the prefill / decode block
+runners.
+
+## Performance
+
+Measured on NPU2 (AIE2P), `make profile N_TOKENS=32`, 2026-06-28.
+
+| Phase | Measured | Notes |
+|-------|----------|-------|
+| Prefill / TTFT (2048 tokens) | **5.45 s wall** | head_dim=128 → host head-first FA seq↔head transpose included in wall; Gate/Up use registry fused-cast high-prec |
+| Decode / TPOT (steady-state) | **3.5 tok/s** | 36 layers, NPU-compute-bound; full decode O+FFN on NPU |
+
+## Model Config
+
+36 layers, emb_dim=2560, n_heads=32, head_dim=128, n_kv_heads=8 (GQA group=4),
+q_dim=4096 (decoupled, ≠ emb), kv_dim=1024, hidden_dim=9728, vocab_size=151936,
+BF16, rope_theta=1000000, eps=1e-6, tied embeddings (lm_head = embed_tokens),
+**per-head QK-norm** (RMSNorm over head_dim before RoPE — the key Qwen3 delta
+vs Llama).
+
+## Prerequisites
+
+1. **MLIR-AIR base environment** — AMD NPU2 hardware, Peano compiler, the
+   project's standard env: `source utils/env_setup.sh ...`
+
+2. **Extra Python packages** (on top of the base):
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Installs `safetensors`, `huggingface_hub`, `transformers`, and `torch`
+   (used by `make verify` for the HuggingFace bf16 reference comparison).
+
+3. **HuggingFace model access** (one-time):
+   - Qwen3-4B is openly licensed: https://huggingface.co/Qwen/Qwen3-4B
+   - Weights (~8 GB) are auto-downloaded on the first `make run` and cached
+     under `~/.cache/huggingface/hub/`.
+
+## Quick Start
+
+```bash
+# One-time: compile all kernels (cached to disk)
+make compile
+
+# Run inference (instruct model by default; up to 1000 tokens, stops early on EOT)
+make run
+
+# Custom prompt / token budget
+make run PROMPT="How does photosynthesis work?" N_TOKENS=64
+
+# Run with profiling breakdown (per-kernel + per-phase)
+make profile
+
+# Top-k token-level correctness gate (NPU bf16 vs HF transformers bf16,
+# 2 prompts × 32 greedy tokens, k=5) — the production-readiness gate
+make verify
+
+# Per-layer cosine diagnosis lens (informational, single prompt)
+make diagnosis
+```
+
+## Verification
+
+`make verify` is the PASS/FAIL gate: it greedily decodes 32 tokens on the NPU
+and on HF transformers (bf16) for each prompt and checks that every NPU token is
+in HF's top-5 set at that position. Current status: **PASS, exit 0, 2/2 prompts**.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `qwen3_4b_inference.py` | Unified driver: `prepare_runtime` + prefill + decode loop + LM-head |
+| `qwen3_4b_prefill.py` | Prefill builders, `run_transformer_block_qwen3`, `preload_prefill_weights` |
+| `qwen3_4b_decode.py` | Decode builders, `run_decode_block`, per-stage backends, LM-head partitioning |
+| `qwen3_4b_weights.py` | HF safetensors loader (q_norm/k_norm, tied lm_head, rope LUT) |
+| `qwen3_4b_cpu_helpers.py` | NumPy helpers shared by production + verify: `rms_norm`, `qk_norm_per_head`, `attention_reference`, `softmax` |
+| `verify_adapter.py` | Hooks this model's prefill/decode into the shared `../verify/` subsystem |
+| `Makefile` | compile / run / profile / chat / verify / verify-full / diagnosis / clean |
+| `ARCHITECTURE.md` | Per-layer kernel sequence, NPU/CPU mapping, runtime flow, deltas |

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_cpu_helpers.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_cpu_helpers.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Small NumPy CPU helpers shared by production prefill/decode + verify.
+
+Mirrors llama32_1b_cpu_helpers.py. Kept helpers are the ones production
+prefill/decode import at runtime:
+
+  - rms_norm           : LM-head GEMV final-norm + (Qwen3) QK-norm building block.
+  - qk_norm_per_head   : Qwen3 per-head RMSNorm over head_dim, applied to Q and K
+                         after projection and before RoPE.
+  - attention_reference: prefill cpu_attn=True fallback (full GQA attention in F32).
+  - softmax            : used by attention_reference.
+"""
+
+import numpy as np
+
+
+def rms_norm(x, weight, eps=1e-6):
+    """RMS normalization: x / sqrt(mean(x^2) + eps) * weight.
+
+    Qwen3 uses eps=1e-6 (rms_norm_eps in config.json).
+    """
+    x = np.asarray(x, dtype=np.float32)
+    weight = np.asarray(weight, dtype=np.float32)
+    rms = np.sqrt(np.mean(x * x, axis=-1, keepdims=True) + eps)
+    return (x / rms) * weight
+
+
+def qk_norm_per_head(x, weight, n_heads, head_dim, eps=1e-6):
+    """Qwen3 per-head RMSNorm.
+
+    Args:
+        x: (seq, n_heads*head_dim) projected Q or K (pre-RoPE).
+        weight: (head_dim,) q_norm or k_norm weight.
+    Returns:
+        (seq, n_heads*head_dim) normed, same layout.
+    """
+    x = np.asarray(x, dtype=np.float32)
+    seq = x.shape[0]
+    xh = x.reshape(seq, n_heads, head_dim)
+    rms = np.sqrt(np.mean(xh * xh, axis=-1, keepdims=True) + eps)
+    xh = (xh / rms) * np.asarray(weight, dtype=np.float32)
+    return xh.reshape(seq, n_heads * head_dim)
+
+
+def softmax(x, axis=-1):
+    x = np.asarray(x, dtype=np.float32)
+    x_max = np.max(x, axis=axis, keepdims=True)
+    exp_x = np.exp(x - x_max)
+    return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
+
+
+def attention_reference(q, k, v, n_heads, n_kv_heads):
+    """Multi-head GQA attention with causal mask (F32). q/k already RoPE'd."""
+    q = np.asarray(q, dtype=np.float32)
+    k = np.asarray(k, dtype=np.float32)
+    v = np.asarray(v, dtype=np.float32)
+
+    seq_len = q.shape[0]
+    head_dim = q.shape[1] // n_heads
+    group_size = n_heads // n_kv_heads
+
+    q = q.reshape(seq_len, n_heads, head_dim).transpose(1, 0, 2)
+    k = k.reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+    v = v.reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+
+    scale = 1.0 / np.sqrt(head_dim)
+    causal_mask = np.triu(np.full((seq_len, seq_len), -np.inf, dtype=np.float32), k=1)
+
+    out_heads = np.empty((n_heads, seq_len, head_dim), dtype=np.float32)
+    for h in range(n_heads):
+        kv_idx = h // group_size
+        scores = q[h] @ k[kv_idx].T * scale
+        scores = scores + causal_mask
+        probs = softmax(scores, axis=-1)
+        out_heads[h] = probs @ v[kv_idx]
+
+    return out_heads.transpose(1, 0, 2).reshape(seq_len, n_heads * head_dim)

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
@@ -82,7 +82,9 @@ def build_rms_qkv_qknorm_rope_gemv_module(config):
     head_dim = config.head_dim
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
-    return _build(emb_dim, q_dim, kv_dim, n_heads, n_kv_heads, head_dim, qknorm_eps=1e-6)
+    return _build(
+        emb_dim, q_dim, kv_dim, n_heads, n_kv_heads, head_dim, qknorm_eps=1e-6
+    )
 
 
 def _rms_qkv_qknorm_rope_gemv_backend(verbose=False):
@@ -108,16 +110,20 @@ _LM_N_PART = 8192  # % 64 == 0; n_part/32 - 1 = 255 (at the repeat-count limit)
 # herd_m=8 that caps tile_m*K <= 32768. K=2560 -> tile_m<=12 (use 8). The O
 # GEMV has the larger K=q_dim=4096 -> tile_m*4096<=32768 -> tile_m<=8, but 8
 # lands exactly at the L2 ceiling (A=524288 + C overflows), so O uses tile_m=4.
-_GEMV_QO = (8, 8, 8)        # Q proj (M=4096 K=2560)
-_GEMV_KV = (8, 8, 8)        # K/V proj (M=1024 K=2560)
-_GEMV_O = (4, 4, 8)         # O proj (M=2560 K=4096 DECOUPLED; tile_m=4 to fit L2, m_input=4 | tile_m)
-_GEMV_GATEUP = (8, 8, 8)    # Gate/Up proj (M=9728 K=2560)
-_GEMV_DOWN = (2, 2, 8)      # Down proj (M=2560 K=9728). m_input=2 (NOT 1): the B
-                            # vector is streamed once per (launch × tile_m/m_input)
-                            # and hoisted into one push_queue whose repeat_count =
-                            # M/(herd_m*m_input)-1 must be <=255. m_input=1 gives
-                            # 2560/8-1=319 (OVERFLOW); m_input=2 gives 159. Mirrors
-                            # llama32_3b down (2,2,8). omit_pingpong keeps L1 in budget.
+_GEMV_QO = (8, 8, 8)  # Q proj (M=4096 K=2560)
+_GEMV_KV = (8, 8, 8)  # K/V proj (M=1024 K=2560)
+_GEMV_O = (
+    4,
+    4,
+    8,
+)  # O proj (M=2560 K=4096 DECOUPLED; tile_m=4 to fit L2, m_input=4 | tile_m)
+_GEMV_GATEUP = (8, 8, 8)  # Gate/Up proj (M=9728 K=2560)
+_GEMV_DOWN = (2, 2, 8)  # Down proj (M=2560 K=9728). m_input=2 (NOT 1): the B
+# vector is streamed once per (launch × tile_m/m_input)
+# and hoisted into one push_queue whose repeat_count =
+# M/(herd_m*m_input)-1 must be <=255. m_input=1 gives
+# 2560/8-1=319 (OVERFLOW); m_input=2 gives 159. Mirrors
+# llama32_3b down (2,2,8). omit_pingpong keeps L1 in budget.
 
 
 # ---------------------------------------------------------------------------
@@ -139,16 +145,17 @@ def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="m
     GEMV slice through stitch_elf so the public func is renamed to `name`,
     matching the per-projection instance_name in the backend kwargs.
     """
-    _mv_dir = os.path.join(
-        _PROG_EXAMPLES, "matrix_vector_multiplication", "bf16"
-    )
+    _mv_dir = os.path.join(_PROG_EXAMPLES, "matrix_vector_multiplication", "bf16")
     if _mv_dir not in sys.path:
         sys.path.insert(0, _mv_dir)
     from matvec import build_module as build_gemv
     from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
 
-    gemv_ir = str(build_gemv(m, k, tile_m, m_input, herd_m, bfloat16, bfloat16,
-                             link_with=link_with))
+    gemv_ir = str(
+        build_gemv(
+            m, k, tile_m, m_input, herd_m, bfloat16, bfloat16, link_with=link_with
+        )
+    )
     base_args = [
         FuncArg("%arg0", f"memref<{m}x{k}xbf16>"),
         FuncArg("%arg1", f"memref<{k}xbf16>"),
@@ -157,7 +164,9 @@ def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="m
     # GEMV func args: {0: weight (MxK), 1: input (K,), 2: output (M,)}.
     slices = [
         KernelSlice(
-            gemv_ir, "g", {0: 0, 1: 1, 2: 2},
+            gemv_ir,
+            "g",
+            {0: 0, 1: 1, 2: 2},
             extern_syms={"@matvec_vectorized_bf16_bf16", "@linalg_fill_bf16"},
         )
     ]
@@ -232,7 +241,9 @@ def compile_decode_kernels(cache, config, verbose=False):
     compile_mv()
     compile_rope()
 
-    print("\n--- rms_qkv_qknorm_rope_gemv (FUSED: RMSNorm+QKV+QK-norm+RoPE, 8 launches) ---")
+    print(
+        "\n--- rms_qkv_qknorm_rope_gemv (FUSED: RMSNorm+QKV+QK-norm+RoPE, 8 launches) ---"
+    )
     cache.compile_and_cache(
         "rms_qkv_qknorm_rope_gemv",
         build_rms_qkv_qknorm_rope_gemv_module(config),
@@ -243,18 +254,21 @@ def compile_decode_kernels(cache, config, verbose=False):
     print(f"\n--- o_gemv (O proj GEMV, {emb_dim}x{q_dim}) ---")
     o_tm, o_mi, o_hm = _GEMV_O
     cache.compile_and_cache(
-        "o_gemv", build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
+        "o_gemv",
+        build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
         _gemv_backend(verbose, "o_gemv"),
     )
     print(f"\n--- gate_gemv (Gate proj GEMV, {hidden_dim}x{emb_dim}) ---")
     g_tm, g_mi, g_hm = _GEMV_GATEUP
     cache.compile_and_cache(
-        "gate_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
+        "gate_gemv",
+        build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
         _gemv_backend(verbose, "gate_gemv"),
     )
     print(f"\n--- up_gemv (Up proj GEMV, {hidden_dim}x{emb_dim}) ---")
     cache.compile_and_cache(
-        "up_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
+        "up_gemv",
+        build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
         _gemv_backend(verbose, "up_gemv"),
     )
     # Down proj GEMV (M=emb=2560, K=hidden=9728). The STANDALONE matvec stages A
@@ -262,15 +276,23 @@ def compile_decode_kernels(cache, config, verbose=False):
     # swiglu cascade overflowed L1). Needs its own mv.o with DIM_M_OUTPUT=tile_m
     # (the shared mv.o uses 8); link down_mv.o. omit_pingpong so the large B fits.
     import shutil as _shutil
+
     d_tm, d_mi, d_hm = _GEMV_DOWN
-    compile_mv(tile_m=d_tm)            # writes mv.o with DIM_M_OUTPUT=d_tm
+    compile_mv(tile_m=d_tm)  # writes mv.o with DIM_M_OUTPUT=d_tm
     _shutil.copy2("mv.o", "down_mv.o")
-    compile_mv()                       # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
+    compile_mv()  # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
     print(f"\n--- down_gemv (Down proj GEMV, {emb_dim}x{hidden_dim}) ---")
     cache.compile_and_cache(
         "down_gemv",
-        build_gemv_module(emb_dim, hidden_dim, d_tm, d_mi, d_hm,
-                          name="down_gemv", link_with="down_mv.o"),
+        build_gemv_module(
+            emb_dim,
+            hidden_dim,
+            d_tm,
+            d_mi,
+            d_hm,
+            name="down_gemv",
+            link_with="down_mv.o",
+        ),
         _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
     )
 
@@ -290,7 +312,9 @@ def compile_decode_kernels(cache, config, verbose=False):
 # ---------------------------------------------------------------------------
 
 
-def decode_attention_cpu(q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim):
+def decode_attention_cpu(
+    q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim
+):
     """Single-query GQA attention with KV cache.
 
     Args:
@@ -366,23 +390,27 @@ def run_decode_block(
     res = cache.load_and_run(
         "rms_qkv_qknorm_rope_gemv",
         _rms_qkv_qknorm_rope_gemv_backend(verbose),
-        x_in,                                              # 0 x_in
+        x_in,  # 0 x_in
         layer_weights.attn_norm.reshape(emb_dim).astype(bfloat16),  # 1 norm_w (static)
-        np.zeros(emb_dim, dtype=bfloat16),                 # 2 normed
-        layer_weights._wq_t,                               # 3 wq (static)
-        np.zeros(q_dim, dtype=bfloat16),                   # 4 q
-        layer_weights._wk_t,                               # 5 wk (static)
-        np.zeros(kv_dim, dtype=bfloat16),                  # 6 k
-        layer_weights._wv_t,                               # 7 wv (static)
-        np.zeros(kv_dim, dtype=bfloat16),                  # 8 v
-        np.asarray(layer_weights.q_norm, bfloat16).reshape(head_dim),  # 9 q_norm (static)
-        np.asarray(layer_weights.k_norm, bfloat16).reshape(head_dim),  # 10 k_norm (static)
-        np.zeros(q_dim, dtype=bfloat16),                   # 11 q_n
-        np.zeros(kv_dim, dtype=bfloat16),                  # 12 k_n
-        lut_q,                                             # 13 lut_q (DYNAMIC)
-        lut_k,                                             # 14 lut_k (DYNAMIC)
-        np.zeros(q_dim, dtype=bfloat16),                   # 15 q_roped
-        np.zeros(kv_dim, dtype=bfloat16),                  # 16 k_roped
+        np.zeros(emb_dim, dtype=bfloat16),  # 2 normed
+        layer_weights._wq_t,  # 3 wq (static)
+        np.zeros(q_dim, dtype=bfloat16),  # 4 q
+        layer_weights._wk_t,  # 5 wk (static)
+        np.zeros(kv_dim, dtype=bfloat16),  # 6 k
+        layer_weights._wv_t,  # 7 wv (static)
+        np.zeros(kv_dim, dtype=bfloat16),  # 8 v
+        np.asarray(layer_weights.q_norm, bfloat16).reshape(
+            head_dim
+        ),  # 9 q_norm (static)
+        np.asarray(layer_weights.k_norm, bfloat16).reshape(
+            head_dim
+        ),  # 10 k_norm (static)
+        np.zeros(q_dim, dtype=bfloat16),  # 11 q_n
+        np.zeros(kv_dim, dtype=bfloat16),  # 12 k_n
+        lut_q,  # 13 lut_q (DYNAMIC)
+        lut_k,  # 14 lut_k (DYNAMIC)
+        np.zeros(q_dim, dtype=bfloat16),  # 15 q_roped
+        np.zeros(kv_dim, dtype=bfloat16),  # 16 k_roped
         output_indices=[8, 15, 16],
         static_input_indices={1, 3, 5, 7, 9, 10},
         intermediate_indices={2, 4, 6, 8, 11, 12, 15, 16},
@@ -402,8 +430,13 @@ def run_decode_block(
     # --- CPU attention ---
     with cache.profiler.time_cpu("decode_attention_cpu"):
         attn_out = decode_attention_cpu(
-            q_roped, k_cache_layer, v_cache_layer, current_pos,
-            n_heads, n_kv_heads, head_dim,
+            q_roped,
+            k_cache_layer,
+            v_cache_layer,
+            current_pos,
+            n_heads,
+            n_kv_heads,
+            head_dim,
         )
     inter["attn_out"] = attn_out
 
@@ -411,9 +444,9 @@ def run_decode_block(
     ro = cache.load_and_run(
         "o_gemv",
         _gemv_backend(verbose, "o_gemv"),
-        layer_weights._wo_t,                        # arg0 wo (static) (emb, q_dim)
-        np.ascontiguousarray(attn_out),             # arg1 attn_out (q_dim,)
-        np.zeros(emb_dim, dtype=bfloat16),          # arg2 proj (emb,)
+        layer_weights._wo_t,  # arg0 wo (static) (emb, q_dim)
+        np.ascontiguousarray(attn_out),  # arg1 attn_out (q_dim,)
+        np.zeros(emb_dim, dtype=bfloat16),  # arg2 proj (emb,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -426,14 +459,18 @@ def run_decode_block(
     inter["res1"] = res1.astype(bfloat16)
 
     # FFN RMSNorm (host, eps=1e-6)
-    normed2 = rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6).reshape(emb_dim).astype(bfloat16)
+    normed2 = (
+        rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6)
+        .reshape(emb_dim)
+        .astype(bfloat16)
+    )
 
     rg = cache.load_and_run(
         "gate_gemv",
         _gemv_backend(verbose, "gate_gemv"),
-        layer_weights._wgate_t,                     # arg0 w_gate (static) (hidden, emb)
-        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
-        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 gate (hidden,)
+        layer_weights._wgate_t,  # arg0 w_gate (static) (hidden, emb)
+        np.ascontiguousarray(normed2),  # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),  # arg2 gate (hidden,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -443,9 +480,9 @@ def run_decode_block(
     ru = cache.load_and_run(
         "up_gemv",
         _gemv_backend(verbose, "up_gemv"),
-        layer_weights._wup_t,                       # arg0 w_up (static) (hidden, emb)
-        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
-        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 up (hidden,)
+        layer_weights._wup_t,  # arg0 w_up (static) (hidden, emb)
+        np.ascontiguousarray(normed2),  # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),  # arg2 up (hidden,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},
@@ -461,9 +498,9 @@ def run_decode_block(
     rd = cache.load_and_run(
         "down_gemv",
         _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
-        layer_weights._wdown_t,                     # arg0 w_down (static) (emb, hidden)
-        np.ascontiguousarray(swig),                 # arg1 swig (hidden,)
-        np.zeros(emb_dim, dtype=bfloat16),          # arg2 down (emb,)
+        layer_weights._wdown_t,  # arg0 w_down (static) (emb, hidden)
+        np.ascontiguousarray(swig),  # arg1 swig (hidden,)
+        np.zeros(emb_dim, dtype=bfloat16),  # arg2 down (emb,)
         output_indices=[2],
         static_input_indices={0},
         intermediate_indices={2},

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
@@ -1,0 +1,477 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen3-4B Decode on MLIR-AIR (NPU2).
+
+Single-token autoregressive generation with KV cache. Mirrors the Phase-2
+prefill (qwen3_4b_prefill.py) deltas, applied to the M=1 GEMV path:
+
+  1. QKV BIAS on host (Qwen2 family, attention_bias=True; NOT QK-norm — that
+     is Qwen3). After the Q/K/V GEMV projection, a per-channel bias is added on
+     the HOST: q=(q_dim,)+bq, k=(kv_dim,)+bk, v=(kv_dim,)+bv, BEFORE RoPE for
+     q/k (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention; V is
+     bias-added and used directly). RoPE linearity is irrelevant here — we just
+     do the cheap single-token elementwise add between the (bias-free) GEMV
+     and the standalone RoPE ELFs.
+
+  2. Dims: emb=2560, q_dim=4096 (32*128), kv_dim=1024 (8*128),
+     hidden=9728, head_dim=128. o_proj is DECOUPLED (q_dim=4096 != emb=2560).
+     The fused llama/qwen3 `o_gemv_ffn` cascade (`matvec_swiglu_rms`)
+     double-buffers the full reduction K in L1 and overflows 64 KB L1 at
+     hidden=9728, so it is NOT used. Instead decode uses STANDALONE per-projection
+     GEMV ELFs (the plain `matvec` builder, 3-arg A@B) for O / Gate / Up / Down,
+     and does the residual add / FFN RMSNorm / SwiGLU on the host (single-token,
+     cheap, exact). Down (K=9728) also runs on the NPU as its own standalone ELF
+     (A staged in L2, B streamed L3->L1; the standalone is NOT blocked by the L1
+     overflow the fused cascade hits).
+
+  3. LM-head vocab = 151936. Per-partition GEMV broadcasts the K=emb input
+     vector with a push_queue repeat_count ~= n_part/32 - 1, capped at [0:255]
+     → n_part <= 8192. Use 19 partitions × 8192 (19*8192 = 155648 >= 151936;
+     last partition zero-padded, logits truncated to vocab on host). Same as
+     Qwen3-0.6B (shared vocab 151936).
+
+Decode attention is CPU (decode_attention_cpu); single-token attention is
+trivial on host (head_dim=128 FA risk is irrelevant at M=1).
+
+Decode GEMV tile configs (M×K : tile_m m_input herd_m):
+  Q     4096×2560 : 8 8 8
+  K/V   1024×2560 : 8 8 8
+  O     2560×4096 : 4 4 8   (DECOUPLED; tile_m=4 to fit L2 at K=4096)
+  Gate/Up 9728×2560 : 8 8 8
+  Down  2560×9728 : 2 2 8   (NPU standalone, omit_pingpong + own down_mv.o;
+        m_input=2 NOT 1 so push_queue repeat=M/(herd_m*m_input)-1=159 <=255)
+
+MEASURED (2026-06-27): with O/Gate/Up/Down on NPU, the residual + FFN RMSNorm +
+SwiGLU left on host are ~0.045ms/layer of M=1 numpy (microbench at emb=2560/
+hidden=9728). Moving them to a standalone NPU ELF would add a ~0.7-1.4ms dispatch
+per op to replace ~0.02ms numpy — a large regression — and folding into the GEMV
+epilogue is the matvec_swiglu_rms cascade that overflows L1 here. Glue stays on
+host by design; the decode cost is now the NPU GEMVs (real compute).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_PROG_EXAMPLES = str(Path(__file__).resolve().parent.parent.parent)
+if _PROG_EXAMPLES not in sys.path:
+    sys.path.insert(0, _PROG_EXAMPLES)
+_LLMS_DIR = str(Path(__file__).resolve().parent.parent)
+if _LLMS_DIR not in sys.path:
+    sys.path.insert(0, _LLMS_DIR)
+
+from qwen3_4b_weights import LlamaConfig
+from qwen3_4b_cpu_helpers import rms_norm
+
+
+def build_rms_qkv_qknorm_rope_gemv_module(config):
+    """Fused decode ELF: RMSNorm + Q/K/V GEMV + per-head QK-norm + RoPE (M=1).
+
+    The GEMV builders are generic (not registry-coupled), so the shared decode
+    builder works directly for qwen3_4b's dims (emb=2560)."""
+    from shared.builders.rms_qkv_qknorm_rope_multi import (
+        build_rms_qkv_qknorm_rope_gemv_module as _build,
+    )
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    return _build(emb_dim, q_dim, kv_dim, n_heads, n_kv_heads, head_dim, qknorm_eps=1e-6)
+
+
+def _rms_qkv_qknorm_rope_gemv_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "rms_qkv_qknorm_rope_gemv",
+    }
+
+
+# LM-head decode partitioning. vocab=151936. Per-partition GEMV broadcasts the
+# K=emb_dim input vector with a push_queue repeat_count ~= n_part/32 - 1, capped
+# at [0:255] → n_part <= 8192. 19 * 8192 = 155648 >= 151936; the final partition
+# carries zero-padded rows (logits truncated to vocab on host).
+_LM_N_PARTITIONS = 19
+_LM_N_PART = 8192  # % 64 == 0; n_part/32 - 1 = 255 (at the repeat-count limit)
+
+# Decode GEMV tile configs (tile_m, m_input, herd_m). Qwen3-4B dims:
+#   Q     M=4096 K=2560 ; K/V M=1024 K=2560 ; O M=2560 K=4096 (DECOUPLED) ;
+#   Gate/Up M=9728 K=2560 ; Down M=2560 K=9728 (HOST).
+# matvec L2 budget: A_l2 = tile_m*herd_m*K*2 bytes must be <= 512 KiB. With
+# herd_m=8 that caps tile_m*K <= 32768. K=2560 -> tile_m<=12 (use 8). The O
+# GEMV has the larger K=q_dim=4096 -> tile_m*4096<=32768 -> tile_m<=8, but 8
+# lands exactly at the L2 ceiling (A=524288 + C overflows), so O uses tile_m=4.
+_GEMV_QO = (8, 8, 8)        # Q proj (M=4096 K=2560)
+_GEMV_KV = (8, 8, 8)        # K/V proj (M=1024 K=2560)
+_GEMV_O = (4, 4, 8)         # O proj (M=2560 K=4096 DECOUPLED; tile_m=4 to fit L2, m_input=4 | tile_m)
+_GEMV_GATEUP = (8, 8, 8)    # Gate/Up proj (M=9728 K=2560)
+_GEMV_DOWN = (2, 2, 8)      # Down proj (M=2560 K=9728). m_input=2 (NOT 1): the B
+                            # vector is streamed once per (launch × tile_m/m_input)
+                            # and hoisted into one push_queue whose repeat_count =
+                            # M/(herd_m*m_input)-1 must be <=255. m_input=1 gives
+                            # 2560/8-1=319 (OVERFLOW); m_input=2 gives 159. Mirrors
+                            # llama32_3b down (2,2,8). omit_pingpong keeps L1 in budget.
+
+
+# ---------------------------------------------------------------------------
+# Builder 1: standalone single-projection GEMV ELF (plain matvec, A@B).
+#   Used for O / Gate / Up / Down — the residual / RMSNorm / SwiGLU around
+#   them is done on the host (single token, cheap, exact). Avoids the cascade
+#   builders' K % 512 == 0 requirement which qwen2.5 dims violate.
+# ---------------------------------------------------------------------------
+
+
+def build_gemv_module(m, k, tile_m, m_input, herd_m=8, name="gemv", link_with="mv.o"):
+    """Standalone GEMV ELF: C[m] = A[m,k] @ B[k]. 3-arg func.
+
+    Func args: %arg0 A (m,k)  %arg1 B (k,)  %arg2 C (m,)
+
+    The raw `matvec` builder names its func @matvec_bf16; for ELF output the
+    backend's instance_name must match the module's func name (else the loaded
+    kernel symbol `main:<instance_name>` is not found). We stitch the single
+    GEMV slice through stitch_elf so the public func is renamed to `name`,
+    matching the per-projection instance_name in the backend kwargs.
+    """
+    _mv_dir = os.path.join(
+        _PROG_EXAMPLES, "matrix_vector_multiplication", "bf16"
+    )
+    if _mv_dir not in sys.path:
+        sys.path.insert(0, _mv_dir)
+    from matvec import build_module as build_gemv
+    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg
+
+    gemv_ir = str(build_gemv(m, k, tile_m, m_input, herd_m, bfloat16, bfloat16,
+                             link_with=link_with))
+    base_args = [
+        FuncArg("%arg0", f"memref<{m}x{k}xbf16>"),
+        FuncArg("%arg1", f"memref<{k}xbf16>"),
+        FuncArg("%arg2", f"memref<{m}xbf16>"),
+    ]
+    # GEMV func args: {0: weight (MxK), 1: input (K,), 2: output (M,)}.
+    slices = [
+        KernelSlice(
+            gemv_ir, "g", {0: 0, 1: 1, 2: 2},
+            extern_syms={"@matvec_vectorized_bf16_bf16", "@linalg_fill_bf16"},
+        )
+    ]
+    return stitch_elf(name, base_args, slices)
+
+
+# ---------------------------------------------------------------------------
+# Builder 2: LM-head GEMV (19 partitions, n_part=8192 for vocab 151936).
+# ---------------------------------------------------------------------------
+
+
+def build_lm_head_gemv_qwen_module(emb_dim):
+    from shared.builders.lm_head_gemv_multi import build_lm_head_gemv_module
+
+    return build_lm_head_gemv_module(
+        emb_dim=emb_dim,
+        n_partitions=_LM_N_PARTITIONS,
+        n_part=_LM_N_PART,
+        tile_m=8,
+        m_input=4,
+        herd_m=8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend kwargs
+# ---------------------------------------------------------------------------
+
+
+def _gemv_backend(verbose=False, name="gemv", omit_pingpong=False):
+    bk = {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": name,
+    }
+    # Large-K Down GEMV (K=9728): the B vector is ~19 KB; ping-pong would
+    # double-buffer it (4×19 KB > 64 KB L1) and AIE allocation fails. Disable
+    # ping-pong so the standalone Down ELF fits L1 (mirrors qwen25_3b/llama32_3b).
+    if omit_pingpong:
+        bk["omit_pingpong"] = "all"
+    return bk
+
+
+def _lm_gemv_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "lm_head_gemv",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Decode kernel compilation
+# ---------------------------------------------------------------------------
+
+
+def compile_decode_kernels(cache, config, verbose=False):
+    """Compile the Qwen3 decode kernels."""
+    from shared.infra.external_kernels import compile_mv, compile_rope
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+
+    print(f"\n{'='*60}\nCompiling Qwen3 decode kernels...\n{'='*60}\n")
+
+    # External .o: GEMV (mv.o), RoPE (rope.o).
+    compile_mv()
+    compile_rope()
+
+    print("\n--- rms_qkv_qknorm_rope_gemv (FUSED: RMSNorm+QKV+QK-norm+RoPE, 8 launches) ---")
+    cache.compile_and_cache(
+        "rms_qkv_qknorm_rope_gemv",
+        build_rms_qkv_qknorm_rope_gemv_module(config),
+        _rms_qkv_qknorm_rope_gemv_backend(verbose),
+    )
+
+    # Standalone projection GEMVs. O proj is DECOUPLED (M=emb, K=q_dim).
+    print(f"\n--- o_gemv (O proj GEMV, {emb_dim}x{q_dim}) ---")
+    o_tm, o_mi, o_hm = _GEMV_O
+    cache.compile_and_cache(
+        "o_gemv", build_gemv_module(emb_dim, q_dim, o_tm, o_mi, o_hm, name="o_gemv"),
+        _gemv_backend(verbose, "o_gemv"),
+    )
+    print(f"\n--- gate_gemv (Gate proj GEMV, {hidden_dim}x{emb_dim}) ---")
+    g_tm, g_mi, g_hm = _GEMV_GATEUP
+    cache.compile_and_cache(
+        "gate_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="gate_gemv"),
+        _gemv_backend(verbose, "gate_gemv"),
+    )
+    print(f"\n--- up_gemv (Up proj GEMV, {hidden_dim}x{emb_dim}) ---")
+    cache.compile_and_cache(
+        "up_gemv", build_gemv_module(hidden_dim, emb_dim, g_tm, g_mi, g_hm, name="up_gemv"),
+        _gemv_backend(verbose, "up_gemv"),
+    )
+    # Down proj GEMV (M=emb=2560, K=hidden=9728). The STANDALONE matvec stages A
+    # in L2 and streams B L3->L1, so K=9728 compiles + runs (only the *fused*
+    # swiglu cascade overflowed L1). Needs its own mv.o with DIM_M_OUTPUT=tile_m
+    # (the shared mv.o uses 8); link down_mv.o. omit_pingpong so the large B fits.
+    import shutil as _shutil
+    d_tm, d_mi, d_hm = _GEMV_DOWN
+    compile_mv(tile_m=d_tm)            # writes mv.o with DIM_M_OUTPUT=d_tm
+    _shutil.copy2("mv.o", "down_mv.o")
+    compile_mv()                       # restore mv.o (DIM_M_OUTPUT=8) for o/gate/up
+    print(f"\n--- down_gemv (Down proj GEMV, {emb_dim}x{hidden_dim}) ---")
+    cache.compile_and_cache(
+        "down_gemv",
+        build_gemv_module(emb_dim, hidden_dim, d_tm, d_mi, d_hm,
+                          name="down_gemv", link_with="down_mv.o"),
+        _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
+    )
+
+    print(f"\n--- lm_head_gemv ({_LM_N_PARTITIONS}-partition, vocab 151936) ---")
+    cache.compile_and_cache(
+        "lm_head_gemv",
+        build_lm_head_gemv_qwen_module(emb_dim),
+        _lm_gemv_backend(verbose),
+    )
+
+    cache._save_manifest()
+    print(f"\nAll {len(cache.artifacts)} decode kernels compiled.")
+
+
+# ---------------------------------------------------------------------------
+# CPU decode attention (with KV cache)
+# ---------------------------------------------------------------------------
+
+
+def decode_attention_cpu(q, k_cache, v_cache, current_pos, n_heads, n_kv_heads, head_dim):
+    """Single-query GQA attention with KV cache.
+
+    Args:
+        q: (q_dim,) — RoPE'd (and bias-added) query vector for the current token.
+        k_cache: (n_kv_heads, max_seq, head_dim) — cached keys (after bias+RoPE).
+        v_cache: (n_kv_heads, max_seq, head_dim) — cached values (after bias).
+        current_pos: current token position (0-indexed).
+    Returns:
+        attn_out: (q_dim,) bfloat16.
+    """
+    group_size = n_heads // n_kv_heads
+    scale = 1.0 / np.sqrt(head_dim)
+    seq_len = current_pos + 1
+
+    q_heads = q.astype(np.float32).reshape(n_heads, head_dim)
+    k_cached = k_cache[:, :seq_len, :].astype(np.float32)
+    v_cached = v_cache[:, :seq_len, :].astype(np.float32)
+
+    out = np.zeros((n_heads, head_dim), dtype=np.float32)
+    for h in range(n_heads):
+        kv_h = h // group_size
+        scores = (q_heads[h] @ k_cached[kv_h].T) * scale
+        probs = np.exp(scores - scores.max())
+        probs = probs / probs.sum()
+        out[h] = probs @ v_cached[kv_h]
+
+    return out.reshape(-1).astype(bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# Single decode transformer block
+# ---------------------------------------------------------------------------
+
+
+def run_decode_block(
+    x_bf16,
+    layer_weights,
+    cache,
+    config,
+    k_cache_layer,
+    v_cache_layer,
+    current_pos,
+    rope_lut_bf16,
+    verbose=False,
+):
+    """Run one Qwen3 transformer block for a single decode token.
+
+    Stages: rms_qkv_qknorm_rope_gemv (NPU: RMSNorm + Q/K/V GEMV + per-head
+    QK-norm + RoPE) -> KV-cache write -> CPU attention -> O GEMV (NPU)
+    -> residual (host) -> FFN RMSNorm (host) -> Gate/Up GEMV (NPU)
+    -> SwiGLU (host) -> Down GEMV (NPU) -> FFN residual (host).
+    """
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    layer_idx = getattr(layer_weights, "_layer_idx", None)
+    _suffix = f"_L{layer_idx}" if layer_idx is not None else None
+    inter = {}
+
+    x_in = x_bf16.flatten().astype(bfloat16)
+
+    # RoPE LUT for this position (position-dependent — NOT static).
+    rope_lut_pos = rope_lut_bf16[current_pos : current_pos + 1]  # (1, head_dim)
+    lut_q = np.tile(rope_lut_pos, (n_heads, 1)).flatten().astype(bfloat16)
+    lut_k = np.tile(rope_lut_pos, (n_kv_heads, 1)).flatten().astype(bfloat16)
+
+    # --- One ELF = RMSNorm + Q/K/V GEMV + per-head QK-norm + RoPE ---
+    res = cache.load_and_run(
+        "rms_qkv_qknorm_rope_gemv",
+        _rms_qkv_qknorm_rope_gemv_backend(verbose),
+        x_in,                                              # 0 x_in
+        layer_weights.attn_norm.reshape(emb_dim).astype(bfloat16),  # 1 norm_w (static)
+        np.zeros(emb_dim, dtype=bfloat16),                 # 2 normed
+        layer_weights._wq_t,                               # 3 wq (static)
+        np.zeros(q_dim, dtype=bfloat16),                   # 4 q
+        layer_weights._wk_t,                               # 5 wk (static)
+        np.zeros(kv_dim, dtype=bfloat16),                  # 6 k
+        layer_weights._wv_t,                               # 7 wv (static)
+        np.zeros(kv_dim, dtype=bfloat16),                  # 8 v
+        np.asarray(layer_weights.q_norm, bfloat16).reshape(head_dim),  # 9 q_norm (static)
+        np.asarray(layer_weights.k_norm, bfloat16).reshape(head_dim),  # 10 k_norm (static)
+        np.zeros(q_dim, dtype=bfloat16),                   # 11 q_n
+        np.zeros(kv_dim, dtype=bfloat16),                  # 12 k_n
+        lut_q,                                             # 13 lut_q (DYNAMIC)
+        lut_k,                                             # 14 lut_k (DYNAMIC)
+        np.zeros(q_dim, dtype=bfloat16),                   # 15 q_roped
+        np.zeros(kv_dim, dtype=bfloat16),                  # 16 k_roped
+        output_indices=[8, 15, 16],
+        static_input_indices={1, 3, 5, 7, 9, 10},
+        intermediate_indices={2, 4, 6, 8, 11, 12, 15, 16},
+        bo_key=f"rms_qkv_qknorm_rope_gemv{_suffix}" if _suffix else None,
+    )
+    v = res[8].astype(bfloat16)
+    q_roped = res[15].astype(bfloat16)
+    k_roped = res[16].astype(bfloat16)
+    inter["v"] = v
+    inter["q_roped"] = q_roped
+    inter["k_roped"] = k_roped
+
+    # --- Update KV cache (K after qk-norm+RoPE, V raw projection) ---
+    k_cache_layer[:, current_pos, :] = k_roped.reshape(n_kv_heads, head_dim)
+    v_cache_layer[:, current_pos, :] = v.reshape(n_kv_heads, head_dim)
+
+    # --- CPU attention ---
+    with cache.profiler.time_cpu("decode_attention_cpu"):
+        attn_out = decode_attention_cpu(
+            q_roped, k_cache_layer, v_cache_layer, current_pos,
+            n_heads, n_kv_heads, head_dim,
+        )
+    inter["attn_out"] = attn_out
+
+    # --- Stage E: O proj GEMV + residual + FFN (RMSNorm/SwiGLU on host) ---
+    ro = cache.load_and_run(
+        "o_gemv",
+        _gemv_backend(verbose, "o_gemv"),
+        layer_weights._wo_t,                        # arg0 wo (static) (emb, q_dim)
+        np.ascontiguousarray(attn_out),             # arg1 attn_out (q_dim,)
+        np.zeros(emb_dim, dtype=bfloat16),          # arg2 proj (emb,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"o_gemv{_suffix}" if _suffix else None,
+    )
+    proj = ro[2].astype(np.float32)
+
+    # residual 1 (host)
+    res1 = proj + x_in.astype(np.float32)
+    inter["res1"] = res1.astype(bfloat16)
+
+    # FFN RMSNorm (host, eps=1e-6)
+    normed2 = rms_norm(res1.reshape(1, emb_dim), layer_weights.ffn_norm, eps=1e-6).reshape(emb_dim).astype(bfloat16)
+
+    rg = cache.load_and_run(
+        "gate_gemv",
+        _gemv_backend(verbose, "gate_gemv"),
+        layer_weights._wgate_t,                     # arg0 w_gate (static) (hidden, emb)
+        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 gate (hidden,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"gate_gemv{_suffix}" if _suffix else None,
+    )
+    gate = rg[2].astype(np.float32)
+    ru = cache.load_and_run(
+        "up_gemv",
+        _gemv_backend(verbose, "up_gemv"),
+        layer_weights._wup_t,                       # arg0 w_up (static) (hidden, emb)
+        np.ascontiguousarray(normed2),              # arg1 normed2 (emb,)
+        np.zeros(hidden_dim, dtype=bfloat16),       # arg2 up (hidden,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"up_gemv{_suffix}" if _suffix else None,
+    )
+    up = ru[2].astype(np.float32)
+    # SwiGLU (host)
+    swig = ((gate / (1.0 + np.exp(-gate))) * up).astype(bfloat16)
+    # Down projection: M=emb=2560, K=hidden=9728. The STANDALONE matvec stages
+    # A in L2 and streams B L3->L1, so K=9728 compiles + runs on NPU (only the
+    # *fused* swiglu cascade overflowed L1). Runs as its own down_gemv ELF,
+    # like o/gate/up.
+    rd = cache.load_and_run(
+        "down_gemv",
+        _gemv_backend(verbose, "down_gemv", omit_pingpong=True),
+        layer_weights._wdown_t,                     # arg0 w_down (static) (emb, hidden)
+        np.ascontiguousarray(swig),                 # arg1 swig (hidden,)
+        np.zeros(emb_dim, dtype=bfloat16),          # arg2 down (emb,)
+        output_indices=[2],
+        static_input_indices={0},
+        intermediate_indices={2},
+        bo_key=f"down_gemv{_suffix}" if _suffix else None,
+    )
+    down = rd[2].astype(np.float32)
+
+    out = (down + res1).astype(bfloat16)
+    inter["ffn_out"] = out
+    return out, inter

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_decode.py
@@ -6,13 +6,12 @@
 Single-token autoregressive generation with KV cache. Mirrors the Phase-2
 prefill (qwen3_4b_prefill.py) deltas, applied to the M=1 GEMV path:
 
-  1. QKV BIAS on host (Qwen2 family, attention_bias=True; NOT QK-norm — that
-     is Qwen3). After the Q/K/V GEMV projection, a per-channel bias is added on
-     the HOST: q=(q_dim,)+bq, k=(kv_dim,)+bk, v=(kv_dim,)+bv, BEFORE RoPE for
-     q/k (HF Qwen2 order: proj -> +bias -> RoPE(Q,K) -> attention; V is
-     bias-added and used directly). RoPE linearity is irrelevant here — we just
-     do the cheap single-token elementwise add between the (bias-free) GEMV
-     and the standalone RoPE ELFs.
+  1. QK-NORM (Qwen3 family, no qkv bias). The rms_qkv_qknorm_rope_gemv ELF
+     fuses, on-device: RMSNorm -> Q/K/V GEMV -> per-head RMSNorm of Q and K
+     (q_norm/k_norm, shape (head_dim,)) -> RoPE(Q,K). HF Qwen3 order:
+     proj -> QK-norm(Q,K per head) -> RoPE(Q,K) -> attention; V is used
+     directly. There is NO qkv bias (attention_bias=False, unlike Qwen2.5).
+     q_norm/k_norm are passed as static ELF args (indices 9/10).
 
   2. Dims: emb=2560, q_dim=4096 (32*128), kv_dim=1024 (8*128),
      hidden=9728, head_dim=128. o_proj is DECOUPLED (q_dim=4096 != emb=2560).

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
@@ -89,7 +89,9 @@ class Session:
 # ---------------------------------------------------------------------------
 
 
-def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16):
+def prepare_runtime(
+    prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16
+):
     """One-time runtime init: transpose decode GEMV weights, tag layer idx,
     pre-load prefill + decode + LM-head BOs."""
     print(f"\n{'='*60}")
@@ -110,13 +112,27 @@ def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_
     if not hasattr(weights, "_decode_weights_transposed"):
         print("  Pre-transposing weights for decode GEMV...")
         for lw in weights.layers:
-            lw._wq_t = np.ascontiguousarray(lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T)    # (q_dim, emb)
-            lw._wk_t = np.ascontiguousarray(lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
-            lw._wv_t = np.ascontiguousarray(lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
-            lw._wo_t = np.ascontiguousarray(lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T)    # (emb, q_dim)
-            lw._wgate_t = np.ascontiguousarray(lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T)  # (hidden, emb)
-            lw._wup_t = np.ascontiguousarray(lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T)      # (hidden, emb)
-            lw._wdown_t = np.ascontiguousarray(lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T)  # (emb, hidden)
+            lw._wq_t = np.ascontiguousarray(
+                lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T
+            )  # (q_dim, emb)
+            lw._wk_t = np.ascontiguousarray(
+                lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T
+            )  # (kv_dim, emb)
+            lw._wv_t = np.ascontiguousarray(
+                lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T
+            )  # (kv_dim, emb)
+            lw._wo_t = np.ascontiguousarray(
+                lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T
+            )  # (emb, q_dim)
+            lw._wgate_t = np.ascontiguousarray(
+                lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T
+            )  # (hidden, emb)
+            lw._wup_t = np.ascontiguousarray(
+                lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T
+            )  # (hidden, emb)
+            lw._wdown_t = np.ascontiguousarray(
+                lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T
+            )  # (emb, hidden)
         weights._decode_weights_transposed = True
 
     # 2. Tag layer index for per-layer BO isolation.
@@ -166,23 +182,23 @@ def _preload_decode_weights(decode_cache, weights, config):
         decode_cache.load_and_run(
             "rms_qkv_qknorm_rope_gemv",
             _rms_qkv_qknorm_rope_gemv_backend(),
-            np.zeros(emb_dim, dtype=bfloat16),                     # 0 x_in
-            lw.attn_norm.reshape(emb_dim).astype(bfloat16),        # 1 norm_w (static)
-            np.zeros(emb_dim, dtype=bfloat16),                     # 2 normed
-            lw._wq_t,                                              # 3 wq (static)
-            np.zeros(q_dim, dtype=bfloat16),                       # 4 q
-            lw._wk_t,                                              # 5 wk (static)
-            np.zeros(kv_dim, dtype=bfloat16),                      # 6 k
-            lw._wv_t,                                              # 7 wv (static)
-            np.zeros(kv_dim, dtype=bfloat16),                      # 8 v
-            np.asarray(lw.q_norm, bfloat16).reshape(head_dim),     # 9 q_norm (static)
-            np.asarray(lw.k_norm, bfloat16).reshape(head_dim),     # 10 k_norm (static)
-            np.zeros(q_dim, dtype=bfloat16),                       # 11 q_n
-            np.zeros(kv_dim, dtype=bfloat16),                      # 12 k_n
-            lut_q_dummy,                                           # 13 lut_q (dynamic)
-            lut_k_dummy,                                           # 14 lut_k (dynamic)
-            np.zeros(q_dim, dtype=bfloat16),                       # 15 q_roped
-            np.zeros(kv_dim, dtype=bfloat16),                      # 16 k_roped
+            np.zeros(emb_dim, dtype=bfloat16),  # 0 x_in
+            lw.attn_norm.reshape(emb_dim).astype(bfloat16),  # 1 norm_w (static)
+            np.zeros(emb_dim, dtype=bfloat16),  # 2 normed
+            lw._wq_t,  # 3 wq (static)
+            np.zeros(q_dim, dtype=bfloat16),  # 4 q
+            lw._wk_t,  # 5 wk (static)
+            np.zeros(kv_dim, dtype=bfloat16),  # 6 k
+            lw._wv_t,  # 7 wv (static)
+            np.zeros(kv_dim, dtype=bfloat16),  # 8 v
+            np.asarray(lw.q_norm, bfloat16).reshape(head_dim),  # 9 q_norm (static)
+            np.asarray(lw.k_norm, bfloat16).reshape(head_dim),  # 10 k_norm (static)
+            np.zeros(q_dim, dtype=bfloat16),  # 11 q_n
+            np.zeros(kv_dim, dtype=bfloat16),  # 12 k_n
+            lut_q_dummy,  # 13 lut_q (dynamic)
+            lut_k_dummy,  # 14 lut_k (dynamic)
+            np.zeros(q_dim, dtype=bfloat16),  # 15 q_roped
+            np.zeros(kv_dim, dtype=bfloat16),  # 16 k_roped
             output_indices=[8, 15, 16],
             static_input_indices={1, 3, 5, 7, 9, 10},
             intermediate_indices={2, 4, 6, 8, 11, 12, 15, 16},
@@ -191,34 +207,50 @@ def _preload_decode_weights(decode_cache, weights, config):
 
         # o_gemv: weight static {0}.
         decode_cache.load_and_run(
-            "o_gemv", _gemv_backend(False, "o_gemv"),
-            lw._wo_t, np.zeros(q_dim, dtype=bfloat16),
+            "o_gemv",
+            _gemv_backend(False, "o_gemv"),
+            lw._wo_t,
+            np.zeros(q_dim, dtype=bfloat16),
             np.zeros(emb_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"o_gemv_L{li}",
         )
         # gate_gemv / up_gemv: weight static {0}.
         decode_cache.load_and_run(
-            "gate_gemv", _gemv_backend(False, "gate_gemv"),
-            lw._wgate_t, np.zeros(emb_dim, dtype=bfloat16),
+            "gate_gemv",
+            _gemv_backend(False, "gate_gemv"),
+            lw._wgate_t,
+            np.zeros(emb_dim, dtype=bfloat16),
             np.zeros(hidden_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"gate_gemv_L{li}",
         )
         decode_cache.load_and_run(
-            "up_gemv", _gemv_backend(False, "up_gemv"),
-            lw._wup_t, np.zeros(emb_dim, dtype=bfloat16),
+            "up_gemv",
+            _gemv_backend(False, "up_gemv"),
+            lw._wup_t,
+            np.zeros(emb_dim, dtype=bfloat16),
             np.zeros(hidden_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"up_gemv_L{li}",
         )
         # down_gemv: M=emb=2560, K=hidden=9728. Standalone GEMV ELF on NPU (only
         # the fused cascade overflowed L1). Weight static {0}.
         decode_cache.load_and_run(
-            "down_gemv", _gemv_backend(False, "down_gemv", omit_pingpong=True),
-            lw._wdown_t, np.zeros(hidden_dim, dtype=bfloat16),
+            "down_gemv",
+            _gemv_backend(False, "down_gemv", omit_pingpong=True),
+            lw._wdown_t,
+            np.zeros(hidden_dim, dtype=bfloat16),
             np.zeros(emb_dim, dtype=bfloat16),
-            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            output_indices=[2],
+            static_input_indices={0},
+            intermediate_indices={2},
             bo_key=f"down_gemv_L{li}",
         )
 
@@ -335,10 +367,14 @@ def run_npu_prefill(
             k_roped = inter["k_roped"]
             v_biased = inter["v"]
             k_cache[layer_idx, :, :seq_len, :] = (
-                k_roped.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+                k_roped.astype(bfloat16)
+                .reshape(seq_len, n_kv_heads, head_dim)
+                .transpose(1, 0, 2)
             )
             v_cache[layer_idx, :, :seq_len, :] = (
-                v_biased.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+                v_biased.astype(bfloat16)
+                .reshape(seq_len, n_kv_heads, head_dim)
+                .transpose(1, 0, 2)
             )
         prefill_cache.profiler.end_layer(layer_idx, t0)
 
@@ -347,7 +383,11 @@ def run_npu_prefill(
     pred_pos = prompt_len - 1
     with prefill_cache.profiler.time_cpu("final_rms_norm"):
         last_hidden = np.asarray(x_bf16, dtype=np.float32)[pred_pos : pred_pos + 1]
-        last_normed = rms_norm(last_hidden, weights.final_norm, eps=EPS).flatten().astype(bfloat16)
+        last_normed = (
+            rms_norm(last_hidden, weights.final_norm, eps=EPS)
+            .flatten()
+            .astype(bfloat16)
+        )
 
     logits_row = _run_lm_head(decode_cache, weights, last_normed, vocab_size)
     prefill_token = int(np.argmax(logits_row))
@@ -364,7 +404,14 @@ def run_npu_prefill(
 
 
 def run_npu_decode_step(
-    x_decode_bf16, weights, config, decode_cache, rope_lut_bf16, k_cache, v_cache, current_pos
+    x_decode_bf16,
+    weights,
+    config,
+    decode_cache,
+    rope_lut_bf16,
+    k_cache,
+    v_cache,
+    current_pos,
 ):
     """Run one NPU decode step: 36 blocks + final RMSNorm + LM-head."""
     vocab_size = weights.lm_head.shape[0]
@@ -387,7 +434,9 @@ def run_npu_decode_step(
         x_normed = rms_norm(
             x.astype(np.float32).reshape(1, config.emb_dim), weights.final_norm, eps=EPS
         )
-    logits = _run_lm_head(decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size)
+    logits = _run_lm_head(
+        decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size
+    )
     next_token = int(np.argmax(logits))
     return next_token, logits
 
@@ -423,9 +472,17 @@ def generate(
         print(f"{'='*60}\n")
 
     prefill_token, _logits, k_cache, v_cache, prompt_len = run_npu_prefill(
-        prompt_tokens, weights, config, prefill_cache, decode_cache,
-        rope_lut_bf16, max_seq, tokenizer=tokenizer, cpu_attn=cpu_attn,
-        profile=profile, quiet=True,
+        prompt_tokens,
+        weights,
+        config,
+        prefill_cache,
+        decode_cache,
+        rope_lut_bf16,
+        max_seq,
+        tokenizer=tokenizer,
+        cpu_attn=cpu_attn,
+        profile=profile,
+        quiet=True,
     )
 
     ttft = time.perf_counter() - ttft_start
@@ -451,8 +508,14 @@ def generate(
 
     for _ in range(n_tokens):
         next_token, _ = run_npu_decode_step(
-            x_decode, weights, config, decode_cache, rope_lut_bf16,
-            k_cache, v_cache, current_pos,
+            x_decode,
+            weights,
+            config,
+            decode_cache,
+            rope_lut_bf16,
+            k_cache,
+            v_cache,
+            current_pos,
         )
         generated_tokens.append(next_token)
         current_pos += 1
@@ -466,7 +529,9 @@ def generate(
     t_decode = time.time() - t_dec
     n_gen = len(generated_tokens) - 1
     if not streaming and n_gen > 0:
-        print(f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)")
+        print(
+            f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)"
+        )
 
     if prefill_cache.profiler.enabled:
         print(f"\n{'='*60}\nPREFILL detail")
@@ -490,15 +555,21 @@ def build_session(args) -> Session:
     seq_len = 2048
 
     prefill_cache = KernelCache(
-        "prefill_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+        "prefill_kernel_cache",
+        verbose=args.verbose,
+        profiler=Profiler(enabled=args.profile),
     )
     decode_cache = KernelCache(
-        "decode_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+        "decode_kernel_cache",
+        verbose=args.verbose,
+        profiler=Profiler(enabled=args.profile),
     )
 
     if not args.run_only:
         print("Compiling prefill kernels...")
-        compile_all_kernels(prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn)
+        compile_all_kernels(
+            prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn
+        )
         print("\nCompiling decode kernels...")
         compile_decode_kernels(decode_cache, config, verbose=args.verbose)
 
@@ -518,14 +589,23 @@ def build_session(args) -> Session:
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-    rope_lut_bf16 = generate_rope_lut(config=config, seq_len=seq_len + args.n_tokens).astype(bfloat16)
+    rope_lut_bf16 = generate_rope_lut(
+        config=config, seq_len=seq_len + args.n_tokens
+    ).astype(bfloat16)
 
-    prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16)
+    prepare_runtime(
+        prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16
+    )
 
     return Session(
-        config=config, seq_len=seq_len, weights=weights, tokenizer=tokenizer,
-        prefill_cache=prefill_cache, decode_cache=decode_cache,
-        rope_lut_bf16=rope_lut_bf16, model_variant=args.model,
+        config=config,
+        seq_len=seq_len,
+        weights=weights,
+        tokenizer=tokenizer,
+        prefill_cache=prefill_cache,
+        decode_cache=decode_cache,
+        rope_lut_bf16=rope_lut_bf16,
+        model_variant=args.model,
     )
 
 
@@ -539,18 +619,30 @@ def _tokenize_prompt(session: Session, prompt_text: str) -> list:
     return session.tokenizer.encode(prompt_text)
 
 
-def run_once(session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None):
+def run_once(
+    session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None
+):
     ttft_start = time.perf_counter()
     with session.prefill_cache.profiler.time_cpu("tokenize"):
         tokens = _tokenize_prompt(session, prompt_text)
     prompt_len_actual = len(tokens)
     with session.prefill_cache.profiler.time_cpu("eos_pad"):
         if len(tokens) < session.seq_len:
-            tokens = tokens + [session.tokenizer.eos_token_id] * (session.seq_len - len(tokens))
+            tokens = tokens + [session.tokenizer.eos_token_id] * (
+                session.seq_len - len(tokens)
+            )
     generated = generate(
-        tokens, session.weights, session.config, session.prefill_cache,
-        session.decode_cache, session.rope_lut_bf16, tokenizer=session.tokenizer,
-        n_tokens=n_tokens, profile=profile, cpu_attn=cpu_attn, on_token=on_token,
+        tokens,
+        session.weights,
+        session.config,
+        session.prefill_cache,
+        session.decode_cache,
+        session.rope_lut_bf16,
+        tokenizer=session.tokenizer,
+        n_tokens=n_tokens,
+        profile=profile,
+        cpu_attn=cpu_attn,
+        on_token=on_token,
         ttft_start=ttft_start,
     )
     return generated, prompt_len_actual
@@ -589,8 +681,14 @@ def repl_loop(session, args):
         sys.stdout.write("\nResponse: ")
         sys.stdout.flush()
         try:
-            run_once(session, prompt, n_tokens=args.n_tokens, profile=False,
-                     cpu_attn=args.cpu_attn, on_token=_cb)
+            run_once(
+                session,
+                prompt,
+                n_tokens=args.n_tokens,
+                profile=False,
+                cpu_attn=args.cpu_attn,
+                on_token=_cb,
+            )
         except KeyboardInterrupt:
             print("\n[interrupted]")
             continue
@@ -608,7 +706,9 @@ if __name__ == "__main__":
     parser.add_argument("--cpu-attn", action="store_true", default=False)
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("--prompt", type=str, default="What is the capital of France?")
-    parser.add_argument("--model", type=str, choices=["base", "instruct"], default="instruct")
+    parser.add_argument(
+        "--model", type=str, choices=["base", "instruct"], default="instruct"
+    )
     parser.add_argument("--interactive", action="store_true")
     args = parser.parse_args()
 
@@ -625,7 +725,10 @@ if __name__ == "__main__":
         repl_loop(session, args)
     else:
         generated, plen = run_once(
-            session, args.prompt, n_tokens=args.n_tokens, profile=args.profile,
+            session,
+            args.prompt,
+            n_tokens=args.n_tokens,
+            profile=args.profile,
             cpu_attn=args.cpu_attn,
         )
         _print_one_shot_output(session, args.prompt, generated, plen)

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
@@ -4,10 +4,10 @@
 """Qwen3-4B BF16 Inference on MLIR-AIR (NPU2).
 
 Unified driver: NPU prefill (36 layers) + NPU decode (KV cache) + NPU LM-head.
-Direct re-parameterization of qwen25_1_5b_inference.py (same Qwen3 deltas:
-QKV bias on host, NO QK-norm, eps=1e-6, tied embeddings, vocab=151936 LM-head
-per-partition). 3B dims: emb=q_dim=2048 (square O), kv_dim=256, hidden=11008,
-head_dim=128, 36 layers.
+Qwen3 deltas: QK-norm enabled (per-head RMSNorm q_norm/k_norm fused into the
+NPU rms_qkv_qknorm_rope ELF), NO qkv bias, eps=1e-6, tied embeddings,
+vocab=151936 LM-head per-partition. 4B dims: emb=2560, q_dim=4096 (32*128,
+DECOUPLED o_proj), kv_dim=1024 (8*128), hidden=9728, head_dim=128, 36 layers.
 
 Usage:
     cd build_peano

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_inference.py
@@ -1,0 +1,631 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen3-4B BF16 Inference on MLIR-AIR (NPU2).
+
+Unified driver: NPU prefill (36 layers) + NPU decode (KV cache) + NPU LM-head.
+Direct re-parameterization of qwen25_1_5b_inference.py (same Qwen3 deltas:
+QKV bias on host, NO QK-norm, eps=1e-6, tied embeddings, vocab=151936 LM-head
+per-partition). 3B dims: emb=q_dim=2048 (square O), kv_dim=256, hidden=11008,
+head_dim=128, 36 layers.
+
+Usage:
+    cd build_peano
+    python3 ../qwen3_4b_inference.py --compile-only
+    python3 ../qwen3_4b_inference.py --run-only --n-tokens 32 --prompt "..."
+    python3 ../qwen3_4b_inference.py --run-only --n-tokens 32 --profile
+"""
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from qwen3_4b_weights import LlamaConfig, load_weights, generate_rope_lut
+from qwen3_4b_cpu_helpers import rms_norm
+from shared.infra.cache import KernelCache, Profiler
+from qwen3_4b_prefill import (
+    compile_all_kernels,
+    run_transformer_block_qwen3,
+    preload_prefill_weights,
+)
+from qwen3_4b_decode import (
+    compile_decode_kernels,
+    run_decode_block,
+    _rms_qkv_qknorm_rope_gemv_backend,
+    _gemv_backend,
+    _lm_gemv_backend,
+    _LM_N_PARTITIONS,
+    _LM_N_PART,
+)
+
+EPS = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Streaming-decode helpers (BPE-safe incremental output)
+# ---------------------------------------------------------------------------
+
+
+class _StreamState:
+    def __init__(self) -> None:
+        self.printed_len: int = 0
+
+
+def _delta_text(tokenizer: Any, ids: list, state: _StreamState) -> str:
+    decoded = tokenizer.decode(ids, skip_special_tokens=True)
+    delta = decoded[state.printed_len :]
+    state.printed_len = len(decoded)
+    return delta
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    config: Any
+    seq_len: int
+    weights: Any
+    tokenizer: Any
+    prefill_cache: Any
+    decode_cache: Any
+    rope_lut_bf16: np.ndarray
+    model_variant: str
+
+
+# ---------------------------------------------------------------------------
+# Runtime preparation
+# ---------------------------------------------------------------------------
+
+
+def prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16):
+    """One-time runtime init: transpose decode GEMV weights, tag layer idx,
+    pre-load prefill + decode + LM-head BOs."""
+    print(f"\n{'='*60}")
+    print("Preparing runtime (one-time init, outside profiling scope)...")
+    print(f"{'='*60}")
+    t0 = time.time()
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    # 1. Pre-transpose decode GEMV weights. GEMV expects W[out, in]; HF/our
+    #    loader stores projections as (in, out) (y = x @ W), so transpose.
+    if not hasattr(weights, "_decode_weights_transposed"):
+        print("  Pre-transposing weights for decode GEMV...")
+        for lw in weights.layers:
+            lw._wq_t = np.ascontiguousarray(lw.wq.astype(bfloat16).reshape(emb_dim, q_dim).T)    # (q_dim, emb)
+            lw._wk_t = np.ascontiguousarray(lw.wk.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
+            lw._wv_t = np.ascontiguousarray(lw.wv.astype(bfloat16).reshape(emb_dim, kv_dim).T)   # (kv_dim, emb)
+            lw._wo_t = np.ascontiguousarray(lw.wo.astype(bfloat16).reshape(q_dim, emb_dim).T)    # (emb, q_dim)
+            lw._wgate_t = np.ascontiguousarray(lw.w_gate.astype(bfloat16).reshape(emb_dim, hidden_dim).T)  # (hidden, emb)
+            lw._wup_t = np.ascontiguousarray(lw.w_up.astype(bfloat16).reshape(emb_dim, hidden_dim).T)      # (hidden, emb)
+            lw._wdown_t = np.ascontiguousarray(lw.w_down.astype(bfloat16).reshape(hidden_dim, emb_dim).T)  # (emb, hidden)
+        weights._decode_weights_transposed = True
+
+    # 2. Tag layer index for per-layer BO isolation.
+    for i, lw in enumerate(weights.layers):
+        lw._layer_idx = i
+
+    # 3. Pre-load prefill block weights into per-layer BOs (skipped on the real
+    #    prefill pass via static_input_indices).
+    preload_prefill_weights(weights, config, prefill_cache, seq_len, rope_lut_bf16)
+
+    # 4. Pre-load decode weights into per-layer BOs + LM-head GEMV.
+    _preload_decode_weights(decode_cache, weights, config)
+
+    t_prep = time.time() - t0
+    print(f"  Runtime prepared in {t_prep:.1f}s")
+    prefill_cache.profiler.preprocessing_s = t_prep
+    decode_cache.profiler.preprocessing_s = t_prep
+
+
+def _preload_decode_weights(decode_cache, weights, config):
+    """Pre-load all decode block weights into per-layer BOs (skipped on
+    subsequent calls via static_input_indices)."""
+    if hasattr(weights, "_decode_weights_preloaded_to_bos"):
+        return
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    vocab_size = weights.lm_head.shape[0]
+
+    print("  Pre-loading decode weights into per-layer BOs...")
+    _was = decode_cache.profiler.enabled
+    decode_cache.profiler.enabled = False
+
+    lut_q_dummy = np.zeros(n_heads * head_dim, dtype=bfloat16)
+    lut_k_dummy = np.zeros(n_kv_heads * head_dim, dtype=bfloat16)
+
+    for li in range(config.n_layers):
+        lw = weights.layers[li]
+
+        # Fused decode ELF warmup (RMSNorm+QKV GEMV+QK-norm+RoPE). LUTs
+        # (args 13/14) are position-dependent -> NOT static.
+        decode_cache.load_and_run(
+            "rms_qkv_qknorm_rope_gemv",
+            _rms_qkv_qknorm_rope_gemv_backend(),
+            np.zeros(emb_dim, dtype=bfloat16),                     # 0 x_in
+            lw.attn_norm.reshape(emb_dim).astype(bfloat16),        # 1 norm_w (static)
+            np.zeros(emb_dim, dtype=bfloat16),                     # 2 normed
+            lw._wq_t,                                              # 3 wq (static)
+            np.zeros(q_dim, dtype=bfloat16),                       # 4 q
+            lw._wk_t,                                              # 5 wk (static)
+            np.zeros(kv_dim, dtype=bfloat16),                      # 6 k
+            lw._wv_t,                                              # 7 wv (static)
+            np.zeros(kv_dim, dtype=bfloat16),                      # 8 v
+            np.asarray(lw.q_norm, bfloat16).reshape(head_dim),     # 9 q_norm (static)
+            np.asarray(lw.k_norm, bfloat16).reshape(head_dim),     # 10 k_norm (static)
+            np.zeros(q_dim, dtype=bfloat16),                       # 11 q_n
+            np.zeros(kv_dim, dtype=bfloat16),                      # 12 k_n
+            lut_q_dummy,                                           # 13 lut_q (dynamic)
+            lut_k_dummy,                                           # 14 lut_k (dynamic)
+            np.zeros(q_dim, dtype=bfloat16),                       # 15 q_roped
+            np.zeros(kv_dim, dtype=bfloat16),                      # 16 k_roped
+            output_indices=[8, 15, 16],
+            static_input_indices={1, 3, 5, 7, 9, 10},
+            intermediate_indices={2, 4, 6, 8, 11, 12, 15, 16},
+            bo_key=f"rms_qkv_qknorm_rope_gemv_L{li}",
+        )
+
+        # o_gemv: weight static {0}.
+        decode_cache.load_and_run(
+            "o_gemv", _gemv_backend(False, "o_gemv"),
+            lw._wo_t, np.zeros(q_dim, dtype=bfloat16),
+            np.zeros(emb_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"o_gemv_L{li}",
+        )
+        # gate_gemv / up_gemv: weight static {0}.
+        decode_cache.load_and_run(
+            "gate_gemv", _gemv_backend(False, "gate_gemv"),
+            lw._wgate_t, np.zeros(emb_dim, dtype=bfloat16),
+            np.zeros(hidden_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"gate_gemv_L{li}",
+        )
+        decode_cache.load_and_run(
+            "up_gemv", _gemv_backend(False, "up_gemv"),
+            lw._wup_t, np.zeros(emb_dim, dtype=bfloat16),
+            np.zeros(hidden_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"up_gemv_L{li}",
+        )
+        # down_gemv: M=emb=2560, K=hidden=9728. Standalone GEMV ELF on NPU (only
+        # the fused cascade overflowed L1). Weight static {0}.
+        decode_cache.load_and_run(
+            "down_gemv", _gemv_backend(False, "down_gemv", omit_pingpong=True),
+            lw._wdown_t, np.zeros(hidden_dim, dtype=bfloat16),
+            np.zeros(emb_dim, dtype=bfloat16),
+            output_indices=[2], static_input_indices={0}, intermediate_indices={2},
+            bo_key=f"down_gemv_L{li}",
+        )
+
+    # LM-head GEMV weights (19 partitions, n_part=8192).
+    weights._lm_weight_parts_gemv = []
+    for p in range(_LM_N_PARTITIONS):
+        n_start = p * _LM_N_PART
+        n_end = min(n_start + _LM_N_PART, vocab_size)
+        w = np.zeros((_LM_N_PART, emb_dim), dtype=bfloat16)
+        if n_end > n_start:
+            w[: n_end - n_start, :] = np.ascontiguousarray(
+                weights.lm_head[n_start:n_end, :]
+            ).astype(bfloat16)
+        weights._lm_weight_parts_gemv.append(w)
+
+    lm_inputs = [np.zeros(emb_dim, dtype=bfloat16)]
+    for p in range(_LM_N_PARTITIONS):
+        lm_inputs.append(weights._lm_weight_parts_gemv[p])
+        lm_inputs.append(np.zeros(_LM_N_PART, dtype=bfloat16))
+    decode_cache.load_and_run(
+        "lm_head_gemv",
+        _lm_gemv_backend(),
+        *lm_inputs,
+        output_indices=[2 + 2 * p for p in range(_LM_N_PARTITIONS)],
+        static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+    )
+
+    decode_cache.profiler.enabled = _was
+    weights._decode_weights_preloaded_to_bos = True
+    print(f"  Pre-loaded {config.n_layers} decode layers + LM Head.")
+
+
+# ---------------------------------------------------------------------------
+# NPU LM-head (19-partition GEMV) — shared by prefill end + decode.
+# ---------------------------------------------------------------------------
+
+
+def _run_lm_head(decode_cache, weights, x_normed_bf16, vocab_size):
+    lm_inputs = [x_normed_bf16.flatten().astype(bfloat16)]
+    out_idx = []
+    for p in range(_LM_N_PARTITIONS):
+        lm_inputs.append(weights._lm_weight_parts_gemv[p])
+        lm_inputs.append(np.zeros(_LM_N_PART, dtype=bfloat16))
+        out_idx.append(2 + 2 * p)
+    res = decode_cache.load_and_run(
+        "lm_head_gemv",
+        _lm_gemv_backend(),
+        *lm_inputs,
+        output_indices=out_idx,
+        static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+    )
+    logits = np.zeros(vocab_size, dtype=np.float32)
+    for p in range(_LM_N_PARTITIONS):
+        n_start = p * _LM_N_PART
+        n_end = min(n_start + _LM_N_PART, vocab_size)
+        logits[n_start:n_end] = res[2 + 2 * p][: n_end - n_start].astype(np.float32)
+    return logits
+
+
+# ---------------------------------------------------------------------------
+# NPU Prefill with KV cache extraction
+# ---------------------------------------------------------------------------
+
+
+def run_npu_prefill(
+    token_ids,
+    weights,
+    config,
+    prefill_cache,
+    decode_cache,
+    rope_lut_bf16,
+    max_seq,
+    tokenizer,
+    cpu_attn=True,
+    profile=False,
+    quiet=False,
+):
+    """Run NPU prefill (36 Qwen3 layers) and extract KV cache.
+
+    Returns: (prefill_token, logits_row, k_cache, v_cache, prompt_len).
+    K cache stores k_roped (AFTER bias AND RoPE); V stores bias-added projection.
+    """
+    seq_len = len(token_ids)
+    emb_dim = config.emb_dim
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    vocab_size = weights.lm_head.shape[0]
+
+    k_cache = np.zeros((config.n_layers, n_kv_heads, max_seq, head_dim), dtype=bfloat16)
+    v_cache = np.zeros((config.n_layers, n_kv_heads, max_seq, head_dim), dtype=bfloat16)
+
+    with prefill_cache.profiler.time_cpu("embed_lookup"):
+        x_bf16 = weights.embed_table[token_ids].astype(np.float32).astype(bfloat16)
+
+    if not quiet:
+        print(f"Running NPU prefill ({config.n_layers} layers, seq_len={seq_len})...")
+    t_start = time.time()
+
+    for layer_idx in range(config.n_layers):
+        t0 = prefill_cache.profiler.start_layer()
+        x_bf16, inter = run_transformer_block_qwen3(
+            x_bf16,
+            weights.layers[layer_idx],
+            rope_lut_bf16,
+            config,
+            prefill_cache,
+            layer_idx=layer_idx,
+            cpu_attn=cpu_attn,
+            verbose=profile,
+        )
+        with prefill_cache.profiler.time_cpu("kv_cache_extract"):
+            k_roped = inter["k_roped"]
+            v_biased = inter["v"]
+            k_cache[layer_idx, :, :seq_len, :] = (
+                k_roped.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+            )
+            v_cache[layer_idx, :, :seq_len, :] = (
+                v_biased.astype(bfloat16).reshape(seq_len, n_kv_heads, head_dim).transpose(1, 0, 2)
+            )
+        prefill_cache.profiler.end_layer(layer_idx, t0)
+
+    # Final RMSNorm (eps=1e-6) on the prediction-position row + NPU LM-head.
+    prompt_len = len([t for t in token_ids if t != tokenizer.eos_token_id])
+    pred_pos = prompt_len - 1
+    with prefill_cache.profiler.time_cpu("final_rms_norm"):
+        last_hidden = np.asarray(x_bf16, dtype=np.float32)[pred_pos : pred_pos + 1]
+        last_normed = rms_norm(last_hidden, weights.final_norm, eps=EPS).flatten().astype(bfloat16)
+
+    logits_row = _run_lm_head(decode_cache, weights, last_normed, vocab_size)
+    prefill_token = int(np.argmax(logits_row))
+
+    t_prefill = time.time() - t_start
+    if not quiet:
+        print(f"NPU prefill done in {t_prefill:.2f}s. First token: {prefill_token}")
+    return prefill_token, logits_row, k_cache, v_cache, prompt_len
+
+
+# ---------------------------------------------------------------------------
+# Single decode step
+# ---------------------------------------------------------------------------
+
+
+def run_npu_decode_step(
+    x_decode_bf16, weights, config, decode_cache, rope_lut_bf16, k_cache, v_cache, current_pos
+):
+    """Run one NPU decode step: 36 blocks + final RMSNorm + LM-head."""
+    vocab_size = weights.lm_head.shape[0]
+    x = x_decode_bf16.copy()
+    for layer_idx in range(config.n_layers):
+        t0 = decode_cache.profiler.start_layer()
+        x, _ = run_decode_block(
+            x,
+            weights.layers[layer_idx],
+            decode_cache,
+            config,
+            k_cache[layer_idx],
+            v_cache[layer_idx],
+            current_pos,
+            rope_lut_bf16,
+        )
+        decode_cache.profiler.end_layer(layer_idx, t0)
+
+    with decode_cache.profiler.time_cpu("final_rms_norm"):
+        x_normed = rms_norm(
+            x.astype(np.float32).reshape(1, config.emb_dim), weights.final_norm, eps=EPS
+        )
+    logits = _run_lm_head(decode_cache, weights, x_normed.flatten().astype(bfloat16), vocab_size)
+    next_token = int(np.argmax(logits))
+    return next_token, logits
+
+
+# ---------------------------------------------------------------------------
+# Full generation
+# ---------------------------------------------------------------------------
+
+
+def generate(
+    prompt_tokens,
+    weights,
+    config,
+    prefill_cache,
+    decode_cache,
+    rope_lut_bf16,
+    tokenizer,
+    n_tokens=10,
+    profile=False,
+    cpu_attn=True,
+    on_token=None,
+    ttft_start=None,
+):
+    seq_len = len(prompt_tokens)
+    max_seq = seq_len + n_tokens
+    streaming = on_token is not None
+    if ttft_start is None:
+        ttft_start = time.perf_counter()
+
+    if not streaming:
+        print(f"\n{'='*60}")
+        print(f"Qwen3 Inference: prompt_len={seq_len}, n_tokens={n_tokens}")
+        print(f"{'='*60}\n")
+
+    prefill_token, _logits, k_cache, v_cache, prompt_len = run_npu_prefill(
+        prompt_tokens, weights, config, prefill_cache, decode_cache,
+        rope_lut_bf16, max_seq, tokenizer=tokenizer, cpu_attn=cpu_attn,
+        profile=profile, quiet=True,
+    )
+
+    ttft = time.perf_counter() - ttft_start
+    if not streaming:
+        print(f"Time to first token (TTFT): {ttft:.2f}s. First token: {prefill_token}")
+
+    generated_tokens = [prefill_token]
+    current_pos = prompt_len
+    x_decode = weights.embed_table[prefill_token].astype(bfloat16)
+
+    stream_state = _StreamState() if streaming else None
+    if streaming:
+        on_token(prefill_token, _delta_text(tokenizer, generated_tokens, stream_state))
+
+    if not streaming:
+        print(f"\nDecoding {n_tokens} tokens...")
+    t_dec = time.time()
+
+    eos_ids = {tokenizer.eos_token_id}
+    eot = tokenizer.convert_tokens_to_ids("<|im_end|>")
+    if isinstance(eot, int) and eot >= 0:
+        eos_ids.add(eot)
+
+    for _ in range(n_tokens):
+        next_token, _ = run_npu_decode_step(
+            x_decode, weights, config, decode_cache, rope_lut_bf16,
+            k_cache, v_cache, current_pos,
+        )
+        generated_tokens.append(next_token)
+        current_pos += 1
+        with decode_cache.profiler.time_cpu("embed_lookup"):
+            x_decode = weights.embed_table[next_token].astype(bfloat16)
+        if streaming:
+            on_token(next_token, _delta_text(tokenizer, generated_tokens, stream_state))
+        if next_token in eos_ids:
+            break
+
+    t_decode = time.time() - t_dec
+    n_gen = len(generated_tokens) - 1
+    if not streaming and n_gen > 0:
+        print(f"\nGenerated {n_gen} tokens in {t_decode:.2f}s ({n_gen / t_decode:.2f} tok/s)")
+
+    if prefill_cache.profiler.enabled:
+        print(f"\n{'='*60}\nPREFILL detail")
+        prefill_cache.profiler.report()
+    if decode_cache.profiler.enabled:
+        print(f"\n{'='*60}\nDECODE detail")
+        decode_cache.profiler.report()
+
+    return generated_tokens
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+MODEL_CHOICES = {"base": "Qwen/Qwen3-4B", "instruct": "Qwen/Qwen3-4B"}
+
+
+def build_session(args) -> Session:
+    config = LlamaConfig()
+    seq_len = 2048
+
+    prefill_cache = KernelCache(
+        "prefill_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+    )
+    decode_cache = KernelCache(
+        "decode_kernel_cache", verbose=args.verbose, profiler=Profiler(enabled=args.profile)
+    )
+
+    if not args.run_only:
+        print("Compiling prefill kernels...")
+        compile_all_kernels(prefill_cache, config, seq_len, verbose=args.verbose, cpu_attn=args.cpu_attn)
+        print("\nCompiling decode kernels...")
+        compile_decode_kernels(decode_cache, config, verbose=args.verbose)
+
+    if args.compile_only:
+        print("\nCompilation passed.")
+        sys.exit(0)
+
+    if args.run_only:
+        prefill_cache.load_manifest()
+        decode_cache.load_manifest()
+
+    model_id = MODEL_CHOICES.get(args.model, args.model)
+    print(f"\nLoading weights ({model_id})...")
+    weights = load_weights(model_id, config=config)
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    rope_lut_bf16 = generate_rope_lut(config=config, seq_len=seq_len + args.n_tokens).astype(bfloat16)
+
+    prepare_runtime(prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16)
+
+    return Session(
+        config=config, seq_len=seq_len, weights=weights, tokenizer=tokenizer,
+        prefill_cache=prefill_cache, decode_cache=decode_cache,
+        rope_lut_bf16=rope_lut_bf16, model_variant=args.model,
+    )
+
+
+def _tokenize_prompt(session: Session, prompt_text: str) -> list:
+    if session.model_variant == "instruct":
+        messages = [{"role": "user", "content": prompt_text}]
+        chat_text = session.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        return session.tokenizer.encode(chat_text)
+    return session.tokenizer.encode(prompt_text)
+
+
+def run_once(session, prompt_text, *, n_tokens, profile=False, cpu_attn=True, on_token=None):
+    ttft_start = time.perf_counter()
+    with session.prefill_cache.profiler.time_cpu("tokenize"):
+        tokens = _tokenize_prompt(session, prompt_text)
+    prompt_len_actual = len(tokens)
+    with session.prefill_cache.profiler.time_cpu("eos_pad"):
+        if len(tokens) < session.seq_len:
+            tokens = tokens + [session.tokenizer.eos_token_id] * (session.seq_len - len(tokens))
+    generated = generate(
+        tokens, session.weights, session.config, session.prefill_cache,
+        session.decode_cache, session.rope_lut_bf16, tokenizer=session.tokenizer,
+        n_tokens=n_tokens, profile=profile, cpu_attn=cpu_attn, on_token=on_token,
+        ttft_start=ttft_start,
+    )
+    return generated, prompt_len_actual
+
+
+def _print_one_shot_output(session, prompt_text, generated, prompt_len_actual):
+    print(f"\n{'='*60}")
+    if session.model_variant == "instruct":
+        response = session.tokenizer.decode(generated, skip_special_tokens=True).strip()
+        print(f"Q: {prompt_text}")
+        print(f"A: {response}")
+    else:
+        prompt_tokens = _tokenize_prompt(session, prompt_text)
+        all_tokens = prompt_tokens[:prompt_len_actual] + generated
+        print("Generated text:")
+        print(session.tokenizer.decode(all_tokens))
+
+
+def repl_loop(session, args):
+    print("\nInteractive mode — Ctrl-D or /quit to exit.\n")
+
+    def _cb(_tid, delta):
+        sys.stdout.write(delta)
+        sys.stdout.flush()
+
+    while True:
+        try:
+            prompt = input("Prompt> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if not prompt:
+            continue
+        if prompt in ("/quit", "/exit"):
+            return
+        sys.stdout.write("\nResponse: ")
+        sys.stdout.flush()
+        try:
+            run_once(session, prompt, n_tokens=args.n_tokens, profile=False,
+                     cpu_attn=args.cpu_attn, on_token=_cb)
+        except KeyboardInterrupt:
+            print("\n[interrupted]")
+            continue
+        print("\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Qwen3-4B Inference (NPU)")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--run-only", action="store_true")
+    parser.add_argument("--n-tokens", type=int, default=10)
+    parser.add_argument("--profile", action="store_true")
+    # Default: NPU head-first FlashAttention. Pass --cpu-attn to fall back to
+    # the FP32 host attention reference.
+    parser.add_argument("--cpu-attn", action="store_true", default=False)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--prompt", type=str, default="What is the capital of France?")
+    parser.add_argument("--model", type=str, choices=["base", "instruct"], default="instruct")
+    parser.add_argument("--interactive", action="store_true")
+    args = parser.parse_args()
+
+    if args.interactive:
+        if args.compile_only:
+            parser.error("--interactive cannot be combined with --compile-only")
+        if not args.run_only:
+            parser.error("--interactive requires --run-only")
+        args.profile = False
+
+    session = build_session(args)
+
+    if args.interactive:
+        repl_loop(session, args)
+    else:
+        generated, plen = run_once(
+            session, args.prompt, n_tokens=args.n_tokens, profile=args.profile,
+            cpu_attn=args.cpu_attn,
+        )
+        _print_one_shot_output(session, args.prompt, generated, plen)

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_prefill.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_prefill.py
@@ -69,7 +69,6 @@ if _LLMS_DIR not in sys.path:
 from qwen3_4b_weights import LlamaConfig
 from qwen3_4b_cpu_helpers import attention_reference
 
-
 # ---------------------------------------------------------------------------
 # GEMM method/tile spec — REGISTRY-DRIVEN. Every qwen3_4b prefill GEMM now
 # pulls its method + tiles from the kernel registry (gemm_registry_config),
@@ -104,13 +103,29 @@ def _build_gemm_ir(m, k, n, spec, herd_m=8, herd_n=4):
 
     direct -> fully-lowered example builder (no external mm.o); fused-cast ->
     the shared _build_gemm_module (links mm_m64.o)."""
-    tm, k2, k1, tn = spec["tile_m"], spec["tile_k_l2"], spec["tile_k_l1"], spec["tile_n"]
+    tm, k2, k1, tn = (
+        spec["tile_m"],
+        spec["tile_k_l2"],
+        spec["tile_k_l1"],
+        spec["tile_n"],
+    )
     if spec["method"] == "direct":
         from matrix_multiplication.bf16_in_bf16_out.run import build_module_lowered
 
         return str(
             build_module_lowered(
-                m, k, n, tm, k2, k1, tn, herd_m, herd_n, bfloat16, bfloat16, arch="aie2p"
+                m,
+                k,
+                n,
+                tm,
+                k2,
+                k1,
+                tn,
+                herd_m,
+                herd_n,
+                bfloat16,
+                bfloat16,
+                arch="aie2p",
             )
         )
     from shared.builders.gemm_builder import _build_gemm_module
@@ -157,7 +172,13 @@ def build_rms_qkv_qknorm_rope_module(seq_len, config):
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
     return _build(
-        seq_len, emb_dim, q_dim, kv_dim, n_heads, n_kv_heads, head_dim,
+        seq_len,
+        emb_dim,
+        q_dim,
+        kv_dim,
+        n_heads,
+        n_kv_heads,
+        head_dim,
         qknorm_eps=1e-6,
         gemm_spec_fn=gemm_spec,
     )
@@ -216,14 +237,22 @@ def _build_residual_add_2d_ir(seq_len, emb_dim):
                 @segment(name="radd_seg", operands=[proj_flat, xres_flat, out_flat])
                 def add_seg(s_proj, s_xres, s_out):
                     row_map = AffineMap.get(
-                        0, 2,
-                        [AffineExpr.get_add(
-                            AffineExpr.get_mul(AffineSymbolExpr.get(0),
-                                               AffineConstantExpr.get(rows_per_pe)),
-                            AffineSymbolExpr.get(1))],
+                        0,
+                        2,
+                        [
+                            AffineExpr.get_add(
+                                AffineExpr.get_mul(
+                                    AffineSymbolExpr.get(0),
+                                    AffineConstantExpr.get(rows_per_pe),
+                                ),
+                                AffineSymbolExpr.get(1),
+                            )
+                        ],
                     )
 
-                    @herd(name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out])
+                    @herd(
+                        name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out]
+                    )
                     def add_body(_tx, _ty, _sx, _sy, h_proj, h_xres, h_out):
                         l1_p = AllocOp(l1_ty, [], [])
                         l1_x = AllocOp(l1_ty, [], [])
@@ -233,17 +262,46 @@ def _build_residual_add_2d_ir(seq_len, emb_dim):
                         for iv in range_(0, rows_per_pe, 1):
                             r = affine_apply(row_map, [_tx, iv])
                             off = arith.muli(r, arith.ConstantOp.create_index(emb_dim))
-                            dma_memcpy_nd(l1_p, h_proj, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
-                            dma_memcpy_nd(l1_x, h_xres, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            dma_memcpy_nd(
+                                l1_p,
+                                h_proj,
+                                src_offsets=[off],
+                                src_sizes=[emb_dim],
+                                src_strides=[1],
+                            )
+                            dma_memcpy_nd(
+                                l1_x,
+                                h_xres,
+                                src_offsets=[off],
+                                src_sizes=[emb_dim],
+                                src_strides=[1],
+                            )
                             for j in range_(0, emb_dim, 16):
                                 sp = subview(l1_p.result, [j], [16], [1])
                                 sx = subview(l1_x.result, [j], [16], [1])
                                 so = subview(l1_o.result, [j], [16], [1])
-                                vp = transfer_read(vec_ty, sp, [c0], identity_map, cst0, [True])
-                                vx = transfer_read(vec_ty, sx, [c0], identity_map, cst0, [True])
-                                transfer_write(None, arith.addf(vp, vx), so, [c0], identity_map, [True])
+                                vp = transfer_read(
+                                    vec_ty, sp, [c0], identity_map, cst0, [True]
+                                )
+                                vx = transfer_read(
+                                    vec_ty, sx, [c0], identity_map, cst0, [True]
+                                )
+                                transfer_write(
+                                    None,
+                                    arith.addf(vp, vx),
+                                    so,
+                                    [c0],
+                                    identity_map,
+                                    [True],
+                                )
                                 yield_([])
-                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[off], dst_sizes=[emb_dim], dst_strides=[1])
+                            dma_memcpy_nd(
+                                h_out,
+                                l1_o,
+                                dst_offsets=[off],
+                                dst_sizes=[emb_dim],
+                                dst_strides=[1],
+                            )
                             yield_([])
                         DeallocOp(l1_p)
                         DeallocOp(l1_x)
@@ -264,41 +322,60 @@ def build_o_res_norm_module(seq_len, emb_dim, q_dim, o_herd_m=8, o_herd_n=4):
       [+ f32 C-scratch tail for the fused-cast O GEMM]
     """
     from shared.infra.stitching import (
-        _wrap_ir_in_launch, stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+        _wrap_ir_in_launch,
+        stitch_elf,
+        KernelSlice,
+        FuncArg,
+        alloc_gemm_scratch,
     )
     from weighted_rms_norm.weighted_rms_norm import build_module as build_rms
 
-    o_spec = gemm_spec(seq_len, q_dim, emb_dim, "high")   # fused-cast _m64
-    print(f"  [1/3] O GEMM ({o_spec['method']})  {seq_len}x{q_dim}x{emb_dim} (DECOUPLED)...")
+    o_spec = gemm_spec(seq_len, q_dim, emb_dim, "high")  # fused-cast _m64
+    print(
+        f"  [1/3] O GEMM ({o_spec['method']})  {seq_len}x{q_dim}x{emb_dim} (DECOUPLED)..."
+    )
     o_ir = _build_gemm_ir(seq_len, q_dim, emb_dim, o_spec, o_herd_m, o_herd_n)
     print("  [2/3] Residual Add...")
     res_add_ir = _build_residual_add_2d_ir(seq_len, emb_dim)
     print("  [3/3] FFN RMSNorm...")
-    rms_ir = _wrap_ir_in_launch(str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8)))
+    rms_ir = _wrap_ir_in_launch(
+        str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8))
+    )
 
     scratch_args, scratch_for = alloc_gemm_scratch(
-        [(o_spec, seq_len, emb_dim)], base_arg_count=7,
+        [(o_spec, seq_len, emb_dim)],
+        base_arg_count=7,
     )
 
     def _amap(i, w, o, sc):
         return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
 
     base_args = [
-        FuncArg("%arg0", f"memref<{seq_len}x{q_dim}xbf16>"),     # attn_out (DECOUPLED)
-        FuncArg("%arg1", f"memref<{q_dim}x{emb_dim}xbf16>"),     # wo (DECOUPLED)
-        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),   # proj
-        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),   # x_resid
-        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),   # res1 (out)
-        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),             # ffn_norm
-        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),   # normed2 (out)
+        FuncArg("%arg0", f"memref<{seq_len}x{q_dim}xbf16>"),  # attn_out (DECOUPLED)
+        FuncArg("%arg1", f"memref<{q_dim}x{emb_dim}xbf16>"),  # wo (DECOUPLED)
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),  # proj
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),  # x_resid
+        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),  # res1 (out)
+        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),  # ffn_norm
+        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),  # normed2 (out)
     ]
     slices = [
-        KernelSlice(o_ir, "og", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(o_spec)),
+        KernelSlice(
+            o_ir,
+            "og",
+            _amap(0, 1, 2, scratch_for[0]),
+            extern_syms=_gemm_externs(o_spec),
+        ),
         KernelSlice(res_add_ir, "ra", {0: 2, 1: 3, 2: 4}, private_from=False),
         KernelSlice(rms_ir, "rm", {0: 4, 1: 5, 2: 6}, private_from=False),
     ]
-    module = stitch_elf("o_res_norm", base_args, slices, scratch_args=scratch_args,
-                        debug_dump_path="/tmp/debug_o_res_norm_4b.mlir")
+    module = stitch_elf(
+        "o_res_norm",
+        base_args,
+        slices,
+        scratch_args=scratch_args,
+        debug_dump_path="/tmp/debug_o_res_norm_4b.mlir",
+    )
     print(f"  o_res_norm module: {len(str(module).splitlines())} lines, parsed OK")
     return module, scratch_for
 
@@ -310,18 +387,27 @@ def _build_single_gemm_elf(name, sym, seq_len, k_dim, n_dim, herd_m=8, herd_n=4)
     needs an f32 C-scratch func arg + the external mm_m64.o symbols. Returns
     (module, scratch_for_index) where scratch_for_index is the f32-scratch combined
     arg index (or None for a direct/drain method that needs no scratch)."""
-    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch
+    from shared.infra.stitching import (
+        stitch_elf,
+        KernelSlice,
+        FuncArg,
+        alloc_gemm_scratch,
+    )
+
     g_spec = gemm_spec(seq_len, k_dim, n_dim, "high")
-    print(f"  [{name}] {name} GEMM ({g_spec['method']}) {seq_len}x{k_dim}x{n_dim} "
-          f"(tk_l2={g_spec['tile_k_l2']}, tn={g_spec['tile_n']})...")
+    print(
+        f"  [{name}] {name} GEMM ({g_spec['method']}) {seq_len}x{k_dim}x{n_dim} "
+        f"(tk_l2={g_spec['tile_k_l2']}, tn={g_spec['tile_n']})..."
+    )
     gemm_ir = _build_gemm_ir(seq_len, k_dim, n_dim, g_spec, herd_m, herd_n)
     base_args = [
-        FuncArg("%arg0", f"memref<{seq_len}x{k_dim}xbf16>"),   # normed2
-        FuncArg("%arg1", f"memref<{k_dim}x{n_dim}xbf16>"),     # weight
-        FuncArg("%arg2", f"memref<{seq_len}x{n_dim}xbf16>"),   # out
+        FuncArg("%arg0", f"memref<{seq_len}x{k_dim}xbf16>"),  # normed2
+        FuncArg("%arg1", f"memref<{k_dim}x{n_dim}xbf16>"),  # weight
+        FuncArg("%arg2", f"memref<{seq_len}x{n_dim}xbf16>"),  # out
     ]
     scratch_args, scratch_for = alloc_gemm_scratch(
-        [(g_spec, seq_len, n_dim)], base_arg_count=3,
+        [(g_spec, seq_len, n_dim)],
+        base_arg_count=3,
     )
     sc = scratch_for[0]
     amap = {0: 0, 1: 1, 2: sc, 3: 2} if sc is not None else {0: 0, 1: 1, 2: 2}
@@ -333,14 +419,16 @@ def _build_single_gemm_elf(name, sym, seq_len, k_dim, n_dim, herd_m=8, herd_n=4)
 
 def build_gate_module(seq_len, emb_dim, hidden_dim, gate_herd_m=8, gate_herd_n=4):
     """ELF A2: Gate(fused-cast high-prec, registry) alone -> gate (seq,hidden)."""
-    return _build_single_gemm_elf("gate", "gg", seq_len, emb_dim, hidden_dim,
-                                  gate_herd_m, gate_herd_n)
+    return _build_single_gemm_elf(
+        "gate", "gg", seq_len, emb_dim, hidden_dim, gate_herd_m, gate_herd_n
+    )
 
 
 def build_up_module(seq_len, emb_dim, hidden_dim, up_herd_m=8, up_herd_n=4):
     """ELF A3: Up(fused-cast high-prec, registry) alone -> up (seq,hidden)."""
-    return _build_single_gemm_elf("up", "ug", seq_len, emb_dim, hidden_dim,
-                                  up_herd_m, up_herd_n)
+    return _build_single_gemm_elf(
+        "up", "ug", seq_len, emb_dim, hidden_dim, up_herd_m, up_herd_n
+    )
 
 
 # SwiGLU runs on the NPU as a standalone ELF (silu_and_mul.build_module_2d).
@@ -365,9 +453,12 @@ def _swiglu_tile_n(seq_len, hidden_dim, herd_x=8):
 def build_swiglu_module(seq_len, hidden_dim, herd_x=8, herd_y=1):
     """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (seq x hidden)."""
     from silu_and_mul.silu_and_mul import build_module_2d as build_swiglu
+
     tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
-    print(f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
-          f"iters={seq_len * hidden_dim // (tile_n * herd_x)})...")
+    print(
+        f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
+        f"iters={seq_len * hidden_dim // (tile_n * herd_x)})..."
+    )
     module = build_swiglu(seq_len, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
     print(f"  swiglu module: {len(str(module).splitlines())} lines, parsed OK")
     return module
@@ -414,7 +505,8 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                 @segment(name="dadd_seg", operands=[down_flat, res_flat, l_out])
                 def add_seg(s_down, s_res, s_out):
                     offset_map = AffineMap.get(
-                        0, 3,
+                        0,
+                        3,
                         [
                             AffineExpr.get_add(
                                 AffineSymbolExpr.get(0),
@@ -432,7 +524,9 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                         ],
                     )
 
-                    @herd(name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out])
+                    @herd(
+                        name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out]
+                    )
                     def add_body(_tx, _ty, _sx, _sy, h_down, h_res, h_out):
                         l1_d = AllocOp(l1_ty, [], [])
                         l1_r = AllocOp(l1_ty, [], [])
@@ -441,17 +535,46 @@ def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
                         cst0 = arith.ConstantOp(xrt_dtype, 0.0)
                         for loop_iv in range_(0, chunk_size, tile_n):
                             offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
-                            dma_memcpy_nd(l1_d, h_down, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
-                            dma_memcpy_nd(l1_r, h_res, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            dma_memcpy_nd(
+                                l1_d,
+                                h_down,
+                                src_offsets=[offset],
+                                src_sizes=[tile_n],
+                                src_strides=[1],
+                            )
+                            dma_memcpy_nd(
+                                l1_r,
+                                h_res,
+                                src_offsets=[offset],
+                                src_sizes=[tile_n],
+                                src_strides=[1],
+                            )
                             for j in range_(0, tile_n, 16):
                                 sd = subview(l1_d.result, [j], [16], [1])
                                 sr = subview(l1_r.result, [j], [16], [1])
                                 so = subview(l1_o.result, [j], [16], [1])
-                                vd = transfer_read(vec_ty, sd, [c0], identity_map, cst0, [True])
-                                vr = transfer_read(vec_ty, sr, [c0], identity_map, cst0, [True])
-                                transfer_write(None, arith.addf(vd, vr), so, [c0], identity_map, [True])
+                                vd = transfer_read(
+                                    vec_ty, sd, [c0], identity_map, cst0, [True]
+                                )
+                                vr = transfer_read(
+                                    vec_ty, sr, [c0], identity_map, cst0, [True]
+                                )
+                                transfer_write(
+                                    None,
+                                    arith.addf(vd, vr),
+                                    so,
+                                    [c0],
+                                    identity_map,
+                                    [True],
+                                )
                                 yield_([])
-                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[offset], dst_sizes=[tile_n], dst_strides=[1])
+                            dma_memcpy_nd(
+                                h_out,
+                                l1_o,
+                                dst_offsets=[offset],
+                                dst_sizes=[tile_n],
+                                dst_strides=[1],
+                            )
                             yield_([])
                         DeallocOp(l1_d)
                         DeallocOp(l1_r)
@@ -469,18 +592,27 @@ def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd
       [+ f32 C-scratch tail for the fused-cast Down]
     """
     from shared.infra.stitching import (
-        stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+        stitch_elf,
+        KernelSlice,
+        FuncArg,
+        alloc_gemm_scratch,
     )
+
     n_total = seq_len * emb_dim
     d_spec = gemm_spec(seq_len, hidden_dim, emb_dim, "high")  # fused-cast _m64
-    print(f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
-          f"(tn={d_spec['tile_n']})...")
-    down_ir = _build_gemm_ir(seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n)
+    print(
+        f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
+        f"(tn={d_spec['tile_n']})..."
+    )
+    down_ir = _build_gemm_ir(
+        seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n
+    )
     print("  [down_add] FFN Add (2D -> 1D)...")
     ffn_add_ir = _build_down_add_2d_to_1d_ir(seq_len, emb_dim)
 
     scratch_args, scratch_for = alloc_gemm_scratch(
-        [(d_spec, seq_len, emb_dim)], base_arg_count=5,
+        [(d_spec, seq_len, emb_dim)],
+        base_arg_count=5,
     )
 
     def _amap(i, w, o, sc):
@@ -489,16 +621,27 @@ def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd
     base_args = [
         FuncArg("%arg0", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # swiglu
         FuncArg("%arg1", f"memref<{hidden_dim}x{emb_dim}xbf16>"),  # w_down
-        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),     # down
-        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),     # res1
-        FuncArg("%arg4", f"memref<{n_total}xbf16>"),              # output
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),  # down
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),  # res1
+        FuncArg("%arg4", f"memref<{n_total}xbf16>"),  # output
     ]
     slices = [
-        KernelSlice(down_ir, "dg", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(d_spec), private_from=True),
+        KernelSlice(
+            down_ir,
+            "dg",
+            _amap(0, 1, 2, scratch_for[0]),
+            extern_syms=_gemm_externs(d_spec),
+            private_from=True,
+        ),
         KernelSlice(ffn_add_ir, "fa", {0: 2, 1: 3, 2: 4}, private_from=False),
     ]
-    module = stitch_elf("down_add", base_args, slices, scratch_args=scratch_args,
-                        debug_dump_path="/tmp/debug_down_add_4b.mlir")
+    module = stitch_elf(
+        "down_add",
+        base_args,
+        slices,
+        scratch_args=scratch_args,
+        debug_dump_path="/tmp/debug_down_add_4b.mlir",
+    )
     print(f"  down_add module: {len(str(module).splitlines())} lines, parsed OK")
     return module, scratch_for
 
@@ -599,23 +742,33 @@ def _resolve_scratch_for(config, seq_len=2048):
         out = []
         for s in specs:
             if s["needs_f32_scratch"]:
-                out.append(nxt); nxt += 1
+                out.append(nxt)
+                nxt += 1
             else:
                 out.append(None)
         return out
 
     # Fused rms_qkv_qknorm_rope ELF: Q/K/V specs, scratch tail starts at 17.
-    _FUSED_SCRATCH_FOR = _alloc([
-        gemm_spec(seq_len, config.emb_dim, q_dim),
-        gemm_spec(seq_len, config.emb_dim, kv_dim),
-        gemm_spec(seq_len, config.emb_dim, kv_dim),
-    ], 17)
-    _ORES_SCRATCH_FOR = _alloc([
-        gemm_spec(seq_len, q_dim, config.emb_dim),
-    ], 7)
-    _DOWN_SCRATCH_FOR = _alloc([
-        gemm_spec(seq_len, config.hidden_dim, config.emb_dim),
-    ], 5)
+    _FUSED_SCRATCH_FOR = _alloc(
+        [
+            gemm_spec(seq_len, config.emb_dim, q_dim),
+            gemm_spec(seq_len, config.emb_dim, kv_dim),
+            gemm_spec(seq_len, config.emb_dim, kv_dim),
+        ],
+        17,
+    )
+    _ORES_SCRATCH_FOR = _alloc(
+        [
+            gemm_spec(seq_len, q_dim, config.emb_dim),
+        ],
+        7,
+    )
+    _DOWN_SCRATCH_FOR = _alloc(
+        [
+            gemm_spec(seq_len, config.hidden_dim, config.emb_dim),
+        ],
+        5,
+    )
     # gate / up standalone single-GEMM ELFs: scratch tail starts at arg 3.
     _GATE_SCRATCH_FOR = _alloc([gemm_spec(seq_len, emb_dim, hidden_dim)], 3)
     _UP_SCRATCH_FOR = _alloc([gemm_spec(seq_len, emb_dim, hidden_dim)], 3)
@@ -633,16 +786,23 @@ def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
 
-    print(f"\n{'='*60}\nCompiling Qwen3-4B prefill kernels (seq_len={seq_len})...\n{'='*60}\n")
+    print(
+        f"\n{'='*60}\nCompiling Qwen3-4B prefill kernels (seq_len={seq_len})...\n{'='*60}\n"
+    )
 
     from shared.infra.external_kernels import compile_gemm_mm, compile_rope
 
     # mm.o variants for the external (fused-cast) GEMMs; Gate/Up direct-codegen
     # needs NO external .o. rope.o for head_dim=128.
-    compile_gemm_mm(tile_m=32, tile_n=128, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o")
-    compile_gemm_mm(tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o")
+    compile_gemm_mm(
+        tile_m=32, tile_n=128, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o"
+    )
+    compile_gemm_mm(
+        tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o"
+    )
     compile_rope()
     from shared.infra.external_kernels import compile_silu_and_mul
+
     compile_silu_and_mul()  # silu_and_mul.o for the standalone NPU SwiGLU ELF
 
     print("\n--- rms_qkv_qknorm_rope (FUSED: RMSNorm+QKV+QK-norm+RoPE, 8 launches) ---")
@@ -668,8 +828,9 @@ def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
     cache.compile_and_cache("up", up_mod, _up_backend(verbose))
 
     print("\n--- swiglu (NPU SwiGLU: silu(gate)*up) ---")
-    cache.compile_and_cache("swiglu", build_swiglu_module(seq_len, hidden_dim),
-                            _swiglu_backend(verbose))
+    cache.compile_and_cache(
+        "swiglu", build_swiglu_module(seq_len, hidden_dim), _swiglu_backend(verbose)
+    )
 
     print("\n--- down_add (Down GEMM [launch 0] + FFN Add) ---")
     down_mod, down_scratch = build_down_add_module(seq_len, emb_dim, hidden_dim)
@@ -717,23 +878,23 @@ def _fused_qknorm_rope_call(
         fused_scratch = _FUSED_SCRATCH_FOR
 
     args = [
-        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),          # 0 x_in (dynamic)
-        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),           # 1 norm_w (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                        # 2 normed (inter)
-        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),           # 3 wq (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 4 q (inter)
-        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),          # 5 wk (static)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 6 k (inter)
-        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),          # 7 wv (static)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 8 v (inter/out)
-        np.asarray(lw.q_norm, dtype=bfloat16).reshape(head_dim),            # 9 q_norm (static)
-        np.asarray(lw.k_norm, dtype=bfloat16).reshape(head_dim),            # 10 k_norm (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 11 q_n (inter)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 12 k_n (inter)
-        lut_q,                                                              # 13 lut_q (static)
-        lut_k,                                                              # 14 lut_k (static)
-        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 15 q_roped (inter/out)
-        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 16 k_roped (inter/out)
+        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),  # 0 x_in (dynamic)
+        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),  # 1 norm_w (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 normed (inter)
+        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),  # 3 wq (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 4 q (inter)
+        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),  # 5 wk (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 6 k (inter)
+        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),  # 7 wv (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 8 v (inter/out)
+        np.asarray(lw.q_norm, dtype=bfloat16).reshape(head_dim),  # 9 q_norm (static)
+        np.asarray(lw.k_norm, dtype=bfloat16).reshape(head_dim),  # 10 k_norm (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 11 q_n (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 12 k_n (inter)
+        lut_q,  # 13 lut_q (static)
+        lut_k,  # 14 lut_k (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),  # 15 q_roped (inter/out)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),  # 16 k_roped (inter/out)
     ]
     inter = {2, 4, 6, 8, 11, 12, 15, 16}
     for sc, cols in zip(fused_scratch or [], (q_dim, kv_dim, kv_dim)):
@@ -790,19 +951,29 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
         # One fused ELF: RMSNorm + Q/K/V GEMM + per-head QK-norm + RoPE.
         _fused_qknorm_rope_call(
-            cache, lw, config, seq_len, lut_q, lut_k, layer_idx,
+            cache,
+            lw,
+            config,
+            seq_len,
+            lut_q,
+            lut_k,
+            layer_idx,
             np.zeros((seq_len, emb_dim), dtype=bfloat16),
         )
 
         # o_res_norm: static {1,5}. Outputs res1 (arg4), normed2 (arg6).
         ores_args = [
-            np.zeros((seq_len, q_dim), dtype=bfloat16),                           # 0 attn_out (DECOUPLED)
-            np.asarray(lw.wo, dtype=bfloat16).reshape(q_dim, emb_dim),            # 1 wo (static, DECOUPLED)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 2 proj (inter)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 3 x_resid
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 4 res1 (out)
-            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(emb_dim),            # 5 ffn_norm (static)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 6 normed2 (out)
+            np.zeros((seq_len, q_dim), dtype=bfloat16),  # 0 attn_out (DECOUPLED)
+            np.asarray(lw.wo, dtype=bfloat16).reshape(
+                q_dim, emb_dim
+            ),  # 1 wo (static, DECOUPLED)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 proj (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 3 x_resid
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 4 res1 (out)
+            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(
+                emb_dim
+            ),  # 5 ffn_norm (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 6 normed2 (out)
         ]
         ores_inter = set()
         for sc, cols in zip(ores_scratch, (emb_dim,)):
@@ -810,7 +981,9 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
                 ores_inter.add(sc)
         cache.load_and_run(
-            "o_res_norm", _o_res_norm_backend(), *ores_args,
+            "o_res_norm",
+            _o_res_norm_backend(),
+            *ores_args,
             output_indices=[4, 6],
             static_input_indices={1, 5},
             intermediate_indices={2, 4, 6} | ores_inter,
@@ -819,9 +992,11 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
         # gate: static {1}. Output gate (arg2). fused-cast -> f32 scratch tail.
         gate_args = [
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
-            np.asarray(lw.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_gate (static)
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 0 normed2
+            np.asarray(lw.w_gate, dtype=bfloat16).reshape(
+                emb_dim, hidden_dim
+            ),  # 1 w_gate (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 gate (out)
         ]
         gate_int = {2}
         for sc in gate_scratch:
@@ -829,16 +1004,22 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 gate_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
                 gate_int.add(sc)
         cache.load_and_run(
-            "gate", _gate_backend(), *gate_args,
-            output_indices=[2], static_input_indices={1}, intermediate_indices=gate_int,
+            "gate",
+            _gate_backend(),
+            *gate_args,
+            output_indices=[2],
+            static_input_indices={1},
+            intermediate_indices=gate_int,
             bo_key=f"gate_L{layer_idx}",
         )
 
         # up: static {1}. Output up (arg2). fused-cast -> f32 scratch tail.
         up_args = [
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
-            np.asarray(lw.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),      # 1 w_up (static)
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 0 normed2
+            np.asarray(lw.w_up, dtype=bfloat16).reshape(
+                emb_dim, hidden_dim
+            ),  # 1 w_up (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 up (out)
         ]
         up_int = {2}
         for sc in up_scratch:
@@ -846,14 +1027,19 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 up_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
                 up_int.add(sc)
         cache.load_and_run(
-            "up", _up_backend(), *up_args,
-            output_indices=[2], static_input_indices={1}, intermediate_indices=up_int,
+            "up",
+            _up_backend(),
+            *up_args,
+            output_indices=[2],
+            static_input_indices={1},
+            intermediate_indices=up_int,
             bo_key=f"up_L{layer_idx}",
         )
 
         # SwiGLU: NPU ELF (no static weights — only warms the per-layer BO set).
         cache.load_and_run(
-            "swiglu", _swiglu_backend(),
+            "swiglu",
+            _swiglu_backend(),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
             np.zeros((seq_len, hidden_dim), dtype=bfloat16),
@@ -864,11 +1050,13 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
 
         # down_add: static {1}.
         down_args = [
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 0 swiglu
-            np.asarray(lw.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),    # 1 w_down (static)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
-            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 3 res1
-            np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 0 swiglu
+            np.asarray(lw.w_down, dtype=bfloat16).reshape(
+                hidden_dim, emb_dim
+            ),  # 1 w_down (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 down (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 3 res1
+            np.zeros(n_total, dtype=bfloat16),  # 4 output (out)
         ]
         down_inter = set()
         for sc, cols in zip(down_scratch, (emb_dim,)):
@@ -876,7 +1064,9 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
                 down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
                 down_inter.add(sc)
         cache.load_and_run(
-            "down_add", _down_add_backend(), *down_args,
+            "down_add",
+            _down_add_backend(),
+            *down_args,
             output_indices=[4],
             static_input_indices={1},
             intermediate_indices={2, 4} | down_inter,
@@ -922,8 +1112,15 @@ def run_transformer_block_qwen3(
 
     # ---- Stages A-C: one ELF = RMSNorm + Q/K/V GEMM + QK-norm(Q,K) + RoPE(Q,K).
     res = _fused_qknorm_rope_call(
-        cache, layer_weights, config, seq_len, lut_q, lut_k, layer_idx,
-        x_bf16, verbose=verbose,
+        cache,
+        layer_weights,
+        config,
+        seq_len,
+        lut_q,
+        lut_k,
+        layer_idx,
+        x_bf16,
+        verbose=verbose,
     )
     v = res[8].reshape(seq_len, kv_dim)
     q_roped = res[15].reshape(seq_len, q_dim)
@@ -977,13 +1174,19 @@ def run_transformer_block_qwen3(
 
     # ELF A1: o_res_norm (O decoupled) -> res1 (arg4) + normed2 (arg6).
     ores_args = [
-        np.asarray(attn_out, dtype=bfloat16).reshape(seq_len, q_dim),          # 0 attn_out (DECOUPLED)
-        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(q_dim, emb_dim),  # 1 wo (static, DECOUPLED)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
-        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),          # 3 x_resid
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
-        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(emb_dim),   # 5 ffn_norm (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+        np.asarray(attn_out, dtype=bfloat16).reshape(
+            seq_len, q_dim
+        ),  # 0 attn_out (DECOUPLED)
+        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(
+            q_dim, emb_dim
+        ),  # 1 wo (static, DECOUPLED)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 proj (inter)
+        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),  # 3 x_resid
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 4 res1 (out)
+        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(
+            emb_dim
+        ),  # 5 ffn_norm (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 6 normed2 (out)
     ]
     ores_inter = set()
     for sc, cols in zip(ores_scratch, (emb_dim,)):
@@ -1050,9 +1253,9 @@ def run_transformer_block_qwen3(
     sw_res = cache.load_and_run(
         "swiglu",
         _swiglu_backend(verbose),
-        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),   # 0 gate
-        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),     # 1 up
-        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                 # 2 swiglu (out)
+        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 0 gate
+        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 1 up
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 swiglu (out)
         output_indices=[2],
         intermediate_indices={2},
         bo_key=f"swiglu_L{layer_idx}",
@@ -1061,11 +1264,13 @@ def run_transformer_block_qwen3(
 
     # ELF B: down_add -> output (arg4). Down GEMM is launch 0.
     down_args = [
-        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),       # 0 swiglu
-        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),  # 1 w_down (static)
-        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
-        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),            # 3 res1
-        np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 0 swiglu
+        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(
+            hidden_dim, emb_dim
+        ),  # 1 w_down (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),  # 2 down (inter)
+        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),  # 3 res1
+        np.zeros(n_total, dtype=bfloat16),  # 4 output (out)
     ]
     down_inter = set()
     for sc, cols in zip(down_scratch, (emb_dim,)):

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_prefill.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_prefill.py
@@ -1,0 +1,1086 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen3-4B Prefill on MLIR-AIR (NPU2).
+
+Direct re-parameterization of qwen3_0_6b (SAME architecture: Qwen3 QK-norm
+host-side, NO bias, eps=1e-6, tied embeddings, head_dim=128, DECOUPLED O
+proj where q_dim != emb_dim). Only the dims grow:
+
+    qwen3_0_6b : emb=1024, q_dim=2048, kv_dim=1024, hidden=3072, 28 layers
+    qwen3_4b   : emb=2560, q_dim=4096, kv_dim=1024, hidden=9728, 36 layers
+
+The two Qwen3 deltas vs LLAMA-3.2 (handled exactly as in qwen3_0_6b):
+
+  1. QK-norm: per-head RMSNorm over head_dim on Q and K AFTER the projection
+     GEMM and BEFORE RoPE. RoPE's linearity does not commute the nonlinear
+     QK-norm past it, so we build a Qwen-specific 8-launch ELF that does
+     RMSNorm + Q/K/V GEMM + per-head QK-norm(Q,K) + RoPE(Q,K) all on the NPU
+     (rms_qkv_qknorm_rope).
+
+  2. Decoupled head_dim: n_heads*head_dim = 4096 != hidden_size = 2560.
+        q_proj : 2560 -> 4096   (32 heads x 128)
+        k/v    : 2560 -> 1024   (8 heads x 128)
+        o_proj : 4096 -> 2560   (NOT square)
+     We build a Qwen-specific o_ffn ELF whose O GEMM is K=q_dim=4096,
+     N=emb_dim=2560; the residual/RMSNorm/FFN tail stays emb_dim=2560.
+
+ALIGNMENT + the O+FFN un-merge (REGISTRY-DRIVEN):
+Every GEMM N and K is divisible by 512 (emb=2560=512x5, q_dim=4096=512x8,
+kv_dim=1024, hidden=9728=512x19). All five GEMM shapes now resolve in the
+kernel registry to high-precision fused-cast (mm_m64.o, tile_m=64, tn=128):
+    Q/K/V/O/Down            -> fused-cast tk_l2=256
+    Gate/Up (2048x2560x9728) -> fused-cast tk_l2=64
+The Gate/Up tk_l2=64 (NOT 256) keeps the f32-out B-tile DMA stride within the
+AIE [1:1048576] range at N=9728 — the registry tuning that unblocked the
+high-precision path that the old hardcoded tk_l2=256 fused-cast overflowed.
+Gate/Up are now fused-cast high-prec (mean_rel_L1 9.8e-3, 5528 GFLOPS) instead
+of the former direct-codegen low-prec (1.4e-2, 4397 GFLOPS): more accurate AND
+~1.26x faster.
+
+The merged qwen3_0_6b 8-launch o_ffn ELF still cannot compile here (hidden=9728
+exhausts the merged ELF L1/BD budget), so the O+FFN tail stays SPLIT into FIVE
+pieces (matching the N=11008 case), with the O GEMM kept DECOUPLED:
+    o_res_norm : O(fused-cast, K=q_dim=4096 N=emb=2560) + Residual + FFN-RMSNorm
+    gate       : Gate(fused-cast high-prec, registry) alone   [+ f32 scratch]
+    up         : Up(fused-cast high-prec, registry) alone     [+ f32 scratch]
+    swiglu     : NPU SwiGLU silu(gate)*up   (standalone ELF, tile_n tuned to
+                  fit both L1 and the BD pool at hidden=9728)
+    down_add   : Down(fused-cast, launch 0) + FFN-Add
+
+Attention uses the CPU fallback (cpu_attn=True), matching llama / qwen3_0_6b
+(head_dim=128 -> NPU FlashAttention hang risk).
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+# Add programming_examples/ and llms/ to path for shared.* + registry imports.
+_PROG_EXAMPLES = str(Path(__file__).resolve().parent.parent.parent)
+if _PROG_EXAMPLES not in sys.path:
+    sys.path.insert(0, _PROG_EXAMPLES)
+_LLMS_DIR = str(Path(__file__).resolve().parent.parent)
+if _LLMS_DIR not in sys.path:
+    sys.path.insert(0, _LLMS_DIR)
+
+from qwen3_4b_weights import LlamaConfig
+from qwen3_4b_cpu_helpers import attention_reference
+
+
+# ---------------------------------------------------------------------------
+# GEMM method/tile spec — REGISTRY-DRIVEN. Every qwen3_4b prefill GEMM now
+# pulls its method + tiles from the kernel registry (gemm_registry_config),
+# exactly like the qwen3_0_6b / qwen3_1_7b siblings, so the example tracks the
+# tuned registry instead of a hardcoded table. The registry now has emb=2560
+# entries (Phase-1 GEMM sweep was promoted into it):
+#     Q/K/V/O/Down (512-aligned)  -> fused-cast tk_l2=256 tn=128 (mm_m64.o)
+#     Gate/Up (2048x2560x9728)    -> fused-cast tk_l2=64  tn=128 (mm_m64.o)
+# The Gate/Up tk_l2=64 (vs 256) keeps the f32-out B-tile DMA stride within the
+# AIE [1:1048576] range at N=9728, so the high-precision fused-cast path now
+# compiles AND is more accurate (mean_rel_L1 9.8e-3 vs the old direct-codegen
+# low-prec 1.4e-2) AND ~1.26x faster (5528 vs 4397 GFLOPS).
+#
+# gemm_registry_config returns the keys this builder needs: method, tile_m,
+# tile_k_l2, tile_k_l1, tile_n, n_launches, needs_f32_scratch, sym_suffix,
+# build_kwargs.
+# ---------------------------------------------------------------------------
+
+
+def gemm_spec(m, k, n, precision="high"):
+    """Per-GEMM build recipe for one qwen3_4b shape, from the kernel registry.
+
+    `precision` is forwarded to the registry ("high" for all qwen3_4b GEMMs;
+    every shape resolves to high-precision fused-cast)."""
+    from shared.builders.gemm_builder import gemm_registry_config
+
+    return gemm_registry_config(m, k, n, "bf16", precision)
+
+
+def _build_gemm_ir(m, k, n, spec, herd_m=8, herd_n=4):
+    """Build lowered IR for one GEMM by its method spec.
+
+    direct -> fully-lowered example builder (no external mm.o); fused-cast ->
+    the shared _build_gemm_module (links mm_m64.o)."""
+    tm, k2, k1, tn = spec["tile_m"], spec["tile_k_l2"], spec["tile_k_l1"], spec["tile_n"]
+    if spec["method"] == "direct":
+        from matrix_multiplication.bf16_in_bf16_out.run import build_module_lowered
+
+        return str(
+            build_module_lowered(
+                m, k, n, tm, k2, k1, tn, herd_m, herd_n, bfloat16, bfloat16, arch="aie2p"
+            )
+        )
+    from shared.builders.gemm_builder import _build_gemm_module
+
+    return str(
+        _build_gemm_module(
+            m, k, n, tm, k2, k1, tn, herd_m, herd_n, **dict(spec["build_kwargs"])
+        )
+    )
+
+
+def _gemm_externs(spec):
+    """Extern symbols a GEMM slice contributes (empty for direct-codegen)."""
+    if spec["method"] == "direct":
+        return set()
+    sfx = spec["sym_suffix"]
+    return {
+        "@matmul_bf16",
+        "@op_has_no_registered_library_name" + sfx,
+        "@zero_f32_mn" + sfx,
+        "@f32_to_bf16_mn" + sfx,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Builder 1 (FUSED): RMSNorm + Q/K/V GEMM + per-head QK-norm(Q,K) + RoPE(Q,K).
+#   8-launch ELF that does the entire attention-input stage on the NPU. See
+#   shared/builders/rms_qkv_qknorm_rope_multi.py. qwen3_4b's attention-input
+#   GEMM shapes (emb=2560) are NOT in the kernel registry, so we inject this
+#   model's gemm_spec (all Q/K/V are 512-aligned fused-cast _m64, validated by
+#   the Phase-1 standalone sweep) via gemm_spec_fn.
+# ---------------------------------------------------------------------------
+
+
+def build_rms_qkv_qknorm_rope_module(seq_len, config):
+    from shared.builders.rms_qkv_qknorm_rope_multi import (
+        build_rms_qkv_qknorm_rope_module as _build,
+    )
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    return _build(
+        seq_len, emb_dim, q_dim, kv_dim, n_heads, n_kv_heads, head_dim,
+        qknorm_eps=1e-6,
+        gemm_spec_fn=gemm_spec,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder 2: O proj (DECOUPLED) + Residual + FFN, SPLIT into FIVE pieces.
+#   Gate/Up must be direct low-prec (fused-cast overflows the AIE DMA stride at
+#   N=9728), so the merged 8-launch o_ffn won't compile. We adopt the qwen25_3b
+#   un-merge, keeping the O GEMM DECOUPLED (K=q_dim=4096, N=emb=2560):
+#     o_res_norm : O(fused-cast decoupled) + Residual + FFN-RMSNorm
+#     gate       : Gate(direct) alone
+#     up         : Up(direct)   alone
+#     HOST SwiGLU: silu(gate)*up
+#     down_add   : Down(fused-cast, launch 0) + FFN-Add
+# ---------------------------------------------------------------------------
+
+
+def _build_residual_add_2d_ir(seq_len, emb_dim):
+    """Residual add: proj(seq,emb) + x_resid(seq,emb) -> res1(seq,emb) 2D."""
+    from air.ir import MemRefType, IntegerAttr, AffineMap, AffineExpr
+    from air.ir import AffineSymbolExpr, AffineConstantExpr, AffineMapAttr, VectorType
+    from air.dialects.air import module_builder, launch, segment, herd, dma_memcpy_nd
+    from air.dialects.air import MemorySpace, T
+    from air.dialects.affine import apply as affine_apply
+    from air.dialects import arith
+    from air.dialects.memref import AllocOp, DeallocOp, subview
+    from air.dialects.vector import transfer_read, transfer_write
+    from air.dialects.func import FuncOp
+    from air.dialects.scf import for_ as range_, yield_
+    from air.backend.xrt_runner import type_mapper
+
+    n_total = seq_len * emb_dim
+
+    @module_builder
+    def _build():
+        from air.dialects.memref import collapse_shape as memref_collapse_shape
+
+        xrt_dtype = type_mapper(bfloat16)
+        twod_ty = MemRefType.get([seq_len, emb_dim], xrt_dtype)
+        flat_ty = MemRefType.get([n_total], xrt_dtype)
+        rows_per_pe = seq_len // 8
+        l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l1_ty = MemRefType.get([emb_dim], xrt_dtype, memory_space=l1_space)
+        vec_ty = VectorType.get([16], xrt_dtype)
+        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+
+        @FuncOp.from_py_func(twod_ty, twod_ty, twod_ty)
+        def res_add(proj_2d, xres_2d, out_2d):
+            @launch(operands=[proj_2d, xres_2d, out_2d])
+            def add_launch(l_proj, l_xres, l_out):
+                proj_flat = memref_collapse_shape(flat_ty, l_proj, [[0, 1]])
+                xres_flat = memref_collapse_shape(flat_ty, l_xres, [[0, 1]])
+                out_flat = memref_collapse_shape(flat_ty, l_out, [[0, 1]])
+
+                @segment(name="radd_seg", operands=[proj_flat, xres_flat, out_flat])
+                def add_seg(s_proj, s_xres, s_out):
+                    row_map = AffineMap.get(
+                        0, 2,
+                        [AffineExpr.get_add(
+                            AffineExpr.get_mul(AffineSymbolExpr.get(0),
+                                               AffineConstantExpr.get(rows_per_pe)),
+                            AffineSymbolExpr.get(1))],
+                    )
+
+                    @herd(name="radd_herd", sizes=[8, 1], operands=[s_proj, s_xres, s_out])
+                    def add_body(_tx, _ty, _sx, _sy, h_proj, h_xres, h_out):
+                        l1_p = AllocOp(l1_ty, [], [])
+                        l1_x = AllocOp(l1_ty, [], [])
+                        l1_o = AllocOp(l1_ty, [], [])
+                        c0 = arith.ConstantOp.create_index(0)
+                        cst0 = arith.ConstantOp(xrt_dtype, 0.0)
+                        for iv in range_(0, rows_per_pe, 1):
+                            r = affine_apply(row_map, [_tx, iv])
+                            off = arith.muli(r, arith.ConstantOp.create_index(emb_dim))
+                            dma_memcpy_nd(l1_p, h_proj, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            dma_memcpy_nd(l1_x, h_xres, src_offsets=[off], src_sizes=[emb_dim], src_strides=[1])
+                            for j in range_(0, emb_dim, 16):
+                                sp = subview(l1_p.result, [j], [16], [1])
+                                sx = subview(l1_x.result, [j], [16], [1])
+                                so = subview(l1_o.result, [j], [16], [1])
+                                vp = transfer_read(vec_ty, sp, [c0], identity_map, cst0, [True])
+                                vx = transfer_read(vec_ty, sx, [c0], identity_map, cst0, [True])
+                                transfer_write(None, arith.addf(vp, vx), so, [c0], identity_map, [True])
+                                yield_([])
+                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[off], dst_sizes=[emb_dim], dst_strides=[1])
+                            yield_([])
+                        DeallocOp(l1_p)
+                        DeallocOp(l1_x)
+                        DeallocOp(l1_o)
+
+    return str(_build())
+
+
+def build_o_res_norm_module(seq_len, emb_dim, q_dim, o_herd_m=8, o_herd_n=4):
+    """ELF A1: O(fused-cast, DECOUPLED K=q_dim N=emb) + Residual + FFN-RMSNorm.
+
+    Func args:
+      %arg0 attn_out (seq,q_dim)  <- DECOUPLED
+      %arg1 wo (q_dim,emb)        <- DECOUPLED
+      %arg2 proj (seq,emb)
+      %arg3 x_resid (seq,emb)     %arg4 res1 (seq,emb)   <- OUTPUT (feeds down_add)
+      %arg5 ffn_norm (emb,)       %arg6 normed2 (seq,emb) <- OUTPUT (feeds gate/up)
+      [+ f32 C-scratch tail for the fused-cast O GEMM]
+    """
+    from shared.infra.stitching import (
+        _wrap_ir_in_launch, stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+    )
+    from weighted_rms_norm.weighted_rms_norm import build_module as build_rms
+
+    o_spec = gemm_spec(seq_len, q_dim, emb_dim, "high")   # fused-cast _m64
+    print(f"  [1/3] O GEMM ({o_spec['method']})  {seq_len}x{q_dim}x{emb_dim} (DECOUPLED)...")
+    o_ir = _build_gemm_ir(seq_len, q_dim, emb_dim, o_spec, o_herd_m, o_herd_n)
+    print("  [2/3] Residual Add...")
+    res_add_ir = _build_residual_add_2d_ir(seq_len, emb_dim)
+    print("  [3/3] FFN RMSNorm...")
+    rms_ir = _wrap_ir_in_launch(str(build_rms(seq_len, emb_dim, bfloat16, 16, herd_x=8)))
+
+    scratch_args, scratch_for = alloc_gemm_scratch(
+        [(o_spec, seq_len, emb_dim)], base_arg_count=7,
+    )
+
+    def _amap(i, w, o, sc):
+        return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
+
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{q_dim}xbf16>"),     # attn_out (DECOUPLED)
+        FuncArg("%arg1", f"memref<{q_dim}x{emb_dim}xbf16>"),     # wo (DECOUPLED)
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),   # proj
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),   # x_resid
+        FuncArg("%arg4", f"memref<{seq_len}x{emb_dim}xbf16>"),   # res1 (out)
+        FuncArg("%arg5", f"memref<{emb_dim}xbf16>"),             # ffn_norm
+        FuncArg("%arg6", f"memref<{seq_len}x{emb_dim}xbf16>"),   # normed2 (out)
+    ]
+    slices = [
+        KernelSlice(o_ir, "og", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(o_spec)),
+        KernelSlice(res_add_ir, "ra", {0: 2, 1: 3, 2: 4}, private_from=False),
+        KernelSlice(rms_ir, "rm", {0: 4, 1: 5, 2: 6}, private_from=False),
+    ]
+    module = stitch_elf("o_res_norm", base_args, slices, scratch_args=scratch_args,
+                        debug_dump_path="/tmp/debug_o_res_norm_4b.mlir")
+    print(f"  o_res_norm module: {len(str(module).splitlines())} lines, parsed OK")
+    return module, scratch_for
+
+
+def _build_single_gemm_elf(name, sym, seq_len, k_dim, n_dim, herd_m=8, herd_n=4):
+    """Build a standalone single-GEMM ELF (Gate or Up), registry-driven.
+
+    The registry resolves these (2048x2560x9728) to fused-cast high-prec, which
+    needs an f32 C-scratch func arg + the external mm_m64.o symbols. Returns
+    (module, scratch_for_index) where scratch_for_index is the f32-scratch combined
+    arg index (or None for a direct/drain method that needs no scratch)."""
+    from shared.infra.stitching import stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch
+    g_spec = gemm_spec(seq_len, k_dim, n_dim, "high")
+    print(f"  [{name}] {name} GEMM ({g_spec['method']}) {seq_len}x{k_dim}x{n_dim} "
+          f"(tk_l2={g_spec['tile_k_l2']}, tn={g_spec['tile_n']})...")
+    gemm_ir = _build_gemm_ir(seq_len, k_dim, n_dim, g_spec, herd_m, herd_n)
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{k_dim}xbf16>"),   # normed2
+        FuncArg("%arg1", f"memref<{k_dim}x{n_dim}xbf16>"),     # weight
+        FuncArg("%arg2", f"memref<{seq_len}x{n_dim}xbf16>"),   # out
+    ]
+    scratch_args, scratch_for = alloc_gemm_scratch(
+        [(g_spec, seq_len, n_dim)], base_arg_count=3,
+    )
+    sc = scratch_for[0]
+    amap = {0: 0, 1: 1, 2: sc, 3: 2} if sc is not None else {0: 0, 1: 1, 2: 2}
+    slices = [KernelSlice(gemm_ir, sym, amap, extern_syms=_gemm_externs(g_spec))]
+    module = stitch_elf(name, base_args, slices, scratch_args=scratch_args)
+    print(f"  {name} module: {len(str(module).splitlines())} lines, parsed OK")
+    return module, scratch_for
+
+
+def build_gate_module(seq_len, emb_dim, hidden_dim, gate_herd_m=8, gate_herd_n=4):
+    """ELF A2: Gate(fused-cast high-prec, registry) alone -> gate (seq,hidden)."""
+    return _build_single_gemm_elf("gate", "gg", seq_len, emb_dim, hidden_dim,
+                                  gate_herd_m, gate_herd_n)
+
+
+def build_up_module(seq_len, emb_dim, hidden_dim, up_herd_m=8, up_herd_n=4):
+    """ELF A3: Up(fused-cast high-prec, registry) alone -> up (seq,hidden)."""
+    return _build_single_gemm_elf("up", "ug", seq_len, emb_dim, hidden_dim,
+                                  up_herd_m, up_herd_n)
+
+
+# SwiGLU runs on the NPU as a standalone ELF (silu_and_mul.build_module_2d).
+# It compiles at hidden=9728 once tile_n is in the BD/L1 sweet spot (band
+# ~[3584, 5120]; too large overflows L1, too small exhausts the BD pool).
+# Verified standalone on NPU2: mean_rel_L1=1.02e-2 (registry SwiGLU tier).
+
+# Largest compiling tile_n per hidden (fewest loop iters), from a compile sweep.
+_SWIGLU_TILE_N = {8960: 5120, 9728: 4864, 11008: 4096}
+
+
+def _swiglu_tile_n(seq_len, hidden_dim, herd_x=8):
+    if hidden_dim in _SWIGLU_TILE_N:
+        return _SWIGLU_TILE_N[hidden_dim]
+    half = (seq_len * hidden_dim) // herd_x
+    for t in range(5120, 1024, -64):
+        if half % t == 0:
+            return t
+    raise RuntimeError(f"No SwiGLU tile_n for seq={seq_len} hidden={hidden_dim}")
+
+
+def build_swiglu_module(seq_len, hidden_dim, herd_x=8, herd_y=1):
+    """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (seq x hidden)."""
+    from silu_and_mul.silu_and_mul import build_module_2d as build_swiglu
+    tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
+    print(f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
+          f"iters={seq_len * hidden_dim // (tile_n * herd_x)})...")
+    module = build_swiglu(seq_len, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
+    print(f"  swiglu module: {len(str(module).splitlines())} lines, parsed OK")
+    return module
+
+
+def _build_down_add_2d_to_1d_ir(seq_len, emb_dim):
+    """Eltwise add: down(seq,emb) + res1(seq,emb) -> output(seq*emb,)."""
+    from air.ir import MemRefType, IntegerAttr, AffineMap, AffineExpr
+    from air.ir import AffineSymbolExpr, AffineConstantExpr, AffineMapAttr, VectorType
+    from air.dialects.air import module_builder, launch, segment, herd, dma_memcpy_nd
+    from air.dialects.air import MemorySpace, T
+    from air.dialects.affine import apply as affine_apply
+    from air.dialects import arith
+    from air.dialects.memref import AllocOp, DeallocOp, subview
+    from air.dialects.vector import transfer_read, transfer_write
+    from air.dialects.func import FuncOp
+    from air.dialects.scf import for_ as range_, yield_
+    from air.backend.xrt_runner import type_mapper
+
+    n_total = seq_len * emb_dim
+
+    @module_builder
+    def _build():
+        from air.dialects.memref import collapse_shape as memref_collapse_shape
+
+        xrt_dtype = type_mapper(bfloat16)
+        twod_ty = MemRefType.get([seq_len, emb_dim], xrt_dtype)
+        out_1d_ty = MemRefType.get([n_total], xrt_dtype)
+        total_tiles = 8
+        chunk_size = n_total // total_tiles
+        tile_n = emb_dim
+        l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l1_ty = MemRefType.get([tile_n], xrt_dtype, memory_space=l1_space)
+        vec_ty = VectorType.get([16], xrt_dtype)
+        identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+
+        @FuncOp.from_py_func(twod_ty, twod_ty, out_1d_ty)
+        def down_add(down_2d, res_2d, out_1d):
+            @launch(operands=[down_2d, res_2d, out_1d])
+            def add_launch(l_down, l_res, l_out):
+                down_flat = memref_collapse_shape(out_1d_ty, l_down, [[0, 1]])
+                res_flat = memref_collapse_shape(out_1d_ty, l_res, [[0, 1]])
+
+                @segment(name="dadd_seg", operands=[down_flat, res_flat, l_out])
+                def add_seg(s_down, s_res, s_out):
+                    offset_map = AffineMap.get(
+                        0, 3,
+                        [
+                            AffineExpr.get_add(
+                                AffineSymbolExpr.get(0),
+                                AffineExpr.get_mul(
+                                    AffineExpr.get_add(
+                                        AffineExpr.get_mul(
+                                            AffineSymbolExpr.get(1),
+                                            AffineConstantExpr.get(1),
+                                        ),
+                                        AffineSymbolExpr.get(2),
+                                    ),
+                                    AffineConstantExpr.get(chunk_size),
+                                ),
+                            )
+                        ],
+                    )
+
+                    @herd(name="dadd_herd", sizes=[8, 1], operands=[s_down, s_res, s_out])
+                    def add_body(_tx, _ty, _sx, _sy, h_down, h_res, h_out):
+                        l1_d = AllocOp(l1_ty, [], [])
+                        l1_r = AllocOp(l1_ty, [], [])
+                        l1_o = AllocOp(l1_ty, [], [])
+                        c0 = arith.ConstantOp.create_index(0)
+                        cst0 = arith.ConstantOp(xrt_dtype, 0.0)
+                        for loop_iv in range_(0, chunk_size, tile_n):
+                            offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
+                            dma_memcpy_nd(l1_d, h_down, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            dma_memcpy_nd(l1_r, h_res, src_offsets=[offset], src_sizes=[tile_n], src_strides=[1])
+                            for j in range_(0, tile_n, 16):
+                                sd = subview(l1_d.result, [j], [16], [1])
+                                sr = subview(l1_r.result, [j], [16], [1])
+                                so = subview(l1_o.result, [j], [16], [1])
+                                vd = transfer_read(vec_ty, sd, [c0], identity_map, cst0, [True])
+                                vr = transfer_read(vec_ty, sr, [c0], identity_map, cst0, [True])
+                                transfer_write(None, arith.addf(vd, vr), so, [c0], identity_map, [True])
+                                yield_([])
+                            dma_memcpy_nd(h_out, l1_o, dst_offsets=[offset], dst_sizes=[tile_n], dst_strides=[1])
+                            yield_([])
+                        DeallocOp(l1_d)
+                        DeallocOp(l1_r)
+                        DeallocOp(l1_o)
+
+    return str(_build())
+
+
+def build_down_add_module(seq_len, emb_dim, hidden_dim, down_herd_m=8, down_herd_n=4):
+    """ELF B: Down(fused-cast, launch 0) + FFN-Add.
+
+    Func args:
+      %arg0 swiglu (seq,hid)  %arg1 w_down (hid,emb)  %arg2 down (seq,emb)
+      %arg3 res1 (seq,emb)    %arg4 output (seq*emb,)
+      [+ f32 C-scratch tail for the fused-cast Down]
+    """
+    from shared.infra.stitching import (
+        stitch_elf, KernelSlice, FuncArg, alloc_gemm_scratch,
+    )
+    n_total = seq_len * emb_dim
+    d_spec = gemm_spec(seq_len, hidden_dim, emb_dim, "high")  # fused-cast _m64
+    print(f"  [down_add] Down GEMM ({d_spec['method']}) {seq_len}x{hidden_dim}x{emb_dim} "
+          f"(tn={d_spec['tile_n']})...")
+    down_ir = _build_gemm_ir(seq_len, hidden_dim, emb_dim, d_spec, down_herd_m, down_herd_n)
+    print("  [down_add] FFN Add (2D -> 1D)...")
+    ffn_add_ir = _build_down_add_2d_to_1d_ir(seq_len, emb_dim)
+
+    scratch_args, scratch_for = alloc_gemm_scratch(
+        [(d_spec, seq_len, emb_dim)], base_arg_count=5,
+    )
+
+    def _amap(i, w, o, sc):
+        return {0: i, 1: w, 2: sc, 3: o} if sc is not None else {0: i, 1: w, 2: o}
+
+    base_args = [
+        FuncArg("%arg0", f"memref<{seq_len}x{hidden_dim}xbf16>"),  # swiglu
+        FuncArg("%arg1", f"memref<{hidden_dim}x{emb_dim}xbf16>"),  # w_down
+        FuncArg("%arg2", f"memref<{seq_len}x{emb_dim}xbf16>"),     # down
+        FuncArg("%arg3", f"memref<{seq_len}x{emb_dim}xbf16>"),     # res1
+        FuncArg("%arg4", f"memref<{n_total}xbf16>"),              # output
+    ]
+    slices = [
+        KernelSlice(down_ir, "dg", _amap(0, 1, 2, scratch_for[0]), extern_syms=_gemm_externs(d_spec), private_from=True),
+        KernelSlice(ffn_add_ir, "fa", {0: 2, 1: 3, 2: 4}, private_from=False),
+    ]
+    module = stitch_elf("down_add", base_args, slices, scratch_args=scratch_args,
+                        debug_dump_path="/tmp/debug_down_add_4b.mlir")
+    print(f"  down_add module: {len(str(module).splitlines())} lines, parsed OK")
+    return module, scratch_for
+
+
+# ---------------------------------------------------------------------------
+# Backend kwargs
+# ---------------------------------------------------------------------------
+
+
+def _rms_qkv_qknorm_rope_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "rms_qkv_qknorm_rope",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _o_res_norm_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "o_res_norm",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _gate_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "gate",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _up_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "up",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+def _swiglu_backend(verbose=False):
+    # ELF symbol name must match the top func name in build_module_2d.
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "silu_and_mul_2d",
+    }
+
+
+def _down_add_backend(verbose=False):
+    return {
+        "verbose": verbose,
+        "omit_while_true_loop": False,
+        "output_format": "elf",
+        "instance_name": "down_add",
+        "runtime_loop_tiling_sizes": [2, 2],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Compilation
+# ---------------------------------------------------------------------------
+
+# Set by compile_all_kernels so the block runner knows scratch-arg indices.
+# All GEMMs are now registry-driven fused-cast (Q/K/V/O/Gate/Up/Down), each
+# needing one f32 C-scratch tail arg. gate/up are standalone single-GEMM ELFs
+# whose scratch is arg index 3; o_res_norm (O) -> [7]; down_add (Down) -> [5];
+# rms_qkv_qknorm_rope (Q/K/V) -> [17..].
+_ORES_SCRATCH_FOR = None
+_DOWN_SCRATCH_FOR = None
+_GATE_SCRATCH_FOR = None
+_UP_SCRATCH_FOR = None
+# Scratch-arg indices for the FUSED rms_qkv_qknorm_rope ELF (Q/K/V fused-cast).
+_FUSED_SCRATCH_FOR = None
+
+
+def _resolve_scratch_for(config, seq_len=2048):
+    """Recompute all scratch_for lists from the spec (for --run-only path)."""
+    global _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR, _FUSED_SCRATCH_FOR
+    global _GATE_SCRATCH_FOR, _UP_SCRATCH_FOR
+    q_dim = config.n_heads * config.head_dim
+    kv_dim = config.n_kv_heads * config.head_dim
+    hidden_dim = config.hidden_dim
+    emb_dim = config.emb_dim
+
+    def _alloc(specs, base):
+        nxt = base
+        out = []
+        for s in specs:
+            if s["needs_f32_scratch"]:
+                out.append(nxt); nxt += 1
+            else:
+                out.append(None)
+        return out
+
+    # Fused rms_qkv_qknorm_rope ELF: Q/K/V specs, scratch tail starts at 17.
+    _FUSED_SCRATCH_FOR = _alloc([
+        gemm_spec(seq_len, config.emb_dim, q_dim),
+        gemm_spec(seq_len, config.emb_dim, kv_dim),
+        gemm_spec(seq_len, config.emb_dim, kv_dim),
+    ], 17)
+    _ORES_SCRATCH_FOR = _alloc([
+        gemm_spec(seq_len, q_dim, config.emb_dim),
+    ], 7)
+    _DOWN_SCRATCH_FOR = _alloc([
+        gemm_spec(seq_len, config.hidden_dim, config.emb_dim),
+    ], 5)
+    # gate / up standalone single-GEMM ELFs: scratch tail starts at arg 3.
+    _GATE_SCRATCH_FOR = _alloc([gemm_spec(seq_len, emb_dim, hidden_dim)], 3)
+    _UP_SCRATCH_FOR = _alloc([gemm_spec(seq_len, emb_dim, hidden_dim)], 3)
+    return _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR
+
+
+def compile_all_kernels(cache, config, seq_len, verbose=False, cpu_attn=False):
+    global _ORES_SCRATCH_FOR, _DOWN_SCRATCH_FOR, _FUSED_SCRATCH_FOR
+    global _GATE_SCRATCH_FOR, _UP_SCRATCH_FOR
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    print(f"\n{'='*60}\nCompiling Qwen3-4B prefill kernels (seq_len={seq_len})...\n{'='*60}\n")
+
+    from shared.infra.external_kernels import compile_gemm_mm, compile_rope
+
+    # mm.o variants for the external (fused-cast) GEMMs; Gate/Up direct-codegen
+    # needs NO external .o. rope.o for head_dim=128.
+    compile_gemm_mm(tile_m=32, tile_n=128, tile_k_l1=32, sym_suffix="_m32", out_name="mm_m32.o")
+    compile_gemm_mm(tile_m=64, tile_n=128, tile_k_l1=32, sym_suffix="_m64", out_name="mm_m64.o")
+    compile_rope()
+    from shared.infra.external_kernels import compile_silu_and_mul
+    compile_silu_and_mul()  # silu_and_mul.o for the standalone NPU SwiGLU ELF
+
+    print("\n--- rms_qkv_qknorm_rope (FUSED: RMSNorm+QKV+QK-norm+RoPE, 8 launches) ---")
+    fused_mod, fused_scratch = build_rms_qkv_qknorm_rope_module(seq_len, config)
+    _FUSED_SCRATCH_FOR = fused_scratch
+    cache.compile_and_cache(
+        "rms_qkv_qknorm_rope", fused_mod, _rms_qkv_qknorm_rope_backend(verbose)
+    )
+
+    print("\n--- o_res_norm (O proj decoupled + Residual + FFN RMSNorm) ---")
+    ores_mod, ores_scratch = build_o_res_norm_module(seq_len, emb_dim, q_dim)
+    _ORES_SCRATCH_FOR = ores_scratch
+    cache.compile_and_cache("o_res_norm", ores_mod, _o_res_norm_backend(verbose))
+
+    print("\n--- gate (Gate GEMM, fused-cast registry) ---")
+    gate_mod, gate_scratch = build_gate_module(seq_len, emb_dim, hidden_dim)
+    _GATE_SCRATCH_FOR = gate_scratch
+    cache.compile_and_cache("gate", gate_mod, _gate_backend(verbose))
+
+    print("\n--- up (Up GEMM, fused-cast registry) ---")
+    up_mod, up_scratch = build_up_module(seq_len, emb_dim, hidden_dim)
+    _UP_SCRATCH_FOR = up_scratch
+    cache.compile_and_cache("up", up_mod, _up_backend(verbose))
+
+    print("\n--- swiglu (NPU SwiGLU: silu(gate)*up) ---")
+    cache.compile_and_cache("swiglu", build_swiglu_module(seq_len, hidden_dim),
+                            _swiglu_backend(verbose))
+
+    print("\n--- down_add (Down GEMM [launch 0] + FFN Add) ---")
+    down_mod, down_scratch = build_down_add_module(seq_len, emb_dim, hidden_dim)
+    _DOWN_SCRATCH_FOR = down_scratch
+    cache.compile_and_cache("down_add", down_mod, _down_add_backend(verbose))
+
+    # Flash Attention (head-first, head_dim=128). Skip if using CPU fallback.
+    if not cpu_attn:
+        print("\n--- flash_attn (head-first FA, head_dim=128) ---")
+        from shared.infra.fa_headfirst import compile_headfirst_fa
+
+        compile_headfirst_fa(cache, seq_len, n_heads, n_kv_heads, head_dim, verbose)
+    else:
+        print("\n--- Skipping flash_attn (CPU attention fallback) ---")
+
+    cache._save_manifest()
+    print(f"\nAll {len(cache.artifacts)} kernels compiled to {cache.cache_dir}/")
+
+
+# ---------------------------------------------------------------------------
+# Prefill weight pre-load (BO reuse)
+# ---------------------------------------------------------------------------
+
+
+def _fused_qknorm_rope_call(
+    cache, lw, config, seq_len, lut_q, lut_k, layer_idx, x_in, verbose=False
+):
+    """Issue one rms_qkv_qknorm_rope ELF call (fused prefill attention-input).
+
+    Single owner of the fused arg layout + index sets, shared by the preload
+    warmup (x_in zeroed) and the block runner (x_in = real hidden). Returns the
+    cache.load_and_run result tuple (output_indices=[8, 15, 16] -> v, q_roped,
+    k_roped).
+    """
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    fused_scratch = _FUSED_SCRATCH_FOR
+    if fused_scratch is None:
+        _resolve_scratch_for(config, seq_len)
+        fused_scratch = _FUSED_SCRATCH_FOR
+
+    args = [
+        np.asarray(x_in, dtype=bfloat16).reshape(seq_len, emb_dim),          # 0 x_in (dynamic)
+        np.asarray(lw.attn_norm, dtype=bfloat16).reshape(emb_dim),           # 1 norm_w (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                        # 2 normed (inter)
+        np.asarray(lw.wq, dtype=bfloat16).reshape(emb_dim, q_dim),           # 3 wq (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 4 q (inter)
+        np.asarray(lw.wk, dtype=bfloat16).reshape(emb_dim, kv_dim),          # 5 wk (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 6 k (inter)
+        np.asarray(lw.wv, dtype=bfloat16).reshape(emb_dim, kv_dim),          # 7 wv (static)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 8 v (inter/out)
+        np.asarray(lw.q_norm, dtype=bfloat16).reshape(head_dim),            # 9 q_norm (static)
+        np.asarray(lw.k_norm, dtype=bfloat16).reshape(head_dim),            # 10 k_norm (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 11 q_n (inter)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 12 k_n (inter)
+        lut_q,                                                              # 13 lut_q (static)
+        lut_k,                                                              # 14 lut_k (static)
+        np.zeros((seq_len, q_dim), dtype=bfloat16),                          # 15 q_roped (inter/out)
+        np.zeros((seq_len, kv_dim), dtype=bfloat16),                         # 16 k_roped (inter/out)
+    ]
+    inter = {2, 4, 6, 8, 11, 12, 15, 16}
+    for sc, cols in zip(fused_scratch or [], (q_dim, kv_dim, kv_dim)):
+        if sc is not None:
+            args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            inter.add(sc)
+    return cache.load_and_run(
+        "rms_qkv_qknorm_rope",
+        _rms_qkv_qknorm_rope_backend(verbose),
+        *args,
+        output_indices=[8, 15, 16],
+        static_input_indices={1, 3, 5, 7, 9, 10, 13, 14},
+        intermediate_indices=inter,
+        bo_key=f"rms_qkv_qknorm_rope_L{layer_idx}",
+    )
+
+
+def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
+    """Pre-load all prefill block weights into per-layer BOs once.
+
+    The warmup call layout MUST match run_transformer_block_qwen3 exactly.
+    """
+    if hasattr(weights, "_prefill_weights_preloaded"):
+        return
+
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    n_total = seq_len * emb_dim
+
+    print("Pre-loading prefill block weights (per-layer BOs)...")
+    profiler_enabled = cache.profiler.enabled
+    cache.profiler.enabled = False
+
+    lut_q = np.repeat(rope_lut_bf16[:seq_len], n_heads, axis=0).flatten()
+    lut_k = np.repeat(rope_lut_bf16[:seq_len], n_kv_heads, axis=0).flatten()
+
+    ores_scratch = _ORES_SCRATCH_FOR
+    down_scratch = _DOWN_SCRATCH_FOR
+    if ores_scratch is None or down_scratch is None:
+        ores_scratch, down_scratch = _resolve_scratch_for(config, seq_len)
+    gate_scratch = _GATE_SCRATCH_FOR
+    up_scratch = _UP_SCRATCH_FOR
+    if gate_scratch is None or up_scratch is None:
+        _resolve_scratch_for(config, seq_len)
+        gate_scratch, up_scratch = _GATE_SCRATCH_FOR, _UP_SCRATCH_FOR
+
+    for layer_idx in range(config.n_layers):
+        lw = weights.layers[layer_idx]
+
+        # One fused ELF: RMSNorm + Q/K/V GEMM + per-head QK-norm + RoPE.
+        _fused_qknorm_rope_call(
+            cache, lw, config, seq_len, lut_q, lut_k, layer_idx,
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),
+        )
+
+        # o_res_norm: static {1,5}. Outputs res1 (arg4), normed2 (arg6).
+        ores_args = [
+            np.zeros((seq_len, q_dim), dtype=bfloat16),                           # 0 attn_out (DECOUPLED)
+            np.asarray(lw.wo, dtype=bfloat16).reshape(q_dim, emb_dim),            # 1 wo (static, DECOUPLED)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 2 proj (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 3 x_resid
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 4 res1 (out)
+            np.asarray(lw.ffn_norm, dtype=bfloat16).reshape(emb_dim),            # 5 ffn_norm (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                         # 6 normed2 (out)
+        ]
+        ores_inter = set()
+        for sc, cols in zip(ores_scratch, (emb_dim,)):
+            if sc is not None:
+                ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+                ores_inter.add(sc)
+        cache.load_and_run(
+            "o_res_norm", _o_res_norm_backend(), *ores_args,
+            output_indices=[4, 6],
+            static_input_indices={1, 5},
+            intermediate_indices={2, 4, 6} | ores_inter,
+            bo_key=f"o_res_norm_L{layer_idx}",
+        )
+
+        # gate: static {1}. Output gate (arg2). fused-cast -> f32 scratch tail.
+        gate_args = [
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
+            np.asarray(lw.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),    # 1 w_gate (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 gate (out)
+        ]
+        gate_int = {2}
+        for sc in gate_scratch:
+            if sc is not None:
+                gate_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
+                gate_int.add(sc)
+        cache.load_and_run(
+            "gate", _gate_backend(), *gate_args,
+            output_indices=[2], static_input_indices={1}, intermediate_indices=gate_int,
+            bo_key=f"gate_L{layer_idx}",
+        )
+
+        # up: static {1}. Output up (arg2). fused-cast -> f32 scratch tail.
+        up_args = [
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 0 normed2
+            np.asarray(lw.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),      # 1 w_up (static)
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 2 up (out)
+        ]
+        up_int = {2}
+        for sc in up_scratch:
+            if sc is not None:
+                up_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
+                up_int.add(sc)
+        cache.load_and_run(
+            "up", _up_backend(), *up_args,
+            output_indices=[2], static_input_indices={1}, intermediate_indices=up_int,
+            bo_key=f"up_L{layer_idx}",
+        )
+
+        # SwiGLU: NPU ELF (no static weights — only warms the per-layer BO set).
+        cache.load_and_run(
+            "swiglu", _swiglu_backend(),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            output_indices=[2],
+            intermediate_indices={2},
+            bo_key=f"swiglu_L{layer_idx}",
+        )
+
+        # down_add: static {1}.
+        down_args = [
+            np.zeros((seq_len, hidden_dim), dtype=bfloat16),                       # 0 swiglu
+            np.asarray(lw.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),    # 1 w_down (static)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
+            np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 3 res1
+            np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+        ]
+        down_inter = set()
+        for sc, cols in zip(down_scratch, (emb_dim,)):
+            if sc is not None:
+                down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+                down_inter.add(sc)
+        cache.load_and_run(
+            "down_add", _down_add_backend(), *down_args,
+            output_indices=[4],
+            static_input_indices={1},
+            intermediate_indices={2, 4} | down_inter,
+            bo_key=f"down_add_L{layer_idx}",
+        )
+
+    cache.profiler.enabled = profiler_enabled
+    weights._prefill_weights_preloaded = True
+    print(f"  Pre-loaded {config.n_layers} prefill layers.")
+
+
+# ---------------------------------------------------------------------------
+# Single transformer block
+# ---------------------------------------------------------------------------
+
+
+def run_transformer_block_qwen3(
+    x_bf16,
+    layer_weights,
+    rope_lut_bf16,
+    config,
+    cache,
+    layer_idx=0,
+    cpu_attn=True,
+    verbose=False,
+):
+    """Run one Qwen3-4B transformer block on NPU (kernels pre-compiled)."""
+    seq_len = x_bf16.shape[0]
+    emb_dim = config.emb_dim
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+    hidden_dim = config.hidden_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    n_total = seq_len * emb_dim
+
+    inter = {}
+
+    # RoPE LUTs (seq-first, repeated per head).
+    lut_q = np.repeat(rope_lut_bf16[:seq_len], n_heads, axis=0).flatten()
+    lut_k = np.repeat(rope_lut_bf16[:seq_len], n_kv_heads, axis=0).flatten()
+
+    # ---- Stages A-C: one ELF = RMSNorm + Q/K/V GEMM + QK-norm(Q,K) + RoPE(Q,K).
+    res = _fused_qknorm_rope_call(
+        cache, layer_weights, config, seq_len, lut_q, lut_k, layer_idx,
+        x_bf16, verbose=verbose,
+    )
+    v = res[8].reshape(seq_len, kv_dim)
+    q_roped = res[15].reshape(seq_len, q_dim)
+    k_roped = res[16].reshape(seq_len, kv_dim)
+    inter["v"] = v
+    inter["q_roped"] = q_roped
+    inter["k_roped"] = k_roped
+
+    # ---- Stage D: GQA attention ----
+    if cpu_attn:
+        # HOST cpu fallback (FP32 causal GQA reference).
+        with cache.profiler.time_cpu("prefill_cpu_attention"):
+            attn_out = attention_reference(
+                q_roped.astype(np.float32),
+                k_roped.astype(np.float32),
+                v.astype(np.float32),
+                n_heads,
+                n_kv_heads,
+            ).astype(bfloat16)
+    else:
+        # NPU head-first FlashAttention (head_dim=128). Decoupled O: q_roped is
+        # [seq, q_dim=4096] (32*128), v is [seq, kv_dim=1024] (8*128); the
+        # wrapper returns [seq, n_heads*head_dim=4096], which feeds the
+        # decoupled O proj (4096 -> emb_dim=2560). q_roped/k_roped are
+        # post-QK-norm post-RoPE seq-first; v is the raw projection seq-first.
+        from shared.infra.fa_headfirst import npu_fa_headfirst
+
+        attn_out = npu_fa_headfirst(
+            cache,
+            np.ascontiguousarray(q_roped),
+            np.ascontiguousarray(k_roped),
+            np.ascontiguousarray(v),
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            seq_len,
+            verbose=verbose,
+        )
+    inter["attn_out"] = attn_out
+
+    # ---- Stage E: O proj + Residual + FFN ----
+    ores_scratch = _ORES_SCRATCH_FOR
+    down_scratch = _DOWN_SCRATCH_FOR
+    if ores_scratch is None or down_scratch is None:
+        ores_scratch, down_scratch = _resolve_scratch_for(config, seq_len)
+    gate_scratch = _GATE_SCRATCH_FOR
+    up_scratch = _UP_SCRATCH_FOR
+    if gate_scratch is None or up_scratch is None:
+        _resolve_scratch_for(config, seq_len)
+        gate_scratch, up_scratch = _GATE_SCRATCH_FOR, _UP_SCRATCH_FOR
+
+    # ELF A1: o_res_norm (O decoupled) -> res1 (arg4) + normed2 (arg6).
+    ores_args = [
+        np.asarray(attn_out, dtype=bfloat16).reshape(seq_len, q_dim),          # 0 attn_out (DECOUPLED)
+        np.asarray(layer_weights.wo, dtype=bfloat16).reshape(q_dim, emb_dim),  # 1 wo (static, DECOUPLED)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 proj (inter)
+        np.asarray(x_bf16, dtype=bfloat16).reshape(seq_len, emb_dim),          # 3 x_resid
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 4 res1 (out)
+        np.asarray(layer_weights.ffn_norm, dtype=bfloat16).reshape(emb_dim),   # 5 ffn_norm (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 6 normed2 (out)
+    ]
+    ores_inter = set()
+    for sc, cols in zip(ores_scratch, (emb_dim,)):
+        if sc is not None:
+            ores_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            ores_inter.add(sc)
+    ores_res = cache.load_and_run(
+        "o_res_norm",
+        _o_res_norm_backend(verbose),
+        *ores_args,
+        output_indices=[4, 6],
+        static_input_indices={1, 5},
+        intermediate_indices={2, 4, 6} | ores_inter,
+        bo_key=f"o_res_norm_L{layer_idx}",
+    )
+    res1 = ores_res[4].reshape(seq_len, emb_dim)
+    normed2 = ores_res[6].reshape(seq_len, emb_dim)
+
+    # ELF A2: gate -> gate (arg2). fused-cast -> f32 scratch tail.
+    gate_args = [
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),
+        np.asarray(layer_weights.w_gate, dtype=bfloat16).reshape(emb_dim, hidden_dim),
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+    ]
+    gate_int = {2}
+    for sc in gate_scratch:
+        if sc is not None:
+            gate_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
+            gate_int.add(sc)
+    gate_res = cache.load_and_run(
+        "gate",
+        _gate_backend(verbose),
+        *gate_args,
+        output_indices=[2],
+        static_input_indices={1},
+        intermediate_indices=gate_int,
+        bo_key=f"gate_L{layer_idx}",
+    )
+    gate = gate_res[2].reshape(seq_len, hidden_dim)
+
+    # ELF A3: up -> up (arg2). fused-cast -> f32 scratch tail.
+    up_args = [
+        np.asarray(normed2, dtype=bfloat16).reshape(seq_len, emb_dim),
+        np.asarray(layer_weights.w_up, dtype=bfloat16).reshape(emb_dim, hidden_dim),
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+    ]
+    up_int = {2}
+    for sc in up_scratch:
+        if sc is not None:
+            up_args.append(np.zeros((seq_len, hidden_dim), dtype=np.float32))
+            up_int.add(sc)
+    up_res = cache.load_and_run(
+        "up",
+        _up_backend(verbose),
+        *up_args,
+        output_indices=[2],
+        static_input_indices={1},
+        intermediate_indices=up_int,
+        bo_key=f"up_L{layer_idx}",
+    )
+    up = up_res[2].reshape(seq_len, hidden_dim)
+
+    # SwiGLU: NPU ELF (silu(gate)*up).
+    sw_res = cache.load_and_run(
+        "swiglu",
+        _swiglu_backend(verbose),
+        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),   # 0 gate
+        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),     # 1 up
+        np.zeros((seq_len, hidden_dim), dtype=bfloat16),                 # 2 swiglu (out)
+        output_indices=[2],
+        intermediate_indices={2},
+        bo_key=f"swiglu_L{layer_idx}",
+    )
+    swiglu = sw_res[2].reshape(seq_len, hidden_dim)
+
+    # ELF B: down_add -> output (arg4). Down GEMM is launch 0.
+    down_args = [
+        np.asarray(swiglu, dtype=bfloat16).reshape(seq_len, hidden_dim),       # 0 swiglu
+        np.asarray(layer_weights.w_down, dtype=bfloat16).reshape(hidden_dim, emb_dim),  # 1 w_down (static)
+        np.zeros((seq_len, emb_dim), dtype=bfloat16),                          # 2 down (inter)
+        np.asarray(res1, dtype=bfloat16).reshape(seq_len, emb_dim),            # 3 res1
+        np.zeros(n_total, dtype=bfloat16),                                    # 4 output (out)
+    ]
+    down_inter = set()
+    for sc, cols in zip(down_scratch, (emb_dim,)):
+        if sc is not None:
+            down_args.append(np.zeros((seq_len, cols), dtype=np.float32))
+            down_inter.add(sc)
+    down_res = cache.load_and_run(
+        "down_add",
+        _down_add_backend(verbose),
+        *down_args,
+        output_indices=[4],
+        static_input_indices={1},
+        intermediate_indices={2, 4} | down_inter,
+        bo_key=f"down_add_L{layer_idx}",
+    )
+    output_bf16 = down_res[4].reshape(seq_len, emb_dim)
+    inter["ffn_out"] = output_bf16
+    return output_bf16, inter

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
@@ -1,0 +1,257 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Qwen3-4B Weight Loader
+
+Loads Qwen3-4B weights from HuggingFace safetensors into numpy arrays for
+MLIR-AIR kernel invocations. Mirrors llama32_1b_weights.py with two Qwen3
+deltas:
+  - QK-norm: per-head RMSNorm weights q_norm/k_norm of shape (head_dim,),
+    applied to Q and K (per head) after projection, before RoPE.
+  - Decoupled head_dim: n_heads*head_dim (2048) != hidden_size (1024); the
+    q_proj is (emb_dim, n_heads*head_dim), k/v_proj (emb_dim, n_kv*head_dim).
+  - No qkv bias (attention_bias=false). (Qwen2.5 family DOES have bias.)
+  - Tied embeddings (lm_head = embed_tokens).
+
+Weight convention: HF stores linear weights as (out, in); our GEMM is
+y = x @ W, so projections are transposed to (in, out) on load.
+"""
+
+import os
+import glob as glob_module
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+
+@dataclass
+class LlamaConfig:
+    """Qwen3-4B hyperparameters (named LlamaConfig for downstream reuse)."""
+
+    n_layers: int = 36
+    emb_dim: int = 2560
+    n_heads: int = 32
+    head_dim: int = 128
+    n_kv_heads: int = 8  # GQA: 2 Q heads per KV head
+    hidden_dim: int = 9728
+    vocab_size: int = 151936
+    rope_base: float = 1000000.0
+    qk_norm: bool = True
+    tie_word_embeddings: bool = True
+    dtype: np.dtype = bfloat16
+
+
+@dataclass
+class LayerWeights:
+    """Weight matrices for a single Qwen3 transformer layer.
+
+    All projection shapes follow W such that y = x @ W, i.e. (in, out).
+    q_norm/k_norm are per-head RMSNorm weights of shape (head_dim,).
+    """
+
+    attn_norm: np.ndarray  # (emb_dim,)
+    wq: np.ndarray  # (emb_dim, n_heads*head_dim)
+    wk: np.ndarray  # (emb_dim, n_kv_heads*head_dim)
+    wv: np.ndarray  # (emb_dim, n_kv_heads*head_dim)
+    wo: np.ndarray  # (n_heads*head_dim, emb_dim)
+    ffn_norm: np.ndarray  # (emb_dim,)
+    w_gate: np.ndarray  # (emb_dim, hidden_dim)
+    w_up: np.ndarray  # (emb_dim, hidden_dim)
+    w_down: np.ndarray  # (hidden_dim, emb_dim)
+    q_norm: np.ndarray  # (head_dim,)  Qwen3 QK-norm
+    k_norm: np.ndarray  # (head_dim,)  Qwen3 QK-norm
+
+
+@dataclass
+class LlamaWeights:
+    embed_table: np.ndarray  # (vocab_size, emb_dim)
+    layers: List[LayerWeights] = field(default_factory=list)
+    final_norm: np.ndarray = None  # (emb_dim,)
+    lm_head: np.ndarray = None  # (vocab_size, emb_dim)
+
+
+# HF suffix -> (field, needs_transpose). norms are 1-D (no transpose).
+_HF_LAYER_MAP = {
+    "input_layernorm.weight": ("attn_norm", False),
+    "self_attn.q_proj.weight": ("wq", True),
+    "self_attn.k_proj.weight": ("wk", True),
+    "self_attn.v_proj.weight": ("wv", True),
+    "self_attn.o_proj.weight": ("wo", True),
+    "self_attn.q_norm.weight": ("q_norm", False),
+    "self_attn.k_norm.weight": ("k_norm", False),
+    "post_attention_layernorm.weight": ("ffn_norm", False),
+    "mlp.gate_proj.weight": ("w_gate", True),
+    "mlp.up_proj.weight": ("w_up", True),
+    "mlp.down_proj.weight": ("w_down", True),
+}
+
+
+def _resolve_safetensor_files(model_path: str) -> List[str]:
+    if os.path.isdir(model_path):
+        files = sorted(glob_module.glob(os.path.join(model_path, "*.safetensors")))
+        if not files:
+            raise FileNotFoundError(f"No .safetensors files found in {model_path}")
+        return files
+
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    pattern_glob = "*.safetensors"
+    try:
+        local_dir = snapshot_download(
+            model_path,
+            allow_patterns=["*.safetensors", "*.json"],
+            local_files_only=True,
+        )
+        if not glob_module.glob(os.path.join(local_dir, pattern_glob)):
+            raise LocalEntryNotFoundError(
+                f"local cache for {model_path} has no .safetensors"
+            )
+    except LocalEntryNotFoundError:
+        local_dir = snapshot_download(
+            model_path, allow_patterns=["*.safetensors", "*.json"]
+        )
+    files = sorted(glob_module.glob(os.path.join(local_dir, pattern_glob)))
+    if not files:
+        raise FileNotFoundError(
+            f"No .safetensors files found after downloading {model_path}"
+        )
+    return files
+
+
+def _load_tensor(file_handle, key: str, dtype) -> np.ndarray:
+    tensor = file_handle.get_tensor(key)
+    if hasattr(tensor, "numpy"):
+        tensor = tensor.numpy()
+    return tensor.astype(dtype)
+
+
+def load_weights(
+    model_name_or_path: str,
+    dtype=bfloat16,
+    config: Optional[LlamaConfig] = None,
+) -> LlamaWeights:
+    from safetensors import safe_open
+
+    if config is None:
+        config = LlamaConfig()
+
+    safetensor_files = _resolve_safetensor_files(model_name_or_path)
+
+    key_to_file = {}
+    for filepath in safetensor_files:
+        with safe_open(filepath, framework="numpy") as f:
+            for key in f.keys():
+                key_to_file[key] = filepath
+
+    embed_key = "model.embed_tokens.weight"
+    if embed_key not in key_to_file:
+        raise KeyError(f"Missing weight: {embed_key}")
+    with safe_open(key_to_file[embed_key], framework="numpy") as f:
+        embed_table = _load_tensor(f, embed_key, dtype)
+    assert embed_table.shape == (config.vocab_size, config.emb_dim), (
+        f"embed_table shape mismatch: expected "
+        f"({config.vocab_size}, {config.emb_dim}), got {embed_table.shape}"
+    )
+
+    qd = config.n_heads * config.head_dim
+    kvd = config.n_kv_heads * config.head_dim
+
+    layers = []
+    for layer_idx in range(config.n_layers):
+        layer_tensors = {}
+        for hf_suffix, (field_name, needs_transpose) in _HF_LAYER_MAP.items():
+            hf_key = f"model.layers.{layer_idx}.{hf_suffix}"
+            if hf_key not in key_to_file:
+                raise KeyError(f"Missing weight for layer {layer_idx}: {hf_key}")
+            with safe_open(key_to_file[hf_key], framework="numpy") as f:
+                tensor = _load_tensor(f, hf_key, dtype)
+            if needs_transpose:
+                tensor = np.ascontiguousarray(tensor.T)
+            layer_tensors[field_name] = tensor
+
+        layer = LayerWeights(**layer_tensors)
+
+        assert layer.attn_norm.shape == (config.emb_dim,)
+        assert layer.wq.shape == (config.emb_dim, qd), f"L{layer_idx} wq {layer.wq.shape}"
+        assert layer.wk.shape == (config.emb_dim, kvd), f"L{layer_idx} wk {layer.wk.shape}"
+        assert layer.wv.shape == (config.emb_dim, kvd), f"L{layer_idx} wv {layer.wv.shape}"
+        assert layer.wo.shape == (qd, config.emb_dim), f"L{layer_idx} wo {layer.wo.shape}"
+        assert layer.ffn_norm.shape == (config.emb_dim,)
+        assert layer.w_gate.shape == (config.emb_dim, config.hidden_dim)
+        assert layer.w_up.shape == (config.emb_dim, config.hidden_dim)
+        assert layer.w_down.shape == (config.hidden_dim, config.emb_dim)
+        assert layer.q_norm.shape == (config.head_dim,), f"L{layer_idx} q_norm {layer.q_norm.shape}"
+        assert layer.k_norm.shape == (config.head_dim,), f"L{layer_idx} k_norm {layer.k_norm.shape}"
+
+        layers.append(layer)
+
+    norm_key = "model.norm.weight"
+    if norm_key not in key_to_file:
+        raise KeyError(f"Missing weight: {norm_key}")
+    with safe_open(key_to_file[norm_key], framework="numpy") as f:
+        final_norm = _load_tensor(f, norm_key, dtype)
+    assert final_norm.shape == (config.emb_dim,)
+
+    lm_head_key = "lm_head.weight"
+    if lm_head_key in key_to_file:
+        with safe_open(key_to_file[lm_head_key], framework="numpy") as f:
+            lm_head = _load_tensor(f, lm_head_key, dtype)
+        assert lm_head.shape == (config.vocab_size, config.emb_dim)
+    else:
+        print("  Tied embeddings: reusing embed_table as lm_head.")
+        lm_head = embed_table
+
+    return LlamaWeights(
+        embed_table=embed_table,
+        layers=layers,
+        final_norm=final_norm,
+        lm_head=lm_head,
+    )
+
+
+def generate_rope_lut(
+    config: Optional[LlamaConfig] = None,
+    seq_len: int = 2048,
+    dtype=bfloat16,
+) -> np.ndarray:
+    """Concatenated-layout RoPE LUT [cos..., sin...] of shape (seq_len, head_dim)."""
+    if config is None:
+        config = LlamaConfig()
+
+    head_dim = config.head_dim
+    half = head_dim // 2
+    theta = config.rope_base
+
+    dim_indices = np.arange(0, head_dim, 2, dtype=np.float64)
+    inv_freq = 1.0 / (theta ** (dim_indices / head_dim))
+    positions = np.arange(seq_len, dtype=np.float64)
+    angles = np.outer(positions, inv_freq)
+
+    lut = np.empty((seq_len, head_dim), dtype=np.float64)
+    lut[:, :half] = np.cos(angles)
+    lut[:, half:] = np.sin(angles)
+    return lut.astype(dtype)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Load Qwen3-4B weights, print shapes")
+    parser.add_argument("model_path", type=str)
+    parser.add_argument("--dtype", choices=["bfloat16", "float32"], default="bfloat16")
+    args = parser.parse_args()
+
+    dtype = bfloat16 if args.dtype == "bfloat16" else np.float32
+    config = LlamaConfig()
+    print(f"Loading weights from: {args.model_path}")
+    weights = load_weights(args.model_path, dtype=dtype, config=config)
+    print(f"  embed_table : {weights.embed_table.shape}")
+    print(f"  final_norm  : {weights.final_norm.shape}")
+    print(f"  lm_head     : {weights.lm_head.shape} (tied={weights.lm_head is weights.embed_table})")
+    L0 = weights.layers[0]
+    print(f"  L0 wq {L0.wq.shape} wk {L0.wk.shape} wv {L0.wv.shape} wo {L0.wo.shape}")
+    print(f"  L0 q_norm {L0.q_norm.shape} k_norm {L0.k_norm.shape}")
+    print(f"  {len(weights.layers)} layers loaded successfully.")

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
@@ -176,16 +176,32 @@ def load_weights(
         layer = LayerWeights(**layer_tensors)
 
         assert layer.attn_norm.shape == (config.emb_dim,)
-        assert layer.wq.shape == (config.emb_dim, qd), f"L{layer_idx} wq {layer.wq.shape}"
-        assert layer.wk.shape == (config.emb_dim, kvd), f"L{layer_idx} wk {layer.wk.shape}"
-        assert layer.wv.shape == (config.emb_dim, kvd), f"L{layer_idx} wv {layer.wv.shape}"
-        assert layer.wo.shape == (qd, config.emb_dim), f"L{layer_idx} wo {layer.wo.shape}"
+        assert layer.wq.shape == (
+            config.emb_dim,
+            qd,
+        ), f"L{layer_idx} wq {layer.wq.shape}"
+        assert layer.wk.shape == (
+            config.emb_dim,
+            kvd,
+        ), f"L{layer_idx} wk {layer.wk.shape}"
+        assert layer.wv.shape == (
+            config.emb_dim,
+            kvd,
+        ), f"L{layer_idx} wv {layer.wv.shape}"
+        assert layer.wo.shape == (
+            qd,
+            config.emb_dim,
+        ), f"L{layer_idx} wo {layer.wo.shape}"
         assert layer.ffn_norm.shape == (config.emb_dim,)
         assert layer.w_gate.shape == (config.emb_dim, config.hidden_dim)
         assert layer.w_up.shape == (config.emb_dim, config.hidden_dim)
         assert layer.w_down.shape == (config.hidden_dim, config.emb_dim)
-        assert layer.q_norm.shape == (config.head_dim,), f"L{layer_idx} q_norm {layer.q_norm.shape}"
-        assert layer.k_norm.shape == (config.head_dim,), f"L{layer_idx} k_norm {layer.k_norm.shape}"
+        assert layer.q_norm.shape == (
+            config.head_dim,
+        ), f"L{layer_idx} q_norm {layer.q_norm.shape}"
+        assert layer.k_norm.shape == (
+            config.head_dim,
+        ), f"L{layer_idx} k_norm {layer.k_norm.shape}"
 
         layers.append(layer)
 
@@ -251,7 +267,9 @@ if __name__ == "__main__":
     weights = load_weights(args.model_path, dtype=dtype, config=config)
     print(f"  embed_table : {weights.embed_table.shape}")
     print(f"  final_norm  : {weights.final_norm.shape}")
-    print(f"  lm_head     : {weights.lm_head.shape} (tied={weights.lm_head is weights.embed_table})")
+    print(
+        f"  lm_head     : {weights.lm_head.shape} (tied={weights.lm_head is weights.embed_table})"
+    )
     L0 = weights.layers[0]
     print(f"  L0 wq {L0.wq.shape} wk {L0.wk.shape} wv {L0.wv.shape} wo {L0.wo.shape}")
     print(f"  L0 q_norm {L0.q_norm.shape} k_norm {L0.k_norm.shape}")

--- a/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
+++ b/programming_examples/llms/qwen3_4b/qwen3_4b_weights.py
@@ -8,8 +8,9 @@ MLIR-AIR kernel invocations. Mirrors llama32_1b_weights.py with two Qwen3
 deltas:
   - QK-norm: per-head RMSNorm weights q_norm/k_norm of shape (head_dim,),
     applied to Q and K (per head) after projection, before RoPE.
-  - Decoupled head_dim: n_heads*head_dim (2048) != hidden_size (1024); the
-    q_proj is (emb_dim, n_heads*head_dim), k/v_proj (emb_dim, n_kv*head_dim).
+  - Decoupled dims: q_dim = n_heads*head_dim (32*128 = 4096) != emb_dim (2560);
+    kv_dim = n_kv*head_dim (8*128 = 1024). The q_proj is (emb_dim, q_dim),
+    k/v_proj (emb_dim, kv_dim), so o_proj (q_dim, emb_dim) is non-square.
   - No qkv bias (attention_bias=false). (Qwen2.5 family DOES have bias.)
   - Tied embeddings (lm_head = embed_tokens).
 
@@ -34,7 +35,7 @@ class LlamaConfig:
     emb_dim: int = 2560
     n_heads: int = 32
     head_dim: int = 128
-    n_kv_heads: int = 8  # GQA: 2 Q heads per KV head
+    n_kv_heads: int = 8  # GQA: 4 Q heads per KV head (32 heads / 8 kv)
     hidden_dim: int = 9728
     vocab_size: int = 151936
     rope_base: float = 1000000.0

--- a/programming_examples/llms/qwen3_4b/requirements.txt
+++ b/programming_examples/llms/qwen3_4b/requirements.txt
@@ -1,4 +1,4 @@
-# Additional Python packages for the LLAMA-3.2-1B example.
+# Additional Python packages for the Qwen3-4B example.
 #
 # These are *on top of* the mlir-air base environment (which already
 # provides numpy, ml_dtypes, filelock, pyxrt, etc.).
@@ -6,13 +6,14 @@
 # Install with:
 #     pip install -r requirements.txt
 #
-# After this, you still need a one-time HuggingFace setup:
-#   1. Accept Meta's license at:
-#        https://huggingface.co/meta-llama/Llama-3.2-1B
-#        https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
-#   2. Create a read token at https://huggingface.co/settings/tokens
-#   3. `huggingface-cli login`  (or export HF_TOKEN=<token>)
-# See README.md / docs/usage.md for details.
+# Qwen3-4B is openly licensed (Apache-2.0); no license acceptance is needed.
+# Weights download from the public HuggingFace repos on first use:
+#        https://huggingface.co/Qwen/Qwen3-4B
+#        https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507
+# For gated/private mirrors or to avoid rate limits, optionally authenticate:
+#   1. Create a read token at https://huggingface.co/settings/tokens
+#   2. `huggingface-cli login`  (or export HF_TOKEN=<token>)
+# See README.md for details.
 
 # Weight loading
 safetensors

--- a/programming_examples/llms/qwen3_4b/requirements.txt
+++ b/programming_examples/llms/qwen3_4b/requirements.txt
@@ -1,0 +1,23 @@
+# Additional Python packages for the LLAMA-3.2-1B example.
+#
+# These are *on top of* the mlir-air base environment (which already
+# provides numpy, ml_dtypes, filelock, pyxrt, etc.).
+#
+# Install with:
+#     pip install -r requirements.txt
+#
+# After this, you still need a one-time HuggingFace setup:
+#   1. Accept Meta's license at:
+#        https://huggingface.co/meta-llama/Llama-3.2-1B
+#        https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
+#   2. Create a read token at https://huggingface.co/settings/tokens
+#   3. `huggingface-cli login`  (or export HF_TOKEN=<token>)
+# See README.md / docs/usage.md for details.
+
+# Weight loading
+safetensors
+huggingface_hub
+
+# Tokenizer (chat template) and HuggingFace reference model (used by `make verify`)
+transformers
+torch

--- a/programming_examples/llms/qwen3_4b/run_npu2_compile.lit
+++ b/programming_examples/llms/qwen3_4b/run_npu2_compile.lit
@@ -1,0 +1,20 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen3-4B compile-only smoke test: builds every prefill + decode kernel ELF
+// through the AIR -> AIE -> aiecc -> Peano pipeline. No NPU dispatch, no
+// HuggingFace download.
+//
+// NOT CI-triggered by design: the filename OMITS "peano", so the CI peano
+// suite (`lit --filter "peano"`) does not collect it — llama32_1b's compile
+// lit is the bf16 prefill/decode CI signal; this example shares the same
+// shared/builders + shared/infra assembly. Run on demand:
+//   lit -v programming_examples/llms/qwen3_4b/run_npu2_compile.lit
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_compile
+// RUN: cd test_peano_compile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Compilation passed.

--- a/programming_examples/llms/qwen3_4b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen3_4b/run_npu2_verify.lit
@@ -1,0 +1,17 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen3-4B verify gate: top-k token-level inclusion check, NPU vs HF bf16,
+// 2 prompts × 32 greedy tokens, k=5 (fast CI gate; use `make verify-full` for
+// the full sweep locally). Exercises the full production prefill + decode path
+// through the verify subsystem (verify/verify_runner.py).
+//
+// Skips cleanly when HF_TOKEN is unset (model downloads require it).
+//
+// REQUIRES: ryzen_ai_npu2, peano, hf_token
+//
+// RUN: mkdir -p test_peano_verify
+// RUN: cd test_peano_verify
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: [verify] PASS

--- a/programming_examples/llms/qwen3_4b/verify_adapter.py
+++ b/programming_examples/llms/qwen3_4b/verify_adapter.py
@@ -70,7 +70,9 @@ def build_config():
     return LlamaConfig()
 
 
-def build_runner(model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False):
+def build_runner(
+    model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False
+):
     weights = load_weights(model_name, config=config)
     return NpuRunner(
         weights=weights,
@@ -87,7 +89,9 @@ class NpuRunner:
 
     name = "npu_bf16"
 
-    def __init__(self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False):
+    def __init__(
+        self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False
+    ):
         self.weights = weights
         self.config = config
         self.max_seq = max_seq
@@ -96,16 +100,25 @@ class NpuRunner:
         self.lite_mode = lite_mode
         self._tokenizer = tokenizer
 
-        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(bfloat16)
+        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(
+            bfloat16
+        )
 
         _cache_root = _THIS_DIR / "verify_kernel_cache"
         self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
-        compile_prefill_kernels(self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn)
+        compile_prefill_kernels(
+            self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn
+        )
         self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
         compile_decode_kernels(self.decode_cache, config)
 
         prepare_runtime(
-            self.prefill_cache, self.decode_cache, weights, config, max_seq, self.rope_lut_bf16
+            self.prefill_cache,
+            self.decode_cache,
+            weights,
+            config,
+            max_seq,
+            self.rope_lut_bf16,
         )
 
         self.k_cache = None
@@ -118,9 +131,17 @@ class NpuRunner:
         else:
             padded = list(prompt_tokens)[: self.max_seq]
         prefill_token, logits_row, k_cache, v_cache, prompt_len = run_npu_prefill(
-            padded, self.weights, self.config, self.prefill_cache, self.decode_cache,
-            self.rope_lut_bf16, self.max_seq, tokenizer=self._tokenizer,
-            cpu_attn=self.cpu_attn, profile=False, quiet=True,
+            padded,
+            self.weights,
+            self.config,
+            self.prefill_cache,
+            self.decode_cache,
+            self.rope_lut_bf16,
+            self.max_seq,
+            tokenizer=self._tokenizer,
+            cpu_attn=self.cpu_attn,
+            profile=False,
+            quiet=True,
         )
         self.k_cache = k_cache
         self.v_cache = v_cache
@@ -146,8 +167,14 @@ class NpuRunner:
         layer_intermediates = []
         for li in range(cfg.n_layers):
             x, ints = run_prefill_block(
-                x, self.weights.layers[li], self.rope_lut_bf16, cfg,
-                self.prefill_cache, layer_idx=li, cpu_attn=self.cpu_attn, verbose=False,
+                x,
+                self.weights.layers[li],
+                self.rope_lut_bf16,
+                cfg,
+                self.prefill_cache,
+                layer_idx=li,
+                cpu_attn=self.cpu_attn,
+                verbose=False,
             )
             fo_full = np.asarray(ints["ffn_out"])
             layer_intermediates.append({"ffn_out": fo_full[:prompt_len]})
@@ -165,7 +192,13 @@ class NpuRunner:
     def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
         x = self.weights.embed_table[input_token].astype(bfloat16)
         next_token, logits = run_npu_decode_step(
-            x, self.weights, self.config, self.decode_cache, self.rope_lut_bf16,
-            self.k_cache, self.v_cache, current_pos,
+            x,
+            self.weights,
+            self.config,
+            self.decode_cache,
+            self.rope_lut_bf16,
+            self.k_cache,
+            self.v_cache,
+            current_pos,
         )
         return DecodeStepRecord(lm_head_logits=logits, top1_token=next_token)

--- a/programming_examples/llms/qwen3_4b/verify_adapter.py
+++ b/programming_examples/llms/qwen3_4b/verify_adapter.py
@@ -92,7 +92,7 @@ class NpuRunner:
         self.config = config
         self.max_seq = max_seq
         self.npu_attn = npu_attn
-        self.cpu_attn = not npu_attn  # Qwen3 prefill attention is CPU.
+        self.cpu_attn = not npu_attn  # NPU FlashAttention by default (npu_attn=True).
         self.lite_mode = lite_mode
         self._tokenizer = tokenizer
 

--- a/programming_examples/llms/qwen3_4b/verify_adapter.py
+++ b/programming_examples/llms/qwen3_4b/verify_adapter.py
@@ -104,12 +104,16 @@ class NpuRunner:
             bfloat16
         )
 
-        _cache_root = _THIS_DIR / "verify_kernel_cache"
-        self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
+        _cache_root = _THIS_DIR / "build_peano"
+        self.prefill_cache = KernelCache(
+            str(_cache_root / "prefill_kernel_cache"), verbose=False
+        )
         compile_prefill_kernels(
             self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn
         )
-        self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
+        self.decode_cache = KernelCache(
+            str(_cache_root / "decode_kernel_cache"), verbose=False
+        )
         compile_decode_kernels(self.decode_cache, config)
 
         prepare_runtime(

--- a/programming_examples/llms/qwen3_4b/verify_adapter.py
+++ b/programming_examples/llms/qwen3_4b/verify_adapter.py
@@ -1,0 +1,171 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Verify adapter for the bf16 Qwen3-4B example.
+
+Wraps the production `qwen3_4b_inference` driver into a Runner that
+satisfies `verify/runners/base.Runner`. The shared verify framework
+imports this via `--runner=qwen3_4b.verify_adapter`.
+
+Qwen3-4B has no separate "-Instruct" repo (Qwen3 unifies base and
+instruct), so both MODEL_CHOICES keys map to "Qwen/Qwen3-4B".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LLMS_DIR = _THIS_DIR.parent
+_VERIFY = _LLMS_DIR / "verify"
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_THIS_DIR)):
+    while _p in sys.path:
+        sys.path.remove(_p)
+    sys.path.insert(0, _p)
+
+from shared.infra.cache import KernelCache  # noqa: E402
+from qwen3_4b_prefill import (  # noqa: E402
+    compile_all_kernels as compile_prefill_kernels,
+    run_transformer_block_qwen3 as run_prefill_block,
+)
+from qwen3_4b_decode import compile_decode_kernels  # noqa: E402
+from qwen3_4b_inference import (  # noqa: E402
+    prepare_runtime,
+    run_npu_prefill,
+    run_npu_decode_step,
+)
+from qwen3_4b_weights import (  # noqa: E402
+    LlamaConfig,
+    load_weights,
+    generate_rope_lut,
+)
+from qwen3_4b_cpu_helpers import rms_norm  # noqa: E402
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+
+# Qwen3 unifies base + instruct in one checkpoint.
+MODEL_CHOICES = {
+    "base": "Qwen/Qwen3-4B",
+    "instruct": "Qwen/Qwen3-4B",
+}
+DEFAULT_MODEL = "instruct"
+
+EPS = 1e-6
+
+
+def resolve_model(model_choice_or_id: str) -> str:
+    return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
+
+
+def hf_reference(npu_model_name: str) -> str:
+    """bf16 baseline is its own reference (NPU bf16 vs HF bf16)."""
+    return npu_model_name
+
+
+def build_config():
+    return LlamaConfig()
+
+
+def build_runner(model_name, config, max_seq, tokenizer, *, npu_attn=True, lite_mode=False):
+    weights = load_weights(model_name, config=config)
+    return NpuRunner(
+        weights=weights,
+        config=config,
+        max_seq=max_seq,
+        tokenizer=tokenizer,
+        npu_attn=npu_attn,
+        lite_mode=lite_mode,
+    )
+
+
+class NpuRunner:
+    """Adapter over the bf16 production NPU prefill + decode functions."""
+
+    name = "npu_bf16"
+
+    def __init__(self, weights, config, max_seq, tokenizer, npu_attn=True, lite_mode=False):
+        self.weights = weights
+        self.config = config
+        self.max_seq = max_seq
+        self.npu_attn = npu_attn
+        self.cpu_attn = not npu_attn  # Qwen3 prefill attention is CPU.
+        self.lite_mode = lite_mode
+        self._tokenizer = tokenizer
+
+        self.rope_lut_bf16 = generate_rope_lut(config=config, seq_len=max_seq).astype(bfloat16)
+
+        _cache_root = _THIS_DIR / "verify_kernel_cache"
+        self.prefill_cache = KernelCache(str(_cache_root / "prefill"), verbose=False)
+        compile_prefill_kernels(self.prefill_cache, config, seq_len=max_seq, cpu_attn=self.cpu_attn)
+        self.decode_cache = KernelCache(str(_cache_root / "decode"), verbose=False)
+        compile_decode_kernels(self.decode_cache, config)
+
+        prepare_runtime(
+            self.prefill_cache, self.decode_cache, weights, config, max_seq, self.rope_lut_bf16
+        )
+
+        self.k_cache = None
+        self.v_cache = None
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        eos = self._tokenizer.eos_token_id
+        if len(prompt_tokens) < self.max_seq:
+            padded = list(prompt_tokens) + [eos] * (self.max_seq - len(prompt_tokens))
+        else:
+            padded = list(prompt_tokens)[: self.max_seq]
+        prefill_token, logits_row, k_cache, v_cache, prompt_len = run_npu_prefill(
+            padded, self.weights, self.config, self.prefill_cache, self.decode_cache,
+            self.rope_lut_bf16, self.max_seq, tokenizer=self._tokenizer,
+            cpu_attn=self.cpu_attn, profile=False, quiet=True,
+        )
+        self.k_cache = k_cache
+        self.v_cache = v_cache
+
+        if self.lite_mode:
+            empty = np.empty((0,), dtype=np.float32)
+            return PrefillRecord(
+                layer_intermediates=[],
+                final_hidden_normed=empty,
+                logits_at_pred=logits_row,
+                top1_token=prefill_token,
+            )
+
+        # Diagnosis-only: re-run the prefill layer loop capturing per-layer
+        # ffn_out + final post-norm hidden state.
+        cfg = self.config
+        if len(prompt_tokens) < self.max_seq:
+            pad = np.zeros(self.max_seq - len(prompt_tokens), dtype=prompt_tokens.dtype)
+            padded_diag = np.concatenate([prompt_tokens, pad])
+        else:
+            padded_diag = prompt_tokens[: self.max_seq]
+        x = self.weights.embed_table[padded_diag].astype(np.float32).astype(bfloat16)
+        layer_intermediates = []
+        for li in range(cfg.n_layers):
+            x, ints = run_prefill_block(
+                x, self.weights.layers[li], self.rope_lut_bf16, cfg,
+                self.prefill_cache, layer_idx=li, cpu_attn=self.cpu_attn, verbose=False,
+            )
+            fo_full = np.asarray(ints["ffn_out"])
+            layer_intermediates.append({"ffn_out": fo_full[:prompt_len]})
+
+        x_full_f32 = np.asarray(x, dtype=np.float32)[:prompt_len]
+        x_full_normed = rms_norm(x_full_f32, self.weights.final_norm, eps=EPS)
+
+        return PrefillRecord(
+            layer_intermediates=layer_intermediates,
+            final_hidden_normed=x_full_normed.astype(np.float32),
+            logits_at_pred=logits_row,
+            top1_token=prefill_token,
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        x = self.weights.embed_table[input_token].astype(bfloat16)
+        next_token, logits = run_npu_decode_step(
+            x, self.weights, self.config, self.decode_cache, self.rope_lut_bf16,
+            self.k_cache, self.v_cache, current_pos,
+        )
+        return DecodeStepRecord(lm_head_logits=logits, top1_token=next_token)


### PR DESCRIPTION
## Summary

**Part 3 of 3** of the NPU2 BF16 LLM series (split from #1697). **Depends on #1698** (1/3) for the shared builders/infra; please merge #1698 first.

- **Qwen2.5-3B** (QKV bias, head_dim=128, hidden=11008) — TTFT 4.24 s, 3.5 tok/s
- **Qwen3-4B** (QK-norm, decoupled q_dim=4096, hidden=9728; Gate/Up registry fused-cast high-prec) — TTFT 5.45 s, 3.5 tok/s

Each self-contained, single NPU production path; `make verify` PASS (top-5 token-set vs HF bf16, exit 0). Per-model `ARCHITECTURE.md` documents the NPU/CPU ELF sequence + perf.

## Test plan
- [x] `make verify` exit 0 for both
- [x] Per-model verify/compile lit gates

Series: 1/3 #1698 · 2/3 · 3/3 (this). Supersedes part of #1697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)