### PR TITLE
[AIRRt] Support fused multi-iteration launches with heterogeneous waves

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -71,6 +71,13 @@ constexpr StringLiteral KeepPktHeader = "keep_pkt_header";
 // stamped. Distinct from KeepPktHeader, which is per-flow (offset-0 bearer
 // only).
 constexpr StringLiteral SrcWritesPktHeader = "air.src_writes_pkt_header";
+// Per-op launch-iteration ("wave") index (i64) on runtime-sequence ops of a
+// fused multi-iteration launch. Assigned in AIRRtToNpu right after the fused
+// launch loop is unrolled (program order still reflects wave membership) and
+// propagated onto the ops each airrt op lowers to, so downstream per-wave
+// ordering (RTP arm / set_lock / output-S2MM hoist) groups by this index
+// instead of inferring wave boundaries from op positions.
+constexpr StringLiteral LaunchWave = "air.launch_wave";
 } // namespace attrs
 
 // Copy the DMA-steering / runtime-ordering markers

--- a/mlir/include/air/Util/Util.h
+++ b/mlir/include/air/Util/Util.h
@@ -67,6 +67,15 @@ uint64_t getElementSizeInBytes(const mlir::Type ty);
 scf::ForOp getForRegionIterArgsOwner(Value val);
 // Get the parent scf.parallel op of an init_val
 scf::ParallelOp getParallelRegionInitValsOwner(Operation *op, Value val);
+// Rebuild an scf.index_switch with an extra trailing !air.async.token result.
+// Creates a new switch (same arg/cases, original result types plus a trailing
+// async token), copies the symbol attr, splices each region's ops (excluding
+// the terminator) into the new regions, and RAUWs the original results. Does
+// NOT add region terminators and does NOT erase `sw`: the caller populates each
+// region's async yield and erases the old op in its own idiom.
+scf::IndexSwitchOp
+rebuildIndexSwitchWithTrailingAsyncToken(OpBuilder &b, scf::IndexSwitchOp sw);
+
 // Get the parent air.launch_herd op of a tile id
 HerdOp getHerdArgOwner(Value val);
 // Returns true if the L1 buffer passed as kernel operand `memrefOperand` to

--- a/mlir/lib/Conversion/AIRLoweringPass.cpp
+++ b/mlir/lib/Conversion/AIRLoweringPass.cpp
@@ -1140,6 +1140,35 @@ public:
   }
 };
 
+class ScfIndexSwitchOpConversion
+    : public OpConversionPattern<scf::IndexSwitchOp> {
+public:
+  using OpConversionPattern<scf::IndexSwitchOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::IndexSwitchOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    scf::IndexSwitchOp newOp = dyn_cast_if_present<scf::IndexSwitchOp>(
+        rewriter.cloneWithoutRegions(*op.getOperation()));
+    for (unsigned i = 0; i < op->getNumRegions(); i++)
+      rewriter.inlineRegionBefore(op->getRegion(i), newOp->getRegion(i),
+                                  newOp->getRegion(i).end());
+
+    // Update the switch arg and convert region + result types (air.async.token
+    // -> airrt.event), mirroring ScfForOpConversion.
+    newOp->setOperands(adaptor.getOperands());
+    for (unsigned i = 0; i < newOp->getNumRegions(); i++)
+      if (failed(rewriter.convertRegionTypes(&newOp->getRegion(i),
+                                             *typeConverter)))
+        return failure();
+    for (auto result : newOp.getResults())
+      result.setType(typeConverter->convertType(result.getType()));
+
+    rewriter.replaceOp(op, newOp.getResults());
+    return success();
+  }
+};
+
 class ScfParOpConversion : public OpConversionPattern<scf::ParallelOp> {
 public:
   using OpConversionPattern<scf::ParallelOp>::OpConversionPattern;
@@ -1478,6 +1507,14 @@ public:
       }
       return true;
     });
+    target.addDynamicallyLegalOp<scf::IndexSwitchOp>(
+        [&](scf::IndexSwitchOp op) {
+          for (auto v : op.getResults()) {
+            if (llvm::isa<air::AsyncTokenType>(v.getType()))
+              return false;
+          }
+          return true;
+        });
     target.addIllegalOp<air::WaitAllOp>();
     target.addLegalOp<UnrealizedConversionCastOp>();
 
@@ -1489,11 +1526,12 @@ public:
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(air_patterns,
                                                                    converter);
 
-    air_patterns.add<
-        ScfYieldOpConversion, ScfIfOpConversion, ScfForOpConversion,
-        ScfParOpConversion, ScfReduceReturnOpConversion, ScfReduceOpConversion,
-        AIRDmaMemcpyNdToAIRRtConversion, AIRWaitAllToAIRRtConversion>(converter,
-                                                                      context);
+    air_patterns
+        .add<ScfYieldOpConversion, ScfIfOpConversion, ScfForOpConversion,
+             ScfIndexSwitchOpConversion, ScfParOpConversion,
+             ScfReduceReturnOpConversion, ScfReduceOpConversion,
+             AIRDmaMemcpyNdToAIRRtConversion, AIRWaitAllToAIRRtConversion>(
+            converter, context);
 
     // Build channel counterpart cache to avoid O(n) module walks per channel
     // op during conversion. Without this cache, each of the N channel ops

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -463,6 +464,74 @@ struct RelocateAssumeAlignmentOp
     // Erase the old AssumeAlignmentOp
     rewriter.eraseOp(assumeOp);
 
+    return success();
+  }
+};
+
+// Fold a constant-index scf.index_switch on the host (runtime-sequence) side.
+// After the fused per-wave launch loop is fully unrolled (unrollSCFFors), the
+// wave induction variable becomes a constant in each copy, so a launch-scope
+// scf.index_switch that selects per-wave host feeds (each wave may run a
+// different per-wave mode) has a constant condition. Inline the selected branch
+// so its feed ops land
+// directly in the runtime-sequence body -- an scf.index_switch cannot be a
+// parent of aiex.dma_configure_task_for. On-core (CoreOp) index_switches carry
+// a runtime RTP arm and are lowered elsewhere, so they are left untouched.
+struct FoldConstIndexSwitchPattern
+    : public OpRewritePattern<scf::IndexSwitchOp> {
+  using OpRewritePattern<scf::IndexSwitchOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(scf::IndexSwitchOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getParentOfType<AIE::CoreOp>())
+      return failure();
+    auto argConst = mlir::getConstantIntValue(op.getArg());
+    if (!argConst)
+      return failure();
+    Region *reg = nullptr;
+    ArrayRef<int64_t> cases = op.getCases();
+    for (size_t i = 0; i < cases.size(); ++i) {
+      if (cases[i] == *argConst) {
+        reg = &op.getCaseRegions()[i];
+        break;
+      }
+    }
+    if (!reg)
+      reg = &op.getDefaultRegion();
+    Block &bb = reg->front();
+    auto yield = cast<scf::YieldOp>(bb.getTerminator());
+    SmallVector<Value> results(yield.getOperands());
+    rewriter.eraseOp(yield);
+    // If the switch carried an async drain token (a fused per-wave mode switch
+    // wrapping host feeds is made async upstream so shim-dma-bds can build the
+    // launch_end drain), sever the drain's dependency on it. At this stage feed
+    // synchronization is handled by NpuDmaWaitOp on channels; the launch_end
+    // wait_all only needs its marker attribute (already counted by
+    // markDevicesNeedingLockReset). Rebuild each consuming airrt.wait_all
+    // without the switch-token operand, so the token becomes dead and the
+    // switch (and its inlined branch wait_all) can be erased cleanly -- a
+    // surviving airrt.wait_all -> launch_end wait_all token chain otherwise
+    // breaks the dialect conversion's erase ordering.
+    if (op.getNumResults() > 0 &&
+        isa<airrt::EventType>(op.getResult(op.getNumResults() - 1).getType())) {
+      Value switchTok = op.getResult(op.getNumResults() - 1);
+      SmallVector<Operation *> users(switchTok.getUsers());
+      for (Operation *u : users) {
+        auto wa = dyn_cast<airrt::WaitAllOp>(u);
+        if (!wa)
+          continue;
+        SmallVector<Value> newOperands;
+        for (Value v : wa->getOperands())
+          if (v != switchTok)
+            newOperands.push_back(v);
+        rewriter.setInsertionPoint(wa);
+        auto nwa = airrt::WaitAllOp::create(rewriter, wa.getLoc(),
+                                            wa->getResultTypes(), newOperands);
+        nwa->setAttrs(wa->getDiscardableAttrDictionary());
+        rewriter.replaceOp(wa, nwa->getResults());
+      }
+    }
+    rewriter.inlineBlockBefore(&bb, op);
+    rewriter.replaceOp(op, results);
     return success();
   }
 };
@@ -1691,6 +1760,28 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       }
     }
 
+    // Fold constant-condition launch-scope scf.index_switch after unrolling.
+    // A fused per-wave launch that selects per-wave host feeds via an
+    // scf.index_switch(select(wave_iv < K, ...)) has a constant condition once
+    // the wave loop is unrolled; the arith chain (cmpi/select/index_cast) folds
+    // to a constant and the switch's chosen branch must be inlined so its feed
+    // ops sit directly in the runtime sequence (an index_switch cannot parent
+    // aiex.dma_configure_task_for). Runs the arith folds + branch inlining
+    // greedily so the chain collapses in one sweep.
+    {
+      RewritePatternSet p(ctx);
+      arith::CmpIOp::getCanonicalizationPatterns(p, ctx);
+      arith::SelectOp::getCanonicalizationPatterns(p, ctx);
+      arith::IndexCastOp::getCanonicalizationPatterns(p, ctx);
+      arith::ExtUIOp::getCanonicalizationPatterns(p, ctx);
+      arith::ExtSIOp::getCanonicalizationPatterns(p, ctx);
+      arith::AddIOp::getCanonicalizationPatterns(p, ctx);
+      arith::MulIOp::getCanonicalizationPatterns(p, ctx);
+      arith::SubIOp::getCanonicalizationPatterns(p, ctx);
+      p.insert<FoldConstIndexSwitchPattern>(ctx);
+      (void)applyPatternsGreedily(module, std::move(p));
+    }
+
     // Convert WaitAllOp → NpuDmaWaitOp and purge DMA async tokens.
     // This must happen BEFORE DMA conversion because:
     // 1. WaitAllOp has SSA operands to DmaMemcpyNdOp event tokens
@@ -1838,6 +1929,33 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     auto isRegionDelimiter = [](Operation *o) {
       return isa<AIEX::NpuLoadPdiOp>(o) || o->hasAttr(kLaunchIterBoundaryAttr);
     };
