### PR TITLE
[AIRToAIE] Keep air.refeed_count buffers single-buffer under v2 chain-lock

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5836,7 +5836,14 @@ public:
                       "v2 chain-lock: failed to look up chain lock set "
                       "for ping-pong twin");
                 air::ChainLockSet *cls = clsOrFail.value();
-                if (cls->pp_slots == 1) {
+                // A buffer carrying air.refeed_count is a single-buffer
+                // counting-lock re-broadcast: the resident data is re-sent N
+                // times without a refill. Allocating a 2-slot ping-pong twin
+                // would deadlock, since the second (pong) slot is never filled
+                // when the producer emits a single token. Keep refeed buffers
+                // single-buffer.
+                if (cls->pp_slots == 1 &&
+                    !primaryBuf->hasAttr(air::attrs::RefeedCount)) {
                   AIE::BufferOp twin = allocateBufferOp(
                       this->BufferId, primaryBuf.getType(), tile,
                       /*attr=*/nullptr, /*x=*/-1, /*y=*/-1);

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -5837,13 +5837,13 @@ public:
                       "for ping-pong twin");
                 air::ChainLockSet *cls = clsOrFail.value();
                 // A buffer carrying air.refeed_count is a single-buffer
-                // counting-lock re-broadcast: the resident data is re-sent N
+                // count-free re-broadcast: the resident data is re-sent N
                 // times without a refill. Allocating a 2-slot ping-pong twin
                 // would deadlock, since the second (pong) slot is never filled
                 // when the producer emits a single token. Keep refeed buffers
                 // single-buffer.
                 if (cls->pp_slots == 1 &&
-                    !primaryBuf->hasAttr(air::attrs::RefeedCount)) {
+                    air::getRefeedCount(primaryBuf.getOperation()) <= 1) {
                   AIE::BufferOp twin = allocateBufferOp(
                       this->BufferId, primaryBuf.getType(), tile,
                       /*attr=*/nullptr, /*x=*/-1, /*y=*/-1);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -645,7 +645,8 @@ air::DMAAllocator::getOrCreateChainLockSet(AIE::BufferOp buf,
   // needs the cap_lock primed to N: the first writer acquires cap >= N, and the
   // single reader releases cap by 1 per re-send (N sends drain sig[last]=N and
   // restore cap=N). Default init=1 would deadlock the first writer's acq>=N.
-  int capInit = std::max<int64_t>(1, air::getRefeedCount(buf.getOperation()));
+  int capInit = static_cast<int>(
+      std::max<int64_t>(1, air::getRefeedCount(buf.getOperation())));
   cls.cap_lock = allocateLockOp(device, tile, /*init=*/capInit);
 
   // N init=0 signal locks for the writer→writer (or reader→reader)

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -641,7 +641,12 @@ air::DMAAllocator::getOrCreateChainLockSet(AIE::BufferOp buf,
   // activateChainPingPong, which bumps the cap and pp_slots together so the
   // slot count and buffer count never diverge.
   cls.pp_slots = 1;
-  cls.cap_lock = allocateLockOp(device, tile, /*init=*/1);
+  // A refeed buffer (air.refeed_count=N, single-buffer count-free re-broadcast)
+  // needs the cap_lock primed to N: the first writer acquires cap >= N, and the
+  // single reader releases cap by 1 per re-send (N sends drain sig[last]=N and
+  // restore cap=N). Default init=1 would deadlock the first writer's acq>=N.
+  int capInit = std::max<int64_t>(1, air::getRefeedCount(buf.getOperation()));
+  cls.cap_lock = allocateLockOp(device, tile, /*init=*/capInit);
 
   // N init=0 signal locks for the writer→writer (or reader→reader)
   // transitions plus the producer→consumer (or last-reader→producer)

--- a/mlir/test/Conversion/AIRToAIE/memtile_chain_lock_v2_refeed.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_chain_lock_v2_refeed.mlir
@@ -1,0 +1,109 @@
+//===- memtile_chain_lock_v2_refeed.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="use-lock-race-condition-fix-v2=true row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// A memtile buffer carrying `air.refeed_count = N` is a single-buffer
+// count-free re-broadcast: the resident data is re-sent N times without a
+// refill. Under the v2 chain-lock this must NOT become a 2-slot ping-pong
+// (the pong slot would never fill), so:
+//   1. The cap_lock is primed to init=N (here 3), not the ping-pong init=2.
+//   2. Exactly ONE buffer instance is allocated (no twin).
+//   3. The reader BD chain is a single self-looping BD (next_bd back to
+//      itself), not a two-BD alternation between primary and twin.
+// This is the same fan-in shape as the ping-pong test, plus air.refeed_count.
+
+// CHECK: aie.device
+// CHECK-DAG: %[[MT:.*]] = aie.logical_tile<MemTile>(?, ?)
+
+// cap_lock primed to the refeed count (init=3), not the ping-pong init=2.
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 3 : i32}
+// CHECK-NOT: aie.lock(%[[MT]], {{[0-9]+}}) {init = 2 : i32}
+
+// Single buffer instance (no ping-pong twin), carrying the refeed count.
+// CHECK: aie.buffer(%[[MT]]) {air.refeed_count = 3 : i32, {{.*}} : memref<4x8xbf16, 1
+
+// The reader BD self-loops (single-buffer ring), not a 2-BD alternation.
+// CHECK: aie.memtile_dma(%[[MT]])
+// CHECK: %[[BB:.*]] = aie.dma_start(MM2S, 0, ^[[LOOP:.*]], ^{{.*}})
+// CHECK: ^[[LOOP]]:
+// CHECK: aie.dma_bd({{.*}} : memref<4x8xbf16, 1
+// CHECK: aie.next_bd ^[[LOOP]]
+
+air.channel @w0 [1, 1]
+air.channel @w1 [1, 1]
+air.channel @w2 [1, 1]
+air.channel @w3 [1, 1]
+air.channel @r0 [1, 1]
+func.func @memtile_chain_refeed_v2() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c3 = arith.constant 3 : index
+      %c8 = arith.constant 8 : index
+      %t, %l2 = air.execute -> (memref<4x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split, air.refeed_count = 3 : i32} : memref<4x8xbf16, 1>
+        air.execute_terminator %alloc : memref<4x8xbf16, 1>
+      }
+      air.channel.get @w0[] (%l2[%c0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w1[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w2[] (%l2[%c2, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w3[] (%l2[%c3, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<4x8xbf16, 1>)
+      %d_ = air.execute {memref.dealloc %l2 : memref<4x8xbf16, 1>}
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w1[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h2 tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0)
+            attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w2[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d2 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h3 tile (%tx3, %ty3) in (%sx3=%c1_0, %sy3=%c1_0)
+            attributes {x_loc = 5 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w3[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d3 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<32xbf16, 2>) {
+          %aa = memref.alloc() : memref<32xbf16, 2>
+          air.execute_terminator %aa : memref<32xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<32xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<32xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/memtile_chain_lock_v2_refeed.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_chain_lock_v2_refeed.mlir
@@ -24,8 +24,11 @@
 // CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 3 : i32}
 // CHECK-NOT: aie.lock(%[[MT]], {{[0-9]+}}) {init = 2 : i32}
 
-// Single buffer instance (no ping-pong twin), carrying the refeed count.
-// CHECK: aie.buffer(%[[MT]]) {air.refeed_count = 3 : i32, {{.*}} : memref<4x8xbf16, 1
+// Exactly ONE buffer instance on the memtile (no ping-pong twin), carrying the
+// refeed count. Attribute order is not guaranteed, so match the attr loosely.
+// CHECK-COUNT-1: aie.buffer(%[[MT]])
+// CHECK-SAME: air.refeed_count = 3 : i32
+// CHECK-NOT: aie.buffer(%[[MT]])
 
 // The reader BD self-loops (single-buffer ring), not a 2-BD alternation.
 // CHECK: aie.memtile_dma(%[[MT]])


### PR DESCRIPTION
## Summary
A memtile buffer carrying `air.refeed_count = N` is a single-buffer, count-free re-broadcast: the resident data is re-sent N times without a refill. Under the v2 chain-lock this needs two adjustments so it doesn't get turned into a ping-pong (which deadlocks):

- `getOrCreateChainLockSet` primes the `cap_lock` to `init = max(1, refeed_count)` instead of `1`, so the first writer's `acquire >= N` doesn't deadlock and the single reader releases the cap by one per re-send.
- Ping-pong activation is skipped for refeed buffers: allocating a 2-slot twin would deadlock because the second (pong) slot is never filled when the producer emits a single token.

Composes with the existing v2 chain-lock (`use-lock-race-condition-fix-v2`) and `air.refeed_count` support.

## Test plan
- [x] New lit test `mlir/test/Conversion/AIRToAIE/memtile_chain_lock_v2_refeed.mlir`: fan-in shape + `air.refeed_count = 3` → cap_lock `init = 3` (not the ping-pong `init = 2`), a single buffer instance (no twin), and a self-looping reader BD. Passes with the change, fails without.
- [x] `ninja check-air-mlir` — no new failures (pre-existing Util/Channel env failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)