### PR TITLE
[programming_examples] Add LLM perf history chart page

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -121,7 +121,8 @@ jobs:
       # Pull the append-only time series from the durable `perf-history` branch
       # (accumulated by nightlyPerfBenchmark.yml) so generate_perf_history.py can
       # render the perf-history.html chart page. Best-effort: if the branch
-      # doesn't exist yet (before the first nightly), the page is simply omitted.
+      # doesn't exist yet (before the first nightly), no history is fetched and
+      # the generator emits an empty-state page (so the dashboard link is stable).
       - name: Fetch perf history
         continue-on-error: true
         run: |
@@ -129,9 +130,9 @@ jobs:
           if git fetch --depth 1 origin perf-history 2>/dev/null; then
             git show FETCH_HEAD:history.ndjson > /tmp/llmperf_history/history.ndjson \
               && echo "history.ndjson fetched" \
-              || echo "perf-history branch has no history.ndjson; page will be omitted"
+              || echo "perf-history branch has no history.ndjson; empty-state page will be generated"
           else
-            echo "no perf-history branch yet; page will be omitted"
+            echo "no perf-history branch yet; empty-state page will be generated"
           fi
 
       # Build the repo test target in release mode to build and test.
@@ -163,7 +164,7 @@ jobs:
             --output build_release/docs/programming_examples/index.md \
             --base-url https://github.com/Xilinx/mlir-air/tree/main/programming_examples/ \
             --llm-perf /tmp/llmperf/perf.json
-          # Perf history chart page (omitted if no history.ndjson was fetched).
+          # Perf history chart page (empty-state page if no history was fetched).
           python3 programming_examples/generate_perf_history.py \
             --history /tmp/llmperf_history/history.ndjson \
             --output build_release/docs/programming_examples/perf-history.html

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -118,6 +118,22 @@ jobs:
             && echo "perf.json fetched" \
             || echo "no nightly perf artifact with perf.json available; LLM section will be omitted"
 
+      # Pull the append-only time series from the durable `perf-history` branch
+      # (accumulated by nightlyPerfBenchmark.yml) so generate_perf_history.py can
+      # render the perf-history.html chart page. Best-effort: if the branch
+      # doesn't exist yet (before the first nightly), the page is simply omitted.
+      - name: Fetch perf history
+        continue-on-error: true
+        run: |
+          mkdir -p /tmp/llmperf_history
+          if git fetch --depth 1 origin perf-history 2>/dev/null; then
+            git show FETCH_HEAD:history.ndjson > /tmp/llmperf_history/history.ndjson \
+              && echo "history.ndjson fetched" \
+              || echo "perf-history branch has no history.ndjson; page will be omitted"
+          else
+            echo "no perf-history branch yet; page will be omitted"
+          fi
+
       # Build the repo test target in release mode to build and test.
       - name: Build Docs
         run: |
@@ -147,6 +163,10 @@ jobs:
             --output build_release/docs/programming_examples/index.md \
             --base-url https://github.com/Xilinx/mlir-air/tree/main/programming_examples/ \
             --llm-perf /tmp/llmperf/perf.json
+          # Perf history chart page (omitted if no history.ndjson was fetched).
+          python3 programming_examples/generate_perf_history.py \
+            --history /tmp/llmperf_history/history.ndjson \
+            --output build_release/docs/programming_examples/perf-history.html
 
       - name: Save LLVM Version
         run: |

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -42,8 +42,11 @@ jobs:
     runs-on: amdryzenai5pro340
     # actions: write so the final step can dispatch generateDocs.yml to refresh
     # the GitHub Pages LLM benchmark section with this run's perf.json artifact.
+    # contents: write so the "Append perf history" step can push this run's
+    # datapoints onto the durable `perf-history` branch (the time-series the
+    # perf-history.html chart page is built from).
     permissions:
-      contents: read
+      contents: write
       actions: write
     # Bound total runtime so stuck NPU dispatch/downloads can't occupy the
     # dedicated runner indefinitely. Covers a full build + all models (each
@@ -285,6 +288,47 @@ jobs:
           json.dump(recs, open("perf.json", "w"), indent=2)
           print(json.dumps(recs, indent=2))
           PY