+    // Move an NpuWriteRTPOp before `anchor`, cloning any defining
+    // arith.ConstantOp operand that would otherwise end up after it. The #1732
+    // AIEX API materializes the RTP value as an SSA operand (not an attribute),
+    // so the constant must dominate the moved RTP write.
+    auto moveRtpBefore = [](Operation *rtp, Operation *anchor) {
+      rtp->moveBefore(anchor);
+      for (OpOperand &operandUse : rtp->getOpOperands()) {
+        Value operand = operandUse.get();
+        auto *defOp = operand.getDefiningOp();
+        if (!defOp || !isa<arith::ConstantOp>(defOp))
+          continue;
+        if (defOp->getBlock() != rtp->getBlock())
+          continue;
+        bool defIsAfter = false;
+        for (Operation *cur = rtp->getNextNode(); cur != nullptr;
+             cur = cur->getNextNode())
+          if (cur == defOp) {
+            defIsAfter = true;
+            break;
+          }
+        if (defIsAfter) {
+          OpBuilder b(rtp);
+          Operation *cloned = b.clone(*defOp);
+          operandUse.set(cloned->getResult(0));
+        }
+      }
+    };
     module.walk([&](AIE::RuntimeSequenceOp seq) {
       if (seq.getBody().empty())
         return;
@@ -1848,68 +1966,216 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       SmallVector<Operation *> ops;
       for (auto &o : blk)
         ops.push_back(&o);
+
+      // Partition into delimiter-bounded regions. For each region record its
+      // anchor (first data movement, i.e. first op that is not an RTP write,
+      // set_lock, or air.runtime_hoist feed) and its RTP/set_lock ops in order.
+      struct RegionInfo {
+        Operation *anchor = nullptr;
+        SmallVector<Operation *> rtps;
+        SmallVector<Operation *> locks;
+      };
+      SmallVector<RegionInfo> regions;
       for (size_t i = 0, e = ops.size(); i < e;) {
-        // Region [i, j): j indexes the next delimiter (or the end).
         size_t j = i;
         while (j < e && !isRegionDelimiter(ops[j]))
           ++j;
-        // Anchor at the region's first op that is not an RTP write, set_lock,
-        // or an air.runtime_hoist feed -- i.e. the region's first data
-        // movement.
-        Operation *anchor = nullptr;
+        RegionInfo r;
         for (size_t k = i; k < j; ++k) {
-          if (isa<AIEX::NpuWriteRTPOp, AIEX::SetLockOp>(ops[k]))
-            continue;
-          if (ops[k]->hasAttr(air::attrs::RuntimeHoist))
-            continue;
-          anchor = ops[k];
-          break;
+          if (isa<AIEX::NpuWriteRTPOp>(ops[k]))
+            r.rtps.push_back(ops[k]);
+          else if (isa<AIEX::SetLockOp>(ops[k]))
+            r.locks.push_back(ops[k]);
+          else if (!ops[k]->hasAttr(air::attrs::RuntimeHoist) && !r.anchor)
+            r.anchor = ops[k];
         }
-        if (anchor) {
-          // RTP writes first, then set_locks (release after RTP is latched),
-          // each preserving its intra-region relative order.
-          // When moving an NpuWriteRTPOp, also ensure any arith.ConstantOp
-          // that defines its SSA value operand precedes it. The AIEX API now
-          // materializes the RTP value as an SSA operand rather than an
-          // attribute, so the constant must dominate the RTP op. If the
-          // constant's block position would end up after the moved RTP write,
-          // clone it immediately before the RTP op instead.
-          for (size_t k = i; k < j; ++k) {
-            if (!isa<AIEX::NpuWriteRTPOp>(ops[k]))
-              continue;
-            ops[k]->moveBefore(anchor);
-            // After moving, check each operand: if its defining constant now
-            // comes after the rtp_write in the block, insert a clone before it.
-            for (OpOperand &operandUse : ops[k]->getOpOperands()) {
-              Value operand = operandUse.get();
-              auto *defOp = operand.getDefiningOp();
-              if (!defOp || !isa<arith::ConstantOp>(defOp))
-                continue;
-              if (defOp->getBlock() != ops[k]->getBlock())
-                continue;
-              // Walk forward from the rtp_write; if we reach defOp, it is
-              // after the rtp_write (dominance violation).
-              bool defIsAfter = false;
-              for (Operation *cur = ops[k]->getNextNode(); cur != nullptr;
-                   cur = cur->getNextNode()) {
-                if (cur == defOp) {
-                  defIsAfter = true;
-                  break;
-                }
-              }
-              if (defIsAfter) {
-                // Clone the constant immediately before the rtp_write and
-                // redirect this operand to the clone.
-                OpBuilder b(ops[k]);
-                Operation *cloned = b.clone(*defOp);
-                operandUse.set(cloned->getResult(0));
-              }
-            }
+        regions.push_back(r);
+        i = (j < e) ? j + 1 : j;
+      }
+
+      // Discriminate the RTP-emission style. In the common (single-launch or
+      // load_pdi-reset) style every iteration's RTP block LEADS its own feeds,
+      // so it sits in the same region as its feeds and hoists to that region's
+      // front. But a fused multi-iteration launch whose herd load lowers AFTER
+      // the launch body's feeds emits wave N's RTP block after wave N's feeds
+      // and its boundary drain -- so it lands at the head of region N+1 and,
+      // hoisted there, would arm wave N+1 with wave N's mode (fatal when waves
+      // differ in mode: a later wave would run under an earlier wave's arm).
+      // Detect this "trailing" style: the first feeds
+      // region has no RTP of its own while a later region does. Then pair the
+      // k-th RTP block with the k-th feeds region (shift each RTP back one
+      // region) so every wave is armed before its own feeds.
+      // A fused multi-iteration launch may emit ALL waves' RTP arm blocks (and
+      // all herd-release set_locks) CONSECUTIVELY at the global front (they
+      // land in region 0 together with wave 0's feeds), so the per-region
+      // trailing/ leading split below collapses every wave's arm onto wave 0 --
+      // the later (mode-changing) waves then run under wave 0's arm and, worse,
+      // their herd locks are all released up front, so a cross-mode wave
+      // executes with the
+      // wrong arm. Detect this by splitting the flat RTP/set_lock runs into
+      // per-wave blocks (a new block starts when a herd symbol/lock repeats)
+      // and, when the block count matches the number of feed regions,
+      // distribute the k-th arm+lock block to the front of the k-th feed
+      // region. Gated to fused multi-iteration launches so single-dispatch
+      // sequences are byte-identical.
+      auto splitByRepeat = [](ArrayRef<Operation *> flat, auto key) {
+        using KeyT = decltype(key(std::declval<Operation *>()));
+        SmallVector<SmallVector<Operation *>> blocks;
+        llvm::DenseSet<KeyT> seen;
+        for (auto *o : flat) {
+          KeyT k = key(o);
+          if (blocks.empty() || seen.contains(k)) {
+            blocks.emplace_back();
+            seen.clear();
           }
-          for (size_t k = i; k < j; ++k)
-            if (isa<AIEX::SetLockOp>(ops[k]))
-              ops[k]->moveBefore(anchor);
+          blocks.back().push_back(o);
+          seen.insert(k);
         }
+        return blocks;
+      };
+      auto device = seq->getParentOfType<xilinx::AIE::DeviceOp>();
+      bool fused = device && deviceHasMultiIterLaunch(device);
+      SmallVector<Operation *> feedAnchors;
+      for (auto &r : regions)
+        if (r.anchor)
+          feedAnchors.push_back(r.anchor);
+      SmallVector<Operation *> allRtps, allLocks;
+      for (auto &r : regions) {
+        allRtps.append(r.rtps.begin(), r.rtps.end());
+        allLocks.append(r.locks.begin(), r.locks.end());
+      }
+      auto armBlocks = splitByRepeat(allRtps, [](Operation *o) -> StringRef {
+        return cast<AIEX::NpuWriteRTPOp>(o).getBuffer();
+      });
+      auto lockBlocks =
+          splitByRepeat(allLocks, [](Operation *o) -> Operation * {
+            return cast<AIEX::SetLockOp>(o).getLockOp().getOperation();
+          });
+      bool distributed = false;
+      if (fused && feedAnchors.size() >= 2 &&
+          armBlocks.size() == feedAnchors.size() &&
+          (allLocks.empty() || lockBlocks.size() == feedAnchors.size())) {
+        for (size_t p = 0; p < feedAnchors.size(); ++p) {
+          Operation *anchor = feedAnchors[p];
+          for (auto *rtp : armBlocks[p])
+            moveRtpBefore(rtp, anchor);
+          if (!lockBlocks.empty())
+            for (auto *lk : lockBlocks[p])
+              lk->moveBefore(anchor);
+        }
+        distributed = true;
+      }
+
+      if (distributed) {
+        // handled above.
+      } else {
+        SmallVector<int> feedIdx, rtpIdx;
+        for (int k = 0, e = regions.size(); k < e; ++k) {
+          if (regions[k].anchor)
+            feedIdx.push_back(k);
+          if (!regions[k].rtps.empty() || !regions[k].locks.empty())
+            rtpIdx.push_back(k);
+        }
+        bool trailing = false;
+        if (!feedIdx.empty() && regions[feedIdx.front()].rtps.empty())
+          for (int k : rtpIdx)
+            if (k > feedIdx.front() && !regions[k].rtps.empty()) {
+              trailing = true;
+              break;
+            }
+
+        if (trailing && feedIdx.size() == rtpIdx.size()) {
+          for (size_t p = 0, e = feedIdx.size(); p < e; ++p) {
+            Operation *anchor = regions[feedIdx[p]].anchor;
+            RegionInfo &src = regions[rtpIdx[p]];
+            for (auto *rtp : src.rtps)
+              moveRtpBefore(rtp, anchor);
+            for (auto *lk : src.locks)
+              lk->moveBefore(anchor);
+          }
+        } else {
+          // Leading / default style: hoist each region's own RTP block (RTP
+          // writes first, then set_locks) to the front of its own feeds.
+          for (auto &r : regions) {
+            if (!r.anchor)
+              continue;
+            for (auto *rtp : r.rtps)
+              moveRtpBefore(rtp, r.anchor);
+            for (auto *lk : r.locks)
+              lk->moveBefore(r.anchor);
+          }
+        }
+      }
+    });
+
+    // Per-wave output-S2MM-first ordering for fused multi-iteration launches.
+    // The runtime emits each wave's output S2MM (core->DDR) tasks AFTER that
+    // wave's input MM2S feeds (they follow the
+    // producing air.channel.get in program order). An output S2MM must be armed
+    // BEFORE its producing core hands off data, else the core blocks releasing
+    // its output buffer lock (the S2MM BD is not yet running to drain it) while
+    // the control program is still issuing later input feeds -> deadlock. A
+    // single-mode sequence already arms its outputs first; extend that
+    // to each fused wave by hoisting the wave's output-S2MM configure+start
+    // ahead of the wave's first input feed (after the arm/set_lock block the
+    // RTP hoist just placed). The output drain (dma_await_task) stays at the
+    // wave boundary (emitted by generateAwaitsFromWaitAllOps). Gated to fused
+    // multi-iteration launches so single-dispatch sequences are byte-identical.
+    module.walk([&](AIE::RuntimeSequenceOp seq) {
+      if (seq.getBody().empty())
+        return;
+      auto device = seq->getParentOfType<xilinx::AIE::DeviceOp>();
+      if (!device || !deviceHasMultiIterLaunch(device))
+        return;
+      auto isS2MMOutput = [&](AIEX::DMAConfigureTaskForOp cfg) {
+        StringRef sym = cfg.getAlloc().getLeafReference().getValue();
+        auto alloc = AIE::ShimDMAAllocationOp::getForSymbol(device, sym);
+        return alloc && alloc.getChannelDir() == AIE::DMAChannelDir::S2MM;
+      };
+      auto isRegionDelim = [](Operation *o) {
+        return isa<AIEX::NpuLoadPdiOp>(o) ||
+               o->hasAttr(kLaunchIterBoundaryAttr);
+      };
+      Block &blk = seq.getBody().front();
+      SmallVector<Operation *> ops;
+      for (auto &o : blk)
+        ops.push_back(&o);
+      // Partition into delimiter-bounded regions (waves). A boundary-tagged op
+      // is the LAST op of its region.
+      for (size_t i = 0, e = ops.size(); i < e;) {
+        size_t j = i;
+        while (j < e && !isRegionDelim(ops[j]))
+          ++j;
+        // Region is [i, j] inclusive of the delimiter at j (if any).
+        size_t regionEnd = (j < e) ? j : e - 1;
+        // Anchor = first input feed (configure/start that is not an output
+        // S2MM, not an arm/set_lock/hoist). Collect output S2MM cfg+start.
+        Operation *anchor = nullptr;
+        SmallVector<Operation *> outMoves;
+        for (size_t k = i; k <= regionEnd; ++k) {
+          Operation *o = ops[k];
+          if (isa<AIEX::NpuWriteRTPOp, AIEX::SetLockOp, AIEX::NpuLoadPdiOp>(o))
+            continue;
+          if (auto cfg = dyn_cast<AIEX::DMAConfigureTaskForOp>(o)) {
+            if (isS2MMOutput(cfg)) {
+              outMoves.push_back(cfg);
+              // its single start task moves with it.
+              for (auto *u : cfg.getResult().getUsers())
+                if (isa<AIEX::DMAStartTaskOp>(u))
+                  outMoves.push_back(u);
+              continue;
+            }
+            if (!anchor)
+              anchor = o; // first input feed
+          }
+        }
+        if (anchor)
+          for (auto *m : outMoves)
+            if (m->isBeforeInBlock(anchor)) {
+              // already ahead of the anchor; leave in place.
+            } else {
+              m->moveBefore(anchor);
+            }
         i = (j < e) ? j + 1 : j;
       }
     });
@@ -2423,6 +2689,8 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       if (f.getBody().empty())
         continue;
 
+      mlir::DominanceInfo domInfo(f);
+
       // First pass: collect all DMAConfigureTaskForOp per channel in order
       // Map from metadata symbol -> list of ConfigTasks in order
       llvm::MapVector<StringRef, SmallVector<AIEX::DMAConfigureTaskForOp>>
@@ -2448,6 +2716,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       SmallVector<AIEX::NpuDmaWaitOp> waitOps;
       f.walk([&](AIEX::NpuDmaWaitOp waitOp) { waitOps.push_back(waitOp); });
 
+      // The last surviving await/free task op emitted, used to re-home a
+      // per-iteration boundary marker when its own drain wait produces no
+      // surviving op (heterogeneous waves; see below).
+      Operation *lastEmittedTask = nullptr;
+
       for (auto waitOp : waitOps) {
         StringRef metadata = waitOp.getSymbol();
 
@@ -2470,13 +2743,30 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
           }
         }
 
-        // Find the next ConfigTask for this channel
+        // Find the next ConfigTask for this channel.
+        //
+        // The Nth wait for a channel awaits its Nth config in FIFO order, BUT
+        // only if that config dominates the wait. A fused multi-iteration
+        // launch with HETEROGENEOUS waves (some waves use a channel and
+        // others do not) emits a per-iteration all-shim
+        // boundary drain that waits on EVERY channel at each boundary. For a
+        // channel with no config in the current wave, FIFO would otherwise pair
+        // that boundary wait with a config from a LATER wave -- producing a
+        // dma_await_task whose config operand does not dominate it
+        // (use-before-def). That invalid IR is not caught until
+        // ControlFuncConversion clones the func (the clone leaves the await
+        // referencing the un-mapped original config, crossing into the new
+        // runtime_sequence -> erase-with-uses assert). Guard the match on
+        // dominance: if the next unconsumed config does not dominate this wait,
+        // leave it for a later (dominated) wait and emit no await here.
         AIEX::DMAConfigureTaskForOp matchingConfigTask = nullptr;
         auto it = channelToConfigTasks.find(metadata);
         if (it != channelToConfigTasks.end()) {
           auto &configTasks = it->second;
           unsigned &nextIdx = channelToNextConfigIdx[metadata];
-          if (nextIdx < configTasks.size()) {
+          if (nextIdx < configTasks.size() &&
+              domInfo.properlyDominates(configTasks[nextIdx].getOperation(),
+                                        waitOp.getOperation())) {
             matchingConfigTask = configTasks[nextIdx];
             nextIdx++;
           }
@@ -2486,14 +2776,14 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
         // the surviving task op so the RTP/set_lock hoist can use it as a
         // per-iteration region delimiter (see kLaunchIterBoundaryAttr).
         bool isBoundary = waitOp->hasAttr(kLaunchIterBoundaryAttr);
+        Operation *emittedTask = nullptr;
         if (matchingConfigTask) {
           OpBuilder builder(waitOp);
           if (isS2MM) {
             // S2MM (output): await task - waits for completion AND frees BD
             auto a = AIEX::DMAAwaitTaskOp::create(
                 builder, waitOp.getLoc(), matchingConfigTask.getResult());
-            if (isBoundary)
-              a->setAttr(kLaunchIterBoundaryAttr, builder.getUnitAttr());
+            emittedTask = a;
           } else if (matchingConfigTask->hasAttr(
                          air::attrs::PreserveShimDmaOrder)) {
             // MM2S, paced: do not emit a fire-and-free here. Bounded
@@ -2503,9 +2793,25 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
             // MM2S (input): free task - just frees BD for reuse, no wait
             auto fr = AIEX::DMAFreeTaskOp::create(
                 builder, waitOp.getLoc(), matchingConfigTask.getResult());
-            if (isBoundary)
-              fr->setAttr(kLaunchIterBoundaryAttr, builder.getUnitAttr());
+            emittedTask = fr;
           }
+        }
+        if (emittedTask) {
+          if (isBoundary)
+            emittedTask->setAttr(kLaunchIterBoundaryAttr,
+                                 UnitAttr::get(f.getContext()));
+          lastEmittedTask = emittedTask;
+        } else if (isBoundary && lastEmittedTask) {
+          // The boundary drain wait produced no surviving task op (its channel
+          // has no dominating config in this wave -- e.g. a channel used only
+          // by earlier, heterogeneous waves, or a paced MM2S feed). Without a
+          // surviving tagged op the per-iteration RTP/set_lock hoist would lose
+          // this boundary and collapse every wave's re-arm to the global front
+          // (fatal when waves differ in their RTP arm). Transfer the boundary
+          // marker onto the last
+          // task op emitted before this drain, which sits at the wave boundary.
+          lastEmittedTask->setAttr(kLaunchIterBoundaryAttr,
+                                   UnitAttr::get(f.getContext()));
         }
         // Erase the NpuDmaWaitOp regardless of whether we found a match
         waitOp->erase();
@@ -2607,13 +2913,62 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       }
     };
 
+    // Assign each paced MM2S config task to a launch iteration (wave) using the
+    // kLaunchIterBoundaryAttr delimiters that mark each wave's final drain
+    // (they were placed on the surviving await/free op at each wave boundary).
+    // A config task belongs to the wave that is accumulating until the next
+    // boundary-tagged op is reached in program order. Unlike the old
+    // count-divisibility split, this tolerates HETEROGENEOUS waves (a channel
+    // present in only some waves, e.g. a feed used by some waves but absent
+    // from others): each channel is segmented by the waves in which
+    // it actually appears, so no channel's in-flight set straddles a mode
+    // transition.
+    llvm::DenseMap<Operation *, int64_t> taskWave;
+    bool sawBoundary = false;
+    {
+      int64_t curWave = 0;
+      f.walk([&](Operation *op) {
+        if (auto ct = dyn_cast<AIEX::DMAConfigureTaskForOp>(op)) {
+          if (ct->hasAttr(air::attrs::PreserveShimDmaOrder))
+            taskWave[ct.getOperation()] = curWave;
+        }
+        if (op->hasAttr(kLaunchIterBoundaryAttr)) {
+          curWave++;
+          sawBoundary = true;
+        }
+      });
+    }
+
     for (auto &kv : groups) {
       auto &tasks = kv.second;
       unsigned n = tasks.size();
       // Segment per launch iteration when the iteration count divides the task
       // count evenly (each iteration emits the same per-channel feeds).
       // Otherwise fall back to whole-list pacing.
-      if (numIters > 1 && n % numIters == 0) {
+      if (numIters > 1 && sawBoundary) {
+        // Boundary-delimited per-wave segmentation. Each contiguous run of
+        // same-wave tasks is paced+fenced independently, so a channel absent
+        // from some waves simply contributes fewer segments (no assumption that
+        // every wave emits the same per-channel feed count).
+        SmallVector<AIEX::DMAConfigureTaskForOp> seg;
+        int64_t segWave = -1;
+        auto flush = [&]() {
+          if (!seg.empty()) {
+            paceSegment(seg, /*fenceEnd=*/true);
+            seg.clear();
+          }
+        };
+        for (auto ct : tasks) {
+          auto wi = taskWave.find(ct.getOperation());
+          int64_t w = (wi != taskWave.end()) ? wi->second : segWave;
+          if (w != segWave) {
+            flush();
+            segWave = w;
+          }
+          seg.push_back(ct);
+        }
+        flush();
+      } else if (numIters > 1 && n % numIters == 0) {
         unsigned seg = n / (unsigned)numIters;
         for (int64_t it = 0; it < numIters; it++)
           paceSegment(

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -544,7 +544,10 @@ struct FoldConstIndexSwitchPattern
         rewriter.setInsertionPoint(wa);
         auto nwa = airrt::WaitAllOp::create(rewriter, wa.getLoc(),
                                             wa->getResultTypes(), newOperands);
-        nwa->setAttrs(wa->getDiscardableAttrDictionary());
+        // Copy the full attribute set (matching AIRRtDialect's FoldWaitAll) so
+        // the air.launch_end marker -- load-bearing for multi-iteration launch
+        // detection and wave tagging -- is preserved on the rebuilt op.
+        nwa->setAttrs(wa->getAttrs());
         rewriter.replaceOp(wa, nwa->getResults());
       }
     }

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -204,17 +204,6 @@ static constexpr llvm::StringLiteral kMultiIterLaunchAttr =
 static constexpr llvm::StringLiteral kNumLaunchItersAttr =
     "air.num_launch_iters";
 
-// Marks a runtime-sequence op emitted at a fused multi-iteration launch's
-// per-iteration boundary (the between-iteration full shim drain). Used
-// post-conversion as a region delimiter so the per-herd RTP-write / set_lock
-// hoisting stays scoped to each iteration's sub-sequence instead of collapsing
-// to the global front. Collapsing all N iterations' inits to the front stacks
-// N re-arms before any data movement and drops the per-iteration re-arm, which
-// deadlocks a finite-depth device lock after a couple of iterations. Mirrors
-// the region-delimiting role NpuLoadPdiOp plays on the ELF-reset path.
-static constexpr llvm::StringLiteral kLaunchIterBoundaryAttr =
-    "air.launch_iter_boundary";
-
 static bool deviceHasMultiIterLaunch(xilinx::AIE::DeviceOp device) {
   return device->hasAttr(kMultiIterLaunchAttr);
 }
@@ -223,6 +212,35 @@ static int64_t deviceNumLaunchIters(xilinx::AIE::DeviceOp device) {
   if (auto a = device->getAttrOfType<mlir::IntegerAttr>(kNumLaunchItersAttr))
     return a.getInt();
   return 1;
+}
+
+// Stamp a per-op launch-iteration ("wave") index on the source airrt ops of a
+// fused multi-iteration launch (airrt.dma_memcpy_nd / airrt.herd_load). Must
+// run after the fused launch loop is unrolled (so each iteration's ops are laid
+// out contiguously and program order reflects wave membership) and before the
+// launch_end airrt.wait_all markers are lowered away. The index rides through
+// lowering onto the emitted DMAConfigureTaskForOp / NpuWriteRTPOp / SetLockOp,
+// so the downstream per-wave hoist groups by index rather than inferring wave
+// boundaries from op positions. Gated to fused devices; single-dispatch funcs
+// are left untagged (wave 0 everywhere) for byte-identical output.
+static void assignLaunchWaveIndices(mlir::ModuleOp module) {
+  module.walk([&](mlir::func::FuncOp f) {
+    if (f.getBody().empty())
+      return;
+    auto device = f->getParentOfType<xilinx::AIE::DeviceOp>();
+    if (!device || !deviceHasMultiIterLaunch(device))
+      return;
+    int64_t wave = 0;
+    auto i64 = mlir::IntegerType::get(f.getContext(), 64);
+    f.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      if (isa<xilinx::airrt::DmaMemcpyNdOp, xilinx::airrt::HerdLoadOp>(op))
+        op->setAttr(xilinx::air::attrs::LaunchWave,
+                    mlir::IntegerAttr::get(i64, wave));
+      if (auto w = dyn_cast<xilinx::airrt::WaitAllOp>(op))
+        if (w->hasAttr("air.launch_end"))
+          wave++;
+    });
+  });
 }
 
 // Compute and stamp the reset decision on every device. MUST run after
@@ -729,6 +747,11 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
     // readback (see the air.await_appends barrier below).
     if (op->hasAttr(air::attrs::AppendBarrier))
       configTaskOp->setAttr(air::attrs::AppendBarrier, rewriter.getUnitAttr());
+    // Carry the fused-launch wave index so the per-wave
+    // RTP/set_lock/output-S2MM hoist can group this feed by its launch
+    // iteration.
+    if (auto wave = op->getAttr(air::attrs::LaunchWave))
+      configTaskOp->setAttr(air::attrs::LaunchWave, wave);
 
     // Create the body region of the configure task op
     Block *bodyBlock = rewriter.createBlock(&configTaskOp.getBody());
@@ -854,6 +877,10 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
       }
     }
 
