### PR TITLE
[aircc] Add PDI output format for alternative runtimes on npu1

### DIFF
--- a/mlir/test/aircc/error_invalid_format.mlir
+++ b/mlir/test/aircc/error_invalid_format.mlir
@@ -9,7 +9,7 @@
 
 // RUN: not aircc %s --device=npu1 --output-format=elf --tmpdir=%t 2>&1 | FileCheck %s
 
-// CHECK: Error: output_format='elf' is not supported for npu1
+// CHECK: Error: --output-format=elf is not supported for --device=npu1
 
 module {
   func.func @copy(%arg0: memref<1024xui8>, %arg1: memref<1024xui8>) {

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -529,6 +529,15 @@ class XRTBackend(AirBackend):
                 f"Cannot load XRTCompileArtifact because {artifact.output_binary} file does not exist"
             )
 
+        # PDI artifacts are intended for alternative (non-XRT) runtimes and
+        # cannot be loaded via this XRT-based load() path.
+        if artifact.output_binary.endswith(".pdi"):
+            raise AirBackendError(
+                "output_format='pdi' produces artifacts for alternative runtimes "
+                "and cannot be loaded via XRTBackend.load(). Pass the .pdi file "
+                "and accompanying .insts.bin to your target runtime directly."
+            )
+
         # Determine the loading mode based on file extension
         is_elf = artifact.output_binary.endswith(".elf")
 

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -238,11 +238,14 @@ class XRTBackend(AirBackend):
                     print("Failed to run xrt-smi, using default target device")
                     print(e)
 
-        # Validate output_format compatibility with target device
+        # Validate output_format compatibility with target device.
+        # Full ELF requires aiebu-asm aie2_config which targets npu2/AIE2P only.
+        # PDI output works on all NPU generations.
         if self.output_format == "elf" and "npu1" in target_device:
             raise AirBackendError(
                 f"output_format='elf' is not supported for {target_device} target. "
-                "ELF output format is only supported on npu2 and later devices."
+                "ELF output format is only supported on npu2 and later devices. "
+                "Use output_format='pdi' for a raw PDI alongside the NPU instruction sequence."
             )
 
         # Apply user-specified device column configuration if provided
@@ -277,6 +280,8 @@ class XRTBackend(AirBackend):
             output_binary = f"{output_binary_name}.elf"
         elif self.output_format == "txn":
             output_binary = f"{output_binary_name}.txn"
+        elif self.output_format == "pdi":
+            output_binary = f"{output_binary_name}.pdi"
         else:  # xclbin (default)
             output_binary = f"{output_binary_name}.xclbin"
 
@@ -297,6 +302,9 @@ class XRTBackend(AirBackend):
                 aircc_options += ["--elf-name", output_binary]
                 # Note: ELF mode features (main device wrapper, load_pdi) are
                 # automatically enabled by --output-format=elf in aircc
+            elif self.output_format == "pdi":
+                aircc_options += ["--pdi-name", output_binary]
+                aircc_options += ["-i", insts]
             else:
                 aircc_options += ["-o", output_binary]
                 aircc_options += ["-i", insts]

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -247,13 +247,17 @@ static cl::opt<PlacedIrVerifyMode> placedIrVerifiers(
                           "Run; error on undecidable cases.")),
     cl::init(PIV_error), cl::cat(airCompilerOptions));
 
-enum OutputFormatKind { OF_xclbin, OF_txn, OF_elf, OF_none };
+enum OutputFormatKind { OF_xclbin, OF_txn, OF_elf, OF_pdi, OF_none };
 
 static cl::opt<OutputFormatKind> outputFormat(
     "output-format", cl::desc("Output format for the generated binary"),
     cl::values(clEnumValN(OF_xclbin, "xclbin", "Generate xclbin"),
                clEnumValN(OF_txn, "txn", "Generate transaction binary"),
-               clEnumValN(OF_elf, "elf", "Generate ELF"),
+               clEnumValN(OF_elf, "elf",
+                          "Generate full ELF (npu2 and later only)"),
+               clEnumValN(OF_pdi, "pdi",
+                          "Generate PDI binary alongside NPU instruction "
+                          "sequence (for alternative runtimes)"),
                clEnumValN(OF_none, "none", "Compile-only, no binary output")),
     cl::init(OF_xclbin), cl::cat(airCompilerOptions));
 
@@ -280,6 +284,11 @@ static cl::opt<std::string>
     elfName("elf-name",
             cl::desc("Output filename for full ELF (--output-format=elf)"),
             cl::init("aie.elf"), cl::cat(airCompilerOptions));
