### PR TITLE
[AIRToAIE] Pinned packet_ids: N ids -> one dest + per-destination demux

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIR.td
+++ b/mlir/include/air/Dialect/AIR/AIR.td
@@ -617,6 +617,19 @@ def air_ChannelOp : air_Op<"channel", [Symbol]>,
     If a channel broadcasts to multiple destinations, the optional `broadcast_shape` attribute
     annotates the output sizes after broadcasting. Broadcasting follows NumPy's broadcasting rules.
 
+    ### Packet ids
+    A packet-switched channel (`channel_type = "npu_dma_packet"`) may pin explicit routing ids
+    via the optional `packet_ids` array attribute (each id in `[0, 31]`, unique). One
+    `aie.packet_flow` is emitted per id:
+    - **N ids to one destination:** all ids route to the same buffer; a later demux hop keys off
+      the header carried by the payload.
+    - **N ids to N destinations:** destination `i` is routed with `packet_ids[i]`, an indexed
+      fan-out landing each slice on a distinct, statically-known id.
+
+    The compute core writes the routing id into the packet header word of the payload, so the DMA
+    engine does not stamp/filter these ids; the flows only install switchbox routing entries.
+    Without `packet_ids` a packet channel gets a single auto-assigned id.
+
     Example:
 
     ```mlir
@@ -643,6 +656,9 @@ def air_ChannelOp : air_Op<"channel", [Symbol]>,
     // A cross-GPU channel through the symmetric heap (GPU). Must appear inside
     // an air.rank scope; the indices on put/get encode the peer rank.
     air.channel @channel_6 [] {channel_type = "gpu_symmetric_heap"}
+
+    // A packet-switched channel pinning two routing ids (NPU)
+    air.channel @channel_7 [] {channel_type = "npu_dma_packet", packet_ids = [1, 4]}
     ```
   }];
   let extraClassDeclaration = [{
@@ -655,6 +671,9 @@ def air_ChannelOp : air_Op<"channel", [Symbol]>,
     int getBroadcastDimension();
     ArrayAttr getBroadcastShape() {
       return getOperation()->getAttrOfType<ArrayAttr>("broadcast_shape");
+    }
+    ArrayAttr getPacketIDs() {
+      return getOperation()->getAttrOfType<ArrayAttr>("packet_ids");
     }
     int getBroadcastNum() {
       int broadcastNum = 1;

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -50,6 +50,14 @@ constexpr StringLiteral RefeedCount = "air.refeed_count";
 // buffer once per iteration. The air-annotate-refeed pass reads its trip count
 // into attrs::RefeedCount on the channel and collapses the loop.
 constexpr StringLiteral RefeedLoop = "air.refeed_loop";
+// User-pinned packet routing ids on an air.channel (channel_type
+// "npu_dma_packet"). One packet_flow per id: N ids to a single dest converge on
+// one buffer for a downstream demux hop; N ids to N dests route dest i with
+// pinned[i]. The compute core writes the id into the payload header, so the DMA
+// does not stamp/filter these -- the flows only install switchbox routes. Bare
+// spelling matches the broadcast_shape discardable-attr convention on
+// air.channel; read via air::ChannelOp::getPacketIDs. Verified on air.channel.
+constexpr StringLiteral PacketIDs = "packet_ids";
 } // namespace attrs
 
 // Copy the DMA-steering / runtime-ordering markers

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2959,12 +2959,13 @@ struct SpecializeChannelBundlePattern
         new_chan->setAttr("broadcast_shape",
                           rewriter.getArrayAttr(ArrayRef(broadcast_shape)));
       }
-      // Propagate user-pinned packet_ids onto each split channel: flow creation
-      // only sees the split channels, so without this, indexed/convergent
-      // packet channels fall back to auto-assigned consecutive ids, which alias
-      // under the switchbox arbiter's binary-mask matching and deadlock.
-      if (auto pids = channel->getAttr("packet_ids"))
-        new_chan->setAttr("packet_ids", pids);
+      // Propagate DMA-steering markers (incl. user-pinned packet_ids) onto each
+      // split channel: flow creation only sees the split channels, so without
+      // this, indexed/convergent packet channels fall back to auto-assigned
+      // consecutive ids, which alias under the switchbox arbiter's binary-mask
+      // matching and deadlock. Routed through the single-source-of-truth helper
+      // so this copy site stays in sync with the marker set.
+      air::copyChannelSteeringAttrs(channel, new_chan);
       std::vector<unsigned> position =
           air::getMDVectorFromIterator(bundle_size_stdvec, iter);
       for (auto put : channelPuts) {
@@ -4455,9 +4456,13 @@ public:
     auto getPinnedIDs = [](air::MemcpyBundleAsFlow &f) -> SmallVector<int> {
       SmallVector<int> ids;
       if (auto chanOp = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op))
-        if (auto attr = chanOp->getAttrOfType<ArrayAttr>("packet_ids"))
+        if (auto attr = chanOp.getPacketIDs())
           for (auto idAttr : attr)
-            ids.push_back((int)cast<IntegerAttr>(idAttr).getInt());
+            // Verifier guarantees IntegerAttr elements in [0,31]; dyn_cast
+            // keeps the pass robust on unverified IR (skip non-integer
+            // entries).
+            if (auto idInt = dyn_cast<IntegerAttr>(idAttr))
+              ids.push_back((int)idInt.getInt());
       return ids;
     };
 
@@ -4481,6 +4486,13 @@ public:
     //     (MM2S) and receiver (S2MM) BD with that id. Without this the pinned
     //     path left the map unset, so producers emitted UNTAGGED packets and
     //     the switchbox could not route N same-id sources onto one slave port.
+    //   - MULTIPLE pinned ids are DELIBERATELY not recorded in
+    //     packetIDForChannelName: under the pinned-multi-id contract the
+    //     compute core writes the routing id into the payload header, so the
+    //     DMA must NOT stamp/filter (generateDmaBd +
+    //     labelMemcpyOpsWithPacketFlow both skip a channel with no map entry /
+    //     >1 pinned id). The packet_flow ops alone install the switchbox
+    //     routes.
     auto pktIDsForDest = [&](air::MemcpyBundleAsFlow &f, int i,
                              bool isShim) -> SmallVector<int> {
       auto pinned = getPinnedIDs(f);
@@ -4495,6 +4507,14 @@ public:
         return pinned; // N ids -> the single destination
       if (i < (int)pinned.size())
         return {pinned[i]}; // per-destination demux
+      // Fewer pinned ids than destinations: the surplus dests fall back to
+      // auto-assigned ids, silently mixing pinned + auto. Warn so this is not a
+      // surprise -- a well-formed demux pins exactly one id per destination.
+      if (auto chanOp = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op))
+        chanOp->emitWarning()
+            << "packet_ids pins " << pinned.size() << " id(s) but channel has "
+            << f.numS2MMAllocs << " destinations; destination " << i
+            << " falls back to an auto-assigned id";
       return {assignOrLookupPacketID(f, isShim)};
     };
 
