### PR TITLE
[CI] Nightly LLM perf benchmark on Krackan Point runner

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -30,13 +30,15 @@ env:
   XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
   VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
   # Pinned run params, shared across the benchmark + extract steps for
-  # run-to-run comparability (single source of truth).
+  # run-to-run comparability (single source of truth). Model is data, not a
+  # fixed name — add further models incrementally without renaming anything.
+  BENCH_MODEL: llama32_1b
   BENCH_PROMPT: What is the capital of France?
   BENCH_N_TOKENS: "128"
 
 jobs:
   benchmark:
-    name: Nightly LLM Perf Benchmark (llama32_1b)
+    name: LLM perf benchmark
     runs-on: amdryzenai5pro340
 
     steps:
@@ -142,9 +144,8 @@ jobs:
           source /opt/xilinx/xrt/setup.sh
           export PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie
 
-          pip install -r programming_examples/llms/llama32_1b/requirements.txt
-
-          MODEL_DIR=programming_examples/llms/llama32_1b
+          MODEL_DIR=programming_examples/llms/$BENCH_MODEL
+          pip install -r $MODEL_DIR/requirements.txt
 
           # Correctness gate — perf on wrong output is meaningless.
           make -C $MODEL_DIR compile PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR
@@ -163,7 +164,7 @@ jobs:
           : "${MLIR_AIE_HASH:?HASH not found in utils/clone-mlir-aie.sh}"
           LLVM_AIE_VERSION=$(python3 -m pip show llvm-aie | awk '/^Version:/{print $2}')
           python3 programming_examples/llms/bench/extract_perf.py profile.txt \
-            --model llama32_1b \
+            --model "$BENCH_MODEL" \
             --runner amdryzenai5pro340 \
             --mlir-air-sha "${{ github.sha }}" \
             --mlir-aie-hash "$MLIR_AIE_HASH" \
