### PR TITLE
[AIRToAIE] MemTile packet S2MM collapse: source-tile discrimination

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -97,6 +97,13 @@ struct allocation_info_t {
   bool foundAlloc(AIE::TileLike tile, air::ChannelOp channel_op);
   bool foundAlloc(AIE::TileLike tile, AIE::DMAChannel channel);
   bool foundPacketFlowAllocInTile(AIE::TileLike tile);
+  // True if a packet-flow memcpy on `tile` belongs to the SAME logical flow as
+  // `memcpyOp` (same channel decl + same constant bundle indices). Used for
+  // S2MM-side collapse discrimination: distinct sources must not share a
+  // physical channel. A non-constant index cannot be proven equal and is
+  // treated as distinct (safe: forces a separate channel).
+  bool foundSamePacketFlowInTile(AIE::TileLike tile,
+                                 air::MemcpyInterface memcpyOp);
 
   bool foundAlloc(air::ChannelOp channel_op);
   bool foundAlloc(AIE::DMAChannel channel);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1506,6 +1506,26 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
     isPacketFlowOp = chanTypeRes.value() == "npu_dma_packet";
   }
 
+  // (sym, indices) endpoint key for a memcpy op — used to discriminate
+  // packet-flow collapse below. Two memcpys with the same (channel
+  // symbol, indices) tuple represent the same logical flow (different
+  // invocations of the same put-get pair); two memcpys with different
+  // (sym, indices) tuples represent DIFFERENT logical flows from
+  // potentially different sources.
+  auto endpointKey = [](air::MemcpyInterface mc)
+      -> std::optional<std::pair<StringRef, SmallVector<int64_t, 4>>> {
+    auto chan = dyn_cast<air::ChannelInterface>(mc.getOperation());
+    if (!chan)
+      return std::nullopt;
+    SmallVector<int64_t, 4> idx;
+    for (auto v : chan.getIndices()) {
+      auto c = getConstantIntValue(v);
+      idx.push_back(c.value_or(-1));
+    }
+    return std::make_pair(chan.getChanName(), idx);
+  };
+  auto newKey = endpointKey(memcpyOp);
+
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
@@ -1516,9 +1536,26 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
       return t;
     }
     // Search for existing packet-flow allocations on this tile, and try to
-    // reuse the channel allocation. EXCEPT: never collapse a channel marked
-    // air.dedicated_dma_channel with anything (in either direction) -- give it
-    // a private physical DMA channel.
+    // reuse the channel allocation.
+    //
+    // EXCEPT: never collapse a channel marked air.dedicated_dma_channel with
+    // anything (in either direction) -- give it a private physical DMA channel.
+    //
+    // For the MM2S side (source-side memtile): promiscuous collapse is the
+    // intended behavior — multiple downstream consumers share one source MM2S
+    // port via pkt_id multiplexing (a broadcast packet channel emits to N L1
+    // destinations, or several packet channels multiplex one source port).
+    //
+    // For the S2MM side (receiver-side memtile): discriminate by (channel
+    // symbol, indices) endpoint key. Collapse only when the new memcpy and an
+    // existing one share the same key (same logical flow, possibly different
+    // invocations from scf.for unroll or ping-pong). Different (sym, indices)
+    // tuples mean different upstream sources and must NOT share one physical
+    // S2MM channel — each (src, dst) pair belongs on its own physical S2MM
+    // channel at the receiver memtile (a multi-source fan-in into a shared L2
+    // buffer needs one physical writer channel per source). Over-collapse
+    // silently merged N sources onto S2MM 0 of the dst memtile, blowing past
+    // the memtile_dma block budget once unrolling + ping-pong combined.
     if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       bool tDedicated = false;
       for (auto o : t.memcpyOps) {
@@ -1528,7 +1565,24 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
           break;
         }
       }
