### PR TITLE
[AIRToAIE] Honor air.shim_col to pin a flow's shim column

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1591,9 +1591,17 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   }
 
   // Find a bucket LTO with a free channel in this direction; else open
-  // a new unhinted shim LTO.
+  // a new unhinted shim LTO. When shim-col-pinned, only reuse an LTO already
+  // on the pinned column -- otherwise a col-less (or off-column) bucket LTO
+  // would capture this flow on the non-packet/dedicated paths and silently
+  // drop the pin.
   AIE::LogicalTileOp tileLT = nullptr;
   walkBucketLTOs([&](AIE::LogicalTileOp lt) {
+    if (shimColPin >= 0) {
+      auto ltCol = lt.tryGetCol();
+      if (!ltCol || (int)*ltCol != shimColPin)
+        return false;
+    }
     if ((int)channelsUsedOn(lt).size() < shim_dma_channels) {
       tileLT = lt;
       return true;

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1447,15 +1447,28 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
 
   std::vector<int> dma_ops_get_id = collectDmaIds(dma_ops);
 
-  // L3-direct broadcasts (channel decl carries `broadcast_shape`) bucket
-  // by their first-dest's incidental col/Op, which gives each broadcast
-  // its own shim LTO and overflows the ShimNOC col count. Spread them
-  // across existing shim LTOs instead (see fallback below).
+  // Single channel-decl lookup for the two attrs that steer shim bucketing:
+  //   `broadcast_shape`: L3-direct broadcasts bucket by their first-dest's
+  //     incidental col/Op, giving each broadcast its own shim LTO and
+  //     overflowing the ShimNOC col count; spread them across existing shim
+  //     LTOs instead (see fallback below).
+  //   `air.shim_col`: pin this flow's shim LogicalTileOp to a physical column
+  //     (applied to bucketCol below, after it is derived).
   bool isBroadcastL3Put = false;
+  int shimColPin = -1;
   if (auto chanIf =
           dyn_cast_if_present<air::ChannelInterface>(memcpyOp.getOperation())) {
-    if (auto chanDecl = getChannelDeclarationThroughSymbol(chanIf))
+    if (auto chanDecl = getChannelDeclarationThroughSymbol(chanIf)) {
       isBroadcastL3Put = chanDecl->hasAttr("broadcast_shape");
+      if (auto a = chanDecl->getAttrOfType<mlir::IntegerAttr>("air.shim_col")) {
+        int pin = (int)a.getInt();
+        int numCols = device.getTargetModel().columns();
+        if (pin < 0 || pin >= numCols)
+          return memcpyOp.emitOpError("air.shim_col column ")
+                 << pin << " is out of range [0, " << numCols << ")";
+        shimColPin = pin;
+      }
+    }
   }
 
   // Bucket key: the far-side col when known, else derive it from a memtile
@@ -1477,22 +1490,13 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
     return -1;
   };
   int bucketCol = bucketColFor(col, otherSideOp);
-  // Shim-column pin: a channel decl carrying an `air.shim_col` IntegerAttr
-  // forces this flow into its own bucket AND pins the opened shim LogicalTileOp
-  // to that physical column (the placer honors LogicalTileOp's col attr via
-  // tryGetCol). Used to route flows that must land on DISTINCT free shim
-  // columns (e.g. two append streams onto separate shim cols). Without the
-  // column pin, a separate bucket alone yields a col-less LTO whose centroid
-  // falls on the (saturated) producer column.
-  int shimColPin = -1;
-  if (auto chanIf =
-          dyn_cast_if_present<air::ChannelInterface>(memcpyOp.getOperation())) {
-    if (auto chanDecl = getChannelDeclarationThroughSymbol(chanIf))
-      if (auto a = chanDecl->getAttrOfType<mlir::IntegerAttr>("air.shim_col")) {
-        shimColPin = (int)a.getInt();
-        bucketCol = shimColPin;
-      }
-  }
+  // A shim-col pin forces the flow into its own bucket keyed on the pinned
+  // column and pins the opened shim LogicalTileOp there (the placer honors the
+  // col attr via tryGetCol). Same-pin flows share that bucket/column; without
+  // the pin a separate bucket alone yields a col-less LTO whose centroid falls
+  // on the (saturated) producer column.
+  if (shimColPin >= 0)
+    bucketCol = shimColPin;
   auto sameBucket = [&](const allocation_info_t &t) {
     int tCol = bucketColFor(t.col, t.otherSideLTO);
     if (bucketCol >= 0 && tCol >= 0)

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1477,6 +1477,22 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
     return -1;
   };
   int bucketCol = bucketColFor(col, otherSideOp);
+  // Shim-column pin: a channel decl carrying an `air.shim_col` IntegerAttr
+  // forces this flow into its own bucket AND pins the opened shim LogicalTileOp
+  // to that physical column (the placer honors LogicalTileOp's col attr via
+  // tryGetCol). Used to route flows that must land on DISTINCT free shim
+  // columns (e.g. two append streams onto separate shim cols). Without the
+  // column pin, a separate bucket alone yields a col-less LTO whose centroid
+  // falls on the (saturated) producer column.
+  int shimColPin = -1;
+  if (auto chanIf =
+          dyn_cast_if_present<air::ChannelInterface>(memcpyOp.getOperation())) {
+    if (auto chanDecl = getChannelDeclarationThroughSymbol(chanIf))
+      if (auto a = chanDecl->getAttrOfType<mlir::IntegerAttr>("air.shim_col")) {
+        shimColPin = (int)a.getInt();
+        bucketCol = shimColPin;
+      }
+  }
   auto sameBucket = [&](const allocation_info_t &t) {
     int tCol = bucketColFor(t.col, t.otherSideLTO);
     if (bucketCol >= 0 && tCol >= 0)
@@ -1519,6 +1535,15 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
     AIE::LogicalTileOp packetLT = nullptr;
     int packetCh = -1;
     walkBucketLTOs([&](AIE::LogicalTileOp lt) {
+      // When this flow is shim-col-pinned, only reuse a packet channel whose
+      // LogicalTileOp sits on the pinned column -- otherwise a previously
+      // opened (unpinned, off-column) packet LTO would capture this flow and
+      // silently ignore the pin.
+      if (shimColPin >= 0) {
+        auto ltCol = lt.tryGetCol();
+        if (!ltCol || (int)*ltCol != shimColPin)
+          return false;
+      }
       for (auto &t :
            llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs)) {
         if (t.dma_tile.getOperation() != lt.getOperation())
@@ -1648,11 +1673,12 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
         }
       }
     }
-    tileLT = AIE::LogicalTileOp::create(b, device.getLoc(),
-                                        AIE::AIETileType::ShimNOCTile,
-                                        /*col=*/IntegerAttr(),
-                                        /*row=*/IntegerAttr(),
-                                        /*allocation_scheme=*/StringAttr());
+    tileLT = AIE::LogicalTileOp::create(
+        b, device.getLoc(), AIE::AIETileType::ShimNOCTile,
+        /*col=*/shimColPin >= 0 ? b.getI32IntegerAttr(shimColPin)
+                                : IntegerAttr(),
+        /*row=*/IntegerAttr(),
+        /*allocation_scheme=*/StringAttr());
   }
 
   auto usedChans = channelsUsedOn(tileLT);
@@ -1666,8 +1692,13 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   if (dma_channel < 0)
     return memcpyOp.emitOpError("out of shim DMA channels");
 
+  // When shim-col-pinned, record the pinned col as this entry's col so
+  // sameBucket (which keys on t.col) groups same-pin packet flows together --
+  // letting two pinned packet channels packet-multiplex onto ONE shim
+  // LTO/channel at the pinned column instead of each opening its own LTO there.
+  int baseCol = shimColPin >= 0 ? shimColPin : col;
   auto baseRes = air::DMAAllocator::allocNewDmaChannel(
-      memcpyOp, tileLT, dma_channel, col, row, dma_ops_get_id);
+      memcpyOp, tileLT, dma_channel, baseCol, row, dma_ops_get_id);
   if (failed(baseRes))
     return baseRes;
   // Stamp the bucket key on the record the base allocator just pushed.

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin.mlir
@@ -1,0 +1,52 @@
+//===- shim_column_pin.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
+
+// A packet channel decl carrying an `air.shim_col` IntegerAttr pins its opened
+// shim LogicalTileOp to that physical column (and forces the flow into its own
+// bucket). This routes flows that must land on a specific / distinct free shim
+// column, e.g. two independent shim sources kept on separate columns.
+//
+// Without the pin both shim sources open column-less ShimNOCTiles (col "?"),
+// whose placement centroid falls on the producer column; the pinned tile below
+// would then also be "?" and this test's col-3 match would fail.
+
+// The unpinned channel @a opens a column-less shim tile; the pinned channel @b
+// opens a shim tile pinned to column 3.
+// CHECK-DAG: %[[UNPIN:.*]] = aie.logical_tile<ShimNOCTile>(?, ?)
+// CHECK-DAG: %[[PIN:.*]] = aie.logical_tile<ShimNOCTile>(3, ?)
+// CHECK-DAG: aie.shim_dma_allocation @air_a(%[[UNPIN]], MM2S, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_b(%[[PIN]], MM2S, 0)
+
+air.channel @a [1, 1] {channel_type = "npu_dma_packet"}
+air.channel @b [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
+air.channel @ah [1, 1]
+air.channel @bh [1, 1]
+func.func @f(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+  %c1 = arith.constant 1 : index
+  air.channel.put @a[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+  air.channel.put @b[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
+  air.segment @seg {
+    %c1_0 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %m0 = memref.alloc() : memref<64xi32, 1>
+    %m1 = memref.alloc() : memref<64xi32, 1>
+    air.channel.get @a[] (%m0[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+    air.channel.get @b[] (%m1[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+    air.channel.put @ah[] (%m0[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+    air.channel.put @bh[] (%m1[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
+    memref.dealloc %m0 : memref<64xi32, 1>
+    memref.dealloc %m1 : memref<64xi32, 1>
+    air.herd @h tile(%tx, %ty) in (%sx = %c2, %sy = %c1_0) {
+      %b0 = memref.alloc() : memref<64xi32, 2>
+      air.channel.get @ah[%tx, %ty] (%b0[] [] []) {id = 7 : i32} : (memref<64xi32, 2>)
+      memref.dealloc %b0 : memref<64xi32, 2>
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin_dedicated.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin_dedicated.mlir
@@ -1,0 +1,50 @@
+//===- shim_column_pin_dedicated.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
+
+// air.shim_col composes with air.dedicated_dma_channel: two dedicated packet
+// drains pinned to the SAME column share one shim LogicalTileOp (same-pin
+// bucket) but take DISTINCT DMA channels (dedicated flows never collapse onto
+// one channel). This is the device->host K/V readback shape co-located on one
+// shim column.
+
+// One col-3 shim tile hosts both drains on separate S2MM channels 0 and 1.
+// CHECK: %[[PIN:.*]] = aie.logical_tile<ShimNOCTile>(3, ?)
+// CHECK-DAG: aie.shim_dma_allocation @air_ka(%[[PIN]], S2MM, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_va(%[[PIN]], S2MM, 1)
+// CHECK-NOT: aie.logical_tile<ShimNOCTile>(3,
+
+air.channel @ka [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32, air.dedicated_dma_channel}
+air.channel @va [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32, air.dedicated_dma_channel}
+air.channel @tok [1, 1]
+air.channel @tov [1, 1]
+func.func @f(%outk: memref<64xi32>, %outv: memref<64xi32>) {
+  %c1 = arith.constant 1 : index
+  air.segment @seg {
+    %c1_0 = arith.constant 1 : index
+    %mk = memref.alloc() : memref<64xi32, 1>
+    %mv = memref.alloc() : memref<64xi32, 1>
+    air.channel.get @tok[] (%mk[] [] []) {id = 1 : i32} : (memref<64xi32, 1>)
+    air.channel.get @tov[] (%mv[] [] []) {id = 2 : i32} : (memref<64xi32, 1>)
+    air.channel.put @ka[] (%mk[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+    air.channel.put @va[] (%mv[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+    memref.dealloc %mk : memref<64xi32, 1>
+    memref.dealloc %mv : memref<64xi32, 1>
+    air.herd @h tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) {
+      %b0 = memref.alloc() : memref<64xi32, 2>
+      %b1 = memref.alloc() : memref<64xi32, 2>
+      air.channel.put @tok[%tx, %ty] (%b0[] [] []) {id = 5 : i32} : (memref<64xi32, 2>)
+      air.channel.put @tov[%tx, %ty] (%b1[] [] []) {id = 6 : i32} : (memref<64xi32, 2>)
+      memref.dealloc %b0 : memref<64xi32, 2>
+      memref.dealloc %b1 : memref<64xi32, 2>
+    }
+  }
+  air.channel.get @ka[] (%outk[] [] []) {id = 7 : i32} : (memref<64xi32>)
+  air.channel.get @va[] (%outv[] [] []) {id = 8 : i32} : (memref<64xi32>)
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin_invalid.mlir
@@ -1,0 +1,33 @@
+//===- shim_column_pin_invalid.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" 2>&1 | FileCheck %s
+
+// An air.shim_col past the device's column count is rejected rather than
+// silently pinning to a nonexistent column (npu2 has 8 columns: valid [0, 8)).
+// CHECK: air.shim_col column 99 is out of range [0, 8)
+
+air.channel @a [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 99 : i32}
+air.channel @ah [1, 1]
+func.func @f(%arg0: memref<64xi32>) {
+  %c1 = arith.constant 1 : index
+  air.channel.put @a[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+  air.segment @seg {
+    %c1_0 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %m0 = memref.alloc() : memref<64xi32, 1>
+    air.channel.get @a[] (%m0[] [] []) {id = 2 : i32} : (memref<64xi32, 1>)
+    air.channel.put @ah[] (%m0[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+    memref.dealloc %m0 : memref<64xi32, 1>
+    air.herd @h tile(%tx, %ty) in (%sx = %c2, %sy = %c1_0) {
+      %b0 = memref.alloc() : memref<64xi32, 2>
+      air.channel.get @ah[%tx, %ty] (%b0[] [] []) {id = 4 : i32} : (memref<64xi32, 2>)
+      memref.dealloc %b0 : memref<64xi32, 2>
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin_multiplex.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin_multiplex.mlir
@@ -1,0 +1,49 @@
+//===- shim_column_pin_multiplex.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
+
+// Two packet channels pinned to the SAME air.shim_col share one bucket keyed on
+// that column, so they packet-multiplex onto ONE shim LogicalTileOp / DMA
+// channel at the pinned column instead of each opening its own shim there. This
+// exercises the same-pin reuse path (the reuse walk restricted to LTOs on the
+// pinned column).
+
+// Exactly one col-3 shim tile is opened, and both allocations land on it at the
+// same MM2S channel.
+// CHECK: %[[PIN:.*]] = aie.logical_tile<ShimNOCTile>(3, ?)
+// CHECK-DAG: aie.shim_dma_allocation @air_a(%[[PIN]], MM2S, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_b(%[[PIN]], MM2S, 0)
+// CHECK-NOT: aie.logical_tile<ShimNOCTile>(3,
+
+air.channel @a [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
+air.channel @b [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
+air.channel @ah [1, 1]
+air.channel @bh [1, 1]
+func.func @f(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+  %c1 = arith.constant 1 : index
+  air.channel.put @a[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+  air.channel.put @b[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
+  air.segment @seg {
+    %c1_0 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %m0 = memref.alloc() : memref<64xi32, 1>
+    %m1 = memref.alloc() : memref<64xi32, 1>
+    air.channel.get @a[] (%m0[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+    air.channel.get @b[] (%m1[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+    air.channel.put @ah[] (%m0[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+    air.channel.put @bh[] (%m1[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
+    memref.dealloc %m0 : memref<64xi32, 1>
+    memref.dealloc %m1 : memref<64xi32, 1>
+    air.herd @h tile(%tx, %ty) in (%sx = %c2, %sy = %c1_0) {
+      %b0 = memref.alloc() : memref<64xi32, 2>
+      air.channel.get @ah[%tx, %ty] (%b0[] [] []) {id = 7 : i32} : (memref<64xi32, 2>)
+      memref.dealloc %b0 : memref<64xi32, 2>
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin_s2mm.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin_s2mm.mlir
@@ -1,0 +1,51 @@
+//===- shim_column_pin_s2mm.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
+
+// air.shim_col on the device->host (S2MM) side: two independent packet drains
+// pinned to distinct columns land on separate shim tiles at those columns.
+// Without the pin both drains collapse onto ONE shared column-less shim tile
+// (see the pre-fix behaviour: a single `ShimNOCTile(?, ?)` carrying both
+// S2MM 0 allocations), which forces two device->host streams through one shim
+// column instead of the two free columns they were meant to use.
+
+// The two pinned drains open separate shim tiles at columns 3 and 4.
+// CHECK-DAG: %[[K:.*]] = aie.logical_tile<ShimNOCTile>(3, ?)
+// CHECK-DAG: %[[V:.*]] = aie.logical_tile<ShimNOCTile>(4, ?)
+// CHECK-DAG: aie.shim_dma_allocation @air_ka(%[[K]], S2MM, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_va(%[[V]], S2MM, 0)
+
+air.channel @ka [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
+air.channel @va [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 4 : i32}
+air.channel @tok [1, 1]
+air.channel @tov [1, 1]
+func.func @f(%outk: memref<64xi32>, %outv: memref<64xi32>) {
+  %c1 = arith.constant 1 : index
+  air.segment @seg {
+    %c1_0 = arith.constant 1 : index
+    %mk = memref.alloc() : memref<64xi32, 1>
+    %mv = memref.alloc() : memref<64xi32, 1>
+    air.channel.get @tok[] (%mk[] [] []) {id = 1 : i32} : (memref<64xi32, 1>)
+    air.channel.get @tov[] (%mv[] [] []) {id = 2 : i32} : (memref<64xi32, 1>)
+    air.channel.put @ka[] (%mk[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+    air.channel.put @va[] (%mv[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+    memref.dealloc %mk : memref<64xi32, 1>
+    memref.dealloc %mv : memref<64xi32, 1>
+    air.herd @h tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) {
+      %b0 = memref.alloc() : memref<64xi32, 2>
+      %b1 = memref.alloc() : memref<64xi32, 2>
+      air.channel.put @tok[%tx, %ty] (%b0[] [] []) {id = 5 : i32} : (memref<64xi32, 2>)
+      air.channel.put @tov[%tx, %ty] (%b1[] [] []) {id = 6 : i32} : (memref<64xi32, 2>)
+      memref.dealloc %b0 : memref<64xi32, 2>
+      memref.dealloc %b1 : memref<64xi32, 2>
+    }
+  }
+  air.channel.get @ka[] (%outk[] [] []) {id = 7 : i32} : (memref<64xi32>)
+  air.channel.get @va[] (%outv[] [] []) {id = 8 : i32} : (memref<64xi32>)
+  return
+}


### PR DESCRIPTION
## Summary

The shim DMA allocator buckets flows by column and opens a column-less `ShimNOCTile` `LogicalTileOp` for each new bucket, letting the placer pick the physical column later (its centroid tends toward the producer column). There was no way to force a specific shim source onto a chosen free column, so two independent shim sources that must live on distinct columns could collapse onto the same (saturated) producer column.

- Add an optional `air.shim_col` `IntegerAttr` on an `air.channel`. When set, `ShimDMAAllocator::allocNewDmaChannel` forces the flow into its own bucket and pins the opened `ShimNOCTile` to that physical column (the placer honors the `LogicalTileOp` col attr via `tryGetCol`).
- The pinned column is recorded as the allocation's bucket col so several same-pin packet channels multiplex onto one shim LTO/channel at that column, and packet-channel reuse is restricted to LTOs already on the pinned column.
- Channels without `air.shim_col` are unchanged.

## Test plan

- [x] New lit test `shim_column_pin.mlir`: two shim packet sources, one with `air.shim_col = 3`, lowers that source onto a `ShimNOCTile` pinned to column 3 while the unpinned source stays column-less. Without the attr both are column-less (verified FAIL-without).
- [x] `check-air-mlir`: no new failures (AIRToAIE suite 95/95).