@@ -179,7 +180,9 @@ jobs:
         run: |
           source air-venv/bin/activate
           {
-            echo "### Nightly LLM Perf Benchmark — llama32_1b"
+            echo "### LLM perf benchmark"
+            echo ""
+            echo "Model: \`$BENCH_MODEL\`"
             echo ""
             if [ -f perf.json ]; then
               TTFT=$(python3 -c "import json;print(json.load(open('perf.json'))['metrics']['ttft_ms'])")
@@ -198,7 +201,7 @@ jobs:
       - name: Upload perf artifact
         uses: actions/upload-artifact@v4
         with:
-          name: llama32_1b-perf-${{ github.run_id }}
+          name: perf-${{ env.BENCH_MODEL }}-${{ github.run_id }}
           path: |
             perf.json
             profile.txt

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -29,6 +29,10 @@ env:
   DEBIAN_FRONTEND: noninteractive
   XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
   VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
+  # Pinned run params, shared across the benchmark + extract steps for
+  # run-to-run comparability (single source of truth).
+  BENCH_PROMPT: What is the capital of France?
+  BENCH_N_TOKENS: "128"
 
 jobs:
   benchmark:
@@ -141,7 +145,6 @@ jobs:
           pip install -r programming_examples/llms/llama32_1b/requirements.txt
 
           MODEL_DIR=programming_examples/llms/llama32_1b
-          PROMPT="What is the capital of France?"
 
           # Correctness gate — perf on wrong output is meaningless.
           make -C $MODEL_DIR compile PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR
@@ -149,13 +152,16 @@ jobs:
 
           # Perf capture — pinned MODEL/N_TOKENS/PROMPT for run-to-run comparability.
           make -C $MODEL_DIR profile PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR \
-            MODEL=base N_TOKENS=128 PROMPT="$PROMPT" | tee profile.txt
+            MODEL=base N_TOKENS="$BENCH_N_TOKENS" PROMPT="$BENCH_PROMPT" | tee profile.txt
 
       - name: Extract perf numbers
         run: |
           source air-venv/bin/activate
-          MLIR_AIE_HASH=$(grep -m1 -oP '(^|\s)HASH=\K[0-9a-f]+' utils/clone-mlir-aie.sh)
-          LLVM_AIE_VERSION=$(python3 -m pip show llvm-aie | grep ^Version: | awk '{print $2}')
+          # Portable extraction (no GNU-only grep -P); fails the step if the
+          # HASH line ever disappears from clone-mlir-aie.sh.
+          MLIR_AIE_HASH=$(awk -F= '$1 ~ /(^| )HASH$/ {print $2; exit}' utils/clone-mlir-aie.sh)
+          : "${MLIR_AIE_HASH:?HASH not found in utils/clone-mlir-aie.sh}"
+          LLVM_AIE_VERSION=$(python3 -m pip show llvm-aie | awk '/^Version:/{print $2}')
           python3 programming_examples/llms/bench/extract_perf.py profile.txt \
             --model llama32_1b \
             --runner amdryzenai5pro340 \
@@ -163,8 +169,8 @@ jobs:
             --mlir-aie-hash "$MLIR_AIE_HASH" \
             --llvm-aie-version "$LLVM_AIE_VERSION" \
             --model-variant base \
-            --n-tokens 128 \
-            --prompt "What is the capital of France?" \
+            --n-tokens "$BENCH_N_TOKENS" \
+            --prompt "$BENCH_PROMPT" \
             > perf.json
           cat perf.json
 

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -1,0 +1,198 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Nightly LLM end-to-end performance benchmark on the dedicated Krackan Point
+# runner (Ryzen AI 5 PRO 340, label `amdryzenai5pro340`). Runs the correctness
+# gate (verify) then captures perf (profile), extracts the end-to-end latency
+# numbers into perf.json, and uploads it as an artifact. Kept out of the per-PR
+# matrix so perf numbers are contention-free.
+#
+# PR #1 of 2: capture + upload artifact only. A later PR wires up GitHub Pages
+# rendering of the history.
+
+name: Nightly LLM Perf Benchmark
+
+on:
+  schedule:
+    - cron: '17 4 * * *'  # Daily at 04:17 (off-:00 to avoid CI fleet pile-up)
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: nightly-perf-benchmark
+  cancel-in-progress: false
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  XILINXD_LICENSE_FILE: /opt/xilinx/Xilinx.lic
+  VITIS: /opt/ryzen_ai-1.3.0.1/vitis_aie_essentials
+
+jobs:
+  benchmark:
+    name: Nightly LLM Perf Benchmark (llama32_1b)
+    runs-on: amdryzenai5pro340
+
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: "true"
+
+      - name: Setup environment
+        run: |
+          python3.12 -m venv air-venv
+          source air-venv/bin/activate
+          pip cache purge
+          pip install --upgrade pip
+          pip install lit cmake joblib
+          pip install --pre torch-mlir torchvision \
+            --index-url https://download.pytorch.org/whl/nightly/cpu \
+            -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+
+      - name: Get mlir-aie
+        run: |
+          utils/clone-mlir-aie.sh
+          source air-venv/bin/activate
+          pushd mlir-aie
+          pip install -r python/requirements.txt
+          pip install -r python/requirements_ml.txt
+          pip install "torchvision==0.27.1+cpu" --index-url https://download.pytorch.org/whl/cpu
+          pip install -r python/requirements_dev.txt
+
+          VERSION=$(utils/clone-llvm.sh --get-wheel-version)
+          pip -q download mlir==$VERSION \
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+          unzip -q mlir-*.whl
+          find mlir -exec touch -a -m -t 201108231405.14 {} \;
+
+          popd
+
+      - name: Install mlir-aie from wheel
+        run: |
+          source air-venv/bin/activate
+          MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
+          pip install mlir_aie==$MLIR_AIE_VERSION \
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+
+      - name: Get llvm-aie
+        run: |
+          source air-venv/bin/activate
+          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+      - name: Build mlir-air
+        run: |
+          source air-venv/bin/activate
+
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
+          source /opt/xilinx/xrt/setup.sh
+
+          WHL_MLIR_DIR=$(pwd)/mlir-aie/mlir
+          MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
+          PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie
+          CMAKEMODULES_DIR=$(pwd)/mlir-aie/cmake/modulesXilinx
+
+          mkdir -p build_assert
+          pushd build_assert
+
+          sudo prlimit -lunlimited --pid $$
+
+          cmake .. \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DPython3_EXECUTABLE=$(which python) \
+            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_ASM_COMPILER=clang \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/ \
+            -DLLVM_EXTERNAL_LIT=$(which lit) \
+            -DLLVM_DIR=${WHL_MLIR_DIR}/lib/cmake/llvm \
+            -DMLIR_DIR=${WHL_MLIR_DIR}/lib/cmake/mlir \
+            -DAIE_DIR=${MLIR_AIE_INSTALL_DIR}/lib/cmake/aie \
+            -Dx86_64_TOOLCHAIN_FILE=$PWD/../cmake/modules/toolchain_x86_64.cmake \
+            -DAIR_RUNTIME_TARGETS:STRING="x86_64" \
+            -DXRT_ROOT=/opt/xilinx/xrt \
+            -DENABLE_RUN_XRT_TESTS=ON \
+            -DPEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}
+          ninja install
+
+          pip install $PWD/../python/spensor
+          popd
+
+      - name: Run benchmark (verify gate + profile capture)
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          source air-venv/bin/activate
+
+          export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
+          source /opt/xilinx/xrt/setup.sh
+          export PEANO_INSTALL_DIR=$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie
+
+          pip install -r programming_examples/llms/llama32_1b/requirements.txt
+
+          MODEL_DIR=programming_examples/llms/llama32_1b
+          PROMPT="What is the capital of France?"
+
+          # Correctness gate — perf on wrong output is meaningless.
+          make -C $MODEL_DIR compile PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR
+          make -C $MODEL_DIR verify  PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR
+
+          # Perf capture — pinned MODEL/N_TOKENS/PROMPT for run-to-run comparability.
+          make -C $MODEL_DIR profile PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR \
+            MODEL=base N_TOKENS=128 PROMPT="$PROMPT" | tee profile.txt
+
+      - name: Extract perf numbers
+        run: |
+          source air-venv/bin/activate
+          MLIR_AIE_HASH=$(grep -m1 -oP '(^|\s)HASH=\K[0-9a-f]+' utils/clone-mlir-aie.sh)
+          LLVM_AIE_VERSION=$(python3 -m pip show llvm-aie | grep ^Version: | awk '{print $2}')
+          python3 programming_examples/llms/bench/extract_perf.py profile.txt \
+            --model llama32_1b \
+            --runner amdryzenai5pro340 \
+            --mlir-air-sha "${{ github.sha }}" \
+            --mlir-aie-hash "$MLIR_AIE_HASH" \
+            --llvm-aie-version "$LLVM_AIE_VERSION" \
+            --model-variant base \
+            --n-tokens 128 \
+            --prompt "What is the capital of France?" \
+            > perf.json
+          cat perf.json
+
+      - name: Job summary
+        if: always()
+        run: |
+          source air-venv/bin/activate
+          {
+            echo "### Nightly LLM Perf Benchmark — llama32_1b"
+            echo ""
+            if [ -f perf.json ]; then
+              TTFT=$(python3 -c "import json;print(json.load(open('perf.json'))['metrics']['ttft_ms'])")
+              TPS=$(python3 -c "import json;print(json.load(open('perf.json'))['metrics']['decode_tokens_per_sec'])")
+              echo "**verify (correctness gate): PASS**"
+              echo ""
+              echo "| Metric | Value |"
+              echo "| --- | --- |"
+              echo "| TTFT (prefill) | ${TTFT} ms |"
+              echo "| Decode throughput | ${TPS} tok/s |"
+            else
+              echo "**FAILED before perf capture** — see step logs (verify gate or profile did not complete)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload perf artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llama32_1b-perf-${{ github.run_id }}
+          path: |
+            perf.json
+            profile.txt

--- a/programming_examples/llms/bench/extract_perf.py
+++ b/programming_examples/llms/bench/extract_perf.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Extract end-to-end latency numbers from `make profile` stdout into JSON.
+
+Decoupled from model code: parses the human-readable summary printed by the
+LLM inference scripts. Exits non-zero if an expected metric line is missing,
+so silent format drift fails the nightly instead of publishing empty numbers.
+"""
+
+import argparse
+import datetime
+import json
+import re
+import sys
+
+PREFILL_RE = re.compile(r"End-to-end \(prefill, per query\)\s+([\d.]+)\s*ms")
+DECODE_RE = re.compile(r"End-to-end \(per token\)\s+([\d.]+)\s*ms")
+
+
+def _find(pattern, text, label):
+    m = pattern.search(text)
+    if m is None:
+        sys.exit(f"error: could not find '{label}' latency line in profile output")
+    return float(m.group(1))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "input",
+        nargs="?",
+        help="profile stdout file (default: read stdin)",
+    )
+    p.add_argument("--model", default="llama32_1b")
+    p.add_argument("--runner", default="")
+    p.add_argument("--mlir-air-sha", default="")
+    p.add_argument("--mlir-aie-hash", default="")
+    p.add_argument("--llvm-aie-version", default="")
+    p.add_argument("--model-variant", default="")
+    p.add_argument("--n-tokens", type=int, default=0)
+    p.add_argument("--prompt", default="")
+    args = p.parse_args()
+
+    text = open(args.input).read() if args.input else sys.stdin.read()
+
+    # First token is produced at the end of NPU prefill, so prefill end-to-end
+    # latency is the time-to-first-token. Decode throughput is the reciprocal
+    # of per-token latency.
+    ttft_ms = _find(PREFILL_RE, text, "prefill")
+    decode_ms_per_token = _find(DECODE_RE, text, "decode")
+
+    data = {
+        "model": args.model,
+        "timestamp_utc": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "runner": args.runner,
+        "metrics": {
+            "ttft_ms": ttft_ms,
+            "decode_tokens_per_sec": round(1000.0 / decode_ms_per_token, 2),
+        },
+        "toolchain": {
+            "mlir_air_sha": args.mlir_air_sha,
+            "mlir_aie_hash": args.mlir_aie_hash,
+            "llvm_aie_version": args.llvm_aie_version,
+        },
+        "run_params": {
+            "model_variant": args.model_variant,
+            "n_tokens": args.n_tokens,
+            "prompt": args.prompt,
+        },
+    }
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/llms/bench/extract_perf.py
+++ b/programming_examples/llms/bench/extract_perf.py
@@ -41,7 +41,11 @@ def main():
     p.add_argument("--prompt", default="")
     args = p.parse_args()
 
-    text = open(args.input).read() if args.input else sys.stdin.read()
+    if args.input:
+        with open(args.input, encoding="utf-8") as f:
+            text = f.read()
+    else:
+        text = sys.stdin.read()
 
     # First token is produced at the end of NPU prefill, so prefill end-to-end
     # latency is the time-to-first-token. Decode throughput is the reciprocal


### PR DESCRIPTION
## Summary
- New scheduled workflow `nightlyPerfBenchmark.yml` (cron `17 4 * * *` + `workflow_dispatch`) on the dedicated `amdryzenai5pro340` (Ryzen AI 5 PRO 340 / Krackan Point) runner.
- Runs the `llama32_1b` **verify** correctness gate (top-k token-set vs HF bf16), then captures **profile** numbers, reporting **TTFT** (prefill) and **decode tok/s**.
- `programming_examples/llms/bench/extract_perf.py` parses `make profile` stdout into `perf.json` (metrics + mlir-air/mlir-aie/llvm-aie SHAs); a job summary surfaces PASS + the two metrics; `perf.json`+`profile.txt` uploaded as an artifact.
- Kept **out of the per-PR matrix** (`buildAndTestRyzenAI.yml` untouched) so perf is contention-free. This is PR 1 of 2 — a follow-up wires up a GitHub Pages dashboard.

## Design notes
- verify runs before profile: perf on wrong output is meaningless, so the job fails if the correctness gate fails.
- Pinned `MODEL=base N_TOKENS=128` + fixed prompt for run-to-run comparability.
- All three toolchain SHAs captured per datapoint (llvm-aie is pulled nightly, mlir-aie from pinned wheel).

## Test plan
- [x] Hardware-verified locally on NPU2 (Strix): compile OK, `[verify] PASS` (2/2 prompts), profile TTFT=1235.34 ms, decode=11.18 tok/s.
- [x] `extract_perf.py` validated against real hardware profile output (correct JSON, exit 0; exits non-zero on missing metric line).
- [ ] After merge: `gh workflow run nightlyPerfBenchmark.yml` to validate end-to-end on the runner (secrets/self-hosted runner only available post-merge on the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)