### PR TITLE
[CI] Move LLM tests out of the per-PR gate; fix adf.h in kernel compiles

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -151,26 +151,12 @@ jobs:
           # concurrent NPU inference causing out-of-memory crashes.
           ninja check-programming-examples-peano || ninja check-programming-examples-peano
 
-          # LLM compile gate: llama32_1b only (fast, no HF download, no NPU
-          # dispatch). Runs on every PR — no secrets needed. Sequential (-j1)
-          # is set in the CMake target definition.
-          ninja check-programming-examples-llms-compile-llama32_1b || ninja check-programming-examples-llms-compile-llama32_1b
-
-          # LLM full suite (all models compile + verify): run only when
-          # HF_TOKEN is available, i.e. on pushes to main or workflow_dispatch
-          # by repo owners. Fork PRs never have access to secrets so this block
-          # is effectively skipped for external contributors.
-          # Sequential (-j1) set in CMake target to prevent NPU OOM.
-          if [ -n "${{ secrets.HF_TOKEN }}" ]; then
-            # All-models compile (catches regressions in non-llama32_1b models)
-            ninja check-programming-examples-llms-compile || ninja check-programming-examples-llms-compile
-
-            # All-models verify (hf_token gated; HF_TOKEN scoped to sub-shell)
-            (
-              export HF_TOKEN="${{ secrets.HF_TOKEN }}"
-              ninja check-programming-examples-llms-verify || ninja check-programming-examples-llms-verify
-            )
-          fi
+          # LLM compile/verify are intentionally NOT run here. They are covered
+          # end to end (compile + verify + perf, all models) by the dedicated
+          # nightly benchmark (nightlyPerfBenchmark.yml) on the Krackan runner,
+          # which serves weights from a warm offline HF cache. Running them in
+          # the per-PR matrix duplicated that work, was slow (int4's compile
+          # alone exceeds the 600s per-test timeout), and needed HF secrets.
 
           # Chess tests disabled to reduce CI time. Uncomment to re-enable:
           # ninja check-programming-examples-chess

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -120,16 +120,11 @@ set_target_properties(check-programming-examples PROPERTIES FOLDER "Tests")
 # Matched by path (llms/.*/run_npu2_compile) so lit filename need NOT carry
 # any backend suffix. Sequential (-j1) because concurrent LLM compilations
 # can exhaust host memory on CI runners.
-# llama32_1b_int4 is excluded: its `make compile` builds all three prefill
-# backends and exceeds the PR CI's 600s per-test timeout. Its kernels are
-# covered end to end by the nightly LLM perf benchmark instead — the int4
-# decode + bf16 prefill via run_npu2_profile's compile-inference, and the
-# bfp16 prefill via run_npu2_verify_prefill_bfp16.
 add_lit_testsuite(check-programming-examples-llms-compile
   "Running LLM compile-only tests (all models, sequential)"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${TEST_DEPENDS}
-  ARGS ${AIR_TEST_LIT_ARGS} -j1 --filter "llms/.*/run_npu2_compile" --filter-out "llms/llama32_1b_int4/"
+  ARGS ${AIR_TEST_LIT_ARGS} -j1 --filter "llms/.*/run_npu2_compile"
 )
 set_target_properties(check-programming-examples-llms-compile PROPERTIES FOLDER "Tests")
 

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -120,11 +120,16 @@ set_target_properties(check-programming-examples PROPERTIES FOLDER "Tests")
 # Matched by path (llms/.*/run_npu2_compile) so lit filename need NOT carry
 # any backend suffix. Sequential (-j1) because concurrent LLM compilations
 # can exhaust host memory on CI runners.
+# llama32_1b_int4 is excluded: its `make compile` builds all three prefill
+# backends and exceeds the PR CI's 600s per-test timeout. Its kernels are
+# covered end to end by the nightly LLM perf benchmark instead — the int4
+# decode + bf16 prefill via run_npu2_profile's compile-inference, and the
+# bfp16 prefill via run_npu2_verify_prefill_bfp16.
 add_lit_testsuite(check-programming-examples-llms-compile
   "Running LLM compile-only tests (all models, sequential)"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${TEST_DEPENDS}
-  ARGS ${AIR_TEST_LIT_ARGS} -j1 --filter "llms/.*/run_npu2_compile"
+  ARGS ${AIR_TEST_LIT_ARGS} -j1 --filter "llms/.*/run_npu2_compile" --filter-out "llms/llama32_1b_int4/"
 )
 set_target_properties(check-programming-examples-llms-compile PROPERTIES FOLDER "Tests")
 

--- a/programming_examples/llms/shared/infra/external_kernels.py
+++ b/programming_examples/llms/shared/infra/external_kernels.py
@@ -64,6 +64,13 @@ _PEANO_FLAGS = [
     "-std=c++20",
     "--target=aie2p-none-unknown-elf",
     "-DNDEBUG",
+    # Short-circuit aie_api's ADF graph headers: aie.hpp -> aie_adf.hpp (guarded
+    # by __AIE_API_AIE_ADF_HPP__) -> adf/stream.hpp -> #include <adf.h>. adf.h is
+    # a Vitis-only header absent from the Peano include path, so without this
+    # guard the compile fails with "'adf.h' file not found". These compute
+    # kernels don't use the ADF stream API; the XRT kernel tests pass the same
+    # define.
+    "-D__AIE_API_AIE_ADF_HPP__",
     "-Wno-parentheses",
     "-Wno-attributes",
     "-Wno-macro-redefined",


### PR DESCRIPTION
## Summary
Two toolchain/CI cleanups surfaced by the recurring `amdhx370` per-PR failures.

1. **Move LLM compile/verify out of the per-PR CI** (`buildAndTestRyzenAI.yml`). All LLM models are already exercised end-to-end (compile + verify + perf) by the dedicated **nightly benchmark** (`nightlyPerfBenchmark.yml`) on the Krackan runner, serving weights from a warm offline HF cache. Running them in the per-PR matrix was redundant, slow (int4's compile alone exceeds the 600s per-test timeout), and needed HF secrets. Supersedes the earlier narrow `--filter-out` of int4 (reverted here).

2. **Fix `'adf.h' file not found` on LLM kernel compiles.** `aie_api`'s `aie.hpp → aie_adf.hpp → adf/stream.hpp` pulls in the Vitis-only `adf.h`, absent from the Peano include path. Add `-D__AIE_API_AIE_ADF_HPP__` to the shared kernel compile flags to short-circuit that chain — the XRT kernel tests already pass the same define, and these compute kernels don't use the ADF stream API. Keeps the nightly's LLM kernel compiles green against the newer mlir-aie headers.

## Out of scope (flagged)
A separate `amdhx370` failure remains: an **aircc crash** (segfault in `getAttrDictionary()`) on the non-LLM `xrt/17_gemm_8x16_transform_vec_4x4` test, coming from the workflow's **unpinned nightly `llvm-aie`**. That needs a toolchain pin/fix and is not addressed here.

## Test plan
- [x] `buildAndTestRyzenAI.yml` YAML parses.
- [x] Locally recompiled `mm_m32.o` with `-D__AIE_API_AIE_ADF_HPP__` in `_PEANO_FLAGS` — builds clean (no regression on the current mlir-aie). Full adf.h reproduction requires the newer mlir-aie wheel used on CI; fix is the same define the XRT tests use and the header guard chain confirms it short-circuits the `adf.h` include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
