### PR TITLE
[utils] Bump mlir-aie to 1.3.5.dev62+g157e8b8

### DIFF
--- a/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/airrt_to_npu.mlir
@@ -14,10 +14,10 @@
 // CHECK: aie.shim_dma_allocation @airMemcpyId2(%shim_noc_tile_0_0, MM2S, 0)
 // CHECK: aie.runtime_sequence @func0(%[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId2 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32> offset = 0 len = 64
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId7 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32> offset = 0 len = 64
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T1]])
 // CHECK: }
@@ -54,10 +54,10 @@ module {
 // CHECK: aie.shim_dma_allocation @airMemcpyId2(%shim_noc_tile_0_0, MM2S, 0)
 // CHECK: aie.runtime_sequence @func1(%[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId2 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32> offset = 0 len = 64
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId7 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32> offset = 0 len = 64
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T1]])
 // CHECK:   aiex.dma_await_task(%[[T1]])
@@ -100,16 +100,16 @@ module {
 // CHECK: aie.shim_dma_allocation @airMemcpyId5(%shim_noc_tile_0_0, MM2S, 0)
 // CHECK: aie.runtime_sequence @func2(%[[VAL_0:.*]]: memref<32x32xi32>, %[[VAL_1:.*]]: memref<32x32xi32>, %[[VAL_2:.*]]: memref<32x32xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId5 {
-// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<32x32xi32>, 0, 1024
+// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<32x32xi32> offset = 0 len = 1024
 // CHECK:   aiex.dma_start_task
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId5 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<32x32xi32>, 0, 1024
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<32x32xi32> offset = 0 len = 1024
 // CHECK:   aiex.dma_start_task
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId5 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<32x32xi32>, 0, 1024
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<32x32xi32> offset = 0 len = 1024
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T3:.*]] = aiex.dma_configure_task_for @airMemcpyId16 {
-// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<32x32xi32>, 0, 1024
+// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<32x32xi32> offset = 0 len = 1024
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T3]])
 // CHECK:   aiex.dma_await_task(%[[T3]])
