### PR TITLE
[programming_examples] Align llama32_1b_q4nx with the shared LLM driver contract

### DIFF
--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -35,7 +35,7 @@ PEANO_KBASE    := -std=c++20 --target=aie2p-none-unknown-elf \
 # weight files are read at build time -- the compile is weight-free).
 DECODE_ENV     := VOCAB_CHUNK_I2=14 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1
 
-.PHONY: help compile-decode clean
+.PHONY: help compile-decode _compile_decode_build clean
 
 help:
 	@echo "============================================================"
@@ -52,12 +52,24 @@ help:
 ## Build the fused decode: Peano kernels + two templates (decode_L2048 + decode_L2047
 ## slope ref). ~15 min. Weight-free (runtime BOs), like the prefill compile.
 ##
+## Idempotent: if both templates are already present, skip (the ~15 min build only
+## runs once). `make clean` forces a rebuild. Consumers that call this repeatedly
+## (e.g. the llama32_1b_q4nx verify + profile lits) thus pay the cost at most once.
+##
 ## REPRODUCIBILITY (toolchain): the inline-attn merge path shells out to an EXTERNAL
 ## `llvm-link` (resolved from PATH). It MUST be a pre-lifetime-change LLVM (e.g. the system
 ## /usr/bin/llvm-link, LLVM 20). A newer LLVM (>=23) llvm-link upgrades the llvm.lifetime
 ## intrinsic to the no-size form and Peano opt (LLVM 21) then rejects the merged IR
 ## ("Broken module found"). Keep any such LLVM's bin OFF PATH. The preflight aborts early.
 compile-decode:
+	@if [ -f $(srcdir)/decode_L2048.xclbin ] && [ -f $(srcdir)/decode_L2048.insts.bin ] \
+	    && [ -f $(srcdir)/decode_L2047.xclbin ] && [ -f $(srcdir)/decode_L2047.insts.bin ]; then \
+	  echo "Decode templates already built (decode_L2048 + decode_L2047); skipping. Run 'make clean' to force a rebuild."; \
+	else \
+	  $(MAKE) -f $(srcdir)/Makefile _compile_decode_build; \
+	fi
+
+_compile_decode_build:
 	@echo ">>> preflight: llvm-link must be a pre-change LLVM (<23) for the inline-attn merge"
 	@LLVM_LINK=$$(command -v llvm-link || true); \
 	  if [ -z "$$LLVM_LINK" ]; then echo "ERROR: no llvm-link on PATH (need system LLVM ~20)"; exit 1; fi; \

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -223,6 +223,33 @@ try:
 except Exception:
     print("Peano check failed.")
 
