### PR TITLE
[CI] Robust offline LLM perf: fix weight download + gate tests on cached weights

### DIFF
--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -15,9 +15,10 @@
 # download landed in the cache the nightly reads.
 #
 # Uses the huggingface_hub Python API (snapshot_download / scan_cache_dir), not
-# the CLI: the `huggingface-cli` command was renamed to `hf` and now no-ops in
-# recent huggingface_hub (>=1.x), so the CLI path silently fails. The Python API
-# is stable across versions.
+# the CLI: in huggingface_hub >=1.x the command was renamed to `hf` and the
+# legacy `huggingface-cli download` invocation is deprecated -- it prints a
+# deprecation notice and no longer performs the download, so seeding fails. The
+# Python API is stable across versions.
 
 name: Download LLM Weights
 
@@ -105,7 +106,7 @@ jobs:
         run: |
           source hf-venv/bin/activate
           python3 - <<'PY'
-          import random, sys, time
+          import random, sys, time, traceback
           from huggingface_hub import snapshot_download
 
           # Weight/config/tokenizer files only.
@@ -145,6 +146,10 @@ jobs:
                       print(f"attempt {attempt} failed for {m}: "
                             f"{type(e).__name__}: {e}", flush=True)
                       if attempt == ATTEMPTS:
+                          # Full traceback on the final attempt so a non-transient
+                          # cause (auth/permission, a bug) is diagnosable from the
+                          # logs rather than hidden behind repeated str(e) lines.
+                          traceback.print_exc()
                           break
                       delay = min(300, 10 * (2 ** (attempt - 1))) + random.uniform(0, 5)
                       print(f"  retrying in {delay:.1f}s", flush=True)

--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -11,8 +11,13 @@
 #
 # Run this ONCE, and again only after adding a new model or clearing the cache.
 # It is workflow_dispatch ONLY: never scheduled, never on push/PR, so it cannot
-# slow down normal CI. The before/after `scan-cache` output is the evidence that
-# a download landed in the cache the nightly reads.
+# slow down normal CI. The before/after cache scan is the evidence that a
+# download landed in the cache the nightly reads.
+#
+# Uses the huggingface_hub Python API (snapshot_download / scan_cache_dir), not
+# the CLI: the `huggingface-cli` command was renamed to `hf` and now no-ops in
+# recent huggingface_hub (>=1.x), so the CLI path silently fails. The Python API
+# is stable across versions.
 
 name: Download LLM Weights (manual)
 
@@ -44,57 +49,82 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up huggingface_hub CLI
+      - name: Set up huggingface_hub
         run: |
           python3.12 -m venv hf-venv
           source hf-venv/bin/activate
           pip install --upgrade pip
-          pip install "huggingface_hub[cli]"
+          pip install huggingface_hub
 
       - name: Show HF cache BEFORE
         run: |
           source hf-venv/bin/activate
-          echo "HF cache dir: ${HF_HOME:-$HOME/.cache/huggingface}"
-          huggingface-cli scan-cache || echo "(cache empty or not yet created)"
+          python3 - <<'PY'
+          from huggingface_hub import scan_cache_dir
+          from huggingface_hub.utils import CacheNotFound
+          try:
+              info = scan_cache_dir()
+          except CacheNotFound:
+              print("(cache not created yet)")
+          else:
+              for r in sorted(info.repos, key=lambda r: r.repo_id):
+                  print(f"{r.repo_id:60s} {r.size_on_disk_str:>10s}  "
+                        f"revs={len(list(r.revisions))}")
+              print(f"TOTAL on disk: {info.size_on_disk_str}")
+          PY
 
       - name: Download all model weights
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source hf-venv/bin/activate
+          python3 - <<'PY'
+          import sys, time
+          from huggingface_hub import snapshot_download
 
-          # Model list lives in programming_examples/llms/hf_models.txt (single
-          # source of truth). Ignore blank lines and '#' comments.
-          list=programming_examples/llms/hf_models.txt
-          mapfile -t models < <(grep -vE '^[[:space:]]*(#|$)' "$list")
-          echo "Seeding ${#models[@]} models from $list"
+          # Weight/config/tokenizer files only (skip .pth/.gguf/.bin duplicates).
+          PATTERNS = ["*.safetensors", "*.json", "*.txt", "*.model",
+                      "tokenizer*", "*.tiktoken"]
 
