### PR TITLE
[AIRToAIE] Honor keep_pkt_header on packet channels

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -179,6 +179,11 @@ struct MemcpyBundleAsFlow {
   std::string
       memcpyResourceType; // The type of mechanism used for the memcpy op,
                           // including dma_stream, dma_packet, and cascade.
+  // When the source channel carries the `keep_pkt_header` attribute, the kernel
+  // writes the packet-header word itself and the resulting aie.packet_flow is
+  // emitted with {keep_pkt_header = true} so the switchbox keeps (does not
+  // strip) the header at the destination.
+  bool keep_pkt_header = false;
   LogicalResult pushBackMemcpyOpToBundle(air::DmaMemcpyNdOp memcpyOp);
   LogicalResult pushBackMemcpyOpToBundle(air::ChannelGetOp memcpyOp);
   LogicalResult pushBackMemcpyOpToBundle(air::ChannelPutOp memcpyOp);

--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -58,14 +58,27 @@ constexpr StringLiteral RefeedLoop = "air.refeed_loop";
 // spelling matches the broadcast_shape discardable-attr convention on
 // air.channel; read via air::ChannelOp::getPacketIDs. Verified on air.channel.
 constexpr StringLiteral PacketIDs = "packet_ids";
+// The kernel writes the routing packet header into the payload itself.
+// air-to-aie must not stamp a static pkt_id on the producer BD (that would
+// prepend a second header word) and emits the aie.packet_flow with
+// {keep_pkt_header = true} so the switchbox keeps the header at the
+// destination. For a split bundle keep is per-flow (only the offset-0 bearer
+// keeps it); see SrcWritesPktHeader. Bare spelling matches the packet_flow attr
+// in the AIE dialect. Verified on air.channel.
+constexpr StringLiteral KeepPktHeader = "keep_pkt_header";
+// Bundle-wide derived marker set on every split of a KeepPktHeader channel: the
+// bundle source writes its own header, so no split's producer BD may be
+// stamped. Distinct from KeepPktHeader, which is per-flow (offset-0 bearer
+// only).
+constexpr StringLiteral SrcWritesPktHeader = "air.src_writes_pkt_header";
 } // namespace attrs
 
 // Copy the DMA-steering / runtime-ordering markers
 // (attrs::MemtileDmaChannelMin, RuntimeHoist, AwaitAppends, AppendBarrier,
-// RefeedCount) that
-// must survive channel-op re-instantiation from src to dst. Single source of
-// truth for the marker set, so copy sites (Util::copyPaddingAttributes,
-// ComposeMemrefOpOnChannelOp) cannot diverge. Both ops must be live (call
+// RefeedCount, PacketIDs, KeepPktHeader) that must survive channel-op
+// re-instantiation from src to dst. Single source of truth for the marker set,
+// so copy sites (Util::copyPaddingAttributes, ComposeMemrefOpOnChannelOp,
+// SpecializeChannelBundlePattern) cannot diverge. Both ops must be live (call
 // before erasing src).
 void copyChannelSteeringAttrs(Operation *src, Operation *dst);
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -3717,7 +3717,7 @@ public:
     return createPacketFlowOp(builder, flowID, source, sourceBundle,
                               sourceChannel, dest, destBundle, destChannel,
                               keepPktHeader ? builder.getBoolAttr(true)
-                                            : mlir::BoolAttr(nullptr));
+                                            : mlir::BoolAttr());
   }
 
   /// Query an existing packet flow operation from within the AIE device.

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2959,61 +2959,39 @@ struct SpecializeChannelBundlePattern
         new_chan->setAttr("broadcast_shape",
                           rewriter.getArrayAttr(ArrayRef(broadcast_shape)));
       }
