### PR TITLE
[AIRToAIE] Multi-producer packet-flow convergence (N producers -> 1 S2MM)

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -163,12 +163,15 @@ struct MemcpyBundleAsFlow {
                           // flows of the same index can share DMA channels)
   std::vector<allocation_info_t> S2MM_alloc;
   std::vector<std::vector<Operation *>> S2MM;
-  // MM2S is symmetric to S2MM: one allocation per producer, to support N
-  // producers converging on a single destination S2MM (multi-producer packet
-  // flow). MM2S_alloc[j] pairs with MM2S[j]. Single-producer flows keep
-  // numMM2SAllocs == 1.
+  // MM2S is symmetric to S2MM: one allocation per distinct producer tile, to
+  // support N producers converging on a single destination S2MM (multi-producer
+  // packet flow). MM2S_alloc is indexed by producer tile in [0, numMM2SAllocs);
+  // MM2S holds one entry per put op, so several MM2S ops from the same producer
+  // tile map to one MM2S_alloc entry (the index spaces do NOT align). Grouping
+  // of puts to producer-tile indices happens in simpleDMAChannelAllocation.
+  // Single-producer flows keep numMM2SAllocs == 1.
   std::vector<allocation_info_t> MM2S_alloc;
-  std::vector<Operation *> MM2S; // air::ChannelPuts (one per producer)
+  std::vector<Operation *> MM2S; // air::ChannelPuts (one entry per put op)
   air::MemorySpace MM2S_memspace;
   air::MemorySpace S2MM_memspace;
   int numMM2SAllocs = 0;

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -163,8 +163,12 @@ struct MemcpyBundleAsFlow {
                           // flows of the same index can share DMA channels)
   std::vector<allocation_info_t> S2MM_alloc;
   std::vector<std::vector<Operation *>> S2MM;
-  allocation_info_t MM2S_alloc;
-  std::vector<Operation *> MM2S; // air::ChannelPuts
+  // MM2S is symmetric to S2MM: one allocation per producer, to support N
+  // producers converging on a single destination S2MM (multi-producer packet
+  // flow). MM2S_alloc[j] pairs with MM2S[j]. Single-producer flows keep
+  // numMM2SAllocs == 1.
+  std::vector<allocation_info_t> MM2S_alloc;
+  std::vector<Operation *> MM2S; // air::ChannelPuts (one per producer)
   air::MemorySpace MM2S_memspace;
   air::MemorySpace S2MM_memspace;
   int numMM2SAllocs = 0;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4406,8 +4406,8 @@ public:
     //   Pass 2: intra-device packet flows (assignIntraDevicePacketID --
     //           lowest gap in claimedPacketIDs).
     //   Pass 3: stream and cascade flows (no pkt_id involved).
-    auto isInvalidAlloc = [&](air::MemcpyBundleAsFlow &f, int i) {
-      if (!f.MM2S_alloc.getDmaTile() || !f.S2MM_alloc[i].getDmaTile()) {
+    auto isInvalidAlloc = [&](air::MemcpyBundleAsFlow &f, int j, int i) {
+      if (!f.MM2S_alloc[j].getDmaTile() || !f.S2MM_alloc[i].getDmaTile()) {
         LLVM_DEBUG(llvm::dbgs()
                    << "AIRToAIE: skipping memcpy flow due to invalid DMA "
                       "tile allocation (MM2S or S2MM tile is null)\n");
@@ -4415,8 +4415,8 @@ public:
       }
       return false;
     };
-    auto isShimFlowAt = [&](air::MemcpyBundleAsFlow &f, int i) {
-      return f.MM2S_alloc.getDmaTile().isShimNOCorPLTile() ||
+    auto isShimFlowAt = [&](air::MemcpyBundleAsFlow &f, int j, int i) {
+      return f.MM2S_alloc[j].getDmaTile().isShimNOCorPLTile() ||
              f.S2MM_alloc[i].getDmaTile().isShimNOCorPLTile();
     };
     // The flow-op key for packetIDForChannelName is the air.channel symbol
@@ -4442,31 +4442,39 @@ public:
       return it->second;
     };
 
-    // Pass 1: shim packet flows.
+    // Pass 1: shim packet flows. Nested over producers (j) x dests (i): one
+    // packet_flow per (producer, dest). For multi-producer convergence the
+    // shared dest pkt id is memoized by channel name in assignOrLookupPacketID,
+    // so all producers of one channel land on the dest S2MM with the SAME id.
     for (auto &f : memcpy_flows) {
       if (f.memcpyResourceType != "npu_dma_packet")
         continue;
       for (int i = 0; i < f.numS2MMAllocs; i++) {
-        if (isInvalidAlloc(f, i))
-          continue;
-        if (!isShimFlowAt(f, i))
-          continue;
-        int flowID = assignOrLookupPacketID(f, /*isShim=*/true);
-        getPacketFlowOp(
-            aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-            AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
-            f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-            (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
-        // Backlink: the host runtime keys packet identification on
-        // (shim tile, pkt_id), so the matching MM2S shim alloc carries the id.
-        for (auto &sa : shim_dma_alloc.mm2s_allocs) {
-          if (sa.getDmaTile().getOperation() ==
-                  f.MM2S_alloc.getDmaTile().getOperation() &&
-              sa.dma_channel == f.MM2S_alloc.dma_channel &&
-              sa.col == f.MM2S_alloc.col && sa.row == f.MM2S_alloc.row &&
-              sa.dma_id == f.MM2S_alloc.dma_id) {
-            sa.packet_flow_id = flowID;
-            break;
+        for (int j = 0; j < f.numMM2SAllocs; j++) {
+          if (isInvalidAlloc(f, j, i))
+            continue;
+          if (!isShimFlowAt(f, j, i))
+            continue;
+          int flowID = assignOrLookupPacketID(f, /*isShim=*/true);
+          getPacketFlowOp(
+              aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
+              AIE::WireBundle::DMA,
+              (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
+              (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+          // Backlink: the host runtime keys packet identification on
+          // (shim tile, pkt_id), so the matching MM2S shim alloc carries the
+          // id.
+          for (auto &sa : shim_dma_alloc.mm2s_allocs) {
+            if (sa.getDmaTile().getOperation() ==
+                    f.MM2S_alloc[j].getDmaTile().getOperation() &&
+                sa.dma_channel == f.MM2S_alloc[j].dma_channel &&
+                sa.col == f.MM2S_alloc[j].col &&
+                sa.row == f.MM2S_alloc[j].row &&
+                sa.dma_id == f.MM2S_alloc[j].dma_id) {
+              sa.packet_flow_id = flowID;
+              break;
+            }
           }
         }
       }
@@ -4477,16 +4485,19 @@ public:
       if (f.memcpyResourceType != "npu_dma_packet")
         continue;
       for (int i = 0; i < f.numS2MMAllocs; i++) {
-        if (isInvalidAlloc(f, i))
-          continue;
-        if (isShimFlowAt(f, i))
-          continue;
-        int flowID = assignOrLookupPacketID(f, /*isShim=*/false);
-        getPacketFlowOp(
-            aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-            AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
-            f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-            (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+        for (int j = 0; j < f.numMM2SAllocs; j++) {
+          if (isInvalidAlloc(f, j, i))
+            continue;
+          if (isShimFlowAt(f, j, i))
+            continue;
+          int flowID = assignOrLookupPacketID(f, /*isShim=*/false);
+          getPacketFlowOp(
+              aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
+              AIE::WireBundle::DMA,
+              (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
+              (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+        }
       }
     }
 
@@ -4496,20 +4507,25 @@ public:
           f.memcpyResourceType != "npu_cascade")
         continue;
       for (int i = 0; i < f.numS2MMAllocs; i++) {
-        if (isInvalidAlloc(f, i))
-          continue;
-        if (f.memcpyResourceType == "npu_dma_stream")
-          getFlowOp(
-              aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-              AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
-              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-              (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
-        else
-          getCascadeFlowOp(
-              aie_device, f.MM2S_alloc.getDmaTile()->getResult(0),
-              AIE::WireBundle::DMA, (uint32_t)f.MM2S_alloc.dma_channel.channel,
-              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-              (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
+        for (int j = 0; j < f.numMM2SAllocs; j++) {
+          if (isInvalidAlloc(f, j, i))
+            continue;
+          if (f.memcpyResourceType == "npu_dma_stream")
+            getFlowOp(aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                      AIE::WireBundle::DMA,
+                      (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                      f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                      AIE::WireBundle::DMA,
+                      (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
+          else
+            getCascadeFlowOp(aie_device,
+                             f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                             AIE::WireBundle::DMA,
+                             (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                             f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                             AIE::WireBundle::DMA,
+                             (uint32_t)f.S2MM_alloc[i].dma_channel.channel);
+        }
       }
     }
     return success();

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1760,21 +1760,24 @@ air::ShimDMAAllocator::foundFlowReuseOpportunity(
             f.S2MM_alloc[i].dma_channel.direction ==
                 alloc.dma_channel.direction &&
             f.S2MM_alloc[i].dma_channel.channel == alloc.dma_channel.channel) {
-          if (f.MM2S_alloc.getDmaTile() &&
-              f.MM2S_alloc.getDmaTile().isShimTile()) {
-            return f.MM2S_alloc;
+          for (auto &mm2s : f.MM2S_alloc) {
+            if (mm2s.getDmaTile() && mm2s.getDmaTile().isShimTile()) {
+              return mm2s;
+            }
           }
         }
       }
-    } else if (!isMM2S && f.MM2S_alloc.getDmaTile() == alloc.getDmaTile() &&
-               f.MM2S_alloc.dma_channel.direction ==
-                   alloc.dma_channel.direction &&
-               f.MM2S_alloc.dma_channel.channel == alloc.dma_channel.channel) {
-
-      for (unsigned i = 0; i < f.S2MM_alloc.size(); i++) {
-        if (f.S2MM_alloc[i].getDmaTile() &&
-            f.S2MM_alloc[i].getDmaTile().isShimTile()) {
-          return f.S2MM_alloc[i];
+    } else {
+      for (auto &mm2s : f.MM2S_alloc) {
+        if (mm2s.getDmaTile() == alloc.getDmaTile() &&
+            mm2s.dma_channel.direction == alloc.dma_channel.direction &&
+            mm2s.dma_channel.channel == alloc.dma_channel.channel) {
+          for (unsigned i = 0; i < f.S2MM_alloc.size(); i++) {
+            if (f.S2MM_alloc[i].getDmaTile() &&
+                f.S2MM_alloc[i].getDmaTile().isShimTile()) {
+              return f.S2MM_alloc[i];
+            }
+          }
         }
       }
     }
@@ -1938,21 +1941,24 @@ air::MemTileDMAAllocator::foundFlowReuseOpportunity(
             f.S2MM_alloc[i].dma_channel.direction ==
                 alloc.dma_channel.direction &&
             f.S2MM_alloc[i].dma_channel.channel == alloc.dma_channel.channel) {
-          if (f.MM2S_alloc.getDmaTile() &&
-              f.MM2S_alloc.getDmaTile().isMemTile()) {
-            return f.MM2S_alloc;
+          for (auto &mm2s : f.MM2S_alloc) {
+            if (mm2s.getDmaTile() && mm2s.getDmaTile().isMemTile()) {
+              return mm2s;
+            }
           }
         }
       }
-    } else if (isMM2S && f.MM2S_alloc.getDmaTile() == alloc.getDmaTile() &&
-               f.MM2S_alloc.dma_channel.direction ==
-                   alloc.dma_channel.direction &&
-               f.MM2S_alloc.dma_channel.channel == alloc.dma_channel.channel) {
-
-      for (unsigned i = 0; i < f.S2MM_alloc.size(); i++) {
-        if (f.S2MM_alloc[i].getDmaTile() &&
-            f.S2MM_alloc[i].getDmaTile().isMemTile()) {
-          return f.S2MM_alloc[i];
+    } else {
+      for (auto &mm2s : f.MM2S_alloc) {
+        if (mm2s.getDmaTile() == alloc.getDmaTile() &&
+            mm2s.dma_channel.direction == alloc.dma_channel.direction &&
+            mm2s.dma_channel.channel == alloc.dma_channel.channel) {
+          for (unsigned i = 0; i < f.S2MM_alloc.size(); i++) {
+            if (f.S2MM_alloc[i].getDmaTile() &&
+                f.S2MM_alloc[i].getDmaTile().isMemTile()) {
+              return f.S2MM_alloc[i];
+            }
+          }
         }
       }
     }
@@ -2155,6 +2161,11 @@ air::MemcpyBundleAsFlow::pushBackMemcpyOpToBundle(air::ChannelPutOp memcpyOp) {
     return memcpyOp->emitOpError("unrecognized memory space on memref");
   MM2S_memspace = *putMS;
   memcpyResourceType = chan.getChannelType().str();
+  // numMM2SAllocs (number of DISTINCT producer tiles) is computed during DMA
+  // channel allocation, where each put's tile is resolved -- a single producer
+  // doing multiple puts (loop / ping-pong) stays ONE producer, while distinct
+  // producer tiles (packet fan-in convergence) become N. See
+  // simpleDMAChannelAllocation.
   return success();
 }
 
@@ -2179,6 +2190,7 @@ air::MemcpyBundleAsFlow::MemcpyBundleAsFlow(air::DmaMemcpyNdOp dmaMemcpyOp) {
                                            std::vector<Operation *>());
   S2MM = v1;
   S2MM_alloc = std::vector<air::allocation_info_t>(numS2MMAllocs);
+  MM2S_alloc = std::vector<air::allocation_info_t>(numMM2SAllocs);
   memcpyResourceType = "npu_dma_stream";
 }
 
@@ -2198,6 +2210,7 @@ air::MemcpyBundleAsFlow::MemcpyBundleAsFlow(air::ChannelOp chan) {
                                            std::vector<Operation *>());
   S2MM = v1;
   S2MM_alloc = std::vector<air::allocation_info_t>(numS2MMAllocs);
+  MM2S_alloc = std::vector<air::allocation_info_t>(numMM2SAllocs);
   memcpyResourceType = chan.getChannelType().str();
 }
 
@@ -2339,6 +2352,55 @@ void air::reorderL3PacketPutsByFlowOrder(
   }
 }
 
+// Resolve the memory space of a single S2MM receiver op (the destination of
+// the data movement). A broadcast/demux flow may fan out to receivers in
+// DIFFERENT memory spaces (e.g. one dest is an L1 compute tile, others are L2
+// memtile relays), so allocation must dispatch per-receiver rather than on the
+// flow's aggregate S2MM_memspace (which only records the last receiver seen).
+static std::optional<air::MemorySpace>
+getS2MMReceiverMemorySpace(Operation *o) {
+  if (auto get = dyn_cast_if_present<air::ChannelGetOp>(o))
+    return air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(get.getMemref().getType()));
+  if (auto dma = dyn_cast_if_present<air::DmaMemcpyNdOp>(o))
+    return air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(dma.getDstMemref().getType()));
+  return std::nullopt;
+}
+
+// Resolve the memory space of a single MM2S producer op (the source of the data
+// movement). A convergent flow may have producers in DIFFERENT memory spaces
+// (e.g. an L1 compute core + an L2 memtile both feeding one S2MM), so MM2S
+// allocation must dispatch per-producer rather than
+// on the flow's aggregate MM2S_memspace.
+static std::optional<air::MemorySpace>
+getMM2SProducerMemorySpace(Operation *o) {
+  if (auto put = dyn_cast_if_present<air::ChannelPutOp>(o))
+    return air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(put.getMemref().getType()));
+  if (auto dma = dyn_cast_if_present<air::DmaMemcpyNdOp>(o))
+    return air::getMemorySpace(
+        llvm::cast<BaseMemRefType>(dma.getSrcMemref().getType()));
+  return std::nullopt;
+}
+
+// The producer tile of an MM2S op, used as the packet grouping key: an L1
+// producer's parent aie.core tile, or an L2 producer's owning memtile.
+static Operation *getMM2SProducerTileKey(Operation *o) {
+  if (auto ms = getMM2SProducerMemorySpace(o)) {
+    if (*ms == air::MemorySpace::L1) {
+      if (auto core = o->getParentOfType<AIE::CoreOp>())
+        return core.getTileOp().getOperation();
+    } else if (*ms == air::MemorySpace::L2) {
+      auto memcpyOpIf = cast<air::MemcpyInterface>(o);
+      if (auto buf = getUnderlyingBufferOp(memcpyOpIf.getSrcMemref()))
+        return buf.getTile()
+            .getDefiningOp(); // TileOp or logical tile (pre-place)
+    }
+  }
+  return nullptr;
+}
+
 // AIR channel to AIE flow scheduling strategy 1: round robin
 // Problem: no awareness wrt channel put and get pattern, leading to deadlocks
 LogicalResult air::simpleDMAChannelAllocation(
@@ -2354,8 +2416,83 @@ LogicalResult air::simpleDMAChannelAllocation(
     // dedicated late pass (see lowerAIRMMIOChannelOps).
     if (f.memcpyResourceType == "npu_mmio")
       continue;
-    if (f.MM2S_memspace == air::MemorySpace::L1) {
+    {
+      // Allocate MM2S producers. Dispatch PER-PRODUCER by memory space so a
+      // convergent packet flow with mixed-memspace producers (e.g. an L1
+      // compute core + an L2 memtile both feeding one S2MM) gets each its right
+      // DMA resource: L1 -> tile
+      // DMA channel (requires an aie.core parent), L2 -> memtile DMA channel.
+      // PACKET channels group producers by DISTINCT tile (L1 or L2), so each
+      // producer tile gets one packet_flow / MM2S alloc index. A single
+      // producer doing multiple puts (loop / ping-pong) stays ONE alloc.
+      // Non-packet (circuit/cascade) keeps single-alloc behavior (idx==0). L3
+      // (shim) producers are handled in the dedicated shim passes below.
+      bool isPacket = f.memcpyResourceType == "npu_dma_packet";
+      SmallVector<Operation *> producerTiles;
       for (auto o : f.MM2S) {
+        auto pms = getMM2SProducerMemorySpace(o);
+        if (pms != air::MemorySpace::L1 && pms != air::MemorySpace::L2)
+          continue;
+        auto memcpyOpIf = cast<air::MemcpyInterface>(o);
+        AIE::TileOp coreTile; // valid for L1 producers
+        if (pms == air::MemorySpace::L1) {
+          auto core = memcpyOpIf->getParentOfType<AIE::CoreOp>();
+          if (!core)
+            return memcpyOpIf->emitOpError(
+                "memcpy op not outlined in an aie.core op.");
+          coreTile = core.getTileOp();
+        }
+        int idx = 0;
+        if (isPacket) {
+          Operation *tileKey = getMM2SProducerTileKey(o);
+          idx = -1;
+          for (int k = 0; k < (int)producerTiles.size(); k++)
+            if (producerTiles[k] == tileKey) {
+              idx = k;
+              break;
+            }
+          if (idx < 0) {
+            idx = (int)producerTiles.size();
+            producerTiles.push_back(tileKey);
+          }
+        }
+        if ((int)f.MM2S_alloc.size() <= idx)
+          f.MM2S_alloc.resize(idx + 1);
+
+        FailureOr<air::allocation_info_t> alloc_res;
+        if (pms == air::MemorySpace::L1) {
+          if (f.memcpyResourceType == "npu_dma_stream" ||
+              f.memcpyResourceType == "npu_dma_packet") {
+            alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
+                memcpyOpIf, coreTile, f.MM2S_alloc[idx].dma_channel.channel);
+          } else if (f.memcpyResourceType == "npu_cascade") {
+            alloc_res = core_cascade_alloc.coreCascadeAlloc(memcpyOpIf);
+          }
+        } else { // L2 (memtile) producer
+          if (f.memcpyResourceType != "npu_dma_stream" &&
+              f.memcpyResourceType != "npu_dma_packet")
+            return memcpyOpIf->emitOpError(
+                "only supports npu_dma_stream or npu_dma_packet "
+                "connections at L2 memory");
+          alloc_res = memtile_dma_alloc.simpleDmaChannelAlloc(memcpyOpIf);
+        }
+        if (failed(alloc_res))
+          return failure();
+        f.MM2S_alloc[idx] = alloc_res.value();
+        if (!f.MM2S_alloc[idx].valid())
+          return failure();
+      }
+      if (isPacket && !producerTiles.empty())
+        f.numMM2SAllocs = (int)producerTiles.size();
+    }
+    // Allocate tile DMA channels for L1 receivers. Dispatch per-receiver (not
+    // on f.S2MM_memspace) so a broadcast/demux flow with mixed-memspace dests
+    // gets each L1 dest a tile DMA channel here; its L2 dests are allocated a
+    // memtile channel in the second pass below.
+    for (size_t i = 0; i < f.S2MM.size(); i++) {
+      for (auto o : f.S2MM[i]) {
+        if (getS2MMReceiverMemorySpace(o) != air::MemorySpace::L1)
+          continue;
         auto memcpyOpIf = cast<air::MemcpyInterface>(o);
         auto core = memcpyOpIf->getParentOfType<AIE::CoreOp>();
         if (!core) {
@@ -2368,7 +2505,7 @@ LogicalResult air::simpleDMAChannelAllocation(
         if (f.memcpyResourceType == "npu_dma_stream" ||
             f.memcpyResourceType == "npu_dma_packet") {
           alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-              memcpyOpIf, tile, f.MM2S_alloc.dma_channel.channel);
+              memcpyOpIf, tile, f.S2MM_alloc[i].dma_channel.channel);
           if (failed(alloc_res))
             return failure();
         } else if (f.memcpyResourceType == "npu_cascade") {
@@ -2377,39 +2514,9 @@ LogicalResult air::simpleDMAChannelAllocation(
             return failure();
         }
 
-        f.MM2S_alloc = alloc_res.value();
-        if (!f.MM2S_alloc.valid())
+        f.S2MM_alloc[i] = alloc_res.value();
+        if (!f.S2MM_alloc[i].valid())
           return failure();
-      }
-    }
-    if (f.S2MM_memspace == air::MemorySpace::L1) {
-      for (size_t i = 0; i < f.S2MM.size(); i++) {
-        for (auto o : f.S2MM[i]) {
-          auto memcpyOpIf = cast<air::MemcpyInterface>(o);
-          auto core = memcpyOpIf->getParentOfType<AIE::CoreOp>();
-          if (!core) {
-            return memcpyOpIf->emitOpError(
-                "memcpy op not outlined in an aie.core op.");
-          }
-          auto tile = core.getTileOp();
-
-          FailureOr<air::allocation_info_t> alloc_res;
-          if (f.memcpyResourceType == "npu_dma_stream" ||
-              f.memcpyResourceType == "npu_dma_packet") {
-            alloc_res = tile_dma_alloc.simpleDmaChannelAlloc(
-                memcpyOpIf, tile, f.S2MM_alloc[i].dma_channel.channel);
-            if (failed(alloc_res))
-              return failure();
-          } else if (f.memcpyResourceType == "npu_cascade") {
-            alloc_res = core_cascade_alloc.coreCascadeAlloc(memcpyOpIf);
-            if (failed(alloc_res))
-              return failure();
-          }
-
-          f.S2MM_alloc[i] = alloc_res.value();
-          if (!f.S2MM_alloc[i].valid())
-            return failure();
-        }
       }
     }
   }
@@ -2417,8 +2524,16 @@ LogicalResult air::simpleDMAChannelAllocation(
     // MMIO channels are not allocated to any DMA resource at L2 either.
     if (f.memcpyResourceType == "npu_mmio")
       continue;
-    if (f.MM2S_memspace == air::MemorySpace::L2) {
-      for (auto o : f.MM2S) {
+    // (L2 (memtile) MM2S producers are allocated in the unified per-producer
+    // MM2S pass above, which dispatches L1 -> tile DMA and L2 -> memtile DMA
+    // and groups packet producers across both memory spaces.) Allocate memtile
+    // DMA channels for L2 receivers. Dispatch per-receiver so a broadcast/demux
+    // flow with mixed-memspace dests gets each L2 dest a memtile channel here
+    // (its L1 dests were allocated a tile channel above).
+    for (size_t i = 0; i < f.S2MM.size(); i++) {
+      for (auto o : f.S2MM[i]) {
+        if (getS2MMReceiverMemorySpace(o) != air::MemorySpace::L2)
+          continue;
         auto memcpyOpIf = cast<air::MemcpyInterface>(o);
         // Report error if the data movement lowers to neither dma stream
         // (aie.flow) nor dma packet flow (aie.packet_flow).
@@ -2430,25 +2545,7 @@ LogicalResult air::simpleDMAChannelAllocation(
         auto alloc_res = memtile_dma_alloc.simpleDmaChannelAlloc(memcpyOpIf);
         if (failed(alloc_res) || !alloc_res->valid())
           return failure();
-        f.MM2S_alloc = alloc_res.value();
-      }
-    }
-    if (f.S2MM_memspace == air::MemorySpace::L2) {
-      for (size_t i = 0; i < f.S2MM.size(); i++) {
-        for (auto o : f.S2MM[i]) {
-          auto memcpyOpIf = cast<air::MemcpyInterface>(o);
-          // Report error if the data movement lowers to neither dma stream
-          // (aie.flow) nor dma packet flow (aie.packet_flow).
-          if (f.memcpyResourceType != "npu_dma_stream" &&
-              f.memcpyResourceType != "npu_dma_packet")
-            return memcpyOpIf->emitOpError(
-                "only supports npu_dma_stream or npu_dma_packet "
-                "connections at L2 memory");
-          auto alloc_res = memtile_dma_alloc.simpleDmaChannelAlloc(memcpyOpIf);
-          if (failed(alloc_res) || !alloc_res->valid())
-            return failure();
-          f.S2MM_alloc[i] = alloc_res.value();
-        }
+        f.S2MM_alloc[i] = alloc_res.value();
       }
     }
   }
@@ -2484,6 +2581,7 @@ LogicalResult air::simpleDMAChannelAllocation(
     if (f.memcpyResourceType == "npu_mmio")
       return success();
     if (f.MM2S_memspace == air::MemorySpace::L3) {
+      // L3 (shim/host) producers stay single-producer (numMM2SAllocs==1).
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.MM2S) {
           auto memcpyOpIf = cast<air::MemcpyInterface>(o);
@@ -2501,7 +2599,7 @@ LogicalResult air::simpleDMAChannelAllocation(
               s2mmTile.tryGetRow().value_or(-1), f.S2MM[i]);
           if (failed(alloc_res) || !alloc_res->valid())
             return failure();
-          f.MM2S_alloc = alloc_res.value();
+          f.MM2S_alloc[0] = alloc_res.value();
         }
       }
     }
@@ -2518,10 +2616,12 @@ LogicalResult air::simpleDMAChannelAllocation(
           return memcpyOpIf->emitOpError(
               "only supports npu_dma_stream or npu_dma_packet "
               "connections at L3 memory");
-        if (!f.MM2S_alloc.getDmaTile())
+        if (f.MM2S_alloc.empty() || !f.MM2S_alloc[0].getDmaTile())
           return memcpyOpIf->emitOpError(
               "failed to get MM2S tile for L3 allocation.");
-        auto mm2sTile = f.MM2S_alloc.getDmaTile();
+        // L3 (shim) S2MM consumer is single-producer (fan-in to a shim dest is
+        // unsupported); use the sole producer alloc.
+        auto mm2sTile = f.MM2S_alloc[0].getDmaTile();
         auto alloc_res = shim_dma_alloc.allocNewDmaChannel(
             memcpyOpIf, mm2sTile, mm2sTile.tryGetCol().value_or(-1),
             mm2sTile.tryGetRow().value_or(-1), f.MM2S);
@@ -2573,8 +2673,12 @@ bool air::groupingMemcpysByLoop(
   std::map<AIE::CoreOp, std::vector<scf::ForOp>> for_loops_log_mm2s,
       for_loops_log_s2mm;
   for (auto &f : memcpy_flows) {
-    if (f.MM2S_memspace == air::MemorySpace::L1) {
+    {
+      // Group by loop only for L1 producers (dispatch per-producer, since a
+      // convergent flow may also have L2 memtile producers with no aie.core).
       for (auto o : f.MM2S) {
+        if (getMM2SProducerMemorySpace(o) != air::MemorySpace::L1)
+          continue;
         auto core = o->getParentOfType<AIE::CoreOp>();
         f.flow_op_group = foundInVector<scf::ForOp>(
             o->getParentOfType<scf::ForOp>(), for_loops_log_mm2s[core]);
@@ -2583,9 +2687,13 @@ bool air::groupingMemcpysByLoop(
         }
       }
     }
-    if (f.S2MM_memspace == air::MemorySpace::L1) {
+    {
+      // Group by loop only for L1 receivers (dispatch per-receiver, since a
+      // broadcast/demux flow may also have L2 dests with no aie.core parent).
       for (size_t i = 0; i < f.S2MM.size(); i++) {
         for (auto o : f.S2MM[i]) {
+          if (getS2MMReceiverMemorySpace(o) != air::MemorySpace::L1)
+            continue;
           auto core = o->getParentOfType<AIE::CoreOp>();
           f.flow_op_group = foundInVector<scf::ForOp>(
               o->getParentOfType<scf::ForOp>(), for_loops_log_s2mm[core]);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2352,6 +2352,21 @@ void air::reorderL3PacketPutsByFlowOrder(
   }
 }
 
+// Resolve the memory space of one endpoint (source when isSource, else
+// destination) of a memcpy op via the air::MemcpyInterface, which already
+// abstracts the src/dst memref across channel puts/gets and dma_memcpy_nd. This
+// keeps the per-endpoint dispatch working uniformly for any MemcpyInterface op.
+static std::optional<air::MemorySpace>
+getMemcpyEndpointMemorySpace(Operation *o, bool isSource) {
+  auto memcpyOpIf = dyn_cast_if_present<air::MemcpyInterface>(o);
+  if (!memcpyOpIf)
+    return std::nullopt;
+  Value ref = isSource ? memcpyOpIf.getSrcMemref() : memcpyOpIf.getDstMemref();
+  if (!ref)
+    return std::nullopt;
+  return air::getMemorySpace(llvm::cast<BaseMemRefType>(ref.getType()));
+}
+
 // Resolve the memory space of a single S2MM receiver op (the destination of
 // the data movement). A broadcast/demux flow may fan out to receivers in
 // DIFFERENT memory spaces (e.g. one dest is an L1 compute tile, others are L2
@@ -2359,13 +2374,7 @@ void air::reorderL3PacketPutsByFlowOrder(
 // flow's aggregate S2MM_memspace (which only records the last receiver seen).
 static std::optional<air::MemorySpace>
 getS2MMReceiverMemorySpace(Operation *o) {
-  if (auto get = dyn_cast_if_present<air::ChannelGetOp>(o))
-    return air::getMemorySpace(
-        llvm::cast<BaseMemRefType>(get.getMemref().getType()));
-  if (auto dma = dyn_cast_if_present<air::DmaMemcpyNdOp>(o))
-    return air::getMemorySpace(
-        llvm::cast<BaseMemRefType>(dma.getDstMemref().getType()));
-  return std::nullopt;
+  return getMemcpyEndpointMemorySpace(o, /*isSource=*/false);
 }
 
 // Resolve the memory space of a single MM2S producer op (the source of the data
@@ -2375,17 +2384,19 @@ getS2MMReceiverMemorySpace(Operation *o) {
 // on the flow's aggregate MM2S_memspace.
 static std::optional<air::MemorySpace>
 getMM2SProducerMemorySpace(Operation *o) {
-  if (auto put = dyn_cast_if_present<air::ChannelPutOp>(o))
-    return air::getMemorySpace(
-        llvm::cast<BaseMemRefType>(put.getMemref().getType()));
-  if (auto dma = dyn_cast_if_present<air::DmaMemcpyNdOp>(o))
-    return air::getMemorySpace(
-        llvm::cast<BaseMemRefType>(dma.getSrcMemref().getType()));
-  return std::nullopt;
+  return getMemcpyEndpointMemorySpace(o, /*isSource=*/true);
 }
 
-// The producer tile of an MM2S op, used as the packet grouping key: an L1
-// producer's parent aie.core tile, or an L2 producer's owning memtile.
+// The producer tile of an MM2S op, used as the grouping key that collapses
+// multiple puts from ONE producer tile (loop / ping-pong) onto a single MM2S
+// allocation while keeping DISTINCT producer tiles apart. Key identity:
+//   - L1 producer: the parent aie.core's tile op.
+//   - L2 producer: the owning tile of the source buffer -- a physical
+//     AIE::TileOp once placed, or the logical-tile op pre-placement.
+// The returned op is used only for pointer-identity comparison within one
+// flow's producer list, so a physical or logical tile op is equally valid as
+// long as one producer tile yields one stable key. Returns null when the tile
+// cannot be resolved (caller treats a null key as "ungroupable").
 static Operation *getMM2SProducerTileKey(Operation *o) {
   if (auto ms = getMM2SProducerMemorySpace(o)) {
     if (*ms == air::MemorySpace::L1) {
@@ -2394,8 +2405,7 @@ static Operation *getMM2SProducerTileKey(Operation *o) {
     } else if (*ms == air::MemorySpace::L2) {
       auto memcpyOpIf = cast<air::MemcpyInterface>(o);
       if (auto buf = getUnderlyingBufferOp(memcpyOpIf.getSrcMemref()))
-        return buf.getTile()
-            .getDefiningOp(); // TileOp or logical tile (pre-place)
+        return buf.getTile().getDefiningOp();
     }
   }
   return nullptr;
@@ -2443,6 +2453,11 @@ LogicalResult air::simpleDMAChannelAllocation(
           coreTile = core.getTileOp();
         }
         int idx = 0;
+        // Only PACKET flows group producers per distinct tile (each grouped
+        // producer gets its own packet_flow / MM2S alloc, all converging on the
+        // shared dest S2MM via a common pkt id). Non-packet (circuit / cascade)
+        // flows keep idx==0: their multiple MM2S ops are per-index / broadcast
+        // endpoints resolved elsewhere, not fan-in convergence onto one alloc.
         if (isPacket) {
           Operation *tileKey = getMM2SProducerTileKey(o);
           idx = -1;
@@ -2530,6 +2545,11 @@ LogicalResult air::simpleDMAChannelAllocation(
     // DMA channels for L2 receivers. Dispatch per-receiver so a broadcast/demux
     // flow with mixed-memspace dests gets each L2 dest a memtile channel here
     // (its L1 dests were allocated a tile channel above).
+    // Ordering invariant: moving L2 MM2S allocation into the first loop is safe
+    // because MM2S and S2MM draw from independent per-tile channel pools (a
+    // memtile has separate MM2S and S2MM DMA channel sets), so allocating all
+    // MM2S before all S2MM does not perturb S2MM channel assignments relative
+    // to the old interleaved order.
     for (size_t i = 0; i < f.S2MM.size(); i++) {
       for (auto o : f.S2MM[i]) {
         if (getS2MMReceiverMemorySpace(o) != air::MemorySpace::L2)

--- a/mlir/test/Conversion/AIRToAIE/packet_producers_mixed_memspace.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_producers_mixed_memspace.mlir
@@ -1,0 +1,89 @@
+//===- packet_producers_mixed_memspace.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Multi-producer packet convergence with MIXED-memory-space producers: one
+// packet channel @x is fed by BOTH an L2 memtile (a relay buffer streamed back
+// out MM2S) and an L1 compute core, converging on one destination memtile S2MM.
+// This exercises the per-producer DMA-resource dispatch: an L2-memtile producer
+// gets a memtile MM2S, an L1-core producer gets a tile MM2S, both landing on the
+// same destination S2MM with the same pkt id.
+//
+// Before the multi-producer change (scalar MM2S_alloc), this pattern did not
+// lower at all: the L2-memtile packet producer hit "memcpy op not outlined in
+// an aie.core op" because the single-producer model assumed a core source.
+
+// A memtile-sourced flow AND a core-sourced flow, SAME pkt id, converging on the
+// SAME destination memtile S2MM:
+// CHECK: aie.packet_flow([[PID:[0-9]+]]) {
+// CHECK-NEXT: aie.packet_source<%logical_mem, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[DST:.*]], DMA : [[DCH:[0-9]+]]>
+// CHECK: aie.packet_flow([[PID]]) {
+// CHECK-NEXT: aie.packet_source<%tile_{{[0-9]+_[0-9]+}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[DST]], DMA : [[DCH]]>
+
+air.channel @tomt [1, 1]
+air.channel @x [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @mixed_producers() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      // L2 memtile producer: relay a core-produced buffer onto @x (MM2S from L2).
+      %tm, %l2p = air.execute -> (memref<8xbf16, 1>) {
+        %a2 = memref.alloc() : memref<8xbf16, 1>
+        air.execute_terminator %a2 : memref<8xbf16, 1>
+      }
+      air.channel.get @tomt[] (%l2p[] [] []) : (memref<8xbf16, 1>)
+      air.channel.put @x[] (%l2p[] [] []) : (memref<8xbf16, 1>)
+      // Destination memtile buffer assembled from @x (2 producers: L2 + L1).
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split} : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      air.channel.get @x[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @x[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<2x8xbf16, 1> }
+      %dp = air.execute { memref.dealloc %l2p : memref<8xbf16, 1> }
+      // L1 core producer #1: feeds the L2 relay via @tomt.
+      air.herd @hp tile (%txp, %typ) in (%sxp=%c1_0, %syp=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @tomt[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %dpp = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      // L1 core producer #2: puts directly onto @x (the mixed 2nd producer).
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<16xbf16, 2>) {
+          %aa = memref.alloc() : memref<16xbf16, 2>
+          air.execute_terminator %aa : memref<16xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<16xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<16xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_same_tile_multi_put.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_same_tile_multi_put.mlir
@@ -1,0 +1,61 @@
+//===- packet_same_tile_multi_put.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Grouping-key dedup: ONE producer tile doing MULTIPLE puts to a packet channel
+// (the loop / ping-pong shape) is ONE producer, not many. The per-producer MM2S
+// grouping keys on the producer TILE (getMM2SProducerTileKey), so two puts from
+// the same aie.core collapse onto a SINGLE MM2S alloc and emit EXACTLY ONE
+// packet_flow -- distinct from packet_two_producers_one_channel.mlir where the
+// two puts come from two DIFFERENT tiles and correctly emit two flows.
+
+// EXACTLY one packet_flow despite two puts from the same tile:
+// CHECK-COUNT-1: aie.packet_flow({{[0-9]+}}) {
+// CHECK-NOT: aie.packet_flow(
+
+air.channel @x [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @same_tile_multi_put() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c8 = arith.constant 8 : index
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split} : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      air.channel.get @x[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @x[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<2x8xbf16, 1> }
+      // ONE producer herd doing TWO puts to @x (same tile).
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<16xbf16, 2>) {
+          %aa = memref.alloc() : memref<16xbf16, 2>
+          air.execute_terminator %aa : memref<16xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<16xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<16xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_single_producer_one_flow.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_single_producer_one_flow.mlir
@@ -1,0 +1,56 @@
+//===- packet_single_producer_one_flow.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Single-producer regression pin for the multi-producer change: a packet
+// channel @x with ONE producer must still lower to EXACTLY ONE packet_flow
+// (numMM2SAllocs == 1, "lowers identically"). Guards against the per-producer
+// vectorization accidentally emitting spurious extra flows for the common
+// 1-producer case.
+
+// EXACTLY one packet_flow (one producer -> one memtile S2MM):
+// CHECK-COUNT-1: aie.packet_flow({{[0-9]+}}) {
+// CHECK-NOT: aie.packet_flow(
+
+air.channel @x [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @single_producer_one_flow() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %t, %l2 = air.execute -> (memref<8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split} : memref<8xbf16, 1>
+        air.execute_terminator %alloc : memref<8xbf16, 1>
+      }
+      air.channel.get @x[] (%l2[] [] []) : (memref<8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<8xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<8xbf16, 1> }
+      // Single producer herd.
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_three_producers_one_channel.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_three_producers_one_channel.mlir
@@ -1,0 +1,93 @@
+//===- packet_three_producers_one_channel.mlir -----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// N=3 producer -> 1-consumer PACKET convergence. Extends
+// packet_two_producers_one_channel.mlir past N=2 to confirm the per-producer
+// grouping loop scales: THREE distinct producer tiles putting to ONE packet
+// channel @x emit THREE packet_flows carrying the SAME pkt id and converging on
+// the SAME destination memtile S2MM.
+
+// All three producer tiles and the destination exist:
+// CHECK-DAG: aie.tile(2, 3)
+// CHECK-DAG: aie.tile(3, 3)
+// CHECK-DAG: aie.tile(4, 3)
+// THREE packet_flows, one per producer, SAME pkt id, SAME destination channel:
+// CHECK: aie.packet_flow([[PID:[0-9]+]]) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[DST:.*]], DMA : [[DCH:[0-9]+]]>
+// CHECK: aie.packet_flow([[PID]]) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[DST]], DMA : [[DCH]]>
+// CHECK: aie.packet_flow([[PID]]) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[DST]], DMA : [[DCH]]>
+
+air.channel @x [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @three_producers_one_channel() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c8 = arith.constant 8 : index
+      // Shared L2 buffer fed by the three producers (one sub-region row each).
+      %t, %l2 = air.execute -> (memref<3x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split} : memref<3x8xbf16, 1>
+        air.execute_terminator %alloc : memref<3x8xbf16, 1>
+      }
+      // THREE gets from the SAME channel @x -> converge on one memtile S2MM.
+      air.channel.get @x[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<3x8xbf16, 1>)
+      air.channel.get @x[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<3x8xbf16, 1>)
+      air.channel.get @x[] (%l2[%c2,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<3x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<3x8xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<3x8xbf16, 1> }
+      // THREE producer herds on DISTINCT tiles, each putting to @x.
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h2 tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0)
+            attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d2 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      // Consumer herd reads the assembled buffer.
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<24xbf16, 2>) {
+          %aa = memref.alloc() : memref<24xbf16, 2>
+          air.execute_terminator %aa : memref<24xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<24xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<24xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_two_producers_one_channel.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_two_producers_one_channel.mlir
@@ -1,0 +1,93 @@
+//===- packet_two_producers_one_channel.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// N-producer -> 1-consumer PACKET convergence: a broadcast/assembly buffer
+// is fed by multiple producer cores writing
+// ONE memtile S2MM via packet flows, temporally). Distinct from
+// memtile_packet_two_sources_one_dst.mlir, which uses N DISTINCT channels (each
+// single-producer); here it is ONE channel @x with TWO puts from TWO distinct
+// producer tiles.
+//
+// The bug: `MemcpyBundleAsFlow` modelled a flow as 1-producer -> N-consumer
+// (scalar MM2S_alloc), so the two same-channel puts collapsed to one alloc and
+// air-to-aie emitted only ONE packet_flow -- the second producer's flow was
+// silently DROPPED, so the consumer slot it fed never filled (runtime deadlock).
+// Fix: MM2S_alloc is a vector (one per distinct producer tile), so a multi-put
+// packet channel emits one packet_flow per producer, all converging on the
+// shared destination S2MM with the SAME pkt id (foundPacketFlowAllocInTile
+// merges the dest).
+
+// Both producer tiles exist:
+// CHECK-DAG: aie.tile(2, 3)
+// CHECK-DAG: aie.tile(3, 3)
+// TWO packet_flows (one per producer), carrying the SAME pkt id and converging
+// on the SAME memtile destination DMA channel. Pre-fix only ONE was emitted
+// (the second producer's flow was dropped).
+// CHECK: aie.packet_flow([[PID:[0-9]+]]) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[MT:.*]], DMA : [[DCH:[0-9]+]]>
+// CHECK: aie.packet_flow([[PID]]) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : {{[0-9]+}}>
+// CHECK-NEXT: aie.packet_dest<%[[MT]], DMA : [[DCH]]>
+
+air.channel @x [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @r0 [1, 1]
+func.func @packet_two_producers_one_channel() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // Shared L2 buffer fed by the two producers (one sub-region row each).
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split} : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      // TWO gets from the SAME channel @x -> converge on one memtile S2MM.
+      air.channel.get @x[] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @x[] (%l2[%c1_1, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute {
+        memref.dealloc %l2 : memref<2x8xbf16, 1>
+      }
+      // TWO producer herds on DISTINCT tiles, each putting to @x.
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @x[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      // Consumer herd reads the assembled buffer.
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<16xbf16, 2>) {
+          %aa = memref.alloc() : memref<16xbf16, 2>
+          air.execute_terminator %aa : memref<16xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<16xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<16xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_two_producers_one_channel.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_two_producers_one_channel.mlir
@@ -8,8 +8,8 @@
 // RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
 
 // N-producer -> 1-consumer PACKET convergence: a broadcast/assembly buffer
-// is fed by multiple producer cores writing
-// ONE memtile S2MM via packet flows, temporally). Distinct from
+// is fed by multiple producer cores writing ONE memtile S2MM via packet flows.
+// Distinct from
 // memtile_packet_two_sources_one_dst.mlir, which uses N DISTINCT channels (each
 // single-producer); here it is ONE channel @x with TWO puts from TWO distinct
 // producer tiles.


### PR DESCRIPTION
## Summary
`MemcpyBundleAsFlow` modelled a flow as **one producer → N consumers**: `MM2S_alloc` was a single `allocation_info_t`. When one packet channel is fed by **multiple producer cores** (N puts on the same channel converging on one destination S2MM — e.g. an assembly/broadcast buffer written by several compute tiles), the extra producers collapsed onto the single `MM2S_alloc` and air-to-aie emitted only **one** `packet_flow` — the other producers' flows were silently dropped, so the destination slots they fed never filled (runtime deadlock).

## Change
Make MM2S symmetric to S2MM:
- `MM2S_alloc` → `std::vector<allocation_info_t>` (one entry per distinct producer tile), `MM2S` the matching vector of channel puts, `numMM2SAllocs` the producer count.
- MM2S DMA allocation dispatches **per producer** (mixed L1-core + L2-memtile producers each get their correct DMA resource); `foundFlowReuseOpportunity` iterates producers.
- The packet / stream / cascade flow-emission passes loop over `(producer j, dest i)`, emitting one flow each.
- Multi-producer packet convergence shares one destination pkt id (memoized by channel name), so all producers land on the destination S2MM with the same id; the source-tile S2MM discrimination (already upstream) keeps distinct producers on their own physical channels.
- Single-producer flows keep `numMM2SAllocs == 1` and lower identically.

## Test
- New `packet_two_producers_one_channel.mlir`: one packet channel with two puts from two producer tiles → **two `packet_flow`s (same pkt id) converging on one memtile S2MM**. Pre-fix only one flow was emitted (verified FAILS without the change).
- `ninja check-air-mlir`: no new failures (pre-existing env-only failures unchanged); all existing packet paths (`memtile_packet_two_sources_one_dst`, `packet_broadcast_mixed_memspace`, shim packet) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)