### PR TITLE
[AIRMiscPasses] Don't split L2 memrefs with non-channel users

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2170,16 +2170,11 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     // air.herd operand), which has no single owning sub-buffer. Splitting such
     // a buffer would leave that use dangling on the original alloc, which is
     // then erased. Leave the buffer intact if any use escapes the
-    // {channel put/get, dealloc} set.
+    // {channel put/get, dealloc} set. air.execute is not IsolatedFromAbove, so
+    // an async dealloc is a memref.dealloc directly using the memref (matched
+    // below); the wrapping air.execute is never itself a user.
     auto isPartitionableUser = [](Operation *user) {
-      if (isa<air::ChannelPutOp, air::ChannelGetOp, memref::DeallocOp>(user))
-        return true;
-      // A dealloc wrapped in an air.execute is the async form of the above.
-      if (auto exec = dyn_cast<air::ExecuteOp>(user))
-        return llvm::any_of(exec.getChildOps(), [](Operation &child) {
-          return isa<memref::DeallocOp>(child);
-        });
-      return false;
+      return isa<air::ChannelPutOp, air::ChannelGetOp, memref::DeallocOp>(user);
     };
     if (llvm::any_of(memref.getUsers(), [&](Operation *user) {
           return !isPartitionableUser(user);

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2163,6 +2163,28 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     Value memref = allocOp.getMemref();
     if (auto exec = dyn_cast_if_present<air::ExecuteOp>(allocOp->getParentOp()))
       memref = exec->getResult(1);
+    // Precondition: partitioning is only defined for a buffer whose entire
+    // liveness is channel-mediated. `partitionMemref` rewrites the memref
+    // operand of each channel put/get onto a sub-buffer and moves the dealloc;
+    // it cannot redistribute any other use (e.g. the buffer captured as an
+    // air.herd operand), which has no single owning sub-buffer. Splitting such
+    // a buffer would leave that use dangling on the original alloc, which is
+    // then erased. Leave the buffer intact if any use escapes the
+    // {channel put/get, dealloc} set.
+    auto isPartitionableUser = [](Operation *user) {
+      if (isa<air::ChannelPutOp, air::ChannelGetOp, memref::DeallocOp>(user))
+        return true;
+      // A dealloc wrapped in an air.execute is the async form of the above.
+      if (auto exec = dyn_cast<air::ExecuteOp>(user))
+        return llvm::any_of(exec.getChildOps(), [](Operation &child) {
+          return isa<memref::DeallocOp>(child);
+        });
+      return false;
+    };
+    if (llvm::any_of(memref.getUsers(), [&](Operation *user) {
+          return !isPartitionableUser(user);
+        }))
+      continue;
     // Maps of MM2S and S2MM channels and their sub-channels.
     llvm::MapVector<air::ChannelOp, SmallVector<SmallVector<Value>>>
         MM2SChannels, S2MMChannels;

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap.mlir
@@ -81,7 +81,7 @@ func.func @test(%arg0: memref<128x1024xbf16>) {
       %p30 = air.channel.put async [%g3] @chan_out[%c3_0, %c0_0] (%a3[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
       %p31 = air.channel.put async [%g3] @chan_out[%c3_0, %c1_0] (%a3[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
       %c4_0 = arith.constant 4 : index
-      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) args(%a=%a0, %b=%a1, %c=%a2, %d=%a3) : memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32>, memref<8x1024xbf16, 1 : i32> {
+      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) {
         %async_token_h, %r = air.execute -> (memref<8x512xbf16, 2 : i32>) {
           %alloc = memref.alloc() : memref<8x512xbf16, 2 : i32>
           air.execute_terminator %alloc : memref<8x512xbf16, 2 : i32>

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_launch_cap_s2mm.mlir
@@ -74,7 +74,7 @@ func.func @test_s2mm(%arg0: memref<128x1024xbf16>) {
       %op2 = air.channel.put async [%p20, %p21] @chan_out[%c2_0] (%a2[] [] []) : (memref<8x1024xbf16, 1 : i32>)
       %op3 = air.channel.put async [%p30, %p31] @chan_out[%c3_0] (%a3[] [] []) : (memref<8x1024xbf16, 1 : i32>)
       %c4_0 = arith.constant 4 : index
-      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) args(%a=%a0) : memref<8x1024xbf16, 1 : i32> {
+      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) {
         %async_token_h, %r = air.execute -> (memref<8x512xbf16, 2 : i32>) {
           %alloc = memref.alloc() : memref<8x512xbf16, 2 : i32>
           air.execute_terminator %alloc : memref<8x512xbf16, 2 : i32>

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_nonchannel_user.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_nonchannel_user.mlir
@@ -1,0 +1,64 @@
+//===- air_split_l2_memref_nonchannel_user.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1" | FileCheck %s
+
+// Precondition: the L2-memref split only redistributes channel put/get uses
+// (and the dealloc) onto sub-buffers; it has no way to reassign any other use.
+// Here the 8x1024 buffer is captured as an air.herd operand in addition to its
+// multiple-in-single-out channel pattern. Because that operand cannot be
+// mapped to a single sub-buffer, the buffer is not partitionable and must be
+// left intact (previously the pass split the channels and then asserted while
+// erasing the still-referenced alloc).
+
+// CHECK-LABEL: func.func @nonchannel_user
+// CHECK: memref.alloc() : memref<8x1024xbf16, 1 : i32>
+// CHECK-NOT: memref<8x512xbf16, 1 : i32>
+
+air.channel @chan_in [4, 2]
+air.channel @chan_out [4]
+func.func @nonchannel_user(%arg0: memref<128x1024xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg1) in (%arg2=%c1) args(%arg3=%arg0) : memref<128x1024xbf16> attributes {id = 1 : i32} {
+    %c0 = arith.constant 0 : index
+    %c1_l = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %c8 = arith.constant 8 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %g0 = air.channel.get async @chan_out[%c0] (%arg3[%c0, %c0] [%c8, %c1024] [%c1024, %c1_l]) {id = 1 : i32} : (memref<128x1024xbf16>)
+    %5 = air.segment @seg async {
+      %c0_0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c2_0 = arith.constant 2 : index
+      %c4_0 = arith.constant 4 : index
+      %c8_0 = arith.constant 8 : index
+      %c512 = arith.constant 512 : index
+      %c1024_0 = arith.constant 1024 : index
+      %async_token_a, %a0 = air.execute -> (memref<8x1024xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<8x1024xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<8x1024xbf16, 1 : i32>
+      }
+      // Multiple-in-single-out channel pattern (would otherwise split).
+      %p00 = air.channel.get async [%async_token_a] @chan_in[%c0_0, %c0_0] (%a0[%c0_0, %c0_0] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %p01 = air.channel.get async [%async_token_a] @chan_in[%c0_0, %c1_0] (%a0[%c0_0, %c512] [%c8_0, %c512] [%c1024_0, %c1_0]) : (memref<8x1024xbf16, 1 : i32>)
+      %op0 = air.channel.put async [%p00, %p01] @chan_out[%c0_0] (%a0[] [] []) : (memref<8x1024xbf16, 1 : i32>)
+      // Non-channel use: the L2 buffer is captured as an air.herd operand.
+      %h = air.herd @h async tile (%tx, %ty) in (%sx=%c4_0, %sy=%c2_0) args(%a=%a0) : memref<8x1024xbf16, 1 : i32> {
+        %async_token_h, %r = air.execute -> (memref<8x512xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<8x512xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<8x512xbf16, 2 : i32>
+        }
+        %ph = air.channel.put async [%async_token_h] @chan_in[%tx, %ty] (%r[] [] []) : (memref<8x512xbf16, 2 : i32>)
+        air.herd_terminator
+      }
+      air.segment_terminator
+    }
+    air.launch_terminator
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`AIRSplitL2MemrefForBufferConstraintPass` partitions an L2 buffer by redistributing its `air.channel.put`/`get` accesses onto sub-buffers and moving the dealloc. `partitionMemref` has no way to reassign any *other* use of the buffer. But `getTargetMemrefAllocs` decided split-eligibility purely from put/get counts and never validated that precondition.

As a result, a buffer that also has a non-channel use — e.g. captured as an `air.herd` operand — had its channel ops rewritten (STEP 3), and then the unconditional `eraseOp` of the still-referenced original alloc asserted:

```
PatternMatch.cpp:156: RewriterBase::eraseOp: Assertion `op->use_empty() && "expected 'op' to have no uses"' failed
```

The decision has to be made upfront: by the time `partitionMemref` runs, the channel ops are already tiled, so there is no clean mid-way abort. Guarding the `eraseOp` instead would leave a half-split buffer with a herd reading the now-unfilled original (silent miscompile).

## Fix

Enforce the transform's actual precondition in `getTargetMemrefAllocs`: only partition an alloc whose *every* use is a channel put/get or its dealloc; otherwise leave it intact. The check is per-buffer, so unrelated splittable buffers in the same segment still split normally.

## Tests

- New `air_split_l2_memref_nonchannel_user.mlir`: an L2 buffer with a multiple-in-single-out channel pattern that is *also* an `air.herd` operand is left intact (previously crashed).
- The existing `launch_cap` / `launch_cap_s2mm` tests fed buffers with **dead `air.herd` operands** into the split analysis. Those buffers assert-crash if the cap does not skip them, so the cap "skip" was masking this same crash. Dropped the dead operands so the cap is exercised on genuinely splittable buffers (the skip remarks still fire).

## Test plan

- [x] `check-air-mlir` Transform + Conversion suites: 376 pass, 0 fail (5 expected xfail, 7 unsupported).