-          rc=0
-          for m in "${models[@]}"; do
-            echo "::group::download $m"
-            ok=0
-            # Retry per model: the runner's HF egress drops connections at random.
-            for attempt in 1 2 3 4 5; do
-              if huggingface-cli download "$m" \
-                   --include "*.safetensors" "*.json" "*.txt" "*.model" \
-                             "tokenizer*" "*.tiktoken"; then
-                ok=1
-                break
-              fi
-              echo "attempt $attempt failed for $m; retrying in $((attempt * 15))s"
-              sleep $((attempt * 15))
-            done
-            if [ "$ok" -ne 1 ]; then
-              echo "ERROR: failed to download $m after 5 attempts"
-              rc=1
-            fi
-            echo "::endgroup::"
-          done
-          exit $rc
+          # Single source of truth for the model list.
+          models = [s.strip()
+                    for s in open("programming_examples/llms/hf_models.txt")
+                    if s.strip() and not s.strip().startswith("#")]
+          print(f"Seeding {len(models)} models", flush=True)
+
+          rc = 0
+          for m in models:
+              ok = False
+              # Retry per model: the runner's HF egress drops connections at random.
+              for attempt in range(1, 6):
+                  try:
+                      snapshot_download(m, allow_patterns=PATTERNS)
+                      print(f"OK  {m}", flush=True)
+                      ok = True
+                      break
+                  except Exception as e:
+                      print(f"attempt {attempt} failed for {m}: {e}", flush=True)
+                      time.sleep(attempt * 15)
+              if not ok:
+                  print(f"ERROR: failed to download {m} after 5 attempts", flush=True)
+                  rc = 1
+          sys.exit(rc)
+          PY
 
       - name: Show HF cache AFTER
         if: always()
         run: |
           source hf-venv/bin/activate
-          echo "HF cache dir: ${HF_HOME:-$HOME/.cache/huggingface}"
-          huggingface-cli scan-cache
+          python3 - <<'PY'
+          from huggingface_hub import scan_cache_dir
+          from huggingface_hub.utils import CacheNotFound
+          try:
+              info = scan_cache_dir()
+          except CacheNotFound:
+              print("(cache not created)")
+          else:
+              for r in sorted(info.repos, key=lambda r: r.repo_id):
+                  print(f"{r.repo_id:60s} {r.size_on_disk_str:>10s}  "
+                        f"revs={len(list(r.revisions))}")
+              print(f"TOTAL on disk: {info.size_on_disk_str}")
+          PY

--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -82,9 +82,13 @@ jobs:
           import sys, time
           from huggingface_hub import snapshot_download
 