+# The fused-decode inline-attn merge (programming_examples/fused_decode) shells out
+# to an external `llvm-link` that MUST be a pre-lifetime-change LLVM (< 23); a newer
+# llvm-link rewrites the llvm.lifetime intrinsic and Peano opt then rejects the
+# merged IR. Expose a feature so decode-e2e tests (e.g. llama32_1b_q4nx
+# verify/profile) report UNSUPPORTED rather than hard-fail on a runner where no
+# compatible llvm-link is on PATH.
+try:
+    _llvm_link = shutil.which("llvm-link")
+    if _llvm_link:
+        _ll_out = subprocess.run(
+            [_llvm_link, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).stdout.decode("utf-8")
+        _ll_m = re.search(r"version (\d+)", _ll_out)
+        if _ll_m and int(_ll_m.group(1)) < 23:
+            config.available_features.add("llvm_link_pre23")
+            print(f"llvm-link {_ll_m.group(1)} (<23) found: fused-decode merge enabled.")
+        else:
+            print(
+                "llvm-link on PATH is not <23 "
+                f"({_ll_out.strip().splitlines()[0] if _ll_out.strip() else '?'}); "
+                "fused-decode decode tests will be UNSUPPORTED."
+            )
+    else:
+        print("llvm-link not on PATH; fused-decode decode tests will be UNSUPPORTED.")
+except Exception as e:
+    print(f"llvm-link check failed: {e}")
+
 # Test if Chess is available
 if not config.enable_chess_tests:
     print("Chess tests disabled.")

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -238,7 +238,9 @@ try:
         _ll_m = re.search(r"version (\d+)", _ll_out)
         if _ll_m and int(_ll_m.group(1)) < 23:
             config.available_features.add("llvm_link_pre23")
-            print(f"llvm-link {_ll_m.group(1)} (<23) found: fused-decode merge enabled.")
+            print(
+                f"llvm-link {_ll_m.group(1)} (<23) found: fused-decode merge enabled."
+            )
         else:
             print(
                 "llvm-link on PATH is not <23 "

--- a/programming_examples/llms/README.md
+++ b/programming_examples/llms/README.md
@@ -11,6 +11,7 @@ multi-launch ELFs and gates correctness against a Hugging Face bf16 reference.
 |---|---|---|---|---|---|---|
 | **Llama-3.2-1B** | `meta-llama/Llama-3.2-1B` | 16 | 2048 / 64 / 8192 | GQA 32Q/8KV | reference exemplar | prefill + decode |
 | **Llama-3.2-1B int4-AWQ** | `amd/Llama-3.2-1B-Instruct-awq-...` | 16 | 2048 / 64 / 8192 | GQA 32Q/8KV | int4-AWQ (prefill) | prefill; decode follow-up |
+| **Llama-3.2-1B Q4NX** | `FastFlowLM/Llama-3.2-1B-NPU2` | 16 | 2048 / 64 / 8192 | GQA 32Q/8KV | q4nx 4-bit weights, fused decode | prefill + decode |
 | **SmolLM2-1.7B** | `HuggingFaceTB/SmolLM2-1.7B` | 24 | 2048 / 64 / 8192 | MHA 32Q/32KV | pure MHA | prefill + decode |
 | **Qwen2.5-0.5B** | `Qwen/Qwen2.5-0.5B` | 24 | 896 / 64 / 4864 | GQA 14Q/2KV | QKV bias | prefill + decode |
 | **Qwen2.5-1.5B** | `Qwen/Qwen2.5-1.5B` | 28 | 1536 / 128 / 8960 | GQA 12Q/2KV | QKV bias, hd=128 | prefill + decode |
@@ -19,6 +20,7 @@ multi-launch ELFs and gates correctness against a Hugging Face bf16 reference.
 | **Qwen3-1.7B** | `Qwen/Qwen3-1.7B` | 28 | 2048 / 128 / 6144 | GQA 16Q/8KV | QK-norm, hd=128 | prefill + decode |
 | **Qwen3-4B** | `Qwen/Qwen3-4B` | 36 | 2560 / 128 / 9728 | GQA 32Q/8KV | QK-norm, decoupled q_dim=4096 | prefill + decode |
 | **Llama-3.2-3B** | `meta-llama/Llama-3.2-3B` | 28 | 3072 / 128 / 8192 | GQA 24Q/8KV | pure Llama, hd=128 | prefill + decode |
+| **Llama-3.2-3B Q4NX** | `FastFlowLM/Llama-3.2-3B-NPU2` | 28 | 3072 / 128 / 8192 | GQA 24Q/8KV | q4nx 4-bit weights | prefill + decode |
 
 All are decoder-only with RMSNorm + SwiGLU FFN + RoPE. The architecture axes that
 shape each deployment's dataflow:
@@ -83,7 +85,9 @@ model directory.
 llms/
 ├── llama32_1b/         # bf16 Llama-3.2-1B (the reference exemplar)
 ├── llama32_1b_int4/    # int4-AWQ variant (own quantized builders)
+├── llama32_1b_q4nx/    # Q4NX 4-bit Llama-3.2-1B (fused decode superkernel)
 ├── llama32_3b/         # bf16 Llama-3.2-3B (pure Llama, head_dim=128)
+├── llama32_3b_q4nx/    # Q4NX 4-bit Llama-3.2-3B (reuses the bf16 3B runner)
 ├── smollm2_1_7b/       # bf16 SmolLM2-1.7B (MHA)
 ├── qwen25_0_5b/        # Qwen2.5-0.5B  (QKV bias, head_dim=64)
 ├── qwen25_1_5b/        # Qwen2.5-1.5B  (QKV bias, head_dim=128)

--- a/programming_examples/llms/llama32_1b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_1b_q4nx/Makefile
@@ -1,20 +1,21 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 #
-# LLAMA-3.2-1B Q4NX prefill on NPU2 (MLIR-AIR)
+# LLAMA-3.2-1B Q4NX Inference on NPU2 (MLIR-AIR)
+#
+# Same driver contract as the other llms/ examples: run/profile/chat drive the
+# unified prefill+decode inference driver, and verify plugs into the shared
+# verify/ subsystem (top-k token-set inclusion, NPU q4nx vs HF bf16). Weights
+# come from FastFlowLM's 4-bit model.q4nx bundle (dequant->bf16 on the host).
 #
 # Quick start:
-#   make compile        — Build/cache the 4 prefill ELFs (~3 min; no weights needed)
-#   make run            — Prefill the "Paris" prompt; gate on first-token argmax 12366
-#   make profile        — Warm TTFT benchmark at CTX
+#   make compile        — Build/cache the prefill ELFs (~3 min; no weights needed)
+#   make compile-decode — Build the fused decode templates (~15 min; no weights)
+#   make run            — Run inference: NPU prefill + fused NPU decode
+#   make verify         — Top-k token-set inclusion gate: NPU q4nx vs HF bf16
 #
-# Performance (NPU2, AMD Strix), warm TTFT:
-#   ctx 256 -> 243 ms | 512 -> 305 ms | 1024 -> 560 ms | 2048 -> ~933 ms
-#
-# Unlike the HF-reference examples, this one gates on the greedy first token
-# (" Paris", 12366), not `make verify` vs HF bf16. All weights come from the single
-# model.q4nx bundle on the Hub (MODEL_SOURCE/Q4NX_MODEL_SOURCE, default FastFlowLM/Llama-3.2-1B-NPU2);
-# see README.md.
+# Config: 16 layers, emb=2048, 32 heads / 8 KV heads, head_dim=64,
+#         hidden=8192, vocab=128256 (NPU2, AMD Strix).
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -24,100 +25,144 @@ else
   BUILD_DIR := build_chess
 endif
 
-# Configurable parameters
-CTX           ?= 2048
-# Weight source: HF repo id (model.q4nx bundle) or a local dir/file. Default is the
-# self-contained model.q4nx on the Hub; the prefill downloads + dequantizes it.
-MODEL_SOURCE  ?= FastFlowLM/Llama-3.2-1B-NPU2
-export Q4NX_MODEL_SOURCE  := $(MODEL_SOURCE)
-export Q4NX_SEQ_LEN       := $(CTX)
-export Q4NX_CACHE_DIR     := $(srcdir)/$(BUILD_DIR)/q4nx_kernel_cache_$(CTX)
-# Use the tuned temporal+causal-skip prefill FlashAttention (auto-falls back to
-# seqfirst when CTX % 512 != 0). This is the headline ~0.93s TTFT path.
+# Configurable parameters (shared driver contract)
+N_TOKENS ?= 1000
+PROMPT   ?= What is the capital of France?
+MODEL    ?= instruct
+# Q4NX weight source (HF repo id with a model.q4nx, or a local dir/file).
+MODEL_SOURCE ?= FastFlowLM/Llama-3.2-1B-NPU2
+export Q4NX_MODEL_SOURCE := $(MODEL_SOURCE)
+
+# Prefill-only latency sweep (see `make profile-prefill`): 256 | 512 | 1024 | 2048.
+CTX ?= 2048
+export Q4NX_SEQ_LEN   := $(CTX)
+export Q4NX_CACHE_DIR := $(srcdir)/$(BUILD_DIR)/q4nx_kernel_cache_$(CTX)
+# Tuned temporal+causal-skip prefill FlashAttention (falls back to seqfirst when
+# CTX % 512 != 0). This is the headline ~0.93s TTFT prefill path.
 export TEMPORAL_CAUSAL_SKIP := 1
 
-DRIVER := $(srcdir)/llama32_1b_q4nx_prefill.py
+# Unified prefill+decode inference driver (run/profile/chat/gen/ask/compile).
+DRIVER := $(srcdir)/llama32_1b_q4nx_inference.py
+# Prefill engine (weight-integrity Paris gate + the CTX prefill latency sweep).
+PREFILL := $(srcdir)/llama32_1b_q4nx_prefill.py
+# The fused per-token decode is a SEPARATE reusable example: one dispatch =
+# 16 layers + LM head. `make compile-decode` delegates to it; the inference
+# driver loads its templates + decode_insts_gen at run time.
+FUSED_DECODE := $(srcdir)/../../fused_decode
 
-# ---- fused per-token decode (the chatbot's second path) ----
-# The decode is a SEPARATE example: programming_examples/fused_decode/ (one dispatch =
-# 16 layers + LM head). `make compile-decode` here delegates to it; the chatbot driver
-# loads its templates + decode_insts_gen at run time.
-INFER          := $(srcdir)/llama32_1b_q4nx_inference.py
-FUSED_DECODE   := $(srcdir)/../../fused_decode
+# Shared verify framework (programming_examples/llms/verify/).
+VERIFY_RUNNER = $(srcdir)/../verify/verify_runner.py
+RUNNER_ADAPTER = llama32_1b_q4nx.verify_adapter
 
-.PHONY: help compile run verify profile clean compile-decode chat ask gen
+.PHONY: help compile run profile chat verify verify-full diagnosis clean \
+        compile-decode profile-prefill verify-paris ask gen
 
 help:
 	@echo "============================================================"
-	@echo " LLAMA-3.2-1B Q4NX prefill on NPU2 (MLIR-AIR)"
+	@echo " LLAMA-3.2-1B Q4NX Inference on NPU2 (MLIR-AIR)"
 	@echo "============================================================"
 	@echo ""
-	@echo "Prefill (single-path):"
-	@echo "  make compile          Build/cache the 4 prefill ELFs (~3 min, no weights)"
-	@echo "  make run              Prefill 'The capital of France is' -> Paris gate"
-	@echo "  make verify           Same Paris argmax gate (12366) as the CI correctness check"
-	@echo "  make profile          Warm TTFT benchmark at CTX"
+	@echo "Quick start:"
+	@echo "  make compile          Build/cache the prefill ELFs (~3 min, no weights)"
+	@echo "  make compile-decode   Build the fused decode templates (~15 min, no weights)"
+	@echo "  make run              Run inference ($(N_TOKENS) tokens): NPU prefill + decode"
+	@echo "  make chat             Interactive chat REPL (streaming output)"
+	@echo "  make profile          Run with profiling breakdown"
 	@echo ""
-	@echo "Chatbot (prefill + fused decode):"
-	@echo "  make compile-decode   Build the fused_decode templates (delegates; ~15 min)"
-	@echo "  make chat             Interactive multi-turn chatbot (streams tokens)"
-	@echo "  make ask PROMPT=...   Single Q&A turn"
-	@echo "  make gen              Full prefill+decode Paris gate -> *** PARIS ***"
-	@echo "  (needs Q4NX_DECODE_WEIGHTS_NPZ ~28min once + Q4NX_GOLDEN_DIR; see README.md Build)"
+	@echo "Correctness:"
+	@echo "  make verify           Top-k token-set inclusion gate: NPU q4nx vs HF bf16 (2 prompts x 32 tokens, k=5)"
+	@echo "  make verify-full      Same gate over the full prompt set"
+	@echo "  make diagnosis        Per-layer ffn_out cosine vs HF bf16 (single prompt, informational)"
+	@echo "  make verify-paris     Fast weight-integrity smoke: prefill first-token argmax gate (12366 ' Paris')"
+	@echo ""
+	@echo "Prefill latency sweep:"
+	@echo "  make profile-prefill  Warm prefill TTFT benchmark at CTX (per-ELF breakdown)"
 	@echo ""
 	@echo "Options (override with make VAR=value):"
-	@echo "  CTX=2048              Prefill context length: 256 | 512 | 1024 | 2048"
+	@echo "  N_TOKENS=1000         Max decode tokens for run/profile/chat"
+	@echo "  PROMPT=\"...\"          Input prompt text (run/profile/diagnosis)"
+	@echo "  MODEL=base|instruct   Model variant (default: instruct)"
+	@echo "  CTX=2048              Prefill context length for profile-prefill: 256 | 512 | 1024 | 2048"
+	@echo "  MODEL_SOURCE=...       Q4NX weight source (default: $(MODEL_SOURCE))"
 	@echo ""
 	@echo "Data (external overrides; see README.md):"
 	@echo "  Q4NX_GOLDEN_DIR / Q4NX_DECODE_WEIGHTS_NPZ pre-supply the derived decode caches."
-	@echo ""
-	@echo "Examples:"
-	@echo "  make run CTX=1024"
-	@echo "  make profile CTX=2048"
 
-## Build/cache the 4 prefill ELFs (rms_gemms_rope + flash_attn + o_ffn + lm_head_gemv).
+## Build/cache the prefill ELFs (rms_gemms_rope + flash_attn + o_ffn + lm_head_gemv).
 ## No weight data or NPU dispatch required.
 compile:
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && python3 $(DRIVER) --compile-only
 
-## Prefill the canonical prompt; PASS iff first-token argmax == 12366 (" Paris").
-run:
-	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER)
-
-## Correctness gate: the HF greedy first-token argmax (" Paris", 12366). This is the
-## Q4NX analogue of the other examples' `make verify` vs HF bf16 (which does not apply
-## here — no HF checkpoint, external Q4NX weights). `run` and `verify` are the same
-## gate; `verify` is the name CI expects.
-verify: run
-
-## Warm TTFT benchmark at CTX (per-ELF BO-write / NPU-run / BO-read breakdown).
-profile:
-	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(DRIVER)
-
 ## Build the fused decode (delegates to the standalone programming_examples/fused_decode
 ## example): the Peano kernels + two templates (decode_L2048 + decode_L2047). ~15 min.
 ## Weight-free build; needs a pre-change llvm-link (see that example's README
-## Reproducibility). The chatbot driver loads its templates at run time.
+## Reproducibility). The inference driver loads its templates at run time.
 compile-decode:
 	$(MAKE) -C $(FUSED_DECODE) compile-decode
 
-## Interactive multi-turn chatbot (streams the reply token-by-token; /clear resets, /exit quits).
+## Run unified inference (NPU prefill + fused NPU decode).
+run:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) \
+		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
+
+## Run with the decode-throughput / TTFT profiling summary.
+profile:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) \
+		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
+
+## Interactive chat REPL (streams the reply token-by-token; /clear resets, /exit quits).
 chat:
-	python3 $(INFER) --interactive $(CHAT_ARGS)
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) \
+		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
+
+# ---- shared verify subsystem (top-k token-set inclusion, NPU q4nx vs HF bf16) ----
+
+## Top-k token-set inclusion gate (NPU q4nx vs HF bf16, 2 prompts x 32 tokens, k=5).
+verify:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL) --max-prompts 2
+
+## Full-sweep variant of `make verify` (all prompts in the prompt file).
+verify-full:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL)
+
+## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational).
+diagnosis:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
+
+## Fast weight-integrity smoke: prefill "The capital of France is"; PASS iff the
+## first-token argmax == 12366 (" Paris"). Cheap (prefill only, no decode build).
+verify-paris:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(PREFILL) --model $(MODEL_SOURCE)
+
+## Warm prefill TTFT benchmark at CTX (per-ELF BO-write / NPU-run / BO-read breakdown).
+profile-prefill:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL)
 
 ## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
 ask:
-	python3 $(INFER) --prompt "$(PROMPT)" $(CHAT_ARGS)
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
 
 ## Full prefill+decode Paris gate: first generated token 12366 -> *** PARIS ***.
 gen:
-	python3 $(INFER) --greedy --n-tokens 12
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --greedy --n-tokens 12
 
-## Remove prefill build artifacts + kernel/weight caches. (Decode templates live in the
-## fused_decode example; run `make -C ../../fused_decode clean` to remove those.)
+## Remove all build artifacts, kernel/weight caches, and verify reports. (Decode
+## templates live in the fused_decode example; run `make -C ../../fused_decode clean`.)
 clean:
 	rm -rf $(BUILD_DIR) $(srcdir)/_q4nx_* $(srcdir)/.wcache 2>/dev/null || true