-      if (!memcpyIsDedicatedChannel(memcpyOp) && !tDedicated) {
+      bool canCollapse = !memcpyIsDedicatedChannel(memcpyOp) && !tDedicated;
+      if (canCollapse && !isMM2S.value()) {
+        // S2MM-side: require (sym, indices) match.
+        canCollapse = false;
+        if (newKey.has_value()) {
+          for (auto o : t.memcpyOps) {
+            auto existingMc = dyn_cast_if_present<air::MemcpyInterface>(o);
+            if (!existingMc)
+              continue;
+            auto existingKey = endpointKey(existingMc);
+            if (existingKey == newKey) {
+              canCollapse = true;
+              break;
+            }
+          }
+        }
+      }
+      if (canCollapse) {
         t.memcpyOps.push_back(memcpyOp.getOperation());
         return t;
       }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -677,6 +677,42 @@ bool xilinx::air::allocation_info_t::foundPacketFlowAllocInTile(
   return false;
 }
 
+// Same-logical-flow test: same channel declaration and same constant bundle
+// indices. A non-constant index cannot be proven equal, so it is distinct.
+static bool isSamePacketFlowEndpoint(air::MemcpyInterface a,
+                                     air::MemcpyInterface b) {
+  auto chanA = dyn_cast_if_present<air::ChannelInterface>(a.getOperation());
+  auto chanB = dyn_cast_if_present<air::ChannelInterface>(b.getOperation());
+  if (!chanA || !chanB)
+    return false;
+  if (air::getChannelDeclarationThroughSymbol(chanA) !=
+      air::getChannelDeclarationThroughSymbol(chanB))
+    return false;
+  auto idxA = chanA.getIndices();
+  auto idxB = chanB.getIndices();
+  if (idxA.size() != idxB.size())
+    return false;
+  for (auto [va, vb] : llvm::zip_equal(idxA, idxB)) {
+    auto ca = getConstantIntValue(va);
+    auto cb = getConstantIntValue(vb);
+    if (!ca || !cb || *ca != *cb)
+      return false;
+  }
+  return true;
+}
+
+bool xilinx::air::allocation_info_t::foundSamePacketFlowInTile(
+    AIE::TileLike tile, air::MemcpyInterface memcpyOp) {
+  if (!foundAlloc(tile))
+    return false;
+  for (auto o : memcpyOps) {
+    auto existingMc = dyn_cast_if_present<air::MemcpyInterface>(o);
+    if (existingMc && isSamePacketFlowEndpoint(existingMc, memcpyOp))
+      return true;
+  }
+  return false;
+}
+
 // DMAAllocator impl.
 
 // A simple selection sorting implementation.
@@ -1506,26 +1542,6 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
     isPacketFlowOp = chanTypeRes.value() == "npu_dma_packet";
   }
 
-  // (sym, indices) endpoint key for a memcpy op — used to discriminate
-  // packet-flow collapse below. Two memcpys with the same (channel
-  // symbol, indices) tuple represent the same logical flow (different
-  // invocations of the same put-get pair); two memcpys with different
-  // (sym, indices) tuples represent DIFFERENT logical flows from
-  // potentially different sources.
-  auto endpointKey = [](air::MemcpyInterface mc)
-      -> std::optional<std::pair<StringRef, SmallVector<int64_t, 4>>> {
-    auto chan = dyn_cast<air::ChannelInterface>(mc.getOperation());
-    if (!chan)
-      return std::nullopt;
-    SmallVector<int64_t, 4> idx;
-    for (auto v : chan.getIndices()) {
-      auto c = getConstantIntValue(v);
-      idx.push_back(c.value_or(-1));
-    }
-    return std::make_pair(chan.getChanName(), idx);
-  };
-  auto newKey = endpointKey(memcpyOp);
-
   // Search for existing dma channel allocation
   unsigned num_allocs = 0;
   for (auto &t : *allocs) {
@@ -1535,27 +1551,13 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
       t.memcpyOps.push_back(memcpyOp.getOperation());
       return t;
     }