+    // Fused-launch wave index (if any): propagated onto the emitted RTP writes
+    // and set_locks so the per-wave hoist groups this arm by its iteration.
+    auto waveAttr = op->getAttr(air::attrs::LaunchWave);
+
     // for each herd core, emit write_rtp ops for every herd operand
     // followed by a write32 to the herd lock, setting it to 1.
     for (int phys_x = loc_x; phys_x < size_x + loc_x; phys_x++) {
@@ -889,8 +916,10 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
               Value vVal = arith::ConstantOp::create(
                   rewriter, op.getLoc(), rewriter.getI32Type(),
                   rewriter.getI32IntegerAttr(v));
-              AIEX::NpuWriteRTPOp::create(rewriter, op.getLoc(), name, rtp_slot,
-                                          vVal);
+              auto rtpOp = AIEX::NpuWriteRTPOp::create(rewriter, op.getLoc(),
+                                                       name, rtp_slot, vVal);
+              if (waveAttr)
+                rtpOp->setAttr(air::attrs::LaunchWave, waveAttr);
             }
             rtp_slot++;
           }
@@ -915,8 +944,11 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
         if (!lockOp)
           continue;
 
-        AIEX::SetLockOp::create(rewriter, op.getLoc(), lockOp.getResult(),
-                                rewriter.getI32IntegerAttr(1));
+        auto setLockOp =
+            AIEX::SetLockOp::create(rewriter, op.getLoc(), lockOp.getResult(),
+                                    rewriter.getI32IntegerAttr(1));
+        if (waveAttr)
+          setLockOp->setAttr(air::attrs::LaunchWave, waveAttr);
       }
     }
     rewriter.eraseOp(op);
