### PR TITLE
[AIRToAIE] Honor air.memtile_col to pin an L2 buffer's memtile column

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2479,7 +2479,11 @@ void L2MemrefToMemTileMap(
     if (pin >= 0)
       col = pin;
     bucketCols.push_back(col);
-    if (col >= 0)
+    // Only affinity-derived cols feed the saturation trigger. A user pin is an
+    // explicit request that is honored on both branches, so it must not push
+    // the module into the saturation fallback and thereby perturb the
+    // placement of unrelated, unpinned buckets.
+    if (pin < 0 && col >= 0)
       colDemand[col]++;
   }
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2452,12 +2452,17 @@ void L2MemrefToMemTileMap(
     return pinned;
   };
 
-  SmallVector<int> bucketCols;
+  // Derive pins once here (deriveBucketPin emits warnings), then reuse the
+  // cached value on every downstream path so each invalid/conflicting pin is
+  // diagnosed exactly once.
+  SmallVector<int> bucketCols, bucketPins;
   bucketCols.reserve(memref_buckets.size());
+  bucketPins.reserve(memref_buckets.size());
   llvm::DenseMap<int, int> colDemand;
   for (auto &bucket : memref_buckets) {
     int col = deriveBucketCol(bucket);
     int pin = deriveBucketPin(bucket);
+    bucketPins.push_back(pin);
     if (pin >= 0)
       col = pin;
     bucketCols.push_back(col);
@@ -2535,7 +2540,7 @@ void L2MemrefToMemTileMap(
     int globalCounter = 0;
     for (size_t i = 0; i < memref_buckets.size(); i++) {
       auto &bucket = memref_buckets[i];
-      int pin = deriveBucketPin(bucket);
+      int pin = bucketPins[i];
       if (pin >= 0) {
         AIE::TileLike memtile = findOrCreateLtoForCol(pin);
         for (auto bucket_elem : bucket)

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2327,31 +2327,44 @@ void L2MemrefToMemTileMap(
       return static_cast<int>(attr.getInt());
     return -1;
   };
+  // True iff `alloc` shares an air.channel with any member of `bucket`.
+  auto sharesChannelWithBucket = [&](ArrayRef<memref::AllocOp> bucket,
+                                     memref::AllocOp alloc) {
+    for (auto bucket_elem : bucket)
+      if (areReferencedByTheSameAIRChannel(alloc.getMemref(),
+                                           bucket_elem.getMemref()))
+        return true;
+    return false;
+  };
+  // True iff `allocPin` (a valid pin, i.e. >= 0) conflicts with a distinct pin
+  // already present in `bucket`.
+  auto bucketHasConflictingPin = [&](ArrayRef<memref::AllocOp> bucket,
+                                     int allocPin) {
+    for (auto other : bucket) {
+      int otherPin = allocPinCol(other);
+      if (otherPin >= 0 && otherPin != allocPin)
+        return true;
+    }
+    return false;
+  };
   auto placeMemrefInSharedBucket =
       [&](SmallVector<SmallVector<memref::AllocOp>> &memref_buckets,
           memref::AllocOp alloc) {
         int allocPin = allocPinCol(alloc);
         for (auto &bucket : memref_buckets) {
-          for (auto bucket_elem : bucket) {
-            if (areReferencedByTheSameAIRChannel(alloc.getMemref(),
-                                                 bucket_elem.getMemref())) {
-              // Pin-aware bucketing: if the new alloc carries an
-              // air.memtile_col pin distinct from any pin already in this
-              // bucket, refuse to merge. This is what makes MT->MT hops
-              // expressible — two L2 buffers sharing one channel (the
-              // hop's intermediate) end up in DIFFERENT buckets, so the
-              // shared channel becomes a real cross-memtile flow.
-              if (allocPin >= 0) {
-                for (auto other : bucket) {
-                  int otherPin = allocPinCol(other);
-                  if (otherPin >= 0 && otherPin != allocPin)
-                    return false;
-                }
-              }
-              bucket.push_back(alloc);
-              return true;
-            }
-          }
+          if (!sharesChannelWithBucket(bucket, alloc))
+            continue;
+          // Pin-aware bucketing: if the alloc carries an air.memtile_col pin
+          // distinct from any pin already in this bucket, skip it (don't
+          // merge) and keep scanning — the alloc may still share a channel
+          // with a different, pin-compatible bucket. Refusing the merge is
+          // what makes MT->MT hops expressible: two L2 buffers sharing one
+          // channel (the hop's intermediate) end up in DIFFERENT buckets, so
+          // the shared channel becomes a real cross-memtile flow.
+          if (allocPin >= 0 && bucketHasConflictingPin(bucket, allocPin))
+            continue;
+          bucket.push_back(alloc);
+          return true;
         }
         return false;
       };

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2320,13 +2320,34 @@ void L2MemrefToMemTileMap(
   // First stage in memref placement: grouping memrefs referenced by the same
   // air.channel.
   SmallVector<SmallVector<memref::AllocOp>> memref_buckets;
+  // Returns the user-pinned col for an alloc if it carries
+  // `air.memtile_col`, else -1.
+  auto allocPinCol = [](memref::AllocOp a) -> int {
+    if (auto attr = a->getAttrOfType<IntegerAttr>("air.memtile_col"))
+      return static_cast<int>(attr.getInt());
+    return -1;
+  };
   auto placeMemrefInSharedBucket =
       [&](SmallVector<SmallVector<memref::AllocOp>> &memref_buckets,
           memref::AllocOp alloc) {
+        int allocPin = allocPinCol(alloc);
         for (auto &bucket : memref_buckets) {
           for (auto bucket_elem : bucket) {
             if (areReferencedByTheSameAIRChannel(alloc.getMemref(),
                                                  bucket_elem.getMemref())) {
+              // Pin-aware bucketing: if the new alloc carries an
+              // air.memtile_col pin distinct from any pin already in this
+              // bucket, refuse to merge. This is what makes MT->MT hops
+              // expressible — two L2 buffers sharing one channel (the
+              // hop's intermediate) end up in DIFFERENT buckets, so the
+              // shared channel becomes a real cross-memtile flow.
+              if (allocPin >= 0) {
+                for (auto other : bucket) {
+                  int otherPin = allocPinCol(other);
+                  if (otherPin >= 0 && otherPin != allocPin)
+                    return false;
+                }
+              }
               bucket.push_back(alloc);
               return true;
             }
@@ -2406,12 +2427,39 @@ void L2MemrefToMemTileMap(
     }
     return colHasMemTile(consensus) ? consensus : -1;
   };
+  // User-controlled memtile column pin via discardable
+  // `air.memtile_col` IntegerAttr on the memref.alloc op. Hint-only:
+  // invalid columns warn and fall through. Strict-first-wins on conflict
+  // within a bucket (bucket = allocs sharing one air.channel).
+  auto deriveBucketPin = [&](ArrayRef<memref::AllocOp> bucket) -> int {
+    int pinned = -1;
+    for (auto alloc : bucket) {
+      auto attr = alloc->getAttrOfType<IntegerAttr>("air.memtile_col");
+      if (!attr)
+        continue;
+      int col = static_cast<int>(attr.getInt());
+      if (!colHasMemTile(col)) {
+        alloc->emitWarning("air.memtile_col=")
+            << col << " has no memtile in target; ignoring";
+        continue;
+      }
+      if (pinned == -1)
+        pinned = col;
+      else if (pinned != col)
+        alloc->emitWarning("air.memtile_col=")
+            << col << " conflicts with bucket pin=" << pinned << "; ignoring";
+    }
+    return pinned;
+  };
 
   SmallVector<int> bucketCols;
   bucketCols.reserve(memref_buckets.size());
   llvm::DenseMap<int, int> colDemand;
   for (auto &bucket : memref_buckets) {
     int col = deriveBucketCol(bucket);
+    int pin = deriveBucketPin(bucket);
+    if (pin >= 0)
+      col = pin;
     bucketCols.push_back(col);
     if (col >= 0)
       colDemand[col]++;
@@ -2434,32 +2482,8 @@ void L2MemrefToMemTileMap(
       break;
     }
 
-  if (saturated) {
-    // Multi-bucket shapes (operand classes like A/B/C) get a per-shape
-    // counter so each class restarts at memtile 0 and bucket-i maps to
-    // memtile-i; singleton shapes keep using a global counter so unrelated
-    // one-off buffers still spread across the pool.
-    auto bucketShape = [](SmallVectorImpl<memref::AllocOp> &bucket) -> Type {
-      return bucket.empty() ? Type() : bucket.front().getMemref().getType();
-    };
-    llvm::DenseMap<Type, int> shapeCount;
-    for (auto &bucket : memref_buckets)
-      shapeCount[bucketShape(bucket)]++;
-    llvm::DenseMap<Type, int> perShapeCounter;
-    int globalCounter = 0;
-    for (auto &bucket : memref_buckets) {
-      Type shape = bucketShape(bucket);
-      int slot =
-          (shapeCount[shape] > 1) ? perShapeCounter[shape]++ : globalCounter++;
-      auto memtile = memtiles[slot % memtiles.size()];
-      for (auto bucket_elem : bucket)
-        memrefToMemTileMap[bucket_elem] = memtile;
-    }
-    return;
-  }
-
-  // Col-affinity assignment: hint pre-emitted LTOs to derived cols and
-  // share one LTO per col. Spill over to round-robin for unhinted buckets.
+  // Hoisted out of the col-affinity branch so the saturation branch can
+  // also honor user pins via findOrCreateLtoForCol.
   OpBuilder builder(m);
   builder.setInsertionPointToStart(m.getBody());
   for (auto &o : m.getBody()->getOperations()) {
@@ -2496,6 +2520,40 @@ void L2MemrefToMemTileMap(
     colToMemtile[col] = tl;
     return tl;
   };
+
+  if (saturated) {
+    // Honor user pins even under saturation: pinned buckets route through
+    // findOrCreateLtoForCol so they land on their requested col; unpinned
+    // buckets distribute via the existing per-shape / global round-robin.
+    auto bucketShape = [](SmallVectorImpl<memref::AllocOp> &bucket) -> Type {
+      return bucket.empty() ? Type() : bucket.front().getMemref().getType();
+    };
+    llvm::DenseMap<Type, int> shapeCount;
+    for (auto &bucket : memref_buckets)
+      shapeCount[bucketShape(bucket)]++;
+    llvm::DenseMap<Type, int> perShapeCounter;
+    int globalCounter = 0;
+    for (size_t i = 0; i < memref_buckets.size(); i++) {
+      auto &bucket = memref_buckets[i];
+      int pin = deriveBucketPin(bucket);
+      if (pin >= 0) {
+        AIE::TileLike memtile = findOrCreateLtoForCol(pin);
+        for (auto bucket_elem : bucket)
+          memrefToMemTileMap[bucket_elem] = memtile;
+        continue;
+      }
+      Type shape = bucketShape(bucket);
+      int slot =
+          (shapeCount[shape] > 1) ? perShapeCounter[shape]++ : globalCounter++;
+      auto memtile = memtiles[slot % memtiles.size()];
+      for (auto bucket_elem : bucket)
+        memrefToMemTileMap[bucket_elem] = memtile;
+    }
+    return;
+  }
+
+  // Col-affinity assignment: hint pre-emitted LTOs to derived cols and
+  // share one LTO per col. Spill over to round-robin for unhinted buckets.
 
   SmallVector<size_t> unhintedBuckets;
   for (size_t i = 0; i < memref_buckets.size(); i++) {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2320,6 +2320,14 @@ void L2MemrefToMemTileMap(
   // First stage in memref placement: grouping memrefs referenced by the same
   // air.channel.
   SmallVector<SmallVector<memref::AllocOp>> memref_buckets;
+  // `air.memtile_col` is the memtile-level analogue of `air.shim_col` (see
+  // AIRToAIESchedulingUtils.cpp). Two deliberate differences: (1) it is carried
+  // on the memref.alloc rather than the channel decl, because L2 placement
+  // buckets are keyed by alloc; (2) it is hint-only (an invalid column warns
+  // and falls through) rather than a hard error, because a memtile column that
+  // exists on one target may not on another and the hint should stay portable.
+  // Caveat: it is a discardable attr on memref.alloc, so set it late (after
+  // air-dependency) — earlier rewrites that reconstruct allocs may drop it.
   // Returns the user-pinned col for an alloc if it carries
   // `air.memtile_col`, else -1.
   auto allocPinCol = [](memref::AllocOp a) -> int {
@@ -2440,17 +2448,16 @@ void L2MemrefToMemTileMap(
     }
     return colHasMemTile(consensus) ? consensus : -1;
   };
-  // User-controlled memtile column pin via discardable
-  // `air.memtile_col` IntegerAttr on the memref.alloc op. Hint-only:
-  // invalid columns warn and fall through. Strict-first-wins on conflict
-  // within a bucket (bucket = allocs sharing one air.channel).
+  // Resolve the single valid pin for a bucket. Invalid columns (no memtile in
+  // the target) warn and fall through. The conflict branch is a defensive net:
+  // placeMemrefInSharedBucket already refuses to merge allocs carrying distinct
+  // pins, so a bucket normally holds at most one distinct valid pin.
   auto deriveBucketPin = [&](ArrayRef<memref::AllocOp> bucket) -> int {
     int pinned = -1;
     for (auto alloc : bucket) {
-      auto attr = alloc->getAttrOfType<IntegerAttr>("air.memtile_col");
-      if (!attr)
+      int col = allocPinCol(alloc);
+      if (col < 0)
         continue;
-      int col = static_cast<int>(attr.getInt());
       if (!colHasMemTile(col)) {
         alloc->emitWarning("air.memtile_col=")
             << col << " has no memtile in target; ignoring";

--- a/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin.mlir
+++ b/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin.mlir
@@ -1,0 +1,64 @@
+//===- l2_memtile_column_pin.mlir --------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// A memref.alloc for an L2 buffer may carry an `air.memtile_col` IntegerAttr to
+// pin the memtile column its bucket lands on, overriding the default
+// round-robin / column-affinity assignment. Invalid columns warn and fall
+// through; a distinct pin on an alloc sharing a channel forces that alloc into
+// its own bucket (so the shared channel becomes a real cross-memtile flow).
+//
+// Here alloc_0 is pinned to column 7 and alloc_1 to column 5, so their lowered
+// memtile LogicalTileOps carry those explicit columns (row still deferred to
+// the placer). Without the pin they follow the default column-affinity /
+// round-robin assignment and do not land on the requested columns.
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=5 device=xcve2802 use-objectfifo=false" | FileCheck %s
+
+// CHECK-DAG: %[[M7:.*]] = aie.logical_tile<MemTile>(7, ?)
+// CHECK-DAG: %[[M5:.*]] = aie.logical_tile<MemTile>(5, ?)
+// CHECK-DAG: aie.buffer(%[[M7]]) {{{.*}}} : memref<32xi32, 1>
+// CHECK-DAG: aie.buffer(%[[M5]]) {{{.*}}} : memref<64xi32, 1>
+
+module {
+  air.channel @ch_a [1, 1]
+  air.channel @ch_b [1, 1]
+  func.func @pin_test() {
+    %c1 = arith.constant 1 : index
+    air.launch (%arg0) in (%arg1=%c1) {
+      air.segment @segment_0 attributes {x_size = 3 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_0, %alloc_0 = air.execute -> (memref<32xi32, 1>) {
+          %a = memref.alloc() {air.memtile_col = 7 : i32} : memref<32xi32, 1>
+          air.execute_terminator %a : memref<32xi32, 1>
+        }
+        %async_token_1, %alloc_1 = air.execute -> (memref<64xi32, 1>) {
+          %a = memref.alloc() {air.memtile_col = 5 : i32} : memref<64xi32, 1>
+          air.execute_terminator %a : memref<64xi32, 1>
+        }
+        %t0 = air.channel.put async [%async_token_0] @ch_a[] (%alloc_0[] [] []) : (memref<32xi32, 1>)
+        %t1 = air.channel.put async [%async_token_1] @ch_b[] (%alloc_1[] [] []) : (memref<64xi32, 1>)
+        %h0 = air.herd @herd_col6 async tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+          %async_token_10, %l1_buf = air.execute -> (memref<32xi32, 2>) {
+            %b = memref.alloc() : memref<32xi32, 2>
+            air.execute_terminator %b : memref<32xi32, 2>
+          }
+          %g0 = air.channel.get async [%async_token_10] @ch_a[] (%l1_buf[] [] []) : (memref<32xi32, 2>)
+          %dealloc = air.execute [%g0] { memref.dealloc %l1_buf : memref<32xi32, 2> }
+        }
+        %h1 = air.herd @herd_col7 async tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0) attributes {x_loc = 7 : i64, y_loc = 3 : i64} {
+          %async_token_20, %l1_buf2 = air.execute -> (memref<64xi32, 2>) {
+            %b = memref.alloc() : memref<64xi32, 2>
+            air.execute_terminator %b : memref<64xi32, 2>
+          }
+          %g1 = air.channel.get async [%async_token_20] @ch_b[] (%l1_buf2[] [] []) : (memref<64xi32, 2>)
+          %dealloc = air.execute [%g1] { memref.dealloc %l1_buf2 : memref<64xi32, 2> }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_invalid.mlir
+++ b/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_invalid.mlir
@@ -1,0 +1,41 @@
+//===- l2_memtile_column_pin_invalid.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// air.memtile_col is a hint: a column with no memtile in the target warns and
+// falls through to the default assignment rather than failing. The buffer is
+// still placed on some memtile.
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=5 device=xcve2802 use-objectfifo=false" -verify-diagnostics | FileCheck %s
+
+// CHECK: aie.buffer({{.*}}) {{{.*}}} : memref<32xi32, 1>
+
+module {
+  air.channel @ch_a [1, 1]
+  func.func @invalid_pin() {
+    %c1 = arith.constant 1 : index
+    air.launch (%arg0) in (%arg1=%c1) {
+      air.segment @segment_0 attributes {x_size = 3 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_0, %alloc_0 = air.execute -> (memref<32xi32, 1>) {
+          // expected-warning @+1 {{air.memtile_col=999 has no memtile in target; ignoring}}
+          %a = memref.alloc() {air.memtile_col = 999 : i32} : memref<32xi32, 1>
+          air.execute_terminator %a : memref<32xi32, 1>
+        }
+        %t0 = air.channel.put async [%async_token_0] @ch_a[] (%alloc_0[] [] []) : (memref<32xi32, 1>)
+        %h0 = air.herd @herd_0 async tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+          %async_token_10, %l1 = air.execute -> (memref<32xi32, 2>) {
+            %b = memref.alloc() : memref<32xi32, 2>
+            air.execute_terminator %b : memref<32xi32, 2>
+          }
+          %g = air.channel.get async [%async_token_10] @ch_a[] (%l1[] [] []) : (memref<32xi32, 2>)
+          %d = air.execute [%g] { memref.dealloc %l1 : memref<32xi32, 2> }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_mt_hop.mlir
+++ b/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_mt_hop.mlir
@@ -1,0 +1,55 @@
+//===- l2_memtile_column_pin_mt_hop.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Two L2 buffers that share ONE air.channel (@ch_mid, the intermediate of an
+// L3 -> L2 -> L2 -> L1 hop) normally merge into a single bucket and collapse
+// onto one memtile. Distinct `air.memtile_col` pins refuse that merge, so the
+// shared channel becomes a real cross-memtile (MT->MT) flow: alloc_0 lands on
+// column 7 and alloc_1 on column 5.
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=5 device=xcve2802 use-objectfifo=false" | FileCheck %s
+
+// CHECK-DAG: %[[M7:.*]] = aie.logical_tile<MemTile>(7, ?)
+// CHECK-DAG: %[[M5:.*]] = aie.logical_tile<MemTile>(5, ?)
+// CHECK-DAG: aie.buffer(%[[M7]]) {{{.*}}} : memref<32xi32, 1>
+// CHECK-DAG: aie.buffer(%[[M5]]) {{{.*}}} : memref<64xi32, 1>
+
+module {
+  air.channel @ch_in [1, 1]
+  air.channel @ch_mid [1, 1]
+  air.channel @ch_out [1, 1]
+  func.func @mt_hop(%ext : memref<32xi32>) {
+    %c1 = arith.constant 1 : index
+    air.launch (%arg0) in (%arg1=%c1) args(%e=%ext) : memref<32xi32> {
+      %p = air.channel.put async @ch_in[] (%e[] [] []) : (memref<32xi32>)
+      air.segment @segment_0 attributes {x_size = 3 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %async_token_0, %alloc_0 = air.execute -> (memref<32xi32, 1>) {
+          %a = memref.alloc() {air.memtile_col = 7 : i32} : memref<32xi32, 1>
+          air.execute_terminator %a : memref<32xi32, 1>
+        }
+        %g_in = air.channel.get async [%async_token_0] @ch_in[] (%alloc_0[] [] []) : (memref<32xi32, 1>)
+        %p_mid = air.channel.put async [%g_in] @ch_mid[] (%alloc_0[] [] []) : (memref<32xi32, 1>)
+        %async_token_1, %alloc_1 = air.execute -> (memref<64xi32, 1>) {
+          %a = memref.alloc() {air.memtile_col = 5 : i32} : memref<64xi32, 1>
+          air.execute_terminator %a : memref<64xi32, 1>
+        }
+        %g_mid = air.channel.get async [%async_token_1] @ch_mid[] (%alloc_1[] [] []) : (memref<64xi32, 1>)
+        %p_out = air.channel.put async [%g_mid] @ch_out[] (%alloc_1[] [] []) : (memref<64xi32, 1>)
+        %h0 = air.herd @herd_0 async tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+          %async_token_10, %l1 = air.execute -> (memref<64xi32, 2>) {
+            %b = memref.alloc() : memref<64xi32, 2>
+            air.execute_terminator %b : memref<64xi32, 2>
+          }
+          %g = air.channel.get async [%async_token_10] @ch_out[] (%l1[] [] []) : (memref<64xi32, 2>)
+          %d = air.execute [%g] { memref.dealloc %l1 : memref<64xi32, 2> }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_saturation.mlir
+++ b/mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin_saturation.mlir
@@ -1,0 +1,66 @@
+//===- l2_memtile_column_pin_saturation.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Pins are honored even when placement falls back to the round-robin
+// "saturation" path. Here two unpinned buckets both derive column 6 (their
+// consumer herds are at col 6), which saturates that column and forces the
+// round-robin fallback. The pinned bucket (64xi32, col 5) is excluded from the
+// saturation trigger and still routes to column 5 via findOrCreateLtoForCol;
+// the unpinned 32xi32 buffers distribute across the pool.
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=5 device=xcve2802 use-objectfifo=false" | FileCheck %s
+
+// CHECK-DAG: %[[M5:.*]] = aie.logical_tile<MemTile>(5, ?)
+// CHECK-DAG: aie.buffer(%[[M5]]) {{{.*}}} : memref<64xi32, 1>
+
+module {
+  air.channel @ch_a [1, 1]
+  air.channel @ch_b [1, 1]
+  air.channel @ch_c [1, 1]
+  func.func @sat_pin() {
+    %c1 = arith.constant 1 : index
+    air.launch (%arg0) in (%arg1=%c1) {
+      air.segment @segment_0 attributes {x_size = 4 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %ta, %a = air.execute -> (memref<32xi32, 1>) {
+          %x = memref.alloc() : memref<32xi32, 1>
+          air.execute_terminator %x : memref<32xi32, 1>
+        }
+        %tb, %b = air.execute -> (memref<32xi32, 1>) {
+          %x = memref.alloc() : memref<32xi32, 1>
+          air.execute_terminator %x : memref<32xi32, 1>
+        }
+        %tc, %c = air.execute -> (memref<64xi32, 1>) {
+          %x = memref.alloc() {air.memtile_col = 5 : i32} : memref<64xi32, 1>
+          air.execute_terminator %x : memref<64xi32, 1>
+        }
+        %pa = air.channel.put async [%ta] @ch_a[] (%a[] [] []) : (memref<32xi32, 1>)
+        %pb = air.channel.put async [%tb] @ch_b[] (%b[] [] []) : (memref<32xi32, 1>)
+        %pc = air.channel.put async [%tc] @ch_c[] (%c[] [] []) : (memref<64xi32, 1>)
+        %ha = air.herd @herd_a async tile (%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+          %t, %l = air.execute -> (memref<32xi32, 2>) { %z = memref.alloc() : memref<32xi32, 2>
+            air.execute_terminator %z : memref<32xi32, 2> }
+          %g = air.channel.get async [%t] @ch_a[] (%l[] [] []) : (memref<32xi32, 2>)
+          %d = air.execute [%g] { memref.dealloc %l : memref<32xi32, 2> }
+        }
+        %hb = air.herd @herd_b async tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0) attributes {x_loc = 6 : i64, y_loc = 4 : i64} {
+          %t, %l = air.execute -> (memref<32xi32, 2>) { %z = memref.alloc() : memref<32xi32, 2>
+            air.execute_terminator %z : memref<32xi32, 2> }
+          %g = air.channel.get async [%t] @ch_b[] (%l[] [] []) : (memref<32xi32, 2>)
+          %d = air.execute [%g] { memref.dealloc %l : memref<32xi32, 2> }
+        }
+        %hc = air.herd @herd_c async tile (%tx3, %ty3) in (%sx3=%c1_0, %sy3=%c1_0) attributes {x_loc = 7 : i64, y_loc = 3 : i64} {
+          %t, %l = air.execute -> (memref<64xi32, 2>) { %z = memref.alloc() : memref<64xi32, 2>
+            air.execute_terminator %z : memref<64xi32, 2> }
+          %g = air.channel.get async [%t] @ch_c[] (%l[] [] []) : (memref<64xi32, 2>)
+          %d = air.execute [%g] { memref.dealloc %l : memref<64xi32, 2> }
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
Adds an `air.memtile_col` IntegerAttr on an L2 `memref.alloc` to pin the memtile column its bucket lands on in `L2MemrefToMemTileMap`, overriding the default round-robin / column-affinity assignment.

- **Hint-only**: invalid columns (no memtile in the target) warn and fall through; strict-first-wins on conflict within a bucket.
- **Pin-aware bucketing**: two L2 buffers sharing one `air.channel` but carrying distinct pins are refused a merge, so they land in different buckets and the shared channel becomes a real cross-memtile flow. This makes explicit memtile→memtile hops expressible.
- Pins are honored on **both** the column-affinity path and the saturation path (the latter now routes pinned buckets through `findOrCreateLtoForCol`).

Without this, designs that must spread L2 aggregator buffers across specific memtile columns collapse onto too few memtiles and can exhaust a memtile channel's BD-ID budget.

## Test plan
- [x] New lit test `mlir/test/Conversion/AIRToAIE/l2_memtile_column_pin.mlir`: two allocs pinned to distinct columns (7 and 5) lower to `MemTile(7, ?)` / `MemTile(5, ?)`; passes with the change, fails without (stock places them by affinity).
- [x] `ninja check-air-mlir` — no new failures (pre-existing Util/Channel env failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)