-	@echo "Prefill build dirs and caches removed. Rebuild with 'make compile'."
+	rm -rf $(srcdir)/../verify/reports 2>/dev/null || true
+	@echo "Build dirs, caches and verify/reports/ removed. Rebuild with 'make compile'."

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -89,7 +89,10 @@ the single `model.q4nx` bundle on the Hub:
   Q4NX projections + bf16 norms/embed + a (tied) lm_head. The **prefill** downloads
   and dequantizes it directly. The **decode/chatbot** derives its q4k-cascade requant
   cache + embed/norm golden from the *same* bundle on first use (one-time pack,
-  cached under `~/.cache/q4nx/`). May also be a local dir/file.
+  cached under `~/.cache/q4nx/`). May also be a local dir/file. For the default Hub
+  repo the download **pins a revision** compatible with this loader's Q4NX codec
+  (`_PINNED_Q4NX_REVISION` in `llama32_1b_q4nx_weights.py`) — the Hub bundle is
+  periodically re-packed to a newer block layout that would otherwise fail to load.
 
 `tie_word_embeddings=true`, so the LM head is the full-precision `embed_tokens` (the
 bundle's separate Q4NX lm_head is ignored).

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -17,10 +17,13 @@ interactive chatbot on NPU2 (AIE2P):
   RMSNorm, argmax / stochastic sampler, chat template, EOS, and streaming output
   run on the host between tokens.
 
-Like the sibling `llama32_1b` / `llama32_1b_int4`, but it consumes external Q4NX
-weights and gates on the greedy first token (" Paris", id 12366) rather than a
-`make verify` top-k comparison vs HF transformers bf16 (there is no HF checkpoint
-for these weights). See [Correctness](#correctness) and [Data](#data).
+Like the sibling `llama32_1b` / `llama32_1b_int4`, it plugs into the shared driver
+contract (`make run`/`profile`/`chat`/`verify`) and the `verify/` subsystem. It
+consumes external Q4NX weights, so `make verify` compares the NPU q4nx run against
+the HF **bf16** sibling checkpoint (`meta-llama/Llama-3.2-1B-Instruct`) — the same
+NPU-vs-bf16 proxy the `llama32_3b_q4nx` example uses. A fast weight-integrity smoke
+(greedy first token " Paris", id 12366) is kept as `make verify-paris`. See
+[Correctness](#correctness) and [Data](#data).
 
 ## Architecture
 
@@ -104,20 +107,23 @@ make compile CTX=2048
 #   ~15 min; weight-free build, but needs a pre-change llvm-link (see Reproducibility).
 make compile-decode
 
+# Run inference (NPU prefill + fused NPU decode)
+make run
+
+# With the decode-throughput / TTFT profiling summary
+make profile
+
 # Interactive multi-turn chatbot (streams tokens)
 make chat
 
 # Single Q&A turn
 make ask PROMPT="What is the capital of France?"
 
-# Paris gate: prefill+decode, first token 12366 -> *** PARIS ***
-make gen
-
-# Prefill-only Paris gate
-make run
-
-# Same prefill Paris gate (name CI expects)
+# Correctness gate: top-k token-set inclusion, NPU q4nx vs HF bf16
 make verify
+
+# Fast weight-integrity smoke: prefill first token 12366 -> *** PARIS ***
+make verify-paris
 ```
 
 Direct invocation (equivalent to `make chat`):
@@ -135,11 +141,17 @@ Options: `--temperature 0.7 --top-k 5 --top-p 0.9`, `--rep-penalty`, `--seed`,
 
 ## Correctness
 
-The Paris gate is greedy first-token parity: for "The capital of France is", prefill
-predicts argmax **12366 (" Paris")** and the fused decode continues coherently
-(`make gen` / `make run` print `*** PARIS ***`). This replaces the HF-reference
-`make verify` used by the other examples (no HF checkpoint exists for these Q4NX
-weights).
+`make verify` runs the shared `verify/` top-k token-set inclusion gate (k=5,
+first-divergence over 32 greedy tokens across 2 prompts) comparing the NPU q4nx
+prefill + fused decode against the HF **bf16** sibling checkpoint
+(`meta-llama/Llama-3.2-1B-Instruct`) — driven by `verify_adapter.py`. `make
+verify-full` runs the full prompt set; `make diagnosis` is the informational
+per-layer lens. Since there is no bf16 checkpoint for the q4nx weights themselves,
+the reference is the bf16 sibling (identical to the `llama32_3b_q4nx` approach).
+
+`make verify-paris` is a fast weight-integrity smoke: for "The capital of France
+is", prefill predicts argmax **12366 (" Paris")** and prints `*** PARIS ***` —
+no decode build or HF reference required.
 
 ## How it works
 

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -156,8 +156,11 @@ def _prefill_worker(prompt, out_path, seq_len):
 
 def run_prefill(prompt, seq_len, kv_path):
     """Spawn the prefill worker (clean NPU release before decode)."""
+    # Note: avoid the token "prompt_len=" here so it doesn't shadow the canonical
+    # "Inference: prompt_len=<seq_len>" line that bench/extract_perf.py parses (it
+    # takes the first match).
     print(
-        f"[inference] prefill (seq_len={seq_len}, prompt_len={len(prompt)})...",
+        f"[inference] prefill (seq_len={seq_len}, prompt={len(prompt)} tok)...",
         flush=True,
     )
     cmd = [
@@ -610,13 +613,17 @@ def generate(
     if n_gen > 0:
         tps = n_gen / t_decode
         # Canonical driver lines consumed by bench/extract_perf.py: the
-        # parenthesized "(Y.YY tok/s)" is the throughput the perf harness parses,
-        # and "prompt_len=P" is the KV-cache depth the decode ran against.
+        # parenthesized "(Y.YY tok/s)" is the throughput the perf harness parses.
+        # "prompt_len" reports the NOMINAL prefill/decode context window (seq_len,
+        # == the decoder's ATTN_MAXL), matching the sibling drivers which print the
+        # padded seq_len (2048) — so the nightly's context_len column stays
+        # consistent. (Both here and the siblings decode from the real prompt
+        # position onward, so per-token tok/s is measured at the same real depth.)
         print(
             f"Generated {n_gen} tokens in {t_decode:.2f}s ({tps:.2f} tok/s)",
             flush=True,
         )
-        print(f"Inference: prompt_len={P}, n_tokens={n_gen}", flush=True)
+        print(f"Inference: prompt_len={seq_len}, n_tokens={n_gen}", flush=True)
         if profile:
             print(
                 f"[profile] decode {t_decode / n_gen * 1000:.1f} ms/token, "
@@ -670,6 +677,7 @@ class Session:
     def __init__(self, seq_len=2048):
         import numpy as np, time
 
+        self.seq_len = seq_len  # nominal prefill/decode context window (reported)
         sys.path.insert(0, str(_HERE))
         sys.path.insert(0, str(_DEC))
         from llama32_1b_q4nx_prefill import LlamaQ4nxPrefill
@@ -782,7 +790,7 @@ class Session:
                 f"({n_gen / t_decode:.2f} tok/s)",
                 flush=True,
             )
-            print(f"Inference: prompt_len={P}, n_tokens={n_gen}", flush=True)
+            print(f"Inference: prompt_len={self.seq_len}, n_tokens={n_gen}", flush=True)
         return gen_ids
 
 

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -39,8 +39,16 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 _PE = _HERE.parent.parent  # programming_examples
 _DEC = _PE / "fused_decode"  # standalone fused superkernel decode example
-_TOKENIZER = os.environ.get(
+# Tokenizer: a local Llama-3.2-1B tokenizer dir if present, else fall back to the
+# HF checkpoint (base/instruct share one tokenizer) so `make run`/`profile` work
+# without a hand-set Q4NX_TOKENIZER_DIR — same source the other llms/ examples use.
+_LOCAL_TOKENIZER = os.environ.get(
     "Q4NX_TOKENIZER_DIR", os.path.expanduser("~/q4nx_data/tokenizer/Llama-3.2-1B")
+)
+_TOKENIZER = (
+    _LOCAL_TOKENIZER
+    if os.path.isdir(_LOCAL_TOKENIZER)
+    else "meta-llama/Llama-3.2-1B-Instruct"
 )
 PARIS_PROMPT = [128000, 791, 6864, 315, 9822, 374]  # BOS + "The capital of France is"
 
@@ -164,6 +172,23 @@ def run_prefill(prompt, seq_len, kv_path):
         ",".join(map(str, prompt)),
     ]
     subprocess.run(cmd, check=True)
+
+
+def _compile_only(seq_len=2048):
+    """Build/cache the prefill ELFs and exit (no weights, no NPU dispatch).
+
+    This is the weight-free CI smoke signal (`make compile`). Constructing
+    LlamaQ4nxPrefill compiles the prefill engines; the fused decode templates
+    are a separate ~15 min build (`make compile-decode`)."""
+    sys.path.insert(0, str(_HERE))
+    from llama32_1b_q4nx_prefill import LlamaQ4nxPrefill
+
+    print(
+        f"[inference] compile-only: building prefill ELFs (seq_len={seq_len})...",
+        flush=True,
+    )
+    LlamaQ4nxPrefill(seq_len=seq_len, n_layers=16)  # constructs -> compiles engines
+    print("Compilation passed.", flush=True)
 
 
 # ------------------------------------------------------------------ fused decoder
@@ -518,6 +543,7 @@ def generate(
     stop_on_eos=True,
     seed=0,
     greedy=False,
+    profile=False,
 ):
     import numpy as np, time
 
@@ -530,11 +556,9 @@ def generate(
     P = fk.shape[1]
     ttft = time.perf_counter() - t_ttft0
     print(f"[inference] prefill first token = {first} (Paris=12366)", flush=True)
-    print(
-        f"[inference] TTFT: {ttft:.2f}s (prefill worker incl. weight load + LM head). "
-        f"First token: {first}",
-        flush=True,
-    )
+    # Canonical driver line consumed by bench/extract_perf.py (shared with the
+    # other llms/ examples). The prefill worker includes weight load + LM head.
+    print(f"Time to first token (TTFT): {ttft:.2f}s", flush=True)
 
     # ONE decode xclbin serves L in [1, ATTN_MAXL]; the decoder picks the template that covers
     # the requested reach (rt<M> for short, compile-time L<M> up to 2048). Cap at its ATTN_MAXL.
@@ -584,11 +608,21 @@ def generate(
     t_decode = time.perf_counter() - t_decode0
     n_gen = len(gen_ids) - 1  # exclude the prefill-provided first token
     if n_gen > 0:
+        tps = n_gen / t_decode
+        # Canonical driver lines consumed by bench/extract_perf.py: the
+        # parenthesized "(Y.YY tok/s)" is the throughput the perf harness parses,
+        # and "prompt_len=P" is the KV-cache depth the decode ran against.
         print(
-            f"[inference] decode: {n_gen} tokens in {t_decode:.2f}s  "
-            f"{n_gen / t_decode:.2f} tok/s  ({t_decode / n_gen * 1000:.1f} ms/token)",
+            f"Generated {n_gen} tokens in {t_decode:.2f}s ({tps:.2f} tok/s)",
             flush=True,
         )
+        print(f"Inference: prompt_len={P}, n_tokens={n_gen}", flush=True)
+        if profile:
+            print(
+                f"[profile] decode {t_decode / n_gen * 1000:.1f} ms/token, "
+                f"prefill TTFT {ttft:.2f}s, P={P}",
+                flush=True,
+            )
     return gen_ids
 
 
@@ -698,11 +732,7 @@ class Session:
         P = K.shape[1]
         ttft = time.perf_counter() - t_ttft0
         print(f"[inference] prefill first token = {first}", flush=True)
-        print(
-            f"[inference] TTFT: {ttft:.2f}s (prefill compute; weights preloaded). "
-            f"First token: {first}",
-            flush=True,
-        )
+        print(f"Time to first token (TTFT): {ttft:.2f}s", flush=True)
         n_eff = min(n_tokens or self.attn_maxl, self.attn_maxl - P)
         if n_eff <= 0:
             print(
@@ -748,10 +778,11 @@ class Session:
         n_gen = len(gen_ids) - 1
         if n_gen > 0:
             print(
-                f"[inference] decode: {n_gen} tokens in {t_decode:.2f}s  "
-                f"{n_gen / t_decode:.2f} tok/s  ({t_decode / n_gen * 1000:.1f} ms/token)",
+                f"Generated {n_gen} tokens in {t_decode:.2f}s "
+                f"({n_gen / t_decode:.2f} tok/s)",
                 flush=True,
             )
+            print(f"Inference: prompt_len={P}, n_tokens={n_gen}", flush=True)
         return gen_ids
 
 
@@ -880,6 +911,33 @@ def main():
     ap.add_argument(
         "--n-tokens", type=int, default=9, help="tokens to generate (<= ATTN_MAXL-P)"
     )
+    # Canonical driver contract (shared with the other llms/ examples): the
+    # Makefile run/profile/chat targets pass these through.
+    ap.add_argument(
+        "--model",
+        type=str,
+        default="instruct",
+        help="model variant: 'instruct' (chat template) or 'base' (raw encode). "
+        "Also selects the HF bf16 reference in verify_adapter.py.",
+    )
+    ap.add_argument(
+        "--run-only",
+        action="store_true",
+        help="run inference (kernels are compiled on demand / from cache). "
+        "Accepted for parity with the other examples; running is the default.",
+    )
+    ap.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="build/cache the prefill ELFs and exit (no weights, no NPU dispatch). "
+        "The fused decode templates are a separate build: `make compile-decode`.",
+    )
+    ap.add_argument(
+        "--profile",
+        action="store_true",
+        help="print the decode-throughput / TTFT profiling summary (machine-readable "
+        "lines consumed by bench/extract_perf.py).",
+    )
     ap.add_argument(
         "--temperature", type=float, default=0.7, help="the reference default 0.7"
     )
@@ -927,6 +985,10 @@ def main():
         _prefill_worker(prompt, args._kv_path, args.seq_len)
         return
 
+    if args.compile_only:
+        _compile_only(args.seq_len)
+        return
+
     if args.interactive:
         interactive_chat(
             system=args.system,
@@ -940,10 +1002,12 @@ def main():
         )
         return
 
+    # 'base' variant (or --raw) encodes without the chat template.
+    raw_encode = args.raw or args.model == "base"
     if args.prompt_ids:
         prompt = [int(x) for x in args.prompt_ids.split(",")]
     elif args.prompt:
-        if args.raw:
+        if raw_encode:
             from transformers import AutoTokenizer
 
             prompt = AutoTokenizer.from_pretrained(_TOKENIZER).encode(args.prompt)
@@ -967,6 +1031,7 @@ def main():
         stop_on_eos=not args.no_eos_stop,
         seed=args.seed,
         greedy=args.greedy,
+        profile=args.profile,
     )
     print("=" * 60)
     print(f"[inference] gen ids: {gen_ids}")

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -69,9 +69,23 @@ _EVEN = np.array(
 _ODD = _EVEN + 1
 
 
+# Pinned model.q4nx revisions for the known FastFlowLM repos. The Hub bundles are
+# periodically re-packed to newer Q4NX block layouts (e.g. a 4096-i16/block form)
+# that this loader's codec (2560 i16/block; see proj_qmm_pack) does not parse, so
+# a bare `hf_hub_download` of the latest revision breaks with a reshape error.
+# Pin the last revision that matches the codec above. Custom repo ids / local
+# paths are always used as-is (unpinned).
+_PINNED_Q4NX_REVISION = {
+    "FastFlowLM/Llama-3.2-1B-NPU2": "d0c7f84ac9c5cf796db0fc8255afac42592d9db3",
+}
+
+
 def resolve_q4nx_model(model):
     """Resolve `model` to a local model.q4nx path. `model` may be an HF repo id
-    (contains '/'), a directory containing model.q4nx, or a direct file path."""
+    (contains '/'), a directory containing model.q4nx, or a direct file path.
+
+    For a known FastFlowLM repo id, a compatible revision is pinned (see
+    `_PINNED_Q4NX_REVISION`); other repo ids download their latest revision."""
     import os
 
     if os.path.isfile(model):
@@ -83,7 +97,9 @@ def resolve_q4nx_model(model):
     # treat as an HF repo id
     from huggingface_hub import hf_hub_download
 
-    return hf_hub_download(model, "model.q4nx")
+    return hf_hub_download(
+        model, "model.q4nx", revision=_PINNED_Q4NX_REVISION.get(model)
+    )
 
 
 class Q4nxModel:

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_compile.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_compile.lit
@@ -6,12 +6,12 @@
 // AIR -> AIE -> aiecc -> Peano pipeline. No NPU dispatch and no weight data
 // (weights are runtime BOs), so this is the signal CI can always give without
 // the external Q4NX weights. Pairs with run_npu2_verify.lit (end-to-end
-// Paris-argmax correctness, gated on the weight data).
+// top-k correctness, gated on the weight data).
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: mkdir -p test_npu2_compile
-// RUN: cd test_npu2_compile
+// RUN: mkdir -p test_peano_compile
+// RUN: cd test_peano_compile
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: Compilation passed.

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
@@ -7,7 +7,7 @@
 // from the model.q4nx bundle pre-seeded into the runner's HF cache. Perf is
 // best-effort; this test gates only that profiling ran end to end.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
@@ -5,9 +5,11 @@
 // decode), capturing TTFT + decode throughput into llama32_1b_q4nx.perf.json via
 // bench/extract_perf.py (collected by the nightly LLM benchmark). Weights come
 // from the model.q4nx bundle pre-seeded into the runner's HF cache. Perf is
-// best-effort; this test gates only that profiling ran end to end.
+// best-effort; this test gates only that profiling ran end to end. The driver
+// chat-templates the prompt, so it also needs the HF tokenizer (falls back to the
+// meta-llama checkpoint) -- hence the meta-llama hfweights requirement below.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct, hfweights_fastflowlm_llama_3_2_1b_npu2
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
@@ -1,19 +1,20 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
-// LLAMA-3.2-1B Q4NX prefill profiling: compile then run the warm TTFT benchmark
-// at CTX, capturing prefill TTFT + context length into llama32_1b_q4nx.perf.json
-// via bench/extract_perf.py (collected by the nightly LLM benchmark). Weights come
+// LLAMA-3.2-1B Q4NX profiling: compile then profile on NPU2 (prefill + fused
+// decode), capturing TTFT + decode throughput into llama32_1b_q4nx.perf.json via
+// bench/extract_perf.py (collected by the nightly LLM benchmark). Weights come
 // from the model.q4nx bundle pre-seeded into the runner's HF cache. Perf is
 // best-effort; this test gates only that profiling ran end to end.
 //
 // REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
 //
-// RUN: mkdir -p test_npu2_profile
-// RUN: cd test_npu2_profile
+// RUN: mkdir -p test_peano_profile
+// RUN: cd test_peano_profile
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
-// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR CTX=2048 | tee profile.txt
-// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_1b_q4nx --n-tokens 0 > llama32_1b_q4nx.perf.json
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N_TOKENS=128 PROMPT="What is the capital of France?" | tee profile.txt
+// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_1b_q4nx > llama32_1b_q4nx.perf.json
 // RUN: FileCheck %s < llama32_1b_q4nx.perf.json
 // CHECK: "model": "llama32_1b_q4nx"

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_verify.lit
@@ -1,20 +1,21 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
-// LLAMA-3.2-1B Q4NX prefill correctness gate: greedy first-token argmax.
-// Runs the full on-device prefill of "The capital of France is" and PASSes iff
-// the first greedy token is 12366 (" Paris") -- matching HF greedy decoding.
+// Llama-3.2-1B Q4NX verify gate: top-k token-level inclusion check, NPU q4nx vs
+// HF bf16, 2 prompts x 32 greedy tokens, k=5 (use `make verify-full` for the
+// full sweep locally). Exercises the full production prefill + fused decode path
+// through the verify subsystem (verify/verify_runner.py); NPU weights come from
+// the FastFlowLM model.q4nx bundle, the reference from the HF bf16 checkpoint.
 //
-// This is the Q4NX analogue of the other examples' `make verify` vs HF bf16
-// (which does not apply here: greedy-token parity against HF, not top-k). The
-// weights come from the model.q4nx bundle on the Hub, pre-seeded into the perf
-// runner's HF cache, so it is gated on that repo being present (skips cleanly
-// where absent).
+// (The fast weight-integrity Paris-argmax smoke lives at `make verify-paris`.)
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
+// Skips cleanly when HF_TOKEN is unset (reference + tokenizer downloads need it).
 //
-// RUN: mkdir -p test_npu2_verify
-// RUN: cd test_npu2_verify
+// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct, hfweights_fastflowlm_llama_3_2_1b_npu2
+//
+// RUN: mkdir -p test_peano_verify
+// RUN: cd test_peano_verify
 // RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
-// CHECK: *** PARIS ***
+// CHECK: [verify] PASS

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_verify.lit
@@ -11,7 +11,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (reference + tokenizer downloads need it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct, hfweights_fastflowlm_llama_3_2_1b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct, hfweights_fastflowlm_llama_3_2_1b_npu2
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify

--- a/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
@@ -126,11 +126,14 @@ class NpuRunner:
         self.dec.KV[:] = 0
         self.dec.seed_kv(K, V, self._P)
 
-        # Q4NX prefill doesn't expose per-layer ffn_out; the diagnosis lens is
-        # left empty (the shared runner skips empty intermediates gracefully).
+        # Q4NX prefill doesn't expose per-layer ffn_out, so the diagnosis lens has
+        # no data. Return one empty dict per layer (len == n_layers) rather than an
+        # empty list: the diagnosis path indexes layer_intermediates[li] per layer,
+        # and `.get("ffn_out")` on an empty dict yields None, which the shared
+        # runner skips gracefully (an empty list would IndexError).
         empty = np.empty((0,), dtype=np.float32)
         return PrefillRecord(
-            layer_intermediates=[],
+            layer_intermediates=[{} for _ in range(_N_LAYERS)],
             final_hidden_normed=empty,
             logits_at_pred=logits,
             top1_token=first,

--- a/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Verify adapter for the Q4NX Llama-3.2-1B example.
+
+The NPU runs the FastFlowLM 4-bit `model.q4nx` weights (dequant'd to bf16); the
+reference is the HF **bf16** checkpoint. The shared verify gate compares
+NPU-q4nx vs HF-bf16 (top-k token-set inclusion) — the same NPU-vs-bf16 proxy the
+3B Q4NX adapter uses.
+
+Unlike the 3B Q4NX adapter (which reuses the bf16 llama32_3b `NpuRunner`
+verbatim), the 1B decode is the fused superkernel: prefill runs through
+`LlamaQ4nxPrefill` and each decode step through the one-xclbin `FusedDecoder`.
+So this adapter drives those two components directly to satisfy the shared
+`prefill()` / `decode_step()` Runner contract.
+
+Pointed at via `--runner=llama32_1b_q4nx.verify_adapter`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LLMS_DIR = _THIS_DIR.parent
+_VERIFY = _LLMS_DIR / "verify"
+_LLAMA1B = _LLMS_DIR / "llama32_1b"
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_LLAMA1B), str(_THIS_DIR)):
+    while _p in sys.path:
+        sys.path.remove(_p)
+    sys.path.insert(0, _p)
+
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+
+# Q4NX Llama-3.2-1B shares the bf16 1B architecture (16 layers, emb=2048,
+# 32Q/8KV, head_dim=64); reuse its config so the shared HfRunner sees the dims
+# it needs (n_layers / emb_dim / n_kv_heads / head_dim).
+from llama32_1b_weights import LlamaConfig  # noqa: E402
+
+MODEL_CHOICES = {
+    "base": "meta-llama/Llama-3.2-1B",
+    "instruct": "meta-llama/Llama-3.2-1B-Instruct",
+}
+DEFAULT_MODEL = "instruct"
+
+# NPU weight source (model.q4nx bundle). `model_name` selects the tokenizer + HF
+# bf16 reference; the NPU weights always come from here.
+Q4NX_MODEL_SOURCE = os.environ.get("Q4NX_MODEL_SOURCE", "FastFlowLM/Llama-3.2-1B-NPU2")
+
+_N_LAYERS = 16
+
+
+def build_config():
+    return LlamaConfig()
+
+
+def resolve_model(model_choice_or_id: str) -> str:
+    return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
+
+
+def hf_reference(npu_model_name: str) -> str:
+    """Reference is the HF bf16 checkpoint (NPU q4nx vs HF bf16)."""
+    return npu_model_name
+
+
+def build_runner(
+    model_name: str,
+    config,
+    max_seq: int,
+    tokenizer,
+    *,
+    npu_attn: bool = True,
+    lite_mode: bool = False,
+):
+    """Compile/load the Q4NX prefill + fused decode kernels, return an NpuRunner."""
+    return NpuRunner(max_seq=max_seq, tokenizer=tokenizer, lite_mode=lite_mode)
+
+
+class NpuRunner:
+    """Adapter over the Q4NX fused prefill + one-xclbin decode.
+
+    prefill() runs `LlamaQ4nxPrefill` (full logits + per-layer KV) and seeds the
+    decoder's region-major KV cache; decode_step() dispatches one fused token
+    through `FusedDecoder`. Mirrors the resident pipeline in
+    `llama32_1b_q4nx_inference.Session`."""
+
+    name = "npu_q4nx"
+
+    def __init__(self, max_seq: int, tokenizer, lite_mode: bool = False):
+        self.max_seq = max_seq
+        self.lite_mode = lite_mode
+        self._tokenizer = tokenizer
+
+        from llama32_1b_q4nx_prefill import LlamaQ4nxPrefill
+        from llama32_1b_q4nx_inference import FusedDecoder
+
+        self.prefiller = LlamaQ4nxPrefill(seq_len=max_seq, n_layers=_N_LAYERS)
+        self.prefiller.load_weights(model=Q4NX_MODEL_SOURCE)
+        self.dec = FusedDecoder()
+        self.attn_maxl = self.dec.ATTN_MAXL
+        self._P = 0
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        ids = [int(t) for t in prompt_tokens]
+        self.prefiller.clear_context()
+        logits = np.asarray(self.prefiller.prefill(ids), np.float32)
+        first = int(logits.argmax())
+        K = np.stack(
+            [
+                np.asarray(self.prefiller.kv_view(l)[0], np.float32)
+                for l in range(_N_LAYERS)
+            ]
+        )
+        V = np.stack(
+            [
+                np.asarray(self.prefiller.kv_view(l)[1], np.float32)
+                for l in range(_N_LAYERS)
+            ]
+        )
+        self._P = K.shape[1]
+        # Reset + seed the decoder's region-major KV cache from this prefill.
+        self.dec.KV[:] = 0
+        self.dec.seed_kv(K, V, self._P)
+
+        # Q4NX prefill doesn't expose per-layer ffn_out; the diagnosis lens is
+        # left empty (the shared runner skips empty intermediates gracefully).
+        empty = np.empty((0,), dtype=np.float32)
+        return PrefillRecord(
+            layer_intermediates=[],
+            final_hidden_normed=empty,
+            logits_at_pred=logits,
+            top1_token=first,
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        logits = np.asarray(
+            self.dec.dispatch(int(input_token), int(current_pos)), np.float32
+        )
+        return DecodeStepRecord(
+            lm_head_logits=logits,
+            top1_token=int(logits.argmax()),
+        )


### PR DESCRIPTION
## Summary

The Q4NX Llama-3.2-1B example (added in #1764) diverged from the other 11 `llms/` examples in exactly the driver / Makefile / lit layer that CI consumes:

- `run`/`verify`/`profile` targeted the **prefill** script instead of the inference driver, so decode had **zero** functional CI coverage.
- It was the only model without a `verify_adapter.py` — no plug into the shared `verify/` subsystem.
- `make profile` ran the prefill benchmark, so `decode_tokens_per_sec` came out **null** in the nightly perf JSON.

This brings it onto the canonical contract shared by the other examples, while keeping the legitimate Q4NX extras (external `model.q4nx` weights, the standalone fused decode, the `CTX` prefill-latency sweep). The decisive precedent is `llama32_3b_q4nx`, which already conforms.

## Changes

- **`llama32_1b_q4nx_inference.py`**: add `--run-only` / `--compile-only` / `--profile` / `--model`; emit the canonical lines `bench/extract_perf.py` parses — `Time to first token (TTFT): Xs`, `Generated N tokens in Xs (Y tok/s)`, `Inference: prompt_len=N, n_tokens=M`. Fall back to the HF tokenizer when no local dir is configured.
- **`Makefile`**: add `N_TOKENS`/`PROMPT`/`MODEL` + `VERIFY_RUNNER`/`RUNNER_ADAPTER`; repoint `run`/`profile`/`chat` at the inference driver; add `verify`/`verify-full`/`diagnosis` via the shared `verify/` subsystem; keep the prefill Paris gate as `verify-paris` and the `CTX` sweep as `profile-prefill`; `cd $(BUILD_DIR)` consistently.
- **`verify_adapter.py`** (new): drive the fused prefill + one-xclbin decode through the shared `prefill()` / `decode_step()` Runner contract; reference is the HF bf16 sibling (top-k token-set inclusion), matching `llama32_3b_q4nx`.
- **lit**: flip `verify` to `CHECK: [verify] PASS`; `profile` now passes `N_TOKENS`/`PROMPT` and drops `--n-tokens 0` so decode tok/s is captured; rename workdirs to `test_peano_*`.
- **README**: document the new targets; list both Q4NX models in the `llms/` table + tree.

## Test plan

Verified on NPU2 (AIE2P / Strix, Peano):

- [x] `make compile` → `Compilation passed.`
- [x] `make verify-paris` → first-token argmax `12366` (` Paris`) → `*** PARIS ***`
- [x] `make compile-decode` → `decode_L2048` + `decode_L2047` templates
- [x] `make gen` → coherent decode (` Paris. The capital of Germany is Berlin...`), canonical TTFT / tok/s / prompt_len lines
- [x] `make profile` → `extract_perf.py` yields non-null `decode_tokens_per_sec` (was `null`) + `context_len`
- [x] `make verify` → `[verify] PASS` (top-k 2/2, NPU q4nx vs HF bf16)
- [x] All three `run_npu2_*.lit` `CHECK` patterns validated against the real NPU2 outputs