+
+static cl::opt<std::string>
+    pdiName("pdi-name",
+            cl::desc("Output filename for PDI binary (--output-format=pdi)"),
+            cl::init("aie.pdi"), cl::cat(airCompilerOptions));
 
 static cl::opt<bool>
     debugIr("debug-ir",
@@ -924,11 +933,14 @@ static LogicalResult runAieCompilation() {
                  << deviceName.getValue() << "\n";
   }
 
-  // Validate output format
+  // Validate output format: full ELF requires aiebu-asm aie2_config which
+  // targets npu2/AIE2P and is not supported on npu1/Phoenix.
   if (outputFormat == OF_elf &&
       deviceName.getValue().find("npu1") != std::string::npos) {
     llvm::errs() << "Error: output_format='elf' is not supported for "
-                 << deviceName.getValue() << " target.\n";
+                 << deviceName.getValue()
+                 << " target. Use output_format='xclbin' (default) or "
+                    "output_format='pdi' for npu1.\n";
     return failure();
   }
 
@@ -1241,17 +1253,22 @@ static LogicalResult runAieCompilation() {
       aieccCmd.push_back("--xclbin-name=" + xclbinFile);
     } else if (outputFormat == OF_txn) {
       aieccCmd.push_back("--aie-generate-txn");
+    } else if (outputFormat == OF_pdi) {
+      aieccCmd.push_back("--aie-generate-pdi");
+      aieccCmd.push_back("--pdi-name=" + pdiName.getValue());
     }
     // OF_none = no output generation options
 
-    // NPU instruction generation (not for ELF mode)
+    // NPU instruction generation (not for ELF mode, which embeds sequences).
+    // PDI mode still needs the instruction sequence as a sidecar file for the
+    // alternative runtime to program shim DMAs at dispatch time.
     if (outputFormat != OF_elf) {
       aieccCmd.push_back("--aie-generate-npu-insts");
       aieccCmd.push_back("--npu-insts-name=" + instsFile);
     }
 
-    // Xclbin metadata (not for ELF mode)
-    if (outputFormat != OF_elf) {
+    // Xclbin metadata (xclbin mode only)
+    if (outputFormat == OF_xclbin) {
       if (!kernelName.empty())
         aieccCmd.push_back("--xclbin-kernel-name=" + kernelName.getValue());
       if (!instanceName.empty())

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -937,10 +937,10 @@ static LogicalResult runAieCompilation() {
   // targets npu2/AIE2P and is not supported on npu1/Phoenix.
   if (outputFormat == OF_elf &&
       deviceName.getValue().find("npu1") != std::string::npos) {
-    llvm::errs() << "Error: output_format='elf' is not supported for "
+    llvm::errs() << "Error: --output-format=elf is not supported for --device="
                  << deviceName.getValue()
-                 << " target. Use output_format='xclbin' (default) or "
-                    "output_format='pdi' for npu1.\n";
+                 << ". Use --output-format=xclbin (default) or "
+                    "--output-format=pdi for npu1.\n";
     return failure();
   }
 
@@ -1259,10 +1259,13 @@ static LogicalResult runAieCompilation() {
     }
     // OF_none = no output generation options
 
-    // NPU instruction generation (not for ELF mode, which embeds sequences).
-    // PDI mode still needs the instruction sequence as a sidecar file for the
-    // alternative runtime to program shim DMAs at dispatch time.
-    if (outputFormat != OF_elf) {
+    // NPU instruction generation.
+    // - ELF: sequences are embedded in the ELF by aiebu-asm, skip.
+    // - none: compile-only, no binary output requested, skip.
+    // - PDI: sidecar insts file needed by the alternative runtime to program
+    //   shim DMAs at dispatch time.
+    // - xclbin/txn: always needed.
+    if (outputFormat != OF_elf && outputFormat != OF_none) {
       aieccCmd.push_back("--aie-generate-npu-insts");
       aieccCmd.push_back("--npu-insts-name=" + instsFile);
     }


### PR DESCRIPTION
## Summary

- Adds `--output-format=pdi` to `aircc` and `output_format='pdi'` to `XRTBackend`, exposing raw PDI output for alternative runtimes (non-XRT) that can directly load PDI binaries on npu1/Phoenix
- PDI output produces `<name>.pdi` (via the existing CDO→bootgen path, already the internal intermediate in the xclbin flow) alongside `<name>.insts.bin` (the NPU instruction sequence sidecar any runtime needs to program shim DMAs at dispatch time)
- Narrows the npu1 exclusion guard to `output-format=elf` only — ELF requires `aiebu-asm aie2_config` which targets npu2/AIE2P; PDI generation via bootgen works on all NPU generations
- Fixes xclbin metadata flags (`--xclbin-kernel-name`, `--xclbin-instance-name`, `--xclbin-kernel-id`, `--xclbin-input`) being incorrectly forwarded to aiecc for `txn` and (now) `pdi` modes; they are now gated on `OF_xclbin` only

Motivated by [amd/Triton-XDNA#53](https://github.com/amd/Triton-XDNA/issues/53).

## Test plan

- [ ] Verify `aircc --output-format=pdi --device=npu1 input.mlir` produces `aie.pdi` + `insts.bin` alongside each other
- [ ] Verify `aircc --output-format=elf --device=npu1 input.mlir` still errors with an informative message pointing to `pdi` as the alternative
- [ ] Verify existing `xclbin` and `txn` paths are unaffected
- [ ] CI: `ninja check-air-mlir check-air-python`

🤖 Generated with [Claude Code](https://claude.com/claude-code)