### PR TITLE
Fix exponential recursion in CanonicalizeAsyncOpDeps WaitAll flattening

### DIFF
--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -446,10 +446,9 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
   // chains down to their non-WaitAll leaf tokens. A visited-set is required:
   // the WaitAll async-dependency graph can be a DAG with shared ancestors
   // (e.g. buffers reused across unrolled loop rounds), and without dedup this
-  // recursion re-descends shared sub-graphs exponentially (and never
-  // terminates on a dependency cycle). Visiting each WaitAll once is
-  // correctness-preserving here: leaves are deduplicated by the caller's
-  // newAsyncDeps SetVector.
+  // recursion re-descends shared sub-graphs exponentially. Visiting each
+  // WaitAll once is correctness-preserving here: leaves are deduplicated by
+  // the caller's newAsyncDeps SetVector.
   llvm::SmallPtrSet<Operation *, 16> visitedWaitAll;
   std::function<void(SmallVector<Value>, SmallVector<Value> &)>
       getDirectDependenciesGreedily;

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -442,16 +442,26 @@ static LogicalResult CanonicalizeAsyncOpDeps(OpT op,
   auto memrefsWrittenBySinkOp = getAllMemrefsAccessedByOp(
       op.getOperation(), /*walkConsumers=*/true, getAllWriteAccess);
   auto resourcesUsedBySinkOp = getSymbolRefsUsedByOp(op.getOperation());
-  // make a list of new async token operands
+  // make a list of new async token operands. Flatten transitive WaitAllOp
+  // chains down to their non-WaitAll leaf tokens. A visited-set is required:
+  // the WaitAll async-dependency graph can be a DAG with shared ancestors
+  // (e.g. buffers reused across unrolled loop rounds), and without dedup this
+  // recursion re-descends shared sub-graphs exponentially (and never
+  // terminates on a dependency cycle). Visiting each WaitAll once is
+  // correctness-preserving here: leaves are deduplicated by the caller's
+  // newAsyncDeps SetVector.
+  llvm::SmallPtrSet<Operation *, 16> visitedWaitAll;
   std::function<void(SmallVector<Value>, SmallVector<Value> &)>
       getDirectDependenciesGreedily;
-  getDirectDependenciesGreedily = [&getDirectDependenciesGreedily](
+  getDirectDependenciesGreedily = [&getDirectDependenciesGreedily,
+                                   &visitedWaitAll](
                                       SmallVector<Value> depList,
                                       SmallVector<Value> &directDeps) {
     for (auto v : depList) {
-      if (auto wa = dyn_cast_if_present<air::WaitAllOp>(v.getDefiningOp()))
-        getDirectDependenciesGreedily(wa.getAsyncDependencies(), directDeps);
-      else
+      if (auto wa = dyn_cast_if_present<air::WaitAllOp>(v.getDefiningOp())) {
+        if (visitedWaitAll.insert(wa.getOperation()).second)
+          getDirectDependenciesGreedily(wa.getAsyncDependencies(), directDeps);
+      } else
         directDeps.push_back(v);
     }
     return;


### PR DESCRIPTION
## Summary

`getDirectDependenciesGreedily` (in `CanonicalizeAsyncOpDeps<WaitAllOp>`, `AIRDialect.cpp`) recursively flattens transitive `air.wait_all` dependency chains down to their non-`WaitAll` leaf tokens, but does so with **no visited-set**.

The `wait_all` async-dependency graph can be a DAG with shared ancestors — e.g. when an L2 buffer is reused across unrolled loop iterations, many `wait_all` ops share the same upstream `wait_all` sub-graph. Without dedup, the recursion re-descends those shared sub-graphs **exponentially**, so `-air-to-aie` CPU-spins (stable RSS — this is not OOM) and can fail to terminate on such IR.

The fix adds a `visitedWaitAll` `SmallPtrSet` so each `WaitAll` is descended at most once. This is correctness-preserving: the caller already deduplicates the collected leaf tokens via its `newAsyncDeps` `SetVector`, so visiting a shared `WaitAll` once yields the same leaf set.

## Impact

On IR exhibiting the shared-ancestor pattern, `-air-to-aie` went from a ~200 s hang to ~0.5 s.

## Test plan

- [x] `ninja check-air-mlir` (Transform / Conversion suites) pass
- [x] Verified on a large flash-attention module where `-air-to-aie` previously hung