### PR TITLE
Skip NFL channel fusion for puts/gets inside a multi-result scf.if

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4182,6 +4182,28 @@ public:
     std::map<air::ChannelOp, air::ChannelOp> chan_merge_map;
     std::vector<std::pair<air::ChannelOp, air::ChannelOp>> nfl_merge_pairs;
 
+    // wrapRegionsWithForLoops (used by the NFL merge below) can only wrap a
+    // region whose parent op yields a single async token. Broadcast
+    // specialization can place several channel puts in one multi-result scf.if
+    // (e.g. a per-row multicast of a broadcast channel), which that helper
+    // erases while results #1.. still have uses. Detect that case so the NFL
+    // merge is skipped for such channels (leaving them un-multiplexed, which is
+    // correct -- fusion is only an optimization).
+    auto opInMultiResultIfOp = [](air::ChannelOp chan) -> bool {
+      auto inMultiResultIf = [](Operation *op) -> bool {
+        if (auto ifOp = op->getParentOfType<scf::IfOp>())
+          return ifOp->getNumResults() > 1;
+        return false;
+      };
+      for (auto p : air::getChannelPutOpThroughSymbol(chan))
+        if (inMultiResultIf(p))
+          return true;
+      for (auto g : air::getChannelGetOpThroughSymbol(chan))
+        if (inMultiResultIf(g))
+          return true;
+      return false;
+    };
+
     // Identify mergeable channel pairs and classify fusion type.
     for (unsigned i = 0; i < channelOps.size() - 1; i++) {
       for (unsigned j = i + 1; j < channelOps.size(); j++) {
@@ -4201,7 +4223,10 @@ public:
           chan_merge_map[chanB] = chanA;
         } else if (mergeType == "NFL") {
           // Case 2: Fuse channels into a new loop (requires creating an
-          // scf.for).
+          // scf.for). Skip if either channel's ops sit inside a multi-result
+          // scf.if, which wrapRegionsWithForLoops cannot safely wrap.
+          if (opInMultiResultIfOp(chanA) || opInMultiResultIfOp(chanB))
+            continue;
           chan_merge_map[chanB] = chanA;
           nfl_merge_pairs.push_back(std::make_pair(chanA, chanB));
         }

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -5319,6 +5319,13 @@ private:
       // Get the operation that owns this region.
       Operation *parentOp = region->getParentOp();
 
+      // wrapRegionsWithForLoops replaces parentOp with a new scf.for whose
+      // single result carries the async token. A multi-result parent (e.g. a
+      // multi-result scf.if) would leave results #1.. with dangling uses after
+      // the erase. Callers must filter such ops out before reaching here.
+      assert(parentOp->getNumResults() <= 1 &&
+             "wrapRegionsWithForLoops: parent op must have at most one result");
+
       // Insert the new `scf.for` loop *before* the parent operation.
       builder.setInsertionPoint(parentOp);
 

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4188,20 +4188,36 @@ public:
     // (e.g. a per-row multicast of a broadcast channel), which that helper
     // erases while results #1.. still have uses. Detect that case so the NFL
     // merge is skipped for such channels (leaving them un-multiplexed, which is
-    // correct -- fusion is only an optimization).
-    auto opInMultiResultIfOp = [](air::ChannelOp chan) -> bool {
+    // correct -- fusion is only an optimization). Scan ALL enclosing scf.if
+    // ancestors (not just the nearest), and memoize per channel since this runs
+    // inside the O(N^2) channel-pair loop below.
+    llvm::DenseMap<Operation *, bool> multiResultIfMemo;
+    auto opInMultiResultIfOp =
+        [&multiResultIfMemo](air::ChannelOp chan) -> bool {
+      auto it = multiResultIfMemo.find(chan.getOperation());
+      if (it != multiResultIfMemo.end())
+        return it->second;
       auto inMultiResultIf = [](Operation *op) -> bool {
-        if (auto ifOp = op->getParentOfType<scf::IfOp>())
-          return ifOp->getNumResults() > 1;
+        for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+          if (auto ifOp = dyn_cast<scf::IfOp>(p))
+            if (ifOp->getNumResults() > 1)
+              return true;
         return false;
       };
+      bool res = false;
       for (auto p : air::getChannelPutOpThroughSymbol(chan))
-        if (inMultiResultIf(p))
-          return true;
-      for (auto g : air::getChannelGetOpThroughSymbol(chan))
-        if (inMultiResultIf(g))
-          return true;
-      return false;
+        if (inMultiResultIf(p)) {
+          res = true;
+          break;
+        }
+      if (!res)
+        for (auto g : air::getChannelGetOpThroughSymbol(chan))
+          if (inMultiResultIf(g)) {
+            res = true;
+            break;
+          }
+      multiResultIfMemo[chan.getOperation()] = res;
+      return res;
     };
 
     // Identify mergeable channel pairs and classify fusion type.

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels.mlir
@@ -2049,3 +2049,73 @@ module {
     return
   }
 }
+
+// -----
+
+// NFL mode: do NOT wrap channel puts into a new scf.for when they sit inside a
+// multi-result scf.if. wrapRegionsWithForLoops erases the scf.if after
+// replacing only result #0, leaving results #1.. with dangling uses. The guard
+// must leave both channels un-fused (correct -- fusion is only an opt).
+//
+// This is a regression test: before the fix, air-fuse-channels crashed with a
+// use-after-erase failure on modules of this shape.
+
+// Channels must remain separate (not renamed to a single symbol).
+// CHECK: air.channel @channel_mr_0
+// CHECK: air.channel @channel_mr_1
+// CHECK-LABEL: func_nfl_skip_multiresult_scf_if
+// Both puts must still be present inside the scf.if and not wrapped in a new
+// scf.for (which would crash due to the multi-result parent being erased).
+// CHECK: scf.if
+// CHECK: air.channel.put{{.*}}@channel_mr_0
+// CHECK: air.channel.put{{.*}}@channel_mr_1
+// AGGRESSIVE: air.channel @channel_mr_0
+// AGGRESSIVE: air.channel @channel_mr_1
+// AGGRESSIVE-LABEL: func_nfl_skip_multiresult_scf_if
+// AGGL1: air.channel @channel_mr_0
+// AGGL1: air.channel @channel_mr_1
+// AGGL1-LABEL: func_nfl_skip_multiresult_scf_if
+
+module {
+  air.channel @channel_mr_0 [1, 1]
+  air.channel @channel_mr_1 [1, 1]
+  // Two NFL-mergeable channels whose puts are inside a 2-result scf.if.
+  // The scf.if returns both an async token and an index -- making it a
+  // multi-result op that wrapRegionsWithForLoops cannot safely erase.
+  func.func @func_nfl_skip_multiresult_scf_if() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1) {
+      %1 = air.segment async {
+        %c1_s = arith.constant 1 : index
+        %alloc = memref.alloc() : memref<4x4xi32, 1>
+        %cond = arith.constant true
+        // A 2-result scf.if: yields (!air.async.token, index).
+        // Broadcast specialization produces exactly this shape when it emits a
+        // per-row multicast of a broadcast channel inside a region that already
+        // returns an extra value. The second result makes this a multi-result op
+        // that wrapRegionsWithForLoops cannot safely erase.
+        %tok, %extra = scf.if %cond -> (!air.async.token, index) {
+          %t0 = air.channel.put async @channel_mr_0[] (%alloc[] [] []) : (memref<4x4xi32, 1>)
+          %c0 = arith.constant 0 : index
+          scf.yield %t0, %c0 : !air.async.token, index
+        } else {
+          %t1 = air.channel.put async @channel_mr_1[] (%alloc[] [] []) : (memref<4x4xi32, 1>)
+          %c0 = arith.constant 0 : index
+          scf.yield %t1, %c0 : !air.async.token, index
+        }
+        %2 = air.herd @herd_mr_0 async tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) {
+          %alloc_l1 = memref.alloc() : memref<4x4xi32, 2>
+          air.channel.get @channel_mr_0[%tx, %ty] (%alloc_l1[] [] []) : (memref<4x4xi32, 2>)
+          memref.dealloc %alloc_l1 : memref<4x4xi32, 2>
+        }
+        %3 = air.herd @herd_mr_1 async tile (%tx, %ty) in (%sx=%c1_s, %sy=%c1_s) {
+          %alloc_l1 = memref.alloc() : memref<4x4xi32, 2>
+          air.channel.get @channel_mr_1[%tx, %ty] (%alloc_l1[] [] []) : (memref<4x4xi32, 2>)
+          memref.dealloc %alloc_l1 : memref<4x4xi32, 2>
+        }
+        memref.dealloc %alloc : memref<4x4xi32, 1>
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary

The "new for loop" (NFL) channel-merge path in `air-fuse-channels` (`AIRDependencyScheduleOpt.cpp`) wraps the merged channel's put/get in a freshly created `scf.for` via `wrapRegionsWithForLoops`. That helper can only wrap a region whose parent op yields a **single** async token.

Broadcast specialization can place several `air.channel.put`s in **one multi-result `scf.if`** (e.g. a per-row multicast of a broadcast channel). Feeding such a channel into the NFL merge makes `wrapRegionsWithForLoops` erase the `scf.if` while its results `#1..` are still in use, crashing the pass.

This PR guards the NFL merge: skip a candidate pair when either channel has a put/get inside a multi-result `scf.if`. Leaving those channels un-multiplexed is correct — channel fusion is only an optimization, so the result is still valid, just un-fused for that channel.

## Test plan

- [x] `ninja check-air-mlir` (Transform / Conversion suites) pass
- [x] Verified on a broadcast-channel flash-attention module that previously crashed `air-fuse-channels` in the NFL path; it now compiles and the end-to-end LLM prefill token gate passes.