### PR TITLE
[AIRToAIE] air.no_chain_lock opt-out for memtile chain-lock

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -78,6 +78,20 @@ constexpr StringLiteral SrcWritesPktHeader = "air.src_writes_pkt_header";
 // ordering (RTP arm / set_lock / output-S2MM hoist) groups by this index
 // instead of inferring wave boundaries from op positions.
 constexpr StringLiteral LaunchWave = "air.launch_wave";
+// Opt-out (unit attr) on a shared-L2 memref.alloc: keep the buffer on the
+// legacy counted-lock template even under use-lock-race-condition-fix-v2,
+// instead of the daisy-chained chain-lock. Honored only for fan-out broadcast
+// buffers, whose N readers are independent compute cores: the chain-lock
+// over-serializes those reads and can deadlock against a competing fan-in
+// chain. Must be tagged on the alloc itself (the air.execute wrapper is already
+// lowered away by the time AIRToAIE reads it); propagated onto the lowered
+// AIE::BufferOp so air::isChainLockCandidate can exclude it.
+constexpr StringLiteral NoChainLock = "air.no_chain_lock";
+// Opt-out (unit attr) on a shared-L2 memref.alloc (or its enclosing
+// air.execute): leave this L2 buffer intact instead of partitioning it. Used by
+// hand-written aggregator patterns where splitting would multiply the
+// launch-level shim endpoint count.
+constexpr StringLiteral NoSplit = "air.no_split";
 } // namespace attrs
 
 // Copy the DMA-steering / runtime-ordering markers

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2398,6 +2398,14 @@ struct AllocL2BuffersPattern : public OpRewritePattern<memref::AllocOp> {
       buffer->setAttr(air::attrs::RefeedCount,
                       rewriter.getI32IntegerAttr(refeedN));
 
+    // Propagate the opt-out chain-lock pin from the source alloc to the
+    // lowered buffer so isChainLockCandidate can exclude it. Used to keep
+    // fan-out broadcast buffers (e.g. a per-column weight fan read by N
+    // distinct compute cores) on the legacy counted-lock template instead of
+    // the v2 daisy-chain, which over-serializes independent readers.
+    if (alloc->hasAttr("air.no_chain_lock"))
+      buffer->setAttr("air.no_chain_lock", rewriter.getUnitAttr());
+
     rewriter.replaceOp(alloc, buffer->getResults());
     bufferToMemtileMap[buffer] = tile;
     return success();

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -2403,8 +2403,8 @@ struct AllocL2BuffersPattern : public OpRewritePattern<memref::AllocOp> {
     // fan-out broadcast buffers (e.g. a per-column weight fan read by N
     // distinct compute cores) on the legacy counted-lock template instead of
     // the v2 daisy-chain, which over-serializes independent readers.
-    if (alloc->hasAttr("air.no_chain_lock"))
-      buffer->setAttr("air.no_chain_lock", rewriter.getUnitAttr());
+    if (alloc->hasAttr(air::attrs::NoChainLock))
+      buffer->setAttr(air::attrs::NoChainLock, rewriter.getUnitAttr());
 
     rewriter.replaceOp(alloc, buffer->getResults());
     bufferToMemtileMap[buffer] = tile;

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -581,6 +581,13 @@ bool air::isChainLockCandidate(AIE::BufferOp buf) {
   // buffers are eligible (this is a memtile-specific lock pattern).
   if (!isL2MemtileBuffer(buf))
     return false;
+  // Opt-out: a buffer explicitly pinned with `air.no_chain_lock` keeps the
+  // legacy counted-lock template. Used for fan-out broadcast buffers whose N
+  // readers are independent compute cores (e.g. a per-column weight fan): the
+  // v2 daisy-chain serializes those readers unnecessarily and can deadlock
+  // when it competes with a fan-in chain under multi-block streaming.
+  if (buf->hasAttr("air.no_chain_lock"))
+    return false;
   int nW = 0, nR = 0;
   countChainBufferRoles(buf, nW, nR);
   // Fan-in: N writers (N>1) + 1 reader.

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -581,21 +581,25 @@ bool air::isChainLockCandidate(AIE::BufferOp buf) {
   // buffers are eligible (this is a memtile-specific lock pattern).
   if (!isL2MemtileBuffer(buf))
     return false;
-  // Opt-out: a buffer explicitly pinned with `air.no_chain_lock` keeps the
-  // legacy counted-lock template. Used for fan-out broadcast buffers whose N
-  // readers are independent compute cores (e.g. a per-column weight fan): the
-  // v2 daisy-chain serializes those readers unnecessarily and can deadlock
-  // when it competes with a fan-in chain under multi-block streaming.
-  if (buf->hasAttr("air.no_chain_lock"))
-    return false;
   int nW = 0, nR = 0;
   countChainBufferRoles(buf, nW, nR);
-  // Fan-in: N writers (N>1) + 1 reader.
+  // Fan-in: N writers (N>1) + 1 reader. The chain-lock is required here to
+  // prevent write-side corruption, so the opt-out below is NOT honored.
   if (nW > 1 && nR == 1)
     return true;
   // Fan-out: 1 writer + N readers (N>1).
-  if (nW == 1 && nR > 1)
+  if (nW == 1 && nR > 1) {
+    // Opt-out: a buffer explicitly pinned with `air.no_chain_lock` keeps the
+    // legacy counted-lock template. Used for fan-out broadcast buffers whose N
+    // readers are independent compute cores (e.g. a per-column weight fan):
+    // concurrent reads never conflict, so the daisy-chain only over-serializes
+    // them and can deadlock against a competing fan-in chain under multi-block
+    // streaming. Scoped to fan-out: reverting fan-in to the counted lock would
+    // reintroduce the very race the chain-lock fixes.
+    if (buf->hasAttr(air::attrs::NoChainLock))
+      return false;
     return true;
+  }
   // Single-writer/single-reader (legacy 1:1) or MIMO (M writers + N
   // readers) are NOT chain-lock candidates; legacy lock template
   // applies.

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2165,10 +2165,10 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     // by hand-written aggregator patterns (e.g. a per-column output assembler)
     // where splitting would multiply the launch-level shim endpoint count and
     // defeat the aggregation, overflowing the memtile BD limit.
-    bool optOut = allocOp->hasAttr("air.no_split");
+    bool optOut = allocOp->hasAttr(air::attrs::NoSplit);
     if (!optOut)
       if (auto exec = allocOp->getParentOfType<air::ExecuteOp>())
-        optOut = exec->hasAttr("air.no_split");
+        optOut = exec->hasAttr(air::attrs::NoSplit);
     if (optOut)
       continue;
     Value memref = allocOp.getMemref();

--- a/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock.mlir
@@ -1,0 +1,105 @@
+//===- memtile_no_chain_lock.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="use-lock-race-condition-fix-v2=true row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Opt-out test: the same 1-writer + 4-reader fan-out shared L2 buffer that the
+// v2 chain-lock lowers to a daisy-chain (1 cap init=2 + 4 init=0 signal locks +
+// a ping-pong twin buffer) instead keeps the LEGACY counted-lock template when
+// its source alloc is pinned with `air.no_chain_lock` -- even with the v2 fix
+// requested. This is for fan-out broadcast buffers whose N readers are
+// independent compute cores: daisy-chaining them serializes independent readers
+// unnecessarily and can deadlock when competing with a fan-in chain.
+
+// CHECK: aie.device
+// CHECK-DAG: %[[MT:.*]] = aie.logical_tile<MemTile>(?, ?)
+
+// Legacy counted-lock cap (init = number of readers = 4), NOT the v2 chain-lock
+// cap (init = 2) and NOT the 4 per-reader init=0 signal locks.
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 4 : i32}
+// CHECK-NOT: aie.lock(%[[MT]], {{[0-9]+}}) {init = 2 : i32}
+
+// Exactly ONE buffer instance (no ping-pong twin), carrying the opt-out pin.
+// CHECK: aie.buffer(%[[MT]]) {air.no_chain_lock, {{.*}}} : memref<4x8xbf16, 1
+// CHECK-NOT: aie.buffer(%[[MT]])
+
+air.channel @w0 [1, 1]
+air.channel @r0 [1, 1]
+air.channel @r1 [1, 1]
+air.channel @r2 [1, 1]
+air.channel @r3 [1, 1]
+func.func @memtile_fanout_no_chain_lock() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c3 = arith.constant 3 : index
+      %c8 = arith.constant 8 : index
+      // Shared L2 buffer pinned air.no_chain_lock: 1 full write + 4 sub-region reads.
+      %t, %l2 = air.execute -> (memref<4x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split, air.no_chain_lock} : memref<4x8xbf16, 1>
+        air.execute_terminator %alloc : memref<4x8xbf16, 1>
+      }
+      air.channel.get @w0[] (%l2[] [] []) : (memref<4x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[%c0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.put @r1[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.put @r2[] (%l2[%c2, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.put @r3[] (%l2[%c3, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      %d_ = air.execute {
+        memref.dealloc %l2 : memref<4x8xbf16, 1>
+      }
+      air.herd @hw tile (%txw, %tyw) in (%sxw=%c1_0, %syw=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<32xbf16, 2>) {
+          %aa = memref.alloc() : memref<32xbf16, 2>
+          air.execute_terminator %aa : memref<32xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1[] [] []) : (memref<32xbf16, 2>)
+        %dw = air.execute {memref.dealloc %l1 : memref<32xbf16, 2>}
+      }
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0)
+            attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.get @r1[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h2 tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0)
+            attributes {x_loc = 5 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.get @r2[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d2 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h3 tile (%tx3, %ty3) in (%sx3=%c1_0, %sy3=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.get @r3[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d3 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock.mlir
@@ -24,7 +24,7 @@
 // CHECK-NOT: aie.lock(%[[MT]], {{[0-9]+}}) {init = 2 : i32}
 
 // Exactly ONE buffer instance (no ping-pong twin), carrying the opt-out pin.
-// CHECK: aie.buffer(%[[MT]]) {air.no_chain_lock, {{.*}}} : memref<4x8xbf16, 1
+// CHECK: aie.buffer(%[[MT]]) {{.*}}air.no_chain_lock{{.*}} : memref<4x8xbf16, 1
 // CHECK-NOT: aie.buffer(%[[MT]])
 
 air.channel @w0 [1, 1]

--- a/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock_fanin_ignored.mlir
+++ b/mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock_fanin_ignored.mlir
@@ -1,0 +1,106 @@
+//===- memtile_no_chain_lock_fanin_ignored.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="use-lock-race-condition-fix-v2=true row-offset=3 col-offset=2 device=xcve2802" | FileCheck %s
+
+// Scope test: the `air.no_chain_lock` opt-out is honored ONLY for fan-out. A
+// fan-in buffer (4 sub-region writers + 1 full reader) still gets the v2
+// chain-lock even when tagged, because reverting fan-in to the counted lock
+// would reintroduce the write-side race the chain-lock exists to prevent. So
+// this tagged fan-in must lower to the daisy-chain (cap init=2 + 4 init=0
+// signal locks + a ping-pong twin), NOT the legacy counted lock (init=4).
+
+// CHECK: aie.device
+// CHECK-DAG: %[[MT:.*]] = aie.logical_tile<MemTile>(?, ?)
+
+// Chain-lock emitted despite the tag: cap init=2 + 4 signal locks init=0.
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 2 : i32}
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 0 : i32}
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 0 : i32}
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 0 : i32}
+// CHECK-DAG: aie.lock(%[[MT]], {{[0-9]+}}) {init = 0 : i32}
+
+// Two buffer instances (primary + ping-pong twin): the chain-lock path ran.
+// CHECK-DAG: aie.buffer(%[[MT]]) {{.*}} : memref<4x8xbf16, 1
+// CHECK-DAG: aie.buffer(%[[MT]]) {{.*}} : memref<4x8xbf16, 1
+
+air.channel @w0 [1, 1]
+air.channel @w1 [1, 1]
+air.channel @w2 [1, 1]
+air.channel @w3 [1, 1]
+air.channel @r0 [1, 1]
+func.func @memtile_fanin_no_chain_lock_ignored() {
+  %c1 = arith.constant 1 : index
+  air.launch (%a, %b) in (%c=%c1, %d=%c1) {
+    air.segment @seg {
+      %c1_0 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c3 = arith.constant 3 : index
+      %c8 = arith.constant 8 : index
+      // Fan-in buffer tagged air.no_chain_lock: the tag is IGNORED for fan-in.
+      %t, %l2 = air.execute -> (memref<4x8xbf16, 1>) {
+        %alloc = memref.alloc() {air.no_split, air.no_chain_lock} : memref<4x8xbf16, 1>
+        air.execute_terminator %alloc : memref<4x8xbf16, 1>
+      }
+      air.channel.get @w0[] (%l2[%c0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w1[] (%l2[%c1_0, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w2[] (%l2[%c2, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.get @w3[] (%l2[%c3, %c0] [%c1_0, %c8] [%c8, %c1_0]) : (memref<4x8xbf16, 1>)
+      air.channel.put @r0[] (%l2[] [] []) : (memref<4x8xbf16, 1>)
+      %d_ = air.execute {
+        memref.dealloc %l2 : memref<4x8xbf16, 1>
+      }
+      air.herd @h0 tile (%tx0, %ty0) in (%sx0=%c1_0, %sy0=%c1_0)
+            attributes {x_loc = 2 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w0[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d0 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h1 tile (%tx1, %ty1) in (%sx1=%c1_0, %sy1=%c1_0)
+            attributes {x_loc = 3 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w1[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d1 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h2 tile (%tx2, %ty2) in (%sx2=%c1_0, %sy2=%c1_0)
+            attributes {x_loc = 4 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w2[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d2 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @h3 tile (%tx3, %ty3) in (%sx3=%c1_0, %sy3=%c1_0)
+            attributes {x_loc = 5 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<8xbf16, 2>) {
+          %aa = memref.alloc() : memref<8xbf16, 2>
+          air.execute_terminator %aa : memref<8xbf16, 2>
+        }
+        air.channel.put @w3[] (%l1[] [] []) : (memref<8xbf16, 2>)
+        %d3 = air.execute {memref.dealloc %l1 : memref<8xbf16, 2>}
+      }
+      air.herd @hr tile (%txr, %tyr) in (%sxr=%c1_0, %syr=%c1_0)
+            attributes {x_loc = 6 : i64, y_loc = 3 : i64} {
+        %tok, %l1 = air.execute -> (memref<32xbf16, 2>) {
+          %aa = memref.alloc() : memref<32xbf16, 2>
+          air.execute_terminator %aa : memref<32xbf16, 2>
+        }
+        air.channel.get @r0[] (%l1[] [] []) : (memref<32xbf16, 2>)
+        %dr = air.execute {memref.dealloc %l1 : memref<32xbf16, 2>}
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

The v2 memtile chain-lock daisy-chains a shared L2 buffer's endpoints (fan-in writers or fan-out readers) through `init=0` signal locks. For a **fan-out broadcast** buffer whose N readers are **independent compute cores** (e.g. a per-column weight fan), that serialization is unnecessary and can deadlock when it competes with a fan-in chain under multi-block streaming.

This adds an opt-out attribute `air.no_chain_lock`:
- `AllocL2BuffersPattern` propagates the attribute from the source `memref.alloc` onto the lowered `AIE::BufferOp`.
- `isChainLockCandidate` excludes tagged buffers, so they keep the legacy counted-lock template even when `use-lock-race-condition-fix-v2` is requested.

Additive — only affects explicitly-tagged buffers; all existing designs are unchanged.

## Test plan

- [x] New lit test `mlir/test/Conversion/AIRToAIE/memtile_no_chain_lock.mlir`: a 1-writer/4-reader fan-out buffer tagged `air.no_chain_lock` lowers to the legacy cap lock (`init=4`, single buffer instance) instead of the v2 daisy-chain (`init=2` cap + 4 `init=0` signal locks + ping-pong twin). Verified it fails without the fix (chain-lock emitted) and passes with it.
- [x] `ninja check-air-mlir` — no new failures vs `origin/main` baseline; all AIRToAIE tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)