@@ -1060,15 +1092,9 @@ public:
             // current iteration's compute (issue #1373; extended to the
             // multi-iteration xclbin path).
             rewriter.setInsertionPoint(op);
-            for (auto alloc : device.getOps<AIE::ShimDMAAllocationOp>()) {
-              auto w = AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(),
-                                                  alloc.getSymName());
-              // Tag the fused multi-iteration boundary drain so the later
-              // RTP/set_lock hoist keeps each iteration's re-arm scoped to its
-              // own sub-sequence (see kLaunchIterBoundaryAttr).
-              if (multiIter)
-                w->setAttr(kLaunchIterBoundaryAttr, rewriter.getUnitAttr());
-            }
+            for (auto alloc : device.getOps<AIE::ShimDMAAllocationOp>())
+              AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(),
+                                         alloc.getSymName());
           }
         }
       }
@@ -1181,12 +1207,6 @@ public:
         }))
       return failure();
 
-    // A fused multi-iteration launch tags its per-iteration boundary drain so
-    // the later RTP/set_lock hoist stays scoped per iteration. The launch_end's
-    // own operand waits are the iteration's output (S2MM) drains -- they
-    // survive as DMAAwaitTaskOp -- so tagging them gives a boundary marker that
-    // is robust even when the extra all-shim drain below is all paced-MM2S
-    // (which emit no surviving op).
     bool isLaunchEnd = op->hasAttr("air.launch_end");
     bool multiIter = false;
     if (isLaunchEnd) {
@@ -1194,8 +1214,6 @@ public:
         if (llvm::isa<AIE::BaseNPU2TargetModel>(device.getTargetModel()))
           multiIter = deviceHasMultiIterLaunch(device);
     }
-    bool tagBoundary = isLaunchEnd && multiIter;
-    bool taggedOne = false;
 
     llvm::SmallDenseSet<StringRef> waitedChannels;
     for (auto oper : op->getOperands()) {
@@ -1211,11 +1229,7 @@ public:
       // The conversion to DMAAwaitTaskOp vs DMAFreeTaskOp happens later
       // based on channel direction
       StringRef metadata = metadataAttr.getValue();
-      auto w = AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(), metadata);
-      if (tagBoundary) {
-        w->setAttr(kLaunchIterBoundaryAttr, rewriter.getUnitAttr());
-        taggedOne = true;
-      }
+      AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(), metadata);
       waitedChannels.insert(metadata);
     }
 
@@ -1240,30 +1254,14 @@ public:
             // channels not already waited on to synchronize before the
             // next iteration (issue #1373; extended to the multi-iteration
             // xclbin path so each launch iteration fully drains).
-            for (auto alloc : device.getOps<AIE::ShimDMAAllocationOp>()) {
-              if (!waitedChannels.contains(alloc.getSymName())) {
-                auto w = AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(),
-                                                    alloc.getSymName());
-                // Tag the fused multi-iteration boundary drain (see
-                // kLaunchIterBoundaryAttr) so the RTP/set_lock hoist stays
-                // scoped per iteration. Only needed if no operand wait above
-                // was tagged (those are the S2MM outputs that reliably
-                // survive).
-                if (tagBoundary && !taggedOne) {
-                  w->setAttr(kLaunchIterBoundaryAttr, rewriter.getUnitAttr());
-                  taggedOne = true;
-                }
-              }
-            }
+            for (auto alloc : device.getOps<AIE::ShimDMAAllocationOp>())
+              if (!waitedChannels.contains(alloc.getSymName()))
+                AIEX::NpuDmaWaitOp::create(rewriter, op.getLoc(),
+                                           alloc.getSymName());
           }
         }
       }
     }
-    if (tagBoundary && !taggedOne)
-      op->emitWarning(
-          "air.multi_iter_launch: launch_end boundary has no "
-          "surviving DMA wait op to tag; per-iteration RTP/set_lock "
-          "scoping may be incorrect");
 
     // The WaitAllOp may have uses (other WaitAllOps depending on its result).
     // Replace with a new WaitAllOp with no operands to break the dependency
@@ -1796,6 +1794,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // afterwards.
     markDevicesNeedingLockReset(module);
 
+    // Tag each fused-launch source airrt op with its wave index while the
+    // launch_end markers are still present and program order reflects wave
+    // membership (before the markers are lowered by the next step).
+    assignLaunchWaveIndices(module);
+
     generateNpuWaitFromAIRRtWaitAll(module);
 
     // Enforce AIE2 hardware constraints.
@@ -1915,19 +1918,13 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     // expressible in the async dependence graph (RTP writes have no SSA
     // operands; set_locks are batched separately).
     //
-    // The region is delimited by aiex.npu.load_pdi resets (ELF path) or, on the
-    // fused multi-iteration xclbin path, by the per-iteration boundary drain
-    // tagged kLaunchIterBoundaryAttr (emitted at each launch_end). A
-    // multi-iteration launch re-arms DMA/lock state between iterations and each
-    // iteration re-writes its own RTP and re-releases its cores. Hoisting to
-    // the GLOBAL front would then (a) clobber a later iteration's RTP onto an
-    // earlier iteration's slot and (b) stack all N iterations' releases before
-    // any data movement, dropping the per-iteration re-arm -- which deadlocks a
-    // finite-depth device lock after a couple of iterations. Scoping to the
-    // per-boundary region keeps both single-launch sequences (one region ->
-    // front of sequence) and multi-iteration sequences correct.
+    // For single-dispatch sequences the region is delimited by
+    // aiex.npu.load_pdi resets (ELF path); each region's own RTP block hoists
+    // to the front of its own feeds. Fused multi-iteration launches take the
+    // wave-keyed path below instead (each arm is placed by its air.launch_wave
+    // index).
     auto isRegionDelimiter = [](Operation *o) {
-      return isa<AIEX::NpuLoadPdiOp>(o) || o->hasAttr(kLaunchIterBoundaryAttr);
+      return isa<AIEX::NpuLoadPdiOp>(o);
     };
     // Move an NpuWriteRTPOp before `anchor`, cloning any defining
     // arith.ConstantOp operand that would otherwise end up after it. The #1732
@@ -1967,143 +1964,78 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       for (auto &o : blk)
         ops.push_back(&o);
 
