### PR TITLE
[CI] Provide a pre-23 llvm-link so llama32_1b_q4nx is actually benchmarked

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -123,47 +123,70 @@ jobs:
           DEST="$PWD/llvm-link-bin"
           mkdir -p "$DEST"
           python3 - "$URL" mlir/bin/llvm-link "$DEST/llvm-link" <<'PY'
-          import struct, sys, urllib.request, zlib
+          import io, shutil, sys, urllib.request, zipfile
 
           url, member, out = sys.argv[1:4]
 
-          def rng(a, b):
-              r = urllib.request.Request(url, headers={"Range": f"bytes={a}-{b}"})
-              return urllib.request.urlopen(r, timeout=300).read()
 
-          size = int(urllib.request.urlopen(
-              urllib.request.Request(url, method="HEAD"),
-              timeout=60).headers["Content-Length"])
+          class RangeReader(io.RawIOBase):
+              """Seekable read-only file over an HTTP resource, backed by Range
+              requests. Handing this to zipfile keeps the ZIP details (zip64,
+              end-of-central-directory scan, CRC check) in the stdlib."""
 
-          # Locate the central directory from the (zip64) end-of-central-directory.
-          tail = rng(max(0, size - (1 << 20)), size - 1)
-          i = tail.rfind(b"PK\x06\x06")
-          if i >= 0:
-              cd_size, cd_off = struct.unpack("<QQ", tail[i + 40:i + 56])
-          else:
-              j = tail.rfind(b"PK\x05\x06")
-              cd_size, cd_off = struct.unpack("<II", tail[j + 12:j + 20])
+              def __init__(self, url):
+                  self.url, self.pos = url, 0
+                  with urllib.request.urlopen(
+                          urllib.request.Request(url, method="HEAD"),
+                          timeout=60) as r:
+                      length = r.headers.get("Content-Length")
+                  if not length:
+                      sys.exit(f"no Content-Length for {url}; cannot range-read it")
+                  self.size = int(length)
 
-          cd, p, ent = rng(cd_off, cd_off + cd_size - 1), 0, None
-          while p < len(cd) - 4 and cd[p:p + 4] == b"PK\x01\x02":
-              method, = struct.unpack("<H", cd[p + 10:p + 12])
-              csize,  = struct.unpack("<I", cd[p + 20:p + 24])
-              nlen, elen, clen = struct.unpack("<HHH", cd[p + 28:p + 34])
-              lho,    = struct.unpack("<I", cd[p + 42:p + 46])
-              if cd[p + 46:p + 46 + nlen].decode() == member:
-                  ent = (method, csize, lho)
-                  break
-              p += 46 + nlen + elen + clen
-          if ent is None:
-              sys.exit(f"{member} not found in {url}")
+              def readable(self):
+                  return True
 
-          # The local file header's name/extra lengths may differ from the central
-          # directory's, so re-read them to find where the member's bytes start.
-          method, csize, lho = ent
-          n2, e2 = struct.unpack("<HH", rng(lho, lho + 29)[26:30])
-          base = lho + 30 + n2 + e2
-          blob = rng(base, base + csize - 1)
-          open(out, "wb").write(zlib.decompress(blob, -15) if method == 8 else blob)
+              def seekable(self):
+                  return True
+
+              def tell(self):
+                  return self.pos
+
+              def seek(self, off, whence=io.SEEK_SET):
+                  base = {io.SEEK_SET: 0,
+                          io.SEEK_CUR: self.pos,
+                          io.SEEK_END: self.size}[whence]
+                  self.pos = max(0, min(self.size, base + off))
+                  return self.pos
+
+              def readinto(self, buf):
+                  n = min(len(buf), self.size - self.pos)
+                  if n <= 0:
+                      return 0
+                  req = urllib.request.Request(
+                      self.url,
+                      headers={"Range": f"bytes={self.pos}-{self.pos + n - 1}"})
+                  with urllib.request.urlopen(req, timeout=300) as r:
+                      data = r.read()
+                  # A server that ignores Range answers 200 with the whole 1GB body;
+                  # refuse rather than silently downloading it.
+                  if len(data) != n:
+                      sys.exit(f"short read: got {len(data)} of {n} bytes at "
+                               f"offset {self.pos} (Range ignored?)")
+                  buf[:n] = data
+                  self.pos += n
+                  return n
+
+
+          # Buffer so zipfile's small reads don't become one request each.
+          fp = io.BufferedReader(RangeReader(url), buffer_size=1 << 20)
+          with zipfile.ZipFile(fp) as z:
+              try:
+                  info = z.getinfo(member)
+              except KeyError:
+                  sys.exit(f"{member} not found in {url}")
+              with z.open(info) as src, open(out, "wb") as dst:
+                  shutil.copyfileobj(src, dst)
           PY
           chmod +x "$DEST/llvm-link"
           VER=$("$DEST/llvm-link" --version | sed -n 's/.*LLVM version \([0-9]*\).*/\1/p')

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -100,6 +100,80 @@ jobs:
           source air-venv/bin/activate
           python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