-          # Weight/config/tokenizer files only (skip .pth/.gguf/.bin duplicates).
-          PATTERNS = ["*.safetensors", "*.json", "*.txt", "*.model",
-                      "tokenizer*", "*.tiktoken"]
+          # Weight/config/tokenizer files only.
+          ALLOW = ["*.safetensors", "*.json", "*.txt", "*.model", "*.tiktoken"]
+          # Skip files transformers/our loader never use but that otherwise make
+          # snapshot_download report the snapshot "incomplete" if they fail to
+          # fetch on the flaky link: the Llama `original/` dir (sentencepiece +
+          # consolidated.pth duplicate of the fast tokenizer) and license blurbs.
+          IGNORE = ["original/*", "LICENSE*", "USE_POLICY*"]
 
           # Single source of truth for the model list.
           models = [s.strip()
@@ -95,18 +99,24 @@ jobs:
           rc = 0
           for m in models:
               ok = False
-              # Retry per model: the runner's HF egress drops connections at random.
-              for attempt in range(1, 6):
+              # Retry per model: the runner's HF egress drops connections at
+              # random. snapshot_download resumes already-fetched files, so each
+              # attempt makes progress. max_workers=1 keeps one connection open
+              # at a time (gentler on the flaky link).
+              for attempt in range(1, 9):
                   try:
-                      snapshot_download(m, allow_patterns=PATTERNS)
+                      snapshot_download(
+                          m, allow_patterns=ALLOW, ignore_patterns=IGNORE,
+                          max_workers=1,
+                      )
                       print(f"OK  {m}", flush=True)
                       ok = True
                       break
                   except Exception as e:
                       print(f"attempt {attempt} failed for {m}: {e}", flush=True)
-                      time.sleep(attempt * 15)
+                      time.sleep(min(attempt * 15, 60))
               if not ok:
-                  print(f"ERROR: failed to download {m} after 5 attempts", flush=True)
+                  print(f"ERROR: failed to download {m} after 8 attempts", flush=True)
                   rc = 1
           sys.exit(rc)
           PY

--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -56,6 +56,28 @@ jobs:
           pip install --upgrade pip
           pip install huggingface_hub
 
+      - name: Diagnose HF connectivity
+        # Pinpoint where the runner's connection to HF is reset: a failing
+        # metadata curl => firewall/proxy/TLS path to huggingface.co; metadata
+        # OK but snapshot_download still fails => redirected CDN/Xet blob route.
+        # Best-effort (never fails the job); token is kept out of the output.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        continue-on-error: true
+        run: |
+          source hf-venv/bin/activate
+          python3 -c 'import huggingface_hub as h; print("huggingface_hub:", h.__version__)'
+          echo "--- proxy / HF env (token redacted) ---"
+          env | grep -Ei '^(http|https|no)_proxy=|^HF_' | grep -vi 'HF_TOKEN' | sort || true
+          echo "--- curl HF API metadata for a previously-failing repo ---"
+          curl -sS -v --retry 3 --retry-all-errors --connect-timeout 30 --max-time 120 \
+            -H "Authorization: Bearer ${HF_TOKEN}" \
+            "https://huggingface.co/api/models/meta-llama/Llama-3.2-3B" \
+            -o /tmp/llama-3b-metadata.json 2>&1 \
+            | grep -viE 'authorization:|bearer' || true
+          echo "--- metadata bytes fetched ---"
+          wc -c /tmp/llama-3b-metadata.json || true
+
       - name: Show HF cache BEFORE
         run: |
           source hf-venv/bin/activate
@@ -76,10 +98,14 @@ jobs:
       - name: Download all model weights
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Give slow metadata/file responses more room (secondary to retries;
+          # won't cure a hard TCP reset, but harmless and helps slow routes).
+          HF_HUB_ETAG_TIMEOUT: "60"
+          HF_HUB_DOWNLOAD_TIMEOUT: "600"
         run: |
           source hf-venv/bin/activate
           python3 - <<'PY'
-          import sys, time
+          import random, sys, time
           from huggingface_hub import snapshot_download
 
           # Weight/config/tokenizer files only.
@@ -96,14 +122,17 @@ jobs:
                     if s.strip() and not s.strip().startswith("#")]
           print(f"Seeding {len(models)} models", flush=True)
 
+          ATTEMPTS = 8
           rc = 0
           for m in models:
               ok = False
-              # Retry per model: the runner's HF egress drops connections at
-              # random. snapshot_download resumes already-fetched files, so each
-              # attempt makes progress. max_workers=1 keeps one connection open
-              # at a time (gentler on the flaky link).
-              for attempt in range(1, 9):
+              # The runner's HF egress resets connections intermittently.
+              # snapshot_download resumes already-fetched files, so each attempt
+              # makes progress; max_workers=1 keeps a single connection open
+              # (gentler on the flaky link); exponential backoff + jitter waits
+              # out the bad window (~10, 20, 40, 80, 160, 300s) instead of
+              # hammering the same reset.
+              for attempt in range(1, ATTEMPTS + 1):
                   try:
                       snapshot_download(
                           m, allow_patterns=ALLOW, ignore_patterns=IGNORE,
@@ -113,10 +142,16 @@ jobs:
                       ok = True
                       break
                   except Exception as e:
-                      print(f"attempt {attempt} failed for {m}: {e}", flush=True)
-                      time.sleep(min(attempt * 15, 60))
+                      print(f"attempt {attempt} failed for {m}: "
+                            f"{type(e).__name__}: {e}", flush=True)
+                      if attempt == ATTEMPTS:
+                          break
+                      delay = min(300, 10 * (2 ** (attempt - 1))) + random.uniform(0, 5)
+                      print(f"  retrying in {delay:.1f}s", flush=True)
+                      time.sleep(delay)
               if not ok:
-                  print(f"ERROR: failed to download {m} after 8 attempts", flush=True)
+                  print(f"ERROR: failed to download {m} after {ATTEMPTS} attempts",
+                        flush=True)
                   rc = 1
           sys.exit(rc)
           PY

--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -19,7 +19,7 @@
 # recent huggingface_hub (>=1.x), so the CLI path silently fails. The Python API
 # is stable across versions.
 
-name: Download LLM Weights (manual)
+name: Download LLM Weights
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -202,15 +202,31 @@ jobs:
 
           aie_hash, peano_ver, air_sha = sys.argv[1], sys.argv[2], sys.argv[3]
 
-          # Per-model verify pass/fail from the verify xunit output.
+          # Per-model verify status from the verify xunit output. A model may
+          # contribute several run_npu2_verify* lits (e.g. int4 ships a skipped
+          # REQUIRES:false one plus a passing bfp16-prefill one); collapse with
+          # precedence fail > pass > skip so a real result beats a skip.
           vstatus = {}
+          rank = {"skip": 0, "pass": 1, "fail": 2}
           if os.path.exists("verify.xml"):
               for tc in ET.parse("verify.xml").getroot().iter("testcase"):
                   name = (tc.get("classname") or "") + " " + (tc.get("name") or "")
-                  m = re.search(r"llms/([^/ ]+)/run_npu2_verify", name)
-                  if m:
-                      failed = next(tc.iter("failure"), None) is not None
-                      vstatus[m.group(1)] = "fail" if failed else "pass"
+                  # xunit stores the dir in classname (…llms/<model>) and the lit
+                  # in name (run_npu2_verify.lit), joined here by a space — so the
+                  # separator before run_npu2_verify is " " or "/".
+                  m = re.search(r"llms/([^/ ]+)[ /]run_npu2_verify", name)
+                  if not m:
+                      continue
+                  if next(tc.iter("failure"), None) is not None:
+                      st = "fail"
+                  elif next(tc.iter("skipped"), None) is not None:
+                      st = "skip"
+                  else:
+                      st = "pass"
+                  model = m.group(1)
+                  prev = vstatus.get(model)
+                  if prev is None or rank[st] > rank[prev]:
+                      vstatus[model] = st
 
           recs = []
           for f in sorted(glob.glob("build_assert/test/llms/**/*.perf.json", recursive=True)):
@@ -242,11 +258,12 @@ jobs:
           if not recs:
               print("**No results produced** — see step logs.")
           else:
-              print("| model | verify | TTFT (ms) | tok/s |")
-              print("| --- | --- | --- | --- |")
+              print("| model | verify | ctx | TTFT (ms) | tok/s |")
+              print("| --- | --- | --- | --- | --- |")
               for d in sorted(recs, key=lambda r: r["model"]):
                   m = d["metrics"]
                   print(f"| {d['model']} | {d['verify_status'] or '?'} | "
+                        f"{m.get('context_len') or '?'} | "
                         f"{m['ttft_ms']} | {m['decode_tokens_per_sec']} |")
           PY
 

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -145,6 +145,40 @@ if os.environ.get("HF_HUB_DISABLE_XET"):
 if os.environ.get("HF_HUB_OFFLINE"):
     llvm_config.with_environment("HF_HUB_OFFLINE", os.environ["HF_HUB_OFFLINE"])
 
+
+# Gate each LLM example on the weights it loads actually being present in the
+# local HF cache, so the suite runs whatever is seeded and auto-includes a model
+# the moment its weights land -- no hardcoded exclusion to maintain. Each model's
+# verify/profile .lit declares `REQUIRES: hfweights_<normalized repo id>`; here we
+# add that feature for every repo present in the cache. The scan is a local disk
+# read (offline-safe); a no-op if huggingface_hub is unimportable or the cache is
+# empty, in which case those tests report UNSUPPORTED instead of failing on a
+# missing checkpoint. The perf runner's HF egress is flaky, so weights are seeded
+# out of band; this keeps CI green on a partially-seeded cache.
+def _hf_weight_feature(repo_id):
+    return "hfweights_" + re.sub(r"[^a-z0-9]+", "_", repo_id.lower()).strip("_")
+
+
+try:
+    from huggingface_hub import scan_cache_dir
+    from huggingface_hub.utils import CacheNotFound
+
+    try:
+        _hf_cache = scan_cache_dir()
+    except CacheNotFound:
+        _hf_cache = None
+    if _hf_cache is not None:
+        _seeded = sorted(
+            _hf_weight_feature(r.repo_id)
+            for r in _hf_cache.repos
+            if any(rev.size_on_disk > 0 for rev in r.revisions)
+        )
+        for _feat in _seeded:
+            config.available_features.add(_feat)
+        print("HF weights present -> features:", ", ".join(_seeded) or "(none)")
+except ImportError:
+    print("huggingface_hub not importable; hfweights_* features disabled.")
+
 llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
 
 llvm_config.use_default_substitutions()

--- a/programming_examples/llms/bench/extract_perf.py
+++ b/programming_examples/llms/bench/extract_perf.py
@@ -20,9 +20,16 @@ TTFT_S_RE = re.compile(r"Time to first token \(TTFT\):\s*([\d.]+)\s*s")
 PREFILL_MS_RE = re.compile(r"End-to-end \(prefill, per query\)\s+([\d.]+)\s*ms")
 
 # Decode throughput: qwen family + llama3b print "(X.XX tok/s)";
-# llama32_1b prints "End-to-end (per token)  N ms" (throughput = 1000/ms).
+# llama32_1b prints "End-to-end (per token)  N ms" (throughput = 1000/ms);
+# the int4 inference driver prints "Tokens/second: X.XX".
 TOKS_RE = re.compile(r"\(([\d.]+)\s*tok/s\)")
 DECODE_MS_RE = re.compile(r"End-to-end \(per token\)\s+([\d.]+)\s*ms")
+TOKS_LABEL_RE = re.compile(r"Tokens/second:\s*([\d.]+)")
+
+# Context length = prefill sequence length the decode ran against (KV-cache
+# depth), which tok/s depends on. Every inference driver prints
+# "... Inference: prompt_len=N, n_tokens=...".
+CTX_RE = re.compile(r"prompt_len[=:]\s*(\d+)")
 
 
 def _ttft_ms(text):
@@ -43,7 +50,15 @@ def _decode_tok_s(text):
     if m:
         ms = float(m.group(1))
         return round(1000.0 / ms, 2) if ms else None
+    m = TOKS_LABEL_RE.search(text)
+    if m:
+        return round(float(m.group(1)), 2)
     return None
+
+
+def _context_len(text):
+    m = CTX_RE.search(text)
+    return int(m.group(1)) if m else None
 
 
 def main():
@@ -78,6 +93,7 @@ def main():
         "metrics": {
             "ttft_ms": _ttft_ms(text),
             "decode_tokens_per_sec": _decode_tok_s(text),
+            "context_len": _context_len(text),
         },
         "toolchain": {
             "mlir_air_sha": args.mlir_air_sha,

--- a/programming_examples/llms/llama32_1b/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/llama32_1b/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_1b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (gated model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/llama32_1b_int4/Makefile
+++ b/programming_examples/llms/llama32_1b_int4/Makefile
@@ -175,11 +175,11 @@ diagnosis:
 ## Run with per-kernel + per-layer profiling instrumentation.
 profile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
-		--prefill-dtype $(PREFILL_DTYPE) --model $(MODEL) \
-		--prompt "$(PROMPT)" --n-layers $(N_LAYERS) --topk $(TOPK) \
-		--profile \
-		--cache-dir $(srcdir)/verify_kernel_cache
+	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_inference.py \
+		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" \
+		--model-path $(MODEL) \
+		--prefill-cache-dir $(PREFILL_INF_CACHE) \
+		--decode-cache-dir $(DECODE_INF_CACHE)
 
 ## ============================================================
 ## End-to-end inference (bf16 NPU prefill + int4 NPU decode)

--- a/programming_examples/llms/llama32_1b_int4/llama32_1b_int4_prefill.py
+++ b/programming_examples/llms/llama32_1b_int4/llama32_1b_int4_prefill.py
@@ -1157,6 +1157,28 @@ def main():
                 O_FFN_BACKEND,
             )
 
+            # The stock bf16 rms_gemms_rope/o_ffn stitchers link the external
+            # GEMM microkernels mm_m32.o (K/V drain) + mm_m64.o (fused-cast).
+            # Build them before caching so prepare_air_project stages them into
+            # air_project/ (mirrors llama32_1b_prefill.compile_all_kernels); the
+            # int4/bfp16 branches use their own kernels and don't need these.
+            from shared.infra.external_kernels import compile_gemm_mm
+
+            compile_gemm_mm(
+                tile_m=32,
+                tile_n=128,
+                tile_k_l1=32,
+                sym_suffix="_m32",
+                out_name="mm_m32.o",
+            )
+            compile_gemm_mm(
+                tile_m=64,
+                tile_n=128,
+                tile_k_l1=32,
+                sym_suffix="_m64",
+                out_name="mm_m64.o",
+            )
+
             if _need("rms_gemms_rope"):
                 print("\nCompiling rms_gemms_rope (bf16)...")
                 from shared.builders.rms_gemms_rope_multi import (

--- a/programming_examples/llms/llama32_1b_int4/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_amd_llama_3_2_1b_instruct_awq_uint4_asym_g128_bf16_lmhead
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/llama32_1b_int4/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_profile.lit
@@ -1,20 +1,21 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
-// llama32_1b_int4 profiling: compile then profile on NPU2, capturing TTFT + decode
-// throughput into llama32_1b_int4.perf.json via bench/extract_perf.py. Perf is best-effort
-// (a model that does not print a metric yields null); this test gates only that
-// profiling ran end to end. Collected by the CI target
-// check-programming-examples-llms-profile. Correctness is gated separately by
-// run_npu2_verify.lit.
+// llama32_1b_int4 profiling: compile the e2e inference ELFs (bf16 NPU prefill +
+// int4 NPU decode) then run prefill+decode on NPU2, capturing TTFT + int4 decode
+// throughput + context length into llama32_1b_int4.perf.json via
+// bench/extract_perf.py. Perf is best-effort (a model that does not print a metric
+// yields null); this test gates only that profiling ran end to end. Collected by
+// the CI target check-programming-examples-llms-profile. Correctness is gated
+// separately by run_npu2_verify.lit.
 //
 // REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_amd_llama_3_2_1b_instruct_awq_uint4_asym_g128_bf16_lmhead
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile compile-inference PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N_TOKENS=128 PROMPT="What is the capital of France?" | tee profile.txt
-// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_1b_int4 > llama32_1b_int4.perf.json
+// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_1b_int4 --n-tokens 128 > llama32_1b_int4.perf.json
 // RUN: FileCheck %s < llama32_1b_int4.perf.json
 // CHECK: "model": "llama32_1b_int4"

--- a/programming_examples/llms/llama32_1b_int4/run_npu2_verify_prefill_bfp16.lit
+++ b/programming_examples/llms/llama32_1b_int4/run_npu2_verify_prefill_bfp16.lit
@@ -8,7 +8,7 @@
 // from the AMD AWQ checkpoint's config + AWQ-dequant weights (no
 // upstream meta-llama download), so the lit is un-gated.
 //
-// REQUIRES: ryzen_ai_npu2, peano
+// REQUIRES: ryzen_ai_npu2, peano, hfweights_amd_llama_3_2_1b_instruct_awq_uint4_asym_g128_bf16_lmhead
 //
 // RUN: mkdir -p test_peano_verify_prefill_bfp16
 // RUN: cd test_peano_verify_prefill_bfp16

--- a/programming_examples/llms/llama32_3b/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_3b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/llama32_3b/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_3b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen25_0_5b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_0_5b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_0_5b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen25_0_5b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_0_5b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_0_5b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen25_1_5b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_1_5b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_1_5b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen25_1_5b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_1_5b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_1_5b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen25_3b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_3b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_3b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen25_3b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_3b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen2_5_3b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen3_0_6b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen3_0_6b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_0_6b
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen3_0_6b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen3_0_6b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_0_6b
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen3_1_7b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen3_1_7b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_1_7b
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen3_1_7b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen3_1_7b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_1_7b
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/qwen3_4b/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen3_4b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_4b
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen3_4b/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen3_4b/run_npu2_verify.lit
@@ -8,7 +8,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (model downloads require it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_qwen_qwen3_4b
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/smollm2_1_7b/run_npu2_profile.lit
+++ b/programming_examples/llms/smollm2_1_7b/run_npu2_profile.lit
@@ -8,7 +8,7 @@
 // check-programming-examples-llms-profile. Correctness is gated separately by
 // run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_huggingfacetb_smollm2_1_7b_instruct
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/smollm2_1_7b/run_npu2_verify.lit
+++ b/programming_examples/llms/smollm2_1_7b/run_npu2_verify.lit
@@ -17,7 +17,7 @@
 // reference. So if this lit is ever promoted into CI, it needs only
 // ryzen_ai_npu2 + peano — no secret.
 //
-// REQUIRES: ryzen_ai_npu2, peano
+// REQUIRES: ryzen_ai_npu2, peano, hfweights_huggingfacetb_smollm2_1_7b_instruct
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify


### PR DESCRIPTION
## Summary
Makes the nightly offline LLM perf benchmark robust to the Krackan runner's flaky HF egress (it intermittently RSTs TLS handshakes to huggingface.co, so only pre-seeded weights are reliably available), and fixes an int4 build bug the full run surfaced.

Three related changes:

1. **Fix `downloadLLMWeights.yml`** — the manual weight-seeding workflow used `huggingface-cli download`, deprecated in `huggingface_hub` >=1.x (renamed to `hf`; the legacy invocation prints a notice and no longer downloads). Switched to the stable Python `snapshot_download`/`scan_cache_dir` API; reads the model list from `programming_examples/llms/hf_models.txt`; ignores license/`original/` junk that made snapshots report "incomplete"; adds `max_workers=1`, exponential backoff, timeouts, a connectivity diagnostic step, and a traceback on the final failed attempt.

2. **Gate each LLM example on its weights being cached** — instead of a hardcoded exclusion list, `lit.cfg.py` scans the local HF cache and exposes an `hfweights_<repo>` feature per present repo; each model's `verify`/`profile` lit `REQUIRES` the repo it actually loads. Models with cached weights run; those without report **UNSUPPORTED** (green) instead of failing, and auto-enable the moment their weights are seeded. Offline-safe; no-op if `huggingface_hub` is unimportable or the cache is empty. Currently only `qwen3_4b` (needs `Qwen/Qwen3-4B`, not yet seeded) is gated out.

3. **Fix int4 bf16 prefill kernel staging** — the int4 driver's bf16 backend compiles the stock `rms_gemms_rope`/`o_ffn` stitchers, which `link_with` the external GEMM microkernels `mm_m32.o`/`mm_m64.o`, but `main()` never called `compile_gemm_mm` to build them. On a clean tree the ELF link failed with `unable to find air_project/mm_m32.o`. Now built in the bf16 branch (mirrors `llama32_1b_prefill.compile_all_kernels`).

## Test plan
- [x] `downloadLLMWeights.yml` YAML + all 3 python heredocs parse; verified against hf_hub 1.x locally
- [x] `lit.cfg.py` compiles; generated feature names match `REQUIRES`; empty cache -> all UNSUPPORTED; runner-cache sim -> only `qwen3_4b` gated
- [x] int4 bf16 `--compile-only` at seq_len=2048 builds `mm_m32.o`/`mm_m64.o` and links `rms_gemms_rope`/`o_ffn`/`flash_attn` cleanly (was the sole nightly red)
- [x] Nightly dispatch confirms verify.xml pass counts + perf.json record count

🤖 Generated with [Claude Code](https://claude.com/claude-code)