-      // Partition into delimiter-bounded regions. For each region record its
-      // anchor (first data movement, i.e. first op that is not an RTP write,
-      // set_lock, or air.runtime_hoist feed) and its RTP/set_lock ops in order.
-      struct RegionInfo {
-        Operation *anchor = nullptr;
-        SmallVector<Operation *> rtps;
-        SmallVector<Operation *> locks;
-      };
-      SmallVector<RegionInfo> regions;
-      for (size_t i = 0, e = ops.size(); i < e;) {
-        size_t j = i;
-        while (j < e && !isRegionDelimiter(ops[j]))
-          ++j;
-        RegionInfo r;
-        for (size_t k = i; k < j; ++k) {
-          if (isa<AIEX::NpuWriteRTPOp>(ops[k]))
-            r.rtps.push_back(ops[k]);
-          else if (isa<AIEX::SetLockOp>(ops[k]))
-            r.locks.push_back(ops[k]);
-          else if (!ops[k]->hasAttr(air::attrs::RuntimeHoist) && !r.anchor)
-            r.anchor = ops[k];
-        }
-        regions.push_back(r);
-        i = (j < e) ? j + 1 : j;
-      }
-
-      // Discriminate the RTP-emission style. In the common (single-launch or
-      // load_pdi-reset) style every iteration's RTP block LEADS its own feeds,
-      // so it sits in the same region as its feeds and hoists to that region's
-      // front. But a fused multi-iteration launch whose herd load lowers AFTER
-      // the launch body's feeds emits wave N's RTP block after wave N's feeds
-      // and its boundary drain -- so it lands at the head of region N+1 and,
-      // hoisted there, would arm wave N+1 with wave N's mode (fatal when waves
-      // differ in mode: a later wave would run under an earlier wave's arm).
-      // Detect this "trailing" style: the first feeds
-      // region has no RTP of its own while a later region does. Then pair the
-      // k-th RTP block with the k-th feeds region (shift each RTP back one
-      // region) so every wave is armed before its own feeds.
-      // A fused multi-iteration launch may emit ALL waves' RTP arm blocks (and
-      // all herd-release set_locks) CONSECUTIVELY at the global front (they
-      // land in region 0 together with wave 0's feeds), so the per-region
-      // trailing/ leading split below collapses every wave's arm onto wave 0 --
-      // the later (mode-changing) waves then run under wave 0's arm and, worse,
-      // their herd locks are all released up front, so a cross-mode wave
-      // executes with the
-      // wrong arm. Detect this by splitting the flat RTP/set_lock runs into
-      // per-wave blocks (a new block starts when a herd symbol/lock repeats)
-      // and, when the block count matches the number of feed regions,
-      // distribute the k-th arm+lock block to the front of the k-th feed
-      // region. Gated to fused multi-iteration launches so single-dispatch
-      // sequences are byte-identical.
-      auto splitByRepeat = [](ArrayRef<Operation *> flat, auto key) {
-        using KeyT = decltype(key(std::declval<Operation *>()));
-        SmallVector<SmallVector<Operation *>> blocks;
-        llvm::DenseSet<KeyT> seen;
-        for (auto *o : flat) {
-          KeyT k = key(o);
-          if (blocks.empty() || seen.contains(k)) {
-            blocks.emplace_back();
-            seen.clear();
-          }
-          blocks.back().push_back(o);
-          seen.insert(k);
-        }
-        return blocks;
-      };
       auto device = seq->getParentOfType<xilinx::AIE::DeviceOp>();
       bool fused = device && deviceHasMultiIterLaunch(device);
-      SmallVector<Operation *> feedAnchors;
-      for (auto &r : regions)
-        if (r.anchor)
-          feedAnchors.push_back(r.anchor);
-      SmallVector<Operation *> allRtps, allLocks;
-      for (auto &r : regions) {
-        allRtps.append(r.rtps.begin(), r.rtps.end());
-        allLocks.append(r.locks.begin(), r.locks.end());
-      }
-      auto armBlocks = splitByRepeat(allRtps, [](Operation *o) -> StringRef {
-        return cast<AIEX::NpuWriteRTPOp>(o).getBuffer();
-      });
-      auto lockBlocks =
-          splitByRepeat(allLocks, [](Operation *o) -> Operation * {
-            return cast<AIEX::SetLockOp>(o).getLockOp().getOperation();
-          });
-      bool distributed = false;
-      if (fused && feedAnchors.size() >= 2 &&
-          armBlocks.size() == feedAnchors.size() &&
-          (allLocks.empty() || lockBlocks.size() == feedAnchors.size())) {
-        for (size_t p = 0; p < feedAnchors.size(); ++p) {
-          Operation *anchor = feedAnchors[p];
-          for (auto *rtp : armBlocks[p])
-            moveRtpBefore(rtp, anchor);
-          if (!lockBlocks.empty())
-            for (auto *lk : lockBlocks[p])
-              lk->moveBefore(anchor);
-        }
-        distributed = true;
-      }
+      auto getWave = [](Operation *o) -> std::optional<int64_t> {
+        if (auto a = o->getAttrOfType<IntegerAttr>(air::attrs::LaunchWave))
+          return a.getInt();
+        return std::nullopt;
+      };
 
-      if (distributed) {
-        // handled above.
-      } else {
-        SmallVector<int> feedIdx, rtpIdx;
-        for (int k = 0, e = regions.size(); k < e; ++k) {
-          if (regions[k].anchor)
-            feedIdx.push_back(k);
-          if (!regions[k].rtps.empty() || !regions[k].locks.empty())
-            rtpIdx.push_back(k);
+      if (fused) {
+        // Wave-keyed arm placement. Every RTP write / set_lock carries the wave
+        // index of the herd_load it lowered from; move it before the first data
+        // movement of the same wave (that wave's first feed), RTP writes first
+        // then set_locks, preserving program order within a wave. This is
+        // authoritative: no inference of which wave an arm belongs to from its
+        // position in the flattened sequence.
+        llvm::DenseMap<int64_t, Operation *> waveAnchor;
+        for (Operation *o : ops) {
+          if (isa<AIEX::NpuWriteRTPOp, AIEX::SetLockOp>(o))
+            continue;
+          if (o->hasAttr(air::attrs::RuntimeHoist))
+            continue;
+          if (auto w = getWave(o))
+            waveAnchor.try_emplace(*w, o);
         }
-        bool trailing = false;
-        if (!feedIdx.empty() && regions[feedIdx.front()].rtps.empty())
-          for (int k : rtpIdx)
-            if (k > feedIdx.front() && !regions[k].rtps.empty()) {
-              trailing = true;
-              break;
+        for (Operation *o : ops)
+          if (isa<AIEX::NpuWriteRTPOp>(o))
+            if (auto w = getWave(o)) {
+              auto it = waveAnchor.find(*w);
+              if (it != waveAnchor.end())
+                moveRtpBefore(o, it->second);
             }
-
-        if (trailing && feedIdx.size() == rtpIdx.size()) {
-          for (size_t p = 0, e = feedIdx.size(); p < e; ++p) {
-            Operation *anchor = regions[feedIdx[p]].anchor;
-            RegionInfo &src = regions[rtpIdx[p]];
-            for (auto *rtp : src.rtps)
-              moveRtpBefore(rtp, anchor);
-            for (auto *lk : src.locks)
-              lk->moveBefore(anchor);
+        for (Operation *o : ops)
+          if (isa<AIEX::SetLockOp>(o))
+            if (auto w = getWave(o)) {
+              auto it = waveAnchor.find(*w);
+              if (it != waveAnchor.end())
+                o->moveBefore(it->second);
+            }
+      } else {
+        // Single-dispatch (non-fused): hoist each delimiter-bounded region's
+        // own RTP block (RTP writes first, then set_locks) to the front of its
+        // own feeds. Anchor = first data movement (not an RTP write, set_lock,
+        // or air.runtime_hoist feed).
+        struct RegionInfo {
+          Operation *anchor = nullptr;
+          SmallVector<Operation *> rtps;
+          SmallVector<Operation *> locks;
+        };
+        SmallVector<RegionInfo> regions;
+        for (size_t i = 0, e = ops.size(); i < e;) {
+          size_t j = i;
+          while (j < e && !isRegionDelimiter(ops[j]))
+            ++j;
+          RegionInfo r;
+          for (size_t k = i; k < j; ++k) {
+            if (isa<AIEX::NpuWriteRTPOp>(ops[k]))
+              r.rtps.push_back(ops[k]);
+            else if (isa<AIEX::SetLockOp>(ops[k]))
+              r.locks.push_back(ops[k]);
+            else if (!ops[k]->hasAttr(air::attrs::RuntimeHoist) && !r.anchor)
+              r.anchor = ops[k];
           }
-        } else {
-          // Leading / default style: hoist each region's own RTP block (RTP
-          // writes first, then set_locks) to the front of its own feeds.
-          for (auto &r : regions) {
-            if (!r.anchor)
-              continue;
-            for (auto *rtp : r.rtps)
-              moveRtpBefore(rtp, r.anchor);
-            for (auto *lk : r.locks)
-              lk->moveBefore(r.anchor);
-          }
+          regions.push_back(r);
+          i = (j < e) ? j + 1 : j;
+        }
+        for (auto &r : regions) {
+          if (!r.anchor)
+            continue;
+          for (auto *rtp : r.rtps)
+            moveRtpBefore(rtp, r.anchor);
+          for (auto *lk : r.locks)
+            lk->moveBefore(r.anchor);
         }
       }
     });
@@ -2132,51 +2064,42 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
         auto alloc = AIE::ShimDMAAllocationOp::getForSymbol(device, sym);
         return alloc && alloc.getChannelDir() == AIE::DMAChannelDir::S2MM;
       };
-      auto isRegionDelim = [](Operation *o) {
-        return isa<AIEX::NpuLoadPdiOp>(o) ||
-               o->hasAttr(kLaunchIterBoundaryAttr);
+      auto getWave = [](Operation *o) -> std::optional<int64_t> {
+        if (auto a = o->getAttrOfType<IntegerAttr>(air::attrs::LaunchWave))
+          return a.getInt();
+        return std::nullopt;
       };
       Block &blk = seq.getBody().front();
       SmallVector<Operation *> ops;
       for (auto &o : blk)
         ops.push_back(&o);
-      // Partition into delimiter-bounded regions (waves). A boundary-tagged op
-      // is the LAST op of its region.
-      for (size_t i = 0, e = ops.size(); i < e;) {
-        size_t j = i;
-        while (j < e && !isRegionDelim(ops[j]))
-          ++j;
-        // Region is [i, j] inclusive of the delimiter at j (if any).
-        size_t regionEnd = (j < e) ? j : e - 1;
-        // Anchor = first input feed (configure/start that is not an output
-        // S2MM, not an arm/set_lock/hoist). Collect output S2MM cfg+start.
-        Operation *anchor = nullptr;
-        SmallVector<Operation *> outMoves;
-        for (size_t k = i; k <= regionEnd; ++k) {
-          Operation *o = ops[k];
-          if (isa<AIEX::NpuWriteRTPOp, AIEX::SetLockOp, AIEX::NpuLoadPdiOp>(o))
-            continue;
-          if (auto cfg = dyn_cast<AIEX::DMAConfigureTaskForOp>(o)) {
-            if (isS2MMOutput(cfg)) {
-              outMoves.push_back(cfg);
-              // its single start task moves with it.
-              for (auto *u : cfg.getResult().getUsers())
-                if (isa<AIEX::DMAStartTaskOp>(u))
-                  outMoves.push_back(u);
-              continue;
-            }
-            if (!anchor)
-              anchor = o; // first input feed
-          }
-        }
-        if (anchor)
-          for (auto *m : outMoves)
-            if (m->isBeforeInBlock(anchor)) {
-              // already ahead of the anchor; leave in place.
-            } else {
-              m->moveBefore(anchor);
-            }
-        i = (j < e) ? j + 1 : j;
+      // Wave-keyed: for each wave, its first input feed (an MM2S configure) is
+      // the anchor; hoist that wave's output-S2MM configure+start ahead of it.
+      llvm::DenseMap<int64_t, Operation *> waveInputAnchor;
+      for (Operation *o : ops) {
+        auto cfg = dyn_cast<AIEX::DMAConfigureTaskForOp>(o);
+        if (!cfg || isS2MMOutput(cfg))
+          continue;
+        if (auto w = getWave(o))
+          waveInputAnchor.try_emplace(*w, o);
+      }
+      for (Operation *o : ops) {
+        auto cfg = dyn_cast<AIEX::DMAConfigureTaskForOp>(o);
+        if (!cfg || !isS2MMOutput(cfg))
+          continue;
+        auto w = getWave(o);
+        if (!w)
+          continue;
+        auto it = waveInputAnchor.find(*w);
+        if (it == waveInputAnchor.end())
+          continue;
+        Operation *anchor = it->second;
+        if (!cfg->isBeforeInBlock(anchor))
+          cfg->moveBefore(anchor);
+        // its single start task moves with it, staying right after the cfg.
+        for (auto *u : cfg.getResult().getUsers())
+          if (isa<AIEX::DMAStartTaskOp>(u) && !u->isBeforeInBlock(anchor))
+            u->moveBefore(anchor);
       }
     });
 
@@ -2312,12 +2235,12 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       }
     });
 
