### PR TITLE
[AIRToAIE] Preserve offset operand dominance when reordering L3 packet puts

### DIFF
--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -368,6 +368,13 @@ void getBackwardSliceInRegion(OpBuilder builder, Region *region,
                               SmallVectorImpl<Value> &vals,
                               SetVector<Operation *> &backwardSlices);
 
+// Move `op` next to `dest` (after it when `after`, else before), bringing its
+// same-block backward slice along so SSA dominance is preserved: any slice op
+// that ends up trailing `op` is pulled back before it, deps-first. Done only if
+// every slice op is memory-effect-free; otherwise nothing is moved and false is
+// returned, so the caller can avoid a reorder that would strand an impure dep.
+bool moveWithPureBackwardSlice(Operation *op, Operation *dest, bool after);
+
 // Buffer all allocations of memref directly within the func op's body into the
 // func op's arguments.
 void populateBufferMemrefToFuncArgsPattern(RewritePatternSet &patterns);

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -15,8 +15,6 @@
 #include "air/Util/Util.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
-
-#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
@@ -32,7 +30,6 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/OperationSupport.h"
-#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -1358,37 +1355,15 @@ static void deferDeviceToHostDrainWaits(ModuleOp module) {
     if (!anchor)
       return;
 
-    Block *blk = anchor->getBlock();
-    BackwardSliceOptions sliceOpts;
-    sliceOpts.omitBlockArguments = true;
-    sliceOpts.filter = [&](Operation *o) { return o->getBlock() == blk; };
-    llvm::SetVector<Operation *> toHoist;
-    for (auto dma : drainDmas) {
-      llvm::SetVector<Operation *> slice;
-      (void)getBackwardSlice(dma.getOperation(), &slice, sliceOpts);
-      // A side-effecting producer must not be reordered across the intervening
-      // input DMAs; leave such a drain in place rather than risk a hazard.
-      if (llvm::any_of(slice,
-                       [](Operation *o) { return !isMemoryEffectFree(o); }))
-        continue;
-      toHoist.insert(slice.begin(), slice.end());
-      toHoist.insert(dma.getOperation());
-    }
-    // Relocate, in program order, only the to-hoist ops that currently follow
-    // the anchor; those already ahead of it already dominate it. Moving value
-    // definitions earlier is dominance-safe.
-    SmallVector<Operation *> ordered;
-    bool seenAnchor = false;
-    for (Operation *op : window) {
-      if (op == anchor) {
-        seenAnchor = true;
-        continue;
-      }
-      if (seenAnchor && toHoist.contains(op))
-        ordered.push_back(op);
-    }
-    for (Operation *op : ordered)
-      op->moveBefore(anchor);
+    // Relocate each drain that currently follows the anchor to just before it,
+    // carrying its same-block operand slice so dominance holds (deps-first).
+    // Drains already ahead of the anchor already dominate it and are left
+    // alone. A drain whose slice contains a side-effecting op is left in place
+    // rather than reordered across the intervening input DMAs.
+    for (auto dma : drainDmas)
+      if (anchor->isBeforeInBlock(dma.getOperation()))
+        (void)air::moveWithPureBackwardSlice(dma.getOperation(), anchor,
+                                             /*after=*/false);
   });
 }
 

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -8,6 +8,8 @@
 #include "air/Conversion/AIRToAIESchedulingUtils.h"
 #include "air/Util/Util.h"
 
+#include "mlir/Analysis/SliceAnalysis.h"
+
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -2398,6 +2400,24 @@ void air::reorderL3PacketPutsByFlowOrder(
       continue;
     }
     put->moveAfter(it->second);
+    // moveAfter relocates only the put op. Its wrap-and-stride operands
+    // (offset/size/stride) may be produced by same-block ops -- e.g. an
+    // arith.addi computing a per-iteration DDR offset -- which are left in
+    // place and can now follow the put, violating SSA dominance ("operand #N
+    // does not dominate this use"). Pull any same-block backward-slice op that
+    // now trails the put back to just before it, in topological (deps-first)
+    // order so the operands' mutual order stays valid. All such ops are pure
+    // index arithmetic, so relocating them is side-effect free; operands that
+    // already dominate the put are left untouched.
+    Block *pblk = put->getBlock();
+    BackwardSliceOptions bsOpts;
+    bsOpts.omitBlockArguments = true;
+    bsOpts.filter = [&](Operation *o) { return o->getBlock() == pblk; };
+    llvm::SetVector<Operation *> slice;
+    (void)getBackwardSlice(put.getOperation(), &slice, bsOpts);
+    for (Operation *s : slice)
+      if (put.getOperation()->isBeforeInBlock(s))
+        s->moveBefore(put.getOperation());
     prevByBlock[blk] = put;
   }
 }

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -8,8 +8,6 @@
 #include "air/Conversion/AIRToAIESchedulingUtils.h"
 #include "air/Util/Util.h"
 
