### PR TITLE
[utils] Source LLVM from ROCm/llvm-project fork

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -12,10 +12,14 @@
 #
 # This script is called from the github workflows.
 #
+# As of the ROCm/llvm-project migration, LLVM is sourced from the ROCm fork
+# (github.com/ROCm/llvm-project) rather than upstream llvm/llvm-project, to
+# match the MLIR distro wheels mlir-aie builds against.
+#
 ##===----------------------------------------------------------------------===##
 
-export commithash=068c6c5c0c8a0555036a2ff09a99f486548e6e8d
-DATETIME=2026060107
+export commithash=46fcb339fb61119b337f973c7ca9e710a319fdd0
+DATETIME=2026071405
 WHEEL_VERSION=23.0.0.$DATETIME+${commithash:0:8}
 
 if [ x"$1" == x--get-wheel-version ]; then
@@ -27,7 +31,7 @@ target_dir=llvm
 
 # clone llvm if it is not there already
 if [[ ! -d $target_dir ]]; then
-  git clone --depth 1 https://github.com/llvm/llvm-project.git $target_dir
+  git clone --depth 1 https://github.com/ROCm/llvm-project.git $target_dir
 fi
 
 pushd $target_dir


### PR DESCRIPTION
## Summary
- Migrates mlir-air's pinned LLVM/MLIR from upstream `llvm/llvm-project` to the **ROCm fork** `ROCm/llvm-project`, mirroring mlir-aie's migration (mlir-aie #3324/#3326).
- Bumps the MLIR wheel pin `23.0.0.2026060107+068c6c5c` → `23.0.0.2026071405+46fcb339` — the same MLIR distro wheel the currently-pinned mlir-aie (`1.3.5.dev62+g157e8b8`) is built against.
- Keeps mlir-air and the `mlir_aie` wheel it consumes on a single MLIR ABI, removing the upstream/ROCm divergence in the wheel-consuming build paths (Windows, wheels, aie-tools).

## Why now
mlir-aie already moved to the ROCm fork, and that commit is what main pins (dev62). mlir-air's main build inherits mlir-aie's MLIR, but the wheel-consuming workflows still fetched the upstream `mlir` wheel via mlir-air's own `clone-llvm.sh`; this aligns them.

## Local validation (npu2)
Replaced the local MLIR install with the ROCm wheel `46fcb339` and clean-rebuilt both projects:
- mlir-aie and mlir-air both compile cleanly against ROCm-fork MLIR
- `check-air-mlir`: 458 passed, 7 expectedly-failed, 0 unexpected
- `check-air-python`: 10 passed, 0 failed
- e2e `dual_herd_packet_switch` (full-ELF, 6 buffers): PASS
- e2e bf16 matmul (llama 8x4 down): PASS

## Test plan
- [x] CI (build/test, npu1 + npu2 hardware, Windows, wheels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)