-    // Strip the internal per-iteration boundary marker now that the
-    // RTP/set_lock hoist has consumed it, so it does not leak into the emitted
-    // IR.
+    // Strip the internal per-op wave index now that all per-wave ordering
+    // (paced segmentation, RTP/set_lock hoist, output-S2MM hoist) has consumed
+    // it, so it does not leak into the emitted IR.
     module.walk([](Operation *o) {
-      if (o->hasAttr(kLaunchIterBoundaryAttr))
-        o->removeAttr(kLaunchIterBoundaryAttr);
+      if (o->hasAttr(air::attrs::LaunchWave))
+        o->removeAttr(air::attrs::LaunchWave);
     });
     // Strip the internal multi-iteration launch markers -- all their consumers
     // (the launch_end drain, per-iteration paced-MM2S segmentation) have run --
@@ -2716,11 +2639,6 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       SmallVector<AIEX::NpuDmaWaitOp> waitOps;
       f.walk([&](AIEX::NpuDmaWaitOp waitOp) { waitOps.push_back(waitOp); });
 
-      // The last surviving await/free task op emitted, used to re-home a
-      // per-iteration boundary marker when its own drain wait produces no
-      // surviving op (heterogeneous waves; see below).
-      Operation *lastEmittedTask = nullptr;
-
       for (auto waitOp : waitOps) {
         StringRef metadata = waitOp.getSymbol();
 
@@ -2772,18 +2690,12 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
           }
         }
 
-        // Carry a fused multi-iteration boundary tag from the drain wait onto
-        // the surviving task op so the RTP/set_lock hoist can use it as a
-        // per-iteration region delimiter (see kLaunchIterBoundaryAttr).
-        bool isBoundary = waitOp->hasAttr(kLaunchIterBoundaryAttr);
-        Operation *emittedTask = nullptr;
         if (matchingConfigTask) {
           OpBuilder builder(waitOp);
           if (isS2MM) {
             // S2MM (output): await task - waits for completion AND frees BD
-            auto a = AIEX::DMAAwaitTaskOp::create(
-                builder, waitOp.getLoc(), matchingConfigTask.getResult());
-            emittedTask = a;
+            AIEX::DMAAwaitTaskOp::create(builder, waitOp.getLoc(),
+                                         matchingConfigTask.getResult());
           } else if (matchingConfigTask->hasAttr(
                          air::attrs::PreserveShimDmaOrder)) {
             // MM2S, paced: do not emit a fire-and-free here. Bounded
@@ -2791,27 +2703,9 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
             // synthesizeDoubleBufferedAwaits() below.
           } else {
             // MM2S (input): free task - just frees BD for reuse, no wait
-            auto fr = AIEX::DMAFreeTaskOp::create(
-                builder, waitOp.getLoc(), matchingConfigTask.getResult());
-            emittedTask = fr;
+            AIEX::DMAFreeTaskOp::create(builder, waitOp.getLoc(),
+                                        matchingConfigTask.getResult());
           }
-        }
-        if (emittedTask) {
-          if (isBoundary)
-            emittedTask->setAttr(kLaunchIterBoundaryAttr,
-                                 UnitAttr::get(f.getContext()));
-          lastEmittedTask = emittedTask;
-        } else if (isBoundary && lastEmittedTask) {
-          // The boundary drain wait produced no surviving task op (its channel
-          // has no dominating config in this wave -- e.g. a channel used only
-          // by earlier, heterogeneous waves, or a paced MM2S feed). Without a
-          // surviving tagged op the per-iteration RTP/set_lock hoist would lose
-          // this boundary and collapse every wave's re-arm to the global front
-          // (fatal when waves differ in their RTP arm). Transfer the boundary
-          // marker onto the last
-          // task op emitted before this drain, which sits at the wave boundary.
-          lastEmittedTask->setAttr(kLaunchIterBoundaryAttr,
-                                   UnitAttr::get(f.getContext()));
         }
         // Erase the NpuDmaWaitOp regardless of whether we found a match
         waitOp->erase();
@@ -2913,31 +2807,22 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       }
     };
 
-    // Assign each paced MM2S config task to a launch iteration (wave) using the
-    // kLaunchIterBoundaryAttr delimiters that mark each wave's final drain
-    // (they were placed on the surviving await/free op at each wave boundary).
-    // A config task belongs to the wave that is accumulating until the next
-    // boundary-tagged op is reached in program order. Unlike the old
-    // count-divisibility split, this tolerates HETEROGENEOUS waves (a channel
-    // present in only some waves, e.g. a feed used by some waves but absent
-    // from others): each channel is segmented by the waves in which
-    // it actually appears, so no channel's in-flight set straddles a mode
+    // Assign each paced MM2S config task to its launch iteration (wave) from
+    // the air.launch_wave index it carries (propagated from the source
+    // airrt.dma_memcpy_nd). This tolerates HETEROGENEOUS waves (a channel
+    // present in only some waves): each channel is segmented by the waves in
+    // which it actually appears, so no channel's in-flight set straddles a mode
     // transition.
     llvm::DenseMap<Operation *, int64_t> taskWave;
