### PR TITLE
[AIRToAIE] Self-recycling lock for consumerless memtile drain

### DIFF
--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -589,6 +589,24 @@ bool air::isChainLockCandidate(AIE::BufferOp buf) {
   return false;
 }
 
+// True iff `buf` is an L2 memtile buffer that is FILLED by DMA (>=1 writer
+// endpoint) but NEVER READ (0 reader endpoints) within the segment -- a "pure
+// drain" (e.g. a readback whose data is discarded). Such a buffer's receiving
+// BD must SELF-RECYCLE on a single lock: there is no consumer to release a
+// separate producer lock or acquire a separate handoff lock, so the legacy
+// producer/consumer pair (acquire wlock / release rlock) fires exactly once
+// then DEADLOCKS on the next dispatch re-acquiring wlock.
+static bool isConsumerlessMemtileDrain(AIE::BufferOp buf) {
+  if (!buf)
+    return false;
+  auto memrefTy = dyn_cast<MemRefType>(buf.getResult().getType());
+  if (!memrefTy || !air::isL2(memrefTy))
+    return false;
+  int nW = 0, nR = 0;
+  countChainBufferRoles(buf, nW, nR);
+  return nW >= 1 && nR == 0;
+}
+
 void air::classifyChainBuffer(AIE::BufferOp buf, int &numWriters,
                               int &numReaders) {
   countChainBufferRoles(buf, numWriters, numReaders);
@@ -1175,6 +1193,21 @@ FailureOr<std::pair<AIE::LockOp, AIE::LockOp>> air::DMAAllocator::getLockForDMA(
     init_pair =
         getLockValuePair(target_model, bufferOp->getResult(0), air_chan);
   auto init = std::max(init_pair.first, init_pair.second);
+
+  // Consumerless memtile drain: emit ONE self-recycling lock (returned as both
+  // pair elements) so the receiving BD acquires AND releases the same lock and
+  // re-arms every dispatch. A distinct producer/consumer pair would deadlock on
+  // the 2nd dispatch (no consumer to release the producer lock). generateDmaBd
+  // emits acquire(self,1)/release(self,1) automatically when both pair elements
+  // are the same lock. Scoped by nR==0 -> mutually exclusive with the
+  // chain-lock / shared-L1 / producer->consumer paths above.
+  if (UsesSemaphoreLocks && tileIsMemTile &&
+      isConsumerlessMemtileDrain(dyn_cast_or_null<AIE::BufferOp>(bufferOp))) {
+    auto selfLock = allocateLockOp(device, tile, std::max<int64_t>(init, 1));
+    lock_allocation_list.push_back(
+        {bufferOp, air_chan, channel, selfLock, selfLock});
+    return std::make_pair(selfLock, selfLock);
+  }
 
   OpBuilder builder(bufferOp);
   auto rlock = allocateLockOp(device, tile, 0);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -567,13 +567,19 @@ static void countChainBufferRoles(AIE::BufferOp buf, int &numWriters,
   numReaders = getOrderedChainEndpoints(buf, /*writers=*/false).size();
 }
 
-bool air::isChainLockCandidate(AIE::BufferOp buf) {
+// Eligibility guard shared by the memtile-specific lock predicates: only a
+// non-null L2 (memtile) buffer qualifies.
+static bool isL2MemtileBuffer(AIE::BufferOp buf) {
   if (!buf)
     return false;
+  auto memrefTy = dyn_cast<MemRefType>(buf.getResult().getType());
+  return memrefTy && air::isL2(memrefTy);
+}
+
+bool air::isChainLockCandidate(AIE::BufferOp buf) {
   // Predicate is shape-based on the buffer's user list. Only L2 memtile
   // buffers are eligible (this is a memtile-specific lock pattern).
-  auto memrefTy = dyn_cast<MemRefType>(buf.getResult().getType());
-  if (!memrefTy || !air::isL2(memrefTy))
+  if (!isL2MemtileBuffer(buf))
     return false;
   int nW = 0, nR = 0;
   countChainBufferRoles(buf, nW, nR);
@@ -597,13 +603,10 @@ bool air::isChainLockCandidate(AIE::BufferOp buf) {
 // producer/consumer pair (acquire wlock / release rlock) fires exactly once
 // then DEADLOCKS on the next dispatch re-acquiring wlock.
 static bool isConsumerlessMemtileDrain(AIE::BufferOp buf) {
-  if (!buf)
-    return false;
-  auto memrefTy = dyn_cast<MemRefType>(buf.getResult().getType());
-  if (!memrefTy || !air::isL2(memrefTy))
+  if (!isL2MemtileBuffer(buf))
     return false;
   int nW = 0, nR = 0;
-  countChainBufferRoles(buf, nW, nR);
+  air::classifyChainBuffer(buf, nW, nR);
   return nW >= 1 && nR == 0;
 }
 
@@ -1203,7 +1206,8 @@ FailureOr<std::pair<AIE::LockOp, AIE::LockOp>> air::DMAAllocator::getLockForDMA(
   // chain-lock / shared-L1 / producer->consumer paths above.
   if (UsesSemaphoreLocks && tileIsMemTile &&
       isConsumerlessMemtileDrain(dyn_cast_or_null<AIE::BufferOp>(bufferOp))) {
-    auto selfLock = allocateLockOp(device, tile, std::max<int64_t>(init, 1));
+    auto selfLock = allocateLockOp(
+        device, tile, static_cast<int>(std::max<int64_t>(init, 1)));
     lock_allocation_list.push_back(
         {bufferOp, air_chan, channel, selfLock, selfLock});
     return std::make_pair(selfLock, selfLock);

--- a/mlir/test/Conversion/AIRToAIE/consumerless_memtile_drain.mlir
+++ b/mlir/test/Conversion/AIRToAIE/consumerless_memtile_drain.mlir
@@ -6,6 +6,10 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+// The self-recycling drain lock must be emitted identically on all three lock
+// paths, including the daisy-chained race-condition fixes (v1/v2).
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802 use-lock-race-condition-fix=true" | FileCheck %s
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802 use-lock-race-condition-fix-v2=true" | FileCheck %s
 
 // An L2 memtile buffer that is DMA-filled (a channel.get writes into it) but is
 // never read out (no channel.put reads it) within the segment is a "pure drain"
@@ -19,10 +23,16 @@
 // a consumerless L2 buffer (memref<32xi32, 1>) that gets the self lock.
 
 // CHECK: aie.memtile_dma
-// The live relay buffer (memref<64xi32, 1>) appears as two BDs (MM2S drain to
-// the core + S2MM fill); advance past both.
-// CHECK: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
-// CHECK: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
+// Negative control -- the live relay buffer (memref<64xi32, 1>) keeps a DISTINCT
+// producer/consumer lock pair in a crossed pattern: the S2MM fill acquires lock A
+// and releases lock B, then the MM2S forward-to-core acquires B and releases A.
+// A != B is proven structurally by the crossed reuse of the two capture vars.
+// CHECK: aie.use_lock(%[[LIVE_A:.*]], AcquireGreaterEqual, %{{.*}})
+// CHECK-NEXT: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
+// CHECK-NEXT: aie.use_lock(%[[LIVE_B:.*]], Release, %{{.*}})
+// CHECK: aie.use_lock(%[[LIVE_B]], AcquireGreaterEqual, %{{.*}})
+// CHECK-NEXT: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
+// CHECK-NEXT: aie.use_lock(%[[LIVE_A]], Release, %{{.*}})
 // The consumerless drain's S2MM BD (memref<32xi32, 1>) acquires and releases
 // the SAME lock (self-recycling), not a distinct producer/consumer pair.
 // CHECK: aie.use_lock(%[[DRAIN:.*]], AcquireGreaterEqual, %{{.*}})

--- a/mlir/test/Conversion/AIRToAIE/consumerless_memtile_drain.mlir
+++ b/mlir/test/Conversion/AIRToAIE/consumerless_memtile_drain.mlir
@@ -1,0 +1,57 @@
+//===- consumerless_memtile_drain.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// An L2 memtile buffer that is DMA-filled (a channel.get writes into it) but is
+// never read out (no channel.put reads it) within the segment is a "pure drain"
+// -- its data is discarded. Its receiving S2MM BD must SELF-RECYCLE on a single
+// lock (acquire AND release the same lock) so it re-arms every dispatch. The
+// legacy producer/consumer lock pair would fire once, then deadlock on the next
+// dispatch re-acquiring the producer lock (no consumer ever releases it).
+//
+// Here @live_in feeds an L2 buffer that IS forwarded to a core (a normal
+// relay, keeping a distinct producer/consumer lock pair), while @drain_in feeds
+// a consumerless L2 buffer (memref<32xi32, 1>) that gets the self lock.
+
+// CHECK: aie.memtile_dma
+// The live relay buffer (memref<64xi32, 1>) appears as two BDs (MM2S drain to
+// the core + S2MM fill); advance past both.
+// CHECK: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
+// CHECK: aie.dma_bd(%{{.*}} : memref<64xi32, 1>
+// The consumerless drain's S2MM BD (memref<32xi32, 1>) acquires and releases
+// the SAME lock (self-recycling), not a distinct producer/consumer pair.
+// CHECK: aie.use_lock(%[[DRAIN:.*]], AcquireGreaterEqual, %{{.*}})
+// CHECK-NEXT: aie.dma_bd(%{{.*}} : memref<32xi32, 1>
+// CHECK-NEXT: aie.use_lock(%[[DRAIN]], Release, %{{.*}})
+
+module {
+  air.channel @live_in [1, 1]
+  air.channel @drain_in [1, 1]
+  air.channel @to_core [1, 1]
+  func.func @func_drain(%arg0: memref<64xi32>, %arg1: memref<32xi32>) {
+    %c1 = arith.constant 1 : index
+    air.channel.put @live_in[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+    air.channel.put @drain_in[] (%arg1[] [] []) {id = 2 : i32} : (memref<32xi32>)
+    air.segment @seg0 {
+      %c1_0 = arith.constant 1 : index
+      %l2_live = memref.alloc() : memref<64xi32, 1>
+      %l2_drain = memref.alloc() : memref<32xi32, 1>
+      air.channel.get @live_in[] (%l2_live[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
+      air.channel.get @drain_in[] (%l2_drain[] [] []) {id = 4 : i32} : (memref<32xi32, 1>)
+      air.channel.put @to_core[] (%l2_live[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+      air.herd tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) attributes {sym_name = "herd0"} {
+        %buf = memref.alloc() : memref<64xi32, 2>
+        air.channel.get @to_core[%tx, %ty] (%buf[] [] []) {id = 6 : i32} : (memref<64xi32, 2>)
+        memref.dealloc %buf : memref<64xi32, 2>
+      }
+      memref.dealloc %l2_live : memref<64xi32, 1>
+      memref.dealloc %l2_drain : memref<32xi32, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

An L2 memtile buffer that is DMA-filled (≥1 writer endpoint) but **never read** within the segment (0 reader endpoints) is a *pure drain* — its data is discarded. Its receiving S2MM BD must **self-recycle on a single lock**: there is no consumer to release a separate producer lock or acquire a separate handoff lock, so the legacy producer/consumer lock pair fires exactly once and then deadlocks on the next dispatch re-acquiring the producer lock.

`DMAAllocator::getLockForDMA` now detects `nR==0` L2 drains (new `isConsumerlessMemtileDrain` predicate) and emits one self lock — returned as both pair elements, so `generateDmaBd` emits `acquire(self,1)`/`release(self,1)` on the same lock. The branch is scoped `UsesSemaphoreLocks && tileIsMemTile && nR==0`, making it mutually exclusive with the chain-lock / shared-L1 / producer→consumer paths.

## Test plan

- [x] New lit test `mlir/test/Conversion/AIRToAIE/consumerless_memtile_drain.mlir`: a live relay buffer keeps a distinct producer/consumer lock pair, while the consumerless drain's S2MM BD acquires and releases the same lock. Verified it fails without the fix (drain gets distinct locks) and passes with it.
- [x] `ninja check-air-mlir` — no new failures vs `origin/main` baseline; all 112 AIRToAIE tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)