+      # The fused-decode inline-attn merge (programming_examples/fused_decode, used
+      # by llama32_1b_q4nx) shells out to an `llvm-link` resolved from PATH, and it
+      # MUST be a pre-lifetime-change LLVM (<23): a >=23 llvm-link rewrites
+      # llvm.lifetime.{start,end} to the no-size form and Peano opt (LLVM 21) then
+      # rejects the merged module ("immarg operand has non-immediate parameter").
+      # Neither toolchain on this runner provides one -- the llvm-aie wheel ships
+      # clang/opt/llc but no llvm-link, and the pinned mlir distro is LLVM 23 -- so
+      # the q4nx verify+profile lits reported UNSUPPORTED and the model silently
+      # vanished from perf.json.
+      #
+      # Pull the single statically-linked llvm-link (8MB, no libLLVM.so) out of the
+      # LLVM 21 mlir-distro wheel, matching Peano's own LLVM version exactly. A wheel
+      # is a ZIP, so HTTP range requests fetch just that member (~4MB, not the 1GB
+      # wheel). Only llvm-link goes in this dir, so prepending it to PATH cannot
+      # shadow clang/opt/llc for any other build.
+      - name: Get pre-23 llvm-link (fused-decode merge)
+        run: |
+          set -euo pipefail
+          WHEEL="mlir-21.0.0.2025073017%2B77914c96-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          URL="https://github.com/Xilinx/mlir-aie/releases/download/mlir-distro/${WHEEL}"
+          DEST="$PWD/llvm-link-bin"
+          mkdir -p "$DEST"
+          python3 - "$URL" mlir/bin/llvm-link "$DEST/llvm-link" <<'PY'
+          import struct, sys, urllib.request, zlib
+
+          url, member, out = sys.argv[1:4]
+
+          def rng(a, b):
+              r = urllib.request.Request(url, headers={"Range": f"bytes={a}-{b}"})
+              return urllib.request.urlopen(r, timeout=300).read()
+
+          size = int(urllib.request.urlopen(
+              urllib.request.Request(url, method="HEAD"),
+              timeout=60).headers["Content-Length"])
+
+          # Locate the central directory from the (zip64) end-of-central-directory.
+          tail = rng(max(0, size - (1 << 20)), size - 1)
+          i = tail.rfind(b"PK\x06\x06")
+          if i >= 0:
+              cd_size, cd_off = struct.unpack("<QQ", tail[i + 40:i + 56])
+          else:
+              j = tail.rfind(b"PK\x05\x06")
+              cd_size, cd_off = struct.unpack("<II", tail[j + 12:j + 20])
+
+          cd, p, ent = rng(cd_off, cd_off + cd_size - 1), 0, None
+          while p < len(cd) - 4 and cd[p:p + 4] == b"PK\x01\x02":
+              method, = struct.unpack("<H", cd[p + 10:p + 12])
+              csize,  = struct.unpack("<I", cd[p + 20:p + 24])
+              nlen, elen, clen = struct.unpack("<HHH", cd[p + 28:p + 34])
+              lho,    = struct.unpack("<I", cd[p + 42:p + 46])
+              if cd[p + 46:p + 46 + nlen].decode() == member:
+                  ent = (method, csize, lho)
+                  break
+              p += 46 + nlen + elen + clen
+          if ent is None:
+              sys.exit(f"{member} not found in {url}")
+
+          # The local file header's name/extra lengths may differ from the central
+          # directory's, so re-read them to find where the member's bytes start.
+          method, csize, lho = ent
+          n2, e2 = struct.unpack("<HH", rng(lho, lho + 29)[26:30])
+          base = lho + 30 + n2 + e2
+          blob = rng(base, base + csize - 1)
+          open(out, "wb").write(zlib.decompress(blob, -15) if method == 8 else blob)
+          PY
+          chmod +x "$DEST/llvm-link"
+          VER=$("$DEST/llvm-link" --version | sed -n 's/.*LLVM version \([0-9]*\).*/\1/p')
+          if [ -z "$VER" ] || [ "$VER" -ge 23 ]; then
+            echo "ERROR: extracted llvm-link is LLVM '$VER'; need <23" >&2
+            exit 1
+          fi
+          echo "llvm-link = $DEST/llvm-link (LLVM $VER)"
+          echo "$DEST" >> "$GITHUB_PATH"
+
       - name: Build mlir-air
         run: |
           source air-venv/bin/activate