-    // Search for existing packet-flow allocations on this tile, and try to
-    // reuse the channel allocation.
-    //
-    // EXCEPT: never collapse a channel marked air.dedicated_dma_channel with
-    // anything (in either direction) -- give it a private physical DMA channel.
-    //
-    // For the MM2S side (source-side memtile): promiscuous collapse is the
-    // intended behavior — multiple downstream consumers share one source MM2S
-    // port via pkt_id multiplexing (a broadcast packet channel emits to N L1
-    // destinations, or several packet channels multiplex one source port).
-    //
-    // For the S2MM side (receiver-side memtile): discriminate by (channel
-    // symbol, indices) endpoint key. Collapse only when the new memcpy and an
-    // existing one share the same key (same logical flow, possibly different
-    // invocations from scf.for unroll or ping-pong). Different (sym, indices)
-    // tuples mean different upstream sources and must NOT share one physical
-    // S2MM channel — each (src, dst) pair belongs on its own physical S2MM
-    // channel at the receiver memtile (a multi-source fan-in into a shared L2
-    // buffer needs one physical writer channel per source). Over-collapse
-    // silently merged N sources onto S2MM 0 of the dst memtile, blowing past
-    // the memtile_dma block budget once unrolling + ping-pong combined.
+    // Reuse an existing packet-flow channel on this tile via time
+    // multiplexing. Never collapse a channel marked air.dedicated_dma_channel
+    // (either direction). MM2S (source) side collapses promiscuously
+    // (broadcast fan-out / pkt_id multiplexing rely on it); S2MM (receiver)
+    // side collapses only flows proven identical (same channel decl + indices),
+    // since distinct sources fanning into one L2 buffer each need their own
+    // physical S2MM channel.
     if (isPacketFlowOp && t.foundPacketFlowAllocInTile(tile)) {
       bool tDedicated = false;
       for (auto o : t.memcpyOps) {
@@ -1566,22 +1568,8 @@ air::MemTileDMAAllocator::simpleDmaChannelAlloc(air::MemcpyInterface &memcpyOp,
         }
       }
       bool canCollapse = !memcpyIsDedicatedChannel(memcpyOp) && !tDedicated;
-      if (canCollapse && !isMM2S.value()) {
-        // S2MM-side: require (sym, indices) match.
-        canCollapse = false;
-        if (newKey.has_value()) {
-          for (auto o : t.memcpyOps) {
-            auto existingMc = dyn_cast_if_present<air::MemcpyInterface>(o);
-            if (!existingMc)
-              continue;
-            auto existingKey = endpointKey(existingMc);
-            if (existingKey == newKey) {
-              canCollapse = true;
-              break;
-            }
-          }
-        }
-      }
+      if (canCollapse && !isMM2S.value())
+        canCollapse = t.foundSamePacketFlowInTile(tile, memcpyOp);
       if (canCollapse) {
         t.memcpyOps.push_back(memcpyOp.getOperation());
         return t;

--- a/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel.mlir
+++ b/mlir/test/Conversion/AIRToAIE/dedicated_dma_channel.mlir
@@ -10,21 +10,25 @@
 // via the packet-reuse branch. This is honored by both the shim allocator (the
 // L3 puts) and the MemTile allocator (the L2 gets). Here three L3->L2 packet
 // channels share one shim column: the two unmarked ones time-multiplex their
-// physical channel, but the marked one (@pkt_in_2) is pinned to its own.
+// physical shim MM2S, but the marked one (@pkt_in_2) is pinned to its own.
 
 // RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
 
-// MemTile side (S2MM): unmarked pkt_id 0/1 share S2MM 0; dedicated pkt_id 2 is
-// alone on S2MM 1 (packet flow ids follow channel decl order, so pkt_id 2 is
-// @pkt_in_2).
+// MemTile side (S2MM): the receiver applies source-tile discrimination, so each
+// distinct L3->L2 flow lands on its OWN physical S2MM channel (a dedicated
+// channel is therefore never at risk of collapse here). pkt ids follow channel
+// decl order (@pkt_in_0 -> 0, @pkt_in_1 -> 1, @pkt_in_2 -> 2).
 // CHECK: aie.memtile_dma
 // CHECK: aie.dma_start(S2MM, 0
 // CHECK: pkt_id = 0
-// CHECK: pkt_id = 1
 // CHECK: aie.dma_start(S2MM, 1
+// CHECK: pkt_id = 1
+// CHECK: aie.dma_start(S2MM, 2
 // CHECK: pkt_id = 2
 
-// Shim side (MM2S): unmarked pkt_in_0/1 share MM2S 0; dedicated pkt_in_2 -> MM2S 1.
+// Shim side (MM2S): the source keeps promiscuous packet multiplexing, so the
+// dedicated marker is what forces separation -- unmarked pkt_in_0/1 share
+// MM2S 0; dedicated pkt_in_2 -> its own MM2S 1.
 // CHECK: aie.shim_dma_allocation @air_pkt_in_0({{.*}}, MM2S, 0)
 // CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 0)
 // CHECK: aie.shim_dma_allocation @air_pkt_in_2({{.*}}, MM2S, 1)

--- a/mlir/test/Conversion/AIRToAIE/memtile_packet_same_flow_collapse.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_packet_same_flow_collapse.mlir
@@ -1,0 +1,70 @@
+//===- memtile_packet_same_flow_collapse.mlir ------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Companion to memtile_packet_two_sources_one_dst.mlir. Verifies the
+// collapse-PRESERVING side of the S2MM discrimination in
+// MemTileDMAAllocator::simpleDmaChannelAlloc: multiple invocations of the SAME
+// logical flow (same channel decl + same indices, e.g. scf.for unroll or
+// ping-pong) still time-multiplex ONE physical S2MM channel. Only distinct
+// sources get separate channels -- same-flow invocations must not.
+//
+// Here one packet channel (@w0) is used by two get invocations writing disjoint
+// rows of one L2 buffer. Both share S2MM 0 (two BDs, one pkt_id); no second
+// S2MM channel is allocated.
+
+// CHECK: aie.memtile_dma
+// CHECK: aie.dma_start(S2MM, 0
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 0, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 8, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK-NOT: aie.dma_start(S2MM, 1
+
+air.channel @w0 [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @memtile_pkt_same_flow() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      // Two invocations of the SAME channel write disjoint rows of one buffer.
+      air.channel.get @w0[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @w0[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute {memref.dealloc %l2 : memref<2x8xbf16, 1>}
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0) attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok0, %l1a = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1a[] [] []) : (memref<8xbf16, 2>)
+        %tok1, %l1b = air.execute -> (memref<8xbf16, 2>) {
+          %bb = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %bb : memref<8xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1b[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1a : memref<8xbf16, 2>}
+        %d0b = air.execute {memref.dealloc %l1b : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0) attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<16xbf16, 2>) {
+          %aa = memref.alloc() : memref<16xbf16, 2>
+          air.execute_terminator %aa : memref<16xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<16xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<16xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/memtile_packet_two_sources_one_dst.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_packet_two_sources_one_dst.mlir
@@ -1,0 +1,77 @@
+//===- memtile_packet_two_sources_one_dst.mlir -----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Regression for the memtile packet-flow OVER-COLLAPSE bug in
+// MemTileDMAAllocator::simpleDmaChannelAlloc. The packet-reuse branch matched
+// only the destination tile (foundPacketFlowAllocInTile), so N distinct packet
+// flows landing on the same receiver memtile were collapsed onto ONE physical
+// S2MM channel regardless of source. That is wrong on the S2MM (receiver) side:
+// each distinct (channel symbol, indices) endpoint is a different logical flow
+// / source and must get its own physical S2MM channel; only multiple invocations
+// of the SAME flow (scf.for unroll or ping-pong) may share one channel.
+//
+// Here two distinct packet channels (@w0, @w1) each write a disjoint sub-region
+// of one L2 buffer at the receiver memtile. With source discrimination the
+// memtile allocates TWO S2MM channels (one per source); without it both collapse
+// onto S2MM 0. The MM2S (source) side keeps promiscuous collapse (used by
+// broadcast packet fan-out and multi-pkt_id multiplexing), so it is unaffected.
+
+// CHECK: aie.memtile_dma
+// CHECK: aie.dma_start(S2MM, 0
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 0, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK: aie.dma_start(S2MM, 1
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 8, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 1>
+
+air.channel @w0 [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @w1 [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @memtile_pkt_two_src() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      // Two distinct packet channels write disjoint rows of the same L2 buffer.
+      air.channel.get @w0[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @w1[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute {memref.dealloc %l2 : memref<2x8xbf16, 1>}
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0) attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0) attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w1[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0) attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<16xbf16, 2>) {
+          %aa = memref.alloc() : memref<16xbf16, 2>
+          air.execute_terminator %aa : memref<16xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<16xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<16xbf16, 2>}
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary
`MemTileDMAAllocator::simpleDmaChannelAlloc` reused a packet-flow allocation whenever *any* packet flow already existed on the destination tile (`foundPacketFlowAllocInTile`), with no source discrimination. That collapsed N distinct packet flows landing on the same receiver memtile onto **one** physical S2MM channel regardless of source.

For a multi-source fan-in into a shared L2 buffer (N producers each writing a disjoint sub-region) this is wrong: each writer needs its own physical S2MM channel, and merging them onto S2MM 0 blows past the `memtile_dma` block budget once per-writer BD chains (unroll / ping-pong) are added.

## Change
Discriminate packet-flow collapse on the **S2MM (receiver)** side by `(channel symbol, indices)` endpoint key — collapse only when the new memcpy and an existing one share the same key (same logical flow, e.g. different `scf.for`-unroll or ping-pong invocations). Different keys are different sources and each gets its own physical S2MM channel. The **MM2S (source)** side keeps promiscuous collapse, which broadcast packet fan-out and multi-`pkt_id` source multiplexing rely on.

## Tests
- **New** `memtile_packet_two_sources_one_dst.mlir`: two distinct packet channels write disjoint sub-regions of one L2 buffer; with discrimination the memtile allocates two S2MM channels (one per source), without it both collapse onto S2MM 0. (Verified PASS-with / FAIL-without.)
- **Updated** `dedicated_dma_channel.mlir`: on the MemTile S2MM side every distinct flow now gets its own channel (the three L3→L2 gets land on S2MM 0/1/2 individually). The `air.dedicated_dma_channel` marker's effect is still exercised on the shim MM2S side, where promiscuous multiplexing is kept, so the dedicated channel is the one forced off the shared MM2S.
- `ninja check-air-mlir`: no new failures (pre-existing env-only failures unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)