-#include "mlir/Analysis/SliceAnalysis.h"
-
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -2399,25 +2397,12 @@ void air::reorderL3PacketPutsByFlowOrder(
       prevByBlock[blk] = put;
       continue;
     }
-    put->moveAfter(it->second);
-    // moveAfter relocates only the put op. Its wrap-and-stride operands
-    // (offset/size/stride) may be produced by same-block ops -- e.g. an
-    // arith.addi computing a per-iteration DDR offset -- which are left in
-    // place and can now follow the put, violating SSA dominance ("operand #N
-    // does not dominate this use"). Pull any same-block backward-slice op that
-    // now trails the put back to just before it, in topological (deps-first)
-    // order so the operands' mutual order stays valid. All such ops are pure
-    // index arithmetic, so relocating them is side-effect free; operands that
-    // already dominate the put are left untouched.
-    Block *pblk = put->getBlock();
-    BackwardSliceOptions bsOpts;
-    bsOpts.omitBlockArguments = true;
-    bsOpts.filter = [&](Operation *o) { return o->getBlock() == pblk; };
-    llvm::SetVector<Operation *> slice;
-    (void)getBackwardSlice(put.getOperation(), &slice, bsOpts);
-    for (Operation *s : slice)
-      if (put.getOperation()->isBeforeInBlock(s))
-        s->moveBefore(put.getOperation());
+    // Move the put after its flow-order predecessor, carrying its wrap-and-
+    // stride operand slice (e.g. an arith.addi computing a per-iteration DDR
+    // offset) so SSA dominance holds. A put whose slice contains a side-
+    // effecting op is left in place rather than reordered unsafely.
+    (void)air::moveWithPureBackwardSlice(put.getOperation(), it->second,
+                                         /*after=*/true);
     prevByBlock[blk] = put;
   }
 }

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/Iterators.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -2647,6 +2648,30 @@ Operation *air::cloneOpAndOperands(RewriterBase &rewriter, IRMapping &remap,
   // 3) Finally clone the target op itself.
   auto new_op = rewriter.clone(*op, remap);
   return new_op;
+}
+
+bool air::moveWithPureBackwardSlice(Operation *op, Operation *dest,
+                                    bool after) {
+  Block *blk = op->getBlock();
+  BackwardSliceOptions bsOpts;
+  bsOpts.omitBlockArguments = true;
+  bsOpts.filter = [&](Operation *o) { return o->getBlock() == blk; };
+  llvm::SetVector<Operation *> slice;
+  (void)getBackwardSlice(op, &slice, bsOpts);
+  // Relocating a side-effecting op could cross a hazard; bail and let the
+  // caller skip the reorder rather than risk changing semantics.
+  if (llvm::any_of(slice, [](Operation *o) { return !isMemoryEffectFree(o); }))
+    return false;
+  if (after)
+    op->moveAfter(dest);
+  else
+    op->moveBefore(dest);
+  // getBackwardSlice yields deps-first order; pulling each trailing slice op to
+  // just before `op` in that order keeps the operands' mutual order valid.
+  for (Operation *s : slice)
+    if (op->isBeforeInBlock(s))
+      s->moveBefore(op);
+  return true;
 }
 
 bool air::opOrAncestorIsDominantOver(Operation *a, Operation *b) {

--- a/mlir/test/Conversion/AIRToAIE/packet_l3_put_offset_dominance.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_l3_put_offset_dominance.mlir
@@ -20,11 +20,13 @@
 
 // RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
 
-// The offset arithmetic for @pkt_in_1 must remain before its put after reorder.
+// The offset arithmetic for @pkt_in_1 must remain before its put after reorder,
+// and the put must still consume the second arith.addi's result.
+// CHECK-LABEL: func.func @func_l3_put_offset
 // CHECK: air.channel.put @pkt_in_0
-// CHECK: arith.addi
-// CHECK: arith.addi
-// CHECK: air.channel.put @pkt_in_1
+// CHECK: %[[BASE:.*]] = arith.addi
+// CHECK: %[[OFF:.*]] = arith.addi %[[BASE]]
+// CHECK: air.channel.put @pkt_in_1[] (%{{.*}}[%[[OFF]]]
 
 module {
   air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet"}

--- a/mlir/test/Conversion/AIRToAIE/packet_l3_put_offset_dominance.mlir
+++ b/mlir/test/Conversion/AIRToAIE/packet_l3_put_offset_dominance.mlir
@@ -1,0 +1,74 @@
+//===- packet_l3_put_offset_dominance.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// air-to-aie reorders L3 (DDR) packet puts into flow order so that the runtime
+// sequence emits their DMA starts in the order the receiver mem chain expects.
+// The reorder relocates each put with `moveAfter(prev)`. When a put's
+// wrap-and-stride offset is produced by same-block ops (here two `arith.addi`
+// computing a per-iteration DDR offset) that sit between the anchor put and the
+// moved put, `moveAfter` jumps the put ahead of those defining ops, leaving the
+// put using a value defined after it -- an SSA dominance violation
+// ("operand #N does not dominate this use") that fails the verifier.
+//
+// The reorder must pull the offset's same-block backward slice back before the
+// put (deps-first), keeping dominance valid. This test fails to verify without
+// that fix; with it, both offset `arith.addi` ops precede the put that uses them.
+
+// RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
+
+// The offset arithmetic for @pkt_in_1 must remain before its put after reorder.
+// CHECK: air.channel.put @pkt_in_0
+// CHECK: arith.addi
+// CHECK: arith.addi
+// CHECK: air.channel.put @pkt_in_1
+
+module {
+  air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_in_1 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @to_core [1, 1]
+  air.channel @from_core [1, 1]
+  air.channel @out [1, 1]
+  func.func @func_l3_put_offset(%arg0: memref<128xi32>, %arg1: memref<128xi32>, %arg2: memref<64xi32>, %iv: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    // Anchor put (flow order 0).
+    air.channel.put @pkt_in_0[] (%arg0[%c0] [%c64] [%c1]) {id = 1 : i32} : (memref<128xi32>)
+    // Offset arithmetic for the next put, defined BETWEEN the two puts and
+    // derived from a non-constant value (%iv) so it cannot be constant-folded
+    // away. After the reorder moves the put to just-after the anchor, these
+    // defining ops would trail the put that uses them.
+    %base = arith.addi %iv, %c1 : index
+    %off = arith.addi %base, %c64 : index
+    // Put (flow order 1) whose offset operand is %off.
+    air.channel.put @pkt_in_1[] (%arg1[%off] [%c64] [%c1]) {id = 2 : i32} : (memref<128xi32>)
+    air.segment @seg0 {
+      %c1_0 = arith.constant 1 : index
+      %l2_0 = memref.alloc() : memref<64xi32, 1>
+      %l2_1 = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @pkt_in_0[] (%l2_0[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+      air.channel.get @pkt_in_1[] (%l2_1[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+      air.channel.put @to_core[] (%l2_0[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+      air.herd tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) attributes {sym_name = "herd0"} {
+        %buf = memref.alloc() : memref<64xi32, 2>
+        %res = memref.alloc() : memref<64xi32, 2>
+        air.channel.get @to_core[%tx, %ty] (%buf[] [] []) {id = 6 : i32} : (memref<64xi32, 2>)
+        air.channel.put @from_core[%tx, %ty] (%res[] [] []) {id = 7 : i32} : (memref<64xi32, 2>)
+        memref.dealloc %buf : memref<64xi32, 2>
+        memref.dealloc %res : memref<64xi32, 2>
+      }
+      %l2_out = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @from_core[] (%l2_out[] [] []) {id = 8 : i32} : (memref<64xi32, 1>)
+      air.channel.put @out[] (%l2_out[] [] []) {id = 9 : i32} : (memref<64xi32, 1>)
+      memref.dealloc %l2_0 : memref<64xi32, 1>
+      memref.dealloc %l2_1 : memref<64xi32, 1>
+      memref.dealloc %l2_out : memref<64xi32, 1>
+    }
+    air.channel.get @out[] (%arg2[] [] []) {id = 10 : i32} : (memref<64xi32>)
+    return
+  }
+}


### PR DESCRIPTION
## Summary
`reorderL3PacketPutsByFlowOrder` groups L3 (DDR) packet puts into flow order via `put->moveAfter(prev)` so the runtime sequence emits their DMA starts in the order the receiver mem chain expects. `moveAfter` relocates only the put op. When a put's wrap-and-stride **offset** is produced by a same-block op — e.g. an `arith.addi` computing a per-iteration DDR offset — that defining op is left in place and can end up *after* the moved put, tripping the SSA dominance verifier:

```
error: operand #N does not dominate this use
```

## Fix
After moving each put, walk its same-block backward slice and pull any op that now trails the put back before it, in topological (deps-first) order. The affected ops are pure index arithmetic, so relocating them is side-effect free; operands that already dominate the put are left untouched.

## Test
Adds `mlir/test/Conversion/AIRToAIE/packet_l3_put_offset_dominance.mlir`: two L3 packet puts where the second's offset is computed by same-block `arith.addi` ops (derived from a non-constant value so they are not folded) sitting between the puts. It **fails to verify without this change** (`operand #1 does not dominate this use`) and **passes with it** (both `arith.addi` precede the put that uses them).

## Test plan
- [x] `packet_l3_put_offset_dominance.mlir` fails without the fix, passes with it
- [x] `check-air-mlir`: no new failures vs `origin/main` baseline (identical pre-existing set; the new test adds one pass)
- [x] `clang-format-17` clean