-    bool sawBoundary = false;
-    {
-      int64_t curWave = 0;
-      f.walk([&](Operation *op) {
-        if (auto ct = dyn_cast<AIEX::DMAConfigureTaskForOp>(op)) {
-          if (ct->hasAttr(air::attrs::PreserveShimDmaOrder))
-            taskWave[ct.getOperation()] = curWave;
-        }
-        if (op->hasAttr(kLaunchIterBoundaryAttr)) {
-          curWave++;
-          sawBoundary = true;
-        }
-      });
-    }
+    bool sawWave = false;
+    f.walk([&](AIEX::DMAConfigureTaskForOp ct) {
+      if (!ct->hasAttr(air::attrs::PreserveShimDmaOrder))
+        return;
+      if (auto a = ct->getAttrOfType<IntegerAttr>(air::attrs::LaunchWave)) {
+        taskWave[ct.getOperation()] = a.getInt();
+        sawWave = true;
+      }
+    });
 
     for (auto &kv : groups) {
       auto &tasks = kv.second;
@@ -2945,7 +2830,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       // Segment per launch iteration when the iteration count divides the task
       // count evenly (each iteration emits the same per-channel feeds).
       // Otherwise fall back to whole-list pacing.
-      if (numIters > 1 && sawBoundary) {
+      if (numIters > 1 && sawWave) {
         // Boundary-delimited per-wave segmentation. Each contiguous run of
         // same-wave tasks is paced+fenced independently, so a channel absent
         // from some waves simply contributes fewer segments (no assumption that

--- a/mlir/lib/Transform/AIRDependency.cpp
+++ b/mlir/lib/Transform/AIRDependency.cpp
@@ -1464,41 +1464,10 @@ private:
   scf::IndexSwitchOp
   convertScfIndexSwitchToAsync(RewriterBase &rewriter,
                                scf::IndexSwitchOp branch_op) {
-    // Preserve any existing result types; append the async token last so that
-    // insertLoopCarriedDepsInRegion (which appends the token to scf.yield) and
-    // the result ordering stay consistent.
-    SmallVector<Type> yielded_tys(branch_op.getResultTypes());
-    yielded_tys.push_back(air::AsyncTokenType::get(rewriter.getContext()));
-    scf::IndexSwitchOp new_branch_op = scf::IndexSwitchOp::create(
-        rewriter, branch_op.getLoc(), yielded_tys, branch_op.getArg(),
-        branch_op.getCases(),
-        /*caseRegionsCount=*/branch_op.getCases().size());
-
-    if (auto attr = branch_op->getAttrOfType<StringAttr>(
-            SymbolTable::getSymbolAttrName()))
-      new_branch_op->setAttr(SymbolTable::getSymbolAttrName(), attr);
-
-    // Splice the operations from every region (default + cases), excluding the
-    // old terminator; insertLoopCarriedDepsInRegion appends the async yield.
-    auto old_regions = branch_op->getRegions();
-    auto new_regions = new_branch_op->getRegions();
-    for (auto [o_r, n_r] : llvm::zip_equal(old_regions, new_regions)) {
-      if (o_r.empty())
-        continue;
-      if (n_r.empty())
-        rewriter.createBlock(&n_r);
-      auto &bb = n_r.front().getOperations();
-      auto &body = o_r.front().getOperations();
-      bb.splice(bb.begin(), body, body.begin(), --body.end());
-    }
-
-    // Replace uses of old results with the corresponding new results (same
-    // index; the token is appended after, so existing indices are stable).
-    for (auto [old_r, new_r] :
-         llvm::zip(branch_op.getResults(), new_branch_op.getResults()))
-      old_r.replaceAllUsesWith(new_r);
-
-    return new_branch_op;
+    // Append the async token result, splice regions (excluding terminators) and
+    // RAUW; insertLoopCarriedDepsInRegion appends the async yields afterwards
+    // and the caller erases branch_op.
+    return air::rebuildIndexSwitchWithTrailingAsyncToken(rewriter, branch_op);
   }
 
   // Elevating tokens from inside loop body to the yielded token, to maintain

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6798,8 +6798,9 @@ struct AIRLaunchToScfForPattern : public OpRewritePattern<air::LaunchOp> {
 // (markDevicesNeedingLockReset) so no per-wave boundary/pacing is emitted.
 // Rebuild the switch with a trailing !air.async.token result whose regions each
 // yield a wait_all over their dangling tokens, so the scf.for conversion below
-// threads it into the loop-carried drain. Mirrors convertScfIndexSwitchToAsync
-// but standalone (no ExecuteGraph).
+// threads it into the loop-carried drain. Shares the switch rebuild with
+// air-dependency's convertScfIndexSwitchToAsync via
+// air::rebuildIndexSwitchWithTrailingAsyncToken.
 static scf::IndexSwitchOp restoreIndexSwitchDrainToken(scf::IndexSwitchOp sw,
                                                        OpBuilder &b) {
   auto tokTy = air::AsyncTokenType::get(sw.getContext());
@@ -6821,24 +6822,9 @@ static scf::IndexSwitchOp restoreIndexSwitchDrainToken(scf::IndexSwitchOp sw,
                     [&](Region &r) { return regionHasDanglingToken(r); }))
     return sw;
 
-  b.setInsertionPoint(sw);
-  SmallVector<Type> resTys(sw.getResultTypes());
-  resTys.push_back(tokTy);
-  auto newSw = scf::IndexSwitchOp::create(b, sw.getLoc(), resTys, sw.getArg(),
-                                          sw.getCases(), sw.getCases().size());
-  if (auto attr =
-          sw->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
-    newSw->setAttr(SymbolTable::getSymbolAttrName(), attr);
-  // Move ops (excluding the old terminator) into the new regions.
-  for (auto [oR, nR] : llvm::zip_equal(sw->getRegions(), newSw->getRegions())) {
-    if (oR.empty())
-      continue;
-    if (nR.empty())
-      b.createBlock(&nR);
-    auto &nbb = nR.front().getOperations();
-    auto &obb = oR.front().getOperations();
-    nbb.splice(nbb.begin(), obb, obb.begin(), --obb.end());
-  }
+  // Shared rebuild (new switch + trailing async token + region splice + RAUW);
+  // this caller then populates each region's wait_all yield and erases sw.
+  auto newSw = air::rebuildIndexSwitchWithTrailingAsyncToken(b, sw);
   // Terminate each region with a yield of a wait_all over its dangling tokens.
   for (Region &nR : newSw->getRegions()) {
     if (nR.empty())
@@ -6860,8 +6846,7 @@ static scf::IndexSwitchOp restoreIndexSwitchDrainToken(scf::IndexSwitchOp sw,
     yieldVals.push_back(wa.getResult(0));
     scf::YieldOp::create(b, sw.getLoc(), yieldVals);
   }
-  for (auto [o, n] : llvm::zip(sw.getResults(), newSw.getResults()))
-    o.replaceAllUsesWith(n);
+  // The helper already RAUW'd the original results onto newSw.
   sw.erase();
   return newSw;
 }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6786,6 +6786,86 @@ struct AIRLaunchToScfForPattern : public OpRewritePattern<air::LaunchOp> {
   }
 };
 
+// Re-establish an async drain token on a launch-scope scf.index_switch that
+// selects per-iteration host feeds (a fused multi-iteration launch may wrap
+// each iteration's L3->L2 feeds in an scf.index_switch). air-dependency
+// async-converts it,
+// but a subsequent canonicalize drops the switch's unused async-token result --
+// trapping the branch feeds' tokens inside its regions, so the launch-block
+// drain (generateWaitAllToTerminateBlock, later folded into air.launch_end)
+// finds no dangling token and the launch_end marker is never built. Without
+// air.launch_end the fused launch is not detected as multi-iteration
+// (markDevicesNeedingLockReset) so no per-wave boundary/pacing is emitted.
+// Rebuild the switch with a trailing !air.async.token result whose regions each
+// yield a wait_all over their dangling tokens, so the scf.for conversion below
+// threads it into the loop-carried drain. Mirrors convertScfIndexSwitchToAsync
+// but standalone (no ExecuteGraph).
+static scf::IndexSwitchOp restoreIndexSwitchDrainToken(scf::IndexSwitchOp sw,
+                                                       OpBuilder &b) {
+  auto tokTy = air::AsyncTokenType::get(sw.getContext());
+  // Already async: nothing to do.
+  if (sw.getNumResults() &&
+      isa<air::AsyncTokenType>(sw.getResult(sw.getNumResults() - 1).getType()))
+    return sw;
+  // Only rebuild if some region actually holds a dangling async token.
+  auto regionHasDanglingToken = [](Region &r) {
+    if (r.empty())
+      return false;
+    for (Operation &o : r.front().without_terminator())
+      for (Value res : o.getResults())
+        if (isa<air::AsyncTokenType>(res.getType()) && res.use_empty())
+          return true;
+    return false;
+  };
+  if (llvm::none_of(sw->getRegions(),
+                    [&](Region &r) { return regionHasDanglingToken(r); }))
+    return sw;
+
+  b.setInsertionPoint(sw);
+  SmallVector<Type> resTys(sw.getResultTypes());
+  resTys.push_back(tokTy);
+  auto newSw = scf::IndexSwitchOp::create(b, sw.getLoc(), resTys, sw.getArg(),
+                                          sw.getCases(), sw.getCases().size());
+  if (auto attr =
+          sw->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
+    newSw->setAttr(SymbolTable::getSymbolAttrName(), attr);
+  // Move ops (excluding the old terminator) into the new regions.
+  for (auto [oR, nR] : llvm::zip_equal(sw->getRegions(), newSw->getRegions())) {
+    if (oR.empty())
+      continue;
+    if (nR.empty())
+      b.createBlock(&nR);
+    auto &nbb = nR.front().getOperations();
+    auto &obb = oR.front().getOperations();
+    nbb.splice(nbb.begin(), obb, obb.begin(), --obb.end());
+  }
+  // Terminate each region with a yield of a wait_all over its dangling tokens.
+  for (Region &nR : newSw->getRegions()) {
+    if (nR.empty())
+      b.createBlock(&nR);
+    Block &blk = nR.front();
+    SmallVector<Value> dangling;
+    for (Operation &o : blk.without_terminator())
+      for (Value res : o.getResults())
+        if (isa<air::AsyncTokenType>(res.getType()) && res.use_empty())
+          dangling.push_back(res);
+    SmallVector<Value> yieldVals;
+    if (blk.mightHaveTerminator())
+      if (auto y = dyn_cast<scf::YieldOp>(blk.getTerminator())) {
+        yieldVals.append(y.getOperands().begin(), y.getOperands().end());
+        y.erase();
+      }
+    b.setInsertionPointToEnd(&blk);
+    auto wa = air::WaitAllOp::create(b, sw.getLoc(), tokTy, dangling);
+    yieldVals.push_back(wa.getResult(0));
+    scf::YieldOp::create(b, sw.getLoc(), yieldVals);
+  }
+  for (auto [o, n] : llvm::zip(sw.getResults(), newSw.getResults()))
+    o.replaceAllUsesWith(n);
+  sw.erase();
+  return newSw;
+}
+
 // A pass which performs a series of scf.for loop splitting, fusion and
 // specialization, with the goal of generating efficient shim dma block
 // descriptors (BD).
@@ -6826,6 +6906,21 @@ public:
       // folding and finish.
       applyAIRL3DmaFoldingPatterns(func, *device);
       return;
+    }
+
+    // Re-establish drain tokens on any sync launch-scope scf.index_switch
+    // (mode-select host feeds) before the launch is serialized into scf.for, so
+    // AIRLaunchToScfForPattern's generateWaitAllToTerminateBlock threads the
+    // switch's branch-feed tokens into the loop-carried drain / air.launch_end.
+    {
+      OpBuilder b(ctx);
+      SmallVector<scf::IndexSwitchOp> switchesToFix;
+      func.walk([&](air::LaunchOp launch) {
+        for (auto sw : launch.getBody().front().getOps<scf::IndexSwitchOp>())
+          switchesToFix.push_back(sw);
+      });
+      for (auto sw : switchesToFix)
+        restoreIndexSwitchDrainToken(sw, b);
     }
 
     // Convert air.launch to scf.for.

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -273,6 +273,32 @@ scf::ParallelOp air::getParallelRegionInitValsOwner(Operation *op, Value val) {
   return scf::ParallelOp();
 }
 
+scf::IndexSwitchOp
+air::rebuildIndexSwitchWithTrailingAsyncToken(OpBuilder &b,
+                                              scf::IndexSwitchOp sw) {
+  SmallVector<Type> resTys(sw.getResultTypes());
+  resTys.push_back(air::AsyncTokenType::get(sw.getContext()));
+  b.setInsertionPoint(sw);
+  auto newSw = scf::IndexSwitchOp::create(b, sw.getLoc(), resTys, sw.getArg(),
+                                          sw.getCases(), sw.getCases().size());
+  if (auto attr =
+          sw->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
+    newSw->setAttr(SymbolTable::getSymbolAttrName(), attr);
+  // Move ops (excluding the old terminator) into the new regions.
+  for (auto [oR, nR] : llvm::zip_equal(sw->getRegions(), newSw->getRegions())) {
+    if (oR.empty())
+      continue;
+    if (nR.empty())
+      b.createBlock(&nR);
+    auto &nbb = nR.front().getOperations();
+    auto &obb = oR.front().getOperations();
+    nbb.splice(nbb.begin(), obb, obb.begin(), --obb.end());
+  }
+  for (auto [o, n] : llvm::zip(sw.getResults(), newSw.getResults()))
+    o.replaceAllUsesWith(n);
+  return newSw;
+}
+
 // Get the parent air.launch_herd op of a tile id
 air::HerdOp air::getHerdArgOwner(Value val) {
   auto ivArg = llvm::dyn_cast_if_present<BlockArgument>(val);

--- a/mlir/test/Conversion/AIRLowering/air_scf_index_switch_async.mlir
+++ b/mlir/test/Conversion/AIRLowering/air_scf_index_switch_async.mlir
@@ -1,0 +1,35 @@
+//===- air_scf_index_switch_async.mlir --------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -air-to-std %s | FileCheck %s
+
+// A launch-scope scf.index_switch that carries an async drain token (used to
+// select per-iteration host feeds in a fused multi-iteration launch) must have
+// its async-token results converted to !airrt.event, mirroring the scf.for /
+// scf.if conversions. Without the conversion the switch is left carrying an
+// !air.async.token result, which strands the downstream drain.
+
+// CHECK-LABEL: func.func @scf_index_switch
+// CHECK: scf.index_switch %{{.*}} -> !airrt.event
+// CHECK: scf.yield %{{.*}} : !airrt.event
+// CHECK: scf.yield %{{.*}} : !airrt.event
+// CHECK-NOT: !air.async.token
+func.func @scf_index_switch(%arg0: index) {
+  %0 = air.wait_all async
+  %1 = scf.index_switch %arg0 -> !air.async.token
+  case 0 {
+    %2 = air.wait_all async [%0]
+    scf.yield %2 : !air.async.token
+  }
+  default {
+    %3 = air.wait_all async [%0]
+    scf.yield %3 : !air.async.token
+  }
+  air.wait_all [%1]
+  return
+}

--- a/mlir/test/Conversion/AIRRtToNpu/fold_const_index_switch.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/fold_const_index_switch.mlir
@@ -1,0 +1,67 @@
+//===- fold_const_index_switch.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+
+// A launch-scope scf.index_switch that selects an iteration's host feeds by a
+// per-iteration mode has a CONSTANT condition once the iteration loop is
+// unrolled. It must be folded away and its selected branch inlined into the
+// runtime sequence -- an scf.index_switch cannot parent the emitted
+// aiex.dma_configure_task_for. The switch's async drain token (threaded to the
+// air.launch_end wait_all so the launch_end survives shim-dma-bds) is severed so
+// the dead switch can be erased cleanly.
+//
+// Here the condition is constant 0, selecting the case-0 branch (@feedIn); the
+// default branch (@altIn) is dead. Without the fold the scf.index_switch (and
+// @altIn) survive.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl
+// CHECK-NOT: scf.index_switch
+// CHECK: aiex.dma_configure_task_for @feedIn
+// CHECK-NOT: aiex.dma_configure_task_for @altIn
+
+module {
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @altIn(%tile_0_0, MM2S, 1)
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      aie.end
+    }
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %alt = arith.constant 5 : i32
+    %sel = arith.constant 0 : index
+    %ev = scf.index_switch %sel -> !airrt.event
+    case 0 {
+      %f = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %f : !airrt.event
+    }
+    default {
+      %g = airrt.dma_memcpy_nd(%alt, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @altIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %g : !airrt.event
+    }
+    airrt.wait_all %ev {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/fold_const_index_switch_multiiter.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/fold_const_index_switch_multiiter.mlir
@@ -1,0 +1,91 @@
+//===- fold_const_index_switch_multiiter.mlir -----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+
+// Combined coverage: a fused two-iteration launch whose per-iteration feeds are
+// selected by a constant-condition scf.index_switch. FoldConstIndexSwitchPattern
+// inlines each switch's selected branch and rebuilds the consuming launch_end
+// airrt.wait_all WITHOUT the switch token. That rebuild must preserve the
+// air.launch_end marker (a discardable attr, copied via setAttrs) -- it runs
+// BEFORE multi-iteration detection and wave tagging, so dropping it would
+// collapse both waves' arms to the global front. Verify each wave still gets its
+// OWN rtp_write (c7 then c9) armed before its own feed, and the dead branch
+// (@altIn) is gone.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl
+// CHECK-NOT: scf.index_switch
+// Wave 0 arms with c7 before its feed.
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0, %c7{{.*}}) : i32
+// CHECK: aiex.set_lock(%__air_herd_lock_0_2, 1)
+// CHECK: aiex.dma_configure_task_for @outBack
+// CHECK: aiex.dma_configure_task_for @feedIn
+// CHECK: aiex.dma_await_task
+// Wave 1 re-arms with c9 (its own arm, not collapsed to the front) before its feed.
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0, %c9{{.*}}) : i32
+// CHECK: aiex.set_lock(%__air_herd_lock_0_2, 1)
+// CHECK: aiex.dma_configure_task_for @outBack
+// CHECK: aiex.dma_configure_task_for @feedIn
+// CHECK-NOT: aiex.dma_configure_task_for @altIn
+
+module {
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %l = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %r = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<1xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @altIn(%tile_0_0, MM2S, 1)
+    aie.shim_dma_allocation @outBack(%tile_0_0, S2MM, 0)
+    %mem = aie.mem(%tile_0_2) { aie.end }
+    %core = aie.core(%tile_0_2) { aie.end } {link_with = "kernel.o"}
+  } {sym_name = "seg"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @ctrl(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %alt = arith.constant 5 : i32
+    %out = arith.constant 6 : i32
+    %sel = arith.constant 0 : index
+    %rtp0 = arith.constant 7 : i32
+    %rtp1 = arith.constant 9 : i32
+    // iteration 0
+    %ev0 = scf.index_switch %sel -> !airrt.event
+    case 0 {
+      %f = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %f : !airrt.event
+    }
+    default {
+      %g = airrt.dma_memcpy_nd(%alt, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @altIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %g : !airrt.event
+    }
+    %h0 = airrt.herd_load "herd_0" (%rtp0) {segment_name = "seg"} : (i32) -> i64
+    %o0 = airrt.dma_memcpy_nd(%out, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outBack} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    airrt.wait_all %ev0, %o0 {"air.launch_end"}
+    // iteration 1
+    %ev1 = scf.index_switch %sel -> !airrt.event
+    case 0 {
+      %f = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %f : !airrt.event
+    }
+    default {
+      %g = airrt.dma_memcpy_nd(%alt, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @altIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+      scf.yield %g : !airrt.event
+    }
+    %h1 = airrt.herd_load "herd_0" (%rtp1) {segment_name = "seg"} : (i32) -> i64
+    %o1 = airrt.dma_memcpy_nd(%out, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outBack} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    airrt.wait_all %ev1, %o1 {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/fused_multiiter_output_s2mm_first.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/fused_multiiter_output_s2mm_first.mlir
@@ -1,0 +1,92 @@
+//===- fused_multiiter_output_s2mm_first.mlir -----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+
+// A fused multi-iteration launch (two air.launch_end markers, non-ELF) must arm
+// each iteration's output S2MM BEFORE issuing that iteration's input MM2S feed.
+// The producing core blocks releasing its output buffer lock until the output
+// S2MM BD is running to drain it; if the control program is still issuing input
+// feeds at that point the core stalls -> deadlock. So each iteration's output
+// S2MM configure+start is hoisted ahead of its first input feed.
+//
+// The two iterations are HETEROGENEOUS: iteration 0 also drains an extra output
+// (@appendOut) that iteration 1 does not, exercising a per-iteration output set
+// that is not uniform across waves.
+//
+// Without the hoist the input feed (@feedIn) is configured first, and the extra
+// per-wave output has no output-first ordering.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl
+
+// Iteration 0: arm, then BOTH outputs (@appendOut, @outBack) configure+start
+// BEFORE the input feed @feedIn.
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0, %{{.*}}) : i32
+// CHECK: aiex.set_lock(%__air_herd_lock_0_2, 1)
+// CHECK: aiex.dma_configure_task_for @appendOut
+// CHECK: aiex.dma_configure_task_for @outBack
+// CHECK: aiex.dma_configure_task_for @feedIn
+// CHECK: aiex.dma_await_task
+
+// Iteration 1: re-arm lands AFTER iteration 0's drain (no global hoist), and its
+// single output @outBack is configured before @feedIn. @appendOut is absent.
+// CHECK: aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0, %{{.*}}) : i32
+// CHECK: aiex.set_lock(%__air_herd_lock_0_2, 1)
+// CHECK: aiex.dma_configure_task_for @outBack
+// CHECK-NOT: aiex.dma_configure_task_for @appendOut
+// CHECK: aiex.dma_configure_task_for @feedIn
+
+module {
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<1xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @outBack(%tile_0_0, S2MM, 0)
+    aie.shim_dma_allocation @appendOut(%tile_0_0, S2MM, 1)
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      aie.end
+    }
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %out = arith.constant 5 : i32
+    %app = arith.constant 6 : i32
+
+    // unrolled iteration 0 (heterogeneous: also drains @appendOut)
+    %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %rtp0 = arith.constant 7 : i32
+    %h0 = airrt.herd_load "herd_0" (%rtp0) {segment_name = "seg"} : (i32) -> i64
+    %a0 = airrt.dma_memcpy_nd(%app, %c0_i64, %c0_i64, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @appendOut} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %o0 = airrt.dma_memcpy_nd(%out, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outBack} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    airrt.wait_all %o0 {"air.launch_end"}
+
+    // unrolled iteration 1 (no @appendOut)
+    %f1 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    %rtp1 = arith.constant 9 : i32
+    %h1 = airrt.herd_load "herd_0" (%rtp1) {segment_name = "seg"} : (i32) -> i64
+    %o1 = airrt.dma_memcpy_nd(%out, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outBack} : (i32, i64, i64, memref<64xi32>, [i64, i64, i64, i64], [i64, i64, i64, i64], [i64, i64, i64, i64]) : !airrt.event
+    airrt.wait_all %o1 {"air.launch_end"}
+
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/restore_index_switch_drain.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/restore_index_switch_drain.mlir
@@ -1,0 +1,46 @@
+//===- restore_index_switch_drain.mlir --------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-opt-shim-dma-bds="device=npu1" | FileCheck %s
+
+// A launch-scope scf.index_switch selecting per-iteration host feeds is left
+// SYNC (no async result) after air-dependency + canonicalize dropped its unused
+// drain token, stranding the branch feeds' tokens. restoreIndexSwitchDrainToken
+// (in air-opt-shim-dma-bds, via air::rebuildIndexSwitchWithTrailingAsyncToken)
+// must rebuild the switch with a trailing !air.async.token result whose branches
+// each yield a drain over their dangling feed tokens, so the launch-body drain
+// (air.launch_end) consumes it -- otherwise the launch_end marker is never built
+// and the fused multi-iteration launch is not detected downstream.
+
+// CHECK-LABEL: func.func @index_switch_drain
+// CHECK: air.launch
+// CHECK: %[[SW:.*]] = scf.index_switch %{{.*}} -> !air.async.token
+// CHECK: case 0 {
+// CHECK: scf.yield %{{.*}} : !air.async.token
+// CHECK: }
+// CHECK: scf.yield %{{.*}} : !air.async.token
+// CHECK: air.wait_all [%[[SW]]] {air.launch_end}
+func.func @index_switch_drain(%arg0: memref<512x512xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%tx) in (%sx=%c1) args(%buf=%arg0) : memref<512x512xbf16> {
+    %c0 = arith.constant 0 : index
+    %c1_0 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+    %mode = arith.constant 0 : index
+    scf.index_switch %mode
+    case 0 {
+      %p = air.channel.put async @channel_0[%c0, %c0] (%buf[%c0, %c0] [%c512, %c64] [%c512, %c1_0]) {id = 1 : i32} : (memref<512x512xbf16>)
+      scf.yield
+    }
+    default {
+      %q = air.channel.put async @channel_1[%c0, %c0] (%buf[%c0, %c0] [%c512, %c64] [%c512, %c1_0]) {id = 2 : i32} : (memref<512x512xbf16>)
+      scf.yield
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

Enables a single `air.launch` inside an `scf.for` (stitching N iterations into
one dispatch) whose per-iteration host feeds are selected by a launch-scope
`scf.index_switch` (a per-iteration mode arm) to lower correctly. Previously the
switch's async drain token was stripped, so `air.launch_end` never survived, the
launch was not detected as multi-iteration, and no per-iteration (wave)
boundaries were emitted. The runtime sequence then clustered every wave's RTP
arm / herd-release at the global front and armed each output S2MM after its
wave's input feeds, which deadlocks a cross-mode wave transition.

## Changes

- **AIRLoweringPass**: add `ScfIndexSwitchOpConversion` to convert
  `scf.index_switch` async-token results (air-to-std), mirroring the existing
  `scf.for` / `scf.if` conversions.
- **AIRDependencyScheduleOpt**: restore a drain token on a launch-scope
  `scf.index_switch` before serializing the launch to `scf.for`, so the loop-body
  drain / `air.launch_end` survives canonicalize and the multi-iteration launch
  is detected.
- **AIRRtToNpuPass**: fold the constant-condition switch after unrolling; guard
  the wait<->config FIFO match on dominance (avoids a use-before-def await that
  crashed control-func conversion) and re-home the per-iteration boundary
  marker; distribute clustered per-wave RTP arm / lock blocks to each wave's
  feeds; and hoist each wave's output S2MM configure+start ahead of its input
  feeds. All new behavior is gated to fused multi-iteration launches, so
  single-dispatch sequences are unchanged.

## Test plan

- [x] New `air_scf_index_switch_async.mlir` covering the async `scf.index_switch`
  lowering. Fails without the conversion (the switch keeps an
  `!air.async.token` result that fails verification); passes with it.
- [x] `ninja check-air-mlir`: no new failures (only the pre-existing local
  `air_tensor.h` environment failures remain).