### PR TITLE
[ci] Unpin llvm-aie and return to nightly

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -83,8 +83,7 @@ jobs:
       - name: Get llvm-aie
         run: |
           source air-venv/bin/activate
-          # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1056). Revert once fixed upstream.
-          python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       - name: Build and test mlir-air
         run: |

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -51,8 +51,7 @@ export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
 export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # Install llvm-aie
-# Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1056). Revert once fixed upstream.
-python3 -m pip install --force-reinstall "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"
 


### PR DESCRIPTION
## Summary
- Reverts the temporary llvm-aie pin (`21.0.0.2026062301+cb664e8c`) introduced in #1692.
- CI (`buildAndTestRyzenAI.yml`) and the wheel build (`build-mlir-air-using-wheels.sh`) now track the latest llvm-aie nightly again.

## Context
The pin worked around the int->float->int miscompile at -O2 (Xilinx/llvm-aie#1056), where the argument-defining load was scheduled into a soft-float call's delay slots. That codegen bug is now fixed upstream, so the stopgap is no longer needed.

## Test plan
- [x] CI green on latest nightly (`ninja check-air-e2e-peano`, programming examples)