### PR TITLE
Bump mlir-aie dependency to v1.4.0

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -254,7 +254,7 @@ jobs:
             if [ x"$ENABLE_RTTI" == x"OFF" ]; then
               NO_RTTI="-no-rtti"
               NO_RTTI_UNDERSCORE="_no_rtti"
-              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0"
+              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
             else
               MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
             fi
@@ -331,7 +331,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/ \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 
@@ -434,7 +434,7 @@ jobs:
           NO_RTTI_UNDERSCORE=""
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
             NO_RTTI_UNDERSCORE="_no_rtti"
-            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0"
+            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
           else
             MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
           fi
@@ -528,7 +528,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/ \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 

--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -254,9 +254,9 @@ jobs:
             if [ x"$ENABLE_RTTI" == x"OFF" ]; then
               NO_RTTI="-no-rtti"
               NO_RTTI_UNDERSCORE="_no_rtti"
-              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2"
+              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0"
             else
-              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/"
+              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
             fi
 
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
@@ -331,7 +331,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-4' || 'latest-wheels-no-rtti-2' }} \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 
@@ -434,9 +434,9 @@ jobs:
           NO_RTTI_UNDERSCORE=""
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
             NO_RTTI_UNDERSCORE="_no_rtti"
-            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2"
+            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0"
           else
-            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/"
+            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
           fi
 
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
@@ -528,7 +528,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-4' || 'latest-wheels-no-rtti-2' }} \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -78,7 +78,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
 
       - name: Get llvm-aie
         run: |

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -75,7 +75,7 @@ jobs:
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           echo "mlir-aie wheel version: $MLIR_AIE_VERSION"
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
 
       - name: Get cmakeModules
         run: |

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -93,7 +93,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
 
       - name: Get llvm-aie
         run: |

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -733,7 +733,9 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
         rewriter.getIndexType(),          // result type
         metadata,                         // alloc symbol reference
         rewriter.getBoolAttr(issueToken), // issue_token = true for S2MM / paced
