### PR TITLE
[programming_examples] Llama-3.2-3B Q4NX: fully on-NPU decode + NPU prefill with KV handoff

### DIFF
--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -34,14 +34,16 @@ the instruction stream for any `L`, byte-identical to a native per-L build.
 ## Reproducibility (toolchain)
 
 `make compile-decode` merges an inline attention kernel into the core via an **external
-`llvm-link`** (resolved from `PATH`). That `llvm-link` **must be a pre-`llvm.lifetime`-
-change LLVM** (e.g. the system `/usr/bin/llvm-link`, LLVM 20). A newer LLVM (≥ 23)
-`llvm-link` rewrites the `llvm.lifetime` intrinsic to the no-size form, which Peano `opt`
-(LLVM 21) then rejects (`Broken module found`). Keep any ≥23 LLVM's `bin` off `PATH` for
-this build; the Makefile runs a preflight that aborts early otherwise. Verify:
+`llvm-link`** (resolved from `PATH`) whose **LLVM major must equal Peano's** (21 today).
+A newer (≥ 23) one rewrites the `llvm.lifetime` intrinsic to the no-size form, which
+Peano `opt` then rejects (`Broken module found`); an older one (e.g. the system LLVM 20)
+links without complaint and *silently miscompiles* the attention kernels — the decode
+runs at full speed and emits fluent garbage. Keep any mismatched LLVM's `bin` off `PATH`
+for this build; the Makefile preflight aborts early on either. Verify:
 
 ```bash
-which llvm-link && llvm-link --version   # expect LLVM 20.x (or any <23)
+which llvm-link && llvm-link --version
+$PEANO_INSTALL_DIR/bin/clang --version   # majors must match
 ```
 
 Nothing compiled is committed — `make compile-decode` reproduces every kernel object,

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -203,6 +203,38 @@ _MODELS = {
         # The driver MUST set VOCAB_CHUNK_I2=5 (env) to match this UNI_LM.
         UNI_LM=103,  # vocab chunks per LM head (VOCAB_CHUNK_I2=5)
     ),
+    # Llama-3.2-3B: same topology as the 1B entry, only dimensions differ
+    # (FLM's 1B and 3B layer.mlir are byte-structurally identical). head_dim
+    # doubles to 128 and GQA goes 4 q/kv-group -> 3, which the GQA_SEG=4
+    # padding absorbs (Q_HEADS_PADDED_PER_CU stays 8, so SSZ_BLK stays 192).
+    #   I2P = [M, D, 2*INTER, D]/(ROW_BLOCK*NCX*NCY*PAIR_ROWS) = [5,3,16,3]
+    #   J2P = [K, K, K, INTER]/(2*COL_BLOCK)                   = [6,6,6,16]
+    "llama-3.2-3b": dict(
+        K=3072,
+        M=5120,  # DQ+DK+DV = 3072+1024+1024
+        DH_A=128,
+        KV_PER_CU=2,  # 8 kv / 4 CU
+        N_ATTN_CU=4,
+        NPH=4,
+        I2P=[5, 3, 16, 3],
+        J2P=[6, 6, 6, 16],
+        KIDP=[1, 4, 8, 4],
+        GQA_SEG=4,  # ATTN_IMPL_2x4x1
+        PAIR_ROWS=2,
+        N_NORMS=2,
+        HAS_QK_NORM=False,
+        VOCAB_SIZE=128256,
+        UNI_DEC=28,
+        # LM-head vocab chunking: the vocab rms relays logits in whole-K blocks
+        # (VOCAB_RNDS*PAYLOAD // K rounds), so (K/PAYLOAD) must DIVIDE
+        # VOCAB_RNDS = VOCAB_I2*PAIR_ROWS or the round count floor-truncates ->
+        # too few xnorm broadcasts + a short logit drain -> the vocab wave
+        # DEADLOCKS. K/PAYLOAD = 6 here, so the 1B default 14 fails; VOCAB_I2=9
+        # gives RNDS=18 (6 | 18) and 288 rowblocks/chunk, dividing the 4032
+        # full-vocab rowblocks into 14 chunks. The driver MUST set
+        # VOCAB_CHUNK_I2=9 (env) to match this UNI_LM.
+        UNI_LM=14,  # vocab chunks per LM head (VOCAB_CHUNK_I2=9)
+    ),
 }
 MODEL_NAME = _os.environ.get("DECODE_MODEL", "llama-3.2-1b")
 MODEL = _MODELS[MODEL_NAME]
@@ -2909,6 +2941,14 @@ def build_module():
                             a_v = AllocOp(rms_l1, [], [])
                             _voc_blks_2k = VOCAB_RNDS * PAYLOAD // K
                             _xn_per_blk = K // PAYLOAD  # = VOCAB_RNDS // _voc_blks_2k
