### PR TITLE
Fix LLM perf docs auto-publishing (curl dispatch + single dev version)

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -188,12 +188,12 @@ jobs:
       - name: Install MkDocs
         run: pip install -r docs/requirements-mkdocs.txt
 
-      # Deploy the versioned MkDocs site to gh-pages with mike. main-branch
-      # pushes publish the "dev" docs and alias them "latest" so the site root
-      # (which redirects to the default) always resolves.
+      # Deploy the versioned MkDocs site to gh-pages with mike. Pre-release there
+      # is a single "dev" version, set as the default so the site root resolves
+      # to it. When AIR cuts a release, add a numbered version aliased "latest".
       - name: Deploy with mike
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          mike deploy --push --update-aliases dev latest
-          mike set-default --push latest
+          mike deploy --push dev
+          mike set-default --push dev

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -365,17 +365,20 @@ jobs:
       # picks up this run's perf.json. generateDocs.yml downloads the latest
       # nightly artifact (any conclusion) when it regenerates the page. Runs
       # whenever a perf.json was produced (even a partial run), not gated on the
-      # job's overall result. Best-effort: never fails the benchmark job if the
-      # gh CLI is missing on the runner or the dispatch call errors.
+      # job's overall result. Dispatched via the REST API with curl: this
+      # self-hosted runner has no gh CLI, so `gh workflow run` silently no-oped
+      # and the page only ever refreshed on an unrelated push to main. Best-
+      # effort: never fails the benchmark job if the dispatch call errors.
       - name: Refresh docs page
         if: always() && hashFiles('perf.json') != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! command -v gh >/dev/null 2>&1; then
-            echo "gh CLI not available; skipping docs refresh dispatch"
-            exit 0
-          fi
-          gh workflow run generateDocs.yml --repo ${{ github.repository }} --ref main \
-            || echo "generateDocs dispatch failed; page will refresh on next push/nightly"
+          curl -sSf -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/generateDocs.yml/dispatches" \
+            -d '{"ref":"main"}' \
+            && echo "generateDocs dispatch requested" \
+            || echo "generateDocs dispatch failed; page will refresh on next push"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,7 @@ extra_css:
 extra:
   version:
     provider: mike
-    default: latest
+    default: dev
     alias: true
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
The nightly LLM perf page stopped updating. Two independent bugs in the docs-publishing path; this PR fixes both.

## 1. Nightly never triggered a docs rebuild (`nightlyPerfBenchmark.yml`)
The "Refresh docs page" step dispatched `generateDocs.yml` with `gh workflow run`, guarded by `command -v gh`. The nightly runs on the self-hosted `amdryzenai5pro340` runner, which has **no gh CLI**, so the step silently `exit 0`'d every night (`gh CLI not available; skipping docs refresh dispatch`). The page only ever refreshed as a side effect of an unrelated push to `main` — so when `main` went quiet for ~39h, the page fell two nightlies behind even though the data was correctly on the `perf-history` branch.

Fix: dispatch via the REST API with `curl` (present on the runner) instead of `gh`. The job already carries `permissions: actions: write` + `GITHUB_TOKEN`. Verified the endpoint returns `204`.

## 2. Duplicate `/dev/` and `/latest/` URLs (`generateDocs.yml`, `mkdocs.yml`)
`mike` deployed version `dev` **and** a `latest` alias pointing at it, serving two identical URLs. Under GitHub Pages' per-path Fastly cache (600s TTL) they can drift, making one look stale while the other is fresh. Pre-release there is only one version, so publish just `dev` and make it the default. `mike` is retained: at AIR's first release, deploy a numbered version aliased `latest` (`dev` keeps tracking `main`) — no rework.

## Follow-up (one-time, after merge)
The orphaned `latest` alias already on `gh-pages` must be removed once, after this lands (so the old workflow can't recreate it):
```
mike delete --push latest
```
Rewrites `versions.json` to `[{"version":"dev","aliases":[]}]` and drops `/latest/`.

## Test plan
- [ ] Merge → next nightly's "Refresh docs page" logs `generateDocs dispatch requested` and a `generateDocs` run appears.
- [ ] `versions.json` becomes a single `dev`; site root redirects to `/dev/`.
- [ ] Run one-time `mike delete --push latest`; confirm `/latest/` 404s and `/dev/llms/perf-history/` shows the latest nightly.