-        rewriter.getI32IntegerAttr(repeatCount) // repeat_count from highest dim
+        rewriter.getI32IntegerAttr(
+            repeatCount), // repeat_count from highest dim
+        Value()           // repeat_count_val (dynamic repeat count unused here)
     );
     if (paced)
       configTaskOp->setAttr(air::attrs::PreserveShimDmaOrder,
@@ -1092,7 +1094,9 @@ public:
             rewriter.setInsertionPoint(op);
             auto deviceRef = FlatSymbolRefAttr::get(rewriter.getContext(),
                                                     device.getSymName());
-            AIEX::NpuLoadPdiOp::create(rewriter, op.getLoc(), deviceRef);
+            AIEX::NpuLoadPdiOp::create(rewriter, op.getLoc(), deviceRef,
+                                       IntegerAttr(), IntegerAttr(),
+                                       IntegerAttr(), AIEX::ExpandModeAttr());
           } else if (outputElf || multiIter) {
             // No PDI reload needed (no repeat_count DMAs), but still need
             // between-iteration synchronization to prevent the next
@@ -1256,7 +1260,9 @@ public:
           if (outputElf && deviceNeedsLockReset(device)) {
             auto deviceRef = FlatSymbolRefAttr::get(rewriter.getContext(),
                                                     device.getSymName());
-            AIEX::NpuLoadPdiOp::create(rewriter, op.getLoc(), deviceRef);
+            AIEX::NpuLoadPdiOp::create(rewriter, op.getLoc(), deviceRef,
+                                       IntegerAttr(), IntegerAttr(),
+                                       IntegerAttr(), AIEX::ExpandModeAttr());
           } else if (outputElf || multiIter) {
             // No PDI reload needed, but emit NpuDmaWaitOp for any shim
             // channels not already waited on to synchronize before the
@@ -1463,7 +1469,8 @@ AIE::DeviceOp createMainDeviceWrapper(
 
     // Create aiex.configure @device_name { ... }
     auto configureOp = AIEX::ConfigureOp::create(
-        builder, loc, FlatSymbolRefAttr::get(builder.getContext(), deviceName));
+        builder, loc, FlatSymbolRefAttr::get(builder.getContext(), deviceName),
+        AIEX::ExpandModeAttr());
     configureOp.getBody().push_back(new Block);
     builder.setInsertionPointToStart(&configureOp.getBody().front());
 
@@ -3576,6 +3583,7 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
               arith::ConstantOp::create(builder, patchLoc, builder.getI32Type(),
                                         builder.getI32IntegerAttr(buff_offset));
           AIEX::NpuAddressPatchOp::create(builder, patchLoc, addr,
+                                          /* addr_val */ Value(),
                                           /* ddr_id */ 2, buffOffsetVal);
         }
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -266,7 +266,11 @@ tool_dirs = [
 tools = [
     "aie-opt",
     "aie-translate",
-    "aiecc.py",
+    # mlir-aie v1.4.0 replaced the aiecc.py Python wrapper with a native C++
+    # aiecc binary. Register aiecc.py before aiecc so the longer token wins,
+    # and alias it to the binary so existing tests keep working unchanged.
+    ToolSubst("aiecc.py", FindTool("aiecc")),
+    "aiecc",
     "aircc",
     "air-opt",
     "ld.lld",

--- a/test/xrt/01_air_to_npu/run_npu1_chess.lit
+++ b/test/xrt/01_air_to_npu/run_npu1_chess.lit
@@ -5,5 +5,5 @@
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: %python %S/gen.py --trace-size 65536 --trace-offset 65536 --trace-file-name trace.txt
-// RUN: %python -m aie.utils.trace.parse --input trace.txt --mlir air_project/input_with_addresses.mlir --output parse_eventIR_vs.json
+// RUN: %python -m aie.utils.trace.parse --input trace.txt --mlir input_with_addresses.mlir --output parse_eventIR_vs.json
 // RUN: jq . parse_eventIR_vs.json | FileCheck %S/parse_eventIR_vs.json.check

--- a/test/xrt/01_air_to_npu/run_npu1_peano.lit
+++ b/test/xrt/01_air_to_npu/run_npu1_peano.lit
@@ -6,5 +6,5 @@
 // RUN: cd test_peano
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %python %S/gen.py --trace-size 131072 --trace-offset 65536 --trace-file-name trace.txt
-// RUN: %python -m aie.utils.trace.parse --input trace.txt --mlir air_project/input_with_addresses.mlir --output parse_eventIR_vs.json
+// RUN: %python -m aie.utils.trace.parse --input trace.txt --mlir input_with_addresses.mlir --output parse_eventIR_vs.json
 // RUN: jq . parse_eventIR_vs.json | FileCheck %S/parse_eventIR_vs.json.check

--- a/test/xrt/05_extern_func/run_npu1_chess.lit
+++ b/test/xrt/05_extern_func/run_npu1_chess.lit
@@ -6,5 +6,5 @@
 // RUN: cd test_npu1_chess
 // RUN: xchesscc_wrapper aie2 -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu1_chess.lit
+++ b/test/xrt/05_extern_func/run_npu1_chess.lit
@@ -6,5 +6,5 @@
 // RUN: cd test_npu1_chess
 // RUN: xchesscc_wrapper aie2 -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu1_peano.lit
+++ b/test/xrt/05_extern_func/run_npu1_peano.lit
@@ -7,5 +7,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu1_peano.lit
+++ b/test/xrt/05_extern_func/run_npu1_peano.lit
@@ -7,5 +7,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu2_chess.lit
+++ b/test/xrt/05_extern_func/run_npu2_chess.lit
@@ -11,5 +11,5 @@
 // RUN: cd test_npu2_chess
 // RUN: xchesscc_wrapper aie2p -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu2_4col row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu2% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu2_chess.lit
+++ b/test/xrt/05_extern_func/run_npu2_chess.lit
@@ -11,5 +11,5 @@
 // RUN: cd test_npu2_chess
 // RUN: xchesscc_wrapper aie2p -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu2_4col row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu2% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu2_peano.lit
+++ b/test/xrt/05_extern_func/run_npu2_peano.lit
@@ -12,5 +12,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu2_4col row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu2% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu2_peano.lit
+++ b/test/xrt/05_extern_func/run_npu2_peano.lit
@@ -12,5 +12,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu2_4col row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: %python aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu2% %python %S/run.py aie.xclbin

--- a/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
@@ -6,8 +6,8 @@
 // RUN: cd test_npu1_chess
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
@@ -6,8 +6,8 @@
 // RUN: cd test_npu1_chess
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --aie-generate-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --aie-generate-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --aie-generate-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
@@ -6,12 +6,12 @@
 // RUN: cd test_npu1_chess
 // UN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --aie-generate-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --aie-generate-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_chess.lit
@@ -6,12 +6,12 @@
 // RUN: cd test_npu1_chess
 // UN: xchesscc_wrapper aie2 -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --aie-generate-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: %python aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: %python aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1249,26 +1249,29 @@ static LogicalResult runAieCompilation() {
     aieccCmd.push_back(*aiecc);
 
     if (verbose)
-      aieccCmd.push_back("-v");
+      aieccCmd.push_back("--verbose");
 
-    aieccCmd.push_back("--no-aiesim");
     aieccCmd.push_back(xchesscc ? "--xchesscc" : "--no-xchesscc");
     aieccCmd.push_back(xbridge ? "--xbridge" : "--no-xbridge");
-    aieccCmd.push_back("--no-compile-host");
     aieccCmd.push_back("--tmpdir=" + tmpDir.getValue());
 
-    // Output format options
+    // Output format options. The mlir-aie v1.4.0 aiecc is a declarative
+    // driver: each artifact is requested with --get-<name> and named with
+    // --<name>-name=. (Replaces the older --aie-generate-* toggles.)
     if (outputFormat == OF_elf) {
-      aieccCmd.push_back("--generate-full-elf");
+      aieccCmd.push_back("--get-full-elf");
       aieccCmd.push_back("--expand-load-pdis");
       aieccCmd.push_back("--full-elf-name=" + elfName.getValue());
     } else if (outputFormat == OF_xclbin) {
-      aieccCmd.push_back("--aie-generate-xclbin");
+      aieccCmd.push_back("--get-xclbin");
       aieccCmd.push_back("--xclbin-name=" + xclbinFile);
     } else if (outputFormat == OF_txn) {
-      aieccCmd.push_back("--aie-generate-txn");
+      aieccCmd.push_back("--get-txn");
+      aieccCmd.push_back("--txn-name=" + (outputFilename.empty()
+                                              ? std::string("aie.txn.mlir")
+                                              : outputFilename.getValue()));
     } else if (outputFormat == OF_pdi) {
-      aieccCmd.push_back("--aie-generate-pdi");
+      aieccCmd.push_back("--get-pdi");
       aieccCmd.push_back("--pdi-name=" + pdiName.getValue());
     }
     // OF_none = no output generation options
@@ -1280,9 +1283,15 @@ static LogicalResult runAieCompilation() {
     //   shim DMAs at dispatch time.
     // - xclbin/txn: always needed.
     if (outputFormat != OF_elf && outputFormat != OF_none) {
-      aieccCmd.push_back("--aie-generate-npu-insts");
+      aieccCmd.push_back("--get-npu-insts");
       aieccCmd.push_back("--npu-insts-name=" + instsFile);
     }
+
+    // When tracing, also request the address-annotated module so downstream
+    // trace parsing (aie.utils.trace.parse) can map events back to source.
+    // The v1.4.0 aiecc writes this to <tmpdir>/input_with_addresses.mlir.
+    if (traceSize > 0)
+      aieccCmd.push_back("--get-input-with-addresses");
 
     // Xclbin metadata (xclbin mode only)
     if (outputFormat == OF_xclbin) {

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1289,7 +1289,9 @@ static LogicalResult runAieCompilation() {
 
     // When tracing, also request the address-annotated module so downstream
     // trace parsing (aie.utils.trace.parse) can map events back to source.
-    // The v1.4.0 aiecc writes this to <tmpdir>/input_with_addresses.mlir.
+    // The v1.4.0 aiecc writes --get-* artifacts (including
+    // input_with_addresses.mlir) to the current working directory, not the
+    // --tmpdir workdir.
     if (traceSize > 0)
       aieccCmd.push_back("--get-input-with-addresses");
 

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -40,7 +40,7 @@ echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 # Install mlir-aie from wheel
 pushd my_install
 MLIR_AIE_VERSION=$($(dirname ${SCRIPT_PATH})/clone-mlir-aie.sh --get-wheel-version)
-python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
 popd
 export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 echo "WHL_AIE DIR: $MLIR_AIE_INSTALL_DIR"

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=157e8b8c967e47ea19bda83a6972f7c1cf0e4e13
-WHEEL_VERSION=1.3.5.dev62+g${HASH:0:7}
+export HASH=db06374df9bf83d9fc557001ca213368aed15788
+WHEEL_VERSION=1.4.0
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
## Summary
Pins the mlir-aie dependency to the **v1.4.0** release (commit `db06374d`) and adapts mlir-air to the two source-level breaks it introduces. The LLVM pin is unchanged (both still ROCm `46fcb339`), so no LLVM bump is needed.

### 1. AIEX op builders gained optional params
Updated the affected `Op::create()` call sites in `AIRRtToNpuPass.cpp`:
- `DMAConfigureTaskForOp`: trailing `repeat_count_val` `Value()`
- `NpuLoadPdiOp`: trailing `id`/`size`/`address`/`expand_mode` attrs
- `ConfigureOp`: trailing `expand_mode` attr
- `NpuAddressPatchOp`: inserted `addr_val` `Value()`

### 2. aiecc rewritten as a C++ declarative driver
`aiecc.py` is now a thin passthrough to the new C++ `aiecc`, which uses a `--get-<name>` + `--<name>-name=` model. Ported `aircc`'s invocation:
- request artifacts with `--get-xclbin` / `--get-npu-insts` / `--get-full-elf` / `--get-txn` / `--get-pdi`
- drop removed toggles (`--aie-generate-*`, `--no-aiesim`, `--no-compile-host`); `-v` → `--verbose`
- request `--get-input-with-addresses` when tracing so downstream trace parsing has its input module

### 3. Wheel URLs + tests
- All mlir-aie wheel `--find-links` URLs point at the `v1.4.0` release (both rtti and no-rtti wheels live there; 1.4.0 is not in `latest-wheels-4`).
- xrt lit tests that invoke aiecc directly updated to the new `--get-*` CLI (`05_extern_func` active; `23`/`24` disabled lines for consistency).
- `01_air_to_npu` trace-parse reads `input_with_addresses.mlir` from cwd (new aiecc emits `--get-*` artifacts to cwd, not `--tmpdir`).

## Test plan
Verified locally on **npu1 (Phoenix)**, end-to-end through the XRTRunner → aircc → v1.4.0 aiecc path:
- [x] `01_air_to_npu` (compute + trace parse + FileCheck)
- [x] `05_extern_func`
- [x] `35_herd_reduce`
- [x] `37_matmul_transform_4x4_bf16`
- [x] 19/19 `AIRRtToNpu` conversion lit tests
- [ ] npu2 and Chess variants — not validated locally (npu1-only machine, no Chess toolchain); ported per mlir-aie's canonical `--get-*` pattern, to be exercised by the `amdhx370` CI runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)