### PR TITLE
Test new CI runner

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ amd8845hs, amdhx370 ]
+        runner_type: [ amdryzenai5pro340 ]
 
     steps:
 


### PR DESCRIPTION
The new runner has the label `amdryzenai5pro340`. Changes a GitHub workflow to use tag, to test whether it will pick up jobs and whether it works.