+
+      # Append this run's datapoints to the durable `perf-history` branch so the
+      # docs build can plot TTFT/decode over time. Idempotent on run_id, so a
+      # re-dispatched nightly won't double-count. Best-effort: never reds the
+      # benchmark job. The nightly concurrency group serializes runs, so there
+      # is no push race on the branch.
+      - name: Append perf history
+        if: always() && hashFiles('perf.json') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          REPO="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          workdir=$(mktemp -d)
+          if git ls-remote --exit-code --heads "$REPO" perf-history >/dev/null 2>&1; then
+            git clone --branch perf-history --single-branch --depth 50 "$REPO" "$workdir"
+          else
+            # First ever run: create the orphan branch with an empty history.
+            git clone --depth 1 "$REPO" "$workdir"
+            pushd "$workdir"
+            git checkout --orphan perf-history
+            git rm -rf . >/dev/null 2>&1 || true
+            : > history.ndjson
+            popd
+          fi
+          python3 programming_examples/llms/bench/append_history.py \
+            --perf perf.json \
+            --history "$workdir/history.ndjson" \
+            --run-id "${{ github.run_id }}"
+          pushd "$workdir"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add history.ndjson
+            git commit -m "perf-history: nightly ${{ github.sha }} run ${{ github.run_id }}"
+            git push origin HEAD:perf-history
+          else
+            echo "no history change; nothing to push"
+          fi
+          popd
 
       - name: Job summary
         if: always()

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -290,10 +290,11 @@ jobs:
           PY
 
       # Append this run's datapoints to the durable `perf-history` branch so the
-      # docs build can plot TTFT/decode over time. Idempotent on run_id, so a
-      # re-dispatched nightly won't double-count. Best-effort: never reds the
-      # benchmark job. The nightly concurrency group serializes runs, so there
-      # is no push race on the branch.
+      # docs build can plot TTFT/decode over time. Idempotent on run_id, so
+      # re-running this same workflow run won't double-count (a freshly
+      # dispatched run gets a new run_id and is new data, as intended).
+      # Best-effort: never reds the benchmark job. The nightly concurrency group
+      # serializes runs, so there is no push race on the branch.
       - name: Append perf history
         if: always() && hashFiles('perf.json') != ''
         continue-on-error: true

--- a/programming_examples/generate_perf_history.py
+++ b/programming_examples/generate_perf_history.py
@@ -135,7 +135,9 @@ def _series(rows, models, labels, metric):
                 "pointBorderWidth": 3,
                 "spanGaps": False,
                 "tension": 0.2,
-                "_meta": metas,
+                # Non-reserved key: Chart.js has historically used dataset._meta
+                # internally, so keep our per-point metadata under our own name.
+                "verifyMeta": metas,
             }
         )
     return datasets