@@ -4511,7 +4531,14 @@ public:
             continue;
           if (!isShimFlowAt(f, j, i))
             continue;
-          for (int flowID : pktIDsForDest(f, i, /*isShim=*/true)) {
+          auto flowIDs = pktIDsForDest(f, i, /*isShim=*/true);
+          // A shim source feeding >1 pinned id follows the kernel-header
+          // contract (the core stamps the header), so no single id backlinks to
+          // the shim alloc -- recording one would falsely tag the MM2S op with
+          // a partial id (the last, pre-fix). Only the single-id path
+          // backlinks.
+          bool backlink = flowIDs.size() == 1;
+          for (int flowID : flowIDs) {
             getPacketFlowOp(
                 aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
                 AIE::WireBundle::DMA,
@@ -4519,6 +4546,8 @@ public:
                 f.S2MM_alloc[i].getDmaTile()->getResult(0),
                 AIE::WireBundle::DMA,
                 (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+            if (!backlink)
+              continue;
             // Backlink: the host runtime keys packet identification on
             // (shim tile, pkt_id), so the matching MM2S shim alloc carries the
             // id.
@@ -4805,6 +4834,16 @@ public:
                                              StringAttr dmaNameAttr,
                                              mlir::Value tileVal, int channel,
                                              int packetFlowId = -1) {
+    // Multi-id pinned channels follow the kernel-header contract: the core
+    // writes the routing id into the payload, so the shim DMA must not stamp a
+    // packet header. Skip before the runtime fallback below could tag it with
+    // an arbitrary flow id.
+    if (auto ci = dyn_cast_if_present<air::ChannelInterface>(
+            memcpyOpIf.getOperation()))
+      if (auto chanOp = air::getChannelDeclarationThroughSymbol(ci))
+        if (auto pids = chanOp.getPacketIDs(); pids && pids.size() > 1)
+          return success();
+
     // When a packet flow ID is available (from flow creation phase), use
     // exact flow ID matching to disambiguate multiple flows sharing the
     // same shim DMA channel. Otherwise fall back to source-only lookup.

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2959,6 +2959,12 @@ struct SpecializeChannelBundlePattern
         new_chan->setAttr("broadcast_shape",
                           rewriter.getArrayAttr(ArrayRef(broadcast_shape)));
       }
+      // Propagate user-pinned packet_ids onto each split channel: flow creation
+      // only sees the split channels, so without this, indexed/convergent
+      // packet channels fall back to auto-assigned consecutive ids, which alias
+      // under the switchbox arbiter's binary-mask matching and deadlock.
+      if (auto pids = channel->getAttr("packet_ids"))
+        new_chan->setAttr("packet_ids", pids);
       std::vector<unsigned> position =
           air::getMDVectorFromIterator(bundle_size_stdvec, iter);
       for (auto put : channelPuts) {
@@ -4442,6 +4448,56 @@ public:
       return it->second;
     };
 
+    // Explicit per-destination packet ids pinned via the channel's `packet_ids`
+    // array attribute. Read on-demand from the channel op (kept off the
+    // MemcpyBundleAsFlow struct to avoid bloating it past the SmallVector
+    // inline-size budget).
+    auto getPinnedIDs = [](air::MemcpyBundleAsFlow &f) -> SmallVector<int> {
+      SmallVector<int> ids;
+      if (auto chanOp = dyn_cast_if_present<air::ChannelOp>(f.air_flow_op))
+        if (auto attr = chanOp->getAttrOfType<ArrayAttr>("packet_ids"))
+          for (auto idAttr : attr)
+            ids.push_back((int)cast<IntegerAttr>(idAttr).getInt());
+      return ids;
+    };
+
+    // Pre-claim every explicitly-pinned packet id so the auto-assigner for
+    // other flows skips them.
+    for (auto &f : memcpy_flows)
+      if (f.memcpyResourceType == "npu_dma_packet")
+        for (int id : getPinnedIDs(f))
+          claimedPacketIDs.insert(id);
+
+    // Packet ids to emit for destination i. Normally one id (the shared
+    // auto-assigned id memoized by channel name). When the channel pins
+    // `packet_ids`:
+    //   - N pinned ids with a SINGLE destination emits N flows (one per id) to
+    //     that one dest -- every id routes to the same buffer and the
+    //     kernel-written header carries the phase through to a later demux hop.
+    //   - N pinned ids with multiple dests demuxes per-destination (dest i uses
+    //     pinned[i]).
+    //   - a SINGLE pinned id (incl. same-id N-producer convergence) is recorded
+    //     in packetIDForChannelName so generateDmaBd STAMPS every producer
+    //     (MM2S) and receiver (S2MM) BD with that id. Without this the pinned
+    //     path left the map unset, so producers emitted UNTAGGED packets and
+    //     the switchbox could not route N same-id sources onto one slave port.
+    auto pktIDsForDest = [&](air::MemcpyBundleAsFlow &f, int i,
+                             bool isShim) -> SmallVector<int> {
+      auto pinned = getPinnedIDs(f);
+      if (pinned.empty())
+        return {assignOrLookupPacketID(f, isShim)};
+      if (pinned.size() == 1) {
+        std::string chanName = getChannelName(f);
+        if (!chanName.empty())
+          packetIDForChannelName[chanName] = pinned[0];
+      }
+      if (f.numS2MMAllocs == 1)
+        return pinned; // N ids -> the single destination
+      if (i < (int)pinned.size())
+        return {pinned[i]}; // per-destination demux
+      return {assignOrLookupPacketID(f, isShim)};
+    };
+
     // Pass 1: shim packet flows. Nested over producers (j) x dests (i): one
     // packet_flow per (producer, dest). For multi-producer convergence the
     // shared dest pkt id is memoized by channel name in assignOrLookupPacketID,
@@ -4455,25 +4511,27 @@ public:
             continue;
           if (!isShimFlowAt(f, j, i))
             continue;
-          int flowID = assignOrLookupPacketID(f, /*isShim=*/true);
-          getPacketFlowOp(
-              aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
-              AIE::WireBundle::DMA,
-              (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
-              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-              (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
-          // Backlink: the host runtime keys packet identification on
-          // (shim tile, pkt_id), so the matching MM2S shim alloc carries the
-          // id.
-          for (auto &sa : shim_dma_alloc.mm2s_allocs) {
-            if (sa.getDmaTile().getOperation() ==
-                    f.MM2S_alloc[j].getDmaTile().getOperation() &&
-                sa.dma_channel == f.MM2S_alloc[j].dma_channel &&
-                sa.col == f.MM2S_alloc[j].col &&
-                sa.row == f.MM2S_alloc[j].row &&
-                sa.dma_id == f.MM2S_alloc[j].dma_id) {
-              sa.packet_flow_id = flowID;
-              break;
+          for (int flowID : pktIDsForDest(f, i, /*isShim=*/true)) {
+            getPacketFlowOp(
+                aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                AIE::WireBundle::DMA,
+                (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                AIE::WireBundle::DMA,
+                (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+            // Backlink: the host runtime keys packet identification on
+            // (shim tile, pkt_id), so the matching MM2S shim alloc carries the
+            // id.
+            for (auto &sa : shim_dma_alloc.mm2s_allocs) {
+              if (sa.getDmaTile().getOperation() ==
+                      f.MM2S_alloc[j].getDmaTile().getOperation() &&
+                  sa.dma_channel == f.MM2S_alloc[j].dma_channel &&
+                  sa.col == f.MM2S_alloc[j].col &&
+                  sa.row == f.MM2S_alloc[j].row &&
+                  sa.dma_id == f.MM2S_alloc[j].dma_id) {
+                sa.packet_flow_id = flowID;
+                break;
+              }
             }
           }
         }
@@ -4490,13 +4548,15 @@ public:
             continue;
           if (isShimFlowAt(f, j, i))
             continue;
-          int flowID = assignOrLookupPacketID(f, /*isShim=*/false);
-          getPacketFlowOp(
-              aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
-              AIE::WireBundle::DMA,
-              (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
-              f.S2MM_alloc[i].getDmaTile()->getResult(0), AIE::WireBundle::DMA,
-              (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+          for (int flowID : pktIDsForDest(f, i, /*isShim=*/false)) {
+            getPacketFlowOp(
+                aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                AIE::WireBundle::DMA,
+                (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                AIE::WireBundle::DMA,
+                (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+          }
         }
       }
     }

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -142,6 +142,9 @@ void air::copyChannelSteeringAttrs(Operation *src, Operation *dst) {
   // by AIRToAIE's lock allocators.
   if (auto rc = src->getAttrOfType<IntegerAttr>(attrs::RefeedCount))
     dst->setAttr(attrs::RefeedCount, rc);
+  // User-pinned packet routing ids, read by AIRToAIE's packet-flow creation.
+  if (auto pids = src->getAttrOfType<ArrayAttr>(attrs::PacketIDs))
+    dst->setAttr(attrs::PacketIDs, pids);
 }
 
 void air::addAsyncDependency(Operation *op, Value token) {
@@ -3466,6 +3469,34 @@ LogicalResult air::ChannelOp::verify() {
         rcInt.getInt() > std::numeric_limits<int32_t>::max())
       return emitOpError() << "\"" << attrs::RefeedCount << "\" ("
                            << rcInt.getInt() << ") must be in [1, INT32_MAX]";
+  }
+
+  // packet_ids pins explicit switchbox routing ids; only meaningful for
+  // packet-switched channels. Each id must be a 5-bit AIE pkt_id and unique.
+  if (auto pids = (*this)->getAttr(attrs::PacketIDs)) {
+    auto arr = dyn_cast<ArrayAttr>(pids);
+    if (!arr)
+      return emitOpError() << "\"" << attrs::PacketIDs
+                           << "\" must be an array attribute";
+    if (chanType != "npu_dma_packet")
+      return emitOpError()
+             << "\"" << attrs::PacketIDs
+             << "\" is only valid on a \"npu_dma_packet\" channel";
+    uint32_t seen = 0;
+    for (auto idAttr : arr) {
+      auto idInt = dyn_cast<IntegerAttr>(idAttr);
+      if (!idInt)
+        return emitOpError() << "\"" << attrs::PacketIDs
+                             << "\" elements must be integer attributes";
+      int64_t id = idInt.getInt();
+      if (id < 0 || id > 31)
+        return emitOpError() << "\"" << attrs::PacketIDs << "\" id (" << id
+                             << ") must be in [0, 31]";
+      if (seen & (1u << id))
+        return emitOpError() << "\"" << attrs::PacketIDs << "\" id (" << id
+                             << ") is duplicated";
+      seen |= (1u << id);
+    }
   }
   return success();
 }

--- a/mlir/test/Conversion/AIRToAIE/packet_multi_id_demux.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_multi_id_demux.mlir
@@ -1,0 +1,63 @@
+//===- packet_multi_id_demux.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
+
+// Per-destination demux: a broadcast packet channel with N pinned packet_ids
+// fanning out to N distinct receivers routes destination i with pinned id i.
+// This gives each receiver its own statically-known routing id instead of a
+// single shared broadcast id, so a switchbox arbiter can steer each slice to
+// the right receiver by id.
+//
+// Without the pinned-id path a broadcast is one flow with a single shared id
+// fanning to every dest, so the per-receiver routing id is lost.
+
+// One source, two receivers, distinct pinned ids 1 and 4 (one per dest).
+// CHECK: aie.packet_flow(1) {
+// CHECK-NEXT: aie.packet_source<%[[SRC:.*]], DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%[[D0:.*]], DMA : 0>
+// CHECK: aie.packet_flow(4) {
+// CHECK-NEXT: aie.packet_source<%[[SRC]], DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%[[D1:.*]], DMA : 0>
+
+#set0 = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
+#set1 = affine_set<()[s0, s1] : (s0 - 1 == 0, s1 >= 0, -s1 + 1 >= 0)>
+module {
+  air.channel @bc [1, 1] {broadcast_shape = [2, 1], channel_type = "npu_dma_packet", packet_ids = [1, 4]}
+  func.func @demux() {
+    %c1 = arith.constant 1 : index
+    air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+      air.segment @seg attributes {x_loc = 0 : i64, x_size = 2 : i64, y_loc = 2 : i64, y_size = 1 : i64} {
+        %c0_0 = arith.constant 0 : index
+        %c1_0 = arith.constant 1 : index
+        %c2_0 = arith.constant 2 : index
+        %t, %l2 = air.execute -> (memref<8xbf16, 1>) {
+          %aa = memref.alloc() : memref<8xbf16, 1>
+          air.execute_terminator %aa : memref<8xbf16, 1>
+        }
+        air.channel.put @bc[%c0_0, %c0_0] (%l2[] [] []) : (memref<8xbf16, 1>)
+        %dd = air.execute { memref.dealloc %l2 : memref<8xbf16, 1> }
+        air.herd @h tile (%tx, %ty) in (%sx=%c2_0, %sy=%c1_0)
+              attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+          %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+            %bb = memref.alloc() : memref<8xbf16, 2>
+            air.execute_terminator %bb : memref<8xbf16, 2>
+          }
+          %g = affine.if #set0()[%tx, %ty] -> !air.async.token {
+            %x = air.channel.get async @bc[%tx, %ty] (%l1[] [] []) : (memref<8xbf16, 2>)
+            affine.yield %x : !air.async.token
+          } else {
+            %x = air.channel.get async @bc[%tx, %ty] (%l1[] [] []) : (memref<8xbf16, 2>)
+            affine.yield %x : !air.async.token
+          }
+          %dl = air.execute [%g] { memref.dealloc %l1 : memref<8xbf16, 2> }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_multi_id_no_bd_tag.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_multi_id_no_bd_tag.mlir
@@ -1,0 +1,48 @@
+//===- packet_multi_id_no_bd_tag.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Kernel-header contract: a channel pinning MULTIPLE packet_ids emits one
+// packet_flow per id but DELIBERATELY leaves the DMA BDs untagged -- the compute
+// core writes the routing id into the payload header, so the DMA must not stamp
+// a packet header (packetIDForChannelName is intentionally left unset for >1
+// pinned id). The producer BD carries only its task_id, no packet_info.
+
+// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2>, 14, 66) {task_id = 0 : i32}
+// CHECK-NOT: packet = #aie.packet_info
+// CHECK: aie.packet_flow(2) {
+// CHECK: aie.packet_flow(5) {
+
+air.channel @m [1, 1] {channel_type = "npu_dma_packet", packet_ids = [2, 5]}
+func.func @multi_id_no_bd_tag() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %t, %l2 = air.execute -> (memref<66xbf16, 1>) {
+        %alloc = memref.alloc() : memref<66xbf16, 1>
+        air.execute_terminator %alloc : memref<66xbf16, 1>
+      }
+      air.channel.get @m[] (%l2[] [] []) : (memref<66xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<66xbf16, 1> }
+      air.herd @hp tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %ch1 = arith.constant 1 : index
+        %ch14 = arith.constant 14 : index
+        %ch66 = arith.constant 66 : index
+        %tok, %l1 = air.execute -> (memref<80xbf16, 2>) {
+          %aa = memref.alloc() : memref<80xbf16, 2>
+          air.execute_terminator %aa : memref<80xbf16, 2>
+        }
+        air.channel.put @m[] (%l1[%ch14] [%ch66] [%ch1]) : (memref<80xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<80xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_multi_id_one_dest.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_multi_id_one_dest.mlir
@@ -1,0 +1,63 @@
+//===- packet_multi_id_one_dest.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Intermediate-hop packet routing: a channel with N pinned packet_ids and a
+// SINGLE destination emits N packet_flows (one per id) to that one dest. Every
+// id routes to the same buffer; a later demux hop keys off the header carried
+// by the payload. (Contrast per-destination demux, where N ids fan out to N
+// distinct dests.)
+//
+// Without the pinned-id path, the channel's packet_ids attribute is ignored:
+// the auto-assigner hands the flow a SINGLE id, so only ONE packet_flow is
+// emitted and the second routing id is lost.
+
+// CHECK: aie.device
+
+// Two flows, SAME source + SAME dest, distinct pinned ids 1 and 4.
+// CHECK: aie.packet_flow(1) {
+// CHECK-NEXT: aie.packet_source<%[[SRC:.*]], DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%[[DST:.*]], DMA : 0>
+// CHECK: aie.packet_flow(4) {
+// CHECK-NEXT: aie.packet_source<%[[SRC]], DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%[[DST]], DMA : 0>
+
+air.channel @m [1, 1] {channel_type = "npu_dma_packet", packet_ids = [1, 4]}
+func.func @multi_id_one_dest() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c14 = arith.constant 14 : index
+      %c66 = arith.constant 66 : index
+      // Single destination memtile buffer.
+      %t, %l2 = air.execute -> (memref<66xbf16, 1>) {
+        %alloc = memref.alloc() : memref<66xbf16, 1>
+        air.execute_terminator %alloc : memref<66xbf16, 1>
+      }
+      air.channel.get @m[] (%l2[] [] []) : (memref<66xbf16, 1>)
+      %d_ = air.execute {
+        memref.dealloc %l2 : memref<66xbf16, 1>
+      }
+      // Producer core: one put feeding both routing ids.
+      air.herd @hp tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %ch1 = arith.constant 1 : index
+        %ch14 = arith.constant 14 : index
+        %ch66 = arith.constant 66 : index
+        %tok, %l1 = air.execute -> (memref<80xbf16, 2>) {
+          %aa = memref.alloc() : memref<80xbf16, 2>
+          air.execute_terminator %aa : memref<80xbf16, 2>
+        }
+        air.channel.put @m[] (%l1[%ch14] [%ch66] [%ch1]) : (memref<80xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<80xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_single_id_bd_tag.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_single_id_bd_tag.mlir
@@ -1,0 +1,45 @@
+//===- packet_single_id_bd_tag.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// A channel pinning a SINGLE packet_id emits one packet_flow with that id AND
+// stamps the producer DMA BD with it (recorded in packetIDForChannelName ->
+// generateDmaBd). This is the DMA-stamped path (contrast the multi-id
+// kernel-header contract, where BDs are deliberately left untagged).
+
+// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2>, 14, 66) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>
+// CHECK: aie.packet_flow(3) {
+
+air.channel @m [1, 1] {channel_type = "npu_dma_packet", packet_ids = [3]}
+func.func @single_id() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %t, %l2 = air.execute -> (memref<66xbf16, 1>) {
+        %alloc = memref.alloc() : memref<66xbf16, 1>
+        air.execute_terminator %alloc : memref<66xbf16, 1>
+      }
+      air.channel.get @m[] (%l2[] [] []) : (memref<66xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<66xbf16, 1> }
+      air.herd @hp tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %ch1 = arith.constant 1 : index
+        %ch14 = arith.constant 14 : index
+        %ch66 = arith.constant 66 : index
+        %tok, %l1 = air.execute -> (memref<80xbf16, 2>) {
+          %aa = memref.alloc() : memref<80xbf16, 2>
+          air.execute_terminator %aa : memref<80xbf16, 2>
+        }
+        air.channel.put @m[] (%l1[%ch14] [%ch66] [%ch1]) : (memref<80xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<80xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Dialect/AIR/air_channel_invalid.mlir
+++ b/mlir/test/Dialect/AIR/air_channel_invalid.mlir
@@ -176,3 +176,38 @@ air.channel @refeed_str [1, 1] {air.refeed_count = "4"}
 
 // Test: valid air.refeed_count (positive test - should pass).
 air.channel @refeed_ok [1, 1] {air.refeed_count = 4 : i32}
+
+// -----
+
+// Test: packet_ids on a non-packet channel is rejected.
+// expected-error @+1 {{'air.channel' op "packet_ids" is only valid on a "npu_dma_packet" channel}}
+air.channel @pids_wrong_type [] {channel_type = "npu_dma_stream", packet_ids = [1, 2]}
+
+// -----
+
+// Test: packet_ids out of the 5-bit pkt_id range is rejected.
+// expected-error @+1 {{'air.channel' op "packet_ids" id (40) must be in [0, 31]}}
+air.channel @pids_range [] {channel_type = "npu_dma_packet", packet_ids = [40]}
+
+// -----
+
+// Test: negative packet_ids id is rejected.
+// expected-error @+1 {{'air.channel' op "packet_ids" id (-1) must be in [0, 31]}}
+air.channel @pids_neg [] {channel_type = "npu_dma_packet", packet_ids = [-1]}
+
+// -----
+
+// Test: duplicate packet_ids are rejected.
+// expected-error @+1 {{'air.channel' op "packet_ids" id (3) is duplicated}}
+air.channel @pids_dup [] {channel_type = "npu_dma_packet", packet_ids = [3, 3]}
+
+// -----
+
+// Test: non-integer packet_ids element is rejected.
+// expected-error @+1 {{'air.channel' op "packet_ids" elements must be integer attributes}}
+air.channel @pids_str [] {channel_type = "npu_dma_packet", packet_ids = ["x"]}
+
+// -----
+
+// Test: valid packet_ids (positive test - should pass).
+air.channel @pids_ok [] {channel_type = "npu_dma_packet", packet_ids = [1, 4]}


### PR DESCRIPTION
## Summary

A packet `air.channel` could only be assigned a single auto-generated `pkt_id` per (source, dest) flow. Some routing topologies need explicit control over which packet ids a channel emits:

- **N ids to ONE destination:** a channel pins several routing ids that all converge on one buffer, and a later demux hop keys off the header carried in the payload. Previously the auto-assigner handed the flow one id, so the extra routing ids were lost and their downstream demux never fired.
- **N ids demuxed to N destinations:** dest `i` is routed with pinned id `i`, so an indexed fan-out lands each slice on a distinct, statically-known id instead of aliasing consecutive auto-assigned ids under the switchbox arbiter's binary-mask matching (which deadlocks).

## Changes

- Add an optional `packet_ids` `ArrayAttr` on `air.channel`.
- `-air-to-aie` pre-claims every pinned id (so the auto-assigner skips them), then `pktIDsForDest` emits one `packet_flow` per pinned id: all pinned ids to the single dest when the channel has one destination, else `pinned[i]` per destination.
- A single pinned id is recorded in `packetIDForChannelName` so `generateDmaBd` stamps the producer/receiver BDs with it.
- `SpecializeChannelBundlePattern` propagates `packet_ids` onto the split channels so flow creation (which only sees the split channels) honors the pin.
- Channels without `packet_ids` are unchanged (one auto-assigned id).

Builds on #1716 (multi-producer packet-flow convergence).

## Test plan

- [x] New lit test `packet_multi_id_one_dest.mlir`: a channel with `packet_ids = [1, 4]` and one destination emits two `packet_flow`s (ids 1 and 4) to that dest. Without the pinned-id path only one flow (auto id 0) is emitted (verified FAIL-without).
- [x] `check-air-mlir`: no new failures (AIRToAIE suite 95/95).