-      // Propagate DMA-steering markers (incl. user-pinned packet_ids) onto each
-      // split channel: flow creation only sees the split channels, so without
-      // this, indexed/convergent packet channels fall back to auto-assigned
-      // consecutive ids, which alias under the switchbox arbiter's binary-mask
-      // matching and deadlock. Routed through the single-source-of-truth helper
-      // so this copy site stays in sync with the marker set.
+      // Propagate DMA-steering markers (incl. user-pinned packet_ids and
+      // keep_pkt_header) onto each split channel: flow creation only sees the
+      // split channels, so without this, indexed/convergent packet channels
+      // fall back to auto-assigned consecutive ids, which alias under the
+      // switchbox arbiter's binary-mask matching and deadlock. Routed through
+      // the single-source-of-truth helper so this copy site stays in sync with
+      // the marker set.
       air::copyChannelSteeringAttrs(channel, new_chan);
       std::vector<unsigned> position =
           air::getMDVectorFromIterator(bundle_size_stdvec, iter);
-      // keep_pkt_header is per-FLOW, NOT per-channel: only the flow whose dest
-      // write lands at OFFSET 0 retains the packet header -- that one header
-      // becomes the single routing header of the re-emitted packet; every other
-      // contributor (nonzero offset) drops it. keep also couples to BD size
-      // (keep => payload+header, drop => payload); a wrong keep mismatches the
-      // BD word count and deadlocks. The dest of a split channel is its GET
-      // side, so the GET's offset decides keep. Two header modes, both meaning
-      // "the bundle SOURCE writes its own routing header": keep_pkt_header
-      // (gather: the offset-0 bearer keeps it, others strip) and
-      // strip_pkt_header (demux: EVERY dest strips it -> pure payload to the
-      // on-chip consumer). Either way mark EVERY split flow so generateDmaBd
-      // does NOT stamp a static pkt_id on the producer (MM2S) BD -- a static
-      // stamp would add a second header word and shift the payload by 2.
-      if (channel->hasAttr("keep_pkt_header") ||
-          channel->hasAttr("air.strip_pkt_header")) {
-        new_chan->setAttr("air.src_writes_pkt_header", rewriter.getUnitAttr());
-        // strip_pkt_header NEVER sets keep on any flow (keep=false everywhere
-        // -> the switchbox strips the kernel header at every dest).
-        // keep_pkt_header sets keep per-flow: only the flow whose GET lands at
-        // offset 0 keeps it.
-        if (channel->hasAttr("keep_pkt_header")) {
-          bool writesOffsetZero = false;
-          for (auto get : channelGets) {
-            auto gidx =
-                air::convertVecOfConstIndexToVecOfUInt(get.getIndices());
-            if (!areIdenticalVectors(gidx, position))
-              continue;
-            auto offs = get.getOffsets();
-            if (offs.empty()) {
-              writesOffsetZero = true;
-            } else {
-              writesOffsetZero = true;
-              for (auto o : offs) {
-                auto c = getConstantIntValue(o);
-                if (!c || *c != 0) {
-                  writesOffsetZero = false;
-                  break;
-                }
-              }
-            }
-            break;
-          }
-          if (writesOffsetZero)
-            new_chan->setAttr("keep_pkt_header",
-                              channel->getAttr("keep_pkt_header"));
+      // keep_pkt_header is per-flow: only the split whose GET lands at offset 0
+      // keeps the header (it becomes the single routing header); the others
+      // strip it. But every split must still skip the static producer-BD stamp
+      // (the kernel already wrote the header), so mark all splits with
+      // SrcWritesPktHeader and drop KeepPktHeader (copied onto all splits
+      // above) from the non-offset-0 ones.
+      if (new_chan->hasAttr(air::attrs::KeepPktHeader)) {
+        new_chan->setAttr(air::attrs::SrcWritesPktHeader,
+                          rewriter.getUnitAttr());
+        bool writesOffsetZero = false;
+        for (auto get : channelGets) {
+          if (!areIdenticalVectors(
+                  air::convertVecOfConstIndexToVecOfUInt(get.getIndices()),
+                  position))
+            continue;
+          writesOffsetZero = llvm::all_of(get.getOffsets(), [](Value o) {
+            auto c = getConstantIntValue(o);
+            return c && *c == 0;
+          });
+          break;
         }
+        if (!writesOffsetZero)
+          new_chan->removeAttr(air::attrs::KeepPktHeader);
       }
       for (auto put : channelPuts) {
         auto indices_uint =
@@ -3417,6 +3395,20 @@ static void removeDeadGlobalOps(AIE::DeviceOp device) {
   }
   for (auto op : deadGlobals)
     op->erase();
+}
+
+// A packet channel whose kernel writes the routing header into the payload
+// itself: the DMA must not stamp a static pkt_id (that would prepend a second
+// header word). True for multi-id pinned channels (the core writes the id) and
+// for keep_pkt_header / air.src_writes_pkt_header channels (the kernel writes
+// the whole header).
+static bool channelKernelWritesHeader(air::ChannelOp chanOp) {
+  if (!chanOp)
+    return false;
+  if (auto pids = chanOp.getPacketIDs(); pids && pids.size() > 1)
+    return true;
+  return chanOp->hasAttr(air::attrs::KeepPktHeader) ||
+         chanOp->hasAttr(air::attrs::SrcWritesPktHeader);
 }
 
 class AIRToAIEPass : public air::impl::AIRToAIEBase<AIRToAIEPass> {
@@ -4888,21 +4880,12 @@ public:
                                              int packetFlowId = -1) {
     // Kernel-writes-header channels must not be statically stamped, so the
     // shim DMA does not prepend a second header word. Skip before the runtime
-    // fallback below could tag it with an arbitrary flow id. Two cases:
-    //  - multi-id pinned channels (packet_ids > 1): the core writes the routing
-    //    id into the payload;
-    //  - keep_pkt_header / air.src_writes_pkt_header channels: the kernel
-    //  writes
-    //    the whole routing header.
+    // fallback below could tag it with an arbitrary flow id.
     if (auto ci = dyn_cast_if_present<air::ChannelInterface>(
             memcpyOpIf.getOperation()))
-      if (auto chanOp = air::getChannelDeclarationThroughSymbol(ci)) {
-        if (auto pids = chanOp.getPacketIDs(); pids && pids.size() > 1)
-          return success();
-        if (chanOp->hasAttr("keep_pkt_header") ||
-            chanOp->hasAttr("air.src_writes_pkt_header"))
-          return success();
-      }
+      if (channelKernelWritesHeader(
+              air::getChannelDeclarationThroughSymbol(ci)))
+        return success();
 
     // When a packet flow ID is available (from flow creation phase), use
     // exact flow ID matching to disambiguate multiple flows sharing the
@@ -6043,14 +6026,11 @@ public:
     AIE::PacketInfoAttr pktInfoAttr = nullptr;
     if (auto chanIfOp = dyn_cast_if_present<air::ChannelInterface>(
             memcpyOp.getOperation())) {
-      // Channels whose kernel writes the routing header itself
-      // (keep_pkt_header, or the per-split air.src_writes_pkt_header marker set
-      // for such bundles) must NOT be statically stamped: a static pkt_id would
-      // prepend a second header word and shift the payload.
-      auto chanDecl = air::getChannelDeclarationThroughSymbol(chanIfOp);
-      bool kernelWritesHeader =
-          chanDecl && (chanDecl->hasAttr("keep_pkt_header") ||
-                       chanDecl->hasAttr("air.src_writes_pkt_header"));
+      // Channels whose kernel writes the routing header itself must NOT be
+      // statically stamped: a static pkt_id would prepend a second header word
+      // and shift the payload.
+      bool kernelWritesHeader = channelKernelWritesHeader(
+          air::getChannelDeclarationThroughSymbol(chanIfOp));
       auto it = packetIDForChannelName.find(chanIfOp.getChanName().str());
       if (!kernelWritesHeader && it != packetIDForChannelName.end())
         pktInfoAttr =

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2968,6 +2968,53 @@ struct SpecializeChannelBundlePattern
       air::copyChannelSteeringAttrs(channel, new_chan);
       std::vector<unsigned> position =
           air::getMDVectorFromIterator(bundle_size_stdvec, iter);
+      // keep_pkt_header is per-FLOW, NOT per-channel: only the flow whose dest
+      // write lands at OFFSET 0 retains the packet header -- that one header
+      // becomes the single routing header of the re-emitted packet; every other
+      // contributor (nonzero offset) drops it. keep also couples to BD size
+      // (keep => payload+header, drop => payload); a wrong keep mismatches the
+      // BD word count and deadlocks. The dest of a split channel is its GET
+      // side, so the GET's offset decides keep. Two header modes, both meaning
+      // "the bundle SOURCE writes its own routing header": keep_pkt_header
+      // (gather: the offset-0 bearer keeps it, others strip) and
+      // strip_pkt_header (demux: EVERY dest strips it -> pure payload to the
+      // on-chip consumer). Either way mark EVERY split flow so generateDmaBd
+      // does NOT stamp a static pkt_id on the producer (MM2S) BD -- a static
+      // stamp would add a second header word and shift the payload by 2.
+      if (channel->hasAttr("keep_pkt_header") ||
+          channel->hasAttr("air.strip_pkt_header")) {
+        new_chan->setAttr("air.src_writes_pkt_header", rewriter.getUnitAttr());
+        // strip_pkt_header NEVER sets keep on any flow (keep=false everywhere
+        // -> the switchbox strips the kernel header at every dest).
+        // keep_pkt_header sets keep per-flow: only the flow whose GET lands at
+        // offset 0 keeps it.
+        if (channel->hasAttr("keep_pkt_header")) {
+          bool writesOffsetZero = false;
+          for (auto get : channelGets) {
+            auto gidx =
+                air::convertVecOfConstIndexToVecOfUInt(get.getIndices());
+            if (!areIdenticalVectors(gidx, position))
+              continue;
+            auto offs = get.getOffsets();
+            if (offs.empty()) {
+              writesOffsetZero = true;
+            } else {
+              writesOffsetZero = true;
+              for (auto o : offs) {
+                auto c = getConstantIntValue(o);
+                if (!c || *c != 0) {
+                  writesOffsetZero = false;
+                  break;
+                }
+              }
+            }
+            break;
+          }
+          if (writesOffsetZero)
+            new_chan->setAttr("keep_pkt_header",
+                              channel->getAttr("keep_pkt_header"));
+        }
+      }
       for (auto put : channelPuts) {
         auto indices_uint =
             air::convertVecOfConstIndexToVecOfUInt(put.getIndices());
@@ -3632,7 +3679,8 @@ public:
                                     xilinx::AIE::WireBundle sourceBundle,
                                     uint32_t sourceChannel, mlir::Value dest,
                                     xilinx::AIE::WireBundle destBundle,
-                                    uint32_t destChannel, int flowID) {
+                                    uint32_t destChannel, int flowID,
+                                    bool keepPktHeader = false) {
     AIE::PacketFlowOp packetFlowOp = nullptr;
     aie_device.walk([&](AIE::PacketFlowOp pktFlowOp) {
       auto pktSrcOp = getPacketSourceOpInPacketFlowOp(pktFlowOp, source);
@@ -3667,7 +3715,9 @@ public:
 
     builder.setInsertionPoint(aie_device.getBody()->getTerminator());
     return createPacketFlowOp(builder, flowID, source, sourceBundle,
-                              sourceChannel, dest, destBundle, destChannel);
+                              sourceChannel, dest, destBundle, destChannel,
+                              keepPktHeader ? builder.getBoolAttr(true)
+                                            : mlir::BoolAttr(nullptr));
   }
 
   /// Query an existing packet flow operation from within the AIE device.
@@ -4539,13 +4589,14 @@ public:
           // backlinks.
           bool backlink = flowIDs.size() == 1;
           for (int flowID : flowIDs) {
-            getPacketFlowOp(
-                aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
-                f.S2MM_alloc[i].getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+            getPacketFlowOp(aie_device,
+                            f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                            AIE::WireBundle::DMA,
+                            (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                            f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                            AIE::WireBundle::DMA,
+                            (uint32_t)f.S2MM_alloc[i].dma_channel.channel,
+                            flowID, f.keep_pkt_header);
             if (!backlink)
               continue;
             // Backlink: the host runtime keys packet identification on
@@ -4578,13 +4629,14 @@ public:
           if (isShimFlowAt(f, j, i))
             continue;
           for (int flowID : pktIDsForDest(f, i, /*isShim=*/false)) {
-            getPacketFlowOp(
-                aie_device, f.MM2S_alloc[j].getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
-                f.S2MM_alloc[i].getDmaTile()->getResult(0),
-                AIE::WireBundle::DMA,
-                (uint32_t)f.S2MM_alloc[i].dma_channel.channel, flowID);
+            getPacketFlowOp(aie_device,
+                            f.MM2S_alloc[j].getDmaTile()->getResult(0),
+                            AIE::WireBundle::DMA,
+                            (uint32_t)f.MM2S_alloc[j].dma_channel.channel,
+                            f.S2MM_alloc[i].getDmaTile()->getResult(0),
+                            AIE::WireBundle::DMA,
+                            (uint32_t)f.S2MM_alloc[i].dma_channel.channel,
+                            flowID, f.keep_pkt_header);
           }
         }
       }
@@ -4834,15 +4886,23 @@ public:
                                              StringAttr dmaNameAttr,
                                              mlir::Value tileVal, int channel,
                                              int packetFlowId = -1) {
-    // Multi-id pinned channels follow the kernel-header contract: the core
-    // writes the routing id into the payload, so the shim DMA must not stamp a
-    // packet header. Skip before the runtime fallback below could tag it with
-    // an arbitrary flow id.
+    // Kernel-writes-header channels must not be statically stamped, so the
+    // shim DMA does not prepend a second header word. Skip before the runtime
+    // fallback below could tag it with an arbitrary flow id. Two cases:
+    //  - multi-id pinned channels (packet_ids > 1): the core writes the routing
+    //    id into the payload;
+    //  - keep_pkt_header / air.src_writes_pkt_header channels: the kernel
+    //  writes
+    //    the whole routing header.
     if (auto ci = dyn_cast_if_present<air::ChannelInterface>(
             memcpyOpIf.getOperation()))
-      if (auto chanOp = air::getChannelDeclarationThroughSymbol(ci))
+      if (auto chanOp = air::getChannelDeclarationThroughSymbol(ci)) {
         if (auto pids = chanOp.getPacketIDs(); pids && pids.size() > 1)
           return success();
+        if (chanOp->hasAttr("keep_pkt_header") ||
+            chanOp->hasAttr("air.src_writes_pkt_header"))
+          return success();
+      }
 
     // When a packet flow ID is available (from flow creation phase), use
     // exact flow ID matching to disambiguate multiple flows sharing the
@@ -5983,8 +6043,16 @@ public:
     AIE::PacketInfoAttr pktInfoAttr = nullptr;
     if (auto chanIfOp = dyn_cast_if_present<air::ChannelInterface>(
             memcpyOp.getOperation())) {
+      // Channels whose kernel writes the routing header itself
+      // (keep_pkt_header, or the per-split air.src_writes_pkt_header marker set
+      // for such bundles) must NOT be statically stamped: a static pkt_id would
+      // prepend a second header word and shift the payload.
+      auto chanDecl = air::getChannelDeclarationThroughSymbol(chanIfOp);
+      bool kernelWritesHeader =
+          chanDecl && (chanDecl->hasAttr("keep_pkt_header") ||
+                       chanDecl->hasAttr("air.src_writes_pkt_header"));
       auto it = packetIDForChannelName.find(chanIfOp.getChanName().str());
-      if (it != packetIDForChannelName.end())
+      if (!kernelWritesHeader && it != packetIDForChannelName.end())
         pktInfoAttr =
             AIE::PacketInfoAttr::get(ndcpy->getContext(), 0, it->second);
     }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2255,7 +2255,7 @@ air::MemcpyBundleAsFlow::MemcpyBundleAsFlow(air::ChannelOp chan) {
   S2MM_alloc = std::vector<air::allocation_info_t>(numS2MMAllocs);
   MM2S_alloc = std::vector<air::allocation_info_t>(numMM2SAllocs);
   memcpyResourceType = chan.getChannelType().str();
-  keep_pkt_header = chan->hasAttr("keep_pkt_header");
+  keep_pkt_header = chan->hasAttr(air::attrs::KeepPktHeader);
 }
 
 } // namespace xilinx

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2255,6 +2255,7 @@ air::MemcpyBundleAsFlow::MemcpyBundleAsFlow(air::ChannelOp chan) {
   S2MM_alloc = std::vector<air::allocation_info_t>(numS2MMAllocs);
   MM2S_alloc = std::vector<air::allocation_info_t>(numMM2SAllocs);
   memcpyResourceType = chan.getChannelType().str();
+  keep_pkt_header = chan->hasAttr("keep_pkt_header");
 }
 
 } // namespace xilinx

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -145,6 +145,11 @@ void air::copyChannelSteeringAttrs(Operation *src, Operation *dst) {
   // User-pinned packet routing ids, read by AIRToAIE's packet-flow creation.
   if (auto pids = src->getAttrOfType<ArrayAttr>(attrs::PacketIDs))
     dst->setAttr(attrs::PacketIDs, pids);
+  // Kernel-writes-header marker. Copied verbatim;
+  // SpecializeChannelBundlePattern narrows it to the offset-0 bearer per-flow
+  // after this copy.
+  if (auto kph = src->getAttr(attrs::KeepPktHeader))
+    dst->setAttr(attrs::KeepPktHeader, kph);
 }
 
 void air::addAsyncDependency(Operation *op, Value token) {

--- a/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header.mlir
@@ -1,0 +1,48 @@
+//===- packet_keep_pkt_header.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// A packet channel carrying `keep_pkt_header` means the kernel writes the
+// routing header word into the payload itself. air-to-aie must:
+//   - emit the aie.packet_flow with {keep_pkt_header = true} so the switchbox
+//     keeps (does not strip) the header at the destination, and
+//   - NOT statically stamp a pkt_id on the producer BD (a static stamp would
+//     prepend a second header word and shift the payload).
+
+// CHECK: aie.dma_bd({{.*}}memref<8xbf16, 2>, 0, 8) {task_id = 0 : i32}
+// CHECK-NOT: packet = #aie.packet_info
+// CHECK: aie.packet_flow(0) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%{{.*}}, DMA : 0>
+// CHECK-NEXT: } {keep_pkt_header = true}
+
+air.channel @k [1, 1] {channel_type = "npu_dma_packet", keep_pkt_header}
+func.func @f() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %t, %l2 = air.execute -> (memref<8xbf16, 1>) {
+        %alloc = memref.alloc() : memref<8xbf16, 1>
+        air.execute_terminator %alloc : memref<8xbf16, 1>
+      }
+      air.channel.get @k[] (%l2[] [] []) : (memref<8xbf16, 1>)
+      %d_ = air.execute { memref.dealloc %l2 : memref<8xbf16, 1> }
+      air.herd @h tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @k[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header_bundle.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header_bundle.mlir
@@ -1,0 +1,73 @@
+//===- packet_keep_pkt_header_bundle.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// keep_pkt_header is per-FLOW when a bundle is split: two producers gather into
+// one L2 buffer, and only the split whose GET lands at offset 0 keeps the
+// routing header; the offset-8 split strips it. Both producer BDs stay
+// unstamped (air.src_writes_pkt_header marks the whole bundle).
+
+// No BD (producer or receiver) is statically stamped -- the kernel wrote the
+// header itself.
+// CHECK-NOT: packet = #aie.packet_info
+
+// Bundle split: offset-0 bearer keeps keep_pkt_header; sibling only marks
+// src_writes_pkt_header (so its producer BD is still unstamped, but the flow
+// strips the header).
+// CHECK: air.channel @channel_0 [1, 1] {air.src_writes_pkt_header, channel_type = "npu_dma_packet", keep_pkt_header}
+// CHECK: air.channel @channel_1 [1, 1] {air.src_writes_pkt_header, channel_type = "npu_dma_packet"}
+
+// Exactly one flow keeps the header at the switchbox; the sibling does not.
+// CHECK: aie.packet_flow(0) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%{{.*}}, DMA : 0>
+// CHECK-NEXT: } {keep_pkt_header = true}
+// The sibling flow's closing brace carries no attribute dictionary.
+// CHECK: aie.packet_flow(1) {
+// CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : 0>
+// CHECK-NEXT: aie.packet_dest<%{{.*}}, DMA : 1>
+// CHECK-NEXT: }
+
+air.channel @k [2, 1] {channel_type = "npu_dma_packet", keep_pkt_header}
+func.func @f() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %t, %l2 = air.execute -> (memref<2x8xbf16, 1>) {
+        %alloc = memref.alloc() : memref<2x8xbf16, 1>
+        air.execute_terminator %alloc : memref<2x8xbf16, 1>
+      }
+      air.channel.get @k[%c0,   %c0] (%l2[%c0,   %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      air.channel.get @k[%c1_0, %c0] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<2x8xbf16, 1>)
+      %d_ = air.execute {memref.dealloc %l2 : memref<2x8xbf16, 1>}
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0) attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        %z0 = arith.constant 0 : index
+        air.channel.put @k[%z0, %z0] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0) attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        %z1 = arith.constant 1 : index
+        %z0 = arith.constant 0 : index
+        air.channel.put @k[%z1, %z0] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

When a packet `air.channel` carries `keep_pkt_header`, the kernel writes the routing packet-header word into the payload itself. air-to-aie must preserve that header end-to-end instead of the default (auto-assigned pkt_id, switchbox strips the header at the destination):

- Emit the `aie.packet_flow` with `{keep_pkt_header = true}` so the switchbox keeps the header at the destination (`getPacketFlowOp` forwards the flag to `createPacketFlowOp`; `MemcpyBundleAsFlow` reads it off the channel; Pass 1/2 emission passes it).
- Do **not** statically stamp a pkt_id on the producer BD for such a channel (`generateDmaBd` and `labelMemcpyOpsWithPacketFlow` both skip it) — a static stamp would prepend a second header word and shift the payload.
- `keep_pkt_header` is per-flow: for a split channel bundle only the flow whose destination lands at offset 0 keeps the header; the others strip it. `SpecializeChannelBundlePattern` marks the offset-0 bearer and tags every split flow with `air.src_writes_pkt_header` so the stamp-skip applies bundle-wide.
- Channels without `keep_pkt_header` are unchanged.

## Test plan

- [x] New lit test `packet_keep_pkt_header.mlir`: a `keep_pkt_header` packet channel lowers to a `packet_flow` with `{keep_pkt_header = true}` and an unstamped producer BD. Without the change the flow drops the header and the BD is statically stamped (verified FAIL-without).
- [x] `check-air-mlir`: no new failures.