### PR TITLE
[AIRToAIE] Honor air.dedicated_dma_channel in the DMA channel allocators

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -40,6 +40,7 @@ constexpr StringLiteral AppendBarrier = "air.append_barrier";
 constexpr StringLiteral PreserveShimDmaOrder = "air.preserve_shim_dma_order";
 constexpr StringLiteral TileDmaChannel = "air.tile_dma_channel";
 constexpr StringLiteral MemtileDmaChannelMin = "air.memtile_dma_channel_min";
+constexpr StringLiteral DedicatedDmaChannel = "air.dedicated_dma_channel";
 } // namespace attrs
 
 // Copy the DMA-steering / runtime-ordering markers

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -24,6 +24,24 @@
 
 using namespace mlir;
 
+namespace {
+// A channel declared with `air.dedicated_dma_channel` must get its OWN physical
+// DMA channel and never be time-multiplexed (packet-collapsed) with any other
+// flow on the same tile, in either direction. Used to keep a latency-critical
+// packet flow off a shared DMA channel that another (e.g. later-phase) flow
+// would otherwise collapse onto and BD-order ahead of -- starving the first
+// flow's consumer. Honored by the packet-reuse branches of both the shim and
+// MemTile DMA allocators.
+bool memcpyIsDedicatedChannel(xilinx::air::MemcpyInterface mc) {
+  auto chan = mlir::dyn_cast_if_present<xilinx::air::ChannelInterface>(
+      mc.getOperation());
+  if (!chan)
+    return false;
+  auto decl = xilinx::air::getChannelDeclarationThroughSymbol(chan);
+  return decl && decl->hasAttr(xilinx::air::attrs::DedicatedDmaChannel);
+}
+} // namespace
+
 namespace xilinx {
 
 FailureOr<bool> air::isTileInbound(air::MemcpyInterface memcpyOp,
@@ -1075,12 +1093,6 @@ static int effectiveColForMemTileLTO(AIE::LogicalTileOp mtLTO) {
   return *cols.begin();
 }
 
-// Forward declaration: a channel declared with `air.dedicated_dma_channel`
-// must get its OWN physical DMA channel and never be packet-collapsed with
-// another flow on the same tile (defined below for the MemTile allocator;
-// the shim allocator's packet-reuse branch honors it too).
-static bool memcpyIsDedicatedChannel(air::MemcpyInterface mc);
-
 air::ShimDMAAllocator::ShimDMAAllocator(AIE::DeviceOp device)
     : air::DMAAllocator(device, air::MemorySpace::L3) {
   shim_dma_channels = 2;
@@ -1177,10 +1189,13 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   };
 
   // For packet flows: reuse the bucket's existing packet channel if any.
-  // EXCEPT a channel marked `air.dedicated_dma_channel`, which must get its own
-  // physical channel (mirrors MemTileDMAAllocator). This lets a column host
-  // BOTH a packet-multiplexed channel and a separate dedicated channel on the
-  // same column's other DMA channel.
+  // EXCEPT `air.dedicated_dma_channel` (mirrors MemTileDMAAllocator), which is
+  // never collapsed in either direction: a dedicated flow does not reuse an
+  // existing packet channel (guarded here), and an unmarked flow does not reuse
+  // a channel that already hosts a dedicated flow (skipped in the walk below).
+  // This lets a column host BOTH a packet-multiplexed channel and a separate
+  // dedicated channel on the same column's other DMA channel, regardless of
+  // allocation order.
   if (isPacketFlowOp && !memcpyIsDedicatedChannel(memcpyOp)) {
     AIE::LogicalTileOp packetLT = nullptr;
     int packetCh = -1;
@@ -1191,16 +1206,23 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
           continue;
         if (t.dma_channel.direction != dir)
           continue;
+        bool tDedicated = false;
+        bool tPacket = false;
         for (auto o : t.memcpyOps) {
           auto mc = dyn_cast_if_present<air::MemcpyInterface>(o);
           if (!mc)
             continue;
           auto ct = air::getChannelType(mc);
-          if (succeeded(ct) && ct.value() == "npu_dma_packet") {
-            packetLT = lt;
-            packetCh = (int)t.dma_channel.channel;
-            return true;
-          }
+          if (succeeded(ct) && ct.value() == "npu_dma_packet")
+            tPacket = true;
+          if (memcpyIsDedicatedChannel(mc))
+            tDedicated = true;
+        }
+        // Never collapse onto a channel that hosts a dedicated flow.
+        if (tPacket && !tDedicated) {
+          packetLT = lt;
+          packetCh = (int)t.dma_channel.channel;
+          return true;
         }
       }
       return false;
@@ -1453,19 +1475,6 @@ air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
   for (int i = 0, e = aie_target.columns(); i < e; i++) {
     memtile_dma_columns.push_back(i);
   }
-}
-
-// A channel declared with `air.dedicated_dma_channel` must get its OWN physical
-// DMA channel and never be time-multiplexed (collapsed) with any other flow on
-// the same tile. Used to keep a latency-critical packet flow off a shared DMA
-// channel that another (e.g. later-phase) flow would otherwise collapse onto
-// and BD-order ahead of -- starving the first flow's consumer.
-static bool memcpyIsDedicatedChannel(air::MemcpyInterface mc) {
-  auto chan = dyn_cast_if_present<air::ChannelInterface>(mc.getOperation());
-  if (!chan)
-    return false;
-  auto decl = air::getChannelDeclarationThroughSymbol(chan);
-  return decl && decl->hasAttr("air.dedicated_dma_channel");
 }
 
 FailureOr<air::allocation_info_t>

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1075,6 +1075,12 @@ static int effectiveColForMemTileLTO(AIE::LogicalTileOp mtLTO) {
   return *cols.begin();
 }
 
+// Forward declaration: a channel declared with `air.dedicated_dma_channel`
+// must get its OWN physical DMA channel and never be packet-collapsed with
+// another flow on the same tile (defined below for the MemTile allocator;
+// the shim allocator's packet-reuse branch honors it too).
+static bool memcpyIsDedicatedChannel(air::MemcpyInterface mc);
+
 air::ShimDMAAllocator::ShimDMAAllocator(AIE::DeviceOp device)
     : air::DMAAllocator(device, air::MemorySpace::L3) {
   shim_dma_channels = 2;
@@ -1171,7 +1177,11 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   };
 
   // For packet flows: reuse the bucket's existing packet channel if any.
-  if (isPacketFlowOp) {
+  // EXCEPT a channel marked `air.dedicated_dma_channel`, which must get its own
+  // physical channel (mirrors MemTileDMAAllocator). This lets a column host
+  // BOTH a packet-multiplexed channel and a separate dedicated channel on the
+  // same column's other DMA channel.
+  if (isPacketFlowOp && !memcpyIsDedicatedChannel(memcpyOp)) {
     AIE::LogicalTileOp packetLT = nullptr;
     int packetCh = -1;
     walkBucketLTOs([&](AIE::LogicalTileOp lt) {
@@ -1445,6 +1455,19 @@ air::MemTileDMAAllocator::MemTileDMAAllocator(AIE::DeviceOp device)
   }
 }
 
+// A channel declared with `air.dedicated_dma_channel` must get its OWN physical
+// DMA channel and never be time-multiplexed (collapsed) with any other flow on
+// the same tile. Used to keep a latency-critical packet flow off a shared DMA
+// channel that another (e.g. later-phase) flow would otherwise collapse onto
+// and BD-order ahead of -- starving the first flow's consumer.
+static bool memcpyIsDedicatedChannel(air::MemcpyInterface mc) {
+  auto chan = dyn_cast_if_present<air::ChannelInterface>(mc.getOperation());
+  if (!chan)
+    return false;
+  auto decl = air::getChannelDeclarationThroughSymbol(chan);
+  return decl && decl->hasAttr("air.dedicated_dma_channel");
+}
+
 FailureOr<air::allocation_info_t>
 air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
                                                 int chan) {
@@ -1484,10 +1507,22 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
-    // reuse the channel allocation.
+    // reuse the channel allocation. EXCEPT: never collapse a channel marked
+    // air.dedicated_dma_channel with anything (in either direction) -- give it
+    // a private physical DMA channel.
     if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
-      t.memcpyOps.push_back(memcpyOp.getOperation());
-      return t;
+      bool tDedicated = false;
+      for (auto o : t.memcpyOps) {
+        auto existingMc = dyn_cast_if_present<air::MemcpyInterface>(o);
+        if (existingMc && memcpyIsDedicatedChannel(existingMc)) {
+          tDedicated = true;
+          break;
+        }
+      }
+      if (!memcpyIsDedicatedChannel(memcpyOp) && !tDedicated) {
+        t.memcpyOps.push_back(memcpyOp.getOperation());
+        return t;
+      }
     }
   }
   // Need to allocate a new one. TileLike.getNumSourceConnections /

--- a/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel.mlir
+++ b/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel.mlir
@@ -1,0 +1,61 @@
+//===- dedicated_dma_channel.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// A packet-flow channel marked `air.dedicated_dma_channel` must get its OWN
+// physical shim DMA channel and never be collapsed onto a packet-multiplexed
+// channel via the packet-reuse branch. Here three L3->L2 packet channels share
+// one shim column: the two unmarked ones time-multiplex physical MM2S 0, but the
+// marked one (@pkt_in_2) is pinned to its own channel (MM2S 1).
+
+// RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
+
+// CHECK: aie.shim_dma_allocation @air_pkt_in_0({{.*}}, MM2S, 0)
+// CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 0)
+// CHECK: aie.shim_dma_allocation @air_pkt_in_2({{.*}}, MM2S, 1)
+
+module {
+  air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_in_1 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_in_2 [1, 1] {channel_type = "npu_dma_packet", air.dedicated_dma_channel}
+  air.channel @to_core [1, 1]
+  air.channel @from_core [1, 1]
+  air.channel @out [1, 1]
+  func.func @func_dedicated(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>, %arg3: memref<64xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    air.channel.put @pkt_in_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_in_1[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_in_2[] (%arg2[] [] []) {id = 3 : i32} : (memref<64xi32>)
+    air.segment @seg0 {
+      %c1_0 = arith.constant 1 : index
+      %l2_0 = memref.alloc() : memref<64xi32, 1>
+      %l2_1 = memref.alloc() : memref<64xi32, 1>
+      %l2_2 = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @pkt_in_0[] (%l2_0[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+      air.channel.get @pkt_in_1[] (%l2_1[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+      air.channel.get @pkt_in_2[] (%l2_2[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
+      air.channel.put @to_core[] (%l2_0[] [] []) {id = 7 : i32} : (memref<64xi32, 1>)
+      air.herd tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) attributes {sym_name = "herd0"} {
+        %buf = memref.alloc() : memref<64xi32, 2>
+        %res = memref.alloc() : memref<64xi32, 2>
+        air.channel.get @to_core[%tx, %ty] (%buf[] [] []) {id = 8 : i32} : (memref<64xi32, 2>)
+        air.channel.put @from_core[%tx, %ty] (%res[] [] []) {id = 9 : i32} : (memref<64xi32, 2>)
+        memref.dealloc %buf : memref<64xi32, 2>
+        memref.dealloc %res : memref<64xi32, 2>
+      }
+      %l2_out = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @from_core[] (%l2_out[] [] []) {id = 10 : i32} : (memref<64xi32, 1>)
+      air.channel.put @out[] (%l2_out[] [] []) {id = 11 : i32} : (memref<64xi32, 1>)
+      memref.dealloc %l2_0 : memref<64xi32, 1>
+      memref.dealloc %l2_1 : memref<64xi32, 1>
+      memref.dealloc %l2_2 : memref<64xi32, 1>
+      memref.dealloc %l2_out : memref<64xi32, 1>
+    }
+    air.channel.get @out[] (%arg3[] [] []) {id = 12 : i32} : (memref<64xi32>)
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel_order.mlir
+++ b/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel_order.mlir
@@ -1,44 +1,31 @@
-//===- dedicated_dma_channel.mlir -------------------------------*- MLIR -*-===//
+//===- dedicated_dma_channel_order.mlir ------------------------*- MLIR -*-===//
 //
 // Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //===----------------------------------------------------------------------===//
 
-// A packet-flow channel marked `air.dedicated_dma_channel` must get its OWN
-// physical DMA channel and never be collapsed onto a packet-multiplexed channel
-// via the packet-reuse branch. This is honored by both the shim allocator (the
-// L3 puts) and the MemTile allocator (the L2 gets). Here three L3->L2 packet
-// channels share one shim column: the two unmarked ones time-multiplex their
-// physical channel, but the marked one (@pkt_in_2) is pinned to its own.
+// The `air.dedicated_dma_channel` guarantee must be order-independent: a marked
+// channel gets its own physical DMA channel even when it is declared/allocated
+// BEFORE the unmarked flows. This exercises the reverse of the packet-reuse
+// guard -- an unmarked flow must not collapse onto an already-allocated
+// dedicated channel. Here @pkt_in_0 is the marked one; it takes MM2S 0 and the
+// two unmarked flows time-multiplex MM2S 1.
 
 // RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
 
-// MemTile side (S2MM): unmarked pkt_id 0/1 share S2MM 0; dedicated pkt_id 2 is
-// alone on S2MM 1 (packet flow ids follow channel decl order, so pkt_id 2 is
-// @pkt_in_2).
-// CHECK: aie.memtile_dma
-// CHECK: aie.dma_start(S2MM, 0
-// CHECK: pkt_id = 0
-// CHECK: pkt_id = 1
-// CHECK: aie.dma_start(S2MM, 1
-// CHECK: pkt_id = 2
-
-// Shim side (MM2S): unmarked pkt_in_0/1 share MM2S 0; dedicated pkt_in_2 -> MM2S 1.
 // CHECK: aie.shim_dma_allocation @air_pkt_in_0({{.*}}, MM2S, 0)
-// CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 0)
+// CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 1)
 // CHECK: aie.shim_dma_allocation @air_pkt_in_2({{.*}}, MM2S, 1)
 
 module {
-  air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet", air.dedicated_dma_channel}
   air.channel @pkt_in_1 [1, 1] {channel_type = "npu_dma_packet"}
-  air.channel @pkt_in_2 [1, 1] {channel_type = "npu_dma_packet", air.dedicated_dma_channel}
+  air.channel @pkt_in_2 [1, 1] {channel_type = "npu_dma_packet"}
   air.channel @to_core [1, 1]
   air.channel @from_core [1, 1]
   air.channel @out [1, 1]
-  func.func @func_dedicated(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>, %arg3: memref<64xi32>) {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
+  func.func @func_dedicated_first(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>, %arg3: memref<64xi32>) {
     air.channel.put @pkt_in_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
     air.channel.put @pkt_in_1[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
     air.channel.put @pkt_in_2[] (%arg2[] [] []) {id = 3 : i32} : (memref<64xi32>)


### PR DESCRIPTION
## Summary

Adds an opt-in `air.dedicated_dma_channel` channel attribute: a channel so
marked must get its **own** physical DMA channel and is never time-multiplexed
(packet-collapsed) with another flow on the same tile.

Both the shim and MemTile DMA allocators have a packet-reuse branch that merges
multiple packet flows onto one physical channel (to exceed the per-tile physical
channel limit). That collapse is wrong for a latency-critical packet flow that a
later-phase flow would otherwise share a channel with and BD-order ahead of,
starving the first flow's consumer. This adds `memcpyIsDedicatedChannel` and
consults it in both packet-reuse branches, so a marked channel keeps a private
physical channel while unmarked flows still share.

## Test plan
- [x] `dedicated_dma_channel.mlir` — three L3->L2 packet channels on one shim
  column: the two unmarked ones time-multiplex physical MM2S 0, the marked one
  is pinned to MM2S 1. Verified it **fails without** this change (all three
  collapse onto MM2S 0) and passes with it.
- [x] `ninja check-air-mlir` — no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)