@@ -162,22 +162,22 @@ module {
 // CHECK-LABEL: aie.device(npu1_2col) @segment_0 {
 // CHECK:  aie.runtime_sequence @func3(%[[ARG0:.*]]: memref<8x8xi32>)
 // CHECK:  %[[T0:.*]] = aiex.dma_configure_task_for @airMemcpyId14 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 0, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 0 len = 16
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task(%[[T0]])
 // CHECK:  aiex.dma_await_task(%[[T0]])
 // CHECK:  %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId14 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 4, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 4 len = 16
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task(%[[T1]])
 // CHECK:  aiex.dma_await_task(%[[T1]])
 // CHECK:  %[[T2:.*]] = aiex.dma_configure_task_for @airMemcpyId14 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 32, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 32 len = 16
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task(%[[T2]])
 // CHECK:  aiex.dma_await_task(%[[T2]])
 // CHECK:  %[[T3:.*]] = aiex.dma_configure_task_for @airMemcpyId14 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 36, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 36 len = 16
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task(%[[T3]])
 // CHECK:  aiex.dma_await_task(%[[T3]])
@@ -227,19 +227,19 @@ module {
 // CHECK-LABEL: aie.device(npu1_2col) @segment_0
 // CHECK:  aie.runtime_sequence @func4(%[[ARG0:.*]]: memref<8x8xi32>)
 // CHECK:  %[[T0:.*]] = aiex.dma_configure_task_for @air_channel_1 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 0, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 0 len = 16
 // CHECK:  aiex.dma_start_task(%[[T0]])
 // CHECK:  aiex.dma_await_task(%[[T0]])
 // CHECK:  %[[T1:.*]] = aiex.dma_configure_task_for @air_channel_1 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 4, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 4 len = 16
 // CHECK:  aiex.dma_start_task(%[[T1]])
 // CHECK:  aiex.dma_await_task(%[[T1]])
 // CHECK:  %[[T2:.*]] = aiex.dma_configure_task_for @air_channel_1 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 32, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 32 len = 16
 // CHECK:  aiex.dma_start_task(%[[T2]])
 // CHECK:  aiex.dma_await_task(%[[T2]])
 // CHECK:  %[[T3:.*]] = aiex.dma_configure_task_for @air_channel_1 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32>, 36, 16
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8x8xi32> offset = 36 len = 16
 // CHECK:  aiex.dma_start_task(%[[T3]])
 // CHECK:  aiex.dma_await_task(%[[T3]])
 
@@ -322,7 +322,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @func11
 // CHECK-SAME: %arg0: memref<128x128xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @md0 {
-// CHECK:        aie.dma_bd(%arg0 : memref<128x128xbf16>, 0, 4096
+// CHECK:        aie.dma_bd(%arg0 : memref<128x128xbf16> offset = 0 len = 4096
 // CHECK: } {repeat_count = 3 : i32}
 // CHECK: aiex.dma_start_task
 module {
@@ -350,7 +350,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @func12
 // CHECK-SAME: %arg0: memref<32xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @md0 {
-// CHECK:        aie.dma_bd(%arg0 : memref<32xbf16>, 0, 32
+// CHECK:        aie.dma_bd(%arg0 : memref<32xbf16> offset = 0 len = 32
 // CHECK:      aiex.dma_start_task
 module {
   aie.device(npu1_1col) {
@@ -463,67 +463,67 @@ module {
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK:  aie.runtime_sequence @func18(%[[ARG0:.*]]: memref<8192x32768xi32>)
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 0, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 0 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 64, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 64 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 128, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 128 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 192, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 192 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 2097152, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 2097152 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 2097216, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 2097216 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 2097280, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 2097280 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 2097344, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 2097344 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 4194304, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 4194304 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 4194368, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 4194368 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 4194432, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 4194432 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 4194496, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 4194496 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 6291456, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 6291456 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 6291520, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 6291520 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 6291584, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 6291584 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 // CHECK:  aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32>, 6291648, 4096, [<size = 64, stride = 32768>, <size = 64, stride = 1>])
+// CHECK:    aie.dma_bd(%[[ARG0]] : memref<8192x32768xi32> offset = 6291648 len = 4096 sizes = [64, 64] strides = [32768, 1])
 // CHECK:  } {issue_token = true}
 // CHECK:  aiex.dma_start_task
 
@@ -599,19 +599,19 @@ module {
 
 // CHECK-LABEL: aie.runtime_sequence @func21
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10 {
-// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16>, 0, 8192, [<size = 38, stride = 155648>, <size = 2, stride = 64>, <size = 64, stride = 2432>, <size = 64, stride = 1>])
+// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16> offset = 0 len = 8192 sizes = [38, 2, 64, 64] strides = [155648, 64, 2432, 1])
 // CHECK: } {repeat_count = 37 : i32}
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10 {
-// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16>, 5914624, 8192, [<size = 38, stride = 155648>, <size = 2, stride = 64>, <size = 64, stride = 2432>, <size = 64, stride = 1>])
+// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16> offset = 5914624 len = 8192 sizes = [38, 2, 64, 64] strides = [155648, 64, 2432, 1])
 // CHECK: } {repeat_count = 37 : i32}
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10 {
-// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16>, 11829248, 8192, [<size = 38, stride = 155648>, <size = 2, stride = 64>, <size = 64, stride = 2432>, <size = 64, stride = 1>])
+// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16> offset = 11829248 len = 8192 sizes = [38, 2, 64, 64] strides = [155648, 64, 2432, 1])
 // CHECK: } {repeat_count = 37 : i32}
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10 {
-// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16>, 17743872, 8192, [<size = 38, stride = 155648>, <size = 2, stride = 64>, <size = 64, stride = 2432>, <size = 64, stride = 1>])
+// CHECK:   aie.dma_bd(%arg0 : memref<9728x2432xbf16> offset = 17743872 len = 8192 sizes = [38, 2, 64, 64] strides = [155648, 64, 2432, 1])
 // CHECK: } {repeat_count = 37 : i32}
 // CHECK: aiex.dma_start_task
 
@@ -793,12 +793,12 @@ module {
 // CHECK-LABEL: aie.device(npu1_1col) @segment0
 // CHECK: aie.runtime_sequence @packet_attr_transfer(%[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId2 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32>, 0, 64,{{.*}}) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<64xi32> offset = 0 len = 64 sizes = [64] strides = [0]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
 // CHECK:   }
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId7 {
 // CHECK-NOT: packet
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<64xi32> offset = 0 len = 64
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T1]])
 // CHECK: }
@@ -833,7 +833,7 @@ module {
 // CHECK-LABEL: aie.device(npu1_1col) @segment0
 // CHECK: aie.runtime_sequence @packet_attr_with_dims(%[[VAL_0:.*]]: memref<32x64xi32>, %[[VAL_1:.*]]: memref<64xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId2 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<32x64xi32>, 0, 128, [<size = 2, stride = 64>{{.*}}]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<32x64xi32> offset = 0 len = 128 sizes = [2, 64] strides = [64, 0]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
 // CHECK:   }
 // CHECK:   aiex.dma_start_task
 
@@ -868,7 +868,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @broadcast_stride_zero
 // CHECK-SAME: %[[ARG0:.*]]: memref<64xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @airMemcpyId2 {
-// CHECK:        aie.dma_bd(%[[ARG0]] : memref<64xbf16>, 0, 64, [<size = 64, stride = 1>])
+// CHECK:        aie.dma_bd(%[[ARG0]] : memref<64xbf16> offset = 0 len = 64 sizes = [64] strides = [1])
 // CHECK: } {repeat_count = 3 : i32}
 // CHECK: aiex.dma_start_task
 module {
@@ -899,7 +899,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @broadcast_stride_zero_dim2
 // CHECK-SAME: %[[ARG0:.*]]: memref<256xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @airMemcpyId3 {
-// CHECK:        aie.dma_bd(%[[ARG0]] : memref<256xbf16>, 0, 128, [<size = 2, stride = 128>, <size = 64, stride = 1>])
+// CHECK:        aie.dma_bd(%[[ARG0]] : memref<256xbf16> offset = 0 len = 128 sizes = [2, 64] strides = [128, 1])
 // CHECK: } {repeat_count = 2 : i32}
 // CHECK: aiex.dma_start_task
 module {
@@ -935,7 +935,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @broadcast_stride_zero_nested
 // CHECK-SAME: %[[ARG0:.*]]: memref<64xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:        aie.dma_bd(%[[ARG0]] : memref<64xbf16>, 0, 64, [<size = 64, stride = 1>])
+// CHECK:        aie.dma_bd(%[[ARG0]] : memref<64xbf16> offset = 0 len = 64 sizes = [64] strides = [1])
 // CHECK: } {repeat_count = 11 : i32}
 // CHECK: aiex.dma_start_task
 module {
@@ -975,7 +975,7 @@ module {
 // CHECK-LABEL: aie.runtime_sequence @bd_repeat_dim_size1_gap
 // CHECK-SAME: %[[ARG0:.*]]: memref<512x512xbf16>
 // CHECK-NEXT: aiex.dma_configure_task_for @airMemcpyId5 {
-// CHECK:        aie.dma_bd(%[[ARG0]] : memref<512x512xbf16>, 64, 8192, [<size = 4, stride = 65536>, <size = 1, stride = 64>, <size = 128, stride = 512>, <size = 64, stride = 1>])
+// CHECK:        aie.dma_bd(%[[ARG0]] : memref<512x512xbf16> offset = 64 len = 8192 sizes = [4, 1, 128, 64] strides = [65536, 64, 512, 1])
 // CHECK: } {repeat_count = 3 : i32}
 // CHECK: aiex.dma_start_task
 module {

--- a/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/buffer_memref_to_args.mlir
@@ -12,13 +12,13 @@
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK: aie.runtime_sequence @func0(%[[VAL_0:.*]]: memref<8x16xi32>, %[[VAL_1:.*]]: memref<16x8xi32>, %[[VAL_2:.*]]: memref<8x8xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<8x16xi32>, 0, 128
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<8x16xi32> offset = 0 len = 128
 // CHECK:   aiex.dma_start_task
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<16x8xi32>, 0, 128
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<16x8xi32> offset = 0 len = 128
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T2:.*]] = aiex.dma_configure_task_for @airMemcpyId16 {
-// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<8x8xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<8x8xi32> offset = 0 len = 64
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T2]])
 
@@ -63,13 +63,13 @@ module {
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK: aie.runtime_sequence @func1(%[[VAL_0:.*]]: memref<8x16xi32>, %[[VAL_1:.*]]: memref<16x8xi32>, %[[VAL_2:.*]]: memref<8x8xi32>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<8x16xi32>, 0, 128
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<8x16xi32> offset = 0 len = 128
 // CHECK:   aiex.dma_start_task
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<16x8xi32>, 0, 128
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<16x8xi32> offset = 0 len = 128
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T2:.*]] = aiex.dma_configure_task_for @airMemcpyId16 {
-// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<8x8xi32>, 0, 64
+// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<8x8xi32> offset = 0 len = 64
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T2]])
 
@@ -129,13 +129,13 @@ module {
 // CHECK-LABEL: aie.device(npu1_1col)
 // CHECK: aie.runtime_sequence @func2(%[[VAL_0:.*]]: memref<2048x2048xbf16>, %[[VAL_1:.*]]: memref<2048x2048xbf16>, %[[VAL_2:.*]]: memref<2048x2048xbf16>) {
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId4 {
-// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<2048x2048xbf16>, 0, 262144
+// CHECK:     aie.dma_bd(%[[VAL_0]] : memref<2048x2048xbf16> offset = 0 len = 262144
 // CHECK:   aiex.dma_start_task
 // CHECK:   aiex.dma_configure_task_for @airMemcpyId7 {
-// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<2048x2048xbf16>, 0, 262144
+// CHECK:     aie.dma_bd(%[[VAL_1]] : memref<2048x2048xbf16> offset = 0 len = 262144
 // CHECK:   aiex.dma_start_task
 // CHECK:   %[[T2:.*]] = aiex.dma_configure_task_for @airMemcpyId26 {
-// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<2048x2048xbf16>, 0, 16384
+// CHECK:     aie.dma_bd(%[[VAL_2]] : memref<2048x2048xbf16> offset = 0 len = 16384
 // CHECK:   } {issue_token = true}
 // CHECK:   aiex.dma_start_task(%[[T2]])
 

--- a/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_memcpy_split.mlir
@@ -16,19 +16,19 @@
 
 // Block 1
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 0, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 0 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 0
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 0
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131072
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262144
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262144
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393216
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393216
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T0:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -37,19 +37,19 @@
 
 // Block 2
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 0, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 0 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 16
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 16
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131088
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131088
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262160
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262160
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393232
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393232
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -58,19 +58,19 @@
 
 // Block 3
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 0, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 0 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 32
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 32
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131104
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131104
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262176
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262176
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393248
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393248
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T2:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -79,19 +79,19 @@
 
 // Block 4
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 0, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 0 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 48
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 48
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131120
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131120
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262192
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262192
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393264
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393264
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T3:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -100,19 +100,19 @@
 
 // Block 5
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 131072, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 131072 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 0
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 0
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131072
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262144
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262144
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393216
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393216
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T4:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -121,19 +121,19 @@
 
 // Block 6
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 131072, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 131072 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 16
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 16
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131088
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131088
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262160
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262160
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393232
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393232
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T5:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -142,19 +142,19 @@
 
 // Block 7
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 131072, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 131072 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 32
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 32
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131104
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131104
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262176
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262176
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393248
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393248
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T6:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -163,19 +163,19 @@
 
 // Block 8
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 131072, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 131072 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 48
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 48
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131120
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131120
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262192
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262192
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393264
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393264
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T7:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -184,19 +184,19 @@
 
 // Block 9
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 262144, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 262144 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 0
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 0
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131072
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262144
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262144
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393216
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393216
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T8:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -205,19 +205,19 @@
 
 // Block 10
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 262144, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 262144 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 16
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 16
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131088
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131088
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262160
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262160
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393232
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393232
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T9:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -226,19 +226,19 @@
 
 // Block 11
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 262144, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 262144 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 32
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 32
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131104
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131104
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262176
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262176
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393248
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393248
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T10:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -247,19 +247,19 @@
 
 // Block 12
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 262144, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 262144 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 48
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 48
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131120
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131120
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262192
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262192
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393264
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393264
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T11:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -268,19 +268,19 @@
 
 // Block 13
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 393216, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 393216 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 0
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 0
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131072
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262144
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262144
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393216
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393216
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T12:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -289,19 +289,19 @@
 
 // Block 14
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 393216, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 393216 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 16
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 16
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131088
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131088
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262160
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262160
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393232
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393232
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T13:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -310,19 +310,19 @@
 
 // Block 15
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 393216, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 393216 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 32
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 32
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131104
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131104
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262176
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262176
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393248
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393248
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T14:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}
@@ -331,19 +331,19 @@
 
 // Block 16
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16>, 393216, 131072
+// CHECK: aie.dma_bd(%arg0 : memref<512x1024xbf16> offset = 393216 len = 131072
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 48
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 48
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 131120
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 131120
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 262192
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 262192
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId10
-// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16>, 393264
+// CHECK: aie.dma_bd(%arg1 : memref<128x8x8x64xbf16> offset = 393264
 // CHECK: aiex.dma_start_task
 // CHECK: %[[T15:.*]] = aiex.dma_configure_task_for @airMemcpyId29
 // CHECK: {issue_token = true}

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_folding.mlir
@@ -19,10 +19,10 @@
 
 // Block 1
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 0, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 0 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 0, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 0 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_0:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -31,10 +31,10 @@
 
 // Block 2
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 0, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 0 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 16, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 16 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_1:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -43,10 +43,10 @@
 
 // Block 3
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 0, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 0 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 32, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 32 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_2:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -55,10 +55,10 @@
 
 // Block 4
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 0, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 0 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 48, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 48 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_3:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -67,10 +67,10 @@
 
 // Block 5
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 16384, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 16384 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 0, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 0 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_4:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -79,10 +79,10 @@
 
 // Block 6
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 16384, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 16384 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 16, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 16 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_5:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -91,10 +91,10 @@
 
 // Block 7
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 16384, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 16384 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 32, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 32 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_6:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -103,10 +103,10 @@
 
 // Block 8
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 16384, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 16384 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 48, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 48 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_7:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -115,10 +115,10 @@
 
 // Block 9
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 32768, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 32768 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 0, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 0 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_8:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -127,10 +127,10 @@
 
 // Block 10
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 32768, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 32768 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 16, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 16 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_9:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -139,10 +139,10 @@
 
 // Block 11
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 32768, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 32768 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 32, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 32 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_10:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -151,10 +151,10 @@
 
 // Block 12
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 32768, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 32768 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 48, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 48 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_11:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -163,10 +163,10 @@
 
 // Block 13
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 49152, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 49152 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 0, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 0 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_12:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -175,10 +175,10 @@
 
 // Block 14
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 49152, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 49152 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 16, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 16 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_13:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -187,10 +187,10 @@
 
 // Block 15
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 49152, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 49152 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 32, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 32 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_14:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}
@@ -199,10 +199,10 @@
 
 // Block 16
 // CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16>, 49152, 16384
+// CHECK: aie.dma_bd(%arg0 : memref<512x128xbf16> offset = 49152 len = 16384
 // CHECK: aiex.dma_start_task
 // CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16>, 48, 1024
+// CHECK: aie.dma_bd(%arg1 : memref<16x8x8x64xbf16> offset = 48 len = 1024
 // CHECK: aiex.dma_start_task
 // CHECK: %[[TASK_15:.*]] = aiex.dma_configure_task_for @airMemcpyId19
 // CHECK: {issue_token = true}

--- a/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/linear_shim_bd.mlir
@@ -14,7 +14,7 @@
 // Plain contiguous bf16, inner 131136 (>> 1023): single BD, no tiling.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16> offset = 0 len = 131136 sizes = [131136] strides = [1])
 
 module {
   aie.device(npu1) {
@@ -43,7 +43,7 @@ module {
 // tileIllegalWrapDim; now passes through as a single linear BD.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<2049xbf16>, 0, 2049, [<size = 2049, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<2049xbf16> offset = 0 len = 2049 sizes = [2049] strides = [1])
 
 module {
   aie.device(npu1) {
@@ -72,7 +72,7 @@ module {
 // Folds into repeat_count=7 + one linear BD of 2048. Must NOT be tiled.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<2048xbf16>, 0, 2048, [<size = 2048, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<2048xbf16> offset = 0 len = 2048 sizes = [2048] strides = [1])
 // CHECK: repeat_count = 7 : i32
 
 module {
@@ -102,7 +102,7 @@ module {
 // NPU2: same linearization on AIE2P. Guards against device divergence.
 
 // CHECK-LABEL: aie.device(npu2)
-// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16>, 0, 131136, [<size = 131136, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<131136xbf16> offset = 0 len = 131136 sizes = [131136] strides = [1])
 
 module {
   aie.device(npu2) {

--- a/mlir/test/Conversion/AIRRtToNpu/single_device_emit_main.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/single_device_emit_main.mlir
@@ -107,12 +107,12 @@ module {
     // This mimics the test 31 pattern - device @herd_0 with @kernel sequence
     aie.runtime_sequence @kernel(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: memref<*xf32>) {
       %0 = aiex.dma_configure_task_for @air_channel_0_0 {
-        aie.dma_bd(%arg0 : memref<*xf32>, 0, 128, [<size = 16, stride = 256>, <size = 16, stride = 2>, <size = 4, stride = 64>, <size = 2, stride = 1>])
+        aie.dma_bd(%arg0 : memref<*xf32> offset = 0 len = 128 sizes = [16, 16, 4, 2] strides = [256, 2, 64, 1])
         aie.end
       } {repeat_count = 15 : i32}
       aiex.dma_start_task(%0)
       %1 = aiex.dma_configure_task_for @air_channel_2_0 {
-        aie.dma_bd(%arg2 : memref<*xf32>, 0, 128, [<size = 16, stride = 256>, <size = 16, stride = 2>, <size = 4, stride = 64>, <size = 2, stride = 1>])
+        aie.dma_bd(%arg2 : memref<*xf32> offset = 0 len = 128 sizes = [16, 16, 4, 2] strides = [256, 2, 64, 1])
         aie.end
       } {issue_token = true, repeat_count = 15 : i32}
       aiex.dma_start_task(%1)

--- a/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/tile_illegal_wrap_alignment.mlir
@@ -22,7 +22,7 @@
 // yielding an inner segment of 192 * 2 B = 384 B (4-B aligned).
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 683, stride = 192>, <size = 192, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16> offset = 0 len = 131136 sizes = [2, 1, 683, 192] strides = [131137, 0, 192, 1])
 
 module {
   aie.device(npu1) {
@@ -55,7 +55,7 @@ module {
 // already covers the full granularity.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<262273xf32>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 192, stride = 683>, <size = 683, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xf32> offset = 0 len = 131136 sizes = [2, 1, 192, 683] strides = [131137, 0, 683, 1])
 
 module {
   aie.device(npu1) {
@@ -121,7 +121,7 @@ module {
 // inner wrap drops to 4 (* 1 B = 4 B aligned) and the outer wrap becomes 257.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: aie.dma_bd(%arg0 : memref<2057xi8>, 0, 1028, [<size = 2, stride = 1029>, <size = 1, stride = 0>, <size = 257, stride = 4>, <size = 4, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<2057xi8> offset = 0 len = 1028 sizes = [2, 1, 257, 4] strides = [1029, 0, 4, 1])
 
 module {
   aie.device(npu1) {
@@ -153,7 +153,7 @@ module {
 // device divergence going unnoticed.
 
 // CHECK-LABEL: aie.device(npu2)
-// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16>, 0, 131136, [<size = 2, stride = 131137>, <size = 1, stride = 0>, <size = 683, stride = 192>, <size = 192, stride = 1>])
+// CHECK: aie.dma_bd(%arg0 : memref<262273xbf16> offset = 0 len = 131136 sizes = [2, 1, 683, 192] strides = [131137, 0, 192, 1])
 
 module {
   aie.device(npu2) {

--- a/mlir/test/Conversion/AIRToAIE/air_channel_pad.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_pad.mlir
@@ -16,9 +16,8 @@
 
 // CHECK:       aie.memtile_dma(%[[TILE_L2]])
 // The MM2S DMA BD from memtile to compute tile should have padding
-// CHECK:             aie.dma_bd({{.*}}, 0, 16,
-// CHECK-SAME:            [<size = 13, stride = 1>],
-// CHECK-SAME:            [<const_pad_before = 2, const_pad_after = 1>])
+// CHECK:             aie.dma_bd({{.*}} offset = 0 len = 16 sizes = [13] strides = [1]
+// CHECK-SAME:            pad [<const_pad_before = 2, const_pad_after = 1>])
 
 module {
   air.channel @L3ToL2 [1, 1]

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_core_to_core.mlir
@@ -22,7 +22,7 @@
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -39,7 +39,7 @@
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_ping_pong.mlir
@@ -19,12 +19,12 @@
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[CLOCK_PROD]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[CBUF_A]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[CBUF_A]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[CLOCK_CONS]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[CLOCK_PROD]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[CBUF_B]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[CBUF_B]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[CLOCK_CONS]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -50,7 +50,7 @@
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[MLOCK_CONS]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[MBUF]] : memref<32x32xbf16, 1>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[MBUF]] : memref<32x32xbf16, 1> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[MLOCK_PROD]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -113,12 +113,12 @@ func.func @multi_memcpys_over_time() {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -137,12 +137,12 @@ func.func @multi_memcpys_over_time() {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_14]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_14]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -217,12 +217,12 @@ func.func @core_to_core_ping_pong() {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_11]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -241,12 +241,12 @@ func.func @core_to_core_ping_pong() {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_14]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_14]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -329,7 +329,7 @@ func.func @core_to_core_ping_pong() {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[CLOCK_PROD]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[CBUF]] : memref<1x1x4x8x4x8xi32, 2 : i32>, 0, 1024) {task_id = 0 : i32}
+// CHECK:           aie.dma_bd(%[[CBUF]] : memref<1x1x4x8x4x8xi32, 2 : i32> offset = 0 len = 1024) {task_id = 0 : i32}
 // CHECK:           aie.use_lock(%[[CLOCK_CONS]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:  // pred: ^bb0

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_scf_if.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_scf_if.mlir
@@ -22,7 +22,7 @@
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -39,7 +39,7 @@
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:

--- a/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_shared_buffer.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_to_locks_shared_buffer.mlir
@@ -28,7 +28,7 @@
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[RLOCK]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[BUF]] : memref<32x32xbf16, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[BUF]] : memref<32x32xbf16, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[WLOCK]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:

--- a/mlir/test/Conversion/AIRToAIE/air_channel_unequal_trip_no_rotation.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_channel_unequal_trip_no_rotation.mlir
@@ -35,8 +35,8 @@
 // CHECK:       aie.mem(%[[TILE]])
 // CHECK-DAG:     aie.dma_start(S2MM, 0, {{.*}}, {{.*}}, repeat_count = 5)
 // CHECK-DAG:     aie.dma_start(S2MM, 0, {{.*}}, {{.*}}, repeat_count = 3)
-// CHECK-DAG:     aie.dma_bd(%{{.*}} : memref<32x32xbf16, 2>, 0, 1024) {task_id = 0
-// CHECK-DAG:     aie.dma_bd(%{{.*}} : memref<32x32xbf16, 2>, 0, 1024) {task_id = 1
+// CHECK-DAG:     aie.dma_bd(%{{.*}} : memref<32x32xbf16, 2> offset = 0 len = 1024) {task_id = 0
+// CHECK-DAG:     aie.dma_bd(%{{.*}} : memref<32x32xbf16, 2> offset = 0 len = 1024) {task_id = 1
 // CHECK-DAG:     aie.end
 
 air.channel @channel_0 [1, 1]

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie.mlir
@@ -19,7 +19,7 @@
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_14]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_14]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -62,7 +62,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_14]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_14]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -71,7 +71,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_15]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_16]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_16]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_15]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -120,7 +120,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -129,7 +129,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -181,7 +181,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -190,7 +190,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -243,7 +243,7 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -252,7 +252,7 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -395,7 +395,7 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:           aie.use_lock(%[[VAL_5]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:  // pred: ^bb5
@@ -404,19 +404,19 @@ func.func @func6(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb5)
 // CHECK:         ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb5:  // pred: ^bb3
 // CHECK:           aie.dma_start(S2MM, 1, ^bb6, ^bb2)
 // CHECK:         ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb7
 // CHECK:         ^bb7:  // pred: ^bb6
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb6
 // CHECK:         }
@@ -511,7 +511,7 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<16x8xi32, 2>, 0, 128)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<16x8xi32, 2> offset = 0 len = 128)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -520,7 +520,7 @@ func.func @func7(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>, %arg2 : mem
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<16x8xi32, 2>, 0, 128)
+// CHECK:           aie.dma_bd(%[[VAL_4]] : memref<16x8xi32, 2> offset = 0 len = 128)
 // CHECK:           aie.use_lock(%[[VAL_2]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie2_with_shim_dma_bds.mlir
@@ -21,7 +21,7 @@
 // CHECK:    aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:    aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:    aie.dma_bd(%[[VAL_7]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:    aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:    aie.next_bd ^bb1
 // CHECK:  ^bb2:
@@ -36,7 +36,7 @@
 // CHECK:    aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:    aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
+// CHECK:    aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:    aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:    aie.next_bd ^bb1
 // CHECK:  ^bb2:
@@ -78,7 +78,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
+// CHECK:   aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:   aie.use_lock(%[[VAL_10]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -87,7 +87,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_9]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -103,7 +103,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -112,7 +112,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 512)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -157,7 +157,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_13]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_10]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -166,7 +166,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_12]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_9]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -184,7 +184,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -193,7 +193,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 512)
 // CHECK:   aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -243,7 +243,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_19]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -252,7 +252,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_18]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -280,7 +280,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_1]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_15]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -289,7 +289,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_14]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -298,7 +298,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_7]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -307,21 +307,21 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb5)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
 // CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb7)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
 // CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb2)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_aie_with_shim_dma_bds.mlir
@@ -20,7 +20,7 @@
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -35,7 +35,7 @@
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -74,7 +74,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_7]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -83,7 +83,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_6]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -103,7 +103,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -112,7 +112,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 1, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -154,7 +154,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_7]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_7]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -163,7 +163,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_6]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_8]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -183,7 +183,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_4]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<1024xi32> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -192,7 +192,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_3]], Acquire, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_0]] : memref<1024xi32> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }

--- a/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_shimcpy_to_npu.mlir
@@ -19,7 +19,7 @@
 // CHECK:    %[[VAL_6:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:    aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:    aie.dma_bd(%[[VAL_4]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:    aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:    aie.next_bd ^bb1
 // CHECK:  ^bb2:
@@ -66,7 +66,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   %[[VAL_9:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
+// CHECK:   aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:   aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -75,7 +75,7 @@ func.func @func1(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   %[[VAL_10:.*]] = aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -130,7 +130,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_7]] : memref<512xi32, 2> offset = 0 len = 512)
 // CHECK:           aie.use_lock(%[[VAL_4]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -139,7 +139,7 @@ func.func @func2(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_3]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -200,7 +200,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_19]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb2:
@@ -209,7 +209,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:           aie.dma_start(S2MM, 0, ^bb4, ^bb2)
 // CHECK:         ^bb4:
 // CHECK:           aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, %{{.*}})
-// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2>, 0, 1024)
+// CHECK:           aie.dma_bd(%[[VAL_23]] : memref<1024xi32, 2> offset = 0 len = 1024)
 // CHECK:           aie.use_lock(%[[VAL_18]], Release, %{{.*}})
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         }
@@ -238,7 +238,7 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_7]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:
@@ -247,21 +247,21 @@ func.func @func3(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb5)
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_5]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
 // CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb7)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_21]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_8]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
 // CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb2)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1>, 0, 1024)
+// CHECK:   aie.dma_bd(%[[VAL_22]] : memref<1024xi32, 1> offset = 0 len = 1024)
 // CHECK:   aie.use_lock(%[[VAL_6]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
@@ -340,9 +340,9 @@ func.func @func4(%arg0 : memref<1024xi32>, %arg1 : memref<1024xi32>) -> () {
 // Race-condition fix for func5 produces a memtile_dma with paired MM2S/S2MM
 // channels that recycle the same buffer with sizes 1024, 512, 1024, 0.
 // RACECONDFIX-LABEL: aie.memtile_dma
-// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1>, 0, 1024)
-// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1>, 0, 512)
-// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1>, 0, 0)
+// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1> offset = 0 len = 1024)
+// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1> offset = 0 len = 512)
+// RACECONDFIX-DAG: aie.dma_bd(%{{.*}} : memref<1024xi32, 1> offset = 0 len = 0)
 // RACECONDFIX: @func5
 
 #set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 3 >= 0)>
@@ -475,21 +475,21 @@ func.func @func6(%arg5 : memref<8x8xi32>) {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
+// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1> offset = 0 len = 16)
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:  // pred: ^bb0
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4, ^bb5)
 // CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1>, 0, 16)
+// CHECK:   aie.dma_bd({{.*}} : memref<4x4xi32, 1> offset = 0 len = 16)
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:  // pred: ^bb3
 // CHECK:   aie.dma_start(S2MM, 1, ^bb6, ^bb2)
 // CHECK: ^bb6:  // 2 preds: ^bb5, ^bb6
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd({{.*}} : memref<8x16xi32, 1>, 0, 16, [<size = 4, stride = 16>, <size = 4, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<8x16xi32, 1> offset = 0 len = 16 sizes = [4, 4] strides = [16, 1])
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb6
 // CHECK: @func7
@@ -532,7 +532,7 @@ func.func @func7(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd({{.*}} : memref<64x256xi32, 1>, 8192, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<64x256xi32, 1> offset = 8192 len = 8192 sizes = [8, 32, 32] strides = [32, 256, 1])
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb2:  // pred: ^bb0
@@ -568,15 +568,15 @@ func.func @func8(%arg0 : memref<8x16xi32>, %arg1 : memref<16x8xi32>){
 // CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
+// CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2> offset = 0 len = 32)
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2>, 0, 32)
+// CHECK:   aie.dma_bd({{.*}} : memref<32xf32, 2> offset = 0 len = 32)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
-// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 0, 32)
+// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1> offset = 0 len = 32)
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1>, 32, 32)
+// CHECK:   aie.dma_bd({{.*}} : memref<64xf32, 1> offset = 32 len = 32)
 // CHECK: @func9
 // RACECONDFIX: @func9
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -631,15 +631,15 @@ func.func @func9(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2>, 0, 8192)
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2> offset = 0 len = 8192)
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2>, 0, 8192)
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 2> offset = 0 len = 8192)
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1>, 0, 8192)
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1> offset = 0 len = 8192)
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1>, 0, 8192)
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xi32, 1> offset = 0 len = 8192)
 // CHECK: @func10
 // RACECONDFIX: @func10
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -694,15 +694,15 @@ func.func @func10(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
 // CHECK: aie.device(npu1)
 // CHECK: %[[tileDMA_0_4:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2>, 0, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2> offset = 0 len = 8192 sizes = [8, 32, 32] strides = [32, 256, 1])
 // CHECK: %[[tileDMA_0_3:.*]] = aie.mem
 // CHECK:   aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2>, 0, 8192, [<size = 8, stride = 32>, <size = 32, stride = 256>, <size = 32, stride = 1>])
+// CHECK:   aie.dma_bd({{.*}} : memref<32x256xbf16, 2> offset = 0 len = 8192 sizes = [8, 32, 32] strides = [32, 256, 1])
 // CHECK: %[[memTileDMA_2_1:.*]] = aie.memtile_dma
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
-// CHECK:   memref<32x256xbf16, 1>, 0, 8192)
+// CHECK:   memref<32x256xbf16, 1> offset = 0 len = 8192)
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4, ^bb2)
-// CHECK:   memref<32x256xbf16, 1>, 0, 8192)
+// CHECK:   memref<32x256xbf16, 1> offset = 0 len = 8192)
 // CHECK: @func11
 // RACECONDFIX: @func11
 #map = affine_map<()[s0] -> (s0 * 32)>
@@ -790,11 +790,11 @@ func.func @func11(%arg0: memref<128xbf16>, %arg1: memref<128xbf16>) {
 
 // RACECONDFIX: aie.device(npu1)
 // RACECONDFIX: aie.memtile_dma(%[[mem_tile_0_1:.*]])
-// RACECONDFIX-COUNT-3: aie.dma_bd(%[[buf19:.*]] : memref<64x256xbf16, 1>, 0, 0)
-// RACECONDFIX: aie.dma_bd(%[[buf19]] : memref<64x256xbf16, 1>, 0, 16384)
+// RACECONDFIX-COUNT-3: aie.dma_bd(%[[buf19:.*]] : memref<64x256xbf16, 1> offset = 0 len = 0)
+// RACECONDFIX: aie.dma_bd(%[[buf19]] : memref<64x256xbf16, 1> offset = 0 len = 16384)
 // RACECONDFIX: aie.memtile_dma(%[[mem_tile_1_1:.*]])
-// RACECONDFIX-COUNT-11: aie.dma_bd(%[[buf18:.*]] : memref<64x256xbf16, 1>, 0, 0)
-// RACECONDFIX: aie.dma_bd(%[[buf18]] : memref<64x256xbf16, 1>, 0, 16384)
+// RACECONDFIX-COUNT-11: aie.dma_bd(%[[buf18:.*]] : memref<64x256xbf16, 1> offset = 0 len = 0)
+// RACECONDFIX: aie.dma_bd(%[[buf18]] : memref<64x256xbf16, 1> offset = 0 len = 16384)
 // RACECONDFIX: @func12
 
 #map = affine_map<()[s0] -> (s0 * 256)>
@@ -923,7 +923,7 @@ module {
 // CHECK:    %[[VAL_1:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:  ^bb1:
 // CHECK:    aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:    aie.dma_bd(%{{.*}} : memref<1x1x16x16x4x4xf32, 2 : i32>, 0, 4096, [<size = 64, stride = 4>, <size = 16, stride = 256>, <size = 4, stride = 1>])
+// CHECK:    aie.dma_bd(%{{.*}} : memref<1x1x16x16x4x4xf32, 2 : i32> offset = 0 len = 4096 sizes = [64, 16, 4] strides = [4, 256, 1])
 // CHECK:    aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:    aie.next_bd ^bb1
 // CHECK:  ^bb2:
@@ -1442,7 +1442,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:      ^bb1:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32>, 0, 2048, [<size = 8, stride = 8>, <size = 32, stride = 64>, <size = 8, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32> offset = 0 len = 2048 sizes = [8, 32, 8] strides = [8, 64, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      ^bb2:
@@ -1451,7 +1451,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb4, ^bb5, repeat_count = 7)
 // CHECK:      ^bb4:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32>, 0, 6144, [<size = 24, stride = 4>, <size = 64, stride = 96>, <size = 4, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 4>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32> offset = 0 len = 6144 sizes = [24, 64, 4] strides = [4, 96, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 4>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      }
@@ -1459,7 +1459,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:      ^bb1:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32>, 0, 2048, [<size = 8, stride = 8>, <size = 32, stride = 64>, <size = 8, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 1>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32> offset = 0 len = 2048 sizes = [8, 32, 8] strides = [8, 64, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 1>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      ^bb2:
@@ -1468,7 +1468,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb4, ^bb5, repeat_count = 7)
 // CHECK:      ^bb4:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32>, 0, 6144, [<size = 24, stride = 4>, <size = 64, stride = 96>, <size = 4, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 5>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32> offset = 0 len = 6144 sizes = [24, 64, 4] strides = [4, 96, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 5>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      }
@@ -1476,7 +1476,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:      ^bb1:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32>, 0, 2048, [<size = 8, stride = 8>, <size = 32, stride = 64>, <size = 8, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 2>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32> offset = 0 len = 2048 sizes = [8, 32, 8] strides = [8, 64, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 2>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      ^bb2:
@@ -1485,7 +1485,7 @@ module {
 // CHECK:        %{{.*}} = aie.dma_start(MM2S, 0, ^bb4, ^bb5, repeat_count = 7)
 // CHECK:      ^bb4:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32>, 0, 6144, [<size = 24, stride = 4>, <size = 64, stride = 96>, <size = 4, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 6>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32> offset = 0 len = 6144 sizes = [24, 64, 4] strides = [4, 96, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 6>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      }
@@ -1493,7 +1493,7 @@ module {
 // CHECK:        aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:      ^bb1:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32>, 0, 2048, [<size = 8, stride = 8>, <size = 32, stride = 64>, <size = 8, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<32x64xbf16, 1 : i32> offset = 0 len = 2048 sizes = [8, 32, 8] strides = [8, 64, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      ^bb2:
@@ -1502,7 +1502,7 @@ module {
 // CHECK:        %{{.*}} = aie.dma_start(MM2S, 0, ^bb4, ^bb5, repeat_count = 7)
 // CHECK:      ^bb4:
 // CHECK:        aie.use_lock(%{{.*}}, AcquireGreaterEqual, %{{.*}})
-// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32>, 0, 6144, [<size = 24, stride = 4>, <size = 64, stride = 96>, <size = 4, stride = 1>]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 7>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<64x96xbf16, 1 : i32> offset = 0 len = 6144 sizes = [24, 64, 4] strides = [4, 96, 1]) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 7>
 // CHECK:        aie.use_lock(%{{.*}}, Release, %{{.*}})
 // CHECK:        aie.next_bd ^bb2
 // CHECK:      }

--- a/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_to_npu_add_one.mlir
@@ -21,14 +21,14 @@
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[CLOCK_CONS1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[CBUF_OUT]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.dma_bd(%[[CBUF_OUT]] : memref<64xi32, 2> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[CLOCK_PROD1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:  // pred: ^bb0
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4,
 // CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock(%[[CLOCK_PROD2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[CBUF_IN]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.dma_bd(%[[CBUF_IN]] : memref<64xi32, 2> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[CLOCK_CONS2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -64,28 +64,28 @@
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[MLOCK_CONS1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_PROD1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[MLOCK_CONS2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_PROD2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
 // CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb7)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[MLOCK_PROD1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_CONS1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
 // CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb2)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[MLOCK_PROD2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_CONS2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }
@@ -150,14 +150,14 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[CLOCK_CONS1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[CBUF_OUT]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.dma_bd(%[[CBUF_OUT]] : memref<64xi32, 2> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[CLOCK_PROD1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:  // pred: ^bb0
 // CHECK:   aie.dma_start(S2MM, 0, ^bb4,
 // CHECK: ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:   aie.use_lock(%[[CLOCK_PROD2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[CBUF_IN]] : memref<64xi32, 2>, 0, 64)
+// CHECK:   aie.dma_bd(%[[CBUF_IN]] : memref<64xi32, 2> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[CLOCK_CONS2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: }
@@ -193,28 +193,28 @@ func.func @func0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>) -> () {
 // CHECK:   aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK: ^bb1:
 // CHECK:   aie.use_lock(%[[MLOCK_CONS1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_PROD1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb1
 // CHECK: ^bb3:
 // CHECK:   aie.dma_start(MM2S, 1, ^bb4
 // CHECK: ^bb4:
 // CHECK:   aie.use_lock(%[[MLOCK_CONS2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_PROD2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb4
 // CHECK: ^bb5:
 // CHECK:   aie.dma_start(S2MM, 0, ^bb6, ^bb7)
 // CHECK: ^bb6:
 // CHECK:   aie.use_lock(%[[MLOCK_PROD1]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_OUT]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_CONS1]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb6
 // CHECK: ^bb7:
 // CHECK:   aie.dma_start(S2MM, 1, ^bb8, ^bb2)
 // CHECK: ^bb8:
 // CHECK:   aie.use_lock(%[[MLOCK_PROD2]], AcquireGreaterEqual, %{{.*}})
-// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1>, 0, 64)
+// CHECK:   aie.dma_bd(%[[MBUF_IN]] : memref<64xi32, 1> offset = 0 len = 64)
 // CHECK:   aie.use_lock(%[[MLOCK_CONS2]], Release, %{{.*}})
 // CHECK:   aie.next_bd ^bb8
 // CHECK: }

--- a/mlir/test/Conversion/AIRToAIE/memtile_packet_same_flow_collapse.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_packet_same_flow_collapse.mlir
@@ -20,8 +20,8 @@
 
 // CHECK: aie.memtile_dma
 // CHECK: aie.dma_start(S2MM, 0
-// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 0, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
-// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 8, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1> offset = 0 len = 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1> offset = 8 len = 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
 // CHECK-NOT: aie.dma_start(S2MM, 1
 
 air.channel @w0 [1, 1] {channel_type = "npu_dma_packet"}

--- a/mlir/test/Conversion/AIRToAIE/memtile_packet_two_sources_one_dst.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_packet_two_sources_one_dst.mlir
@@ -24,9 +24,9 @@
 
 // CHECK: aie.memtile_dma
 // CHECK: aie.dma_start(S2MM, 0
-// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 0, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1> offset = 0 len = 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 0>
 // CHECK: aie.dma_start(S2MM, 1
-// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1>, 8, 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 1>
+// CHECK: aie.dma_bd(%{{.*}} : memref<2x8xbf16, 1> offset = 8 len = 8) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 1>
 
 air.channel @w0 [1, 1] {channel_type = "npu_dma_packet"}
 air.channel @w1 [1, 1] {channel_type = "npu_dma_packet"}

--- a/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_keep_pkt_header.mlir
@@ -14,7 +14,7 @@
 //   - NOT statically stamp a pkt_id on the producer BD (a static stamp would
 //     prepend a second header word and shift the payload).
 
-// CHECK: aie.dma_bd({{.*}}memref<8xbf16, 2>, 0, 8) {task_id = 0 : i32}
+// CHECK: aie.dma_bd({{.*}}memref<8xbf16, 2> offset = 0 len = 8) {task_id = 0 : i32}
 // CHECK-NOT: packet = #aie.packet_info
 // CHECK: aie.packet_flow(0) {
 // CHECK-NEXT: aie.packet_source<%{{.*}}, DMA : 0>

--- a/mlir/test/Conversion/AIRToAIE/packet_multi_id_no_bd_tag.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_multi_id_no_bd_tag.mlir
@@ -13,7 +13,7 @@
 // a packet header (packetIDForChannelName is intentionally left unset for >1
 // pinned id). The producer BD carries only its task_id, no packet_info.
 
-// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2>, 14, 66) {task_id = 0 : i32}
+// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2> offset = 14 len = 66) {task_id = 0 : i32}
 // CHECK-NOT: packet = #aie.packet_info
 // CHECK: aie.packet_flow(2) {
 // CHECK: aie.packet_flow(5) {

--- a/mlir/test/Conversion/AIRToAIE/packet_single_id_bd_tag.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_single_id_bd_tag.mlir
@@ -12,7 +12,7 @@
 // generateDmaBd). This is the DMA-stamped path (contrast the multi-id
 // kernel-header contract, where BDs are deliberately left untagged).
 
-// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2>, 14, 66) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>
+// CHECK: aie.dma_bd(%{{.*}} : memref<80xbf16, 2> offset = 14 len = 66) {packet = #aie.packet_info<pkt_type = 0, pkt_id = 3>
 // CHECK: aie.packet_flow(3) {
 
 air.channel @m [1, 1] {channel_type = "npu_dma_packet", packet_ids = [3]}

--- a/mlir/test/Transform/AIRMergeUnrolledDevices/merge_unrolled_devices.mlir
+++ b/mlir/test/Transform/AIRMergeUnrolledDevices/merge_unrolled_devices.mlir
@@ -63,7 +63,7 @@ module {
     ^bb1:
       %c1_i32 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_2, AcquireGreaterEqual, %c1_i32)
-      aie.dma_bd(%buf0 : memref<32xi32, 2 : i32>, 0, 32) {task_id = 0 : i32}
+      aie.dma_bd(%buf0 : memref<32xi32, 2 : i32> offset = 0 len = 32) {task_id = 0 : i32}
       %c1_i32_1 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_1, Release, %c1_i32_1)
       aie.next_bd ^bb1
@@ -74,7 +74,7 @@ module {
     ^bb4:
       %c1_i32_2 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, %c1_i32_2)
-      aie.dma_bd(%buf1 : memref<32xi32, 2 : i32>, 0, 32) {task_id = 0 : i32}
+      aie.dma_bd(%buf1 : memref<32xi32, 2 : i32> offset = 0 len = 32) {task_id = 0 : i32}
       %c1_i32_3 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_0, Release, %c1_i32_3)
       aie.next_bd ^bb4
@@ -129,7 +129,7 @@ module {
     ^bb1:
       %c1_i32_9 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_2, AcquireGreaterEqual, %c1_i32_9)
-      aie.dma_bd(%buf2 : memref<32xi32, 2 : i32>, 0, 32) {task_id = 0 : i32}
+      aie.dma_bd(%buf2 : memref<32xi32, 2 : i32> offset = 0 len = 32) {task_id = 0 : i32}
       %c1_i32_10 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_1, Release, %c1_i32_10)
       aie.next_bd ^bb1
@@ -140,7 +140,7 @@ module {
     ^bb4:
       %c1_i32_11 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, %c1_i32_11)
-      aie.dma_bd(%buf3 : memref<32xi32, 2 : i32>, 0, 32) {task_id = 0 : i32}
+      aie.dma_bd(%buf3 : memref<32xi32, 2 : i32> offset = 0 len = 32) {task_id = 0 : i32}
       %c1_i32_12 = arith.constant 1 : i32
       aie.use_lock(%lock_0_2_0, Release, %c1_i32_12)
       aie.next_bd ^bb4

--- a/programming_examples/channel_examples/dual_herd_packet_switch/run_makefile_peano_elf.lit
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/run_makefile_peano_elf.lit
@@ -8,7 +8,3 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: PASS!
-//
-// XFAIL: *
-// Full-ELF with >5 host buffers emits a spurious DDR-aperture offset on arg>=5.
-// Fixed by mlir-aie PR #3345 (runtime-gated offset); un-XFAIL after that lands.

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=660e1a0e04097debaf6846b3bba7893a56fb97fd
-WHEEL_VERSION=1.3.5.dev52+g${HASH:0:7}
+export HASH=157e8b8c967e47ea19bda83a6972f7c1cf0e4e13
+WHEEL_VERSION=1.3.5.dev62+g${HASH:0:7}
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
## Summary
- Bumps the pinned mlir-aie from `1.3.5.dev52+g660e1a0` to `1.3.5.dev62+g157e8b8`.
- Picks up the runtime-gated DDR-aperture offset fix (mlir-aie #3345), which corrects full-ELF launches with more than 5 host buffers (previously produced all-zero output on npu2).
- Un-XFAILs `programming_examples/channel_examples/dual_herd_packet_switch` full-ELF, which was XFAIL'd in the prior bump (#1732) pending that fix and now passes.

## Test plan
- [x] Built mlir-air locally against a local mlir-aie clone at 157e8b8 and ran `dual_herd_packet_switch` (6 host buffers, `OUTPUT_FORMAT=elf`) end-to-end on npu2 → `PASS!`
- [x] CI (dialect/pass, Python, and npu2 e2e suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)