### PR DESCRIPTION
## Problem

The nightly LLM perf benchmark has **never** run `llama32_1b_q4nx`. Both its `run_npu2_verify.lit` and `run_npu2_profile.lit` declare `REQUIRES: llvm_link_pre23`, and the runner has no `llvm-link` on `PATH` at all, so lit skips them ([run 30966373880](https://github.com/Xilinx/mlir-air/actions/runs/30966373880)):

```
llvm-link not on PATH; fused-decode decode tests will be UNSUPPORTED.
...
0.00s: AIR_PROGRAMMING_EXAMPLES :: llms/llama32_1b_q4nx/run_npu2_profile.lit
  Unsupported:   1 (0.30%)
```

Because the "Combine perf JSON" step deliberately skips emitting a row for `skip`-status models, the model then vanishes from `perf.json` and the dashboard with **no signal at all**. The nightly stays green while the documented ~0.93 s TTFT / ~50 tok/s fused-decode path goes completely untested — and the `llama32_1b_int4` row (a different pipeline: unfused per-layer decode with CPU attention, ~15.5 tok/s) gets mistaken for it.

## Why neither installed toolchain supplies `llvm-link`

- The `llvm-aie` (Peano) wheel ships `clang-21`/`opt`/`llc`/`llvm-ar` but **no `llvm-link`**.
- The pinned mlir distro *does* ship one, but it is `23.0.0.2026071405+46fcb339` — exactly the version the gate rejects.

Verified against Peano-emitted IR:

```
clang-21 emits:      call void @llvm.lifetime.start.p0(i64 32, ptr nonnull %a)
LLVM 21 llvm-link:   call void @llvm.lifetime.start.p0(i64 32, ptr nonnull %a)   [preserved]
LLVM 23 llvm-link:   call void @llvm.lifetime.start.p0(ptr %a)                   [auto-upgraded]
```

Peano `opt` accepts the first (`rc=0`) and rejects the second with `immarg operand has non-immediate parameter` / `Attribute after last parameter!` — the `Broken module found` failure documented in `programming_examples/fused_decode/README.md`.

## Fix

Extract `llvm-link` from the **LLVM 21** `mlir-distro` wheel — the same release page the workflow already pulls from, and LLVM 21 matches Peano's own version exactly rather than merely satisfying `<23`.

Two properties keep this cheap:

- `mlir/bin/llvm-link` is **statically linked** (8 MB; `ldd` shows only libc/libstdc++, no `libLLVM.so` to drag along).
- A wheel is a ZIP, so HTTP range requests fetch just that member: **~4 MB and ~2 s**, not the 1020 MB wheel.

It lands in a dedicated directory containing only `llvm-link`, so prepending it to `PATH` cannot shadow `clang`/`opt`/`llc` for any other build. The step fails loudly if the extracted binary is not `<23`.

`PATH` (not just `$PEANO_INSTALL_DIR/bin`) is required: although aiecc's `ShellCommand` searches the Peano prefix first, `programming_examples/lit.cfg.py` uses `shutil.which("llvm-link")` and the fused_decode Makefile preflight uses `command -v`, both of which consult `PATH` only.

## Testing

The failure mode and the fix are both host-toolchain-only, so they reproduce without an NPU2. On an npu1 machine:

- Extracted the step verbatim from the YAML (`yaml.safe_load` → the step's `run` body) and executed it: produces a working `llvm-link`, reports `LLVM 21`, writes the dir to `$GITHUB_PATH`.
- Negative-tested the guard against the LLVM 23 binary: parses `23`, correctly rejects.
- Confirmed the `llvm.lifetime` divergence and the Peano `opt` accept/reject behaviour shown above.

## Consequences to expect on the first nightly

1. This also re-enables the q4nx **verify** lit, which runs under the strict `check-programming-examples-llms-verify` gate — so a q4nx correctness failure will now red the job rather than being silently skipped.
2. Job runtime grows by roughly 40 minutes (each q4nx lit does `make clean` + `compile` ~3 min + `compile-decode` ~15 min). The last run took 2h19m against the 300-minute cap, so it fits, but without much headroom if the 3B/4B models slow down.

## Follow-ups (not in this PR)

- Emit a row with null metrics for `unsupported` models in "Combine perf JSON", so a model that stops being benchmarked is visible on the dashboard instead of disappearing.
- Longer term, shipping `llvm-link` in the `llvm-aie` wheel would remove the need for this step entirely — aiecc already searches `$PEANO_INSTALL_DIR/bin` ahead of `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)