### PR TITLE
ci: compare ccache compiler by content in lintAndFormat

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           key: ${{ runner.os }}-lintformat-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G
+      # ccache defaults to comparing the compiler by mtime; on ephemeral CI
+      # runners the compiler is reinstalled each run with a fresh mtime, so
+      # every object misses even when the cache restores. Compare by content.
+      - name: Configure ccache
+        shell: bash
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=locale,time_macros
 
       - name: Build and Install libxaie
         run: utils/github-clone-build-libxaie.sh


### PR DESCRIPTION

lintAndFormat's C++ ccache restores but never hits (0%). It routes a freshly
apt-installed clang through `CMAKE_CXX_COMPILER_LAUNCHER=ccache` with ccache's
default `mtime` compiler check, and GitHub-hosted runners give that clang a new
mtime every run, so every object misses even when the cache restores. Recent
runs show 0% (0/344 and 0/688) with the cache already present.

Setting `compiler_check=content` fixes it. I validated on a fork:

```
              ccache hits     wall-clock
cold (seed)   0%              16.5 min
warm (fix)    98-100%          7.5 min
```

The other ccache workflows (buildAndTest, buildAndTestNoRuntime, generateDocs,
Windows) already hit ~98% because they compile with the pre-baked image
compiler, so this only touches lintAndFormat.

Same fix as Xilinx/mlir-aie#3385.