+                            # A floor-truncated round count emits too few xnorm
+                            # broadcasts and drains short -> the vocab wave
+                            # deadlocks on device. Catch it at build time.
+                            assert _voc_blks_2k * _xn_per_blk == VOCAB_RNDS, (
+                                f"VOCAB_CHUNK_I2={VOCAB_I2} gives VOCAB_RNDS="
+                                f"{VOCAB_RNDS}, not a multiple of K/PAYLOAD="
+                                f"{_xn_per_blk}"
+                            )
                             for _rv in for_(idx(0), idx(_voc_blks_2k), idx(1)):
                                 _rv.owner.owner.attributes["air.disable_ping_pong"] = (
                                     UnitAttr.get()

--- a/programming_examples/fused_decode/kernels/attn_kv.cc
+++ b/programming_examples/fused_decode/kernels/attn_kv.cc
@@ -266,18 +266,26 @@ __attribute__((noinline)) void scale_div_aie(bf16 *a, bf16 *o, float *l) {
   // though the input a and l are bit-identical. This replicates the EXACT same
   // computation scalarly: within each 64-lane block, group (g,h) occupies lanes
   // [(g*4+h)*8 .. +8) and is scaled by inv-l of head (g*4+h).
+  //
+  // y/a is PADDED (Q_HEADS_PADDED_PER_CU=8 head slots per dim-tile, GQA pad at
+  // the last slot of each group), but o is PACKED (Q_HEADS_PER_CU real heads),
+  // matching the reference and the attnO gather (dim-tile stride Q_HEADS_PER_CU
+  // *8). Read at the padded slot, write at the packed one. GQA pad=0 (1B) makes
+  // packed == padded, so this is a no-op there.
+  constexpr int o_tile = Q_HEADS_PER_CU * 8; // packed dim-tile stride in o
   bf16 invl[8];
   for (int h = 0; h < 8; h++)
     invl[h] = (bf16)getInvBf16(l[h]);
   for (int d = 0; d < F; d++) {
     bf16 *pa = a + d * vec_factor;
-    bf16 *po = o + d * vec_factor;
+    bf16 *po = o + d * o_tile;
     for (int g = 0; g < KV_HEADS_PER_CU; g++) {
       for (int h = 0; h < Q_HEADS_PER_GROUP; h++) {
-        int grp = g * 4 + h;
+        int grp = g * Q_HEADS_PER_GROUP_PADDED + h; // padded slot in y
+        int op = g * Q_HEADS_PER_GROUP + h;         // packed slot in o
         bf16 iv = invl[grp];
         for (int k = 0; k < 8; k++)
-          po[grp * 8 + k] = (bf16)((float)pa[grp * 8 + k] * (float)iv);
+          po[op * 8 + k] = (bf16)((float)pa[grp * 8 + k] * (float)iv);
       }
     }
   }

--- a/programming_examples/fused_decode/models/all_models.h
+++ b/programming_examples/fused_decode/models/all_models.h
@@ -22,6 +22,7 @@
 #define LLAMA_3_2_1B 0
 #define GEMMA3_4B 1
 #define QWEN2_5_3B 2
+#define LLAMA_3_2_3B 3
 
 #ifndef MODEL_TYPE
 #define MODEL_TYPE LLAMA_3_2_1B
@@ -29,6 +30,7 @@
 
 #include "../models/gemma3-4b.h"
 #include "../models/llama3.2-1b.h"
+#include "../models/llama3.2-3b.h"
 #include "../models/qwen2.5-3b.h"
 
 #endif // __ALL_MODELS_H__

--- a/programming_examples/fused_decode/models/llama3.2-3b.h
+++ b/programming_examples/fused_decode/models/llama3.2-3b.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+///@file llama3.2-3b.h
+///@brief Model parameters for llama3.2-3b, matching FastFlowLM's generic
+///       decoding layer for LLAMA_3_2_3B (hidden=3072, 24 heads / 8 kv,
+///       head_dim=128, intermediate=8192, vocab=128256). Same attention
+///       topology as 1B (8 CUs, 2x4x1, 8 kv heads); the head_dim-dependent
+///       widths double vs 1B (per-CU KV = 2*128 = 256, cf. FLM attn_memtile
+///       k_cu_offset:256, d:512).
+#ifndef __LLAMA3_2_3B_H__
+#define __LLAMA3_2_3B_H__
+
+#if MODEL_TYPE == LLAMA_3_2_3B
+constexpr int MODEL_DIM = 3072;
+constexpr int NUM_ATTN_HEADS = 24;
+constexpr int NUM_KV_HEADS = 8;
+constexpr int INTERMEDIATE_SIZE = 8192;
+constexpr int GLU_SLICE = 1024;
+constexpr int DH = 128;
+constexpr int VOCAB_SIZE = 128256;
+constexpr float ATTN_SCALE = 0.08838834764831843f; // 1/sqrt(128)
+
+#define ATTN_IMPL ATTN_IMPL_2x4x1 // 8 kv heads (same as 1B)
+#define A_FUNC A_SILU
+
+constexpr int Q4NX_ROW_BLOCK_SIZE = 32;
+constexpr int Q4NX_COL_BLOCK_SIZE = 256;
+constexpr int Q4NX_GROUP_SIZE = 32;
+#endif
+
+#endif // __LLAMA3_2_3B_H__

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -62,18 +62,19 @@ every context length.
 ## Reproducibility (decode toolchain)
 
 `make compile-decode` merges an inline attention kernel into the core via an
-**external `llvm-link`** (resolved from `PATH`). That `llvm-link` **must be a
-pre-`llvm.lifetime`-change LLVM** (e.g. the system `/usr/bin/llvm-link`, LLVM 20).
-A newer LLVM (≥ 23) `llvm-link` rewrites the `llvm.lifetime` intrinsic to the
-no-size form, which Peano `opt` (LLVM 21) then rejects (`Broken module found`).
+**external `llvm-link`** (resolved from `PATH`) whose **LLVM major must equal
+Peano's** (21 today). A newer (≥ 23) one rewrites the `llvm.lifetime` intrinsic to
+the no-size form, which Peano `opt` then rejects (`Broken module found`); an older
+one (e.g. the system LLVM 20) links without complaint and *silently miscompiles*
+the attention kernels — the decode runs at full speed and emits fluent garbage.
 
-So for the decode build, **keep any ≥23 LLVM's `bin` off `PATH`** (in particular do
-not put an AOMP / mlir-distro LLVM `bin` ahead of `/usr/bin`). `make compile-decode`
-runs a preflight that prints the resolved `llvm-link` and aborts early if it is
-≥ 23. Verify with:
+So keep any mismatched LLVM's `bin` off `PATH` for the decode build. The
+`make compile-decode` preflight prints the resolved `llvm-link` and Peano's version
+and aborts early on any mismatch. Verify with:
 
 ```bash
-which llvm-link && llvm-link --version   # expect LLVM 20.x (or any <23)
+which llvm-link && llvm-link --version
+$PEANO_INSTALL_DIR/bin/clang --version   # majors must match
 ```
 
 Nothing compiled is committed — `make compile` / `make compile-decode` reproduce

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -77,6 +77,7 @@ _ODD = _EVEN + 1
 # paths are always used as-is (unpinned).
 _PINNED_Q4NX_REVISION = {
     "FastFlowLM/Llama-3.2-1B-NPU2": "d0c7f84ac9c5cf796db0fc8255afac42592d9db3",
+    "FastFlowLM/Llama-3.2-3B-NPU2": "790271a87c7bb8158e52e9684a586a496d1fb1c9",
 }
 
 

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_profile.lit
@@ -20,3 +20,9 @@
 // RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_1b_q4nx > llama32_1b_q4nx.perf.json
 // RUN: FileCheck %s < llama32_1b_q4nx.perf.json
 // CHECK: "model": "llama32_1b_q4nx"
+// A parsed number, not just a well-formed file: if the driver's print format drifts
+// out of extract_perf.py's regexes the metric goes null and the published benchmark
+// row silently blanks while the test stays green.
+// CHECK: "ttft_ms": {{[0-9]}}
+// CHECK: "decode_tokens_per_sec": {{[0-9]}}
+// CHECK: "context_len": {{[0-9]}}

--- a/programming_examples/llms/llama32_3b/llama32_3b_prefill.py
+++ b/programming_examples/llms/llama32_3b/llama32_3b_prefill.py
@@ -60,15 +60,20 @@ from llama32_1b_prefill import (  # noqa: E402,F401
 from llama32_1b_cpu_helpers import attention_reference  # noqa: E402
 
 
-def _use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
-    """TEMPORAL_CAUSAL_SKIP=1 (opt-in): use the seq-first temporal-causal FA.
+def use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
+    """Use the seq-first temporal-causal FA wherever it is supported.
 
-    It maps one q-seq-tile per core over NB column-blocks and skips the
-    non-causal part of the K/V stream, and being seq-first it also drops the
-    host transposes the head-first path needs. Requires seq_len % 256 == 0.
-    Off by default: the shipped path stays head-first FA.
+    It maps one q-seq-tile per core over NB column-blocks and, being seq-first,
+    also drops the host transposes the head-first path needs. Measured on
+    Llama-3.2-3B at 2048 context: attention 33.68 -> 26.35 ms/layer, whole
+    prefill 2692.8 -> 2484.1 ms (761 -> 824 tok/s).
+
+    `supports()` restricts this to the shapes whose output placement is
+    actually mapped (head_dim 128, seq_len a multiple of 256, and past 4 rounds
+    only NB == 3); everything else keeps the head-first path. Set
+    TEMPORAL_CAUSAL_SKIP=0 to force head-first back.
     """
-    if os.environ.get("TEMPORAL_CAUSAL_SKIP") != "1":
+    if os.environ.get("TEMPORAL_CAUSAL_SKIP") == "0":
         return False
     from shared.infra.fa_temporal import supports
 
@@ -128,7 +133,7 @@ def compile_all_kernels(cache, config, seq_len, cpu_attn=False):
 
     # 3. Flash Attention (head_dim=128). Skip if using CPU fallback.
     if not cpu_attn:
-        if _use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
+        if use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
             print("\n--- flash_attn (seq-first TEMPORAL-CAUSAL FA, head_dim=128) ---")
             from shared.infra.fa_temporal import compile_temporal_fa
 
@@ -239,7 +244,7 @@ def run_transformer_block(
         # NPU FlashAttention (head_dim=128). q_roped/k_roped are post-RoPE
         # seq-first (pure Llama: no QK-norm, no bias); v is the raw V
         # projection seq-first. Real (un-padded) dims.
-        if _use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
+        if use_temporal_fa(seq_len, n_heads, n_kv_heads, head_dim):
             from shared.infra.fa_temporal import npu_fa_temporal as _npu_fa
         else:
             from shared.infra.fa_headfirst import npu_fa_headfirst as _npu_fa

--- a/programming_examples/llms/llama32_3b/verify_adapter.py
+++ b/programming_examples/llms/llama32_3b/verify_adapter.py
@@ -110,8 +110,9 @@ class NpuRunner:
         self.weights = weights
         self.config = config
         self.max_seq = max_seq
-        # Llama-3.2-3B has head_dim=128; prefill attention uses the shared
-        # HEAD-FIRST FlashAttention wrapper (proven on qwen3_0_6b and siblings).
+        # Llama-3.2-3B has head_dim=128; `use_temporal_fa` picks the seq-first
+        # temporal-causal FA at max_seq=2048 and falls back to the shared
+        # head-first wrapper on shapes it does not map.
         self.npu_attn = npu_attn
         self.cpu_attn = not npu_attn
         self.lite_mode = lite_mode

--- a/programming_examples/llms/llama32_3b_q4nx/.gitignore
+++ b/programming_examples/llms/llama32_3b_q4nx/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.pyc
 prefill_kernel_cache/
 decode_kernel_cache/
+# Prefill ELF cache, keyed by padded seq_len (rebuilt by `make compile`).
+_q4nx_cache_seq*/
 air_project/
 
 # Requant weight cache (the ~2 GB q4nx->bf16 cascade repack; built ONCE per

--- a/programming_examples/llms/llama32_3b_q4nx/.gitignore
+++ b/programming_examples/llms/llama32_3b_q4nx/.gitignore
@@ -7,6 +7,12 @@ prefill_kernel_cache/
 decode_kernel_cache/
 air_project/
 
+# Requant weight cache (the ~2 GB q4nx->bf16 cascade repack; built ONCE per
+# (N_LAYERS, VOCAB_I2) and reused -- never committed).
+.decode_wcache
+.decode_wcache/
+*.npz
+
 # Compiled kernels (reproduced by `make compile`; never committed).
 *.o
 *.ll
@@ -17,3 +23,9 @@ air.mlir
 air.elf
 air.xclbin
 air.insts.bin
+
+# Built decode templates (xclbin/insts; reproduced by `make compile-decode`).
+decode_L*.xclbin
+decode_L*.insts.bin
+decode.xclbin
+decode.insts.bin

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -9,11 +9,13 @@
 # Weights come from FastFlowLM's 4-bit model.q4nx bundle, re-quantized once into
 # the decode's q4k-cascade layout and cached under .decode_wcache/.
 #
-# There is no separate prefill kernel: the prompt is consumed token-by-token
-# through the same on-device decode, so each prompt token costs one decode step.
+# The prompt runs as one batched NPU prefill whose per-layer roped-K / raw-V seed
+# the decode's device KV cache (warm start); generation then costs one fused
+# dispatch per token.
 #
 # Quick start:
-#   make compile        — Build the fused-decode templates (~15 min; no weights needed)
+#   make compile        — Compile the prefill ELFs (~4 min; no weights needed)
+#   make compile-decode — Build the fused decode templates (~15 min; no weights)
 #   make run            — Run inference: 28 layers + LM head on-device, per token
 #   make verify         — Top-k token-set inclusion gate: NPU q4nx vs HF bf16
 #
@@ -68,7 +70,14 @@ DECODE_ENV := DECODE_MODEL=llama-3.2-3b VOCAB_CHUNK_I2=9 UNIFIED=1 LM_HEAD=0 \
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))
 
-.PHONY: help compile compile-decode _compile_decode_build run profile chat verify verify-full ask gen clean
+
+# Prefill engine (weight-integrity Paris gate + the CTX prefill latency sweep).
+PREFILL := $(srcdir)/llama32_3b_q4nx_prefill.py
+# Padded prefill length for profile-prefill.
+CTX ?= 2048
+
+.PHONY: help compile compile-decode _compile_decode_build run profile chat verify \
+        verify-full ask gen verify-paris profile-prefill clean
 
 help:
 	@echo "============================================================"
@@ -76,8 +85,8 @@ help:
 	@echo "============================================================"
 	@echo ""
 	@echo "Quick start:"
-	@echo "  make compile          Build fused-decode templates (~15 min, one-time; no weights)"
-	@echo "  make compile-decode   Same build (templates land in this directory)"
+	@echo "  make compile          Compile prefill ELFs (~4 min, one-time; no weights)"
+	@echo "  make compile-decode   Decode templates, built into this dir (~15 min, no weights)"
 	@echo "  make run              Run inference ($(N_TOKENS) tokens)"
 	@echo "  make chat             Interactive chat REPL (streaming output)"
 	@echo "  make profile          Run with profiling breakdown"
@@ -86,6 +95,8 @@ help:
 	@echo "  make verify           Top-k token-set inclusion gate: NPU q4nx vs HF bf16 (2 prompts x 32 tokens, k=5)"
 	@echo "  make verify-full      Same gate over the full 8-prompt set"
 	@echo "  make gen              Paris gate: greedy decode of \"The capital of France is\""
+	@echo "  make verify-paris     Prefill-only weight-integrity smoke (first token == Paris)"
+	@echo "  make profile-prefill  Warm prefill TTFT benchmark at CTX=$(CTX)"
 	@echo "  make ask PROMPT=...   Single Q&A turn"
 	@echo "  (no 'diagnosis': the fused decode runs all 28 layers in one dispatch,"
 	@echo "   so per-layer intermediates are not observable from the host)"
@@ -97,10 +108,11 @@ help:
 	@echo "  MODEL_SOURCE=...      Q4NX weight source (default: $(MODEL_SOURCE))"
 	@echo "  LBUILD=2048           ATTN_MAXL the decode templates are built for"
 
-## Build the fused-decode kernels + ATTN_MAXL=2048 templates (~15 min; no weights).
-## This example has no separate prefill engine, so `compile` == `compile-decode`.
-compile: compile-decode
-	@echo "Compilation passed."
+## Compile the prefill ELFs (~4 min, cached; no weights needed). The fused decode
+## templates are a separate ~15 min build -- see `make compile-decode`.
+compile:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) --compile-only
 
 ## Build the fused decode at the 3B geometry: Peano kernels (LLAMA_3_2_3B) + two
 ## same-ATTN_MAXL templates (decode_L$(LBUILD) + decode_L$(LREF)) into THIS dir.
@@ -171,6 +183,17 @@ verify-full:
 # No `diagnosis` target: the fused decode runs all 28 layers + the LM head inside a
 # single dispatch, so the per-layer intermediates that lens needs are not observable
 # from the host. `make verify` (token-set vs HF bf16) is the PASS/FAIL gate.
+
+## Fast weight-integrity smoke: prefill "The capital of France is"; PASS iff the
+## first-token argmax == 12366 (" Paris"). Cheap (prefill only, no decode build).
+verify-paris:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(PREFILL) --model $(MODEL_SOURCE)
+
+## Warm prefill TTFT benchmark at CTX (per-ELF BO-write / NPU-run / BO-read breakdown).
+profile-prefill:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL)
 
 ## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
 ask:

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -1,14 +1,20 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 #
-# LLAMA-3.2-3B Q4NX Inference on NPU2 (MLIR-AIR)
+# LLAMA-3.2-3B Q4NX Inference on NPU2 (MLIR-AIR) — FLM-faithful decode
 #
-# Same on-device pipeline as the bf16 llama32_3b example, but weights come from
-# FastFlowLM's 4-bit model.q4nx bundle (dequant->bf16 on the host at load).
+# The whole decoder layer runs on the AIE array (proj -> RoPE -> flash attention
+# with an on-device KV cache -> o-proj -> FFN, x28, + LM head) in ONE dispatch per
+# token via the fused_decode superkernel. No CPU attention, no host KV cache.
+# Weights come from FastFlowLM's 4-bit model.q4nx bundle, re-quantized once into
+# the decode's q4k-cascade layout and cached under .decode_wcache/.
+#
+# There is no separate prefill kernel: the prompt is consumed token-by-token
+# through the same on-device decode, so each prompt token costs one decode step.
 #
 # Quick start:
-#   make compile        — Compile all kernels (~4 min, cached; no weights needed)
-#   make run            — Run inference: NPU prefill + NPU decode
+#   make compile        — Build the fused-decode templates (~15 min; no weights needed)
+#   make run            — Run inference: 28 layers + LM head on-device, per token
 #   make verify         — Top-k token-set inclusion gate: NPU q4nx vs HF bf16
 #
 # Config: 28 layers, emb=3072, 24 heads / 8 KV heads, head_dim=128,
@@ -31,8 +37,38 @@ MODEL_SOURCE ?= FastFlowLM/Llama-3.2-3B-NPU2
 export Q4NX_MODEL_SOURCE := $(MODEL_SOURCE)
 
 DRIVER := $(srcdir)/llama32_3b_q4nx_inference.py
+# The fused per-token decode engine is a SEPARATE reusable example (one dispatch =
+# 28 layers + LM head); this Makefile drives it with the 3B model selection and
+# builds the templates INTO THIS DIRECTORY, the same way gemma3_4b_q4nx does. Every
+# model emits the same decode_L<N>.* names, so per-example output is what keeps a
+# 1B build from silently satisfying a 3B run.
+DEC           := $(srcdir)/../../fused_decode
+DECODE_DRIVER := $(DEC)/fused_decode.py
+AIEOPT_DIR    := $(shell realpath $(dir $(shell which aie-opt))/..)
 
-.PHONY: help compile run profile chat verify verify-full diagnosis clean
+# Per-kernel -O is LOAD-BEARING (see fused_decode/Makefile): proj_qmm/rms_residual/
+# glu/rope -O2; attn_qk/attn_kv inline .ll -O1. 3B differs only by
+# -DMODEL_TYPE=LLAMA_3_2_3B (the header sets the dims, DH=128, ATTN_IMPL, vocab).
+NONATTN_KERNELS := proj_qmm rms_residual glu rope
+ATTN_LL_KERNELS := attn_qk attn_kv
+PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
+  -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-deprecated-declarations \
+  -DNDEBUG -DMODEL_TYPE=LLAMA_3_2_3B -D__AIE_API_AIE_ADF_HPP__ \
+  -I $(AIEOPT_DIR)/include -I $(DEC)/kernels -I $(DEC)/models \
+  -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+
+# 3B decode env: 28 layers, vocab chunked at VOCAB_CHUNK_I2=9. That value is NOT
+# free -- the vocab relay drains whole-K blocks, so (K/PAYLOAD)=6 must divide
+# VOCAB_I2*PAIR_ROWS=18, and it must match the model entry's UNI_LM=14. The 1B
+# default (14) deadlocks the 3B vocab wave.
+DECODE_ENV := DECODE_MODEL=llama-3.2-3b VOCAB_CHUNK_I2=9 UNIFIED=1 LM_HEAD=0 \
+              NLAYERS=1 DECODE_GOLDEN=1
+
+# ATTN_MAXL to build for. 2048 = production; a small value builds fast for a gate.
+LBUILD ?= 2048
+LREF   := $(shell echo $$(($(LBUILD) - 1)))
+
+.PHONY: help compile compile-decode _compile_decode_build run profile chat verify verify-full ask gen clean
 
 help:
 	@echo "============================================================"
@@ -40,7 +76,8 @@ help:
 	@echo "============================================================"
 	@echo ""
 	@echo "Quick start:"
-	@echo "  make compile          Compile all kernels (~4 min, one-time; no weights)"
+	@echo "  make compile          Build fused-decode templates (~15 min, one-time; no weights)"
+	@echo "  make compile-decode   Same build (templates land in this directory)"
 	@echo "  make run              Run inference ($(N_TOKENS) tokens)"
 	@echo "  make chat             Interactive chat REPL (streaming output)"
 	@echo "  make profile          Run with profiling breakdown"
@@ -48,18 +85,57 @@ help:
 	@echo "More targets:"
 	@echo "  make verify           Top-k token-set inclusion gate: NPU q4nx vs HF bf16 (2 prompts x 32 tokens, k=5)"
 	@echo "  make verify-full      Same gate over the full 8-prompt set"
-	@echo "  make diagnosis        Per-layer ffn_out cosine vs HF bf16 (single prompt, informational)"
+	@echo "  make gen              Paris gate: greedy decode of \"The capital of France is\""
+	@echo "  make ask PROMPT=...   Single Q&A turn"
+	@echo "  (no 'diagnosis': the fused decode runs all 28 layers in one dispatch,"
+	@echo "   so per-layer intermediates are not observable from the host)"
 	@echo ""
 	@echo "Options (override with make VAR=value):"
 	@echo "  N_TOKENS=1000         Max decode tokens for run/profile/chat"
-	@echo "  PROMPT=\"...\"          Input prompt text (run/profile/diagnosis)"
+	@echo "  PROMPT=\"...\"          Input prompt text (run/profile)"
 	@echo "  MODEL=base|instruct   Model variant (default: instruct)"
-	@echo "  MODEL_SOURCE=...       Q4NX weight source (default: $(MODEL_SOURCE))"
+	@echo "  MODEL_SOURCE=...      Q4NX weight source (default: $(MODEL_SOURCE))"
+	@echo "  LBUILD=2048           ATTN_MAXL the decode templates are built for"
 
-## Compile all kernels (prefill + decode, ~4 min; no weights needed)
-compile:
-	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --compile-only
+## Build the fused-decode kernels + ATTN_MAXL=2048 templates (~15 min; no weights).
+## This example has no separate prefill engine, so `compile` == `compile-decode`.
+compile: compile-decode
+	@echo "Compilation passed."
+
+## Build the fused decode at the 3B geometry: Peano kernels (LLAMA_3_2_3B) + two
+## same-ATTN_MAXL templates (decode_L$(LBUILD) + decode_L$(LREF)) into THIS dir.
+## ~15 min, skipped when both are already present. Weight-free; the llvm-link major
+## must equal Peano's (the fused_decode preflight enforces it). The driver loads
+## the templates from here at run time.
+compile-decode:
+	@if [ -f $(srcdir)/decode_L$(LBUILD).xclbin ] && [ -f $(srcdir)/decode_L$(LBUILD).insts.bin ] \
+	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ]; then \
+	  echo "3B decode templates already built (decode_L$(LBUILD) + decode_L$(LREF)); skipping. Run 'make clean' to force a rebuild."; \
+	else \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build; \
+	fi
+
+_compile_decode_build:
+	@# Delegate the llvm-link/Peano version preflight to the engine that owns it:
+	@# an llvm-link older than Peano links quietly and miscompiles the attn kernels
+	@# into fluent garbage.
+	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
+	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
+	@echo ">>> 3B non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
+	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	@echo ">>> 3B attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
+	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
+	@echo ">>> 3B template decode_L$(LBUILD) (+ L$(LREF) slope ref)"
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LBUILD).log 2>&1; \
+	  if [ -f decode.xclbin ]; then mv -f decode.xclbin $(srcdir)/decode_L$(LBUILD).xclbin; mv -f decode.insts.bin $(srcdir)/decode_L$(LBUILD).insts.bin; \
+	  else echo "decode_L$(LBUILD) FAILED (see /tmp/llama3b_decode_L$(LBUILD).log)"; tail -30 /tmp/llama3b_decode_L$(LBUILD).log; exit 1; fi
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LREF).log 2>&1; \
+	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin $(srcdir)/decode_L$(LREF).insts.bin; mv -f decode.xclbin $(srcdir)/decode_L$(LREF).xclbin; \
+	  else echo "decode_L$(LREF) FAILED (see /tmp/llama3b_decode_L$(LREF).log)"; tail -30 /tmp/llama3b_decode_L$(LREF).log; exit 1; fi
+	@echo "3B decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."
 
 ## Run unified inference
 run:
@@ -92,14 +168,29 @@ verify-full:
 	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
-## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational).
-diagnosis:
-	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
-		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
+# No `diagnosis` target: the fused decode runs all 28 layers + the LM head inside a
+# single dispatch, so the per-layer intermediates that lens needs are not observable
+# from the host. `make verify` (token-set vs HF bf16) is the PASS/FAIL gate.
 
-## Remove all build artifacts and verify reports.
+## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
+ask:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
+
+## Paris gate: greedy-decode "The capital of France is"; first token must be 12366.
+gen:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --model base --n-tokens 12 \
+		--prompt "The capital of France is"
+
+## Remove build artifacts. Deliberately KEEPS $(srcdir)/.decode_wcache: that is the
+## ~2 GB q4k-cascade requant of the Q4NX weights and takes ~15 min to rebuild, while
+## the lit tests run `clean` before every gate. Delete it by hand to force a re-pack.
 clean:
-	rm -r $(BUILD_DIR) 2>/dev/null || true
-	rm -rf $(srcdir)/../verify/reports
-	@echo "Build directory and verify/reports/ removed. Run 'make compile' to rebuild."
+	rm -f $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
+	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
+	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
+	rm -rf $(BUILD_DIR) $(srcdir)/__pycache__ $(srcdir)/_q4nx_cache_seq* 2>/dev/null || true
+	rm -rf $(srcdir)/../verify/reports 2>/dev/null || true
+	@echo "Decode templates, build dirs, shared-dir kernels and verify/reports/ removed."
+	@echo "Kept .decode_wcache (requant cache); remove it by hand to force a re-pack."

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -59,14 +59,35 @@ single `model.q4nx` bundle:
 `tie_word_embeddings=true`, so the LM head is the full-precision `embed_tokens`
 (the bundle's separate Q4NX lm_head is ignored).
 
-Nothing compiled is committed — `make compile` reproduces every ELF from source
-(see `.gitignore`).
+Nothing compiled is committed — `make compile` / `make compile-decode` reproduce
+every ELF, xclbin, and instruction stream from source (see `.gitignore`).
+
+## Reproducibility (decode toolchain)
+
+`make compile-decode` merges an inline attention kernel into the core via an
+**external `llvm-link`** (resolved from `PATH`) whose **LLVM major must equal
+Peano's** (21 today). A newer (≥ 23) one rewrites `llvm.lifetime` to the no-size
+form and Peano `opt` rejects the merged module (`Broken module found`); an older
+one links quietly and *silently miscompiles* the attention kernels, so the decode
+runs at full speed and emits fluent garbage. The preflight aborts on either:
+
+```bash
+which llvm-link && llvm-link --version   # must match $PEANO_INSTALL_DIR/bin/clang --version
+```
+
+Every model's templates use the same `decode_L<N>.*` filenames, so this example
+builds its own into THIS directory rather than the shared `fused_decode` one
+(same as `gemma3_4b_q4nx`). A 1B build can therefore never satisfy a 3B run.
 
 ## Quick Start
 
 ```bash
 # One-time: compile all prefill + decode kernels (~4 min; no weights needed)
 make compile
+
+# One-time: build the fused decode templates for the 3B geometry (~15 min).
+# They land in this directory as decode_L2048.* / decode_L2047.*.
+make compile-decode
 
 # Run inference (instruct model by default; streams up to 1000 tokens)
 make run

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -2,18 +2,19 @@
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-3B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2
-(AIE2P). Same on-device pipeline as the sibling bf16 [`llama32_3b`](../llama32_3b)
-example — only the **weight source** differs: FastFlowLM's single `model.q4nx`
-bundle, dequantized Q4NX→bf16 on the host at load.
+(AIE2P). The decoder layer runs **entirely on the AIE array** — attention
+included, over a device-resident KV cache — the same mapping FastFlowLM uses.
 
-- **Prefill** (`llama32_3b_q4nx_inference.py` → reuses `llama32_3b_prefill`) —
-  op-by-op bf16 GEMM / RMSNorm / RoPE / SwiGLU / head-first causal-GQA flash
-  attention on the NPU with resident weight BOs; on-device 8-partition LM-head
-  GEMV. Fills a per-layer KV cache.
-- **Autoregressive decode** (`llama32_3b_decode`) — NPU `rms_gemv_rope` +
-  O/Gate/Up/Down GEMVs, CPU attention over the KV cache, NPU LM-head GEMV.
-- **Host orchestration** — embedding, final RMSNorm, argmax, chat template, EOS,
-  and streaming output between tokens.
+- **Prefill** (`llama32_3b_q4nx_prefill.py`) — op-by-op bf16 GEMM / RMSNorm /
+  RoPE / SwiGLU / head-first causal-GQA flash attention on the NPU with resident
+  weight BOs; on-device 8-partition LM-head GEMV. Its per-layer roped-K / raw-V
+  seed the decode's device KV cache, so a long prompt is not replayed token-wise.
+- **Autoregressive decode** (`q4nx_decode_3b.py`) — one dispatch per token through
+  the [`fused_decode`](../../fused_decode) superkernel at `MODEL_TYPE=LLAMA_3_2_3B`:
+  proj → RoPE → flash attention over the on-device KV → O → FFN, ×28 layers, then
+  the LM head. No CPU attention, no host KV.
+- **Host orchestration** — embedding, argmax, chat template, EOS, and streaming
+  output between tokens.
 
 Unlike the 1B Q4NX example (which gates on the greedy first token because it has
 no HF checkpoint), the 3B Q4NX weights are FastFlowLM's packing of the public
@@ -30,10 +31,13 @@ eps=1e-5, tied embeddings (lm_head = embed_tokens). Q4NX codec: 32×256 blocks,
 
 ## Performance (NPU2, AMD Strix, 28 layers, warm)
 
-- **Prefill / TTFT** @ 2048 ≈ **3.6 s** (head_dim=128 head-first FA transpose
+- **Prefill** ≈ **824 tok/s** @ 2048 ctx (head_dim=128 head-first FA transpose
   included in wall).
-- **Decode** ≈ **5 tok/s** (NPU Q/K/V/RoPE + GEMVs, CPU attention). Enable turbo
-  for best latency: `xrt-smi configure -d <BDF> --pmode turbo`.
+- **Decode** ≈ **18.3 tok/s** (54.7 ms/tok) — 28 layers + LM head on-device, one
+  dispatch per token. FastFlowLM's own 3B decode measures ~19.6 tok/s on the same
+  machine.
+
+Both measured at turbo: `xrt-smi configure -d <BDF> --pmode turbo`.
 
 ## Prerequisites
 
@@ -82,7 +86,7 @@ builds its own into THIS directory rather than the shared `fused_decode` one
 ## Quick Start
 
 ```bash
-# One-time: compile all prefill + decode kernels (~4 min; no weights needed)
+# One-time: compile the prefill ELFs (~4 min; no weights needed)
 make compile
 
 # One-time: build the fused decode templates for the 3B geometry (~15 min).
@@ -105,10 +109,16 @@ make chat
 # (2 prompts × 32 greedy tokens, k=5) — the production-readiness gate
 make verify
 
-# Full 8-prompt sweep / per-layer cosine diagnosis lens
+# Full 8-prompt sweep
 make verify-full
-make diagnosis
+
+# Prefill-only weight-integrity smoke (first token == " Paris")
+make verify-paris
 ```
+
+There is no `make diagnosis` here: the fused decode runs all 28 layers and the LM
+head inside one dispatch, so the per-layer intermediates that lens needs are not
+observable from the host. `make verify` is the PASS/FAIL gate.
 
 Override the NPU weight source (e.g. a local bundle):
 
@@ -132,9 +142,12 @@ expected sensitivity of a 4-bit model measured against a bf16 reference.
 weight BOs; final RMSNorm on the host, LM head on-device as an 8-partition GEMV.
 Per-layer roped-K / raw-V are captured into a KV cache.
 
-**Decode** — `llama32_3b_decode`: NPU `rms_gemv_rope` (RMSNorm + Q/K/V + RoPE),
-NPU O/Gate/Up/Down standalone GEMVs, CPU attention over the KV cache, NPU LM-head
-GEMV. Host does embedding, final RMSNorm, argmax, chat templating, and EOS.
+**Decode** — `q4nx_decode_3b.FusedDecode3B` drives the `fused_decode` superkernel
+built at `MODEL_TYPE=LLAMA_3_2_3B`: one dispatch appends K/V at the current slot of
+the device KV cache and runs proj → RoPE → flash attention → O → FFN for all 28
+layers plus the LM head. One `ATTN_MAXL=2048` template serves every context length;
+the per-token instruction stream is patched on the host. Host does embedding,
+argmax, chat templating, and EOS.
 
 **Q4NX weights** — `llama32_3b_q4nx_weights.load_q4nx_weights` wraps the
 shape-agnostic `Q4nxModel` reader (from the 1B Q4NX example) and assembles the
@@ -146,11 +159,13 @@ stage downstream of weight loading is the bf16 `llama32_3b` driver, unchanged.
 | Path | Purpose |
 |---|---|
 | `llama32_3b_q4nx_weights.py` | `load_q4nx_weights` — dequant `model.q4nx` → bf16 into the `llama32_3b` LlamaWeights container |
-| `llama32_3b_q4nx_inference.py` | Thin driver: reuses the `llama32_3b` runtime + generation loop; swaps the weight source + tokenizer |
+| `llama32_3b_q4nx_prefill.py` | NPU prefill engine; hands its per-layer roped-K / raw-V to the decode KV cache |
+| `q4nx_decode_3b.py` | `FusedDecode3B` — one-dispatch-per-token driver for the `fused_decode` superkernel |
+| `llama32_3b_q4nx_inference.py` | Driver + generation loop: prefill → fused decode, chat template, streaming |
 | `verify_adapter.py` | Hooks into the shared `../verify/` subsystem; NPU q4nx vs HF bf16 gate |
-| `Makefile` | compile / run / profile / chat / verify / verify-full / diagnosis / clean |
+| `Makefile` | compile / compile-decode / run / profile / chat / verify / verify-full / verify-paris / clean |
 
-Cross-directory reuse: the sibling [`llama32_3b`](../llama32_3b) prefill + decode +
-inference drivers, the `Q4nxModel` reader from
+Cross-directory reuse: the [`fused_decode`](../../fused_decode) superkernel, the
+sibling [`llama32_3b`](../llama32_3b) prefill builders, the `Q4nxModel` reader from
 [`llama32_1b_q4nx`](../llama32_1b_q4nx), and the shared `llms/` infra + `verify/`
 subsystem.

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
@@ -11,19 +11,19 @@ attention and no host-side KV cache.
 Weights come from FastFlowLM's 4-bit `model.q4nx` bundle, re-quantized once into
 the decode's q4k-cascade layout and cached (see q4nx_decode_3b).
 
-The prompt is consumed token-by-token through the same on-device decode (which
-warms the device KV cache), then generation continues; there is no separate
-prefill kernel, so each prompt token costs a full decode step.
+The prompt runs as ONE batched NPU prefill (llama32_3b_q4nx_prefill) whose per-layer
+roped-K / raw-V seed the decode's device KV cache, then generation continues one
+fused dispatch per token. `--no-prefill` replays the prompt through the decode
+instead (slower TTFT, useful for isolating the decode path).
 
 Usage:
-    python3 llama32_3b_q4nx_inference.py --compile-only     # build decode templates
+    python3 llama32_3b_q4nx_inference.py --compile-only     # build prefill ELFs
     python3 llama32_3b_q4nx_inference.py --run-only --n-tokens 32 --prompt "..."
     python3 llama32_3b_q4nx_inference.py --run-only --interactive
 """
 
 import argparse
 import os
-import subprocess
 import sys
 import time
 from pathlib import Path
@@ -56,16 +56,12 @@ TOKENIZER_DEFAULT = os.environ.get("Q4NX_TOKENIZER", "meta-llama/Llama-3.2-3B-In
 TEMPLATES_DEFAULT = os.environ.get("DECODE_TEMPLATES", str(_THIS_DIR))
 
 
-def compile_templates() -> None:
-    """Build the 3B fused-decode kernels + the two ATTN_MAXL=2048 templates into
-    this example's directory (weight-free, ~15 min; skipped if already built)."""
-    print(
-        f"Building {MODEL_TYPE} fused-decode templates in {_THIS_DIR} ...", flush=True
-    )
-    subprocess.run(
-        ["make", "-C", str(_THIS_DIR), "compile-decode"],
-        check=True,
-    )
+def compile_prefill(seq_len: int) -> None:
+    """Build/cache the prefill ELFs (weight-free, CI-runnable). The fused decode
+    templates are built separately by `make compile-decode` (~15 min)."""
+    from llama32_3b_q4nx_prefill import LlamaQ4nxPrefill
+
+    LlamaQ4nxPrefill(seq_len=seq_len, n_layers=28)  # constructing compiles + caches
 
 
 def _flat_ids(encoded) -> list:
@@ -93,19 +89,40 @@ def format_prompt(tokenizer, prompt: str, model_variant: str) -> list:
     return _flat_ids(tokenizer(prompt)["input_ids"])
 
 
-def generate_stream(dec, tokenizer, prompt_ids, n_tokens, stream=True):
-    """Consume the prompt through the on-device decode, then generate greedily.
+def generate_stream(
+    dec,
+    tokenizer,
+    prompt_ids,
+    n_tokens,
+    stream=True,
+    prefiller=None,
+    min_prefill=None,
+):
+    """Consume the prompt, then generate greedily.
+
+    A prompt of at least `min_prefill` tokens runs as ONE batched NPU prefill whose
+    per-layer roped-K / raw-V seed the decode's device KV cache (the warm-start
+    handoff); shorter prompts are replayed token-by-token through the decode, which
+    is faster than a full padded prefill. Both paths produce identical tokens.
     Returns (generated_ids, prompt_seconds, decode_seconds)."""
-    dec.reset_kv()
+    min_prefill = PREFILL_MIN_TOKENS if min_prefill is None else min_prefill
     P = len(prompt_ids)
     if P >= dec.ATTN_MAXL:
         raise RuntimeError(
             f"prompt length {P} >= decode ATTN_MAXL {dec.ATTN_MAXL}; build a larger template"
         )
+    use_prefill = prefiller is not None and P >= min_prefill
     t0 = time.perf_counter()
-    logits = None
-    for p, t in enumerate(prompt_ids):
-        logits = dec.dispatch(t, p)
+    if use_prefill:
+        prefiller.clear_context()
+        logits = np.asarray(prefiller.prefill(list(prompt_ids)), np.float32)
+        kvs = [prefiller.kv_view(L) for L in range(dec.N_LAYERS)]
+        dec.seed_kv([k for k, _ in kvs], [v for _, v in kvs])
+    else:
+        dec.reset_kv()
+        logits = None
+        for p, t in enumerate(prompt_ids):
+            logits = dec.dispatch(t, p)
     t_prompt = time.perf_counter() - t0
 
     gen = []
@@ -127,6 +144,35 @@ def generate_stream(dec, tokenizer, prompt_ids, n_tokens, stream=True):
     return gen, t_prompt, t_gen
 
 
+# The prefill engine always runs at the padded seq_len (the registry GEMM shapes are
+# built for it), so its cost is ~flat in the real prompt length: ~5 s at seq_len=2048
+# on NPU2. Replaying the prompt through the decode instead costs ~60 ms/token. Short
+# prompts are therefore FASTER token-by-token; only past the crossover does the
+# batched prefill win (and then by a lot: a 512-token prompt is ~5 s vs ~31 s).
+PREFILL_MIN_TOKENS = int(os.environ.get("Q4NX_PREFILL_MIN", "96"))
+
+
+def build_prefiller(args, prompt_len=None):
+    """The NPU prefill engine (None if disabled or not worth it for this prompt).
+    Compiles/caches its ELFs on first use and pre-loads the dequantized weights
+    into resident BOs."""
+    if args.no_prefill:
+        return None
+    if prompt_len is not None and prompt_len < args.prefill_min:
+        print(
+            f"\nPrompt is {prompt_len} tokens (< --prefill-min {args.prefill_min}); "
+            f"replaying it through the decode is faster than a padded "
+            f"seq_len={args.seq_len} prefill. Skipping the prefill engine."
+        )
+        return None
+    from llama32_3b_q4nx_prefill import LlamaQ4nxPrefill
+
+    print(f"\nBuilding NPU prefill engine (seq_len={args.seq_len}) ...")
+    pf = LlamaQ4nxPrefill(seq_len=args.seq_len, n_layers=28)
+    pf.load_weights(model=args.model_source)
+    return pf
+
+
 def build_decoder(args) -> FusedDecode3B:
     if not os.path.isdir(args.templates) or not any(
         f.startswith("decode_L") for f in os.listdir(args.templates)
@@ -139,7 +185,7 @@ def build_decoder(args) -> FusedDecode3B:
     return FusedDecode3B(args.model_source, args.templates, model_type=MODEL_TYPE)
 
 
-def repl(dec, tokenizer, args):
+def repl(dec, tokenizer, args, prefiller=None):
     print("\nInteractive chat (Ctrl-D or 'exit' to quit).")
     while True:
         try:
@@ -150,7 +196,8 @@ def repl(dec, tokenizer, args):
         if not line or line in ("exit", "quit"):
             break
         ids = format_prompt(tokenizer, line, args.model)
-        _, tp, tg = generate_stream(dec, tokenizer, ids, args.n_tokens)
+        pf = prefiller if len(ids) >= args.prefill_min else None
+        _, tp, tg = generate_stream(dec, tokenizer, ids, args.n_tokens, prefiller=pf)
         print(f"\n[{len(ids)} prompt tok in {tp:.2f}s | decode {tg:.2f}s]", flush=True)
 
 
@@ -186,6 +233,26 @@ if __name__ == "__main__":
         default=TEMPLATES_DEFAULT,
         help="directory holding decode_L<N>.{xclbin,insts.bin} builds",
     )
+    parser.add_argument(
+        "--no-prefill",
+        action="store_true",
+        help="replay the prompt token-by-token through the decode instead of the "
+        "batched NPU prefill (slower TTFT; useful for isolating the decode path)",
+    )
+    parser.add_argument(
+        "--seq-len",
+        type=int,
+        default=int(os.environ.get("Q4NX_SEQ_LEN", "2048")),
+        help="padded prefill length (prefill ELFs are compiled for this)",
+    )
+    parser.add_argument(
+        "--prefill-min",
+        dest="prefill_min",
+        type=int,
+        default=PREFILL_MIN_TOKENS,
+        help="use the batched NPU prefill only for prompts at least this long "
+        f"(default {PREFILL_MIN_TOKENS}; shorter prompts decode faster token-by-token)",
+    )
     parser.add_argument("--interactive", action="store_true")
     args = parser.parse_args()
 
@@ -193,7 +260,7 @@ if __name__ == "__main__":
         parser.error("--interactive cannot be combined with --compile-only")
 
     if not args.run_only:
-        compile_templates()
+        compile_prefill(args.seq_len)
         if args.compile_only:
             print("\nCompilation passed.")
             sys.exit(0)
@@ -204,12 +271,18 @@ if __name__ == "__main__":
     dec = build_decoder(args)
 
     if args.interactive:
-        repl(dec, tokenizer, args)
+        # Prompt lengths vary per turn, so build the prefill engine up front and let
+        # generate_stream fall back per turn for short prompts.
+        prefiller = build_prefiller(args)
+        repl(dec, tokenizer, args, prefiller)
         sys.exit(0)
 
     ids = format_prompt(tokenizer, args.prompt, args.model)
+    prefiller = build_prefiller(args, prompt_len=len(ids))
     print(f"\nPrompt: {args.prompt}\n")
-    gen, t_prompt, t_gen = generate_stream(dec, tokenizer, ids, args.n_tokens)
+    gen, t_prompt, t_gen = generate_stream(
+        dec, tokenizer, ids, args.n_tokens, prefiller=prefiller
+    )
     if args.profile:
         npt, ngt = max(len(ids), 1), max(len(gen), 1)
         print(

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
@@ -292,3 +292,16 @@ if __name__ == "__main__":
             f"({1000 * t_gen / ngt:.1f} ms/tok, {ngt / max(t_gen, 1e-9):.1f} tok/s) | "
             f"28 layers + LM head on-device, one dispatch/token"
         )
+        # The three lines bench/extract_perf.py parses into the nightly perf.json
+        # (and thus the published benchmark page). Keep the wording exact -- the
+        # ms/tok summary above matches none of its regexes, so dropping these
+        # publishes a blank row. prompt_len is the KV depth the tok/s was measured
+        # at: the padded prefill window when the prefill engine ran, else the prompt.
+        ctx = args.seq_len if prefiller is not None else len(ids)
+        print(f"Time to first token (TTFT): {t_prompt:.2f}s", flush=True)
+        print(f"Inference: prompt_len={ctx}, n_tokens={len(gen)}", flush=True)
+        print(
+            f"Generated {len(gen)} tokens in {t_gen:.2f}s "
+            f"({ngt / max(t_gen, 1e-9):.2f} tok/s)",
+            flush=True,
+        )

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
@@ -1,50 +1,46 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""LLAMA-3.2-3B Q4NX Inference on MLIR-AIR (NPU2).
+"""LLAMA-3.2-3B Q4NX Inference on MLIR-AIR (NPU2) — FLM-faithful decode.
 
-Same on-device pipeline as the bf16 llama32_3b example (NPU prefill + decode +
-LM head), but weights come from FastFlowLM's 4-bit `model.q4nx` bundle,
-dequantized to bf16 on the host at load. Everything downstream of weight loading
-is the bf16 llama32_3b driver, reused verbatim.
+The whole decoder layer runs on the AIE array: proj -> RoPE -> flash attention
+with an on-device KV cache -> o-proj -> FFN, x28 layers, then the LM head, all in
+ONE dispatch per token via the `fused_decode` superkernel. There is no CPU
+attention and no host-side KV cache.
+
+Weights come from FastFlowLM's 4-bit `model.q4nx` bundle, re-quantized once into
+the decode's q4k-cascade layout and cached (see q4nx_decode_3b).
+
+The prompt is consumed token-by-token through the same on-device decode (which
+warms the device KV cache), then generation continues; there is no separate
+prefill kernel, so each prompt token costs a full decode step.
 
 Usage:
-    cd build_peano
-    python3 ../llama32_3b_q4nx_inference.py --compile-only
-    python3 ../llama32_3b_q4nx_inference.py --run-only --n-tokens 32 --prompt "..."
+    python3 llama32_3b_q4nx_inference.py --compile-only     # build decode templates
+    python3 llama32_3b_q4nx_inference.py --run-only --n-tokens 32 --prompt "..."
+    python3 llama32_3b_q4nx_inference.py --run-only --interactive
 """
 
 import argparse
 import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 
-from ml_dtypes import bfloat16
+import numpy as np
 
 _THIS_DIR = Path(__file__).resolve().parent
 _LLMS_DIR = _THIS_DIR.parent
 _PROG = _LLMS_DIR.parent
-_LLAMA3B = _LLMS_DIR / "llama32_3b"
-_LLAMA1B = _LLMS_DIR / "llama32_1b"
-for _p in (str(_PROG), str(_LLMS_DIR), str(_LLAMA3B), str(_LLAMA1B), str(_THIS_DIR)):
+_FUSED = _PROG / "fused_decode"
+for _p in (str(_PROG), str(_LLMS_DIR), str(_FUSED), str(_THIS_DIR)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from shared.infra.cache import KernelCache, Profiler  # noqa: E402
-from llama32_3b_weights import LlamaConfig, generate_rope_lut  # noqa: E402
-from llama32_3b_prefill import compile_all_kernels  # noqa: E402
-from llama32_3b_decode import compile_decode_kernels  # noqa: E402
+from q4nx_decode_3b import FusedDecode3B, EOS_IDS  # noqa: E402
 
-# Reuse the bf16 driver's runtime + generation loop unchanged.
-from llama32_3b_inference import (  # noqa: E402
-    Session,
-    prepare_runtime,
-    run_once,
-    repl_loop,
-    _print_one_shot_output,
-)
-from llama32_3b_q4nx_weights import load_q4nx_weights  # noqa: E402
-
+MODEL_TYPE = "LLAMA_3_2_3B"
 # NPU weight source: the self-contained model.q4nx bundle (HF repo id or local
 # dir/file). Overridable with --model-source / Q4NX_MODEL_SOURCE.
 MODEL_SOURCE_DEFAULT = os.environ.get(
@@ -53,73 +49,119 @@ MODEL_SOURCE_DEFAULT = os.environ.get(
 # The Q4NX bundle carries no chat template; take the tokenizer from the HF
 # checkpoint (also the bf16 reference the verify gate compares against).
 TOKENIZER_DEFAULT = os.environ.get("Q4NX_TOKENIZER", "meta-llama/Llama-3.2-3B-Instruct")
+# The fused decode templates (decode_L<N>.{xclbin,insts.bin}) are built INTO THIS
+# EXAMPLE'S directory rather than the shared fused_decode one (same pattern as
+# gemma3_4b_q4nx): every model emits the same file names, so per-example output is
+# what keeps a 1B build from silently satisfying a 3B run.
+TEMPLATES_DEFAULT = os.environ.get("DECODE_TEMPLATES", str(_THIS_DIR))
 
 
-def build_session(args) -> Session:
-    """Same as llama32_3b.build_session, but weights come from model.q4nx and the
-    tokenizer from a separate HF checkpoint."""
-    config = LlamaConfig()
-    seq_len = 2048
-
-    prefill_cache = KernelCache(
-        "prefill_kernel_cache",
-        verbose=args.verbose,
-        profiler=Profiler(enabled=args.profile),
+def compile_templates() -> None:
+    """Build the 3B fused-decode kernels + the two ATTN_MAXL=2048 templates into
+    this example's directory (weight-free, ~15 min; skipped if already built)."""
+    print(
+        f"Building {MODEL_TYPE} fused-decode templates in {_THIS_DIR} ...", flush=True
     )
-    decode_cache = KernelCache(
-        "decode_kernel_cache",
-        verbose=args.verbose,
-        profiler=Profiler(enabled=args.profile),
-    )
-
-    if not args.run_only:
-        print("Compiling prefill kernels...")
-        compile_all_kernels(prefill_cache, config, seq_len, cpu_attn=args.cpu_attn)
-        print("\nCompiling decode kernels...")
-        compile_decode_kernels(decode_cache, config)
-
-    if args.compile_only:
-        print("\nCompilation passed.")
-        sys.exit(0)
-
-    if args.run_only:
-        prefill_cache.load_manifest()
-        decode_cache.load_manifest()
-
-    print(f"\nLoading Q4NX weights ({args.model_source})...")
-    weights = load_q4nx_weights(args.model_source, config=config)
-
-    from transformers import AutoTokenizer
-
-    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
-
-    rope_lut_bf16 = generate_rope_lut(
-        config=config, seq_len=seq_len + args.n_tokens
-    ).astype(bfloat16)
-
-    prepare_runtime(
-        prefill_cache, decode_cache, weights, config, seq_len, rope_lut_bf16
+    subprocess.run(
+        ["make", "-C", str(_THIS_DIR), "compile-decode"],
+        check=True,
     )
 
-    return Session(
-        config=config,
-        seq_len=seq_len,
-        weights=weights,
-        tokenizer=tokenizer,
-        prefill_cache=prefill_cache,
-        decode_cache=decode_cache,
-        rope_lut_bf16=rope_lut_bf16,
-        model_variant=args.model,
-    )
+
+def _flat_ids(encoded) -> list:
+    """Normalize tokenizer output to a flat list of ints. apply_chat_template may
+    return a BatchEncoding (a Mapping, not a dict subclass) and/or batch-nested ids."""
+    from collections.abc import Mapping
+
+    if hasattr(encoded, "input_ids"):  # BatchEncoding
+        encoded = encoded.input_ids
+    elif isinstance(encoded, Mapping):
+        encoded = encoded["input_ids"]
+    return [int(t) for t in np.asarray(encoded).reshape(-1)]
+
+
+def format_prompt(tokenizer, prompt: str, model_variant: str) -> list:
+    """Instruct variants get the chat template; base variants get raw text."""
+    if model_variant == "instruct" and getattr(tokenizer, "chat_template", None):
+        return _flat_ids(
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+        )
+    return _flat_ids(tokenizer(prompt)["input_ids"])
+
+
+def generate_stream(dec, tokenizer, prompt_ids, n_tokens, stream=True):
+    """Consume the prompt through the on-device decode, then generate greedily.
+    Returns (generated_ids, prompt_seconds, decode_seconds)."""
+    dec.reset_kv()
+    P = len(prompt_ids)
+    if P >= dec.ATTN_MAXL:
+        raise RuntimeError(
+            f"prompt length {P} >= decode ATTN_MAXL {dec.ATTN_MAXL}; build a larger template"
+        )
+    t0 = time.perf_counter()
+    logits = None
+    for p, t in enumerate(prompt_ids):
+        logits = dec.dispatch(t, p)
+    t_prompt = time.perf_counter() - t0
+
+    gen = []
+    t1 = time.perf_counter()
+    for step in range(n_tokens):
+        nxt = int(np.argmax(logits))
+        if nxt in EOS_IDS:
+            break
+        gen.append(nxt)
+        if stream:
+            print(tokenizer.decode([nxt]), end="", flush=True)
+        p = P + step
+        if step == n_tokens - 1 or p + 1 >= dec.ATTN_MAXL:
+            break
+        logits = dec.dispatch(nxt, p)
+    t_gen = time.perf_counter() - t1
+    if stream:
+        print(flush=True)
+    return gen, t_prompt, t_gen
+
+
+def build_decoder(args) -> FusedDecode3B:
+    if not os.path.isdir(args.templates) or not any(
+        f.startswith("decode_L") for f in os.listdir(args.templates)
+    ):
+        raise SystemExit(
+            f"No decode templates in {args.templates}. Run `make compile-decode` "
+            f"first (or pass --templates)."
+        )
+    print(f"\nLoading Q4NX weights ({args.model_source}) + decode templates ...")
+    return FusedDecode3B(args.model_source, args.templates, model_type=MODEL_TYPE)
+
+
+def repl(dec, tokenizer, args):
+    print("\nInteractive chat (Ctrl-D or 'exit' to quit).")
+    while True:
+        try:
+            line = input("\n> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line or line in ("exit", "quit"):
+            break
+        ids = format_prompt(tokenizer, line, args.model)
+        _, tp, tg = generate_stream(dec, tokenizer, ids, args.n_tokens)
+        print(f"\n[{len(ids)} prompt tok in {tp:.2f}s | decode {tg:.2f}s]", flush=True)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="LLAMA-3.2-3B Q4NX Inference (NPU)")
+    parser = argparse.ArgumentParser(
+        description="LLAMA-3.2-3B Q4NX Inference (NPU2, FLM-faithful on-device decode)"
+    )
     parser.add_argument("--compile-only", action="store_true")
     parser.add_argument("--run-only", action="store_true")
-    parser.add_argument("--n-tokens", type=int, default=10)
+    parser.add_argument("--n-tokens", type=int, default=64)
     parser.add_argument("--profile", action="store_true")
-    parser.add_argument("--cpu-attn", action="store_true", default=False)
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("--prompt", type=str, default="What is the capital of France?")
     parser.add_argument(
@@ -138,26 +180,42 @@ if __name__ == "__main__":
         default=TOKENIZER_DEFAULT,
         help=f"HF tokenizer id (default {TOKENIZER_DEFAULT})",
     )
+    parser.add_argument(
+        "--templates",
+        type=str,
+        default=TEMPLATES_DEFAULT,
+        help="directory holding decode_L<N>.{xclbin,insts.bin} builds",
+    )
     parser.add_argument("--interactive", action="store_true")
     args = parser.parse_args()
 
-    if args.interactive:
+    if args.interactive and args.compile_only:
+        parser.error("--interactive cannot be combined with --compile-only")
+
+    if not args.run_only:
+        compile_templates()
         if args.compile_only:
-            parser.error("--interactive cannot be combined with --compile-only")
-        if not args.run_only:
-            parser.error("--interactive requires --run-only")
-        args.profile = False
+            print("\nCompilation passed.")
+            sys.exit(0)
 
-    session = build_session(args)
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+    dec = build_decoder(args)
 
     if args.interactive:
-        repl_loop(session, args)
-    else:
-        generated, plen = run_once(
-            session,
-            args.prompt,
-            n_tokens=args.n_tokens,
-            profile=args.profile,
-            cpu_attn=args.cpu_attn,
+        repl(dec, tokenizer, args)
+        sys.exit(0)
+
+    ids = format_prompt(tokenizer, args.prompt, args.model)
+    print(f"\nPrompt: {args.prompt}\n")
+    gen, t_prompt, t_gen = generate_stream(dec, tokenizer, ids, args.n_tokens)
+    if args.profile:
+        npt, ngt = max(len(ids), 1), max(len(gen), 1)
+        print(
+            f"\n[profile] prompt {len(ids)} tok in {t_prompt:.3f}s "
+            f"({1000 * t_prompt / npt:.1f} ms/tok) | "
+            f"decode {len(gen)} tok in {t_gen:.3f}s "
+            f"({1000 * t_gen / ngt:.1f} ms/tok, {ngt / max(t_gen, 1e-9):.1f} tok/s) | "
+            f"28 layers + LM head on-device, one dispatch/token"
         )
-        _print_one_shot_output(session, args.prompt, generated, plen)

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_prefill.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_prefill.py
@@ -8,7 +8,8 @@
 # causal-GQA-flash-attention all ON THE NPU with RESIDENT weight BOs, and the
 # final LM head as an on-device GEMV. The whole transformer block runs through
 # the two llama32_3b multi-launch stitchers (rms_gemms_rope + o_ffn) plus the
-# head-first flash attention (head_dim=128), driven by KernelCache.load_and_run
+# seq-first temporal-causal flash attention (head_dim=128), driven by
+# KernelCache.load_and_run
 # with per-layer resident BOs (weights written once).
 #
 # This is the 3B analog of llama32_1b_q4nx_prefill.py: same structure, 3B config.
@@ -64,18 +65,30 @@ class LlamaQ4nxPrefill:
         self.n_layers = n_layers
         self.MAX_L = seq_len
         self.current_context_length = 0
+        from llama32_3b_weights import LlamaConfig, generate_rope_lut
+        from llama32_3b_prefill import compile_all_kernels, use_temporal_fa
+        from shared.infra.backend_presets import LM_GEMV_BACKEND
+
+        self.config = LlamaConfig(n_layers=n_layers)
         # seq_len-specific cache: the stitcher/flash-attn ELFs are compiled for this padded
         # context length, but the KernelCache is keyed by kernel NAME only. A shared dir would
         # let a shorter-context build (e.g. 256) be silently reused for a 2048 request -> the
         # prefill then returns all-zero logits for N beyond the built length. Isolate by seq_len.
-        cache_dir = cache_dir or str(_HERE / f"_q4nx_cache_seq{seq_len}")
+        # The FA variant goes in the name for the same reason: the two wrappers disagree on
+        # operand layout, so reusing one's `flash_attn` ELF under the other permutes the data.
+        _fa = (
+            "tfa"
+            if use_temporal_fa(
+                seq_len,
+                self.config.n_heads,
+                self.config.n_kv_heads,
+                self.config.head_dim,
+            )
+            else "hfa"
+        )
+        cache_dir = cache_dir or str(_HERE / f"_q4nx_cache_seq{seq_len}_{_fa}")
         self.cache = KernelCache(cache_dir=cache_dir, verbose=verbose)
 
-        from llama32_3b_weights import LlamaConfig, generate_rope_lut
-        from llama32_3b_prefill import compile_all_kernels
-        from shared.infra.backend_presets import LM_GEMV_BACKEND
-
-        self.config = LlamaConfig(n_layers=n_layers)
         self.D = self.config.emb_dim
         self.KV_DIM = self.config.n_kv_heads * self.config.head_dim
         self._rope_lut = _bf(
@@ -83,14 +96,14 @@ class LlamaQ4nxPrefill:
         )  # half-split, theta=5e5
         self._lm_backend = dict(LM_GEMV_BACKEND)
 
-        # Compile (or reuse cached) the ELFs: rms_gemms_rope + flash_attn + o_ffn
-        # (the two llama32_3b stitchers + head-first FA) and the 8-partition lm_head GEMV.
+        # Compile (or reuse cached) the ELFs: the two llama32_3b stitchers
+        # (rms_gemms_rope + o_ffn) plus flash_attn, and the 8-partition lm_head GEMV.
         # Q4NX_FORCE_COMPILE=1 forces recompile; otherwise a valid manifest is reused.
         force = os.environ.get("Q4NX_FORCE_COMPILE") == "1"
         if not force:
             self.cache.load_manifest()
         cached = set() if force else set(self.cache.artifacts)
-        if not {"rms_gemms_rope", "o_ffn"}.issubset(cached):
+        if not {"rms_gemms_rope", "o_ffn", "flash_attn"}.issubset(cached):
             compile_all_kernels(self.cache, self.config, seq_len, cpu_attn=False)
         else:
             print(

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_prefill.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_prefill.py
@@ -1,0 +1,354 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Llama-3.2-3B Q4NX prefill in mlir-air.
+#
+# Runs the prefill MECHANISM on the AMD NPU2: Q4NX weights, host dequant
+# Q4NX->bf16 at load, then op-by-op bf16 GEMM / RMSNorm / RoPE / SwiGLU /
+# causal-GQA-flash-attention all ON THE NPU with RESIDENT weight BOs, and the
+# final LM head as an on-device GEMV. The whole transformer block runs through
+# the two llama32_3b multi-launch stitchers (rms_gemms_rope + o_ffn) plus the
+# head-first flash attention (head_dim=128), driven by KernelCache.load_and_run
+# with per-layer resident BOs (weights written once).
+#
+# This is the 3B analog of llama32_1b_q4nx_prefill.py: same structure, 3B config.
+# It captures per-layer roped-K + raw-V so the fused decode can be seeded with a
+# warm KV cache (see q4nx_decode_3b.FusedDecode3B.seed_kv) -- prompt tokens then
+# cost one batched prefill instead of one full decode dispatch each.
+#
+# Gate: first prompt token argmax 12366 (" Paris") for "The capital of France is".
+#
+# Weight source (env-overridable):
+#   Q4NX_MODEL_SOURCE : the model.q4nx bundle -- HF repo id or a local dir/file.
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_HERE = Path(__file__).resolve().parent
+_PROG = str(_HERE.parent.parent)  # programming_examples
+_LLMS = str(_HERE.parent)  # llms
+_LLAMA3B = str(_HERE.parent / "llama32_3b")  # fused-stitcher prefill driver
+_LLAMA1B = str(_HERE.parent / "llama32_1b")  # shared stitcher internals
+for _p in (_PROG, _LLMS, _LLAMA3B, _LLAMA1B, str(_HERE)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from shared.infra.cache import KernelCache  # noqa: E402
+
+# Default weight source: the self-contained model.q4nx bundle on the Hub. May be
+# overridden with --model / Q4NX_MODEL_SOURCE (an HF repo id, or a local dir/file).
+MODEL_DEFAULT = os.environ.get("Q4NX_MODEL_SOURCE", "FastFlowLM/Llama-3.2-3B-NPU2")
+
+VOCAB = 128256
+PROMPT = [128000, 791, 6864, 315, 9822, 374]  # "The capital of France is"
+EXPECT_FIRST = 12366  # " Paris"
+
+# On-device LM head GEMV: 8 partitions of M=16384 (8*16384=131072 >= VOCAB), K=emb_dim.
+_LM_N_PART = 16384
+_LM_N_PARTITIONS = 8
+
+
+def _bf(a):
+    return np.asarray(a, bfloat16)
+
+
+class LlamaQ4nxPrefill:
+    """AIR realization of the Q4NX causal-LM prefill interface (Llama-3.2-3B)."""
+
+    def __init__(self, seq_len=2048, n_layers=28, cache_dir=None, verbose=False):
+        self.seq = seq_len
+        self.n_layers = n_layers
+        self.MAX_L = seq_len
+        self.current_context_length = 0
+        # seq_len-specific cache: the stitcher/flash-attn ELFs are compiled for this padded
+        # context length, but the KernelCache is keyed by kernel NAME only. A shared dir would
+        # let a shorter-context build (e.g. 256) be silently reused for a 2048 request -> the
+        # prefill then returns all-zero logits for N beyond the built length. Isolate by seq_len.
+        cache_dir = cache_dir or str(_HERE / f"_q4nx_cache_seq{seq_len}")
+        self.cache = KernelCache(cache_dir=cache_dir, verbose=verbose)
+
+        from llama32_3b_weights import LlamaConfig, generate_rope_lut
+        from llama32_3b_prefill import compile_all_kernels
+        from shared.infra.backend_presets import LM_GEMV_BACKEND
+
+        self.config = LlamaConfig(n_layers=n_layers)
+        self.D = self.config.emb_dim
+        self.KV_DIM = self.config.n_kv_heads * self.config.head_dim
+        self._rope_lut = _bf(
+            generate_rope_lut(config=self.config, seq_len=seq_len)
+        )  # half-split, theta=5e5
+        self._lm_backend = dict(LM_GEMV_BACKEND)
+
+        # Compile (or reuse cached) the ELFs: rms_gemms_rope + flash_attn + o_ffn
+        # (the two llama32_3b stitchers + head-first FA) and the 8-partition lm_head GEMV.
+        # Q4NX_FORCE_COMPILE=1 forces recompile; otherwise a valid manifest is reused.
+        force = os.environ.get("Q4NX_FORCE_COMPILE") == "1"
+        if not force:
+            self.cache.load_manifest()
+        cached = set() if force else set(self.cache.artifacts)
+        if not {"rms_gemms_rope", "o_ffn"}.issubset(cached):
+            compile_all_kernels(self.cache, self.config, seq_len, cpu_attn=False)
+        else:
+            print(
+                "[q4nx_prefill] using cached stitcher ELFs (skip compile)", flush=True
+            )
+        # LM head on the NPU -- an 8-partition GEMV.
+        if "lm_head_gemv" not in cached:
+            from shared.builders.lm_head_gemv_multi import build_lm_head_gemv_module
+
+            self.cache.compile_and_cache(
+                "lm_head_gemv",
+                build_lm_head_gemv_module(
+                    self.D, n_partitions=_LM_N_PARTITIONS, n_part=_LM_N_PART
+                ),
+                {"verbose": self.cache.verbose, **self._lm_backend},
+            )
+            self.cache._save_manifest()
+
+        # Per-layer KV cache (roped K + raw V), [MAX_L, n_kv_heads*head_dim].
+        self.kv_k = [
+            np.zeros((self.MAX_L, self.KV_DIM), bfloat16) for _ in range(n_layers)
+        ]
+        self.kv_v = [
+            np.zeros((self.MAX_L, self.KV_DIM), bfloat16) for _ in range(n_layers)
+        ]
+        self._weights = None
+        self._embed = None
+        self._final_norm = None
+        self._lm_head = None
+        self._dev_t = 0.0  # accumulated NPU dispatch time (s)
+        self._op_t = {}  # per-op NPU dispatch time (s)
+
+    def _dev(self, fn, *a, tag="?"):
+        import time
+
+        t = time.time()
+        r = fn(*a)
+        dt = time.time() - t
+        self._dev_t += dt
+        self._op_t[tag] = self._op_t.get(tag, 0.0) + dt
+        return r
+
+    # ---- causal_lm interface ----
+    def load_weights(self, model=None):
+        """Load Q4NX transformer weights + embed/lm_head/final-norm from the
+        self-contained `model.q4nx` bundle (HF repo `Q4NX_MODEL_SOURCE`, or a
+        local dir/file), dequant Q4NX->bf16 on the host at load, then pre-load
+        them into per-layer resident BOs (written once; skipped at prefill)."""
+        model = model or os.environ.get("Q4NX_MODEL_SOURCE", MODEL_DEFAULT)
+        from llama32_3b_q4nx_weights import load_q4nx_weights
+        from llama32_3b_prefill import preload_prefill_weights
+
+        print(f"[q4nx_prefill] loading weights from model.q4nx ({model})", flush=True)
+        w = load_q4nx_weights(model, config=self.config)
+        self._weights = w
+        self._embed = w.embed_table
+        self._final_norm = np.asarray(w.final_norm, np.float32)
+        self._lm_head = w.lm_head
+        preload_prefill_weights(w, self.config, self.cache, self.seq, self._rope_lut)
+        self._preload_lm_head_gemv()
+
+    def _preload_lm_head_gemv(self):
+        """Build the 8 padded bf16 lm_head partitions [16384, D] and write them
+        into resident BOs once (static; skipped thereafter)."""
+        self._lm_parts = []
+        for p in range(_LM_N_PARTITIONS):
+            n0 = p * _LM_N_PART
+            n1 = min(n0 + _LM_N_PART, VOCAB)
+            w = np.zeros((_LM_N_PART, self.D), bfloat16)
+            if n1 > n0:
+                w[: n1 - n0] = _bf(self._lm_head[n0:n1])
+            self._lm_parts.append(w)
+        self._lm_head_npu(np.zeros(self.D, bfloat16))  # warm/allocate resident BOs
+
+    def _lm_head_npu(self, hidden_bf16):
+        """On-device final logits from a single bf16 hidden row [D] -> [VOCAB]."""
+        lm_inputs = [np.ascontiguousarray(hidden_bf16, bfloat16)]
+        for p in range(_LM_N_PARTITIONS):
+            lm_inputs.append(self._lm_parts[p])
+            lm_inputs.append(np.zeros(_LM_N_PART, bfloat16))
+        res = self.cache.load_and_run(
+            "lm_head_gemv",
+            self._lm_backend,
+            *lm_inputs,
+            output_indices=[2 + 2 * p for p in range(_LM_N_PARTITIONS)],
+            static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+            intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        )
+        return np.concatenate(res, axis=0)[:VOCAB]
+
+    def _run_layer(self, x, k, N):
+        """One transformer block fully on-device via the llama32_3b stitchers
+        (rms+qkv+rope+attn in rms_gemms_rope+flash_attn, o+residual+rms+gate/up/
+        SiLU+down in o_ffn). Captures roped-K + raw-V into the KV cache."""
+        from llama32_3b_prefill import run_transformer_block
+
+        out, inter = self._dev(
+            run_transformer_block,
+            x,
+            self._weights.layers[k],
+            self._rope_lut,
+            self.config,
+            self.cache,
+            k,
+            False,
+            False,
+            tag="layer",
+        )
+        self.kv_k[k][:N] = np.asarray(inter["k_roped"], bfloat16)[:N]
+        self.kv_v[k][:N] = np.asarray(inter["v"], bfloat16)[:N]
+        return out
+
+    def prefill(self, ids, payload=None):
+        assert self._weights is not None, "call load_weights() first"
+        N = len(ids)
+        assert N <= self.seq, (N, self.seq)
+        base = self.current_context_length
+        x = np.zeros((self.seq, self.D), bfloat16)
+        x[:N] = _bf(np.stack([self._embed[t] for t in ids]))
+        for k in range(self.n_layers):
+            x = self._run_layer(x, k, N)
+        self.current_context_length = base + N
+        # Final RMSNorm on the single prediction row (host, <1ms), then NPU LM head.
+        xf = np.asarray(x[N - 1], np.float32)
+        xn = xf / np.sqrt((xf * xf).mean() + 1e-5) * self._final_norm
+        return self._dev(self._lm_head_npu, _bf(xn), tag="lm_head")
+
+    # ---- KV cache (causal_lm) ----
+    def get_k_cache(self, layer_idx, idx):
+        """Roped-K vector at position idx of a layer."""
+        return self.kv_k[layer_idx][idx]
+
+    def get_v_cache(self, layer_idx, idx):
+        """Raw-V vector at position idx of a layer."""
+        return self.kv_v[layer_idx][idx]
+
+    def kv_view(self, layer_idx):
+        """(roped_K, raw_V) for the filled context [0:ctx] of a layer -> decode handoff."""
+        c = self.current_context_length
+        return self.kv_k[layer_idx][:c], self.kv_v[layer_idx][:c]
+
+    def clear_context(self):
+        self.current_context_length = 0
+        for k in range(self.n_layers):
+            self.kv_k[k][:] = 0
+            self.kv_v[k][:] = 0
+
+    def get_current_context_length(self):
+        return self.current_context_length
+
+    def set_context_length(self, L):
+        self.current_context_length = L
+
+
+def _main():
+    ap = argparse.ArgumentParser(description="Llama-3.2-3B Q4NX prefill on NPU2")
+    ap.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="build/cache the prefill ELFs and exit (no weights, no NPU dispatch)",
+    )
+    ap.add_argument(
+        "--n-layers", type=int, default=int(os.environ.get("NLAYERS", "28"))
+    )
+    ap.add_argument(
+        "--seq-len",
+        type=int,
+        default=int(os.environ.get("Q4NX_SEQ_LEN", "2048")),
+        help="padded prefill length",
+    )
+    ap.add_argument("--cache-dir", default=os.environ.get("Q4NX_CACHE_DIR") or None)
+    ap.add_argument(
+        "--bench-l",
+        type=int,
+        default=int(os.environ.get("Q4NX_BENCH_L", "0")),
+        help="warm TTFT benchmark at this context length",
+    )
+    ap.add_argument(
+        "--model",
+        default=MODEL_DEFAULT,
+        help="weight source: HF repo id (model.q4nx) or a local dir/file "
+        f"(default: {MODEL_DEFAULT})",
+    )
+    args = ap.parse_args()
+
+    print(
+        f"[q4nx_prefill] constructing seq_len={args.seq_len} (compiling engines)...",
+        flush=True,
+    )
+    model = LlamaQ4nxPrefill(
+        seq_len=args.seq_len, n_layers=args.n_layers, cache_dir=args.cache_dir
+    )
+    # --compile-only: build/cache the ELFs and exit (no weights, no NPU dispatch).
+    # CI-runnable without the external Q4NX weight data.
+    if args.compile_only:
+        print("Compilation passed.", flush=True)
+        return 0
+    print("[q4nx_prefill] loading Q4NX weights (host dequant)...", flush=True)
+    model.load_weights(model=args.model)
+    print(f"[q4nx_prefill] prefill prompt N={len(PROMPT)} ...", flush=True)
+    logits = model.prefill(PROMPT)
+    top = int(np.asarray(logits).argmax())
+    print(
+        f"[q4nx_prefill] first-token argmax={top} (expect {EXPECT_FIRST} ' Paris')",
+        flush=True,
+    )
+    ok = top == EXPECT_FIRST
+    print("[q4nx_prefill] *** PARIS ***" if ok else "[q4nx_prefill] MISS", flush=True)
+
+    if args.bench_l:
+        import time
+
+        model.clear_context()
+        ids = [
+            int(t % VOCAB) for t in range(args.bench_l)
+        ]  # synthetic prompt (timing only)
+        print(f"[bench] warmup prefill L={args.bench_l}...", flush=True)
+        model.prefill(ids)
+        model.clear_context()
+        model._dev_t = 0.0
+        model._op_t.clear()
+        # Per-ELF BO-Write (host->dev DMA) vs NPU-Run (on-device) vs BO-Read split.
+        model.cache.profiler.enabled = True
+        for d in (
+            model.cache.profiler.kernel_times,
+            model.cache.profiler.cpu_times,
+            model.cache.profiler.kernel_breakdowns,
+        ):
+            d.clear()
+        model.cache.profiler.layer_times.clear()
+        print(f"[bench] timed prefill L={args.bench_l}...", flush=True)
+        t0 = time.time()
+        model.prefill(ids)
+        wall = time.time() - t0
+        npu = model._dev_t
+        print(
+            f"\n[bench] L={args.bench_l}: WALL={wall*1000:.0f}ms {args.bench_l/wall:.0f} tok/s prefill  |  "
+            f"NPU-dispatch={npu*1000:.0f}ms {args.bench_l/npu:.0f} tok/s  |  host={(wall-npu)*1000:.0f}ms",
+            flush=True,
+        )
+        # Machine-readable perf line for bench/extract_perf.py (TTFT = prefill wall;
+        # decode tok/s is reported separately by the inference path).
+        print(
+            f"[q4nx_prefill] Inference: prompt_len={args.bench_l}, n_tokens=0",
+            flush=True,
+        )
+        print(f"Time to first token (TTFT): {wall:.3f}s", flush=True)
+        print(
+            "[bench] per-op NPU: "
+            + "  ".join(
+                f"{k}={v*1000:.0f}ms"
+                for k, v in sorted(model._op_t.items(), key=lambda x: -x[1])
+            ),
+            flush=True,
+        )
+        model.cache.profiler.report()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -1,0 +1,287 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Reusable NPU2 fused-decode driver for Llama-3.2-3B Q4NX: the FLM-faithful on-device
+# decode (proj -> rope -> flash-attn with on-device KV -> o -> FFN x28 -> lm_head). Loads
+# the 3B fused_decode template + q4k-cascade requant weights + embed/final-norm from the
+# model.q4nx bundle, and exposes dispatch(tok, pos) -> logits. One ATTN_MAXL=2048 template
+# serves every context length via an RTP-L + KV-append insts patch (no CPU attention).
+# Shared by the Paris bring-up and the generate loop.
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_HERE = Path(__file__).resolve().parent
+_LLMS = _HERE.parent
+_PROG = _LLMS.parent
+_DEC = _PROG / "fused_decode"
+_1B = _LLMS / "llama32_1b_q4nx"
+for _p in (str(_PROG), str(_LLMS), str(_DEC), str(_1B), str(_HERE)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def llama3_rope(
+    n_pos,
+    dim,
+    theta=500000.0,
+    factor=32.0,
+    low_freq_factor=1.0,
+    high_freq_factor=4.0,
+    old_ctx=8192.0,
+):
+    """RoPE cos/sin [n_pos, dim] for Llama-3.2 (rope_theta=5e5 + llama3 freq scaling)."""
+    inv = 1.0 / (theta ** (np.arange(0, dim, 2) / dim))
+    low_wl = old_ctx / low_freq_factor
+    high_wl = old_ctx / high_freq_factor
+    wl = 2 * np.pi / inv
+    new = inv.copy()
+    for i in range(len(inv)):
+        if wl[i] > low_wl:
+            new[i] = inv[i] / factor
+        elif wl[i] < high_wl:
+            new[i] = inv[i]
+        else:
+            s = (old_ctx / wl[i] - low_freq_factor) / (
+                high_freq_factor - low_freq_factor
+            )
+            new[i] = (1 - s) * inv[i] / factor + s * inv[i]
+    fr = np.arange(n_pos)[:, None] * new[None, :]
+    emb = np.concatenate([fr, fr], axis=1)
+    return np.cos(emb).astype(np.float32), np.sin(emb).astype(np.float32)
+
+
+# fused_decode model key + vocab chunking. VOCAB_CHUNK_I2 must satisfy
+# (K/PAYLOAD) | VOCAB_I2*PAIR_ROWS -- 6 | 18 here -- or the vocab wave deadlocks;
+# it also has to match the model entry's UNI_LM (see fused_decode.py).
+DECODE_MODEL = "llama-3.2-3b"
+VOCAB_CHUNK_I2 = "9"
+
+
+def load_fd(model_type="LLAMA_3_2_3B"):
+    """Load the fused_decode module for the 3B geometry (unified decode+lm_head,
+    decode path enabled). `model_type` is the C++ -DMODEL_TYPE name; the Python
+    generator selects the same model with DECODE_MODEL."""
+    os.environ.update(
+        DECODE_MODEL=DECODE_MODEL,
+        VOCAB_CHUNK_I2=VOCAB_CHUNK_I2,
+        UNIFIED="1",
+        LM_HEAD="0",
+        NLAYERS="1",
+        DECODE_GOLDEN="1",
+        DECODE_GOLDEN_L="2048",
+    )
+    spec = importlib.util.spec_from_file_location("fu3b", str(_DEC / "fused_decode.py"))
+    fd = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fd)
+    return fd
+
+
+def ensure_requant_cache(model_source, fd, n_layers, wcache_dir=None, verbose=True):
+    """Return the q4k-cascade requant cache path, building it ONCE if missing. Keyed by
+    (n_layers, VOCAB_I2) -- the lm_head pack depends on VOCAB_I2, so a stale chunk size must
+    not be silently reused. A pre-versioning legacy file (VOCAB_I2-agnostic) is adopted once
+    under the versioned name."""
+    from q4nx_requant import build_requant_cache
+
+    wc = Path(wcache_dir) if wcache_dir else (_HERE / ".decode_wcache")
+    wc.mkdir(parents=True, exist_ok=True)
+    cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}.npz"
+    legacy = wc / f"q4nx_3b_decode_L{n_layers}.npz"
+    if cache.exists():
+        return str(cache)
+    if legacy.exists():
+        os.replace(str(legacy), str(cache))  # one-time migration; never re-requant
+        return str(cache)
+    if verbose:
+        print(
+            f"[q4nx-3b] requantizing {n_layers} decode layers + lm_head "
+            f"(VOCAB_I2={fd.VOCAB_I2}); cached ONCE to {cache}",
+            flush=True,
+        )
+    build_requant_cache(model_source, fd, str(cache), n_layers=n_layers)
+    return str(cache)
+
+
+EOS_IDS = (128001, 128009)  # <|end_of_text|>, <|eot_id|>
+
+
+def generate(dec, prompt_ids, n_tokens, greedy=True, sampler=None, stop_on_eos=True):
+    """Option (c) autoregressive generation: decode the prompt token-by-token through the
+    on-device fused decode (warming the on-device KV cache), then continue. dispatch(tok, p)
+    returns the logits predicting the token at position p+1. No CPU attention, no prefill.
+    """
+    import time
+
+    tokens = list(prompt_ids)
+    P = len(tokens)
+    if P >= dec.ATTN_MAXL:
+        raise RuntimeError(
+            f"prompt length {P} >= decode ATTN_MAXL {dec.ATTN_MAXL}; build a larger template"
+        )
+    cap = min(P + n_tokens, dec.ATTN_MAXL)
+
+    t0 = time.perf_counter()
+    logits = None
+    for p in range(P):  # consume the prompt; last logits predicts the first new token
+        logits = dec.dispatch(tokens[p], p)
+    t_prompt = time.perf_counter() - t0
+
+    gen = []
+    t1 = time.perf_counter()
+    for step in range(n_tokens):
+        pred = int(logits.argmax()) if greedy else sampler.sample(logits)
+        gen.append(pred)
+        if stop_on_eos and pred in EOS_IDS:
+            break
+        p = P + step
+        if step == n_tokens - 1 or p >= cap:
+            break
+        tokens.append(pred)
+        logits = dec.dispatch(pred, p)  # feed pred at position p -> logits for p+1
+    t_gen = time.perf_counter() - t1
+    if gen:
+        print(
+            f"[q4nx-3b] prompt {P} tok in {t_prompt:.2f}s; decode {len(gen)} tok in "
+            f"{t_gen:.2f}s ({len(gen) / max(t_gen, 1e-9):.1f} tok/s)",
+            flush=True,
+        )
+    return gen
+
+
+class FusedDecode3B:
+    """One-xclbin fused decode. dispatch(tok, pos) writes the token embedding + per-position
+    rope LUT, runs the 28-layer decode + lm_head on the AIE array (appending this token's
+    roped-K/raw-V into the on-device KV cache at slot `pos`), and returns the vocab logits.
+    The KV cache is device-resident and grown in place -- no CPU attention, no re-upload.
+    """
+
+    def __init__(self, model_source, templates, model_type="LLAMA_3_2_3B", max_L=None):
+        import pyxrt as xrt
+
+        self.xrt = xrt
+        fd = load_fd(model_type)
+        self.fd = fd
+        self.N_LAYERS = fd.UNI_DEC
+        self.DH = fd.DH
+        self.K = fd.K
+        self.VOCAB_SIZE = fd.VOCAB_SIZE
+
+        # decode weights (q4k-cascade requant) + embed/final-norm from the same model.q4nx
+        from llama32_1b_q4nx_weights import Q4nxModel
+
+        cache = ensure_requant_cache(model_source, fd, self.N_LAYERS)
+        z = np.load(cache)
+        W = z["W"].view(bfloat16)
+        Wv16 = W.view(np.int16)
+        RMS_in = list(z["RMS_in"].view(bfloat16))
+        RMS_post = list(z["RMS_post"].view(bfloat16))
+        qm = Q4nxModel(model_source)
+        embed, final_norm, _ = qm.embed_norm_lmhead()
+        self.embed = np.asarray(embed, np.float32).reshape(self.VOCAB_SIZE, self.K)
+        final_norm = np.asarray(final_norm, bfloat16)
+
+        from decode_insts_gen import DecodeInstsGen
+
+        self.gen = DecodeInstsGen(str(templates), max_L=max_L)
+        self.ATTN_MAXL = self.gen.attn_maxl
+        self.rope_cos, self.rope_sin = llama3_rope(self.ATTN_MAXL, self.DH)
+
+        RMS_LAYER = fd.RMS_LAYER
+        KVSZ_TOK = fd.KVSZ_TOK
+        self.VP = fd.VOCAB_SIZE_PADDED
+        self.decode_y = (fd.HOST_ROUNDS + fd.LAYER_RNDS) * fd.PAYLOAD
+        self.ny = self.decode_y + fd.UNI_LM * self.VP
+        self.LREG = self.ATTN_MAXL * KVSZ_TOK
+        RMS_SIZE = self.N_LAYERS * RMS_LAYER + self.DH + self.K
+        rms_slabs = np.concatenate(
+            [np.concatenate([RMS_in[k], RMS_post[k]]) for k in range(self.N_LAYERS)]
+        )
+
+        # XRT: one xclbin + one resident BO set (weights uploaded once)
+        self.dev = xrt.device(0)
+        self.TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        self.FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
+        xb = xrt.xclbin(self.gen.xclbin)
+        self.dev.register_xclbin(xb)
+        ctx = xrt.hw_context(self.dev, xb.get_uuid())
+        xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
+        self.kern = xrt.kernel(ctx, xk.get_name())
+        g = self.kern.group_id
+        HO = xrt.bo.host_only
+        self.x_bo = xrt.bo(self.dev, self.K * 2, HO, g(3))
+        self.w_bo = xrt.bo(self.dev, W.size * 2, HO, g(4))
+        self.r_bo = xrt.bo(self.dev, RMS_SIZE * 2, HO, g(5))
+        self.y_bo = xrt.bo(self.dev, self.ny * 2, HO, g(6))
+        self.kvc = xrt.bo(self.dev, self.N_LAYERS * self.LREG * 2, HO, g(7))
+        self.ib = xrt.bo(self.dev, self.gen.base.nbytes, xrt.bo.cacheable, g(1))
+
+        self.w_bo.write(Wv16, 0)
+        self.w_bo.sync(self.TO)
+        # KV cache seeded empty; the kernel appends each token in-place at slot `pos`.
+        self.reset_kv()
+        # RMS BO: [rms_slabs | DH-wide LUT slot | final_norm]; LUT patched per position.
+        rmsbuf = np.concatenate([rms_slabs, np.zeros(self.DH, bfloat16), final_norm])
+        self.r_bo.write(rmsbuf.view(np.int16), 0)
+        self.r_bo.sync(self.TO)
+        self.rms_lut_off = int(rms_slabs.size)
+
+        # insts base + the L-dependent word slope (RTP-L + KV-append offsets), from two builds.
+        i1 = self.gen.insts_for_L(1)
+        i2 = self.gen.insts_for_L(2)
+        self.ld = np.where(i1 != i2)[0]
+        self.ld_base = i1[self.ld].astype(np.int64)
+        self.ld_slope = i2[self.ld].astype(np.int64) - i1[self.ld].astype(np.int64)
+        self.insts_buf = i1.astype(np.uint32).copy()
+        self.insts_size = int(i1.size)
+        self.ib.write(self.insts_buf, 0)
+        self.ib.sync(self.TO)
+
+    def reset_kv(self):
+        """Zero the device-resident KV cache (start a fresh sequence)."""
+        KV = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
+        self.kvc.write(KV.view(np.int16), 0)
+        self.kvc.sync(self.TO)
+
+    def dispatch(self, tok, p):
+        """One decode step at context length L=p+1: patch insts for L, feed embed[tok] +
+        the position-p rope LUT, run the fused decode, return the vocab logits."""
+        L = p + 1
+        self.insts_buf[self.ld] = (self.ld_base + (L - 1) * self.ld_slope).astype(
+            np.uint32
+        )
+        self.ib.write(self.insts_buf, 0)
+        self.ib.sync(self.TO)
+        x0 = np.asarray(self.embed[tok], bfloat16)
+        h = self.DH // 2
+        lut = np.empty(self.DH, dtype=bfloat16)
+        lut[:h] = self.rope_cos[p][:h].astype(bfloat16)
+        lut[h:] = self.rope_sin[p][:h].astype(bfloat16)
+        self.r_bo.write(lut.view(np.int16), self.rms_lut_off * 2)
+        self.r_bo.sync(self.TO, self.DH * 2, self.rms_lut_off * 2)
+        self.x_bo.write(x0.view(np.int16), 0)
+        self.x_bo.sync(self.TO)
+        st = self.kern(
+            3,
+            self.ib,
+            self.insts_size,
+            self.x_bo,
+            self.w_bo,
+            self.r_bo,
+            self.y_bo,
+            self.kvc,
+        ).wait(60000)
+        if not str(st).endswith("COMPLETED"):
+            raise RuntimeError(f"decode dispatch pos{p} state={st}")
+        voc_n = self.fd.UNI_LM * self.VP
+        self.y_bo.sync(self.FROM, voc_n * 2, self.decode_y * 2)
+        yv = (
+            self.y_bo.read(voc_n * 2, self.decode_y * 2)
+            .view(bfloat16)
+            .astype(np.float32)
+        )
+        return yv[: self.VOCAB_SIZE]

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -312,9 +312,10 @@ class FusedDecode3B:
             raise RuntimeError(f"decode dispatch pos{p} state={st}")
         voc_n = self.fd.UNI_LM * self.VP
         self.y_bo.sync(self.FROM, voc_n * 2, self.decode_y * 2)
-        yv = (
-            self.y_bo.read(voc_n * 2, self.decode_y * 2)
-            .view(bfloat16)
-            .astype(np.float32)
-        )
+        # Zero-copy view into the BO (the shared infra's readback idiom, same
+        # as the 1B sibling): bo.read() returns a buffer whose stride metadata
+        # is pyxrt-build dependent, and .view() on it raises on some runners.
+        yv = np.frombuffer(
+            self.y_bo.map(), dtype=bfloat16, count=voc_n, offset=self.decode_y * 2
+        ).astype(np.float32)
         return yv[: self.VOCAB_SIZE]

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -247,6 +247,39 @@ class FusedDecode3B:
         self.kvc.write(KV.view(np.int16), 0)
         self.kvc.sync(self.TO)
 
+    def seed_kv(self, k_layers, v_layers):
+        """Seed the device KV cache from a prefill (the warm-start handoff).
+
+        `k_layers[L]` / `v_layers[L]` are [ctx, n_kv_heads*DH] roped-K / raw-V as
+        produced by llama32_3b_q4nx_prefill (head-major rows). The device cache is
+        REGION-major: per layer, NGRP K regions then NGRP V regions, each
+        ATTN_MAXL*REGION_W, with position p at p*REGION_W. Within a region the
+        heads served by that column group sit contiguously, so a head-major row
+        splits into NGRP contiguous REGION_W slices -- region gi takes columns
+        [gi*REGION_W, (gi+1)*REGION_W). Returns the seeded context length.
+        """
+        fd = self.fd
+        ctx = int(np.asarray(k_layers[0]).shape[0])
+        if ctx > self.ATTN_MAXL:
+            raise RuntimeError(
+                f"prefill ctx {ctx} exceeds decode ATTN_MAXL {self.ATTN_MAXL}"
+            )
+        region_stride = self.ATTN_MAXL * fd.REGION_W
+        buf = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
+        for L in range(self.N_LAYERS):
+            kL = np.asarray(k_layers[L], bfloat16).reshape(ctx, -1)
+            vL = np.asarray(v_layers[L], bfloat16).reshape(ctx, -1)
+            base = L * self.LREG
+            for gi in range(fd.NGRP):
+                cols = slice(gi * fd.REGION_W, (gi + 1) * fd.REGION_W)
+                kreg = base + gi * region_stride
+                vreg = base + (fd.NGRP + gi) * region_stride
+                buf[kreg : kreg + ctx * fd.REGION_W] = kL[:, cols].reshape(-1)
+                buf[vreg : vreg + ctx * fd.REGION_W] = vL[:, cols].reshape(-1)
+        self.kvc.write(buf.view(np.int16), 0)
+        self.kvc.sync(self.TO)
+        return ctx
+
     def dispatch(self, tok, p):
         """One decode step at context length L=p+1: patch insts for L, feed embed[tok] +
         the position-p rope LUT, run the fused decode, return the vocab logits."""

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_compile.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_compile.lit
@@ -6,9 +6,8 @@
 // no weight download (the kernels are weight-free; Q4NX only changes the host
 // weight source).
 //
-// NOT CI-triggered by design: the filename OMITS "peano", so the CI peano suite
-// (`lit --filter "peano"`) does not collect it. Run on demand:
-//   lit -v programming_examples/llms/llama32_3b_q4nx/run_npu2_compile.lit
+// Collected by `check-programming-examples-llms-compile`, which filters on the path
+// `llms/.*/run_npu2_compile` (not on a "peano" filename), like every other model.
 //
 // REQUIRES: ryzen_ai_npu2, peano
 //

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_profile.lit
@@ -1,18 +1,27 @@
-// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
 // llama32_3b_q4nx profiling: compile then profile on NPU2, capturing TTFT +
 // decode throughput into llama32_3b_q4nx.perf.json via bench/extract_perf.py.
-// Perf is best-effort; this test gates only that profiling ran end to end.
+// The value is what lands on the published benchmark page, so the CHECKs require
+// a parsed number: a driver whose print format drifts out of extract_perf.py's
+// regexes emits nulls, which would otherwise be a green run with a blank row.
 // Correctness is gated separately by run_npu2_verify.lit.
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2
+// `make compile-decode` (shared fused_decode templates, keyed by MODEL_TYPE) is
+// required for the same reason as in run_npu2_verify.lit -- hence llvm_link_pre23.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N_TOKENS=128 PROMPT="What is the capital of France?" | tee profile.txt
 // RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model llama32_3b_q4nx > llama32_3b_q4nx.perf.json
 // RUN: FileCheck %s < llama32_3b_q4nx.perf.json
 // CHECK: "model": "llama32_3b_q4nx"
+// CHECK: "ttft_ms": {{[0-9]}}
+// CHECK: "decode_tokens_per_sec": {{[0-9]}}
+// CHECK: "context_len": {{[0-9]}}

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_verify.lit
@@ -9,10 +9,16 @@
 //
 // Skips cleanly when HF_TOKEN is unset (reference + tokenizer downloads need it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2
+// `make compile-decode` is mandatory here, not an optimization: every model emits
+// the same decode_L<N>.* names into the shared fused_decode dir, so without it this
+// test would consume whichever model's templates ran last (llama32_1b_q4nx sorts
+// first). It is idempotent per MODEL_TYPE, hence llvm_link_pre23 below.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify
 // RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // CHECK: [verify] PASS

--- a/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
@@ -8,11 +8,14 @@ attention + KV cache on the AIE array (no CPU attention, no host KV). The
 reference is the HF **bf16** checkpoint, so the shared gate compares NPU-q4nx vs
 HF-bf16 top-k token-set inclusion — the closest proxy for "matches FLM's 3B".
 
-There is no separate prefill kernel: `prefill()` consumes the prompt token-by-token
-through the on-device decode (warming the device KV cache), exactly like the
-production driver. `layer_intermediates` / `final_hidden_normed` are therefore not
-produced — the per-layer `diagnosis` lens is unavailable for this example; the
-token-set gate is the PASS/FAIL signal.
+`prefill()` mirrors the production driver: prompts of at least PREFILL_MIN_TOKENS
+run through the batched NPU prefill (llama32_3b_q4nx_prefill), whose per-layer
+roped-K / raw-V seed the decode's device KV cache; shorter prompts are replayed
+through the decode (cheaper than a padded prefill). `decode_step()` then dispatches
+one fused token. Q4NX_VERIFY_FORCE_PREFILL=1 forces the prefill path for handoff
+coverage; Q4NX_VERIFY_NO_PREFILL=1 forces the replay path. `layer_intermediates` / `final_hidden_normed` are not produced --
+the fused decode runs all 28 layers in one dispatch, so the per-layer `diagnosis`
+lens is unavailable here; the token-set gate is the PASS/FAIL signal.
 
 Pointed at via `--runner=llama32_3b_q4nx.verify_adapter`.
 """
@@ -37,6 +40,7 @@ for _p in (str(_LLMS_DIR), str(_VERIFY), str(_LLAMA3B), str(_THIS_DIR)):
 from llama32_3b_weights import LlamaConfig  # noqa: E402
 from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
 from q4nx_decode_3b import FusedDecode3B  # noqa: E402
+from llama32_3b_q4nx_inference import PREFILL_MIN_TOKENS  # noqa: E402
 
 MODEL_CHOICES = {
     "base": "meta-llama/Llama-3.2-3B",
@@ -50,6 +54,10 @@ Q4NX_MODEL_SOURCE = os.environ.get("Q4NX_MODEL_SOURCE", "FastFlowLM/Llama-3.2-3B
 # Templates are built into this example's directory by `make compile-decode`, the
 # same place the production driver loads them from.
 DECODE_TEMPLATES = os.environ.get("DECODE_TEMPLATES", str(_THIS_DIR))
+# Padded prefill length (the prefill ELFs are compiled for it).
+PREFILL_SEQ_LEN = int(os.environ.get("Q4NX_SEQ_LEN", "2048"))
+# Same crossover the production driver uses (see llama32_3b_q4nx_inference).
+PREFILL_MIN_TOKENS = int(os.environ.get("Q4NX_PREFILL_MIN", "96"))
 
 
 def resolve_model(model_choice_or_id: str) -> str:
@@ -76,12 +84,41 @@ class FusedDecodeRunner:
             raise RuntimeError(
                 f"max_seq {max_seq} exceeds decode ATTN_MAXL {self._dec.ATTN_MAXL}"
             )
+        # Mirror the production driver: it only uses the batched prefill for prompts
+        # at least PREFILL_MIN_TOKENS long (a padded prefill costs more than replaying
+        # a short prompt through the decode). Building it unconditionally here would
+        # gate a path users never hit for short prompts. Q4NX_VERIFY_FORCE_PREFILL=1
+        # forces it on (covers the prefill->decode KV handoff); NO_PREFILL=1 forces off.
+        self._force_pf = os.environ.get("Q4NX_VERIFY_FORCE_PREFILL") == "1"
+        self._no_pf = os.environ.get("Q4NX_VERIFY_NO_PREFILL") == "1"
+        self._model_source = model_source
+        self._pf = None  # built lazily: only a long enough prompt needs it
+
+    def _prefiller(self):
+        if self._pf is None:
+            from llama32_3b_q4nx_prefill import LlamaQ4nxPrefill
+
+            self._pf = LlamaQ4nxPrefill(
+                seq_len=int(os.environ.get("Q4NX_SEQ_LEN", "2048")),
+                n_layers=self._dec.N_LAYERS,
+            )
+            self._pf.load_weights(model=self._model_source)
+        return self._pf
 
     def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
-        self._dec.reset_kv()
-        logits = None
-        for p, t in enumerate(np.asarray(prompt_tokens).reshape(-1).tolist()):
-            logits = self._dec.dispatch(int(t), p)
+        toks = [int(t) for t in np.asarray(prompt_tokens).reshape(-1)]
+        if not self._no_pf and (self._force_pf or len(toks) >= PREFILL_MIN_TOKENS):
+            pf = self._prefiller()
+            pf.clear_context()
+            logits = np.asarray(pf.prefill(toks), np.float32)
+            kvs = [pf.kv_view(L) for L in range(self._dec.N_LAYERS)]
+            self._dec.reset_kv()
+            self._dec.seed_kv([k for k, _ in kvs], [v for _, v in kvs])
+        else:
+            self._dec.reset_kv()
+            logits = None
+            for p, t in enumerate(toks):
+                logits = self._dec.dispatch(t, p)
         return PrefillRecord(
             layer_intermediates=[],  # single-dispatch superkernel: not observable
             final_hidden_normed=np.empty(0, np.float32),

--- a/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
@@ -99,7 +99,7 @@ class FusedDecodeRunner:
             from llama32_3b_q4nx_prefill import LlamaQ4nxPrefill
 
             self._pf = LlamaQ4nxPrefill(
-                seq_len=int(os.environ.get("Q4NX_SEQ_LEN", "2048")),
+                seq_len=PREFILL_SEQ_LEN,
                 n_layers=self._dec.N_LAYERS,
             )
             self._pf.load_weights(model=self._model_source)

--- a/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
@@ -1,15 +1,18 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Verify adapter for the Q4NX Llama-3.2-3B example.
+"""Verify adapter for the Q4NX Llama-3.2-3B example (FLM-faithful decode).
 
-The NPU runs the FastFlowLM 4-bit `model.q4nx` weights (dequant'd to bf16); the
-reference is the HF **bf16** checkpoint. So the shared verify gate compares
-NPU-q4nx vs HF-bf16 (top-k token-set inclusion) — the closest proxy for "matches
-FLM's 3B behavior".
+Drives the SAME on-device path `make run` uses: the fused_decode superkernel with
+attention + KV cache on the AIE array (no CPU attention, no host KV). The
+reference is the HF **bf16** checkpoint, so the shared gate compares NPU-q4nx vs
+HF-bf16 top-k token-set inclusion — the closest proxy for "matches FLM's 3B".
 
-The NPU runner itself is weight-source-agnostic, so we reuse `NpuRunner` from the
-bf16 llama32_3b adapter verbatim and only swap the weight loader.
+There is no separate prefill kernel: `prefill()` consumes the prompt token-by-token
+through the on-device decode (warming the device KV cache), exactly like the
+production driver. `layer_intermediates` / `final_hidden_normed` are therefore not
+produced — the per-layer `diagnosis` lens is unavailable for this example; the
+token-set gate is the PASS/FAIL signal.
 
 Pointed at via `--runner=llama32_3b_q4nx.verify_adapter`.
 """
@@ -20,19 +23,20 @@ import os
 import sys
 from pathlib import Path
 
+import numpy as np
+
 _THIS_DIR = Path(__file__).resolve().parent
 _LLMS_DIR = _THIS_DIR.parent
 _VERIFY = _LLMS_DIR / "verify"
 _LLAMA3B = _LLMS_DIR / "llama32_3b"
-_LLAMA1B = _LLMS_DIR / "llama32_1b"
-for _p in (str(_LLMS_DIR), str(_VERIFY), str(_LLAMA3B), str(_LLAMA1B), str(_THIS_DIR)):
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_LLAMA3B), str(_THIS_DIR)):
     while _p in sys.path:
         sys.path.remove(_p)
     sys.path.insert(0, _p)
 
-# Reuse the bf16 3B runner + config verbatim.
-from llama32_3b.verify_adapter import NpuRunner, build_config  # noqa: E402
-from llama32_3b_q4nx_weights import load_q4nx_weights  # noqa: E402
+from llama32_3b_weights import LlamaConfig  # noqa: E402
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+from q4nx_decode_3b import FusedDecode3B  # noqa: E402
 
 MODEL_CHOICES = {
     "base": "meta-llama/Llama-3.2-3B",
@@ -40,9 +44,12 @@ MODEL_CHOICES = {
 }
 DEFAULT_MODEL = "instruct"
 
-# NPU weight source (model.q4nx bundle). The `model_name` selects tokenizer + HF
-# bf16 reference; the NPU weights always come from here.
+# NPU weight source (model.q4nx bundle). `model_name` selects tokenizer + HF bf16
+# reference; the NPU weights always come from here.
 Q4NX_MODEL_SOURCE = os.environ.get("Q4NX_MODEL_SOURCE", "FastFlowLM/Llama-3.2-3B-NPU2")
+# Templates are built into this example's directory by `make compile-decode`, the
+# same place the production driver loads them from.
+DECODE_TEMPLATES = os.environ.get("DECODE_TEMPLATES", str(_THIS_DIR))
 
 
 def resolve_model(model_choice_or_id: str) -> str:
@@ -54,6 +61,41 @@ def hf_reference(npu_model_name: str) -> str:
     return npu_model_name
 
 
+def build_config():
+    return LlamaConfig()
+
+
+class FusedDecodeRunner:
+    """Runner over the FLM-faithful fused decode (28 layers + LM head per dispatch)."""
+
+    name = "npu-q4nx-3b-fused-decode"
+
+    def __init__(self, model_source, templates, max_seq):
+        self._dec = FusedDecode3B(model_source, templates)
+        if max_seq > self._dec.ATTN_MAXL:
+            raise RuntimeError(
+                f"max_seq {max_seq} exceeds decode ATTN_MAXL {self._dec.ATTN_MAXL}"
+            )
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        self._dec.reset_kv()
+        logits = None
+        for p, t in enumerate(np.asarray(prompt_tokens).reshape(-1).tolist()):
+            logits = self._dec.dispatch(int(t), p)
+        return PrefillRecord(
+            layer_intermediates=[],  # single-dispatch superkernel: not observable
+            final_hidden_normed=np.empty(0, np.float32),
+            logits_at_pred=logits,
+            top1_token=int(np.argmax(logits)),
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        logits = self._dec.dispatch(int(input_token), int(current_pos))
+        return DecodeStepRecord(
+            lm_head_logits=logits, top1_token=int(np.argmax(logits))
+        )
+
+
 def build_runner(
     model_name: str,
     config,
@@ -63,13 +105,10 @@ def build_runner(
     npu_attn: bool = True,
     lite_mode: bool = False,
 ):
-    """Load Q4NX weights (dequant->bf16), compile NPU kernels, return NpuRunner."""
-    weights = load_q4nx_weights(Q4NX_MODEL_SOURCE, config=config)
-    return NpuRunner(
-        weights=weights,
-        config=config,
-        max_seq=max_seq,
-        tokenizer=tokenizer,
-        npu_attn=npu_attn,
-        lite_mode=lite_mode,
-    )
+    """Attention is ALWAYS on the NPU here (that is the point of this example)."""
+    if not npu_attn:
+        raise ValueError(
+            "llama32_3b_q4nx runs attention on the NPU by design; npu_attn=False "
+            "is not supported (that was the unfaithful CPU-attention path)."
+        )
+    return FusedDecodeRunner(Q4NX_MODEL_SOURCE, DECODE_TEMPLATES, max_seq)

--- a/programming_examples/llms/shared/infra/external_kernels.py
+++ b/programming_examples/llms/shared/infra/external_kernels.py
@@ -226,8 +226,10 @@ def compile_attn_npu2(
 
     Args:
         head_dim: full head dimension (-> dk_full / dv_full).
-        lkp: K/V chunk size per tile (= dk/dv tile). Defaults to head_dim
-            (legacy hd==lkp behavior).
+        lkp: K/V chunk size per tile -- how much of the K/V sequence a tile
+            holds at once. Defaults to head_dim (legacy hd==lkp behavior).
+            It also supplies the DEFAULT d tile, but the two are independent:
+            pass dk_tile/dv_tile to set the d tile separately.
         lqp_tile: Q tile size (tile_size_q). Defaults to lkp.
         dk_tile / dv_tile: the K/V dimension TILE. Default to lkp (the kernel
             slices d into lkp-wide chunks). The temporal-causal kernel keeps d


### PR DESCRIPTION
## What

Makes the Llama-3.2-3B Q4NX decode run **entirely on the NPU** — the whole decoder layer including attention, with an on-device KV cache and one dispatch per token — instead of falling back to host attention, and adds the 3B prefill engine + KV handoff that feeds it.

Rebased onto current `main`, which now carries #1773, #1775, Gemma3-4B (#1772) and Qwen2.5-3B (#1777). Gemma generalized `fused_decode` while this branch was open, so the 3B port has been re-expressed on top of that work rather than alongside it: what used to be a parallel parameterization is now **one more `_MODELS` entry** plus the `models/llama3.2-3b.h` kernel header, and templates are built per example exactly as `gemma3_4b_q4nx` does. `rope.cc`'s bf16 `aie::neg` deadlock fix landed upstream in the meantime and is no longer part of this branch.

Five commits:

- **FLM-faithful Llama-3.2-3B on-NPU decode.** Adds the `llama-3.2-3b` entry to `fused_decode`'s `_MODELS` table (K=3072, M=5120, DH=128, GQA 24/8) and `models/llama3.2-3b.h`. `llama32_3b_q4nx` gains `q4nx_decode_3b.py`, which drives the superkernel: proj → RoPE → flash-attention over the on-device KV → o → FFN, ×28 layers, then the LM head, all resident.
- **3B Q4NX NPU prefill + KV handoff.** `llama32_3b_q4nx_prefill.py` runs the padded prefill on the NPU and hands the resulting per-layer roped-K / raw-V to the decode, so a long prompt is not replayed token-by-token.
- **Make the 3B Q4NX example's CI signal real.** Templates now build into the example's own directory (every model emits the same `decode_L<N>.*` names, so in the nightly — where `llama32_1b_q4nx` sorts first — the 3B lits would otherwise have consumed 1B templates: wrong geometry, fluent garbage, no error), the lits build them first, and the driver emits the canonical profile lines so the published benchmark row is not null against a green lit.
- **Review fixes.** BO readback idiom, a dead constant, the `lkp` docstring.
- **Default the 3B prefill to the temporal-causal FA.** #1773 shipped the seq-first temporal-causal FlashAttention behind `TEMPORAL_CAUSAL_SKIP=1`, off by default, so nothing that ships selected it. It is now the default wherever `fa_temporal.supports()` maps the shape; `TEMPORAL_CAUSAL_SKIP=0` forces head-first back.

Two 3B-specific bring-up fixes are worth calling out, because each was a silent deadlock or silent corruption:

- `attn_kv.cc` `scale_div_aie` (the `ATTN_IMPL_2x4x1` branch) reads its accumulator at **padded** q-head slots but must write `o` **packed**. 3B pads 3 q-heads per group to 4, so the two layouts differ and attention output landed at the wrong head offsets. At 1B they coincide, which is why this only ever bit 3B.
- `VOCAB_CHUNK_I2` must be 9 at 3B, not the 1B default of 14. The vocab relay drains whole-K blocks, so `(K / PAYLOAD)` must divide `VOCAB_I2 * PAIR_ROWS`; 14 truncates at K=3072 and deadlocked the lm_head wave with no diagnostic. The example pins 9 and `fused_decode` now asserts the divisibility at build time.

One bug the FA default flip exposed: the q4nx prefill keyed its ELF cache on `seq_len` alone and skipped compilation whenever `rms_gemms_rope` and `o_ffn` were present — `flash_attn` was not in that set — so an existing head-first cache would have been reused under the temporal wrapper. The two wrappers disagree on operand layout, so that permutes the data silently. The directory is now keyed on the FA variant too.

## Measured (NPU2 Strix, turbo)

Kernels and templates rebuilt from source on this `main` with an `llvm-link` matching Peano's LLVM major, as `fused_decode`'s preflight requires.

| | |
|---|---|
| 3B decode | **20.8 tok/s** (48.0 ms/tok), 28 layers + LM head on-device, one dispatch/token |
| 3B prefill | 824 tok/s @ 2048 ctx (33.68 → 26.35 ms/layer attention, 2692.8 → 2484.1 ms end to end) |
| 1B decode (regression) | 47.2 tok/s, unchanged path |

For reference, FastFlowLM's own 3B decode measures ~19.6 TPS on the same machine.

The prefill gain is the seq-first layout dropping the host transposes the head-first wrapper needs, not causal skipping: at 2048 context the design runs 8 q-rounds and the uniform-prefix rule has the triangle off.

## Validation

All re-run on this `main` after the rebase, with `TEMPORAL_CAUSAL_SKIP` unset so the default path is what runs:

- 3B prefill Paris gate: first-token argmax 12366 (`" Paris"`), log shows `flash_attn (seq-first TEMPORAL-CAUSAL FA, head_dim=128)`.
- 3B `make verify` with `Q4NX_VERIFY_FORCE_PREFILL=1` (top-k token-set vs HF bf16, 2 prompts × 32 tokens): **2/2 PASS**. The forced flag matters — the verify prompts are shorter than the 96-token prefill crossover, so a plain `make verify` never touches the prefill.
- `llama32_3b` bf16 `make verify` (shares the flipped selection): **2/2 PASS**.
- 3B decode output coherent and factually correct across a 48-token continuation.
- **Faithfulness checked, not assumed:** `grep` for `decode_attention_cpu` / `attention_reference` / host softmax across the 3B decode path returns zero hits; the KV cache is a device buffer.
- 1B regression: rebuilt from the same generator, prefill first token 12366, decode 47.2 tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