@@ -189,7 +191,7 @@ function makeChart(canvasId, datasets, yLabel) {{
         tooltip: {{
           callbacks: {{
             afterLabel: function(item) {{
-              const meta = item.dataset._meta && item.dataset._meta[item.dataIndex];
+              const meta = item.dataset.verifyMeta && item.dataset.verifyMeta[item.dataIndex];
               if (!meta) return '';
               let s = 'commit ' + meta.sha;
               if (meta.verify) s += '  (verify: ' + meta.verify + ')';
@@ -214,8 +216,41 @@ makeChart('decode', DECODE_DATASETS, 'Decode throughput (tok/s) — higher is be
 """
 
 
+EMPTY_TEMPLATE = """\
+<!doctype html>
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MLIR-AIR — LLM Performance History</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+         max-width: 1000px; margin: 0 auto; padding: 24px; color: #1b1f23; }}
+  h1 {{ font-size: 1.6rem; margin-bottom: 4px; }}
+  .sub {{ color: #586069; }}
+  a {{ color: #0366d6; }}
+</style>
+</head>
+<body>
+<p><a href="index.html">&larr; Back to Programming Examples dashboard</a></p>
+<h1>LLM Performance History (NPU2)</h1>
+<p class="sub">No nightly performance history has been recorded yet. Charts will appear here once the
+nightly LLM benchmark has published its first datapoints.</p>
+</body>
+</html>
+"""
+
+
 def generate_html(rows):
-    """Render the full self-contained HTML page from history rows."""
+    """Render the full self-contained HTML page from history rows.
+
+    Always returns a valid page: with no rows it renders an empty-state page so
+    the dashboard's link to perf-history.html never 404s (the link is emitted
+    whenever the benchmark section renders, which can precede the first history
+    write).
+    """
+    if not rows:
+        return EMPTY_TEMPLATE.format()
     labels = sorted({r.get("date") for r in rows if r.get("date")})
     models = _model_order(rows)
     ttft = _series(rows, models, labels, "ttft_ms")
@@ -240,11 +275,9 @@ def main():
     args = ap.parse_args()
 
     rows = load_history(args.history)
-    if not rows:
-        print(f"no history rows at {args.history}; page not generated")
-        return 0
-
     args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Always write a page (empty-state when there are no rows) so the dashboard
+    # link to perf-history.html is stable and never 404s.
     args.output.write_text(generate_html(rows))
     print(f"Generated {args.output} ({len(rows)} rows)")
     return 0

--- a/programming_examples/generate_perf_history.py
+++ b/programming_examples/generate_perf_history.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Generates programming_examples/perf-history.html: per-nightly TTFT (ms) and
+# decode tok/s for each LLM, plotted over time with Chart.js. Data comes from
+# the append-only history.ndjson accumulated on the `perf-history` branch by
+# llms/bench/append_history.py.
+#
+# Usage:
+#   python3 generate_perf_history.py --history history.ndjson --output perf-history.html
+#
+# Each history.ndjson line is a flat record:
+#   {"date","timestamp_utc","run_id","air_sha","aie_hash","peano","model",
+#    "ttft_ms","decode_tokens_per_sec","context_len","verify_status"}
+#
+# The x-axis is one point per nightly (labeled by date; the built commit SHA is
+# shown in the tooltip). A datapoint whose verify_status == "fail" is drawn with
+# a red marker so regressions in correctness stand out on the throughput lines.
+
+import argparse
+import json
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# Reused so model ordering/labels match the operator+LLM dashboard.
+try:
+    from generate_readme import LLM_HF_MODELS
+except ImportError:  # pragma: no cover - allow running from another cwd
+    import sys
+
+    sys.path.insert(0, str(SCRIPT_DIR))
+    from generate_readme import LLM_HF_MODELS
+
+FAIL_COLOR = "#d32f2f"
+
+# Distinct-enough palette for up to ~12 model lines; cycled if exceeded.
+# Deliberately excludes orange/red/brown hues so no model line is confusable
+# with the red ✕ used to flag failed-verify points (see _series).
+PALETTE = [
+    "#1f77b4",  # blue
+    "#2ca02c",  # green
+    "#9467bd",  # purple
+    "#17becf",  # cyan
+    "#bcbd22",  # olive
+    "#e377c2",  # magenta
+    "#7f7f7f",  # gray
+    "#393b79",  # indigo
+    "#1b9e77",  # teal
+    "#637939",  # dark green
+    "#756bb1",  # slate
+    "#31a354",  # emerald
+]
+
+
+def load_history(history_path):
+    """Read history.ndjson into a list of row dicts (empty if absent/empty)."""
+    p = Path(history_path) if history_path else None
+    if not p or not p.is_file():
+        return []
+    rows = []
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def _model_order(rows):
+    """Models sorted with dashboard-known ones first (registry order), then any
+    extras alphabetically — so the legend is stable across runs."""
+    present = {r.get("model", "") for r in rows if r.get("model")}
+    known = [m for m in LLM_HF_MODELS if m in present]
+    extra = sorted(present - set(known))
+    return known + extra
+
+
+def _series(rows, models, labels, metric):
+    """Build one Chart.js dataset per model for the given metric key.
+
+    Values are aligned to `labels` (the sorted unique dates); a missing date is
+    null so Chart.js leaves a gap. Per-point colors flag failed-verify runs red.
+    """
+    # (model, date) -> most recent row for that pair
+    by_key = {}
+    for r in rows:
+        by_key[(r.get("model"), r.get("date"))] = r
+
+    datasets = []
+    for i, model in enumerate(models):
+        color = PALETTE[i % len(PALETTE)]
+        data, point_colors, metas = [], [], []
+        point_styles, point_radii, hover_radii = [], [], []
+        for date in labels:
+            r = by_key.get((model, date))
+            if r is None:
+                data.append(None)
+                point_colors.append(color)
+                point_styles.append("circle")
+                point_radii.append(4)
+                hover_radii.append(6)
+                metas.append(None)
+                continue
+            val = r.get(metric)
+            data.append(val)
+            failed = r.get("verify_status") == "fail"
+            # Failed verify is encoded by SHAPE (a red ✕), not color alone, so
+            # it is unambiguous against any line hue and colorblind-friendly.
+            point_colors.append(FAIL_COLOR if failed else color)
+            point_styles.append("crossRot" if failed else "circle")
+            point_radii.append(8 if failed else 4)
+            hover_radii.append(10 if failed else 6)
+            metas.append(
+                {
+                    "sha": (r.get("air_sha") or "")[:7],
+                    "verify": r.get("verify_status") or "",
+                }
+            )
+        datasets.append(
+            {
+                "label": model,
+                "data": data,
+                "borderColor": color,
+                "backgroundColor": color,
+                "pointBackgroundColor": point_colors,
+                "pointBorderColor": point_colors,
+                "pointStyle": point_styles,
+                "pointRadius": point_radii,
+                "pointHoverRadius": hover_radii,
+                "pointBorderWidth": 3,
+                "spanGaps": False,
+                "tension": 0.2,
+                "_meta": metas,
+            }
+        )
+    return datasets
+
+
+HTML_TEMPLATE = """\
+<!doctype html>
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MLIR-AIR — LLM Performance History</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+         max-width: 1000px; margin: 0 auto; padding: 24px; color: #1b1f23; }}
+  h1 {{ font-size: 1.6rem; margin-bottom: 4px; }}
+  .sub {{ color: #586069; margin-top: 0; }}
+  .chart-box {{ margin: 32px 0; }}
+  a {{ color: #0366d6; }}
+  .legend-note {{ color: #586069; font-size: 0.85rem; }}
+</style>
+</head>
+<body>
+<p><a href="index.html">&larr; Back to Programming Examples dashboard</a></p>
+<h1>LLM Performance History (NPU2)</h1>
+<p class="sub">Per-nightly end-to-end inference performance on the AMD Ryzen AI (Krackan Point, NPU2)
+benchmark runner. Each point is one nightly build, labeled by date; hover to see the commit SHA and
+verify status. A <span style="color:{fail_color}; font-weight:700;">red &#10007; marker</span> flags a nightly
+whose correctness verify failed (the marker shape, not just its color, signals the failure).</p>
+<p class="legend-note">Click a model in a legend to toggle its line.</p>
+
+<div class="chart-box"><canvas id="ttft"></canvas></div>
+<div class="chart-box"><canvas id="decode"></canvas></div>
+
+<script>
+const LABELS = {labels_json};
+const TTFT_DATASETS = {ttft_json};
+const DECODE_DATASETS = {decode_json};
+
+function makeChart(canvasId, datasets, yLabel) {{
+  const ctx = document.getElementById(canvasId).getContext('2d');
+  return new Chart(ctx, {{
+    type: 'line',
+    data: {{ labels: LABELS, datasets: datasets }},
+    options: {{
+      responsive: true,
+      interaction: {{ mode: 'nearest', intersect: false }},
+      plugins: {{
+        title: {{ display: true, text: yLabel }},
+        tooltip: {{
+          callbacks: {{
+            afterLabel: function(item) {{
+              const meta = item.dataset._meta && item.dataset._meta[item.dataIndex];
+              if (!meta) return '';
+              let s = 'commit ' + meta.sha;
+              if (meta.verify) s += '  (verify: ' + meta.verify + ')';
+              return s;
+            }}
+          }}
+        }}
+      }},
+      scales: {{
+        x: {{ title: {{ display: true, text: 'nightly (date)' }} }},
+        y: {{ title: {{ display: true, text: yLabel }}, beginAtZero: true }}
+      }}
+    }}
+  }});
+}}
+
+makeChart('ttft', TTFT_DATASETS, 'TTFT (ms) — lower is better');
+makeChart('decode', DECODE_DATASETS, 'Decode throughput (tok/s) — higher is better');
+</script>
+</body>
+</html>
+"""
+
+
+def generate_html(rows):
+    """Render the full self-contained HTML page from history rows."""
+    labels = sorted({r.get("date") for r in rows if r.get("date")})
+    models = _model_order(rows)
+    ttft = _series(rows, models, labels, "ttft_ms")
+    decode = _series(rows, models, labels, "decode_tokens_per_sec")
+    return HTML_TEMPLATE.format(
+        fail_color=FAIL_COLOR,
+        labels_json=json.dumps(labels),
+        ttft_json=json.dumps(ttft),
+        decode_json=json.dumps(decode),
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate the LLM perf history page.")
+    ap.add_argument("--history", required=True, help="Path to history.ndjson")
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=SCRIPT_DIR / "perf-history.html",
+        help="Output HTML path (default: programming_examples/perf-history.html)",
+    )
+    args = ap.parse_args()
+
+    rows = load_history(args.history)
+    if not rows:
+        print(f"no history rows at {args.history}; page not generated")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(generate_html(rows))
+    print(f"Generated {args.output} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -606,6 +606,8 @@ End-to-end LLM inference performance on the AMD Ryzen AI (Krackan Point, NPU2) b
 
 \U0001f7e2 verify passed &nbsp; \U0001f534 verify failed &nbsp; ⚪ verify skipped &nbsp; — metric not captured (e.g. the model's profile run failed)
 
+\U0001f4c8 [Performance history over time](perf-history.html) — per-nightly TTFT and decode throughput plotted per model.
+
 _{provenance}_
 
 """

--- a/programming_examples/llms/bench/append_history.py
+++ b/programming_examples/llms/bench/append_history.py
@@ -7,8 +7,9 @@ The nightly LLM benchmark (nightlyPerfBenchmark.yml) produces a per-run
 line of `history.ndjson` on the durable `perf-history` branch so the docs build
 can plot TTFT / decode throughput over time.
 
-Idempotent: if any row for this run_id already exists, nothing is appended (so
-a re-dispatched or re-run nightly does not double-count).
+Idempotent on run_id: if any row for this run_id already exists, nothing is
+appended, so re-running the *same* workflow run does not double-count. (A newly
+dispatched run gets a fresh run_id and is treated as new data, as intended.)
 
 Usage:
   python3 append_history.py --perf perf.json --history history.ndjson --run-id 123
@@ -42,19 +43,23 @@ def _flat_rows(recs, run_id):
 
 
 def _existing_run_ids(history_path):
-    """Return the set of run_ids already recorded in history.ndjson."""
+    """Return the set of run_ids already recorded in history.ndjson.
+
+    Streamed line-by-line so memory stays bounded as the history grows.
+    """
     ids = set()
     p = Path(history_path)
     if not p.is_file():
         return ids
-    for line in p.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            ids.add(json.loads(line).get("run_id"))
-        except json.JSONDecodeError:
-            continue
+    with p.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ids.add(json.loads(line).get("run_id"))
+            except json.JSONDecodeError:
+                continue
     return ids
 
 
@@ -80,7 +85,13 @@ def main():
     if not perf_path.is_file():
         print(f"no perf.json at {perf_path}; nothing to append")
         return 0
-    recs = json.loads(perf_path.read_text())
+    try:
+        recs = json.loads(perf_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        # Best-effort: a missing/corrupt/partial perf.json should not crash the
+        # CI step (which is itself continue-on-error), just skip this run.
+        print(f"could not read {perf_path} ({e}); nothing to append")
+        return 0
     if not recs:
         print("perf.json is empty; nothing to append")
         return 0

--- a/programming_examples/llms/bench/append_history.py
+++ b/programming_examples/llms/bench/append_history.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Append a nightly perf.json into the append-only history.ndjson time series.
+
+The nightly LLM benchmark (nightlyPerfBenchmark.yml) produces a per-run
+`perf.json` (a list of per-model records). This flattens each record into one
+line of `history.ndjson` on the durable `perf-history` branch so the docs build
+can plot TTFT / decode throughput over time.
+
+Idempotent: if any row for this run_id already exists, nothing is appended (so
+a re-dispatched or re-run nightly does not double-count).
+
+Usage:
+  python3 append_history.py --perf perf.json --history history.ndjson --run-id 123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _flat_rows(recs, run_id):
+    """Yield one flat history row per perf.json record."""
+    for d in recs:
+        m = d.get("metrics", {}) or {}
+        tc = d.get("toolchain", {}) or {}
+        ts = d.get("timestamp_utc", "") or ""
+        yield {
+            "date": ts[:10],
+            "timestamp_utc": ts,
+            "run_id": run_id,
+            "air_sha": tc.get("mlir_air_sha", ""),
+            "aie_hash": tc.get("mlir_aie_hash", ""),
+            "peano": tc.get("llvm_aie_version", ""),
+            "model": d.get("model", ""),
+            "ttft_ms": m.get("ttft_ms"),
+            "decode_tokens_per_sec": m.get("decode_tokens_per_sec"),
+            "context_len": m.get("context_len"),
+            "verify_status": d.get("verify_status", ""),
+        }
+
+
+def _existing_run_ids(history_path):
+    """Return the set of run_ids already recorded in history.ndjson."""
+    ids = set()
+    p = Path(history_path)
+    if not p.is_file():
+        return ids
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ids.add(json.loads(line).get("run_id"))
+        except json.JSONDecodeError:
+            continue
+    return ids
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--perf", required=True, help="Path to the nightly perf.json")
+    ap.add_argument(
+        "--history", required=True, help="Path to history.ndjson (created if absent)"
+    )
+    ap.add_argument(
+        "--run-id",
+        required=True,
+        help="Unique id for this nightly run (dedup key, e.g. github.run_id)",
+    )
+    args = ap.parse_args()
+
+    try:
+        run_id = int(args.run_id)
+    except ValueError:
+        run_id = args.run_id
+
+    perf_path = Path(args.perf)
+    if not perf_path.is_file():
+        print(f"no perf.json at {perf_path}; nothing to append")
+        return 0
+    recs = json.loads(perf_path.read_text())
+    if not recs:
+        print("perf.json is empty; nothing to append")
+        return 0
+
+    if run_id in _existing_run_ids(args.history):
+        print(f"run {run_id} already in history; no change")
+        return 0
+
+    rows = list(_flat_rows(recs, run_id))
+    hist = Path(args.history)
+    hist.parent.mkdir(parents=True, exist_ok=True)
+    with hist.open("a") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    print(f"appended {len(rows)} rows for run {run_id} to {hist}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a separate **perf-history.html** page plotting per-nightly **TTFT (ms)** and **decode tok/s** for each LLM over time (Chart.js), linked from the existing LLM benchmark dashboard.
- x-axis is one point per nightly, labeled by date; the built commit SHA + verify status show in the tooltip.
- Failed-verify nightlies are plotted with a **red ✕ marker** (encoded by shape, not color alone, so it's unambiguous against any line hue and colorblind-friendly); profile failures leave a gap.

## How it works
- **Durable store:** `nightlyPerfBenchmark.yml` appends its per-run datapoints to an append-only `history.ndjson` on an orphan **`perf-history`** branch (created automatically on first run). Idempotent on `run_id`, so a re-dispatched nightly won't double-count. The nightly `concurrency` group serializes runs → no push races.
- **Publish:** `generateDocs.yml` fetches `history.ndjson` from that branch and regenerates `perf-history.html` on every publish, so the gh-pages `keep_files:false` wipe is a non-issue.
- All new CI steps are `continue-on-error` — they can never red the nightly or the docs build.

## Files
- New: `programming_examples/generate_perf_history.py` (page generator)
- New: `programming_examples/llms/bench/append_history.py` (perf.json → history.ndjson, deduped)
- Edit: `.github/workflows/nightlyPerfBenchmark.yml` (append step + `contents: write`)
- Edit: `.github/workflows/generateDocs.yml` (fetch history + generate page)
- Edit: `programming_examples/generate_readme.py` (link to the history page)

## Test plan
- [x] `append_history.py`: idempotent on `run_id`; appends flat rows; preserves null metrics.
- [x] `generate_perf_history.py`: two charts render; per-model lines; red ✕ on failed-verify points with values; null metrics render as gaps; SHA + verify in tooltips; legend toggles. Verified in a locally-built GitHub-Pages-faithful Jekyll site.
- [x] `generate_readme.py`: history link appears under the benchmark table.
- [ ] Post-merge: first nightly creates the `perf-history` branch and publishes the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)