### PR TITLE
[AIR] Decline wrap-and-stride fold on non-constant wraps/strides instead of crashing

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2742,7 +2742,7 @@ struct AIRSpecializeChannelWrapAndStrideInAffineFor
     SmallVector<Value> strides = channel_op.getStrides();
 
     // Non-constant wrap/stride can't fold into a constant-shape BD; decline so
-    // the loop falls through to AIRUnrollScfForIntoBDChain (see the scf.for
+    // the loop falls through to AIRUnrollAffineForIntoBDChain (see the scf.for
     // twin above for the rationale).
     auto isNonConst = [](Value v) { return !getConstantIntValue(v); };
     if (llvm::any_of(wraps, isNonConst) || llvm::any_of(strides, isNonConst))
@@ -2880,10 +2880,18 @@ struct AIRCanonicalizeChannelPutGetOpWrapAndStrideList
     //  (2) The stride list is not empty,
     //  (3) The highest (first) stride is 0, indicating repeat dimension,
     //  (4) The highest (first) size is not 1, indicating non-zero repetition.
-    bool highestDimRepeatActive = enableRepeatAtHighestDim &&
-                                  !strides.empty() &&
-                                  *getConstantIntValue(strides.front()) == 0 &&
-                                  *getConstantIntValue(sizes.front()) != 1;
+    // A non-constant highest stride/size (e.g. an IV-dependent transfer) can be
+    // neither proven to be a repeat dim (stride 0) nor folded; treat it as
+    // "not a repeat" so the op falls through to canonicalizeWrapAndStrideList
+    // (which declines on dynamic dims) rather than dereferencing a null
+    // optional.
+    std::optional<int64_t> frontStride =
+        strides.empty() ? std::nullopt : getConstantIntValue(strides.front());
+    std::optional<int64_t> frontSize =
+        sizes.empty() ? std::nullopt : getConstantIntValue(sizes.front());
+    bool highestDimRepeatActive =
+        enableRepeatAtHighestDim && !strides.empty() && frontStride &&
+        *frontStride == 0 && frontSize && *frontSize != 1;
     // If highest-dimension repeat is active but the op already has the maximum
     // number of dimensions, no rewrite is needed.
     if (highestDimRepeatActive && (int)offsets.size() == maxNumDims) {

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2343,6 +2343,16 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
     SmallVector<Value> wraps = channel_op.getSizes();
     SmallVector<Value> strides = channel_op.getStrides();
 
+    // A hardware buffer descriptor has a constant shape per dimension. If the
+    // channel op already carries a non-constant wrap or stride (e.g. an
+    // IV-dependent transfer size like a causal-triangle (lx+1)*N), folding the
+    // loop into it can never produce a legal constant-shape BD. Decline the
+    // fold and leave the loop intact so AIRUnrollScfForIntoBDChain can unroll
+    // it into a chain of constant-shape descriptors instead.
+    auto isNonConst = [](Value v) { return !getConstantIntValue(v); };
+    if (llvm::any_of(wraps, isNonConst) || llvm::any_of(strides, isNonConst))
+      return failure();
+
     OpBuilder b(channel_op);
     auto memrefTy =
         llvm::dyn_cast<BaseMemRefType>(channel_op.getMemref().getType());
@@ -2730,6 +2740,13 @@ struct AIRSpecializeChannelWrapAndStrideInAffineFor
     SmallVector<Value> offsets = channel_op.getOffsets();
     SmallVector<Value> wraps = channel_op.getSizes();
     SmallVector<Value> strides = channel_op.getStrides();
+
+    // Non-constant wrap/stride can't fold into a constant-shape BD; decline so
+    // the loop falls through to AIRUnrollScfForIntoBDChain (see the scf.for
+    // twin above for the rationale).
+    auto isNonConst = [](Value v) { return !getConstantIntValue(v); };
+    if (llvm::any_of(wraps, isNonConst) || llvm::any_of(strides, isNonConst))
+      return failure();
 
     (void)canonicalizeWrapAndStrideList(
         rewriter, offsets, wraps, strides,

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1472,6 +1472,20 @@ LogicalResult air::canonicalizeWrapAndStrideList(OpBuilder &builder,
     listsHaveChanged = true;
   }
 
+  // Every constant-folding optimization below (maxSize tiling, size-1 erasure,
+  // adjacent-dim merging, default-pattern collapse) assumes constant wrap and
+  // stride values and dereferences getConstantIntValue unconditionally. If any
+  // dimension is dynamic (e.g. an IV-dependent transfer size like a causal
+  // triangle), those steps are both unsafe (null-optional deref) and pointless
+  // (a variant-shape access can't fold into one descriptor — it is resolved by
+  // loop unrolling instead). Return after the length normalization above rather
+  // than crashing on otherwise-valid IR.
+  {
+    auto isNonConst = [](Value v) { return !getConstantIntValue(v); };
+    if (llvm::any_of(sizes, isNonConst) || llvm::any_of(strides, isNonConst))
+      return listsHaveChanged ? success() : failure();
+  }
+
   // If maxSize is given, check whether any size value goes beyond maxSize.
   for (int i = sizes.size() - 1; i >= 0; i--) {
     if (isDefaultDataAccessPattern(sizes, strides))

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-nonconstant-wrap.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-nonconstant-wrap.mlir
@@ -14,10 +14,12 @@
 // into a chain of constant-shape descriptors.
 
 #tri = affine_map<(d0) -> ((d0 + 1) * 8)>
+#dyn = affine_map<(d0) -> ((d0 + 1) * 512)>
 
 air.channel @K [1]
 air.channel @Rect [1, 1]
 air.channel @Kaff [1]
+air.channel @Ks [1]
 
 // CHECK-LABEL: @triangle
 // CHECK-NOT: scf.for
@@ -72,6 +74,27 @@ func.func @triangle_affine(%arg0: memref<2048x512xbf16>) {
   affine.for %lx = 0 to 4 {
     %sz = affine.apply #tri(%lx)
     air.channel.put @Kaff[%c0] (%arg0[%c0, %c0] [%sz, %c64, %c64] [%c512, %c512, %c1]) : (memref<2048x512xbf16>)
+  }
+  return
+}
+
+// A non-constant STRIDE (not only a non-constant wrap) is handled identically:
+// the guards check strides as well as sizes, so the loop declines the fold and
+// unrolls into constant-shape descriptors.
+
+// CHECK-LABEL: @dynstride
+// CHECK-NOT: scf.for
+// CHECK-COUNT-4: air.channel.put @Ks
+// CHECK-NOT: air.channel.put
+func.func @dynstride(%arg0: memref<2048x512xbf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c64 = arith.constant 64 : index
+  scf.for %i = %c0 to %c4 step %c1 {
+    %st = affine.apply #dyn(%i)
+    air.channel.put @Ks[%c0] (%arg0[%c0, %c0] [%c8, %c64, %c64] [%st, %c64, %c1]) : (memref<2048x512xbf16>)
   }
   return
 }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-nonconstant-wrap.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/specialize-nonconstant-wrap.mlir
@@ -1,0 +1,77 @@
+//===- specialize-nonconstant-wrap.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-specialize-channel-wrap-and-stride=scope=func | FileCheck %s
+
+// A hardware buffer descriptor has a constant shape per dimension, so a loop
+// whose channel op carries an IV-dependent wrap SIZE (e.g. a causal-triangle
+// (lx+1)*N transfer) cannot be folded into a single strided descriptor. The
+// pass must decline the fold gracefully (not crash) and let the loop unroll
+// into a chain of constant-shape descriptors.
+
+#tri = affine_map<(d0) -> ((d0 + 1) * 8)>
+
+air.channel @K [1]
+air.channel @Rect [1, 1]
+air.channel @Kaff [1]
+
+// CHECK-LABEL: @triangle
+// CHECK-NOT: scf.for
+// CHECK-COUNT-4: air.channel.put @K
+// CHECK-NOT: air.channel.put
+func.func @triangle(%arg0: memref<2048x512xbf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c64 = arith.constant 64 : index
+  %c512 = arith.constant 512 : index
+  scf.for %lx = %c0 to %c4 step %c1 {
+    %sz = affine.apply #tri(%lx)
+    air.channel.put @K[%c0] (%arg0[%c0, %c0] [%sz, %c64, %c64] [%c512, %c512, %c1]) : (memref<2048x512xbf16>)
+  }
+  return
+}
+
+// A rectangular loop (IV in the data OFFSET, constant wrap) is unaffected: it
+// still folds into a single strided descriptor.
+
+// CHECK-LABEL: @rectangular
+// CHECK-NOT: scf.for
+// CHECK-COUNT-1: air.channel.put @Rect
+// CHECK-NOT: air.channel.put
+func.func @rectangular(%arg0: memref<512x64xbf16, 1>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c64 = arith.constant 64 : index
+  scf.for %j = %c0 to %c4 step %c1 {
+    %off = arith.muli %j, %c16 : index
+    air.channel.put @Rect[%c0, %c0] (%arg0[%off, %c0] [%c8, %c8] [%c64, %c1]) : (memref<512x64xbf16, 1>)
+  }
+  return
+}
+
+// The affine.for twin of @triangle must behave identically (its own specialize
+// pattern also declines the fold on a non-constant wrap and unrolls).
+
+// CHECK-LABEL: @triangle_affine
+// CHECK-NOT: affine.for
+// CHECK-COUNT-4: air.channel.put @Kaff
+// CHECK-NOT: air.channel.put
+func.func @triangle_affine(%arg0: memref<2048x512xbf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c64 = arith.constant 64 : index
+  %c512 = arith.constant 512 : index
+  affine.for %lx = 0 to 4 {
+    %sz = affine.apply #tri(%lx)
+    air.channel.put @Kaff[%c0] (%arg0[%c0, %c0] [%sz, %c64, %c64] [%c512, %c512, %c1]) : (memref<2048x512xbf16>)
+  }
+  return
+}


### PR DESCRIPTION
## Summary
`air-specialize-channel-wrap-and-stride` aborted with an assertion when a channel op inside a loop carried an **IV-dependent wrap size or stride** (e.g. a causal-triangle transfer of size `(i+1)*N`, or an `(i+1)*S` stride). The specialize patterns and the wrap/stride canonicalizer dereferenced `getConstantIntValue` unconditionally.

A variant-shape transfer can never fold into a single constant-shape buffer descriptor, so the fold is genuinely impossible — but the loop is still valid IR that lowers by **unrolling** into a chain of constant-shape descriptors. The pass should decline the fold, not crash.

## Changes
- `AIRSpecializeChannelWrapAndStrideInScfFor` / `...InAffineFor`: early-`return failure()` when the channel op carries a non-constant **wrap or stride**, so the loop falls through to `AIRUnrollScfForIntoBDChain` / `AIRUnrollAffineForIntoBDChain`.
- `canonicalizeWrapAndStrideList`: after list-length normalization, return early when any size/stride is dynamic, before the constant-folding steps that assume constant values.
- `AIRCanonicalizeChannelPutGetOpWrapAndStrideList`: guard the `highestDimRepeatActive` reads of `strides.front()`/`sizes.front()` (a dynamic highest dim is neither a provable repeat nor foldable → treated as not-a-repeat). Closes the `enableRepeatAtHighestDim=true` path used by `AIROptimizeShimDMABDs`.
- New lit test `specialize-nonconstant-wrap.mlir`: non-constant **wrap** (`scf.for` and `affine.for`) and non-constant **stride** (`scf.for`) unroll without crashing; a rectangular IV-in-offset loop still folds to one strided descriptor.

## Test plan
- [x] `ninja check-air-mlir` (477 passed, 0 failed)
- [x] New lit test passes via FileCheck (wrap / stride / affine / rectangular)
- [x] Rectangular wrap-and-stride folding unchanged
