### PR TITLE
Add Qwen2.5-3B on NPU2: Q4_0 prefill + fused decode

### DIFF
--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -1,0 +1,2153 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-3B decode layer — AIR reimplementation (SKELETON, stage 1: proj grid).
+#
+# WHY A SEPARATE FILE: fused_decode.py (the Llama-1B design) is explicitly NOT
+# parametrized — it is hardcoded to the the Llama proj CASCADE topology (16 cores as
+# 8 lead+partner pairs at cols {0,1,6,7}, group/main memtiles). The reference's Qwen2.5 decode
+# layer uses a DIFFERENT device topology (verified by IR diff of the reference
+# LLAMA_3_2_1B layer IR vs the reference QWEN2_3B layer IR):
+#   proj = INDEPENDENT 4x4 SPMD grid, cols {2,3,4,5} x rows {2,3,4,5}, NO cascade;
+#          each core writes only its own y buffer, packet-routed by phase-id to its
+#          OWN per-column memtile (mem_tile_C_1, DMA 0-3 = rows 2-5).
+#   rms=tile(1,2) rope=tile(1,3) glu=tile(6,2) attn=col7 (2 CUs).
+# Keeping this in a separate builder leaves the Llama path byte-identical.
+#
+# SHIM/MEMTILE HOPPING (mirrors reference Qwen flows; cores NEVER touch shim directly):
+#   X BROADCAST : host -> X memtile (col 1, reference mem_tile_1_1) -> inX broadcast to all 16.
+#   WEIGHTS     : host -> per-column W memtile (col 2+cx) -> wL2ToL1 fan to that col's 4 cores.
+#   OUTPUT      : core -> per-column gather memtile (col 2+cx) -> outY -> shim drain.
+# This spreads shim DMA per-column (like the reference: shim_C_0 DMA0,1 -> mem_C_1) instead of
+# collapsing 16 per-core routes onto one centroid shim tile. Reuses the two-hop staging
+# pattern from fused_decode.py (_feed_inX / weight-fan / egress).
+#
+# proj SPMD contract (the reference proj kernel + array layout):
+#   MVM_CORES=16; each core computes M_total/16 output rows per phase, in m=32-row
+#   blocks (outer i loop), contracting K in k=256 col-blocks (inner j loop). Each
+#   32-row block is emitted as ONE packet: y buffer = 16 hdr + 32 payload = 48,
+#   pkt_id at y+14 (proj_qmm_flush_hdr writes exactly *(u32)(y+14)=id; copy<32>(y+16)).
+#   Phases (IS_ATTN==1): ph1 QKV M=2560 K=2048 ->5 rnd pkt1->ROPE; ph2 oproj M=2048
+#   K=2048 ->4 rnd pkt4->RMS; ph3 gateup M=22528 K=2048 ->44 rnd pkt8->GLU; ph4 down
+#   M=2048 K=11264 ->4 rnd pkt4->RMS. round-major core-interleave: round r core c emits r*16+c.
+#
+# STAGE 1 (this file): QKV-only proj grid, host-fed X/W (memtile-staged), per-col gather.
+# Goal = lower clean through aircc + IR-diff the proj-tile region vs the reference QWEN2_3B layer IR.
+import argparse
+import os as _os
+
+from air.ir import (
+    ArrayAttr,
+    BF16Type,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    IntegerType,
+    IntegerAttr,
+    MemRefType,
+    StringAttr,
+    UnitAttr,
+)
+from air.dialects.air import (
+    Channel,
+    ChannelGet,
+    ChannelPut,
+    MemorySpace,
+    T,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects.air import channel as channel_decl
+from air.dialects.func import FuncOp, CallOp
+from air.dialects.memref import AllocOp, DeallocOp
+from air.dialects import arith
+from air.dialects.scf import for_, yield_, index_switch, IfOp
+from air.backend.xrt import XRTBackend
+
+# ============================ Qwen2.5-3B config =============================
+MODEL_DIM = 2048
+K = MODEL_DIM
+ROW_BLOCK = 32  # Q4NX_ROW_BLOCK_SIZE (m)
+COL_BLOCK = 256  # Q4NX_COL_BLOCK_SIZE (k)
+GROUP = 32  # Q4NX_GROUP_SIZE
+BLOCK_BF16 = 2560  # one packed q4k block (bf16 units)
+
+MVM_CORES = 16
+NCX = 4  # proj grid columns (physical cols 2,3,4,5)
+NCY = 4  # proj grid rows (physical rows 2,3,4,5)
+PROJ_COL0 = 2  # physical column of grid tx=0
+PROJ_ROW0 = 2  # physical row of grid ty=0
+# X broadcast memtile column (reference mem_tile_1_1 = the hub column). NOTE Llama puts its X
+# memtile on a column SEPARATE from its hub (col2 vs col1); QWEN_XMT_COL overrides for
+# the loopclose bisect.
+XMT_COL = int(_os.environ.get("QWEN_XMT_COL", "1"))
+# X memtile get granularity (one packet per BD on the @xnorm packet channel).
+XCH = 2 * COL_BLOCK
+# attn-o (ph1 X) refeed memtile column. Default 6 (next to attn col 7), but that makes
+# the oref -> @xnorm -> X memtile(col 1) hop cross the BUSY proj grid (cols 2-5) -- the
+# same cross-column class as the glu bug. QWEN_OREF_COL overrides for the bisect.
+OREF_COL = int(_os.environ.get("QWEN_OREF_COL", "6"))
+# QWEN_OREF_NOPUT=1 (bisect): oref still GATHERS attnO (nothing dangles) but does NOT
+# re-broadcast it as ph1's X; the rms core supplies ph1 X instead (numerically wrong,
+# topology-only). Isolates the oref -> @xnorm -> X memtile path from proj ph1 itself.
+OREF_NOPUT = int(_os.environ.get("QWEN_OREF_NOPUT", "0"))
+# QWEN_OREF_VIA_RMS=1: the attn-o gather memtile does NOT feed @xnorm directly. It hands
+# the gathered o to the rms core over @orms, and the rms core re-emits it as ph1's X on
+# @xnorm (per-put air.refeed_count = OPROJ_REFEED). That makes the rms tile the ONLY
+# physical producer into the hub X ring -- exactly the shape that PASSES at NPH=2 when the
+# oref put is removed (QWEN_OREF_NOPUT=1) -- while keeping the real attn data. Isolates
+# "a second physical X producer starves ph0" from "the attn data itself starves ph0".
+# NOTE: QWEN_PH1_XCHAN is NOT a valid test of the same question -- it turns the hub's X
+# broadcast MM2S into a rigid ph0/ph1 round-robin, which cannot serve 5 ph0 sends then 4
+# ph1 sends and so deadlocks for its own reason (device+IR confirmed 2026-08-05v).
+# QWEN_ORMS_HOST=1 (bisect, requires QWEN_OREF_VIA_RMS=1): feed @orms from the HOST instead
+# of from the attn-o gather memtile, and drain attnO to the host as usual. Splits "the
+# rms-side @orms get + ph1 @xnorm re-emit" from "the attn -> oref memtile -> rms transport".
+ORMS_HOST = int(_os.environ.get("QWEN_ORMS_HOST", "0"))
+# QWEN_OREF_NOCHAIN=1: tag the attn-o gather buffer air.no_chain_lock so the two CU gets do
+# NOT daisy-chain (CU1's write waiting on CU0's). The two attn CUs are cross-coupled through
+# the shared-L1 score buffer, so serializing their outputs can deadlock the pair.
+OREF_NOCHAIN = int(_os.environ.get("QWEN_OREF_NOCHAIN", "0"))
+# QWEN_OREF_DRAIN=1 (bisect, use with QWEN_ORMS_HOST=1): keep the oref memtile GATHER of the
+# two attn CU outputs, but drain the gathered buffer to the host instead of putting @orms
+# (which is host-fed in that mode). Exercises the attn -> oref-memtile leg on its own,
+# without the oref -> rms hop. Coherent: nothing dangles, and the drain keeps the gather
+# live so AIR cannot DCE it (the QWEN_OREF_NOPUT=2 trap).
+OREF_DRAIN = int(_os.environ.get("QWEN_OREF_DRAIN", "0"))
+# QWEN_OREF_HOSTSRC=1 (bisect, use with QWEN_OREF_VIA_RMS=1): the oref memtile is fed from
+# the HOST instead of from attnO (attnO drains to host as usual), but still puts @orms to
+# the rms core over the identical on-chip path. Splits "memtile -> rms transport" from
+# "@orms depends on attn finishing". Host-fed-at-the-CHANNEL (QWEN_ORMS_HOST) already passes,
+# so this pins down whether the memtile hop or the attn dependency is the blocker.
+OREF_HOSTSRC = int(_os.environ.get("QWEN_OREF_HOSTSRC", "0"))
+# QWEN_PH1_XCHAN=1 (diagnostic): give ph1 its own X channel @xnorm2 instead of sharing
+# the convergent @xnorm with the rms ph0 producer.
+PH1_XCHAN = int(_os.environ.get("QWEN_PH1_XCHAN", "0"))
+ROPE_KV_FIRST = int(_os.environ.get("QWEN_ROPE_KV_FIRST", "0"))
+# q-broadcast memtile column (default 6). At 6 it shares mem_6_1 with the oref gather, so
+# ONE memtile both FEEDS attn (toAttnQ) and CONSUMES attn output (attnO). QWEN_QMT_COL=7
+# co-locates the q-broadcast with the attn column and leaves mem_6_1 to oref alone.
+QMT_COL = int(_os.environ.get("QWEN_QMT_COL", "6"))
+EGR_RNDS = int(_os.environ.get("QWEN_EGR_RNDS", "0"))  # 0 = all DEST_TOTAL rounds
+# QWEN_OREF_2HOP=1: split the attn-o gather from the refeed across TWO memtile buffers so
+# the REFEED buffer has exactly ONE fill BD. AIR scales EVERY fill BD of a refeed buffer by N
+# (AIRToAIEPass.cpp:6492); with the 2-CU gather that creates an intermediate xN lock link that
+# The reference Qwen design does NOT have (the reference: xN only on the LAST fill, intermediate link = 1).
+OREF_2HOP = int(_os.environ.get("QWEN_OREF_2HOP", "0"))
+OREF2_COL = int(_os.environ.get("QWEN_OREF2_COL", "0"))
+# QWEN_ROPE_ECHO=1 (witness/experiment): rope drains the qkv it RECEIVED straight to the
+# host instead of emitting ropeQ. attn then never gets q, so the ph0->rope->attn->oref->ph1-X
+# feedback loop is BROKEN while the oref memtile still exists and is armed. If the echo shows
+# up in Y, the ph0 egress is healthy with oref present and the blocker is the loop dynamics;
+# if Y stays zero, an armed-but-unfilled oref alone starves the ph0 egress.
+ROPE_ECHO = int(_os.environ.get("QWEN_ROPE_ECHO", "0"))
+# QWEN_NO_AWAIT_APPENDS=1 (experiment): drop the append->readback RAW barrier so the KV
+# readback is issued immediately. Combined with QWEN_ROPE_ECHO this fully decouples attn
+# (host q + host KV) from ph0, leaving oref structurally present but dependency-free.
+NO_AWAIT_APPENDS = int(_os.environ.get("QWEN_NO_AWAIT_APPENDS", "0"))
+# QWEN_XN_SPLIT=1: emit the ph0 X at the consumer granularity (1 put per get) instead
+# of one whole-K put re-fed XN_REFEED times. See the rms body for the rationale.
+XN_SPLIT = int(_os.environ.get("QWEN_XN_SPLIT", "0"))
+
+DQ = 2048  # NUM_ATTN_HEADS(16) * DH(128)
+DK = 256  # NUM_KV_HEADS(2) * DH(128)
+DV = 256
+# 11008 padded to a multiple of GLU_HID(512) *whose glu trip count NGLU//2 IS EVEN*.
+# 11264 (NGLU=22 -> 11 iterations, ODD) is the natural pad and it CORRUPTS the MLP:
+# AIR unrolls the 2-slice glu loop by 2, and an odd trip count leaves a 2-slice
+# REMAINDER EPILOGUE, so the core lowers to 6 glu_aie calls (4 in the loop + 2 peeled)
+# with a non-uniform lock/release tail and a 4+2 = 6-deep ring. The down X then loses
+# 2 of every 6 chunks and backfills them with stale ones -- device-measured
+# [h0 h1 h2 h3 . . h0 h1 h8 h9 . . h12..h15 . . h12..h15], full-layer cos 0.805.
+# 12288 (NGLU=24 -> 12 iterations, EVEN) unrolls cleanly: 4 calls, uniform 4-deep ring,
+# locks 4/4, full-layer cos 0.998789. The extra pad rows are quantized zeros, so
+# silu(0)*0 = 0 and down's pad columns contribute nothing -- numerics are unchanged.
+# This is exactly why AIR-Llama never showed the bug: its NGLU//2 is 16, already even.
+INTERMEDIATE = int(_os.environ.get("QWEN_INTERMEDIATE", "12288"))
+
+HDR = 16  # y buffer header region (pkt_id at +14)
+YBUF = HDR + ROW_BLOCK  # 48
+PKT_OFF = 14  # dma egress start offset (2 id words + 32 payload)
+PKT_PAY = 2 + ROW_BLOCK  # 34 (matches reference dma_bd %y,14,34)
+
+PKT_ROPE = 1
+PKT_RMS = 4
+PKT_GLU = 8
+PHASES = [
+    ("qkv", DQ + DK + DV, MODEL_DIM, PKT_ROPE),
+    ("oproj", MODEL_DIM, DQ, PKT_RMS),
+    ("gateup", 2 * INTERMEDIATE, MODEL_DIM, PKT_GLU),
+    ("down", MODEL_DIM, INTERMEDIATE, PKT_RMS),
+]
+RB = [m // MVM_CORES // ROW_BLOCK for (_, m, _, _) in PHASES]  # [5,4,44,4]
+NJ = [kk // COL_BLOCK for (_, _, kk, _) in PHASES]  # [8,8,8,44]
+
+# STAGE 2: all 4 proj phases (QKV, o-proj, gate-up, down). vocab (IS_ATTN=0) later.
+# QWEN_NPH = phase-isolation bisection (use ONLY with QWEN_ATTN=0): build just the
+# first N proj phases. NPH=1 = QKV-only (pkt1 -> rope), the earliest phase (the hang
+# is early). Since the truncated phases' packet ids (pkt4 rms / pkt8 glu) are no longer
+# produced, the rms/glu herds + their host feeds/drains + DEST lookups are gated off
+# (HAS_RMS/HAS_GLU below) so the build stays COHERENT (no consumer waits on a packet id
+# that is never emitted = would be a FALSE deadlock). If phase0+feeds COMPLETE alone ->
+# the hang is a multi-phase/phase-transition interaction; if phase0 alone HANGS -> it's
+# the core X/weight-feed + phase-0 egress->rope path.
+import os as _os
+
+NPH = int(_os.environ.get("QWEN_NPH", "4"))
+_RB = RB[:NPH]
+_NJ = NJ[:NPH]
+_PKT = [p[3] for p in PHASES][:NPH]
+_MTOT = [p[1] for p in PHASES][:NPH]
+# distinct packet ids (ordered) for the id-demux egress: 1->rope, 4->rms, 8->glu.
+DEMUX_IDS = list(dict.fromkeys(_PKT))  # [1, 4, 8]
+NDEST = len(DEMUX_IDS)
+# egress rounds per dest (id): rope=QKV(5); rms=oproj(4)+down(4)=8; glu=gateup(44).
+DEST_RNDS = [sum(_RB[p] for p in range(NPH) if _PKT[p] == d) for d in DEMUX_IDS]
+DEST_TOTAL = sum(DEST_RNDS)  # 57 rounds total
+PAYLOAD = MVM_CORES * ROW_BLOCK  # 512 = one round (16 cores x 32 rows)
+# Step B relay drain columns (free cols; rope/rms/glu compute cores replace these in C/D).
+RELAY_COLS = [0, 6, 7][:NDEST]
+
+# ---- surround compute (Step C) ----
+DH = 128  # head_dim (rope cos/sin LUT length)
+ROPE_COL, ROPE_ROW = 1, 3  # reference rope tile(1,3); consumes dest0 (pkt1 QKV)
+# The reference places glu at tile(6,2), but the outY pkt8 demux route hub(col1)->glu@col6
+# runs EASTWARD across the busy proj grid (cols 2-5) and DEADLOCKS (device-confirmed
+# 2026-08-05f: glu@col6 = global stall; glu@col1 = COMPLETES). Llama avoids this because
+# its proj cols are {0,1,6,7}, leaving cols 2-5 free for the hub->glu route; Qwen's
+# contiguous proj 2-5 does not. So glu lives on the HUB column (col1, free row 4), making
+# the pkt8 demux hub-local like rope(1,3)/rms(1,2). QWEN_GLU_COL/ROW override for diag.
+GLU_COL, GLU_ROW = 1, 4
+GLU_COL = int(_os.environ.get("QWEN_GLU_COL", str(GLU_COL)))
+GLU_ROW = int(_os.environ.get("QWEN_GLU_ROW", str(GLU_ROW)))
+GLU_SLICE = 2 * PAYLOAD  # 1024 = [up 512 | gate 512] (two demux rounds per slice)
+GLU_HID = PAYLOAD  # 512 silu(gate)*up out per slice
+# Phase-isolation (QWEN_NPH<4): a surround consumer exists only if its packet id is
+# still produced by one of the kept phases. HAS_ROPE is always true (phase 0 = QKV).
+HAS_ROPE = PKT_ROPE in DEMUX_IDS
+HAS_RMS = PKT_RMS in DEMUX_IDS  # oproj (ph1) and/or down (ph3) kept
+HAS_GLU = PKT_GLU in DEMUX_IDS  # gate-up (ph2) kept
+NGLU = (
+    DEST_RNDS[DEMUX_IDS.index(PKT_GLU)] // 2 if HAS_GLU else 0
+)  # 44/2 = 22 slices -> 11264 = INTERMEDIATE
+DEST_ROPE = DEMUX_IDS.index(PKT_ROPE) if HAS_ROPE else None  # 0
+DEST_RMS = DEMUX_IDS.index(PKT_RMS) if HAS_RMS else None  # 1
+DEST_GLU = DEMUX_IDS.index(PKT_GLU) if HAS_GLU else None  # 2
+
+# ---- attention (Step 2b): 1x8x1, 2 CUs on col 7, DH=128 ----
+# reference Qwen attn topology (from the reference QWEN2_3B layer IR): col 7; attn_qk tile_7_2 &
+# tile_7_4, attn_kv tile_7_3 & tile_7_5 (2 CUs); mem_tile_7_1 stages K/V. 1x8x1 =
+# 1 kv head + 8 q heads per CU (NUM_KV_HEADS=2 -> 2 CUs). We use the DECOMPOSED
+# attn_qk_blk / attn_kv_blk / attn_kv_fin wrappers (lock-free; AIR drives the block
+# loop + ping-pong), which under the Qwen header select the SAME 1x8x1 peano-fixed
+# _attn_qk / attn_fv / calculate_l / scale_div templates as the monolithic kernels.
+# This reuses the proven Llama AIR attn dataflow at DH=128 / 2-CU instead of trying
+# to replicate the monolithic kernel's in-kernel lock protocol.
+import os as _os
+
+N_ATTN_CU = 2
+KV_PER_CU = 1
+Q_HEADS_PER_CU = 8  # 16 attn heads / 2 CUs
+KVPC_DH = KV_PER_CU * DH  # 128 (k/v width per CU)
+ATTN_COL = 7
+ATTN_CU_LOC = [(7, 2, 3), (7, 4, 5)]  # (col, qk_row, kv_row) per CU
+# score slot padded to a multiple of 64 for the v64 loads: logical
+# Q_HEADS_PADDED_PER_CU(8)*16 scores + 8 c floats (=16 bf16 units) = 144 -> 192.
+SSZ_BLK = ((Q_HEADS_PER_CU * 16 + 16 + 63) // 64) * 64  # 192
+QCU = Q_HEADS_PER_CU * DH  # 1024 q (and o) per CU
+KVBLK = 16 * KVPC_DH  # 2048 one 16-key K (or V) block per CU
+# compile-time block count (context length). ATTN_L env for the lowering gate; the
+# kernel masks the last partial block, so one ATTN_MAXL build serves any L (Phase 4
+# patches runtime L). Default small for a fast lower-check.
+ATTN_L = int(_os.environ.get("ATTN_L", "32"))
+ATTN_ROUNDS = (ATTN_L + 15) // 16
+
+# ---- reference-mirroring KV-cache + attn config (ported from fused_decode.py, the proven
+# Llama AIR design, re-parameterized for Qwen 1x8x1 / DH=128 / 2 CUs on col 7). ----
+# The whole rope->q-broadcast(mem_6_1)->attn->attn-o(mem_6_1)->xnorm loopclose and the
+# DDR KV cache append+readback mirror the reference QWEN2_3B layer IR exactly (verified by IR
+# diff). See fused_decode.py lines ~239-303 for the Llama originals of these constants.
+DH_A = DH  # 128 (attn head_dim)
+KVPC_DH = KV_PER_CU * DH_A  # 1*128 = 128 (K or V width per CU)
+# CUs grouped by column: Qwen has BOTH CUs on col 7 -> ONE group (reference mem_7_1 serves
+# all 4 attn tiles on col 7). Llama had 4 CUs on 2 cols (2 groups).
+ATTN_COL_GROUPS = []  # [(col, [cu_idx,...]), ...] in CU order
+for _c, _loc in enumerate(ATTN_CU_LOC):
+    if ATTN_COL_GROUPS and ATTN_COL_GROUPS[-1][0] == _loc[0]:
+        ATTN_COL_GROUPS[-1][1].append(_c)
+    else:
+        ATTN_COL_GROUPS.append((_loc[0], [_c]))
+ATTN_CU_GROUP = {c: gi for gi, (_, cus) in enumerate(ATTN_COL_GROUPS) for c in cus}
+NGRP = len(ATTN_COL_GROUPS)  # 1
+REGION_W = len(ATTN_COL_GROUPS[0][1]) * KVPC_DH  # 2*128 = 256 (per-token per-group K/V)
+DK_TOT_A = N_ATTN_CU * KVPC_DH  # 2*128 = 256 (all-CU K or V width)
+KVSZ_TOK = 2 * DK_TOT_A  # 512 (per-token K++V)
+ATTN_MAXL = ATTN_ROUNDS * 16  # padded context (compile-time block count)
+APPEND_OFF = (ATTN_L - 1) * KVSZ_TOK  # this token's slot in the cache
+REGION_STRIDE = ATTN_MAXL * REGION_W  # per-group region span (one K or V region)
+KV_SPLIT = True  # decoupled K/V memtile rings (separate inKV_K/inKV_V S2MM)
+KV_REGION = True  # region-major DDR KV quadrants [K_grp0 | V_grp0]
+KV_APPEND = True  # rope writes this token's roped-K/raw-V into the DDR cache
+
+# ---- X-loopclose (Step 2c): reuse the proven Llama convergent-xnorm mechanism ----
+# The proj X for each phase comes on-chip (not host toX): ph0 QKV X = rmsnorm(input),
+# ph1 oproj X = attn-o, ph2 gateup X = rmsnorm(input+oproj), ph3 down X = glu-down.
+# All four converge (in phase-time order) on ONE npu_dma_packet channel @xnorm, read
+# by ONE count-free feed loop that broadcasts 256-blocks to the 16 proj cores (inX).
+# Each phase source re-broadcasts REFEED[p] = RB[p] times (rounds/phase): the rms core
+# via channel/per-put air.refeed_count, the attn-o + glu-down via memtile-alloc
+# air.refeed_count (mechanism 2). Mirrors fused_decode.py exactly, re-parameterized.
+# QWEN_ATTN=0 = device-deadlock bisection: drop the whole attn subsystem (KV
+# staging + attn herd + o-gather), rope drains q to host, forces LOOPCLOSE off.
+# Isolates whether a device hang is in attn vs the base proj/surround.
+ATTN = int(_os.environ.get("QWEN_ATTN", "1"))
+# LOOPCLOSE defaults off when attn is cut (ph1's X is the attn output), but can be forced
+# on for the ATTN=0 + NPH=1 bisect: that config has NO attn-sourced X (ph0's X is the rms
+# xnorm), so it isolates the on-chip X-feed loopclose mechanism from the attn subsystem.
+LOOPCLOSE = int(_os.environ.get("QWEN_LOOPCLOSE", "1" if ATTN else "0"))
+
+# DEFAULT ON whenever the on-chip attn-o -> o-proj X path exists: making the rms tile the
+# sole physical producer into the hub X ring is the correct topology, and a second physical
+# producer starves ph0 (device-confirmed: ph0 never completes, KV=0).
+OREF_VIA_RMS = int(_os.environ.get("QWEN_OREF_VIA_RMS", "1" if ATTN else "0"))
+
+# DEFAULT ON when the loopclose/attn X path exists, OFF for the host-toX base.
+# With the on-chip X path the host MUST NOT await the whole weight feed before the data
+# that unblocks proj ph1 is issued: the weight feed only fully drains once ph1 runs, ph1
+# needs its X from the rms tile, and that X depends on attn -- a host-side circular wait
+# (device-confirmed 2026-08-05af; visible only in the aie.runtime_sequence task order, not
+# in any device-side view). Per-phase inW tasks break the cycle. The attn-less base uses
+# host toX, has no such dependency, and is REGRESSED by phase-major (TIMEOUT), so this
+# must stay conditional rather than global.
+W_PHASE_MAJOR = int(
+    _os.environ.get("QWEN_W_PHASE_MAJOR", "1" if (ATTN and LOOPCLOSE) else "0")
+)
+
+# X-buffer section layout. The @ropeLUT / @rmsIn / @rmsW / @orms host feeds all used to
+# read X[0:], i.e. the cos/sin+bias slab, the token activation and the RMSNorm weight
+# were ALIASED onto the same DDR bytes. That is harmless for a topology gate (any bytes
+# will do) but makes real numerics impossible. Give each its own section; sizes and BD
+# structure are unchanged (only the source address differs), so the shim task shape the
+# topology gates depend on is preserved.
+# X_SPLIT=0 restores the old aliased layout for A/B.
+X_SPLIT = int(_os.environ.get("QWEN_X_SPLIT", "1"))
+# Unroll the NGLU-chunk gluOut gather into the down-X memtile buffer (see the
+# comment at the gather). QWEN_DOWN_GATHER_UNROLL=0 restores the rolled form.
+# NOTE: unrolling DEADLOCKS the device (2026-08-06) -- 22 constant-offset gets
+# blow the memtile BD budget. Default OFF; kept only for A/B.
+DOWN_GATHER_UNROLL = int(_os.environ.get("QWEN_DOWN_GATHER_UNROLL", "0"))
+# Emit the down X as NGLU separate GLU_HID puts instead of one whole-INTERMEDIATE
+# put, so the emission granularity matches the X memtile's 512-element gets 1:1
+# (the same rule XN_SPLIT applies to the rms ph0 X feed: @xnorm is a PACKET
+# channel, one put = one packet, and one get = one BD expecting one packet).
+# NOTE: splitting the put BLOWS THE BD BUDGET (aiecc: "Allocator exhausted
+# available BD IDs (maximum 24 available for channel 0)") -- NGLU puts x
+# DOWN_REFEED re-sends is far past 24, so the single whole-buffer put is
+# structurally required here. Default OFF; kept only for A/B.
+DOWN_PUT_SPLIT = int(_os.environ.get("QWEN_DOWN_PUT_SPLIT", "0"))
+# Gather the gluOut chunks two-at-a-time, matching the glu core's 2-slice
+# ping/pong cadence, instead of one per rolled iteration. With the 1-per-iter
+# form the device drops every THIRD glu pair (measured: in pair units the down X
+# came out [P0,P1,--,P0,P4,--,P6,P7,--,P6,P7]), which is a ring-depth mismatch
+# against the depth-2 producer.
+# NOTE: pair-cadence gather DEADLOCKS the device (2026-08-06). Default OFF;
+# kept only for A/B. The rolled 1-get-per-iteration form is the only one of the
+# three that runs -- it is also the one that drops every third pair, so the
+# down-X corruption is still OPEN.
+DOWN_GATHER_PAIRS = int(_os.environ.get("QWEN_DOWN_GATHER_PAIRS", "0"))
+# Give the glu core the reference's depth-2 ping/pong ring (see _glu_body). QWEN_GLU_RING2=0
+# restores the per-slice-alloc form that lowers to a 6-deep ring.
+GLU_RING2 = int(_os.environ.get("QWEN_GLU_RING2", "1"))
+XO_ROPE = 0  # [ROPE_W]  cos|sin LUT + q|k|v bias
+XO_RMSIN = 4096 if X_SPLIT else 0  # [K]  token activation (layer input)
+XO_RMSW = 8192 if X_SPLIT else 0  # [K]  input_layernorm weight
+XO_ORMS = 12288 if X_SPLIT else 0  # [K]  o-handover (QWEN_ORMS_HOST diag only)
+XO_RMSW2 = 16384 if X_SPLIT else 0  # [K]  post_attention_layernorm (ph2 rmsnorm)
+# Multi-layer X layout. The ACTIVATION slot is layer-invariant (it is the in-place
+# residual chain: layer k's @layerOut is layer k+1's @rmsIn), while the rope slab
+# (cos/sin LUT + q|k|v bias) and BOTH rms weights are PER LAYER. With NLAYERS==1 the
+# per-layer stride is 0 and every offset is exactly the single-layer constant, so the
+# verified build is untouched.
+XLAYER = 20480 if _os.environ.get("QWEN_NLAYERS", "1") != "1" else 0
+# Feed post_attention_layernorm for the ph2 rmsnorm. Without it the ph2 norm reuses the
+# ph0 buffer (input_layernorm), i.e. the device computes a DIFFERENT function than HF --
+# device-confirmed by A/B against the golden (w_in 0.9988 vs w_post 0.8961 at
+# INTERMEDIATE=12288). Carried as a SECOND put/get on the EXISTING @rmsW channel (one
+# extra S2MM BD) rather than a new channel: the rms tile's S2MM budget is the documented
+# pressure point (rmsIn pkt2 + rmsW pkt3 are already a rigid positional chain).
+PH2_RMSW = int(_os.environ.get("QWEN_PH2_RMSW", "1"))
+
+# ===== Multi-layer fused decode (stitch NLAYERS runtime sub-sequences) =====
+# Mirrors Llama fused_decode.py: the DEVICE (segment/herds) is emitted ONCE and reused
+# temporally; only the launch-scope L3 feeds get per-layer DDR offsets, scaled by an AIR
+# scf.for induction variable that airrt-to-npu unrolls LATE. So the AIR op count stays
+# CONSTANT (a Python unroll blows up air-to-aie) and the aie.device/xclbin is unchanged --
+# only the runtime instruction sequence grows. NLAYERS=1 is a strict no-op: the loop is
+# 0..1 and every per-layer base folds to 0.
+NLAYERS = int(_os.environ.get("QWEN_NLAYERS", "1"))
+
+# Under LOOPCLOSE the rms core is ALSO the ph0 X producer (@xnorm), so it must exist even
+# when phase-isolation cuts every pkt4 phase (its outY read groups are then empty).
+# QWEN_FORCE_RMS=1 builds the rms tile even without LOOPCLOSE (X still host-fed via toX,
+# rms just does rmsIn -> layerOut). Splits "adding the rms tile" from "the xnorm X-feed"
+# as the cause of the LOOPCLOSE hang.
+FORCE_RMS = int(_os.environ.get("QWEN_FORCE_RMS", "0"))
+BUILD_RMS = HAS_RMS or LOOPCLOSE or FORCE_RMS
+# QWEN_ATTN_NOCOMPUTE=1 = attn-isolation bisection: keep the ENTIRE attn dataflow
+# + lock handshakes (q feed, KV feed, cross-core score handoff, attnO, o-gather)
+# but SKIP the 3 attn kernel calls (attn_qk_blk/attn_kv_blk/attn_kv_fin). attnO then
+# carries uninitialized data (fine -- garbage flows, only the DATAFLOW is tested). If
+# the full design RUNS with this on, the deadlock is INSIDE the attn kernel; if it
+# still HANGS, the deadlock is in the attn dataflow/handshake (score buffer, feeds).
+ATTN_NOCOMPUTE = int(_os.environ.get("QWEN_ATTN_NOCOMPUTE", "0"))
+# finer isolation: skip only the qk or only the kv compute (dataflow/handshake
+# stays). Lets us tell WHICH attn kernel hangs (qk vs kv/fin) on device.
+SKIP_QK = int(_os.environ.get("QWEN_SKIP_QK", "0")) or ATTN_NOCOMPUTE
+SKIP_KV = int(_os.environ.get("QWEN_SKIP_KV", "0")) or ATTN_NOCOMPUTE
+SKIP_KVFIN = int(_os.environ.get("QWEN_SKIP_KVFIN", "0")) or SKIP_KV
+# air.disable_ping_pong on the attn block loops forces the s/v/o handshake to
+# depth-1 (lock init 1). The reference's original double-buffers these (lock init 2, two
+# score buffers). QWEN_ATTN_PINGPONG=1 drops disable_ping_pong so AIR lowers the
+# depth-2 handshake reference uses (investigating the cross-tile-s deadlock).
+ATTN_PINGPONG = int(_os.environ.get("QWEN_ATTN_PINGPONG", "0"))
+# QWEN_SURROUND_NOCOMPUTE=1 (use ONLY with QWEN_ATTN=0): keep the ENTIRE base dataflow
+# (proj MVM + egress + X/weight feeds + rope/rms/glu channel gets+puts) but SKIP the
+# rope/rms/glu compute CallOps. COHERENT (not a header-skip): under ATTN=0/LOOPCLOSE=0
+# the surround outputs (qDrain/layerOut/gluDrain) are circuit drains to host, NOT packet
+# flows, and proj (the header writer via proj_qmm_flush_hdr) still runs. If the base then
+# COMPLETES, the deadlock is inside a surround kernel (rope/rms/glu miscompile); if it
+# still HANGS, the deadlock is in the proj/egress/feed dataflow.
+SURROUND_NOCOMPUTE = int(_os.environ.get("QWEN_SURROUND_NOCOMPUTE", "0"))
+REFEED = list(_RB)  # [5,4,44,4] rounds/phase == re-broadcast counts
+OPROJ_PHASE, GATEUP_PHASE, DOWN_PHASE = 1, 2, 3
+XN_REFEED = REFEED[0]  # ph0 QKV: rms channel-level refeed (5)
+# Phase-isolation (QWEN_NPH<4): a phase's refeed count is only meaningful (and only
+# used under LOOPCLOSE, which is off when ATTN=0) if that phase is built. Guard so
+# import doesn't IndexError when the phase list is truncated.
+OPROJ_REFEED = REFEED[OPROJ_PHASE] if OPROJ_PHASE < NPH else 0  # ph1 attn-o memtile
+GATEUP_REFEED = REFEED[GATEUP_PHASE] if GATEUP_PHASE < NPH else 0  # ph2 rms per-put
+DOWN_REFEED = REFEED[DOWN_PHASE] if DOWN_PHASE < NPH else 0  # ph3 glu-down memtile
+# The attn-o gather memtile (oref) consumes attnO only when the o-proj phase (ph1) is
+# built; otherwise attnO has no on-chip consumer and must be drained to the host.
+# OREF_NOPUT: 0 = normal; 1 = oref removed entirely (attnO -> host, rms supplies ph1 X);
+# 2 = oref still GATHERS attnO but does not put @xnorm (rms supplies ph1 X). 1 vs 2 splits
+# "the attnO gather blocks ph0" from "the oref xnorm put blocks ph0".
+DRAIN_ATTNO = bool(ATTN) and (
+    OREF_NOPUT == 1
+    or OREF_HOSTSRC
+    or (ORMS_HOST and not OREF_DRAIN)
+    or not (LOOPCLOSE and OPROJ_PHASE < NPH)
+)
+RMS_PCOL = 1  # rms core + X memtile column (reference Qwen rms tile_1_2)
+# o-proj rounds / down rounds consumed by the rms residual stream.
+OPROJ_RNDS = OPROJ_REFEED  # 4 (oproj output rounds -> residual1)
+DOWN_RNDS = DOWN_REFEED  # 4 (down output rounds -> residual2)
+
+# ---- QKV bias (Step 3): Qwen2.5 q/k/v_proj.bias (no o bias) ----
+# The rope core adds the bias to qkv BEFORE RoPE (rope.cc add_q_k_v_bias under
+# HAS_QKV_BIAS). The bias slab [q(DQ)|k(DK)|v(DV)] = 2560 is appended after the DH
+# cos/sin LUT in the rope weight buffer, so rope_buffer = DH + DQ+DK+DV = 2688
+# (matches the reference's rope_buffer<2688>). The bias is fed via the ropeLUT channel.
+QKV_BIAS = True
+ROPE_W = DH + (DQ + DK + DV if QKV_BIAS else 0)  # 2688 (128 LUT + 2560 bias)
+
+# per-core counts (all phases)
+X_READS = sum(_RB[p] * _NJ[p] for p in range(NPH))  # 40+32+352+176 = 600 inX gets/core
+W_READS = X_READS  # 600 wL2ToL1 gets/core
+Y_PUTS = sum(_RB)  # 5+4+44+4 = 57 outA puts/core
+# memtile-hop counts
+assert X_READS % 2 == 0
+X_CHUNKS = X_READS // 2  # X memtile 512-chunk gets (each -> 2 inX broadcasts)
+PER_COL_W = NCY * W_READS  # weight blocks per column = 4*600 = 2400
+W_FAN_STEPS = W_READS  # per-col fan steps (each fans NCY blocks) = 600
+# Per-layer DDR slab sizes (elements), used only when NLAYERS>1.
+W_LAYER = NCX * PER_COL_W * BLOCK_BF16  # weights per layer
+
+
+def build_module():
+    @module_builder
+    def build():
+        bf16 = BF16Type.get()
+        f32 = F32Type.get()
+        i32 = IntegerType.get_signless(32)
+        idx_t = IndexType.get()
+        l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        l2 = IntegerAttr.get(T.i32(), MemorySpace.L2)
+
+        def idx(v):
+            return arith.ConstantOp.create_index(v)
+
+        # ---- host operands (L3) ----
+        x_l3 = MemRefType.get([max(X_CHUNKS * 2 * COL_BLOCK, NLAYERS * XLAYER)], bf16)
+        w_l3 = MemRefType.get([NLAYERS * W_LAYER], bf16)
+        # KV blocks (separate operand so the router places its feed on a far shim
+        # column, mirroring the reference's KV on shim col 7; reusing the col-1 X operand
+        # oversubscribed the col-1 shim MM2S).
+        kv_l3 = MemRefType.get([NLAYERS * N_ATTN_CU * 2 * ATTN_ROUNDS * KVBLK], bf16)
+        # 57 rounds x 512, but at least K + DQ: the DRAIN_ATTNO diagnostic path puts
+        # the attention output at Y[K:K+DQ], and under phase isolation DEST_TOTAL
+        # shrinks below that.
+        y_l3 = MemRefType.get([max(DEST_TOTAL * PAYLOAD, K + DQ)], bf16)
+
+        # ---- L1 buffers ----
+        xblk_l1 = MemRefType.get([COL_BLOCK], bf16, memory_space=l1)
+        wblk_l1 = MemRefType.get([BLOCK_BF16], bf16, memory_space=l1)
+        yacc_l1 = MemRefType.get([ROW_BLOCK], f32, memory_space=l1)
+        ybuf_l1 = MemRefType.get([YBUF], bf16, memory_space=l1)
+
+        # ---- L2 memtile staging buffers ----
+        xmt_l2 = MemRefType.get([2 * COL_BLOCK], bf16, memory_space=l2)  # 512
+        wfan_l2 = MemRefType.get([NCY * BLOCK_BF16], bf16, memory_space=l2)  # 4*2560
+        # per-col gather (reference y_buffer<130> = 2 hdr + 4x32; keeps core0's pkt header).
+        col_l2 = MemRefType.get([2 + NCY * ROW_BLOCK], bf16, memory_space=l2)  # 130
+        # hub gather (reference y_buffer<514> = 2 hdr + 4x128; keeps col0's pkt header).
+        hub_l2 = MemRefType.get(
+            [2 + NCX * (NCY * ROW_BLOCK)], bf16, memory_space=l2
+        )  # 514
+        relay_l2 = MemRefType.get([PAYLOAD], bf16, memory_space=l2)  # 512 demux relay
+        # ---- surround compute L1 buffers ----
+        qkv_l1 = MemRefType.get([DQ + DK + DV], bf16, memory_space=l1)  # 2560 QKV
+        ropeq_l1 = MemRefType.get([DQ], bf16, memory_space=l1)  # 2048 roped q
+        ropekv_l1 = MemRefType.get([DK], bf16, memory_space=l1)  # 256 roped k / v
+        ropew_l1 = MemRefType.get(
+            [ROPE_W], bf16, memory_space=l1
+        )  # 2688 = 128 cos/sin LUT + 2560 QKV bias
+        glu_x_l1 = MemRefType.get([GLU_SLICE], bf16, memory_space=l1)  # 1024 [up|gate]
+        glu_hid_l1 = MemRefType.get([GLU_HID], bf16, memory_space=l1)  # 512 silu*up
+        rms_l1 = MemRefType.get([K], bf16, memory_space=l1)  # 2048 rms in/resid/out
+        # ---- attention L1 buffers (DH=128, 8 q/CU, 1 kv/CU) ----
+        aq_l1 = MemRefType.get([QCU], bf16, memory_space=l1)  # 1024 q per CU
+        ak_l1 = MemRefType.get([KVBLK], bf16, memory_space=l1)  # 2048 k block
+        av_l1 = MemRefType.get([KVBLK], bf16, memory_space=l1)  # 2048 v block
+        as_l1 = MemRefType.get([SSZ_BLK], bf16, memory_space=l1)  # 192 shared scores
+        ao_l1 = MemRefType.get([QCU], bf16, memory_space=l1)  # 1024 o per CU
+        m_l1 = MemRefType.get([16], bf16, memory_space=l1)  # running max (8 used)
+        c_l1 = MemRefType.get([8], f32, memory_space=l1)  # softmax correction
+        y_l1 = MemRefType.get([QCU], f32, memory_space=l1)  # 1024 S.V accumulator
+        lden_l1 = MemRefType.get([16], f32, memory_space=l1)  # softmax denominator
+        # q-broadcast memtile (reference mem_tile_6_1 q_buffer<2048>): rope q(2048) fanned
+        # per-CU (1024 each) with the head-reshape stride to the qk cores.
+        qmt_l2 = MemRefType.get([DQ], bf16, memory_space=l2)  # 2048 q broadcast
+        # KV block staging memtile (reference mem_tile_7_1): combined K (resp V) block
+        # [16 keys, REGION_W] for the whole col-group, reshaped per CU to toK/toV.
+        kvcomb_l2 = MemRefType.get([16 * REGION_W], bf16, memory_space=l2)  # 4096
+        # X-loopclose refeed memtiles (reference mem_tile_6_1 role): attn-o (ph1 oproj X =
+        # MODEL_DIM) and glu-down (ph3 down X = INTERMEDIATE) gathered then re-broadcast
+        # into the convergent @xnorm via air.refeed_count (mechanism 2).
+        oref_l2 = MemRefType.get([K], bf16, memory_space=l2)  # 2048 attn-o
+        downref_l2 = MemRefType.get([INTERMEDIATE], bf16, memory_space=l2)  # 11264
+
+        # ---- kernels (reuse proj_qmm.o primitives) ----
+        zero = FuncOp("proj_qmm_zero", ([yacc_l1, i32], []), visibility="private")
+        zero.attributes["link_with"] = StringAttr.get("proj_qmm.o")
+        acc256 = FuncOp(
+            "proj_qmm_acc256", ([xblk_l1, wblk_l1, yacc_l1], []), visibility="private"
+        )
+        acc256.attributes["link_with"] = StringAttr.get("proj_qmm.o")
+        flush_hdr = FuncOp(
+            "proj_qmm_flush_hdr", ([yacc_l1, ybuf_l1, i32], []), visibility="private"
+        )
+        flush_hdr.attributes["link_with"] = StringAttr.get("proj_qmm.o")
+        # rope_compute(q,k,v, qkv, lut, arm): rotate-half RoPE on Q/K (V copied).
+        rope_compute = FuncOp(
+            "rope_compute",
+            ([ropeq_l1, ropekv_l1, ropekv_l1, qkv_l1, ropew_l1, i32], []),
+            visibility="private",
+        )
+        rope_compute.attributes["link_with"] = StringAttr.get("rope.o")
+        # glu_aie(hid, x, arm): x = [up 512 | gate 512] -> hid = silu(gate)*up (512).
+        glu_aie = FuncOp(
+            "glu_aie", ([glu_hid_l1, glu_x_l1, i32], []), visibility="private"
+        )
+        glu_aie.attributes["link_with"] = StringAttr.get("glu.o")
+        # residual_add_aie(y, x_buf, x): y = x_buf + x (residual stream).
+        residual_add_aie = FuncOp(
+            "residual_add_aie", ([rms_l1, rms_l1, rms_l1], []), visibility="private"
+        )
+        residual_add_aie.attributes["link_with"] = StringAttr.get("rms_residual.o")
+        # rms_copy_aie(dst, src): dst = src (MODEL_DIM bf16). Used for the ph1
+        # o-proj X handover -- o-proj's input IS the gathered attention output,
+        # so the rms tile only re-emits it, it does not combine it with anything.
+        rms_copy_aie = FuncOp(
+            "rms_copy_aie", ([rms_l1, rms_l1], []), visibility="private"
+        )
+        rms_copy_aie.attributes["link_with"] = StringAttr.get("rms_residual.o")
+        # rms_norm_aie(y, x, w, arm): y = rmsnorm(x) * w. Produces the proj X feed
+        # (ph0 = rmsnorm(input); ph2 = rmsnorm(input+oproj)) for the X-loopclose.
+        rms_norm_aie = FuncOp(
+            "rms_norm_aie", ([rms_l1, rms_l1, rms_l1, i32], []), visibility="private"
+        )
+        rms_norm_aie.attributes["link_with"] = StringAttr.get("rms_residual.o")
+        # attn (decomposed, lock-free; AIR drives the block loop). s_block is the
+        # LAST memref of attn_qk_blk (producer tag) and a non-last memref of
+        # attn_kv_blk (consumer tag) -> AIR shared-L1 cross-core RAW between the
+        # qk (writer) and kv (reader) tiles of each CU. blk,L passed by value.
+        attn_qk_blk = FuncOp(
+            "attn_qk_blk",
+            ([aq_l1, ak_l1, m_l1, c_l1, as_l1, i32, i32], []),
+            visibility="private",
+        )
+        attn_qk_blk.attributes["link_with"] = StringAttr.get("attn_qk.o")
+        attn_kv_blk = FuncOp(
+            "attn_kv_blk",
+            ([as_l1, av_l1, y_l1, lden_l1, i32, i32], []),
+            visibility="private",
+        )
+        attn_kv_blk.attributes["link_with"] = StringAttr.get("attn_kv.o")
+        attn_kv_fin = FuncOp(
+            "attn_kv_fin", ([y_l1, lden_l1, ao_l1], []), visibility="private"
+        )
+        attn_kv_fin.attributes["link_with"] = StringAttr.get("attn_kv.o")
+
+        # ---- channels (two-hop, mirroring the reference) ----
+        channel_decl("toX", size=[1])  # host -> X memtile (col 1)
+        _inX = Channel(
+            "inX", size=[1, 1], broadcast_shape=[NCX, NCY]
+        )  # Xmt -> 16 cores
+        _inX.operation.attributes["air.shared_resident_ring"] = UnitAttr.get()
+        channel_decl("inW", size=[NCX])  # host -> per-col W memtile
+        channel_decl("wL2ToL1", size=[NCX, NCY])  # W memtile -> col cores
+        # proj core egress is a PACKET flow (the reference: packet_flow(1/4/8) tile_C_r -> mem_C_1,
+        # keep_pkt_header). The kernel-written id (flush_hdr @y+14) rides the packet so the
+        # hub can demux QKV(1)/oproj+down(4)/gateup(8) -> rope/rms/glu.
+        _pin = ArrayAttr.get([IntegerAttr.get(i32, k) for k in DEMUX_IDS])
+        _outA = channel_decl("outA", size=[NCX, NCY], channel_type="npu_dma_packet")
+        _outA.operation.attributes["keep_pkt_header"] = UnitAttr.get()
+        _outA.operation.attributes["packet_ids"] = _pin
+        # col memtile -> mem_1_1 hub (packet, keep header so the hub can demux by id).
+        _toHub = channel_decl("toHub", size=[NCX], channel_type="npu_dma_packet")
+        _toHub.operation.attributes["keep_pkt_header"] = UnitAttr.get()
+        _toHub.operation.attributes["packet_ids"] = _pin
+        # hub id-demux egress: emit the assembled 514 packet on ONE MM2S; switchbox routes
+        # id 1->dest0(rope), 4->dest1(rms), 8->dest2(glu); strip header -> pure 512 payload.
+        _outY = Channel("outY", size=[1, 1], broadcast_shape=[1, NDEST])
+        _outY.operation.attributes["channel_type"] = StringAttr.get("npu_dma_packet")
+        _outY.operation.attributes["air.strip_pkt_header"] = UnitAttr.get()
+        _outY.operation.attributes["packet_ids"] = _pin
+        # Keep the hub demux on S2MM0 at every consumer tile; the shim-sourced feeds
+        # (ropeLUT/rmsIn/rmsW) are pinned to S2MM1 below. Without an explicit pin,
+        # unpinned packet flows REUSE whatever packet channel the tile already has
+        # (AIRToAIESchedulingUtils.cpp:1391), which merges two independent producers
+        # (hub + shim) into ONE ordered BD chain = head-of-line deadlock.
+        _outY.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 0)
+        _lut = channel_decl("ropeLUT", size=[1])  # host cos/sin LUT -> rope core
+        # Pin the LUT feed to the rope tile's S2MM1 (the outY QKV demux keeps S2MM0).
+        # Under LOOPCLOSE the rms core adds two shim packet feeds (rmsIn/rmsW) which
+        # oversubscribe shim col 1, so AIR converts ropeLUT from a circuit flow into a
+        # PACKET flow -- and packet flows on one tile reuse a single physical channel
+        # (AIRToAIESchedulingUtils.cpp:1391) unless pinned. That merged ropeLUT and the
+        # outY QKV payload into ONE strictly-ordered 6-BD chain on rope S2MM0 fed by TWO
+        # INDEPENDENT producers (shim + hub mem_1_1) -> head-of-line deadlock (device-
+        # confirmed 2026-08-05j: the ONLY diff between the hanging LOOPCLOSE build and
+        # the working host-toX build). The pin restores the two-separate-channel layout.
+        _lut.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
+        # ...and feed it from a FREE shim column: the packetization above is triggered by
+        # shim col 1 being oversubscribed (ropeLUT + rmsIn + rmsW + layerOut + qDrain).
+        # Off col 1 the LUT feed stays circuit-switched, which cannot share the rope
+        # tile's packet S2MM at all.
+        _lut.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 0)
+        channel_decl(
+            "gluDrain", size=[1]
+        )  # glu out (down-X) -> shim (Step C; loopclose D)
+        _rmsin = channel_decl(
+            "rmsIn", size=[1]
+        )  # host raw input activation -> rms core
+        _rmsin.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
+        channel_decl("layerOut", size=[1])  # rms residual2 (layer output) -> shim
+        # ---- attention channels (reference-mirroring: rope q -> mem_6_1 q-broadcast tile ->
+        # per-CU qk; K/V via KV staging mem_7_1). Ports fused_decode.py exactly. ----
+        if ATTN:
+            channel_decl("ropeQ", size=[1])  # rope q(2048) -> mem_6_1 q-broadcast tile
+            channel_decl(
+                "toAttnQ", size=[N_ATTN_CU]
+            )  # mem_6_1 -> per-CU qk core (reshaped)
+            # reference mem_7_1 KV staging: combined K (resp V) block [16 keys, REGION_W] per
+            # col-group on SEPARATE flows (KV_SPLIT: independent K/V rings), reshaped per
+            # CU to toK (qk S2MM1) / toV (kv S2MM1). Ports fused_decode.py inKV_K/inKV_V.
+            channel_decl("inKV_K", size=[NGRP])  # cache K [16,REGION_W] -> mem_7_1
+            channel_decl("inKV_V", size=[NGRP])  # cache V [16,REGION_W] -> mem_7_1
+            if KV_APPEND:
+                # reference-faithful on-chip KV-cache append (mirror fused_decode.py:762-775):
+                # rope's roped-K / raw-V leave on ONE dedicated rope MM2S as PACKET flows
+                # pinned to the attn shim col (7) -> DDR cache. Qwen has ONE col group
+                # (NGRP=1) so both K and V transit col 7 (Llama split cols 3/4).
+                # CHANNEL 0, NOT 1: rope also emits ropeQ as a CIRCUIT flow (-> the col-6
+                # q-broadcast memtile). Pinning the appends to MM2S1 left ropeQ to land on
+                # MM2S1 TOO, so one physical output port carried a static circuit route AND
+                # two packet routes -- the packet BDs would be steered by the circuit
+                # connection instead of their packet dests. Llama keeps them apart (circuit
+                # ropeQ on MM2S0, packets on MM2S1); pinning the appends to 0 gives Qwen the
+                # same separation with ropeQ taking the remaining channel.
+                _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
+                _apK.operation.attributes["air.shim_col"] = IntegerAttr.get(
+                    i32, ATTN_COL
+                )
+                _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
+                    i32, 0
+                )
+                _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
+                _apV.operation.attributes["air.shim_col"] = IntegerAttr.get(
+                    i32, ATTN_COL
+                )
+                _apV.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
+                    i32, 0
+                )
+            channel_decl(
+                "toK", size=[N_ATTN_CU]
+            )  # staging -> qk core (k block, reshaped)
+            channel_decl(
+                "toV", size=[N_ATTN_CU]
+            )  # staging -> kv core (v block, reshaped)
+            _ao = channel_decl(
+                "attnO", size=[N_ATTN_CU]
+            )  # kv o -> drain (o-proj X Step D2)
+            if DRAIN_ATTNO:
+                # Bisection path only (no on-chip oref consumer): send the o drain out a
+                # shim column away from col 7, which already carries appendK/appendV +
+                # inKV_K/inKV_V. Sharing col 7 makes two flows target the same shim
+                # dest -> "aie.masterset op targets same destination South: 2" at route
+                # time (this is why the earlier attn-alone bisect would not build).
+                _ao.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 6)
+        else:
+            channel_decl("qDrain", size=[1])  # bisection: rope q -> host
+        if ATTN and ROPE_ECHO:
+            channel_decl(
+                "qDrain", size=[1]
+            )  # echo witness: rope's received qkv -> host
+            # loop-break: attn's q now comes from the HOST, not from rope.
+            channel_decl("hostQ", size=[1])
+        # ---- X-loopclose channels (Step 2c; reuse Llama convergent-xnorm) ----
+        # ONE convergent packet channel carries all 4 phase X sources (rms ph0/ph2,
+        # attn-o ph1, glu-down ph3) into the X memtile, read by ONE feed loop. rms
+        # channel-level refeed = XN_REFEED (ph0); ph2/ph1/ph3 use per-put / memtile
+        # air.refeed_count. Pin the rms core's xnorm output to tile MM2S1 (layerOut
+        # keeps MM2S0) so the placer does not flip layerOut circuit->packet.
+        _xn = channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
+        _xn.operation.attributes["air.refeed_count"] = IntegerAttr.get(i32, XN_REFEED)
+        if OREF_2HOP:
+            channel_decl("oref2", size=[1], channel_type="npu_dma_packet")
+        if OREF_HOSTSRC:
+            _oi = channel_decl("orefIn", size=[1])
+            _oi.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 0)
+        if OREF_DRAIN:
+            _od = channel_decl("orefDrain", size=[1])
+            _od.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 6)
+        if OREF_VIA_RMS:
+            # attn-o gather memtile -> rms core. PIN to the rms tile's S2MM0.
+            # Unpinned, the packet-flow channel reuse collapses it onto S2MM1, which already
+            # carries rmsIn (pkt2) and rmsW (pkt3) as a rigid 3-BD POSITIONAL chain over
+            # three DIFFERENT buffers with different lock pairs. A memtile-sourced @orms then
+            # arrives on a different switchbox port than the shim-sourced rmsIn/rmsW while
+            # both rules target the SAME amsel, so the arbiter interleaves the two streams at
+            # packet granularity and the positional chain desynchronizes -> deadlock.
+            # (device+routed-IR confirmed 2026-08-05x: passing shim-fed @orms has ONE slave
+            # port on tile_1_2 masterset DMA:1; every failing memtile-fed variant has TWO,
+            # independent of oref column and of the attn dependency.)
+            # S2MM0 carries only the o-proj outY get, and the @orms get is emitted BEFORE it
+            # in _rms_body, so the chain order [orms, outY] matches the dataflow order.
+            _orms = channel_decl("orms", size=[1], channel_type="npu_dma_packet")
+            _orms.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 0)
+        if PH1_XCHAN:
+            _xn2 = channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
+            _xn2.operation.attributes["air.refeed_count"] = IntegerAttr.get(
+                i32, OPROJ_REFEED
+            )
+        _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
+        _rmsw = channel_decl("rmsW", size=[1])  # host rms weight -> rms core
+        _rmsw.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
+        channel_decl("gluOut", size=[1])  # glu-down -> down-X refeed memtile (ph3)
+
+        # ============================ proj grid core ============================
+        # The 4 phases run in ONE AIR for_ loop (NOT Python-unrolled) so the core reuses
+        # a SINGLE set of DMA BDs (inX/wL2ToL1 S2MM + outA MM2S). Python-unrolling the
+        # phases makes 4x the BDs -> overflows the 16-BD aie.mem limit. Per-phase rounds
+        # (RB), col-blocks (NJ), and pkt id are index_switch-selected on the phase IV
+        # (mirrors fused_decode.py _psw / the reference proj.cc phase loop).
+        def _core(tx, ty, _sx, _sy):
+            gcx = tx
+            gcy = ty
+            one = arith.ConstantOp(IntegerAttr.get(i32, 1), None).result
+            c2 = idx(2)
+            i2c = [idx(v) for v in _RB]
+            # HALF the col-block count per phase; _gemv doubles it (2*half) so the
+            # inner reduction loop has a PROVABLY-EVEN trip count. AIR's ping-pong
+            # pass unrolls the innermost candidate loop by 2; an opaque
+            # index_switch bound (e.g. [8,8,8,44]) forces a remainder/epilogue copy
+            # -> a THIRD X/W buffer (depth-3). A provably-even 2*half bound has no
+            # epilogue -> clean depth-2 x_0/x_1 + w_0/w_1 rings (matches the reference/Llama).
+            j2h = [idx(v // 2) for v in _NJ]  # [4,4,4,22]
+            pktc = [
+                arith.ConstantOp(IntegerAttr.get(i32, k), None).result for k in _PKT
+            ]
+
+            def _psw(ph, vals, ty_):
+                if len(vals) == 1:
+                    return vals[0]
+                return index_switch(
+                    [ty_],
+                    ph,
+                    list(range(len(vals) - 1)),
+                    case_body_builder=lambda op, i, cv: yield_([vals[i]]),
+                    default_body_builder=lambda op: yield_([vals[-1]]),
+                )
+
+            # Y is depth-1 (single alloc/put per round). The reference/Llama use a depth-2 Y ring,
+            # but AIR can't reproduce it here: the ping-pong pass only reaches the inner
+            # _j reduction (not the round loop); output-unrolling the round loop to get 2
+            # static put sites spawns extra _j rings (X/W depth blows up, worse with the
+            # QKV ODD round count RB=5 needing a tail _gemv -> X/W depth-6); and a
+            # runtime parity-selected buffer fails air-to-aie lock allocation. Device
+            # testing confirmed proj X/W depth (2 vs 3) is NOT the deadlock, so Y depth-1
+            # is left as-is (a serialization difference, not a correctness/deadlock one).
+            for ph in for_(idx(0), idx(NPH), idx(1)):
+                I2v = _psw(ph, i2c, idx_t)
+                J2v = _psw(ph, j2h, idx_t)
+                pktv = _psw(ph, pktc, i32)
+                for _i in for_(idx(0), I2v, idx(1)):
+                    # ONE reduction pass per round (single inX/wL2ToL1 get site) with a
+                    # PROVABLY-EVEN 2*half trip count so the ping-pong unroll has no
+                    # remainder/epilogue copy -> clean depth-2 x_0/x_1 + w_0/w_1 rings.
+                    J2x2 = arith.muli(J2v, c2)
+                    a_acc = AllocOp(yacc_l1, [], [])
+                    CallOp(zero, [a_acc, one])
+                    for _j in for_(idx(0), J2x2, idx(1)):
+                        a_x = AllocOp(xblk_l1, [], [])
+                        ChannelGet("inX", a_x, indices=[gcx, gcy])
+                        a_w = AllocOp(wblk_l1, [], [])
+                        ChannelGet("wL2ToL1", a_w, indices=[gcx, gcy])
+                        CallOp(acc256, [a_x, a_w, a_acc])
+                        DeallocOp(a_x)
+                        DeallocOp(a_w)
+                        yield_([])
+                    a_y = AllocOp(ybuf_l1, [], [])
+                    CallOp(flush_hdr, [a_acc, a_y, pktv])
+                    ChannelPut(
+                        "outA",
+                        a_y,
+                        indices=[gcx, gcy],
+                        offsets=[idx(PKT_OFF)],
+                        sizes=[idx(PKT_PAY)],
+                        strides=[idx(1)],
+                    )
+                    DeallocOp(a_acc)
+                    DeallocOp(a_y)
+                    yield_([])
+                yield_([])
+
+        # ============================ top function ==============================
+        @FuncOp.from_py_func(x_l3, w_l3, kv_l3, y_l3)
+        def qwen_decode(*_fa):
+            def launch_body(*_la):
+                X, W, KV, Y = _la[4], _la[5], _la[6], _la[7]
+                # Multi-layer: the last launch operand is the scf.for induction variable
+                # (see the emit branch at the end of build()). a_iv is None for the
+                # single-layer build, so every per-layer offset below folds to the plain
+                # Python constant it had before and the IR is byte-identical.
+                a_iv = _la[8] if len(_la) > 8 else None
+                KV_LAYER = N_ATTN_CU * 2 * ATTN_ROUNDS * KVBLK
+
+                def _po(slab, off):
+                    """DDR offset `off` inside this layer's `slab`-sized region."""
+                    if a_iv is None or not slab:
+                        return idx(off)
+                    base = arith.muli(a_iv, idx(slab))
+                    return arith.addi(base, idx(off)) if off else base
+
+                def _xo(off):  # per-layer X slab (rope LUT + bias, rms weights)
+                    return _po(XLAYER, off)
+
+                def _wo(off):  # per-layer weight slab
+                    return _po(W_LAYER, off)
+
+                def _kvo(off):  # per-layer KV cache slab
+                    return _po(KV_LAYER, off)
+
+                # --- host X feed -> X memtile (launch scope) ---
+                # LOOPCLOSE: X is produced on-chip (rmsnorm/attn-o/glu-down converge on
+                # @xnorm), so there is NO host toX feed. Stub path host-feeds toX.
+                if not LOOPCLOSE:
+                    for _c in for_(idx(0), idx(X_CHUNKS), idx(1)):
+                        off = arith.muli(_c, idx(2 * COL_BLOCK))
+                        ChannelPut(
+                            "toX",
+                            X,
+                            offsets=[off],
+                            sizes=[idx(2 * COL_BLOCK)],
+                            strides=[idx(1)],
+                        )
+                        yield_([])
+
+                # --- host cos/sin LUT + rms activation feeds, BEFORE the weight feed ---
+                # ORDERING IS LOAD-BEARING (device-confirmed 2026-08-05l). The launch
+                # carries air.preserve_shim_dma_order, so the runtime sequence issues shim
+                # tasks in program order, and it AWAITS the four big inW tasks before
+                # issuing anything that comes later. Under LOOPCLOSE the proj X is produced
+                # ON CHIP by the rms core, so if rmsIn/rmsW are emitted after the weight
+                # feed the host blocks in dma_await_task(inW) -> the weights cannot drain
+                # because the proj cores are stalled on inX -> inX never arrives because the
+                # X memtile is waiting on @xnorm -> the rms core is still waiting for
+                # rmsIn/rmsW the host has not issued = CIRCULAR WAIT. The non-loopclose
+                # build survives only because its @toX feed sits here, ahead of the awaits.
+                ChannelPut(
+                    "ropeLUT",
+                    X,
+                    offsets=[_xo(XO_ROPE)],
+                    sizes=[idx(ROPE_W)],
+                    strides=[idx(1)],
+                )
+                # Phase-isolation: rms exists if it consumes pkt4 OR (LOOPCLOSE) it is
+                # the ph0 X producer.
+                if BUILD_RMS:
+                    ChannelPut(
+                        "rmsIn",
+                        X,
+                        offsets=[idx(XO_RMSIN)],
+                        sizes=[idx(K)],
+                        strides=[idx(1)],
+                    )
+                    # host rms weight -> rms core (LOOPCLOSE: rmsnorm needs the weight)
+                    if LOOPCLOSE:
+                        ChannelPut(
+                            "rmsW",
+                            X,
+                            offsets=[_xo(XO_RMSW)],
+                            sizes=[idx(K)],
+                            strides=[idx(1)],
+                        )
+                        if PH2_RMSW:
+                            ChannelPut(
+                                "rmsW",
+                                X,
+                                offsets=[_xo(XO_RMSW2)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                    if OREF_VIA_RMS and ORMS_HOST and OPROJ_PHASE < NPH:
+                        ChannelPut(
+                            "orms",
+                            X,
+                            offsets=[idx(XO_ORMS)],
+                            sizes=[idx(K)],
+                            strides=[idx(1)],
+                        )
+
+                # --- host weight feed -> per-col W memtile, ROUND-MAJOR (phase-outer,
+                # col-inner) so the NCX proj columns advance in lockstep with the X
+                # broadcast multicast. A channel-major whole-column feed lets
+                # air-opt-shim-dma-bds regroup into per-channel BDs, breaking the
+                # cross-column phase barrier -> deadlock (this is why Llama's
+                # fused_decode.py feeds phase-major + sets air.preserve_shim_dma_order
+                # on the launch). Each column's phase block is fed as TWO contiguous
+                # halves so the shim-dma coalescer merges+tags them
+                # (air.coalesced_shim_feed = the cross-channel phase barrier).
+                colspan = PER_COL_W * BLOCK_BF16
+                STEP_BF16 = NCY * BLOCK_BF16  # one fan step = NCY rows' blocks
+                # PHASE-MAJOR DDR LAYOUT [phase][col][data] (was [col][phase][data]).
+                # The ISSUE order was already phase-major, but a column-major LAYOUT makes a
+                # column's consecutive phase blocks CONTIGUOUS in DDR, so the shim coalescer
+                # merges every phase into ONE awaited task per column. The host then blocks
+                # awaiting weights for phases whose X does not exist yet (phase 1's X is the
+                # attn output, gated on the KV readback issued after that await) = circular
+                # wait. Phase-major separates a column's phase blocks by the other columns'
+                # data, so each PHASE coalesces on its own -- the two halves within a phase
+                # stay adjacent, preserving the air.coalesced_shim_feed cross-channel
+                # barrier -- and the host awaits only the phase it needs next. NOTE the
+                # weight feed is lockstep-coupled to the X broadcast, so it must NOT use
+                # air.shim_feed_no_pace (that attr is documented for feeds with NO shared
+                # broadcast consumer; using it here dropped the barrier and deadlocked
+                # phase 0 -- device-confirmed 2026-08-05o). Total size unchanged (a permutation).
+                # DEFAULT = column-major [col][phase]: the whole column coalesces into ONE
+                # shim task, which the ATTN=0 base REQUIRES (device-confirmed: phase-major
+                # regressed it to a timeout). Phase-major is kept behind QWEN_W_PHASE_MAJOR
+                # for the attn work, where the all-phase await is a circular wait.
+                _pbase = [0]
+                for p in range(NPH):
+                    _pbase.append(_pbase[-1] + NCX * _RB[p] * _NJ[p] * STEP_BF16)
+                _woff = [0]
+                for p in range(NPH):
+                    _woff.append(_woff[-1] + _RB[p] * _NJ[p] * STEP_BF16)
+
+                def _feed_w_phase(p):
+                    span_p = _RB[p] * _NJ[p] * STEP_BF16
+                    hp = span_p // 2
+                    for cx in range(NCX):
+                        cbase = (
+                            _pbase[p] + cx * span_p
+                            if W_PHASE_MAJOR
+                            else cx * colspan + _woff[p]
+                        )
+                        ChannelPut(
+                            "inW",
+                            W,
+                            indices=[idx(cx)],
+                            offsets=[_wo(cbase)],
+                            sizes=[idx(hp)],
+                            strides=[idx(1)],
+                        )
+                        ChannelPut(
+                            "inW",
+                            W,
+                            indices=[idx(cx)],
+                            offsets=[_wo(cbase + hp)],
+                            sizes=[idx(span_p - hp)],
+                            strides=[idx(1)],
+                        )
+
+                # SPLIT THE WEIGHT FEED AROUND THE KV READBACK (mirror Llama's runtime
+                # sequence). The 4 phase groups are CONTIGUOUS in DDR per column, so the
+                # shim coalescer merges them into ONE ~409600-element awaited task/column.
+                # With attn on, the host would then block in dma_await_task(inW) until ALL
+                # phases' weights drain -- but phase 1's X is the attn output, attn needs
+                # the KV readback, and inKV is issued AFTER that await = circular wait
+                # (same class as the rms-feed ordering above). Llama avoids it by emitting
+                # one inW group per phase with the KV readback started between phase 0 and
+                # phase 1. Do the same: phase 0 here, phases 1.. after the KV block.
+                # ATTN=0 keeps the original single contiguous feed (verified-good base).
+                _W_SPLIT = bool(ATTN) and NPH > 1
+                for p in range(1 if _W_SPLIT else NPH):
+                    _feed_w_phase(p)
+
+                # --- host drains -> Y ---
+                # rms layer output (residual2 = input + o-proj + down): K=2048.
+                if BUILD_RMS:
+                    # Multi-layer: chain the residual stream IN PLACE -- layer k writes its
+                    # output back over the X activation slot, which layer k+1 reads as its
+                    # @rmsIn. Same mechanism as Llama (x at a layer-invariant offset). The
+                    # single-layer build keeps draining to Y[0:K] so the verified gate and
+                    # every existing checker are unchanged.
+                    ChannelGet(
+                        "layerOut",
+                        X if NLAYERS > 1 else Y,
+                        indices=[idx(0)],
+                        offsets=[idx(XO_RMSIN if NLAYERS > 1 else 0)],
+                        sizes=[idx(K)],
+                        strides=[idx(1)],
+                    )
+                # --- reference-faithful on-chip KV cache (mirror fused_decode.py
+                # _emit_append / _emit_readback); KV is the persistent DDR cache
+                # [K region (ATTN_MAXL*REGION_W) | V region (ATTN_MAXL*REGION_W)]. ---
+                # (1) APPEND this token's roped-K / raw-V into the cache at this token's
+                #     slot ((ATTN_L-1)*REGION_W within each region); the ChannelGet
+                #     receives rope's appendK/appendV packet flow into DDR. air.append_barrier
+                #     -> AIRRtToNpu orders the append completion before the readback (RAW).
+                # (2) READ BACK the whole cache region-major on inKV_K/inKV_V (one 3D nd-DMA
+                #     per region: [ATTN_ROUNDS blocks][16 keys][REGION_W]); air.await_appends
+                #     on the first readback; air.shim_feed_no_pace = fire-and-free feed.
+                if ATTN:
+                    _rw = (ATTN_L - 1) * REGION_W  # this token's slot within a region
+                    _apk = ChannelGet(
+                        "appendK",
+                        KV,
+                        indices=[idx(0)],
+                        offsets=[_kvo(_rw)],
+                        sizes=[idx(NGRP), idx(REGION_W)],
+                        strides=[idx(REGION_STRIDE), idx(1)],
+                    )
+                    _apk.operation.attributes["air.append_barrier"] = UnitAttr.get()
+                    _apv = ChannelGet(
+                        "appendV",
+                        KV,
+                        indices=[idx(0)],
+                        offsets=[_kvo(NGRP * REGION_STRIDE + _rw)],
+                        sizes=[idx(NGRP), idx(REGION_W)],
+                        strides=[idx(REGION_STRIDE), idx(1)],
+                    )
+                    _apv.operation.attributes["air.append_barrier"] = UnitAttr.get()
+                    _first = True
+                    for gi in range(NGRP):
+                        _pk = ChannelPut(
+                            "inKV_K",
+                            KV,
+                            indices=[idx(gi)],
+                            offsets=[_kvo(gi * REGION_STRIDE)],
+                            sizes=[idx(ATTN_ROUNDS), idx(16), idx(REGION_W)],
+                            strides=[idx(16 * REGION_W), idx(REGION_W), idx(1)],
+                        )
+                        _pv = ChannelPut(
+                            "inKV_V",
+                            KV,
+                            indices=[idx(gi)],
+                            offsets=[_kvo((NGRP + gi) * REGION_STRIDE)],
+                            sizes=[idx(ATTN_ROUNDS), idx(16), idx(REGION_W)],
+                            strides=[idx(16 * REGION_W), idx(REGION_W), idx(1)],
+                        )
+                        _pk.operation.attributes["air.shim_feed_no_pace"] = (
+                            UnitAttr.get()
+                        )
+                        _pv.operation.attributes["air.shim_feed_no_pace"] = (
+                            UnitAttr.get()
+                        )
+                        if _first and not NO_AWAIT_APPENDS:
+                            _pk.operation.attributes["air.await_appends"] = (
+                                UnitAttr.get()
+                            )
+                            _first = False
+                if ATTN and ROPE_ECHO:
+                    ChannelPut(
+                        "hostQ", X, offsets=[idx(0)], sizes=[idx(DQ)], strides=[idx(1)]
+                    )
+                    # NOTE: this OVERLAPS layerOut, which also owns Y[0:K], so Y[0:K]
+                    # is ambiguous in the ATTN=0 / ROPE_ECHO bisect paths. Moving the
+                    # drain to Y[K:] to deconflict was tried and REGRESSED the ATTN=0
+                    # base to TIMEOUT (device-confirmed 2026-08-05ai, zero weights) --
+                    # the offset change perturbs the shim task structure. Left as-is;
+                    # do not "fix" this offset without re-running the ATTN=0 gate.
+                    ChannelGet(
+                        "qDrain",
+                        Y,
+                        offsets=[idx(0)],
+                        sizes=[idx(DQ + DK + DV)],
+                        strides=[idx(1)],
+                    )
+                if OREF_HOSTSRC:
+                    ChannelPut(
+                        "orefIn", X, offsets=[idx(0)], sizes=[idx(K)], strides=[idx(1)]
+                    )
+                if OREF_DRAIN:
+                    ChannelGet(
+                        "orefDrain",
+                        Y,
+                        offsets=[idx(0)],
+                        sizes=[idx(K)],
+                        strides=[idx(1)],
+                    )
+                if not ATTN:
+                    # bisection: drain rope q (2 CUs) to host so rope still completes.
+                    for _cu in range(N_ATTN_CU):
+                        # NOTE: overlaps layerOut, which also owns Y[0:K], so Y[0:K] is
+                        # ambiguous in the ATTN=0 bisect path. Moving this drain to Y[K:]
+                        # to deconflict REGRESSES the ATTN=0 base to TIMEOUT even with
+                        # zero weights -- re-confirmed on a FREE device 2026-08-05aj, so
+                        # it is a real effect of the offset (it perturbs the shim task
+                        # structure), not the earlier contention. Do not "fix" this
+                        # without re-running the ATTN=0 gate.
+                        ChannelGet(
+                            "qDrain",
+                            Y,
+                            offsets=[idx(_cu * QCU)],
+                            sizes=[idx(QCU)],
+                            strides=[idx(1)],
+                        )
+                # Remaining weight phases, issued AFTER the KV readback start (see the
+                # _W_SPLIT note above) so the host never awaits phase-N weights that only
+                # drain once attn has run.
+                if _W_SPLIT:
+                    for p in range(1, NPH):
+                        _feed_w_phase(p)
+
+                # LOOPCLOSE: attn-o and glu-down are consumed on-chip as proj X (ph1/ph3)
+                # via @xnorm, NOT drained to host. Stub path drains them to Y.
+                if DRAIN_ATTNO:
+                    # --- attn o drain (no on-chip oref consumer) -> Y[K:] ---
+                    # Placed AFTER layerOut's Y[0:K] rather than on top of it: this
+                    # drain only exists on diagnostic paths (the default build has an
+                    # on-chip oref consumer and never emits it), so unlike the qDrain
+                    # offsets it costs the verified base nothing, and it makes the
+                    # attention output readable on its own bytes.
+                    for _cu in range(N_ATTN_CU):
+                        ChannelGet(
+                            "attnO",
+                            Y,
+                            indices=[idx(_cu)],
+                            offsets=[idx(K + _cu * QCU)],
+                            sizes=[idx(QCU)],
+                            strides=[idx(1)],
+                        )
+                if not LOOPCLOSE and HAS_GLU:
+                    # glu (dest2/pkt8): NGLU x 512 silu(gate)*up via gluDrain (stub).
+                    _yb = K
+                    for _sg in for_(idx(0), idx(NGLU), idx(1)):
+                        ChannelGet(
+                            "gluDrain",
+                            Y,
+                            offsets=[
+                                arith.addi(idx(_yb), arith.muli(_sg, idx(GLU_HID)))
+                            ],
+                            sizes=[idx(GLU_HID)],
+                            strides=[idx(1)],
+                        )
+                        yield_([])
+
+                @segment(name="seg", operands=[])
+                def seg_body(*_sa):
+                    # --- X memtile hop (col 1): get 512 -> broadcast 2x256 to 16 cores ---
+                    # LOOPCLOSE: the X source is the convergent @xnorm (rms/attn-o/glu),
+                    # NOT host toX. ONE count-free feed loop reads all 4 phases in order.
+                    _xsrc = "xnorm" if LOOPCLOSE else "toX"
+
+                    def _x_feed(src, nchunks):
+                        for _rc in for_(idx(0), idx(nchunks), idx(1)):
+                            xb = AllocOp(xmt_l2, [], [])
+                            xb.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), XMT_COL)
+                            )
+                            xb.operation.attributes["air.no_split"] = UnitAttr.get()
+                            ChannelGet(
+                                src,
+                                xb,
+                                offsets=[idx(0)],
+                                sizes=[idx(2 * COL_BLOCK)],
+                                strides=[idx(1)],
+                            )
+                            for _jj in for_(idx(0), idx(2), idx(1)):
+                                joff = arith.muli(_jj, idx(COL_BLOCK))
+                                ChannelPut(
+                                    "inX",
+                                    xb,
+                                    offsets=[joff],
+                                    sizes=[idx(COL_BLOCK)],
+                                    strides=[idx(1)],
+                                )
+                                yield_([])
+                            DeallocOp(xb)
+                            yield_([])
+
+                    if PH1_XCHAN and LOOPCLOSE:
+                        # DIAGNOSTIC: read ph1's X from its OWN channel (@xnorm2, fed by the
+                        # oref memtile) instead of the convergent @xnorm, one feed loop per
+                        # phase. Tests whether sharing @xnorm between the rms (ph0) producer
+                        # and the attn-dependent oref (ph1) producer is what starves ph0.
+                        for _p in range(NPH):
+                            _x_feed(
+                                "xnorm2" if _p == OPROJ_PHASE else _xsrc,
+                                _RB[_p] * _NJ[_p] // 2,
+                            )
+                    else:
+                        _x_feed(_xsrc, X_CHUNKS)
+
+                    # --- weight fan: per-col memtile peels NCY blocks/step -> cores ---
+                    for cx in range(NCX):
+                        for _ in for_(idx(0), idx(W_FAN_STEPS), idx(1)):
+                            wf = AllocOp(wfan_l2, [], [])
+                            wf.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), PROJ_COL0 + cx)
+                            )
+                            wf.operation.attributes["air.no_split"] = UnitAttr.get()
+                            ChannelGet("inW", wf, indices=[idx(cx)])
+                            for cy in range(NCY):
+                                ChannelPut(
+                                    "wL2ToL1",
+                                    wf,
+                                    indices=[idx(cx), idx(cy)],
+                                    offsets=[cy * BLOCK_BF16],
+                                    sizes=[BLOCK_BF16],
+                                    strides=[1],
+                                )
+                            DeallocOp(wf)
+                            yield_([])
+
+                    # --- egress gather (mirror the reference/Llama _egress): BOTH hops INTERLEAVED
+                    # in ONE round loop so they pipeline across tiles. SEPARATE put-loop
+                    # (col->toHub) then get-loop (toHub->outY) DEADLOCKS: the col memtiles
+                    # fill while the hub isn't draining yet -> backpressure hang (this was
+                    # the base device deadlock). Per round r: gather each col's 4 core
+                    # packets -> toHub[cx], THEN gather the 4 toHub -> outY (id-demux).
+                    # col y_buffer<130> = 2 hdr (core0's kept pkt header) + 4x32 (cores 1-3
+                    # stripped) at 0/34/66/98; hub y_buffer<514> = 2 hdr + 4x128.
+                    _CW = NCY * ROW_BLOCK  # 128 per-col payload
+                    # QWEN_EGR_RNDS caps the egress loop (controlled experiment): run only
+                    # ph0's rounds so the later, attn-gated rounds are never armed. If ph0's
+                    # egress then delivers (KV witness fires), the ph0 path is healthy and the
+                    # blockage comes from the LATER rounds of the same count-free loop.
+                    _egr_n = EGR_RNDS if EGR_RNDS else DEST_TOTAL
+                    for _r in for_(idx(0), idx(_egr_n), idx(1)):
+                        for cx in range(NCX):
+                            cbuf = AllocOp(col_l2, [], [])
+                            cbuf.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), PROJ_COL0 + cx)
+                            )
+                            cbuf.operation.attributes["air.no_split"] = UnitAttr.get()
+                            ChannelGet(
+                                "outA",
+                                cbuf,
+                                indices=[idx(cx), idx(0)],
+                                offsets=[idx(0)],
+                                sizes=[idx(2 + ROW_BLOCK)],
+                                strides=[idx(1)],
+                            )
+                            for cy in range(1, NCY):
+                                ChannelGet(
+                                    "outA",
+                                    cbuf,
+                                    indices=[idx(cx), idx(cy)],
+                                    offsets=[idx(2 + cy * ROW_BLOCK)],
+                                    sizes=[idx(ROW_BLOCK)],
+                                    strides=[idx(1)],
+                                )
+                            ChannelPut(
+                                "toHub",
+                                cbuf,
+                                indices=[idx(cx)],
+                                offsets=[idx(0)],
+                                sizes=[idx(2 + NCY * ROW_BLOCK)],
+                                strides=[idx(1)],
+                            )
+                            DeallocOp(cbuf)
+                        hbuf = AllocOp(hub_l2, [], [])
+                        hbuf.operation.attributes["air.memtile_col"] = IntegerAttr.get(
+                            T.i32(), XMT_COL
+                        )
+                        hbuf.operation.attributes["air.no_split"] = UnitAttr.get()
+                        ChannelGet(
+                            "toHub",
+                            hbuf,
+                            indices=[idx(0)],
+                            offsets=[idx(0)],
+                            sizes=[idx(2 + _CW)],
+                            strides=[idx(1)],
+                        )
+                        for cx in range(1, NCX):
+                            ChannelGet(
+                                "toHub",
+                                hbuf,
+                                indices=[idx(cx)],
+                                offsets=[idx(2 + cx * _CW)],
+                                sizes=[idx(_CW)],
+                                strides=[idx(1)],
+                            )
+                        ChannelPut(
+                            "outY",
+                            hbuf,
+                            indices=[idx(0), idx(0)],
+                            offsets=[idx(0)],
+                            sizes=[idx(2 + NCX * _CW)],
+                            strides=[idx(1)],
+                        )
+                        DeallocOp(hbuf)
+                        yield_([])
+
+                    # ===== rms core (reference tile_1_2): pkt4 (oproj+down) residual stream =====
+                    # h = input + o-proj; res2 = h + down -> layer output. Consumes the 8
+                    # pkt4 demux packets in arrival order (4 o-proj, then 4 down). X-production
+                    # loopclose (rms rmsnorm -> proj X, o-proj X = attn-o) deferred to Phase 2.
+                    # Phase-aware: the pkt4 stream carries the o-proj group (ph1) and the
+                    # down group (ph3) INDEPENDENTLY. Under phase-isolation (QWEN_NPH<4)
+                    # either may be absent, so size/emit each read group from its own phase
+                    # round count (OPROJ_RNDS / DOWN_RNDS, already 0 when the phase is cut)
+                    # instead of splitting DEST_RNDS in half.
+                    _RMS_OP = OPROJ_RNDS  # 4 o-proj rounds (0 if ph1 cut)
+                    _RMS_DN = DOWN_RNDS  # 4 down rounds (0 if ph3 cut)
+
+                    def _rms_body(tx, ty, _sx, _sy):
+                        _one = arith.ConstantOp(IntegerAttr.get(i32, 1), None).result
+                        a_in = AllocOp(rms_l1, [], [])
+                        ChannelGet("rmsIn", a_in, indices=[idx(0)])
+                        a_w = None
+                        a_xn = None
+                        if LOOPCLOSE:
+                            a_w = AllocOp(rms_l1, [], [])
+                            ChannelGet("rmsW", a_w, indices=[idx(0)])
+                            a_w2 = a_w
+                            if PH2_RMSW:
+                                # post_attention_layernorm, second emission on @rmsW
+                                a_w2 = AllocOp(rms_l1, [], [])
+                                ChannelGet("rmsW", a_w2, indices=[idx(0)])
+                            # ph0 QKV X = rmsnorm(input); channel-level refeed XN_REFEED.
+                            # a_xn is KEPT (single y buffer) and REUSED for the ph2 put
+                            # below -- mirrors Llama _rms_decode_body. Two separate xnorm
+                            # buffers make the scheduler form a 2-deep ring and HOIST both
+                            # prod-acquires (c_gateup + c_xn) to the core loop top, but the
+                            # ring's prod lock inits to only the max refeed -> the second
+                            # acquire blocks forever (startup deadlock, rms never emits X).
+                            a_xn = AllocOp(rms_l1, [], [])
+                            CallOp(rms_norm_aie, [a_xn, a_in, a_w, _one])
+                            if XN_SPLIT:
+                                # EMISSION-GRANULARITY match: @xnorm is a PACKET channel, so
+                                # one put = one packet and one get = one BD expecting one
+                                # packet. The X memtile gets XCH=2*COL_BLOCK (512) per BD, but
+                                # the refeed form emits the whole K=2048 buffer as ONE packet
+                                # (x XN_REFEED) -> 5 packets vs 20 BDs (1:4 mismatch). The
+                                # working host-toX feed is 1:1 (20 puts of 512). Emit the same
+                                # 1:1 shape here, in ROUND-MAJOR order (r, then chunk) so the
+                                # X memtile sees c0,c1,c2,c3 per round; per-put refeed_count=1
+                                # overrides the channel-level count (getRefeedCount: an
+                                # explicit per-emission attr wins for ANY value, incl. 1).
+                                for _xr in range(XN_REFEED):
+                                    for _xc in range(K // XCH):
+                                        _pp = ChannelPut(
+                                            "xnorm",
+                                            a_xn,
+                                            offsets=[idx(_xc * XCH)],
+                                            sizes=[idx(XCH)],
+                                            strides=[idx(1)],
+                                        )
+                                        _pp.operation.attributes["air.refeed_count"] = (
+                                            IntegerAttr.get(i32, 1)
+                                        )
+                            else:
+                                ChannelPut(
+                                    "xnorm",
+                                    a_xn,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
+                                )
+                            if OREF_NOPUT and OPROJ_PHASE < NPH:
+                                # bisect stand-in for the muted oref as ph1's X source.
+                                # MUST be emitted HERE, before the o-proj outY get below:
+                                # the get blocks on proj ph1's output, and proj ph1 cannot
+                                # run until this put supplies its X -> emitting it after the
+                                # get is a rms<->proj cycle (device-confirmed 2026-08-05x:
+                                # the core lock trace acquired the outY data lock before the
+                                # ph1 prod-acquire). Also makes the stand-in work at NPH>=3,
+                                # where the gate-up branch below is taken instead.
+                                _pa = ChannelPut(
+                                    "xnorm",
+                                    a_xn,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
+                                )
+                                _pa.operation.attributes["air.refeed_count"] = (
+                                    IntegerAttr.get(i32, OPROJ_REFEED)
+                                )
+                            if OREF_VIA_RMS and OPROJ_PHASE < NPH:
+                                # ph1 X = the attn-o handed over by the oref memtile. Placed
+                                # HERE (right after the ph0 put, before the o-proj outY get)
+                                # so the phase order is ph0 -> ph1 -> ph2.
+                                # DEDICATED landing buffer -- do NOT reuse a_xn. a_xn is the
+                                # buffer MM2S1 is still re-sending XN_REFEED times for ph0,
+                                # and the @orms S2MM acquires a DIFFERENT lock pair than the
+                                # one MM2S1 releases, so AIR does not interlock the incoming
+                                # write against the in-flight refeed sends from the same
+                                # buffer -- the DMA overwrites X mid-refeed (device+IR
+                                # confirmed 2026-08-05x: S2MM1 BD3 Acq lock_1_2_1 vs MM2S1
+                                # Rel lock_1_2_7, no shared lock).
+                                # Land it in a DEDICATED buffer, then write a_xn with a core
+                                # op and emit from a_xn -- the same shape the ph2 gate-up put
+                                # uses. Two reasons it must be this shape:
+                                #  - putting @xnorm straight from a_o makes a SECOND xnorm
+                                #    producer buffer -> AIR forms a 2-deep ring and hoists
+                                #    both prod-acquires to the core loop top -> startup
+                                #    deadlock (device 2026-08-05x: ph0 never completes, KV=0).
+                                #  - getting @orms straight into a_xn gives the incoming S2MM
+                                #    a different lock pair than the one MM2S1 releases, so the
+                                #    in-flight ph0 refeed sends from a_xn are NOT interlocked
+                                #    against the overwrite.
+                                # The core write is what forces the a_xn prod-acquire, which
+                                # blocks until all XN_REFEED ph0 sends have drained.
+                                # NUMERICS: a_xn = a_o. o-proj consumes the attention output
+                                # verbatim (the residual add against the layer input happens
+                                # AFTER o-proj, in the _RMS_OP block below), so this handover
+                                # is a pure copy.
+                                a_o = AllocOp(rms_l1, [], [])
+                                ChannelGet(
+                                    "orms",
+                                    a_o,
+                                    indices=[idx(0)],
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
+                                )
+                                if not SURROUND_NOCOMPUTE:
+                                    CallOp(rms_copy_aie, [a_xn, a_o])
+                                _po = ChannelPut(
+                                    "xnorm",
+                                    a_xn,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
+                                )
+                                _po.operation.attributes["air.refeed_count"] = (
+                                    IntegerAttr.get(i32, OPROJ_REFEED)
+                                )
+                                DeallocOp(a_o)
+                        a_op = None
+                        a_h = a_in  # h = input when the o-proj group is cut
+                        if _RMS_OP:
+                            a_op = AllocOp(rms_l1, [], [])
+                            # o-proj: single full-size get (the id-4 packet flow reassembles
+                            # the _RMS_OP 512-packets into ONE dest BD) -- mirror Llama
+                            # fused_decode.py:2662. Per-round 512 gets (the old form) cycle 4
+                            # S2MM BDs on dest_rms and DEADLOCK once the down read-group is
+                            # added (device-confirmed 2026-08-05g: NPH=4 per-round = TIMEOUT).
+                            ChannelGet(
+                                "outY",
+                                a_op,
+                                indices=[idx(0), idx(DEST_RMS)],
+                                offsets=[idx(0)],
+                                sizes=[idx(_RMS_OP * PAYLOAD)],
+                                strides=[idx(1)],
+                            )
+                            a_h = AllocOp(rms_l1, [], [])
+                            if not SURROUND_NOCOMPUTE:
+                                CallOp(residual_add_aie, [a_h, a_in, a_op])
+                        if LOOPCLOSE and GATEUP_PHASE < NPH:
+                            # ph2 gate-up X = rmsnorm(input+oproj); per-put refeed GATEUP.
+                            # REUSE a_xn (the ph0 buffer) so the two puts share ONE single-
+                            # buffer ring -> the prod-acquire for each phase stays INTERLEAVED
+                            # after its rms_norm (Llama's working cadence), not batched at the
+                            # loop top.
+                            CallOp(rms_norm_aie, [a_xn, a_h, a_w2, _one])
+                            _p2 = ChannelPut(
+                                "xnorm",
+                                a_xn,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                            _p2.operation.attributes["air.refeed_count"] = (
+                                IntegerAttr.get(i32, GATEUP_REFEED)
+                            )
+                            DeallocOp(a_xn)
+                            DeallocOp(a_w)
+                            if PH2_RMSW:
+                                DeallocOp(a_w2)
+                        elif LOOPCLOSE:
+                            # gate-up phase cut: the ph0 xnorm buffers are still live.
+                            # (the OREF_NOPUT ph1 stand-in is emitted above, before the
+                            # o-proj outY get, to avoid the rms<->proj cycle.)
+                            DeallocOp(a_xn)
+                            DeallocOp(a_w)
+                            if PH2_RMSW:
+                                DeallocOp(a_w2)
+                        a_dn = None
+                        a_r2 = a_h  # layer out = h when the down group is cut
+                        if _RMS_DN:
+                            a_dn = AllocOp(rms_l1, [], [])
+                            # down: single full-size get (packet reassembly) -- mirror Llama
+                            # fused_decode.py:2703.
+                            ChannelGet(
+                                "outY",
+                                a_dn,
+                                indices=[idx(0), idx(DEST_RMS)],
+                                offsets=[idx(0)],
+                                sizes=[idx(_RMS_DN * PAYLOAD)],
+                                strides=[idx(1)],
+                            )
+                            a_r2 = AllocOp(rms_l1, [], [])
+                            if not SURROUND_NOCOMPUTE:
+                                CallOp(residual_add_aie, [a_r2, a_h, a_dn])
+                        ChannelPut(
+                            "layerOut",
+                            a_r2,
+                            offsets=[idx(0)],
+                            sizes=[idx(K)],
+                            strides=[idx(1)],
+                        )
+                        # Dealloc each distinct buffer once (a_h aliases a_in when the
+                        # o-proj group is cut; a_r2 aliases a_h when the down group is).
+                        _seen = []
+                        for _b in (a_in, a_op, a_h, a_dn, a_r2):
+                            if _b is not None and not any(_b is _s for _s in _seen):
+                                _seen.append(_b)
+                                DeallocOp(_b)
+
+                    # Phase-isolation: instantiate rms only if pkt4 (oproj/down) is
+                    # produced by a kept phase; else it would block on outY gets that
+                    # never arrive = a FALSE deadlock. (_rms_body is defined but unused.)
+                    if BUILD_RMS:
+                        rms_h = herd(name="rms", sizes=[1, 1], operands=[])(_rms_body)
+                        rms_h.attributes["link_with"] = StringAttr.get("rms_residual.o")
+                        rms_h.attributes["x_loc"] = IntegerAttr.get(
+                            T.i64(), 1
+                        )  # tile(1,2)
+                        rms_h.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                    proj_h = herd(name="proj", sizes=[NCX, NCY], operands=[])(_core)
+                    proj_h.attributes["link_with"] = StringAttr.get("proj_qmm.o")
+                    # proj_qmm q4k dequant is stack-heavy (4x vector<float,128> +
+                    # 4x bf16 + accums + sfix lambda per iter); 10K overflows into
+                    # adjacent L1 buffers -> downstream egress lock waits forever
+                    # (device hang). Bump ONLY proj to 24K (Qwen3.5 proj same fix).
+                    proj_h.attributes["stack_size"] = IntegerAttr.get(T.i32(), 24576)
+                    proj_h.attributes["x_loc"] = IntegerAttr.get(T.i64(), PROJ_COL0)
+                    proj_h.attributes["y_loc"] = IntegerAttr.get(T.i64(), PROJ_ROW0)
+
+                    # ===== rope core (reference tile_1_3): QKV(dest0/pkt1) -> roped q/k/v =====
+                    def _rope_body(tx, ty, _sx, _sy):
+                        a_qkv = AllocOp(qkv_l1, [], [])
+                        for _rq in range(DEST_RNDS[DEST_ROPE]):  # 5 QKV rounds
+                            ChannelGet(
+                                "outY",
+                                a_qkv,
+                                indices=[idx(0), idx(DEST_ROPE)],
+                                offsets=[idx(_rq * PAYLOAD)],
+                                sizes=[idx(PAYLOAD)],
+                                strides=[idx(1)],
+                            )
+                        a_lut = AllocOp(ropew_l1, [], [])
+                        ChannelGet("ropeLUT", a_lut, indices=[idx(0)])
+                        a_q = AllocOp(ropeq_l1, [], [])
+                        a_k = AllocOp(ropekv_l1, [], [])
+                        a_v = AllocOp(ropekv_l1, [], [])
+                        _one = arith.ConstantOp(IntegerAttr.get(i32, 1), None).result
+                        if not SURROUND_NOCOMPUTE:
+                            CallOp(rope_compute, [a_q, a_k, a_v, a_qkv, a_lut, _one])
+                        # The reference: rope emits the FULL roped q (DQ=2048) on ONE MM2S -> mem_6_1
+                        # q-broadcast tile, which fans+reshapes per-CU to the qk cores. This
+                        # frees rope's 2nd MM2S for the k/v cache-append (added next). The
+                        # ATTN=0 bisection still drains q to host per-CU (qDrain).
+                        if ATTN:
+                            # QWEN_ROPE_KV_FIRST=1 (witness): emit the KV appends BEFORE the
+                            # ropeQ put. The KV cache readback is a progress witness, so this
+                            # tells apart "rope never received its qkv" (KV still 0) from
+                            # "rope received it but blocked on the ropeQ put" (KV becomes
+                            # nonzero once the appends are no longer behind that put).
+                            if ROPE_ECHO:
+                                ChannelPut(
+                                    "qDrain",
+                                    a_qkv,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(DQ + DK + DV)],
+                                    strides=[idx(1)],
+                                )
+                            if not ROPE_KV_FIRST and not ROPE_ECHO:
+                                ChannelPut(
+                                    "ropeQ",
+                                    a_q,
+                                    indices=[idx(0)],
+                                    offsets=[idx(0)],
+                                    sizes=[idx(DQ)],
+                                    strides=[idx(1)],
+                                )
+                            if KV_APPEND:
+                                # reference-faithful append (mirror fused_decode.py:1596-1611):
+                                # this token's roped-K (all heads) + raw-V -> appendK/appendV
+                                # packet flows -> DDR cache. a_k/a_v are the full-width
+                                # DK_TOT_A(256) all-CU K/V (were previously dropped).
+                                ChannelPut(
+                                    "appendK",
+                                    a_k,
+                                    indices=[idx(0)],
+                                    offsets=[idx(0)],
+                                    sizes=[idx(DK_TOT_A)],
+                                    strides=[idx(1)],
+                                )
+                                ChannelPut(
+                                    "appendV",
+                                    a_v,
+                                    indices=[idx(0)],
+                                    offsets=[idx(0)],
+                                    sizes=[idx(DK_TOT_A)],
+                                    strides=[idx(1)],
+                                )
+                            if ROPE_KV_FIRST and not ROPE_ECHO:
+                                ChannelPut(
+                                    "ropeQ",
+                                    a_q,
+                                    indices=[idx(0)],
+                                    offsets=[idx(0)],
+                                    sizes=[idx(DQ)],
+                                    strides=[idx(1)],
+                                )
+                        else:
+                            for _cu in range(N_ATTN_CU):
+                                ChannelPut(
+                                    "qDrain",
+                                    a_q,
+                                    indices=[idx(0)],
+                                    offsets=[idx(_cu * QCU)],
+                                    sizes=[idx(QCU)],
+                                    strides=[idx(1)],
+                                )
+                        DeallocOp(a_qkv)
+                        DeallocOp(a_lut)
+                        DeallocOp(a_q)
+                        DeallocOp(a_k)
+                        DeallocOp(a_v)
+
+                    rope_h = herd(name="rope", sizes=[1, 1], operands=[])(_rope_body)
+                    rope_h.attributes["link_with"] = StringAttr.get("rope.o")
+                    rope_h.attributes["x_loc"] = IntegerAttr.get(T.i64(), ROPE_COL)
+                    rope_h.attributes["y_loc"] = IntegerAttr.get(T.i64(), ROPE_ROW)
+
+                    # ===== glu core (reference tile_6_2): gate-up(dest2/pkt8) -> silu(gate)*up =====
+                    # FAITHFUL 2-slot ping/pong ring (mirror Llama fused_decode.py:2216-2244):
+                    # TWO glu slices per loop iter (ping gx_0/gh_0 + pong gx_1/gh_1) so air-to-aie
+                    # forms a depth-2 S2MM/MM2S ring (lock init 2). A ROLLED 1-slice loop collapses
+                    # to a 1-slot ring: the glu get is 1024 = TWO demux packets, so depth-1 cannot
+                    # overlap the next 1024 fill with the current compute -> the glu core stalls on
+                    # its gets and the pkt8 egress backpressures (device-confirmed 2026-08-05e:
+                    # rolled loop = TIMEOUT even with glu west of the proj grid).
+                    def _glu_body(tx, ty, _sx, _sy):
+                        _one = arith.ConstantOp(IntegerAttr.get(i32, 1), None).result
+
+                        def _slice(gx, gh):
+                            ChannelGet(
+                                "outY",
+                                gx,
+                                indices=[idx(0), idx(DEST_GLU)],
+                                offsets=[idx(0)],
+                                sizes=[idx(GLU_SLICE)],
+                                strides=[idx(1)],
+                            )
+                            if not SURROUND_NOCOMPUTE:
+                                CallOp(glu_aie, [gh, gx, _one])
+                            # LOOPCLOSE: glu-down feeds the down-X refeed memtile (gluOut);
+                            # stub path drains to host (gluDrain).
+                            ChannelPut(
+                                "gluOut" if LOOPCLOSE else "gluDrain",
+                                gh,
+                                offsets=[idx(0)],
+                                sizes=[idx(GLU_HID)],
+                                strides=[idx(1)],
+                            )
+
+                        if GLU_RING2:
+                            # reference-EXACT depth-2 ring: allocate ONE ping pair and ONE pong
+                            # pair OUTSIDE the loop and reuse them, mirroring reference tile_6_2
+                            # (x_0/x_1 1024 S2MM, hid_0/hid_1 512 MM2S, 2 BDs per channel).
+                            # Allocating fresh buffers per slice INSIDE the loop instead
+                            # lowers to a SIX-deep ring on both channels (measured in
+                            # air_project/npu.air.mlir tile_1_4: buf113/116/118/120/111/109
+                            # MM2S + buf114/115/117/119/112/110 S2MM), and the down X then
+                            # loses every third glu PAIR -- a period of exactly 6 chunks,
+                            # matching that depth.
+                            _g = [
+                                (AllocOp(glu_x_l1, [], []), AllocOp(glu_hid_l1, [], []))
+                                for _ in range(2)
+                            ]
+                            for _s in for_(idx(0), idx(NGLU // 2), idx(1)):
+                                _slice(*_g[0])  # ping
+                                _slice(*_g[1])  # pong
+                                yield_([])
+                            for _gx, _gh in _g:
+                                DeallocOp(_gx)
+                                DeallocOp(_gh)
+                        else:
+                            for _s in for_(idx(0), idx(NGLU // 2), idx(1)):
+                                for _ in range(2):
+                                    _gx = AllocOp(glu_x_l1, [], [])
+                                    _gh = AllocOp(glu_hid_l1, [], [])
+                                    _slice(_gx, _gh)
+                                    DeallocOp(_gx)
+                                    DeallocOp(_gh)
+                                yield_([])
+
+                    # Phase-isolation: instantiate glu only if pkt8 (gate-up) is
+                    # produced; else it blocks on outY gets that never arrive.
+                    if HAS_GLU:
+                        glu_h = herd(name="glu", sizes=[1, 1], operands=[])(_glu_body)
+                        glu_h.attributes["link_with"] = StringAttr.get("glu.o")
+                        glu_h.attributes["x_loc"] = IntegerAttr.get(T.i64(), GLU_COL)
+                        glu_h.attributes["y_loc"] = IntegerAttr.get(T.i64(), GLU_ROW)
+
+                    # QWEN_ATTN=0 bisection: skip the whole attn subsystem (it is the
+                    # tail of seg_body) to isolate a device hang to attn vs base.
+                    if not ATTN:
+                        return
+
+                    # ===== q-broadcast memtile (reference mem_tile_6_1 q_buffer<2048>) =====
+                    # Get rope's full roped q (DQ=2048) and fan per-CU (1024 each) with
+                    # the head-reshape stride to the qk cores. Mirrors fused_decode.py
+                    # _qmtb_dec + the reference's q_buffer_1_6 MM2S reshape [<16,8>,<8,128>,<8,1>].
+                    # CU c reads q heads 8c..8c+7 = element base c*1024 (= c*8 * stride 128).
+                    qmtb = AllocOp(qmt_l2, [], [])
+                    qmtb.operation.attributes["air.memtile_col"] = IntegerAttr.get(
+                        T.i32(), QMT_COL
+                    )
+                    qmtb.operation.attributes["air.no_split"] = UnitAttr.get()
+                    ChannelGet(
+                        "hostQ" if ROPE_ECHO else "ropeQ", qmtb, indices=[idx(0)]
+                    )
+                    for cu in range(N_ATTN_CU):
+                        ChannelPut(
+                            "toAttnQ",
+                            qmtb,
+                            indices=[idx(cu)],
+                            offsets=[idx(0), idx(cu * 8), idx(0)],
+                            sizes=[idx(16), idx(8), idx(8)],
+                            strides=[idx(8), idx(DH), idx(1)],
+                        )
+                    DeallocOp(qmtb)
+
+                    # ===== KV staging (reference mem_tile_7_1): reshape combined K/V -> per-CU =====
+                    # Ports fused_decode.py _reblock_dec (KV_SPLIT): per block, get the
+                    # group's combined K (resp V) [16 keys, REGION_W] on the independent
+                    # inKV_K/inKV_V rings, then fan+reshape to each CU's toK/toV with the
+                    # mmul-tiled head layout (reference K [<16,8>,<16,256>,<8,1>], V
+                    # [<2,2048>,<16,8>,<8,256>,<8,1>]). _gw = per-token group width = REGION_W.
+                    _gw = (
+                        REGION_W  # 256 (= len(cus)*KVPC_DH for the single col-7 group)
+                    )
+                    for gi, (_gcol, _cus) in enumerate(ATTN_COL_GROUPS):
+                        for _b in for_(idx(0), idx(ATTN_ROUNDS), idx(1)):
+                            kb = AllocOp(kvcomb_l2, [], [])
+                            kb.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), ATTN_COL)
+                            )
+                            kb.operation.attributes["air.no_split"] = UnitAttr.get()
+                            vb = AllocOp(kvcomb_l2, [], [])
+                            vb.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), ATTN_COL)
+                            )
+                            vb.operation.attributes["air.no_split"] = UnitAttr.get()
+                            ChannelGet("inKV_K", kb, indices=[idx(gi)])
+                            ChannelGet("inKV_V", vb, indices=[idx(gi)])
+                            for _lc, _cc in enumerate(_cus):
+                                _pk = ChannelPut(
+                                    "toK",
+                                    kb,
+                                    indices=[idx(_cc)],
+                                    offsets=[idx(0), idx(0), idx(_lc * KVPC_DH)],
+                                    sizes=[idx(16), idx(16), idx(8)],
+                                    strides=[idx(8), idx(_gw), idx(1)],
+                                )
+                                _pv = ChannelPut(
+                                    "toV",
+                                    vb,
+                                    indices=[idx(_cc)],
+                                    offsets=[
+                                        idx(0),
+                                        idx(0),
+                                        idx(0),
+                                        idx(_lc * KVPC_DH),
+                                    ],
+                                    sizes=[idx(2), idx(16), idx(8), idx(8)],
+                                    strides=[idx(_gw * 8), idx(8), idx(_gw), idx(1)],
+                                )
+                                # Reserve mem_7_1 MM2S 0 for the q-broadcast (mem_6_1->qk)
+                                # + attn-o feedback (kv->mem_6_1) that transit col-7's
+                                # switchbox: KV on MM2S 0 collides with that transit and
+                                # deadlocks once attn actively couples qk<->kv. Mirror the
+                                # proven Llama _reblock_dec fix (col-3 there) -> steer toK/
+                                # toV onto memtile MM2S channels 1+.
+                                _pk.operation.attributes[
+                                    "air.memtile_dma_channel_min"
+                                ] = IntegerAttr.get(T.i32(), 1)
+                                _pv.operation.attributes[
+                                    "air.memtile_dma_channel_min"
+                                ] = IntegerAttr.get(T.i32(), 1)
+                            DeallocOp(kb)
+                            DeallocOp(vb)
+                            yield_([])
+
+                    # per-CU shared score buffers (L1, seg scope) -> herd operands so the
+                    # qk (writer) + kv (reader) tiles of each CU share L1 (AIR shared-L1).
+                    s_bufs = [AllocOp(as_l1, [], []) for _ in range(N_ATTN_CU)]
+
+                    def _qk_body(sh, cu, Lh):
+                        a_q = AllocOp(aq_l1, [], [])
+                        ChannelGet("toAttnQ", a_q, indices=[idx(cu)])
+                        a_m = AllocOp(m_l1, [], [])
+                        a_cc = AllocOp(c_l1, [], [])
+                        for _blk in for_(idx(0), idx(ATTN_ROUNDS), idx(1)):
+                            if not ATTN_PINGPONG:
+                                _blk.owner.owner.attributes["air.disable_ping_pong"] = (
+                                    UnitAttr.get()
+                                )
+                            a_k = AllocOp(ak_l1, [], [])
+                            ChannelGet("toK", a_k, indices=[idx(cu)])
+                            blk_c = arith.index_cast(i32, _blk)
+                            if not SKIP_QK:
+                                CallOp(
+                                    attn_qk_blk, [a_q, a_k, a_m, a_cc, sh, blk_c, Lh]
+                                )
+                            DeallocOp(a_k)
+                            yield_([])
+                        DeallocOp(a_q)
+                        DeallocOp(a_m)
+                        DeallocOp(a_cc)
+
+                    def _kv_body(sh, cu, Lh):
+                        a_y = AllocOp(y_l1, [], [])
+                        a_l = AllocOp(lden_l1, [], [])
+                        a_o = AllocOp(ao_l1, [], [])
+                        for _blk in for_(idx(0), idx(ATTN_ROUNDS), idx(1)):
+                            if not ATTN_PINGPONG:
+                                _blk.owner.owner.attributes["air.disable_ping_pong"] = (
+                                    UnitAttr.get()
+                                )
+                            a_v = AllocOp(av_l1, [], [])
+                            ChannelGet("toV", a_v, indices=[idx(cu)])
+                            blk_c = arith.index_cast(i32, _blk)
+                            if not SKIP_KV:
+                                CallOp(attn_kv_blk, [sh, a_v, a_y, a_l, blk_c, Lh])
+                            DeallocOp(a_v)
+                            yield_([])
+                        if not SKIP_KVFIN:
+                            CallOp(attn_kv_fin, [a_y, a_l, a_o])
+                        ChannelPut(
+                            "attnO",
+                            a_o,
+                            indices=[idx(cu)],
+                            offsets=[idx(0)],
+                            sizes=[idx(QCU)],
+                            strides=[idx(1)],
+                        )
+                        DeallocOp(a_o)
+                        DeallocOp(a_y)
+                        DeallocOp(a_l)
+
+                    def _leaf(ty, cu, sh, Lh, qk_ty):
+                        _isqk = arith.cmpi(arith.CmpIPredicate.eq, ty, idx(qk_ty))
+                        _if = IfOp(_isqk, [], has_else=True)
+                        with InsertionPoint(_if.thenRegion.blocks[0]):
+                            _qk_body(sh, cu, Lh)
+                            yield_([])
+                        with InsertionPoint(_if.elseRegion.blocks[0]):
+                            _kv_body(sh, cu, Lh)
+                            yield_([])
+
+                    def _dispatch(ty, shs, Lh):
+                        _lo = arith.cmpi(arith.CmpIPredicate.slt, ty, idx(2))
+                        _ifp = IfOp(_lo, [], has_else=True)
+                        with InsertionPoint(_ifp.thenRegion.blocks[0]):
+                            _leaf(ty, 0, shs[0], Lh, 0)  # ty0=qk, ty1=kv (CU0)
+                            yield_([])
+                        with InsertionPoint(_ifp.elseRegion.blocks[0]):
+                            _leaf(ty, 1, shs[1], Lh, 2)  # ty2=qk, ty3=kv (CU1)
+                            yield_([])
+
+                    @herd(
+                        name="attn",
+                        sizes=[1, 2 * N_ATTN_CU],
+                        operands=[s_bufs[0].result, s_bufs[1].result],
+                    )
+                    def attn_h(_tx, _ty, _sx, _sy, s0, s1):
+                        Lh = arith.ConstantOp(IntegerAttr.get(i32, ATTN_L), None).result
+                        _dispatch(_ty, [s0, s1], Lh)
+
+                    attn_h.attributes["x_loc"] = IntegerAttr.get(T.i64(), ATTN_COL)
+                    attn_h.attributes["y_loc"] = IntegerAttr.get(T.i64(), 2)
+
+                    # X-loopclose refeed memtiles: emitted LAST, AFTER the q-broadcast
+                    # and attn blocks. Emission order in seg_body is the order the
+                    # memtile DMA programs are built, and mem_6_1 hosts BOTH the
+                    # q-broadcast that FEEDS attn and the oref gather that CONSUMES
+                    # attn's output. Emitting oref first armed the consumer ahead of
+                    # the producer it depends on.
+                    # ===== X-loopclose refeed memtiles (reference mem_tile_6_1 role) =====
+                    # attn-o (ph1 oproj X) + glu-down (ph3 down X) gathered into col-6
+                    # memtiles and re-broadcast into the convergent @xnorm via
+                    # air.refeed_count on the alloc (mechanism 2). Convergence order:
+                    # rms ph0 -> o ph1 -> rms ph2 -> glu ph3.
+                    # Phase-isolation: each refeed memtile serves ONE phase's X, so emit it
+                    # only when that phase is built (else it gathers a producer output that
+                    # is never consumed / never produced = incoherent).
+                    if (
+                        LOOPCLOSE
+                        and OPROJ_PHASE < NPH
+                        and OREF_NOPUT != 1
+                        and (not ORMS_HOST or OREF_DRAIN)
+                    ):
+                        # ph1: gather the 2 CUs' o (1024 each) into 2048, re-broadcast
+                        # OPROJ_REFEED times into @xnorm as the o-proj X.
+                        omtb = AllocOp(oref_l2, [], [])
+                        omtb.operation.attributes["air.memtile_col"] = IntegerAttr.get(
+                            T.i32(), OREF_COL
+                        )
+                        # OREF_VIA_RMS: no refeed at the memtile -- it hands the gathered o
+                        # over once and the rms core does the OPROJ_REFEED re-broadcast.
+                        _oref_refeed_here = not (OREF_2HOP or OREF_VIA_RMS)
+                        omtb.operation.attributes["air.no_split"] = UnitAttr.get()
+                        if OREF_NOCHAIN:
+                            omtb.operation.attributes["air.no_chain_lock"] = (
+                                UnitAttr.get()
+                            )
+                        if not OREF_NOPUT and _oref_refeed_here:
+                            omtb.operation.attributes["air.refeed_count"] = (
+                                IntegerAttr.get(i32, OPROJ_REFEED)
+                            )
+                        if OREF_HOSTSRC:
+                            ChannelGet(
+                                "orefIn",
+                                omtb,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                        else:
+                            for cu in range(N_ATTN_CU):
+                                ChannelGet(
+                                    "attnO",
+                                    omtb,
+                                    indices=[idx(cu)],
+                                    offsets=[idx(cu * QCU)],
+                                    sizes=[idx(QCU)],
+                                    strides=[idx(1)],
+                                )
+                        if OREF_DRAIN:
+                            ChannelPut(
+                                "orefDrain",
+                                omtb,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                        elif not OREF_NOPUT:
+                            ChannelPut(
+                                (
+                                    "oref2"
+                                    if OREF_2HOP
+                                    else (
+                                        "orms"
+                                        if OREF_VIA_RMS
+                                        else ("xnorm2" if PH1_XCHAN else "xnorm")
+                                    )
+                                ),
+                                omtb,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                        DeallocOp(omtb)
+                        if OREF_2HOP and not OREF_NOPUT:
+                            # refeed buffer: ONE fill BD (single get) so AIR's per-BD xN
+                            # scaling lands only on it -> the reference's protocol shape.
+                            omt2 = AllocOp(oref_l2, [], [])
+                            omt2.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), OREF2_COL)
+                            )
+                            omt2.operation.attributes["air.no_split"] = UnitAttr.get()
+                            if not OREF_VIA_RMS:
+                                omt2.operation.attributes["air.refeed_count"] = (
+                                    IntegerAttr.get(i32, OPROJ_REFEED)
+                                )
+                            ChannelGet(
+                                "oref2",
+                                omt2,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                            ChannelPut(
+                                (
+                                    "orms"
+                                    if OREF_VIA_RMS
+                                    else ("xnorm2" if PH1_XCHAN else "xnorm")
+                                ),
+                                omt2,
+                                offsets=[idx(0)],
+                                sizes=[idx(K)],
+                                strides=[idx(1)],
+                            )
+                            DeallocOp(omt2)
+                    if LOOPCLOSE and DOWN_PHASE < NPH:
+                        # ph3: gather NGLU glu slices into INTERMEDIATE, re-broadcast
+                        # DOWN_REFEED times into @xnorm as the down X.
+                        db = AllocOp(downref_l2, [], [])
+                        # glu-down on col0 (DISTINCT from attn-o on col6) so the @xnorm
+                        # convergence does NOT merge o (ph1) + down (ph3) onto ONE mem_6_1
+                        # MM2S ring. Sharing the ring forces the DMA to alternate o,down,o,
+                        # down..., but o must be re-fed OPROJ_REFEED times for proj ph1
+                        # BEFORE down (ph3) is ever produced (down needs ph1->ph2->glu) ->
+                        # the ring blocks on the not-yet-ready down after 1 o send ->
+                        # deadlock. reference keeps both on mem_6_1 but on SEPARATE MM2S channels
+                        # (o=MM2S5, down=MM2S0); AIR can't force that per-channel, so mirror
+                        # Llama and split onto distinct memtile columns.
+                        db.operation.attributes["air.memtile_col"] = IntegerAttr.get(
+                            T.i32(), 0
+                        )
+                        db.operation.attributes["air.no_split"] = UnitAttr.get()
+                        db.operation.attributes["air.refeed_count"] = IntegerAttr.get(
+                            i32, DOWN_REFEED
+                        )
+                        # UNROLLED gather (constant offsets), not a rolled scf.for with
+                        # an IV-derived offset. Rolled, the NGLU=22 gets lower to a BD ring
+                        # whose wrap does not divide 22, so chunks are duplicated and
+                        # dropped: the down X came out as
+                        #   [h0 h1 h2 h3 . . h0 h1 h8 h9 . . h12..h15 . . h12..h15]
+                        # (device-measured 2026-08-06 by fitting the down contribution
+                        # per hid chunk, recon cos 0.998). Llama's equivalent gather is 16
+                        # chunks -- a power of two -- which is why it never showed there.
+                        if DOWN_GATHER_UNROLL:
+                            for _s in range(NGLU):
+                                ChannelGet(
+                                    "gluOut",
+                                    db,
+                                    offsets=[idx(_s * GLU_HID)],
+                                    sizes=[idx(GLU_HID)],
+                                    strides=[idx(1)],
+                                )
+                        elif DOWN_GATHER_PAIRS:
+                            for _s in for_(idx(0), idx(NGLU // 2), idx(1)):
+                                base = arith.muli(_s, idx(2 * GLU_HID))
+                                for _h in range(2):
+                                    ChannelGet(
+                                        "gluOut",
+                                        db,
+                                        offsets=[arith.addi(base, idx(_h * GLU_HID))],
+                                        sizes=[idx(GLU_HID)],
+                                        strides=[idx(1)],
+                                    )
+                                yield_([])
+                        else:
+                            for _s in for_(idx(0), idx(NGLU), idx(1)):
+                                soff = arith.muli(_s, idx(GLU_HID))
+                                ChannelGet(
+                                    "gluOut",
+                                    db,
+                                    offsets=[soff],
+                                    sizes=[idx(GLU_HID)],
+                                    strides=[idx(1)],
+                                )
+                                yield_([])
+                        if DOWN_PUT_SPLIT:
+                            for _s in range(NGLU):
+                                ChannelPut(
+                                    "xnorm",
+                                    db,
+                                    offsets=[idx(_s * GLU_HID)],
+                                    sizes=[idx(GLU_HID)],
+                                    strides=[idx(1)],
+                                )
+                        else:
+                            ChannelPut(
+                                "xnorm",
+                                db,
+                                offsets=[idx(0)],
+                                sizes=[idx(INTERMEDIATE)],
+                                strides=[idx(1)],
+                            )
+                        DeallocOp(db)
+
+            # air.preserve_shim_dma_order: opt out of air-opt-shim-dma-bds'
+            # per-channel BD regrouping. The weight channels (inW) are coupled by
+            # the X broadcast multicast (all proj cores advance in lockstep), so the
+            # round-major host put order (phase-outer, col-inner, above) is
+            # load-bearing and must not be reordered into channel-major BDs (mirrors
+            # Llama fused_decode.py).
+            # Single-layer: emit the launch directly (no scf.for, no IV operand) so the
+            # IR stays byte-identical to the verified build. Multi-layer: wrap it in an
+            # AIR scf.for and thread the induction variable in as the last operand, so the
+            # per-layer DDR offsets are loop-carried. airrt-to-npu unrolls this LATE, so
+            # the AIR op count -- and the aie.device/xclbin -- stay constant; only the
+            # runtime instruction sequence grows by NLAYERS sub-sequences.
+            if NLAYERS > 1:
+                for _iv in for_(idx(0), idx(NLAYERS), idx(1)):
+                    launch(
+                        sizes=[1, 1],
+                        operands=list(_fa) + [_iv],
+                        attributes={"air.preserve_shim_dma_order": UnitAttr.get()},
+                    )(launch_body)
+                    yield_([])
+            else:
+                launch(
+                    sizes=[1, 1],
+                    operands=list(_fa),
+                    attributes={"air.preserve_shim_dma_order": UnitAttr.get()},
+                )(launch_body)
+
+    return build()
+
+
+def run():
+    module = build_module()
+    backend = XRTBackend(
+        omit_while_true_loop=False,
+        output_format="xclbin",
+        kernel_name="MLIR_AIE",
+        stack_size=10240,  # proj_qmm deepest frame ~7KB (<10K); stack-overflow ruled
+        # out for this proj (measured; 16K global did not clear the hang).
+        use_lock_race_condition_fix_v2=True,
+        coalesce_shim_dma=True,
+        debug_ir=bool(int(_os.environ.get("QWEN_DEBUG_IR", "0"))),
+    )
+    print(
+        f"[qwen_decode] proj grid {NCX}x{NCY}=16 cores cols "
+        f"{PROJ_COL0}-{PROJ_COL0+NCX-1}, QKV rounds/core={_RB} nj={_NJ}"
+    )
+    art = backend.compile(
+        module, output_binary_name="decode_qwen", insts="decode_qwen.insts.bin"
+    )
+    print(f"[qwen_decode] emitted {art.output_binary} + {art.insts}")
+    return 0
+
+
+if __name__ == "__main__":
+    argparse.ArgumentParser().parse_args()
+    exit(run())

--- a/programming_examples/fused_decode/kernels/attn_kv.cc
+++ b/programming_examples/fused_decode/kernels/attn_kv.cc
@@ -8,7 +8,16 @@
 // Hot-path inlining (see attn_qk.cc): tuned functions + entry wrappers are
 // always_inline'd so the .ll kernel is llvm-merged into AIR's per-block scf.for
 // loop. Peano only, always built with -DDECODE_INLINE_ATTN.
+// Peano (llvm-aie) spills the online-softmax attention's many live BFP16 matrix
+// accumulators, and a residual cross-regfile spill/reload defect corrupts /
+// deadlocks the inlined attn (the reference implementation). Keep the hot attn
+// helpers (attn_fv/calculate_l/_attn_qk/update) NOINLINE on Peano so each stays
+// a bounded-register function; chess schedules the inlined form correctly.
+#if defined(__chess__)
 #define ATTN_HOT inline __attribute__((always_inline))
+#else
+#define ATTN_HOT __attribute__((noinline))
+#endif
 #define ATTN_ENTRY __attribute__((always_inline))
 
 typedef float y_acc_dtype;
@@ -454,6 +463,9 @@ void scale_div_aie(bf16 *a, bf16 *o, float *l) {
 
 #elif ATTN_IMPL == ATTN_IMPL_1x8x1
 
+#if !defined(__chess__)
+__attribute__((noinline))
+#endif
 void calculate_l(bf16 *__restrict pS, float *__restrict c,
                  float *__restrict l) {
   using MMUL = aie::mmul<GQA_R, GQA_S, GQA_T, bf16, bf16, accfloat>;
@@ -501,11 +513,58 @@ void calculate_l(bf16 *__restrict pS, float *__restrict c,
 
 typedef float y_acc_dtype;
 template <unsigned colQ, unsigned r, unsigned s, unsigned t>
+#if !defined(__chess__)
+__attribute__((noinline))
+#endif
 void attn_fv(bf16 *__restrict pS, bf16 *__restrict pV,
              y_acc_dtype *__restrict pY, float *__restrict c) {
 
   using MMUL = aie::mmul<r, s, t, bf16, bf16, accfloat>;
 
+  bf16 *__restrict pV1 = pV;
+
+#if !defined(__chess__)
+  // Peano: the natural j+=4 form keeps FOUR BFP16 mmul accumulators (Y00..Y03)
+  // AND the 64-wide CORRECT vector live across the loop; peano spills the
+  // accumulators and a cross-regfile spill/reload defect corrupts iterations
+  // (bug B, same AIESpillSlotOptimization family). Restructure so nothing
+  // spills: (1) apply the online-softmax correction y *= CORRECT in a
+  // pure-vector pass (CORRECT is dead afterwards, freeing registers); (2) mac
+  // pass: exactly ONE zero-pressure mmul accumulator seeded from the corrected
+  // acc, full-store (1x8x1 has no plane split -> no radix filter).
+  {
+    aie::vector<bf16, 64> S_up = aie::load_v<64>(pS);
+    aie::vector<bf16, 64> S_down = aie::load_v<64>(pS + 64);
+    aie::vector<bf16, MMUL::size_A> S0 =
+        aie::concat(aie::filter_even(S_up, 8), aie::filter_even(S_down, 8));
+    aie::vector<bf16, MMUL::size_A> S1 =
+        aie::concat(aie::filter_odd(S_up, 8), aie::filter_odd(S_down, 8));
+    // (1) correction pass
+    {
+      aie::vector<y_acc_dtype, 64> CORRECT = aie::concat(
+          aie::broadcast<float, 8>(c[0]), aie::broadcast<float, 8>(c[1]),
+          aie::broadcast<float, 8>(c[2]), aie::broadcast<float, 8>(c[3]),
+          aie::broadcast<float, 8>(c[4]), aie::broadcast<float, 8>(c[5]),
+          aie::broadcast<float, 8>(c[6]), aie::broadcast<float, 8>(c[7]));
+      for (unsigned j = 0; j < colQ; j += 1) {
+        y_acc_dtype *__restrict pYc = pY + j * MMUL::size_C;
+        aie::store_v(pYc, aie::mul(CORRECT, aie::load_v<MMUL::size_C>(pYc))
+                              .template to_vector<y_acc_dtype>());
+      }
+    }
+    // (2) mac pass, single accumulator
+    for (unsigned j = 0; j < colQ; j += 1) {
+      y_acc_dtype *__restrict pYc = pY + j * MMUL::size_C;
+      bf16 *__restrict pVp = pV1 + j * MMUL::size_B;
+      aie::vector<bf16, MMUL::size_B> Vp = aie::load_v<MMUL::size_B>(pVp);
+      MMUL Y(aie::load_v<MMUL::size_C>(pYc));
+      Y.mac(S0, Vp);
+      Vp = aie::load_v<MMUL::size_B>(pVp + MMUL::size_B * colQ);
+      Y.mac(S1, Vp);
+      aie::store_v(pYc, Y.template to_vector<y_acc_dtype>());
+    }
+  }
+#else
   y_acc_dtype *__restrict pY1 = pY;
   bf16 *__restrict pS1 = pS;
 
@@ -533,72 +592,71 @@ void attn_fv(bf16 *__restrict pS, bf16 *__restrict pV,
   aie::vector<y_acc_dtype, 64> CORRECT =
       aie::concat(c0, c1, c2, c3, c4, c5, c6, c7);
 
-  bf16 *__restrict pV1 = pV;
+  for (unsigned j = 0; j < colQ; j += 4)
+    chess_prepare_for_pipelining chess_loop_range(2, ) {
+      // v0
+      bf16 *__restrict pV01 = pV1 + (j + 0) * MMUL::size_B;
+      bf16 *__restrict pV02 = pV1 + (j + 1) * MMUL::size_B;
+      bf16 *__restrict pV03 = pV1 + (j + 2) * MMUL::size_B;
+      bf16 *__restrict pV04 = pV1 + (j + 3) * MMUL::size_B;
 
-  AIE_PREPARE_FOR_PIPELINING AIE_LOOP_RANGE(2) for (unsigned j = 0; j < colQ;
-                                                    j += 4) {
-    // v0
-    bf16 *__restrict pV01 = pV1 + (j + 0) * MMUL::size_B;
-    bf16 *__restrict pV02 = pV1 + (j + 1) * MMUL::size_B;
-    bf16 *__restrict pV03 = pV1 + (j + 2) * MMUL::size_B;
-    bf16 *__restrict pV04 = pV1 + (j + 3) * MMUL::size_B;
+      aie::vector<bf16, MMUL::size_B> V00 = aie::load_v<MMUL::size_B>(pV01);
+      pV01 += MMUL::size_B * colQ;
+      aie::vector<bf16, MMUL::size_B> V01 = aie::load_v<MMUL::size_B>(pV02);
+      pV02 += MMUL::size_B * colQ;
+      aie::vector<bf16, MMUL::size_B> V02 = aie::load_v<MMUL::size_B>(pV03);
+      pV03 += MMUL::size_B * colQ;
+      aie::vector<bf16, MMUL::size_B> V03 = aie::load_v<MMUL::size_B>(pV04);
+      pV04 += MMUL::size_B * colQ;
 
-    aie::vector<bf16, MMUL::size_B> V00 = aie::load_v<MMUL::size_B>(pV01);
-    pV01 += MMUL::size_B * colQ;
-    aie::vector<bf16, MMUL::size_B> V01 = aie::load_v<MMUL::size_B>(pV02);
-    pV02 += MMUL::size_B * colQ;
-    aie::vector<bf16, MMUL::size_B> V02 = aie::load_v<MMUL::size_B>(pV03);
-    pV03 += MMUL::size_B * colQ;
-    aie::vector<bf16, MMUL::size_B> V03 = aie::load_v<MMUL::size_B>(pV04);
-    pV04 += MMUL::size_B * colQ;
+      aie::vector<y_acc_dtype, MMUL::size_C> acc_y00 =
+          aie::load_v<MMUL::size_C>(pY1);
+      aie::vector<y_acc_dtype, MMUL::size_C> acc_y01 =
+          aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C);
+      aie::vector<y_acc_dtype, MMUL::size_C> acc_y02 =
+          aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C * 2);
+      aie::vector<y_acc_dtype, MMUL::size_C> acc_y03 =
+          aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C * 3);
 
-    aie::vector<y_acc_dtype, MMUL::size_C> acc_y00 =
-        aie::load_v<MMUL::size_C>(pY1);
-    aie::vector<y_acc_dtype, MMUL::size_C> acc_y01 =
-        aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C);
-    aie::vector<y_acc_dtype, MMUL::size_C> acc_y02 =
-        aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C * 2);
-    aie::vector<y_acc_dtype, MMUL::size_C> acc_y03 =
-        aie::load_v<MMUL::size_C>(pY1 + MMUL::size_C * 3);
+      aie::accum<accfloat, MMUL::size_C> ACC_Y00;
+      aie::accum<accfloat, MMUL::size_C> ACC_Y01;
+      aie::accum<accfloat, MMUL::size_C> ACC_Y02;
+      aie::accum<accfloat, MMUL::size_C> ACC_Y03;
+      ACC_Y00 = aie::mul(CORRECT, acc_y00);
+      ACC_Y01 = aie::mul(CORRECT, acc_y01);
+      ACC_Y02 = aie::mul(CORRECT, acc_y02);
+      ACC_Y03 = aie::mul(CORRECT, acc_y03);
 
-    aie::accum<accfloat, MMUL::size_C> ACC_Y00;
-    aie::accum<accfloat, MMUL::size_C> ACC_Y01;
-    aie::accum<accfloat, MMUL::size_C> ACC_Y02;
-    aie::accum<accfloat, MMUL::size_C> ACC_Y03;
-    ACC_Y00 = aie::mul(CORRECT, acc_y00);
-    ACC_Y01 = aie::mul(CORRECT, acc_y01);
-    ACC_Y02 = aie::mul(CORRECT, acc_y02);
-    ACC_Y03 = aie::mul(CORRECT, acc_y03);
+      MMUL Y00(ACC_Y00);
+      MMUL Y01(ACC_Y01);
+      MMUL Y02(ACC_Y02);
+      MMUL Y03(ACC_Y03);
 
-    MMUL Y00(ACC_Y00);
-    MMUL Y01(ACC_Y01);
-    MMUL Y02(ACC_Y02);
-    MMUL Y03(ACC_Y03);
+      Y00.mac(S0, V00);
+      Y01.mac(S0, V01);
+      Y02.mac(S0, V02);
+      Y03.mac(S0, V03);
 
-    Y00.mac(S0, V00);
-    Y01.mac(S0, V01);
-    Y02.mac(S0, V02);
-    Y03.mac(S0, V03);
+      V00 = aie::load_v<MMUL::size_B>(pV01);
+      V01 = aie::load_v<MMUL::size_B>(pV02);
+      V02 = aie::load_v<MMUL::size_B>(pV03);
+      V03 = aie::load_v<MMUL::size_B>(pV04);
 
-    V00 = aie::load_v<MMUL::size_B>(pV01);
-    V01 = aie::load_v<MMUL::size_B>(pV02);
-    V02 = aie::load_v<MMUL::size_B>(pV03);
-    V03 = aie::load_v<MMUL::size_B>(pV04);
+      Y00.mac(S1, V00);
+      Y01.mac(S1, V01);
+      Y02.mac(S1, V02);
+      Y03.mac(S1, V03);
 
-    Y00.mac(S1, V00);
-    Y01.mac(S1, V01);
-    Y02.mac(S1, V02);
-    Y03.mac(S1, V03);
-
-    aie::store_v(pY1, Y00.template to_vector<y_acc_dtype>());
-    pY1 += MMUL::size_C;
-    aie::store_v(pY1, Y01.template to_vector<y_acc_dtype>());
-    pY1 += MMUL::size_C;
-    aie::store_v(pY1, Y02.template to_vector<y_acc_dtype>());
-    pY1 += MMUL::size_C;
-    aie::store_v(pY1, Y03.template to_vector<y_acc_dtype>());
-    pY1 += MMUL::size_C;
-  }
+      aie::store_v(pY1, Y00.template to_vector<y_acc_dtype>());
+      pY1 += MMUL::size_C;
+      aie::store_v(pY1, Y01.template to_vector<y_acc_dtype>());
+      pY1 += MMUL::size_C;
+      aie::store_v(pY1, Y02.template to_vector<y_acc_dtype>());
+      pY1 += MMUL::size_C;
+      aie::store_v(pY1, Y03.template to_vector<y_acc_dtype>());
+      pY1 += MMUL::size_C;
+    }
+#endif
 }
 
 template <unsigned N>
@@ -690,8 +748,12 @@ void attn_kv_blk(bf16 *__restrict s_block, bf16 *__restrict v_block,
   if (L - blk * 16 <= 0)
     return;
   float *c = (float *)(s_block + Q_HEADS_PADDED_PER_CU * 16);
+#ifndef SKIP_CALC_L
   calculate_l(s_block, c, l_state);
+#endif
+#ifndef SKIP_ATTN_FV
   attn_fv<DH / 8, GQA_R, GQA_S, GQA_T>(s_block, v_block, y_state, c);
+#endif
 }
 
 void attn_kv_fin(float *__restrict y_state, float *__restrict l_state,

--- a/programming_examples/fused_decode/kernels/attn_qk.cc
+++ b/programming_examples/fused_decode/kernels/attn_qk.cc
@@ -10,7 +10,16 @@
 // so the .ll kernel is llvm-merged into AIR's per-block scf.for loop (no
 // per-block call ABI). Peano only, always built with -DDECODE_INLINE_ATTN (see
 // the chatbot Makefile).
+// Peano (llvm-aie) spills the online-softmax attention's many live BFP16 matrix
+// accumulators, and a residual cross-regfile spill/reload defect corrupts /
+// deadlocks the inlined attn (the reference implementation). Keep the hot attn
+// helpers (attn_fv/calculate_l/_attn_qk/update) NOINLINE on Peano so each stays
+// a bounded-register function; chess schedules the inlined form correctly.
+#if defined(__chess__)
 #define ATTN_HOT inline __attribute__((always_inline))
+#else
+#define ATTN_HOT __attribute__((noinline))
+#endif
 #define ATTN_ENTRY __attribute__((always_inline))
 
 ATTN_HOT aie::vector<bf16, 16> update(bf16 *m, float *c,
@@ -322,9 +331,10 @@ void _attn_qk(bf16 *__restrict pQ, bf16 *__restrict pK, bfloat16 *__restrict pY,
 #elif ATTN_IMPL == ATTN_IMPL_1x8x1
 
 template <unsigned colQ, unsigned r, unsigned s, unsigned t>
-void _attn_qk(bf16 *__restrict pQ, bf16 *__restrict pK, bfloat16 *__restrict pY,
-              bf16 *__restrict m, float *__restrict c, aie::mask<16> &mask,
-              bool &is_first) {
+ATTN_HOT void _attn_qk(bf16 *__restrict pQ, bf16 *__restrict pK,
+                       bfloat16 *__restrict pY, bf16 *__restrict m,
+                       float *__restrict c, aie::mask<16> &mask,
+                       bool &is_first) {
 
   using MMUL = aie::mmul<r, s, t, bf16, bf16, accfloat>;
 

--- a/programming_examples/fused_decode/kernels/model_spec.h
+++ b/programming_examples/fused_decode/kernels/model_spec.h
@@ -13,7 +13,7 @@ constexpr int DQ = NUM_ATTN_HEADS * DH;
 constexpr int DK = NUM_KV_HEADS * DH;
 constexpr int DV = DK;
 
-// Analize the GQA patterns. 2x4x1 packs 2 kv heads per CU; 1x8x1 / 1x4x1 use 1
+// Analyze the GQA patterns. 2x4x1 packs 2 kv heads per CU; 1x8x1 / 1x4x1 use 1
 // kv head per CU (so the CU count equals the kv-head count).
 #if ATTN_IMPL == ATTN_IMPL_2x4x1
 constexpr int NUM_MHA_CU = NUM_KV_HEADS / 2;

--- a/programming_examples/fused_decode/kernels/model_spec.h
+++ b/programming_examples/fused_decode/kernels/model_spec.h
@@ -13,8 +13,13 @@ constexpr int DQ = NUM_ATTN_HEADS * DH;
 constexpr int DK = NUM_KV_HEADS * DH;
 constexpr int DV = DK;
 
-// Analize the GQA patterns
-constexpr int NUM_MHA_CU = 4;
+// Analize the GQA patterns. 2x4x1 packs 2 kv heads per CU; 1x8x1 / 1x4x1 use 1
+// kv head per CU (so the CU count equals the kv-head count).
+#if ATTN_IMPL == ATTN_IMPL_2x4x1
+constexpr int NUM_MHA_CU = NUM_KV_HEADS / 2;
+#else
+constexpr int NUM_MHA_CU = NUM_KV_HEADS;
+#endif
 constexpr int KV_HEADS_PER_CU = NUM_KV_HEADS / NUM_MHA_CU;
 constexpr int Q_HEADS_PER_CU = NUM_ATTN_HEADS / NUM_MHA_CU;
 
@@ -59,7 +64,8 @@ constexpr int VOCAB_SIZE_PADDED =
 ///@brief Q4K block
 ///@param scales: scales and mins, bf16
 ///@param mins: scales and mins, bf16
-///@param qs: 4--bit quants
+///@param qs: 4--bit quants (unsigned for Q4NX, signed for Q4_0)
+#ifndef Q4_0
 typedef struct {
   bf16 scales[Q4NX_ROW_BLOCK_SIZE * Q4NX_COL_BLOCK_SIZE /
               Q4NX_GROUP_SIZE]; // scales and mins, quantized with 6 bits
@@ -67,5 +73,12 @@ typedef struct {
             Q4NX_GROUP_SIZE]; // scales and mins, quantized with 6 bits
   uint4 qs[Q4NX_ROW_BLOCK_SIZE * Q4NX_COL_BLOCK_SIZE]; // 4--bit quants
 } q4k_block_t;
+#else
+typedef struct {
+  bf16 scales[Q4NX_ROW_BLOCK_SIZE * Q4NX_COL_BLOCK_SIZE / Q4NX_GROUP_SIZE];
+  bf16 mins[Q4NX_ROW_BLOCK_SIZE * Q4NX_COL_BLOCK_SIZE / Q4NX_GROUP_SIZE];
+  int4 qs[Q4NX_ROW_BLOCK_SIZE * Q4NX_COL_BLOCK_SIZE]; // signed 4-bit quants
+} q4k_block_t;
+#endif
 
 #endif

--- a/programming_examples/fused_decode/kernels/proj_qmm.cc
+++ b/programming_examples/fused_decode/kernels/proj_qmm.cc
@@ -52,6 +52,7 @@ void proj_qmm_acc(bf16 *__restrict x_full, int j, bf16 *__restrict w,
   constexpr int m = Q4NX_ROW_BLOCK_SIZE; // 32
   constexpr int k = Q4NX_COL_BLOCK_SIZE; // 256
   bf16 *x = x_full + j * k;
+#ifndef Q4_0
   alignas(aie::vector_decl_align) bfloat16 b_col_reduce_add[k / 32]; // 8
 
   // per-group (32 cols) reduction of x, used for the +min term.
@@ -63,6 +64,10 @@ void proj_qmm_acc(bf16 *__restrict x_full, int j, bf16 *__restrict w,
     }
 
   _qmm_q4k_bf16<m, k>((q4k_block_t *)w, x, y_acc, b_col_reduce_add);
+#else
+  // Q4_0: scale-only (no +min term) -> no b_col_reduce, 3-arg form.
+  _qmm_q4k_bf16<m, k>((q4k_block_t *)w, x, y_acc);
+#endif
 }
 
 // the reference-streaming variant of proj_qmm_acc: x is ONE 256-element
@@ -75,8 +80,9 @@ void proj_qmm_acc(bf16 *__restrict x_full, int j, bf16 *__restrict w,
 //   y_acc : caller-provided float accumulator (32), read-modify-written
 void proj_qmm_acc256(bf16 *__restrict x_blk, bf16 *__restrict w,
                      float *__restrict y_acc) {
-  constexpr int m = Q4NX_ROW_BLOCK_SIZE;                             // 32
-  constexpr int k = Q4NX_COL_BLOCK_SIZE;                             // 256
+  constexpr int m = Q4NX_ROW_BLOCK_SIZE; // 32
+  constexpr int k = Q4NX_COL_BLOCK_SIZE; // 256
+#ifndef Q4_0
   alignas(aie::vector_decl_align) bfloat16 b_col_reduce_add[k / 32]; // 8
 
   AIE_PREPARE_FOR_PIPELINING
@@ -88,6 +94,10 @@ void proj_qmm_acc256(bf16 *__restrict x_blk, bf16 *__restrict w,
     }
 
   _qmm_q4k_bf16<m, k>((q4k_block_t *)w, x_blk, y_acc, b_col_reduce_add);
+#else
+  // Q4_0: scale-only (no +min term) -> no b_col_reduce, 3-arg form.
+  _qmm_q4k_bf16<m, k>((q4k_block_t *)w, x_blk, y_acc);
+#endif
 }
 
 // Flush the accumulator to bf16 output (call once after the col-block loop).

--- a/programming_examples/fused_decode/kernels/q4_k.h
+++ b/programming_examples/fused_decode/kernels/q4_k.h
@@ -6,6 +6,11 @@
 #include "aie_kernel_utils.h"
 #include "model_spec.h"
 
+// Two quant layouts: Q4NX (unsigned int4 + per-group min, the default / Llama
+// path) selected when Q4_0 is NOT defined; Q4_0 (signed int4, scale-only, no
+// min -- the Qwen2.5 path) selected when Q4_0 IS defined. The Q4_0 form takes 3
+// args (no b_col_reduce_buffer, since there is no +min term).
+#ifndef Q4_0
 template <int M, int N>
 void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c,
                    bf16 *b_col_reduce_buffer) {
@@ -205,5 +210,208 @@ void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c,
     aie::store_v(c + row, c_accum_f32);
   }
 }
+
+#else // Q4_0: signed int4, scale-only (no per-group min), 3-arg form.
+template <int M, int N>
+inline void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c) {
+  static_assert(N == 256, "N must be = 256");
+  static_assert(M == 32, "M must be = 32");
+  constexpr int pr = 16;
+  constexpr int pc = 8;
+  const q4k_block_t *A_q4k = (q4k_block_t *)A;
+  uint8_t *qs_ptr = (uint8_t *)(A_q4k->qs);
+  float *c_ptr = const_cast<float *>(c);
+
+  AIE_PREPARE_FOR_PIPELINING
+  AIE_LOOP_RANGE(M / pr, M / pr)
+  for (int row = 0; row < M; row += pr) {
+    aie::accum<accfloat, pr> c_accum;
+    c_accum.from_vector(aie::load_v<pr>(c + row));
+    bf16 *it_B = const_cast<bf16 *>(B);
+    bf16 *scales_ptr = const_cast<bf16 *>(A_q4k->scales + row);
+
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_RANGE(N / 32, N / 32)
+    for (int sub_chunk = 0; sub_chunk < N / 32; sub_chunk++) {
+      aie::vector<bf16, 32> b_col = aie::load_v<32>(it_B);
+      it_B += 32;
+
+      aie::vector<bf16, pr> a_scales = aie::load_v<pr>(scales_ptr);
+      scales_ptr += M;
+
+      aie::accum<accfloat, pr> c_local_accum;
+      c_local_accum.from_vector(aie::zeros<float, pr>());
+
+      {
+#if defined(__chess__)
+        aie::vector<int4, pr * 8> a_cc_0 = aie::load_v<pr * 8>((int4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<int4, pr * 8> a_cc_1 = aie::load_v<pr * 8>((int4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<int4, pr * 8> a_cc_2 = aie::load_v<pr * 8>((int4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<int4, pr * 8> a_cc_3 = aie::load_v<pr * 8>((int4 *)qs_ptr);
+        qs_ptr += pr * 4;
+
+        aie::vector<float, pr * 8> a_cc_f32_0 = aie::to_float(a_cc_0, 0);
+        aie::vector<float, pr * 8> a_cc_f32_1 = aie::to_float(a_cc_1, 0);
+        aie::vector<float, pr * 8> a_cc_f32_2 = aie::to_float(a_cc_2, 0);
+        aie::vector<float, pr * 8> a_cc_f32_3 = aie::to_float(a_cc_3, 0);
+#else
+        // Peano's aie-api folds aie::to_float(vector<int4>) to zero (signed
+        // int4 unsupported) -> the whole matmul gets DCE'd. Load as uint4
+        // (works on peano) and sign-correct the 2's-complement nibble (v>=8 ->
+        // v-16) to match chess's to_float(int4).
+        aie::vector<uint4, pr * 8> u_cc_0 =
+            aie::load_v<pr * 8>((uint4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<uint4, pr * 8> u_cc_1 =
+            aie::load_v<pr * 8>((uint4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<uint4, pr * 8> u_cc_2 =
+            aie::load_v<pr * 8>((uint4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        aie::vector<uint4, pr * 8> u_cc_3 =
+            aie::load_v<pr * 8>((uint4 *)qs_ptr);
+        qs_ptr += pr * 4;
+        const aie::vector<float, pr * 8> k_sixteen =
+            aie::broadcast<float, pr * 8>(16.0f);
+        const aie::vector<float, pr * 8> k_eight =
+            aie::broadcast<float, pr * 8>(8.0f);
+        auto sfix = [&](aie::vector<uint4, pr * 8> uv) {
+          aie::vector<float, pr * 8> f = aie::to_float(uv, 0);
+          return aie::select(f, aie::sub(f, k_sixteen), aie::ge(f, k_eight));
+        };
+        aie::vector<float, pr * 8> a_cc_f32_0 = sfix(u_cc_0);
+        aie::vector<float, pr * 8> a_cc_f32_1 = sfix(u_cc_1);
+        aie::vector<float, pr * 8> a_cc_f32_2 = sfix(u_cc_2);
+        aie::vector<float, pr * 8> a_cc_f32_3 = sfix(u_cc_3);
+#endif
+
+        aie::accum<accfloat, pr * 8> a_cc_f32_accum_0;
+        a_cc_f32_accum_0.from_vector(a_cc_f32_0);
+        aie::vector<bf16, pr * 8> a_cc_bf16_0 =
+            a_cc_f32_accum_0.template to_vector<bf16>();
+        aie::accum<accfloat, pr * 8> a_cc_f32_accum_1;
+        a_cc_f32_accum_1.from_vector(a_cc_f32_1);
+        aie::vector<bf16, pr * 8> a_cc_bf16_1 =
+            a_cc_f32_accum_1.template to_vector<bf16>();
+        aie::accum<accfloat, pr * 8> a_cc_f32_accum_2;
+        a_cc_f32_accum_2.from_vector(a_cc_f32_2);
+        aie::vector<bf16, pr * 8> a_cc_bf16_2 =
+            a_cc_f32_accum_2.template to_vector<bf16>();
+        aie::accum<accfloat, pr * 8> a_cc_f32_accum_3;
+        a_cc_f32_accum_3.from_vector(a_cc_f32_3);
+        aie::vector<bf16, pr * 8> a_cc_bf16_3 =
+            a_cc_f32_accum_3.template to_vector<bf16>();
+
+        aie::vector<bf16, pr> a_col_0_0 = a_cc_bf16_0.extract<pr>(0);
+        aie::vector<bf16, pr> a_col_1_0 = a_cc_bf16_0.extract<pr>(1);
+        aie::vector<bf16, pr> a_col_2_0 = a_cc_bf16_0.extract<pr>(2);
+        aie::vector<bf16, pr> a_col_3_0 = a_cc_bf16_0.extract<pr>(3);
+        aie::vector<bf16, pr> a_col_4_0 = a_cc_bf16_0.extract<pr>(4);
+        aie::vector<bf16, pr> a_col_5_0 = a_cc_bf16_0.extract<pr>(5);
+        aie::vector<bf16, pr> a_col_6_0 = a_cc_bf16_0.extract<pr>(6);
+        aie::vector<bf16, pr> a_col_7_0 = a_cc_bf16_0.extract<pr>(7);
+        aie::vector<bf16, pr> a_col_0_1 = a_cc_bf16_1.extract<pr>(0);
+        aie::vector<bf16, pr> a_col_1_1 = a_cc_bf16_1.extract<pr>(1);
+        aie::vector<bf16, pr> a_col_2_1 = a_cc_bf16_1.extract<pr>(2);
+        aie::vector<bf16, pr> a_col_3_1 = a_cc_bf16_1.extract<pr>(3);
+        aie::vector<bf16, pr> a_col_4_1 = a_cc_bf16_1.extract<pr>(4);
+        aie::vector<bf16, pr> a_col_5_1 = a_cc_bf16_1.extract<pr>(5);
+        aie::vector<bf16, pr> a_col_6_1 = a_cc_bf16_1.extract<pr>(6);
+        aie::vector<bf16, pr> a_col_7_1 = a_cc_bf16_1.extract<pr>(7);
+        aie::vector<bf16, pr> a_col_0_2 = a_cc_bf16_2.extract<pr>(0);
+        aie::vector<bf16, pr> a_col_1_2 = a_cc_bf16_2.extract<pr>(1);
+        aie::vector<bf16, pr> a_col_2_2 = a_cc_bf16_2.extract<pr>(2);
+        aie::vector<bf16, pr> a_col_3_2 = a_cc_bf16_2.extract<pr>(3);
+        aie::vector<bf16, pr> a_col_4_2 = a_cc_bf16_2.extract<pr>(4);
+        aie::vector<bf16, pr> a_col_5_2 = a_cc_bf16_2.extract<pr>(5);
+        aie::vector<bf16, pr> a_col_6_2 = a_cc_bf16_2.extract<pr>(6);
+        aie::vector<bf16, pr> a_col_7_2 = a_cc_bf16_2.extract<pr>(7);
+        aie::vector<bf16, pr> a_col_0_3 = a_cc_bf16_3.extract<pr>(0);
+        aie::vector<bf16, pr> a_col_1_3 = a_cc_bf16_3.extract<pr>(1);
+        aie::vector<bf16, pr> a_col_2_3 = a_cc_bf16_3.extract<pr>(2);
+        aie::vector<bf16, pr> a_col_3_3 = a_cc_bf16_3.extract<pr>(3);
+        aie::vector<bf16, pr> a_col_4_3 = a_cc_bf16_3.extract<pr>(4);
+        aie::vector<bf16, pr> a_col_5_3 = a_cc_bf16_3.extract<pr>(5);
+        aie::vector<bf16, pr> a_col_6_3 = a_cc_bf16_3.extract<pr>(6);
+        aie::vector<bf16, pr> a_col_7_3 = a_cc_bf16_3.extract<pr>(7);
+
+        bfloat16 scalar_0_0 = b_col.get(0);
+        bfloat16 scalar_1_0 = b_col.get(1);
+        bfloat16 scalar_2_0 = b_col.get(2);
+        bfloat16 scalar_3_0 = b_col.get(3);
+        bfloat16 scalar_4_0 = b_col.get(4);
+        bfloat16 scalar_5_0 = b_col.get(5);
+        bfloat16 scalar_6_0 = b_col.get(6);
+        bfloat16 scalar_7_0 = b_col.get(7);
+        bfloat16 scalar_0_1 = b_col.get(8);
+        bfloat16 scalar_1_1 = b_col.get(9);
+        bfloat16 scalar_2_1 = b_col.get(10);
+        bfloat16 scalar_3_1 = b_col.get(11);
+        bfloat16 scalar_4_1 = b_col.get(12);
+        bfloat16 scalar_5_1 = b_col.get(13);
+        bfloat16 scalar_6_1 = b_col.get(14);
+        bfloat16 scalar_7_1 = b_col.get(15);
+        bfloat16 scalar_0_2 = b_col.get(16);
+        bfloat16 scalar_1_2 = b_col.get(17);
+        bfloat16 scalar_2_2 = b_col.get(18);
+        bfloat16 scalar_3_2 = b_col.get(19);
+        bfloat16 scalar_4_2 = b_col.get(20);
+        bfloat16 scalar_5_2 = b_col.get(21);
+        bfloat16 scalar_6_2 = b_col.get(22);
+        bfloat16 scalar_7_2 = b_col.get(23);
+        bfloat16 scalar_0_3 = b_col.get(24);
+        bfloat16 scalar_1_3 = b_col.get(25);
+        bfloat16 scalar_2_3 = b_col.get(26);
+        bfloat16 scalar_3_3 = b_col.get(27);
+        bfloat16 scalar_4_3 = b_col.get(28);
+        bfloat16 scalar_5_3 = b_col.get(29);
+        bfloat16 scalar_6_3 = b_col.get(30);
+        bfloat16 scalar_7_3 = b_col.get(31);
+
+        c_local_accum = aie::mac(c_local_accum, a_col_0_0, scalar_0_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_1_0, scalar_1_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_2_0, scalar_2_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_3_0, scalar_3_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_4_0, scalar_4_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_5_0, scalar_5_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_6_0, scalar_6_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_7_0, scalar_7_0);
+        c_local_accum = aie::mac(c_local_accum, a_col_0_1, scalar_0_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_1_1, scalar_1_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_2_1, scalar_2_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_3_1, scalar_3_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_4_1, scalar_4_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_5_1, scalar_5_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_6_1, scalar_6_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_7_1, scalar_7_1);
+        c_local_accum = aie::mac(c_local_accum, a_col_0_2, scalar_0_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_1_2, scalar_1_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_2_2, scalar_2_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_3_2, scalar_3_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_4_2, scalar_4_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_5_2, scalar_5_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_6_2, scalar_6_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_7_2, scalar_7_2);
+        c_local_accum = aie::mac(c_local_accum, a_col_0_3, scalar_0_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_1_3, scalar_1_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_2_3, scalar_2_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_3_3, scalar_3_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_4_3, scalar_4_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_5_3, scalar_5_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_6_3, scalar_6_3);
+        c_local_accum = aie::mac(c_local_accum, a_col_7_3, scalar_7_3);
+      } // end of cc, 32 columns (manually unrolled)
+      c_accum =
+          aie::mac(c_accum, c_local_accum.template to_vector<bf16>(), a_scales);
+    } // end of sub_chunk, 256 columns
+    aie::vector<float, pr> c_accum_f32 = c_accum.template to_vector<float>();
+    aie::store_v(c_ptr, c_accum_f32);
+    c_ptr += pr;
+  }
+}
+#endif // Q4_0
 
 #endif // __Q4_K_H__

--- a/programming_examples/fused_decode/kernels/rope.cc
+++ b/programming_examples/fused_decode/kernels/rope.cc
@@ -101,6 +101,26 @@ void apply_rope(bf16 *restrict y, bf16 *restrict x, bf16 *restrict cos_val,
   }
 }
 
+#ifdef HAS_QKV_BIAS
+///@brief add the per-projection bias (Qwen2.5 q/k/v_proj.bias) to qkv IN-PLACE,
+/// BEFORE RoPE. Bias slab is laid out [q(DQ)|k(DK)|v(DV)] and lives at
+/// rope_w+DH (appended after the DH cos/sin LUT in the rope weight buffer).
+void add_q_k_v_bias(const bf16 *q_k_v_bias_in, bf16 *qkv) {
+  constexpr uint32_t vec_len = 16;
+  static_assert((DQ + DK + DV) % vec_len == 0);
+  const bf16 *bias_ptr = q_k_v_bias_in;
+  AIE_PREPARE_FOR_PIPELINING
+  AIE_LOOP_RANGE((DQ + DK + DV) / vec_len, (DQ + DK + DV) / vec_len)
+  for (int i = 0; i < DQ + DK + DV; i += vec_len) {
+    aie::vector<bf16, vec_len> bias_vec = aie::load_v<vec_len>(bias_ptr);
+    aie::vector<bf16, vec_len> val_vec = aie::load_v<vec_len>(qkv);
+    aie::store_v(qkv, aie::add(bias_vec, val_vec));
+    bias_ptr += vec_len;
+    qkv += vec_len;
+  }
+}
+#endif
+
 ///@brief pseduo RoPE: q = q, k = k + 1, v = v - 1
 ///@param y: output
 ///@param x: input
@@ -177,6 +197,9 @@ void rope(bf16 *restrict q, bf16 *restrict k, bf16 *restrict v,
   _lock_acquire(q_prod_lock);
   _lock_acquire(k_prod_lock, 2);
   _lock_acquire(v_prod_lock, 2);
+#ifdef HAS_QKV_BIAS
+  add_q_k_v_bias(rope_w + DH, qkv); // Qwen2.5 q/k/v bias, before RoPE
+#endif
   pseduo_rope(q, k, v, qkv, rope_w);
   _lock_release(rope_prod_lock);
   _lock_release(qkv_prod_lock);
@@ -192,6 +215,9 @@ void rope_compute(bf16 *restrict q, bf16 *restrict k, bf16 *restrict v,
                   bf16 *restrict qkv, bf16 *restrict rope_w, int _arm) {
   (void)_arm; // per-token RTP arm-gate operand (kept alive so AIR emits the arm
               // lock)
+#ifdef HAS_QKV_BIAS
+  add_q_k_v_bias(rope_w + DH, qkv); // Qwen2.5 q/k/v bias, before RoPE
+#endif
   pseduo_rope(q, k, v, qkv, rope_w);
 }
 }

--- a/programming_examples/fused_decode/models/all_models.h
+++ b/programming_examples/fused_decode/models/all_models.h
@@ -21,6 +21,7 @@
 
 #define LLAMA_3_2_1B 0
 #define GEMMA3_4B 1
+#define QWEN2_5_3B 2
 
 #ifndef MODEL_TYPE
 #define MODEL_TYPE LLAMA_3_2_1B
@@ -28,5 +29,6 @@
 
 #include "../models/gemma3-4b.h"
 #include "../models/llama3.2-1b.h"
+#include "../models/qwen2.5-3b.h"
 
 #endif // __ALL_MODELS_H__

--- a/programming_examples/fused_decode/models/qwen2.5-3b.h
+++ b/programming_examples/fused_decode/models/qwen2.5-3b.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+///@file qwen2.5-3b.h
+///@brief Define the model parameters for the qwen2.5-3b model
+#ifndef __QWEN2_5_3B_H__
+#define __QWEN2_5_3B_H__
+
+#if MODEL_TYPE == QWEN2_5_3B
+constexpr int MODEL_DIM = 2048;
+constexpr int NUM_ATTN_HEADS = 16;
+constexpr int NUM_KV_HEADS = 2;
+constexpr int INTERMEDIATE_SIZE = 11008 + 256; // pad to a multiple of 512
+constexpr int GLU_SLICE = 1024;
+constexpr int DH = 128;
+constexpr int VOCAB_SIZE = 151936;
+constexpr float ATTN_SCALE = 0.08838834764831843f; // 1/sqrt(128)
+
+#define ATTN_IMPL ATTN_IMPL_1x8x1
+#define A_FUNC A_SILU
+#define HAS_QKV_BIAS
+
+// Qwen2.5 weights are signed-int4 (Q4_0) blocks (scale + min + int4), unlike
+// the Llama unsigned-int4 (Q4NX) path.
+#define Q4_0
+
+constexpr int Q4NX_ROW_BLOCK_SIZE = 32;
+constexpr int Q4NX_COL_BLOCK_SIZE = 256;
+constexpr int Q4NX_GROUP_SIZE = 32;
+#endif
+
+#endif // __QWEN2_5_3B_H__

--- a/programming_examples/fused_decode/qwen25_3b_requant.py
+++ b/programming_examples/fused_decode/qwen25_3b_requant.py
@@ -86,7 +86,8 @@ class HFModel:
             )
         idx = d / "model.safetensors.index.json"
         if idx.is_file():
-            files = sorted(set(json.load(open(idx))["weight_map"].values()))
+            with open(idx) as fh:
+                files = sorted(set(json.load(fh)["weight_map"].values()))
             return [str(d / f) for f in files]
         return [str(p) for p in sorted(d.glob("*.safetensors"))]
 

--- a/programming_examples/fused_decode/qwen25_3b_requant.py
+++ b/programming_examples/fused_decode/qwen25_3b_requant.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Build the Qwen2.5-3B fused-decode weight cache (.npz) straight from the HF
+# bf16 checkpoint (Qwen/Qwen2.5-3B-Instruct).
+#
+# Unlike the Llama path -- which re-quantizes an already-4-bit model.q4nx
+# bundle -- no pre-quantized Qwen2.5-3B bundle is needed (or exists locally):
+# the decode kernels only require blocks the proj kernel can dequantize, so we
+# quantize the full-precision weights once, directly. That is also strictly
+# more accurate than requantizing someone else's 4-bit weights.
+#
+# Quant codec: the Qwen kernels are built with -DQ4_0 (models/qwen2.5-3b.h), so
+# q4k_block_t carries SIGNED int4 quants and the `mins` field is unused --
+# w = q * scale, symmetric, per 32-column group. The block byte layout is
+# otherwise identical to the Q4NX path (scales 512B | mins 512B | qs 4096B =
+# 2560 bf16), so the memtile-cascade stream order is the same.
+#
+# Weight stream per layer = 4 phases, each cascade-packed iteration-major:
+#   ph0 QKV   [q(2048) | k(256) | v(256)]  x K=2048   ->  5 rounds
+#   ph1 o     [2048]                       x K=2048   ->  4 rounds
+#   ph2 gate/up  up|gate interleaved in 512-row chunks x K=2048 -> 44 rounds
+#   ph3 down  [2048]                       x K=11264            ->  4 rounds
+# INTERMEDIATE is padded 11008 -> 11264 (multiple of 512); the pad rows are
+# quantized zeros, so silu(0)*0 = 0 and down's pad columns contribute nothing.
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from proj_qmm_pack import (
+    ROW_BLOCK,
+    COL_BLOCK,
+    GROUP,
+    N_GROUPS,
+    PARALLEL,
+    BLOCK_BF16,
+)
+
+HF_REPO = "Qwen/Qwen2.5-3B-Instruct"
+
+_PROJ = {
+    "q": "self_attn.q_proj",
+    "k": "self_attn.k_proj",
+    "v": "self_attn.v_proj",
+    "o": "self_attn.o_proj",
+    "up": "mlp.up_proj",
+    "gate": "mlp.gate_proj",
+    "down": "mlp.down_proj",
+}
+_BIAS = ("self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj")
+
+
+# ---------------------------------------------------------------------------
+# HF safetensors reader (mmap, multi-shard, no torch/transformers dependency)
+# ---------------------------------------------------------------------------
+class HFModel:
+    """mmap + parse a (possibly sharded) HF safetensors checkpoint."""
+
+    def __init__(self, model=HF_REPO):
+        self._shards = {}  # file -> (memmap, header, base)
+        self._where = {}  # tensor name -> file
+        for f in self._resolve(model):
+            mm = np.memmap(f, dtype=np.uint8, mode="r")
+            hlen = int(np.frombuffer(mm[:8].tobytes(), dtype="<u8")[0])
+            hdr = json.loads(mm[8 : 8 + hlen].tobytes())
+            self._shards[f] = (mm, hdr, 8 + hlen)
+            for name in hdr:
+                if name != "__metadata__":
+                    self._where[name] = f
+
+    @staticmethod
+    def _resolve(model):
+        """`model` = HF repo id, a local dir, or a single .safetensors file."""
+        if os.path.isfile(model):
+            return [model]
+        if os.path.isdir(model):
+            d = Path(model)
+        else:
+            from huggingface_hub import snapshot_download
+
+            d = Path(
+                snapshot_download(model, allow_patterns=["*.safetensors", "*.json"])
+            )
+        idx = d / "model.safetensors.index.json"
+        if idx.is_file():
+            files = sorted(set(json.load(open(idx))["weight_map"].values()))
+            return [str(d / f) for f in files]
+        return [str(p) for p in sorted(d.glob("*.safetensors"))]
+
+    def has(self, name):
+        return name in self._where
+
+    def bf16(self, name):
+        """A BF16/F32 tensor as float32, in its declared shape."""
+        mm, hdr, base = self._shards[self._where[name]]
+        e = hdr[name]
+        o0, o1 = e["data_offsets"]
+        raw = mm[base + o0 : base + o1].tobytes()
+        dt = {"BF16": bfloat16, "F32": np.float32, "F16": np.float16}[e["dtype"]]
+        return np.frombuffer(raw, dtype=dt).astype(np.float32).reshape(e["shape"])
+
+
+# ---------------------------------------------------------------------------
+# Q4_0 re-quant + vectorized cascade pack
+# ---------------------------------------------------------------------------
+def requant_q4_0(Wm, group=GROUP):
+    """Symmetric signed-4-bit per-group quant of [M, K] -> (nibbles, scale).
+
+    w ~= q * scale with q in [-8, 7]. scale = amax/8 (the llama.cpp Q4_0
+    magnitude convention): a positive peak element then rounds to +8 and clips
+    to +7, but the finer step everywhere else more than pays for it -- measured
+    rel_l2 over the divisor is flat-bottomed around 7.75-8.0 and worse at 7.
+    All-zero groups get scale 1 (a 0 scale would make the block undequantizable).
+    Returns nibbles as uint8 two's complement (the packer masks with 0xF).
+    """
+    M, Kc = Wm.shape
+    Wg = Wm.reshape(M, Kc // group, group)
+    amax = np.abs(Wg).max(2)
+    sc = np.where(amax <= 0, 1.0, amax / 8.0).astype(np.float32)
+    q = np.clip(np.rint(Wg / sc[..., None]), -8, 7).astype(np.int8)
+    return q.reshape(M, Kc).view(np.uint8), sc
+
+
+def pack_q4k_cascade_fast(q, scale, NCX, NCY):
+    """Vectorized iteration-major cascade pack; == proj_qmm_pack.pack_q4k_cascade
+    (iter_major=True) with all-zero mins, but packs every block at once.
+
+    The reference packer's per-block Python loops cost ~30 min for a 36-layer
+    model; this is the same layout computed with numpy reshapes.
+    """
+    M, K = q.shape
+    assert M % ROW_BLOCK == 0 and K % COL_BLOCK == 0
+    nbi, nbj = M // ROW_BLOCK, K // COL_BLOCK
+    n_cores = NCX * NCY
+    assert nbi % n_cores == 0, (nbi, n_cores)
+    nbi_pc = nbi // n_cores
+    G = ROW_BLOCK // PARALLEL  # row groups per block (2)
+
+    # scales[block][group(8)][row(32)] as bf16 (mins stay zero for Q4_0)
+    sc = (
+        scale.reshape(nbi, ROW_BLOCK, nbj, N_GROUPS)
+        .transpose(0, 2, 3, 1)  # [nbi][nbj][group][row]
+        .astype(bfloat16)
+        .view(np.int16)
+    )
+    mn = np.zeros_like(sc)
+
+    # qs[block][rowgrp(2)][col(256)][pair(8)] = (odd<<4) | even
+    qv = q.reshape(nbi, ROW_BLOCK, nbj, COL_BLOCK).transpose(
+        0, 2, 1, 3
+    )  # [nbi][nbj][row][col]
+    qv = qv.reshape(nbi, nbj, G, PARALLEL // 2, 2, COL_BLOCK)
+    lo = qv[:, :, :, :, 0, :] & 0xF
+    hi = qv[:, :, :, :, 1, :] & 0xF
+    qs = ((hi << 4) | lo).transpose(0, 1, 2, 4, 3)  # [nbi][nbj][g][col][pair]
+    qs = np.ascontiguousarray(qs).reshape(nbi, nbj, -1).view(np.int16)
+
+    blocks = np.concatenate(
+        [sc.reshape(nbi, nbj, -1), mn.reshape(nbi, nbj, -1), qs], axis=2
+    )
+    assert blocks.shape[2] == BLOCK_BF16, blocks.shape
+
+    # stream order [cx][i][j][cy] with gi = i*(NCX*NCY) + cx*NCY + cy
+    cx = np.arange(NCX)[:, None, None, None]
+    i = np.arange(nbi_pc)[None, :, None, None]
+    j = np.arange(nbj)[None, None, :, None]
+    cy = np.arange(NCY)[None, None, None, :]
+    gi = np.broadcast_to(i * n_cores + cx * NCY + cy, (NCX, nbi_pc, nbj, NCY))
+    gj = np.broadcast_to(j, (NCX, nbi_pc, nbj, NCY))
+    return blocks[gi.ravel(), gj.ravel()].reshape(-1)
+
+
+def attn_out_perm(fd):
+    """Permutation mapping an o-proj input column to the attention output element
+    that actually carries it.
+
+    The attention kernel's per-CU output is mmul-TILED, not [head][dv]: device
+    element `dvt*64 + hh*8 + dvi` of a CU holds head `hh`, dv column
+    `dvt*8 + dvi` (DH = 16 tiles x 8). Measured directly on device -- with a
+    uniform-softmax probe whose V column pattern makes each output element report
+    the dv index it read, the map is exactly dv(p) = 8*(p//64) + (p%8).
+
+    Rather than de-tiling on chip, permute the o-proj weight COLUMNS to match:
+    Wo_device = Wo_true[:, attn_out_perm(fd)]. Free, and it keeps the attention
+    output path untouched.
+    """
+    ncu, dh = fd.N_ATTN_CU, fd.DH
+    hpc = fd.Q_HEADS_PER_CU
+    dvi = 8
+    dvt = dh // dvi
+    # [cu][head][dv_tile][dv_inner] = the TRUE (natural) element index ...
+    true = np.arange(ncu * hpc * dh).reshape(ncu, hpc, dvt, dvi)
+    # ... re-read in device order [cu][dv_tile][head][dv_inner].
+    return true.transpose(0, 2, 1, 3).reshape(-1)
+
+
+def _interleave_chunks(a, b, chunk):
+    """[a0|b0|a1|b1|...] in `chunk`-row slices (the GLU stream order)."""
+    n = a.shape[0] // chunk
+    return np.concatenate(
+        [
+            (a if h == 0 else b)[s * chunk : (s + 1) * chunk]
+            for s in range(n)
+            for h in (0, 1)
+        ]
+    )
+
+
+def _pad_rows(w, m):
+    """Zero-pad a [M, K] matrix to [m, K]."""
+    if w.shape[0] == m:
+        return w
+    out = np.zeros((m, w.shape[1]), np.float32)
+    out[: w.shape[0]] = w
+    return out
+
+
+def _pad_cols(w, k):
+    if w.shape[1] == k:
+        return w
+    out = np.zeros((w.shape[0], k), np.float32)
+    out[:, : w.shape[1]] = w
+    return out
+
+
+# ---------------------------------------------------------------------------
+# cache builder
+# ---------------------------------------------------------------------------
+def build_requant_cache(fd, cache_path, model=HF_REPO, n_layers=None, verbose=True):
+    """Re-quantize + cascade-pack the HF Qwen2.5-3B weights into the decode .npz.
+
+    `fd` = the loaded fused_decode_qwen module (supplies the cascade geometry).
+    Writes keys:
+      W        [n_layers, W_LAYER] int16 -- phase-major [ph][cx][...] weight stream
+      RMS_in   [n_layers, K]  bf16 -- input_layernorm
+      RMS_post [n_layers, K]  bf16 -- post_attention_layernorm
+      BIAS     [n_layers, DQ+DK+DV] bf16 -- q|k|v proj bias (Qwen2.5 has these)
+      NORM     [K] bf16 -- final norm
+    """
+    hf = HFModel(model)
+    aperm = attn_out_perm(fd)
+    NCX, NCY, NPH, K = fd.NCX, fd.NCY, fd.NPH, fd.K
+    RB, NJ = fd._RB, fd._NJ
+    DQ, DK, DV = fd.DQ, fd.DK, fd.DV
+    INTER = fd.INTERMEDIATE
+    GLU_CHUNK = fd.PAYLOAD
+    OP, GP, DP = fd.OPROJ_PHASE, fd.GATEUP_PHASE, fd.DOWN_PHASE
+    W_LAYER = sum(RB[p] * NJ[p] for p in range(NPH)) * NCX * NCY * BLOCK_BF16
+    if n_layers is None:
+        n_layers = fd.NLAYERS if hasattr(fd, "NLAYERS") else 1
+
+    W_all, RMS_in, RMS_post, BIAS = [], [], [], []
+    for k in range(n_layers):
+        R = {nm: hf.bf16(f"model.layers.{k}.{t}.weight") for nm, t in _PROJ.items()}
+        ph = [None] * NPH
+        ph[0] = requant_q4_0(np.concatenate([R["q"], R["k"], R["v"]], 0))
+        # o-proj consumes the attention output, which arrives mmul-tiled: permute
+        # its input columns so the device reads each element from where attention
+        # actually put it (see attn_out_perm).
+        ph[OP] = requant_q4_0(R["o"][:, aperm])
+        up = _pad_rows(R["up"], INTER)
+        gate = _pad_rows(R["gate"], INTER)
+        qu, su = requant_q4_0(up)
+        qg, sg = requant_q4_0(gate)
+        ph[GP] = (
+            _interleave_chunks(qu, qg, GLU_CHUNK),
+            _interleave_chunks(su, sg, GLU_CHUNK),
+        )
+        ph[DP] = requant_q4_0(_pad_cols(R["down"], INTER))
+        w = np.concatenate(
+            [pack_q4k_cascade_fast(*ph[p], NCX, NCY) for p in range(NPH)]
+        )
+        assert w.size == W_LAYER, (w.size, W_LAYER)
+        W_all.append(w)
+        RMS_in.append(hf.bf16(f"model.layers.{k}.input_layernorm.weight"))
+        RMS_post.append(hf.bf16(f"model.layers.{k}.post_attention_layernorm.weight"))
+        BIAS.append(
+            np.concatenate([hf.bf16(f"model.layers.{k}.{t}.bias") for t in _BIAS])
+        )
+        if verbose:
+            print(f"[qwen requant] layer {k} packed ({w.size} bf16)", flush=True)
+
+    os.makedirs(os.path.dirname(os.path.abspath(cache_path)) or ".", exist_ok=True)
+    np.savez(
+        cache_path,
+        W=np.stack(W_all),
+        RMS_in=np.stack(RMS_in).astype(bfloat16).view(np.int16),
+        RMS_post=np.stack(RMS_post).astype(bfloat16).view(np.int16),
+        BIAS=np.stack(BIAS).astype(bfloat16).view(np.int16),
+        NORM=hf.bf16("model.norm.weight").astype(bfloat16).view(np.int16),
+    )
+    if verbose:
+        print(f"[qwen requant] wrote {cache_path}", flush=True)
+    return cache_path
+
+
+def to_column_major(w_phase_major, fd):
+    """Re-order one layer's weight stream from phase-major [ph][cx][..] to
+    column-major [cx][ph][..] (the QWEN_W_PHASE_MAJOR=0 DDR layout)."""
+    NCX, NPH = fd.NCX, fd.NPH
+    spans = [fd._RB[p] * fd._NJ[p] * fd.NCY * BLOCK_BF16 for p in range(NPH)]
+    off, parts = 0, [[] for _ in range(NCX)]
+    for p in range(NPH):
+        blk = w_phase_major[off : off + NCX * spans[p]].reshape(NCX, spans[p])
+        for cx in range(NCX):
+            parts[cx].append(blk[cx])
+        off += NCX * spans[p]
+    return np.concatenate([np.concatenate(c) for c in parts])
+
+
+def rope_lut(pos, dh, theta=1000000.0):
+    """[cos(dh/2) | sin(dh/2)] for absolute position `pos` (NeoX/rotate_half)."""
+    inv = 1.0 / (theta ** (np.arange(0, dh, 2, dtype=np.float64) / dh))
+    a = pos * inv
+    return np.concatenate([np.cos(a), np.sin(a)]).astype(np.float32)

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -2,7 +2,13 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 #
-# End-to-end Qwen2.5-3B on NPU2 with NO host reference anywhere in the loop:
+# End-to-end Qwen2.5-3B on NPU2 with NO REFERENCE MODEL anywhere in the loop --
+# every token comes from the NPU prefill and the NPU fused decode, never from a
+# host copy of the model. What DOES still run on the host each token is the
+# final RMSNorm + LM-head projection (`lg = ... @ emb.T` below) and the argmax:
+# the 36 transformer layers are on device, the last projection is not. Moving it
+# on-device is a performance item, not a correctness one -- the decode's own
+# hidden state is what feeds it.
 #
 #   llms/qwen25_3b_q4  --dump-kv  ->  this script  ->  fused_decode_qwen
 #   (NPU prefill, 36 layers)          (KV hand-off)    (NPU decode, 36 layers,

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# End-to-end Qwen2.5-3B on NPU2 with NO host reference anywhere in the loop:
+#
+#   llms/qwen25_3b_q4  --dump-kv  ->  this script  ->  fused_decode_qwen
+#   (NPU prefill, 36 layers)          (KV hand-off)    (NPU decode, 36 layers,
+#                                                        one dispatch/token)
+#
+# Both halves quantize with the SAME Q4_0 codec (qwen25_3b_requant), so the
+# prefill's roped-K / biased-V are exactly what the decode's own rope core would
+# have appended for those positions.
+#
+# LAYOUT HAND-OFF. The prefill emits per layer a seq-major [ctx, 256] roped-K and
+# a [ctx, 256] biased-V (256 = 2 kv heads x head_dim 128, head-major). The fused
+# decode wants, per layer, one region-major slab: K rows at offset 0 and V rows
+# at offset NGRP*REGION_STRIDE, each [ATTN_L, REGION_W] with REGION_W == 256.
+# Same element order, so the hand-off is a slice, not a shuffle -- the check
+# below asserts that rather than assuming it.
+#
+# SLIDING WINDOW. The device always appends this token's K/V at slot ATTN_L-1
+# and attends over all ATTN_L slots, so the host keeps a window of exactly the
+# last ATTN_L positions and shifts it left after every token. Seeding it with
+# the LAST ATTN_L rows of the prefill (absolute positions ctx-ATTN_L .. ctx-1)
+# keeps RoPE consistent -- RoPE is absolute, so a cached entry carries the
+# roping of the position it was computed at.
+#
+#   cd programming_examples/llms/qwen25_3b_q4
+#   python3 qwen25_3b_q4_prefill.py --dump-kv /tmp/kv.npz --prompt "..."
+#   cd ../../fused_decode
+#   QWEN_NLAYERS=36 python3 fused_decode_qwen.py      # 36-layer xclbin
+#   python3 qwen_prefill_to_decode.py --kv /tmp/kv.npz --n-gen 20
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+import pyxrt as xrt
+from ml_dtypes import bfloat16
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import fused_decode_qwen as m  # noqa: E402
+import qwen25_3b_requant as qr  # noqa: E402
+
+TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+FR = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
+
+
+def pack_layer(hf, ap, k):
+    """One layer's Q4_0 cascade-packed weight stream (4 phases)."""
+    R = {nm: hf.bf16(f"model.layers.{k}.{t}.weight") for nm, t in qr._PROJ.items()}
+    ph = [None] * m.NPH
+    ph[0] = qr.requant_q4_0(np.concatenate([R["q"], R["k"], R["v"]], 0))
+    ph[m.OPROJ_PHASE] = qr.requant_q4_0(R["o"][:, ap])
+    qu, su = qr.requant_q4_0(qr._pad_rows(R["up"], m.INTERMEDIATE))
+    qg, sg = qr.requant_q4_0(qr._pad_rows(R["gate"], m.INTERMEDIATE))
+    ph[m.GATEUP_PHASE] = (
+        qr._interleave_chunks(qu, qg, m.PAYLOAD),
+        qr._interleave_chunks(su, sg, m.PAYLOAD),
+    )
+    ph[m.DOWN_PHASE] = qr.requant_q4_0(qr._pad_cols(R["down"], m.INTERMEDIATE))
+    return np.concatenate(
+        [qr.pack_q4k_cascade_fast(*ph[p], m.NCX, m.NCY) for p in range(m.NPH)]
+    )
+
+
+def main():
+    ap_ = argparse.ArgumentParser(description="Qwen2.5-3B NPU prefill -> NPU decode")
+    ap_.add_argument("--kv", default="/tmp/qwen_prefill_kv.npz", help="--dump-kv file")
+    ap_.add_argument(
+        "--n-gen", type=int, default=int(os.environ.get("QWEN_NGEN", "20"))
+    )
+    ap_.add_argument("--xclbin", default="decode_qwen.xclbin")
+    ap_.add_argument("--insts", default="decode_qwen.insts.bin")
+    args = ap_.parse_args()
+
+    NL, L = m.NLAYERS, m.ATTN_L
+    z = np.load(args.kv)
+    ids = [int(t) for t in z["ids"]]
+    ctx = int(z["ctx"])
+    kp = z["k"].view(bfloat16).astype(np.float32)  # [n_layers, ctx, DK]
+    vp = z["v"].view(bfloat16).astype(np.float32)
+    assert kp.shape == (NL, ctx, m.DK), f"prefill KV {kp.shape} != {(NL, ctx, m.DK)}"
+    assert m.REGION_W == m.DK, (m.REGION_W, m.DK)
+    assert ctx >= L, f"prompt gave {ctx} tokens, decode window ATTN_L={L}"
+    print(
+        f"[handoff] prefill KV: {NL} layers x {ctx} tokens; "
+        f"seeding the last ATTN_L={L} positions ({ctx - L}..{ctx - 1})",
+        flush=True,
+    )
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(qr.HF_REPO)
+    hf = qr.HFModel()
+    aperm = qr.attn_out_perm(m)
+    emb = hf.bf16("model.embed_tokens.weight")
+    norm = hf.bf16("model.norm.weight")
+
+    # Host KV window, seeded from the prefill (no reference model involved).
+    Kc = np.ascontiguousarray(kp[:, ctx - L :, :])
+    Vc = np.ascontiguousarray(vp[:, ctx - L :, :])
+
+    X = max(m.X_CHUNKS * 2 * m.COL_BLOCK, NL * m.XLAYER)
+    WSZ = NL * m.W_LAYER
+    KVL = m.N_ATTN_CU * 2 * m.ATTN_ROUNDS * m.KVBLK
+    KVN = NL * KVL
+    YN = max(m.DEST_TOTAL * m.PAYLOAD, m.K + m.DQ)
+
+    print(f"[handoff] packing Q4_0 weights for {NL} layers...", flush=True)
+    xd = np.zeros(X, bfloat16)
+    wd = np.empty(WSZ, np.int16)
+    for k in range(NL):
+        b = k * m.XLAYER
+        wd[k * m.W_LAYER : (k + 1) * m.W_LAYER] = pack_layer(hf, aperm, k)
+        xd[b + m.XO_ROPE + m.DH : b + m.XO_ROPE + m.ROPE_W] = np.concatenate(
+            [hf.bf16(f"model.layers.{k}.{t}.bias") for t in qr._BIAS]
+        ).astype(bfloat16)
+        xd[b + m.XO_RMSW : b + m.XO_RMSW + m.K] = hf.bf16(
+            f"model.layers.{k}.input_layernorm.weight"
+        ).astype(bfloat16)
+        xd[b + m.XO_RMSW2 : b + m.XO_RMSW2 + m.K] = hf.bf16(
+            f"model.layers.{k}.post_attention_layernorm.weight"
+        ).astype(bfloat16)
+
+    dev = xrt.device(0)
+    xb = xrt.xclbin(args.xclbin)
+    dev.register_xclbin(xb)
+    hwc = xrt.hw_context(dev, xb.get_uuid())
+    kern = xrt.kernel(
+        hwc, [q for q in xb.get_kernels() if "MLIR_AIE" in q.get_name()][0].get_name()
+    )
+    g_, HO = kern.group_id, xrt.bo.host_only
+    x_bo = xrt.bo(dev, X * 2, HO, g_(3))
+    w_bo = xrt.bo(dev, WSZ * 2, HO, g_(4))
+    kv_bo = xrt.bo(dev, KVN * 2, HO, g_(5))
+    y_bo = xrt.bo(dev, YN * 2, HO, g_(6))
+    insts = np.fromfile(args.insts, dtype=np.uint32)
+    ib = xrt.bo(dev, insts.nbytes, xrt.bo.cacheable, g_(1))
+    ib.write(insts, 0)
+    ib.sync(TO)
+    w_bo.write(wd.view(np.uint16), 0)
+    w_bo.sync(TO)  # weights are token-invariant
+
+    out_ids = []
+    cur = ids[-1]
+    pos = ctx - 1  # re-run the last prompt token to produce the first logit
+    dev_ms = 0.0
+    t_all = time.time()
+    for step in range(args.n_gen):
+        lut = qr.rope_lut(pos, m.DH).astype(bfloat16)
+        for k in range(NL):
+            xd[k * m.XLAYER + m.XO_ROPE : k * m.XLAYER + m.XO_ROPE + m.DH] = lut
+        xd[m.XO_RMSIN : m.XO_RMSIN + m.K] = np.asarray(emb[cur], np.float32).astype(
+            bfloat16
+        )
+        kvd = np.zeros(KVN, bfloat16)
+        for k in range(NL):
+            kvd[k * KVL :][: L * m.REGION_W] = Kc[k].astype(bfloat16).ravel()
+            kvd[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W] = (
+                Vc[k].astype(bfloat16).ravel()
+            )
+        x_bo.write(xd.view(np.uint16), 0)
+        x_bo.sync(TO)
+        kv_bo.write(kvd.view(np.uint16), 0)
+        kv_bo.sync(TO)
+
+        t0 = time.time()
+        st = kern(3, ib, insts.size, x_bo, w_bo, kv_bo, y_bo).wait(20000)
+        dev_ms += (time.time() - t0) * 1e3
+        if "COMPLETED" not in str(st):
+            print("DISPATCH FAILED:", st)
+            return 1
+        x_bo.sync(FR)
+        kv_bo.sync(FR)
+
+        h = np.frombuffer(x_bo.read(X * 2, 0), dtype=bfloat16).astype(np.float32)[
+            m.XO_RMSIN : m.XO_RMSIN + m.K
+        ]
+        lg = (h / np.sqrt((h * h).mean() + 1e-6) * norm) @ emb.T
+        nxt = int(np.argmax(lg))
+        out_ids.append(nxt)
+
+        # Take this token's K/V (device wrote slot L-1) and slide the window.
+        kvo = np.frombuffer(kv_bo.read(KVN * 2, 0), dtype=bfloat16).astype(np.float32)
+        for k in range(NL):
+            newk = kvo[k * KVL :][: L * m.REGION_W].reshape(L, m.REGION_W)[L - 1]
+            newv = kvo[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W].reshape(
+                L, m.REGION_W
+            )[L - 1]
+            Kc[k] = np.roll(Kc[k], -1, 0)
+            Kc[k][L - 2], Kc[k][L - 1] = newk, 0
+            Vc[k] = np.roll(Vc[k], -1, 0)
+            Vc[k][L - 2], Vc[k][L - 1] = newv, 0
+        cur = nxt
+        pos += 1
+        print(f"  [{step:2d}] {nxt:6d} {tok.decode([nxt])!r}", flush=True)
+
+    wall = time.time() - t_all
+    n = max(len(out_ids), 1)
+    print("\nprompt    :", repr(tok.decode(ids)))
+    print("generated :", repr(tok.decode(out_ids)))
+    print(
+        f"\n{len(out_ids)} tokens | device {dev_ms/n:.1f} ms/tok "
+        f"({1000/(dev_ms/n):.2f} tok/s device-only) | end-to-end {wall/n:.2f} s/tok"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/programming_examples/llms/README.md
+++ b/programming_examples/llms/README.md
@@ -94,6 +94,7 @@ llms/
 ├── qwen25_0_5b/        # Qwen2.5-0.5B  (QKV bias, head_dim=64)
 ├── qwen25_1_5b/        # Qwen2.5-1.5B  (QKV bias, head_dim=128)
 ├── qwen25_3b/          # Qwen2.5-3B    (QKV bias, head_dim=128)
+├── qwen25_3b_q4/       # Q4_0 4-bit Qwen2.5-3B (prefill + fused NPU decode)
 ├── qwen3_0_6b/         # Qwen3-0.6B    (QK-norm, head_dim=128)
 ├── qwen3_1_7b/         # Qwen3-1.7B    (QK-norm, head_dim=128)
 ├── qwen3_4b/           # Qwen3-4B      (QK-norm, decoupled q_dim=4096)

--- a/programming_examples/llms/qwen25_3b_q4/.gitignore
+++ b/programming_examples/llms/qwen25_3b_q4/.gitignore
@@ -1,0 +1,7 @@
+_q4_cache_seq*/
+__pycache__/
+build_*/
+*.elf
+*.o
+*.xclbin
+*.log

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -1,0 +1,49 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-3B Q4_0 prefill on NPU2 (MLIR-AIR).
+#
+#   make compile   — build/cache the prefill ELFs (no weights, no NPU dispatch)
+#   make run       — prefill "The capital of France is" -> expect " Paris"
+#   make bench     — warm TTFT at BENCH_L (default 2048)
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+SEQ_LEN  ?= 2048
+N_LAYERS ?= 36
+BENCH_L  ?= 2048
+MODEL    ?= Qwen/Qwen2.5-3B-Instruct
+
+PREFILL := $(srcdir)/qwen25_3b_q4_prefill.py
+
+.PHONY: help compile run bench weights clean
+
+help:
+	@echo "Qwen2.5-3B Q4_0 prefill (MLIR-AIR, NPU2)"
+	@echo "  make compile   build/cache the prefill ELFs (CI-runnable, no weights)"
+	@echo "  make run       prefill gate: 'The capital of France is' -> ' Paris'"
+	@echo "  make bench     warm TTFT at BENCH_L=$(BENCH_L)"
+	@echo "  make weights   quant-error report for layer 0"
+
+## Build/cache the prefill ELFs and exit. No weights, no NPU dispatch.
+compile:
+	cd $(srcdir) && python3 $(PREFILL) --compile-only \
+		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS)
+
+## First-token gate.
+run:
+	cd $(srcdir) && python3 $(PREFILL) \
+		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL)
+
+## Warm TTFT benchmark (+ per-ELF profile).
+bench:
+	cd $(srcdir) && python3 $(PREFILL) \
+		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL) \
+		--bench-l $(BENCH_L)
+
+## Q4_0 quant-error report for layer 0 (no NPU).
+weights:
+	cd $(srcdir) && python3 $(srcdir)/qwen25_3b_q4_weights.py --model $(MODEL)
+
+clean:
+	rm -rf $(srcdir)/_q4_cache_seq* $(srcdir)/__pycache__

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -16,7 +16,11 @@ relationship `llama32_1b_q4nx` has to `llama32_1b`); this example supplies the
 |---|---|
 | First token, `"The capital of France is"`, 36 layers on NPU2 | **argmax 12095 = `" Paris"`** — PASS |
 | Warm TTFT @ seq_len=2048 | **4.17 s** (491 tok/s prefill), NPU-dispatch 4.17 s, host 5 ms |
-| End-to-end NPU prefill -> NPU fused decode, 36 layers, no host reference | coherent text, **9.54 tok/s** device-only decode |
+| End-to-end NPU prefill -> NPU fused decode, 36 layers, no reference model | coherent text, **9.54 tok/s** device-only decode |
+
+The 36 transformer layers run on the NPU for both prefill and decode. The final
+RMSNorm + LM-head projection and the argmax still run on the host each decode
+token; moving them on-device is a performance item, not a correctness one.
 
 Measured 2026-08-06 on a quiet NPU2 box (load < 0.1). Verify the box is idle
 before trusting any timing here — a busy host makes this DDR-bandwidth-bound

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -1,0 +1,122 @@
+# Qwen2.5-3B Q4_0 Prefill on AMD NPU2 (MLIR-AIR)
+
+Structural port of [`../llama32_1b_q4nx/`](../llama32_1b_q4nx/) to Qwen2.5-3B:
+4-bit weights, host dequant at load, then the whole transformer block —
+RMSNorm, Q/K/V GEMM, QKV bias, RoPE, causal GQA flash attention, O projection,
+SwiGLU, Down — on the NPU, with resident per-layer weight BOs and an on-device
+LM-head GEMV.
+
+The block builders are reused from [`../qwen25_3b/`](../qwen25_3b/) (same
+relationship `llama32_1b_q4nx` has to `llama32_1b`); this example supplies the
+4-bit weight path and the prefill driver.
+
+## Status
+
+| Gate | Result |
+|---|---|
+| First token, `"The capital of France is"`, 36 layers on NPU2 | **argmax 12095 = `" Paris"`** — PASS |
+| Warm TTFT @ seq_len=2048 | **4.17 s** (491 tok/s prefill), NPU-dispatch 4.17 s, host 5 ms |
+| End-to-end NPU prefill -> NPU fused decode, 36 layers, no host reference | coherent text, **9.54 tok/s** device-only decode |
+
+Measured 2026-08-06 on a quiet NPU2 box (load < 0.1). Verify the box is idle
+before trusting any timing here — a busy host makes this DDR-bandwidth-bound
+workload ~30% slower.
+
+## Quant codec: Q4_0, not Q4NX
+
+The Llama example reads an already-4-bit `model.q4nx` bundle whose codec is
+per-block **affine** quant (`w = scale*(q - min)`, unsigned nibbles). Qwen2.5-3B
+has no such bundle, and its NPU kernels are built with `-DQ4_0` — a
+**symmetric signed-int4** codec (`w = q*scale`, `q ∈ [-8,7]`, `scale = amax/8`,
+per 32-element group along the reduction dim). So this example quantizes the
+full-precision HF checkpoint directly, which is also strictly more accurate
+than re-quantizing someone else's 4-bit weights.
+
+The quantizer is `fused_decode/qwen25_3b_requant.requant_q4_0` — the same
+function that builds the fused-decode Qwen weight cache — so **the prefill and
+the fused NPU decode see bit-identical weight values**, and the prefill's KV
+cache is a valid decode input.
+
+Layer-0 quant error (rel L2 vs bf16), `make weights`:
+
+| q | k | v | o | gate | up | down |
+|---|---|---|---|---|---|---|
+| 0.098 | 0.095 | 0.098 | 0.095 | 0.096 | 0.097 | 0.097 |
+
+QKV **bias is not quantized** (it is not quantized in the reference design
+either) — carried as bf16 and fused into the `rms_qkv_bias_rope` ELF.
+
+## Model config
+
+36 layers, emb 2048, 16 heads × head_dim 128, 2 KV heads (GQA group 8),
+hidden 11008, vocab 151936, rope_theta 1e6, eps 1e-6, tied embeddings,
+QKV bias, no QK-norm.
+
+`head_dim=128` → head-first flash attention with host seq↔head transposes; see
+[`../qwen25_3b/ARCHITECTURE.md`](../qwen25_3b/ARCHITECTURE.md).
+
+## Quick start
+
+```bash
+make compile          # build/cache the prefill ELFs (no weights, no NPU)
+make run              # first-token gate -> " Paris"
+make bench BENCH_L=2048   # warm TTFT + per-ELF profile
+make weights          # Q4_0 quant-error report, layer 0
+```
+
+Weights are downloaded from HuggingFace on first use and cached under
+`~/.cache/huggingface/hub/`. Override with `--model` or
+`QWEN_Q4_MODEL_SOURCE=<repo-id-or-local-dir>`.
+
+`seq_len` is fixed at 2048: the GEMM registry shapes exist at M=2048, so the
+prompt is padded and the last real token's row supplies the logit — the same
+constraint the Llama Q4NX example has.
+
+## Where the 4.17 s goes
+
+Per-ELF, averaged over 36 layers (`make bench`):
+
+| ELF | avg/layer | ×36 | note |
+|---|---|---|---|
+| `up` | 23.92 ms | 861 ms | GEMM 2048×2048×11008 |
+| `gate` | 24.10 ms | 868 ms | GEMM 2048×2048×11008 |
+| `flash_attn` | 22.48 ms | 809 ms | ~5% of the FLOPs, 21% of the time |
+| `down_add` | 13.06 ms | 470 ms | GEMM 2048×11008×2048 + residual |
+| `swiglu` | 10.52 ms | 379 ms | elementwise; 86 MB host→DDR per layer |
+| `rms_qkv_bias_rope` | 7.30 ms | 263 ms | fused RMSNorm+QKV+bias+RoPE |
+| `o_res_norm` | 5.48 ms | 197 ms | GEMM 2048×2048×2048 + add + norm |
+| `lm_head_gemv` | 15.92 ms | 16 ms | once |
+
+The GEMMs run at ~4–7 TFLOP/s; `flash_attn` runs at ~0.76 TFLOP/s, and
+`swiglu` is pure data movement. Those two, plus the ~11% of wall spent in BO
+writes of intermediates, are the open optimization targets.
+
+## Hand-off to the fused NPU decode
+
+`--dump-kv` writes the per-layer roped-K / biased-V cache, which
+[`../../fused_decode/qwen_prefill_to_decode.py`](../../fused_decode/qwen_prefill_to_decode.py)
+feeds straight into the fused single-dispatch Qwen decode. Both halves quantize
+with the same Q4_0 codec, so the prefill's K/V are exactly what the decode's own
+rope core would have appended at those positions, and the hand-off is a slice
+(both sides are `[tokens, 256]` head-major) rather than a shuffle.
+
+```bash
+python3 qwen25_3b_q4_prefill.py --dump-kv /tmp/kv.npz --prompt "<32+ tokens>"
+cd ../../fused_decode
+QWEN_NLAYERS=36 python3 fused_decode_qwen.py           # 36-layer xclbin
+QWEN_NLAYERS=36 python3 qwen_prefill_to_decode.py --kv /tmp/kv.npz --n-gen 16
+```
+
+Measured: prompt *"The capital city of France is called Paris, ... the very tall
+iron tower that stands right"* -> *" in the middle. The Eiffel Tower. The tower
+is 33"*, 104.8 ms/token device. The decode's first token equals the prefill's own
+argmax, which is the cross-check that the KV hand-off is correct.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `qwen25_3b_q4_weights.py` | Q4_0 requant/dequant loader → the `qwen25_3b` `LlamaWeights` container |
+| `qwen25_3b_q4_prefill.py` | `Qwen25Q4Prefill` — compile/preload/prefill/KV-cache/bench |
+| `Makefile` | compile / run / bench / weights / clean |
+| `../../fused_decode/qwen_prefill_to_decode.py` | KV hand-off + generation loop on the fused decode |

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_prefill.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_prefill.py
@@ -220,7 +220,15 @@ class Qwen25Q4Prefill:
         assert self._weights is not None, "call load_weights() first"
         N = len(ids)
         assert N <= self.seq, (N, self.seq)
+        # Single-shot prefill only: the embedding write and every layer's KV
+        # write below are indexed from row 0, so a second call would silently
+        # overwrite the cache from the start while current_context_length kept
+        # accumulating. Fail loudly instead of corrupting.
         base = self.current_context_length
+        assert base == 0, (
+            f"incremental prefill is not supported (already prefilled {base} "
+            f"tokens); construct a new instance or reset_context() first"
+        )
         x = np.zeros((self.seq, D), bfloat16)
         x[:N] = np.asarray(self._weights.embed_table[list(ids)], bfloat16)
         for k in range(self.n_layers):

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_prefill.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_prefill.py
@@ -1,0 +1,406 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-3B Q4_0 prefill in mlir-air.
+#
+# Structural port of llama32_1b_q4nx_prefill.py to Qwen2.5-3B: 4-bit weights,
+# host dequant at load, then op-by-op bf16 GEMM / RMSNorm / QKV-bias / RoPE /
+# SwiGLU / causal-GQA flash attention all ON THE NPU with RESIDENT weight BOs,
+# and the final LM head as an on-device GEMV. The whole transformer block runs
+# through the qwen25_3b prefill builders (rms_qkv_bias_rope, flash_attn,
+# o_res_norm, gate, up, swiglu, down_add) driven by KernelCache.load_and_run
+# with per-layer resident BOs (weights written once).
+#
+# Deltas vs the Llama Q4NX example, all model-driven:
+#   codec   Q4_0 symmetric signed-int4 (Qwen kernels are -DQ4_0) instead of the
+#           Q4NX affine codec; quantized straight from the HF bf16 checkpoint
+#           because no pre-quantized Qwen2.5-3B bundle exists. Same values the
+#           fused_decode Qwen weight cache uses -> prefill and decode agree.
+#   shape   36 layers, 16 heads x head_dim 128, 2 kv heads (GQA group 8),
+#           hidden 11008, vocab 151936, rope_theta 1e6, tied lm_head.
+#   bias    q/k/v projection bias (bf16, unquantized), fused into the NPU
+#           rms_qkv_bias_rope ELF.
+#   attn    head_dim=128 -> head-first flash attention (host seq<->head
+#           transposes), see qwen25_3b/ARCHITECTURE.md.
+#
+# The qwen25_3b GEMM registry shapes exist at M=2048, so the whole prefill runs
+# at seq_len=2048 (pad the prompt, read the last real token's row for the
+# logit) -- same constraint as the Llama Q4NX example.
+#
+# Weight source (env-overridable):
+#   QWEN_Q4_MODEL_SOURCE : HF repo id or a local dir of the bf16 checkpoint.
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_HERE = Path(__file__).resolve().parent
+_PROG = str(_HERE.parent.parent)  # programming_examples
+_LLMS = str(_HERE.parent)  # llms
+_QWEN = str(_HERE.parent / "qwen25_3b")  # prefill builders + block runner
+for _p in (_PROG, _LLMS, _QWEN, str(_HERE)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from shared.infra.cache import KernelCache  # noqa: E402
+
+from qwen25_3b_q4_weights import (  # noqa: E402
+    D,
+    DK,
+    DV,
+    DH,
+    N_Q_HEADS,
+    N_KV_HEADS,
+    VOCAB,
+    load_q4_weights,
+)
+
+MODEL_DEFAULT = os.environ.get("QWEN_Q4_MODEL_SOURCE", "Qwen/Qwen2.5-3B-Instruct")
+EPS = 1e-6
+
+# On-device LM head GEMV: 19 partitions of M=8192 (19*8192=155648 >= VOCAB).
+# Matches qwen25_3b_decode._LM_N_PARTITIONS / _LM_N_PART.
+_LM_N_PART = 8192
+_LM_N_PARTITIONS = 19
+
+# "The capital of France is" (Qwen2.5 BPE). Gate: the next token is " Paris".
+PROMPT = [785, 6722, 315, 9625, 374]
+EXPECT_FIRST = 12095  # " Paris"
+
+
+class Qwen25Q4Prefill:
+    """AIR realization of the Q4_0 causal-LM prefill interface (Qwen2.5-3B)."""
+
+    def __init__(self, seq_len=2048, n_layers=36, cache_dir=None, verbose=False):
+        self.seq = seq_len
+        self.n_layers = n_layers
+        self.MAX_L = seq_len
+        self.current_context_length = 0
+        # seq_len-specific cache: the stitcher/flash-attn ELFs are compiled for
+        # this padded context length but KernelCache is keyed by kernel NAME
+        # only, so a shorter-context build would be silently reused for a longer
+        # request (-> zero logits beyond the built length). Isolate by seq_len.
+        cache_dir = cache_dir or str(_HERE / f"_q4_cache_seq{seq_len}")
+        self.cache = KernelCache(cache_dir=cache_dir, verbose=verbose)
+
+        from qwen25_3b_weights import LlamaConfig, generate_rope_lut
+        from qwen25_3b_prefill import compile_all_kernels
+        from qwen25_3b_decode import _lm_gemv_backend
+
+        self.config = LlamaConfig(n_layers=n_layers)
+        self._rope_lut = generate_rope_lut(self.config, seq_len=seq_len)  # theta 1e6
+        self._lm_backend = dict(_lm_gemv_backend())
+
+        # Compile (or reuse cached) the 6 prefill ELFs + flash_attn, plus the
+        # 19-partition lm_head GEMV. QWEN_Q4_FORCE_COMPILE=1 forces a rebuild.
+        force = os.environ.get("QWEN_Q4_FORCE_COMPILE") == "1"
+        if not force:
+            self.cache.load_manifest()
+        cached = set() if force else set(self.cache.artifacts)
+        need = {
+            "rms_qkv_bias_rope",
+            "flash_attn",
+            "o_res_norm",
+            "gate",
+            "up",
+            "swiglu",
+            "down_add",
+        }
+        if not need.issubset(cached):
+            compile_all_kernels(self.cache, self.config, seq_len, cpu_attn=False)
+        else:
+            print(
+                "[qwen_q4_prefill] using cached prefill ELFs (skip compile)", flush=True
+            )
+        if "lm_head_gemv" not in cached:
+            from qwen25_3b_decode import build_lm_head_gemv_qwen_module
+
+            self.cache.compile_and_cache(
+                "lm_head_gemv",
+                build_lm_head_gemv_qwen_module(D),
+                {"verbose": self.cache.verbose, **self._lm_backend},
+            )
+            self.cache._save_manifest()
+
+        # Per-layer KV cache (roped K + biased raw V), [MAX_L, n_kv*head_dim].
+        self.kv_k = [np.zeros((self.MAX_L, DK), bfloat16) for _ in range(n_layers)]
+        self.kv_v = [np.zeros((self.MAX_L, DV), bfloat16) for _ in range(n_layers)]
+        self._weights = None
+        self._dev_t = 0.0  # accumulated NPU dispatch time (s)
+        self._op_t = {}  # per-op NPU dispatch time (s)
+
+    def _dev(self, fn, *a, tag="?"):
+        import time
+
+        t = time.time()
+        r = fn(*a)
+        dt = time.time() - t
+        self._dev_t += dt
+        self._op_t[tag] = self._op_t.get(tag, 0.0) + dt
+        return r
+
+    # ---- causal_lm interface ----
+    def load_weights(self, model=None):
+        """Q4_0-quantize the HF bf16 checkpoint, dequant to bf16 on the host,
+        and pre-load every projection into resident per-layer BOs."""
+        model = model or MODEL_DEFAULT
+        self._weights = load_q4_weights(
+            model, config=self.config, n_layers=self.n_layers
+        )
+        self._preload()
+
+    def _preload(self):
+        """Resident BOs: prefill block weights (written once, then skipped via
+        static_input_indices) + the 19 LM-head partitions."""
+        from qwen25_3b_prefill import preload_prefill_weights
+
+        for i, lw in enumerate(self._weights.layers):
+            lw._layer_idx = i  # per-layer BO isolation
+        preload_prefill_weights(
+            self._weights, self.config, self.cache, self.seq, self._rope_lut
+        )
+        self._preload_lm_head_gemv()
+
+    def _preload_lm_head_gemv(self):
+        """Build the 19 padded bf16 lm_head partitions [8192, D] and write them
+        into resident BOs once (static; skipped thereafter)."""
+        self._lm_parts = []
+        for p in range(_LM_N_PARTITIONS):
+            n0 = p * _LM_N_PART
+            n1 = min(n0 + _LM_N_PART, VOCAB)
+            w = np.zeros((_LM_N_PART, D), bfloat16)
+            if n1 > n0:
+                w[: n1 - n0] = np.asarray(self._weights.lm_head[n0:n1], bfloat16)
+            self._lm_parts.append(w)
+        self._lm_head_npu(np.zeros(D, bfloat16))  # warm/allocate resident BOs
+
+    def _lm_head_npu(self, hidden_bf16):
+        """On-device final logits from a single bf16 hidden row [D] -> [VOCAB]."""
+        lm_inputs = [np.ascontiguousarray(hidden_bf16, bfloat16)]
+        for p in range(_LM_N_PARTITIONS):
+            lm_inputs.append(self._lm_parts[p])
+            lm_inputs.append(np.zeros(_LM_N_PART, bfloat16))
+        res = self.cache.load_and_run(
+            "lm_head_gemv",
+            self._lm_backend,
+            *lm_inputs,
+            output_indices=[2 + 2 * p for p in range(_LM_N_PARTITIONS)],
+            static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+            intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        )
+        return np.concatenate(
+            [np.asarray(res[2 + 2 * p], np.float32) for p in range(_LM_N_PARTITIONS)]
+        )[:VOCAB]
+
+    def _run_layer(self, x, k, N):
+        """One Qwen2.5 transformer block fully on-device. Captures roped-K and
+        biased-V into the KV cache (the decode hand-off)."""
+        from qwen25_3b_prefill import run_transformer_block_qwen25
+
+        out, inter = self._dev(
+            run_transformer_block_qwen25,
+            x,
+            self._weights.layers[k],
+            self._rope_lut,
+            self.config,
+            self.cache,
+            k,
+            False,  # cpu_attn=False -> NPU flash attention
+            False,  # verbose
+            tag="layer",
+        )
+        self.kv_k[k][:N] = np.asarray(inter["k_roped"], bfloat16).reshape(-1, DK)[:N]
+        self.kv_v[k][:N] = np.asarray(inter["v"], bfloat16).reshape(-1, DV)[:N]
+        return out
+
+    def prefill(self, ids, payload=None):
+        assert self._weights is not None, "call load_weights() first"
+        N = len(ids)
+        assert N <= self.seq, (N, self.seq)
+        base = self.current_context_length
+        x = np.zeros((self.seq, D), bfloat16)
+        x[:N] = np.asarray(self._weights.embed_table[list(ids)], bfloat16)
+        for k in range(self.n_layers):
+            x = self._run_layer(x, k, N)
+        self.current_context_length = base + N
+        # Final RMSNorm on the single prediction row (host, <1ms) + NPU LM head.
+        xf = np.asarray(x[N - 1], np.float32)
+        xn = (
+            xf
+            / np.sqrt((xf * xf).mean() + EPS)
+            * np.asarray(self._weights.final_norm, np.float32)
+        )
+        self._last_hidden = xf
+        return self._dev(self._lm_head_npu, np.asarray(xn, bfloat16), tag="lm_head")
+
+    # ---- KV cache (causal_lm) ----
+    def get_k_cache(self, layer_idx, idx):
+        """Roped-K vector at position idx of a layer."""
+        return self.kv_k[layer_idx][idx]
+
+    def get_v_cache(self, layer_idx, idx):
+        """Biased raw-V vector at position idx of a layer."""
+        return self.kv_v[layer_idx][idx]
+
+    def kv_view(self, layer_idx):
+        """(roped_K, biased_V) for the filled context [0:ctx] -> decode hand-off."""
+        c = self.current_context_length
+        return self.kv_k[layer_idx][:c], self.kv_v[layer_idx][:c]
+
+    def clear_context(self):
+        self.current_context_length = 0
+        for k in range(self.n_layers):
+            self.kv_k[k][:] = 0
+            self.kv_v[k][:] = 0
+
+    def get_current_context_length(self):
+        return self.current_context_length
+
+    def set_context_length(self, L):
+        self.current_context_length = L
+
+
+def _main():
+    ap = argparse.ArgumentParser(description="Qwen2.5-3B Q4_0 prefill on NPU2")
+    ap.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="build/cache the prefill ELFs and exit (no weights, no NPU dispatch)",
+    )
+    ap.add_argument(
+        "--n-layers", type=int, default=int(os.environ.get("NLAYERS", "36"))
+    )
+    ap.add_argument(
+        "--seq-len",
+        type=int,
+        default=int(os.environ.get("QWEN_Q4_SEQ_LEN", "2048")),
+        help="padded prefill length",
+    )
+    ap.add_argument("--cache-dir", default=os.environ.get("QWEN_Q4_CACHE_DIR") or None)
+    ap.add_argument(
+        "--bench-l",
+        type=int,
+        default=int(os.environ.get("QWEN_Q4_BENCH_L", "0")),
+        help="warm TTFT benchmark at this context length",
+    )
+    ap.add_argument("--prompt", default=None, help="text prompt (needs transformers)")
+    ap.add_argument(
+        "--dump-kv",
+        default=None,
+        metavar="PATH.npz",
+        help="write the prefill KV cache (roped K + biased V, per layer) plus the "
+        "prompt ids to PATH.npz -- the hand-off to the fused NPU decode. Written "
+        "as raw uint16 so the bf16 payload survives np.savez unchanged.",
+    )
+    ap.add_argument("--model", default=MODEL_DEFAULT)
+    args = ap.parse_args()
+
+    print(
+        f"[qwen_q4_prefill] constructing seq_len={args.seq_len} "
+        f"n_layers={args.n_layers} (compiling engines)...",
+        flush=True,
+    )
+    model = Qwen25Q4Prefill(
+        seq_len=args.seq_len, n_layers=args.n_layers, cache_dir=args.cache_dir
+    )
+    if args.compile_only:
+        print("Compilation passed.", flush=True)
+        return 0
+
+    print("[qwen_q4_prefill] loading Q4_0 weights (host dequant)...", flush=True)
+    model.load_weights(model=args.model)
+
+    ids = PROMPT
+    tok = None
+    if args.prompt:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(args.model)
+        ids = tok(args.prompt, return_tensors=None)["input_ids"]
+    print(f"[qwen_q4_prefill] prefill prompt N={len(ids)} ...", flush=True)
+    logits = model.prefill(ids)
+    top = int(np.asarray(logits).argmax())
+    txt = f" ({tok.decode([top])!r})" if tok else ""
+    print(f"[qwen_q4_prefill] first-token argmax={top}{txt}", flush=True)
+    ok = True
+    if ids == PROMPT:
+        ok = top == EXPECT_FIRST
+        print(
+            (
+                "[qwen_q4_prefill] *** PARIS ***"
+                if ok
+                else f"[qwen_q4_prefill] MISS (expect {EXPECT_FIRST})"
+            ),
+            flush=True,
+        )
+
+    if args.dump_kv:
+        c = model.get_current_context_length()
+        np.savez(
+            args.dump_kv,
+            ids=np.asarray(ids, np.int64),
+            ctx=np.int64(c),
+            # bf16 payloads move as raw uint16: np.savez does not round-trip the
+            # ml_dtypes bf16 dtype tag.
+            k=np.stack([model.kv_k[l][:c] for l in range(model.n_layers)]).view(
+                np.uint16
+            ),
+            v=np.stack([model.kv_v[l][:c] for l in range(model.n_layers)]).view(
+                np.uint16
+            ),
+            hidden=np.asarray(model._last_hidden, np.float32),
+        )
+        print(
+            f"[qwen_q4_prefill] KV dumped -> {args.dump_kv} "
+            f"({model.n_layers} layers x {c} tokens)",
+            flush=True,
+        )
+
+    if args.bench_l:
+        import time
+
+        model.clear_context()
+        bench_ids = [int(t % VOCAB) for t in range(args.bench_l)]  # timing only
+        print(f"[bench] warmup prefill L={args.bench_l}...", flush=True)
+        model.prefill(bench_ids)
+        model.clear_context()
+        model._dev_t = 0.0
+        model._op_t.clear()
+        model.cache.profiler.enabled = True
+        for d in (
+            model.cache.profiler.kernel_times,
+            model.cache.profiler.cpu_times,
+            model.cache.profiler.kernel_breakdowns,
+        ):
+            d.clear()
+        model.cache.profiler.layer_times.clear()
+        print(f"[bench] timed prefill L={args.bench_l}...", flush=True)
+        t0 = time.time()
+        model.prefill(bench_ids)
+        wall = time.time() - t0
+        npu = model._dev_t
+        print(
+            f"\n[bench] L={args.bench_l}: WALL={wall*1000:.0f}ms "
+            f"{args.bench_l/wall:.0f} tok/s prefill  |  "
+            f"NPU-dispatch={npu*1000:.0f}ms {args.bench_l/npu:.0f} tok/s  |  "
+            f"host={(wall-npu)*1000:.0f}ms",
+            flush=True,
+        )
+        print(f"Time to first token (TTFT): {wall:.3f}s", flush=True)
+        print(
+            "[bench] per-op NPU: "
+            + "  ".join(
+                f"{k}={v*1000:.0f}ms"
+                for k, v in sorted(model._op_t.items(), key=lambda x: -x[1])
+            ),
+            flush=True,
+        )
+        model.cache.profiler.report()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
@@ -76,8 +76,13 @@ def _bf(a):
 
 
 def dequant_q4_0(q_u8, scale, group=GROUP):
-    """Inverse of requant_q4_0: (uint8 two's-complement nibbles, [M,K/g] scale)
-    -> float32 [M, K].  w = int8(q) * scale, symmetric, per `group` columns."""
+    """Inverse of requant_q4_0: ([M,K] uint8 holding ONE two's-complement
+    signed-int4 value per element, [M,K/g] scale) -> float32 [M, K].
+    w = int8(q) * scale, symmetric, per `group` columns.
+
+    Note the input is one byte per weight, NOT packed nibbles: requant_q4_0
+    returns unpacked codes in [-8, 7] and the two-per-byte packing happens
+    later, in the cascade packer."""
     return q_u8.view(np.int8).astype(np.float32) * np.repeat(scale, group, axis=1)
 
 

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Q4_0 weight loader for the Qwen2.5-3B Q4 example.
+#
+# Mirrors llama32_1b_q4nx_weights.Q4nxModel, with two deltas that follow from
+# the model rather than from a choice:
+#
+#   1. CODEC. The Llama path reads an already-4-bit `model.q4nx` bundle whose
+#      codec is per-block AFFINE quant (w = scale*(q - min), unsigned nibbles).
+#      Qwen2.5-3B has no such bundle; its NPU kernels are built with -DQ4_0, a
+#      SYMMETRIC signed-int4 codec (w = q*scale, q in [-8,7], scale = amax/8,
+#      per 32-element group along the reduction dim). So this loader quantizes
+#      the full-precision HF checkpoint directly -- which is also strictly more
+#      accurate than re-quantizing someone else's 4-bit weights.
+#
+#      The quantizer is `qwen25_3b_requant.requant_q4_0`, the same function the
+#      fused_decode Qwen weight cache uses, so the prefill and the fused decode
+#      see BIT-IDENTICAL weight values.
+#
+#   2. QKV BIAS. Qwen2.5 has q/k/v projection bias. Bias is NOT quantized (it is
+#      not quantized in the reference design either) -- it is carried as bf16.
+#
+# Everything else -- dequant to bf16, transpose HF (out,in) -> GEMM (in,out),
+# tied lm_head, bf16 norms -- matches the Llama Q4NX loader, so the resulting
+# LlamaWeights container drops straight into the qwen25_3b prefill builders.
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+# The Q4_0 quantizer + HF safetensors reader live with the fused_decode example
+# (single source of truth for the Qwen quant codec).
+_FUSED_DECODE = str(Path(__file__).resolve().parents[2] / "fused_decode")
+_QWEN25_3B = str(Path(__file__).resolve().parent.parent / "qwen25_3b")
+for _p in (_FUSED_DECODE, _QWEN25_3B):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from qwen25_3b_requant import HFModel, HF_REPO, requant_q4_0  # noqa: E402
+from proj_qmm_pack import GROUP  # noqa: E402
+from qwen25_3b_weights import (  # noqa: E402
+    LlamaConfig,
+    LayerWeights,
+    LlamaWeights,
+    generate_rope_lut,
+)
+
+# Qwen2.5-3B dims (mirrors the Llama loader's module-level dim block).
+D = 2048  # model dim
+DQ = 2048  # q proj out (16 heads * 128)
+DK = 256  # k proj out (2 kv heads * 128)
+DV = 256
+DH = 128  # head dim
+N_Q_HEADS = 16
+N_KV_HEADS = 2
+Q_PER_KV = N_Q_HEADS // N_KV_HEADS  # 8
+INTER = 11008  # mlp intermediate
+VOCAB = 151936
+
+_PROJ = {
+    "q": "self_attn.q_proj",
+    "k": "self_attn.k_proj",
+    "v": "self_attn.v_proj",
+    "o": "self_attn.o_proj",
+    "up": "mlp.up_proj",
+    "gate": "mlp.gate_proj",
+    "down": "mlp.down_proj",
+}
+_BIAS = {"bq": "self_attn.q_proj", "bk": "self_attn.k_proj", "bv": "self_attn.v_proj"}
+
+
+def _bf(a):
+    return a.astype(bfloat16).astype(np.float32)
+
+
+def dequant_q4_0(q_u8, scale, group=GROUP):
+    """Inverse of requant_q4_0: (uint8 two's-complement nibbles, [M,K/g] scale)
+    -> float32 [M, K].  w = int8(q) * scale, symmetric, per `group` columns."""
+    return q_u8.view(np.int8).astype(np.float32) * np.repeat(scale, group, axis=1)
+
+
+class Qwen25Q4Model:
+    """HF bf16 checkpoint -> Q4_0 -> bf16, tensor by tensor.
+
+    Deliberately quantize-then-dequantize (rather than using the bf16 weights
+    directly): the point of this example is to run the prefill on the SAME
+    4-bit values the NPU decode consumes, so prefill and decode agree and the
+    prefill's KV cache is a valid decode input.
+    """
+
+    def __init__(self, model=HF_REPO):
+        self.hf = HFModel(model)
+        self.source = model
+
+    def _q4(self, name):
+        """One HF projection [out, in] -> Q4_0 round-trip -> bf16 [in, out]."""
+        w = self.hf.bf16(name)  # [out, in] float32
+        q, sc = requant_q4_0(w)
+        return np.ascontiguousarray(dequant_q4_0(q, sc).T, dtype=bfloat16)
+
+    def layer_weights(self, k):
+        """Q4_0-round-tripped bf16 GEMM input-B [in, out] per projection."""
+        return {nm: self._q4(f"model.layers.{k}.{t}.weight") for nm, t in _PROJ.items()}
+
+    def layer_bias(self, k):
+        """(bq, bk, bv) bf16 -- NOT quantized (matches the reference design)."""
+        return tuple(
+            np.asarray(self.hf.bf16(f"model.layers.{k}.{t}.bias"), bfloat16)
+            for t in (_BIAS["bq"], _BIAS["bk"], _BIAS["bv"])
+        )
+
+    def layer_rms(self, k):
+        """(input_layernorm, post_attention_layernorm) float32 for layer k."""
+        return (
+            self.hf.bf16(f"model.layers.{k}.input_layernorm.weight"),
+            self.hf.bf16(f"model.layers.{k}.post_attention_layernorm.weight"),
+        )
+
+    def embed_norm_lmhead(self):
+        """(embed [VOCAB,D], final_norm [D], lm_head [VOCAB,D]) float32.
+
+        Qwen2.5-3B sets tie_word_embeddings=true, so the LM head IS the
+        full-precision embedding matrix (kept fp, exactly as the Llama Q4NX
+        example keeps its tied head fp)."""
+        embed = self.hf.bf16("model.embed_tokens.weight")
+        norm = self.hf.bf16("model.norm.weight")
+        return embed, norm, embed
+
+
+def load_q4_weights(model=HF_REPO, config=None, n_layers=None, verbose=True):
+    """Build the qwen25_3b `LlamaWeights` container from Q4_0 weights.
+
+    Shape-for-shape identical to qwen25_3b_weights.load_weights(), so every
+    downstream builder / preloader / block runner works unchanged."""
+    config = config or LlamaConfig()
+    n_layers = config.n_layers if n_layers is None else n_layers
+    qm = Qwen25Q4Model(model)
+    if verbose:
+        print(f"[qwen25_3b_q4] Q4_0 requant from {model} ({n_layers} layers)...")
+
+    layers = []
+    for k in range(n_layers):
+        W = qm.layer_weights(k)
+        rms_in, rms_post = qm.layer_rms(k)
+        bq, bk, bv = qm.layer_bias(k)
+        layers.append(
+            LayerWeights(
+                attn_norm=np.asarray(rms_in, bfloat16),
+                wq=W["q"],
+                wk=W["k"],
+                wv=W["v"],
+                wo=W["o"],
+                ffn_norm=np.asarray(rms_post, bfloat16),
+                w_gate=W["gate"],
+                w_up=W["up"],
+                w_down=W["down"],
+                bq=bq,
+                bk=bk,
+                bv=bv,
+            )
+        )
+        if verbose and (k + 1) % 6 == 0:
+            print(f"  ... {k + 1}/{n_layers} layers", flush=True)
+
+    embed, final_norm, lm_head = qm.embed_norm_lmhead()
+    return LlamaWeights(
+        embed_table=np.asarray(embed, bfloat16),
+        layers=layers,
+        final_norm=np.asarray(final_norm, bfloat16),
+        lm_head=np.asarray(lm_head, bfloat16),
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Qwen2.5-3B Q4_0 weight loader")
+    ap.add_argument("--model", default=HF_REPO)
+    ap.add_argument("--n-layers", type=int, default=1)
+    args = ap.parse_args()
+
+    w = load_q4_weights(args.model, n_layers=args.n_layers)
+    L0 = w.layers[0]
+    print(f"embed {w.embed_table.shape} norm {w.final_norm.shape}")
+    print(f"L0 wq {L0.wq.shape} wk {L0.wk.shape} wo {L0.wo.shape} bq {L0.bq.shape}")
+
+    # Quant error vs the fp reference, per projection.
+    qm = Qwen25Q4Model(args.model)
+    for nm, t in _PROJ.items():
+        ref = qm.hf.bf16(f"model.layers.0.{t}.weight").T
+        got = np.asarray(
+            getattr(
+                L0,
+                {
+                    "q": "wq",
+                    "k": "wk",
+                    "v": "wv",
+                    "o": "wo",
+                    "gate": "w_gate",
+                    "up": "w_up",
+                    "down": "w_down",
+                }[nm],
+            ),
+            np.float32,
+        )
+        rel = np.linalg.norm(got - ref) / np.linalg.norm(ref)
+        print(f"  {nm:5s} {str(ref.shape):16s} rel_l2={rel:.4f}")


### PR DESCRIPTION
Stacked on #1771 — it builds on a tree that has the aperiodic-packet-chain split, so the diff below includes that PR's changes until it merges.

## What this adds

An end-to-end Qwen2.5-3B deployment: a Q4_0 prefill example and a 36-layer fused single-dispatch decode, joined so the whole pipeline runs on NPU2 with **no host reference in the loop**.

- `llms/qwen25_3b_q4/` — Q4_0 weight loader + prefill driver, reusing the `qwen25_3b` block builders exactly as `llama32_1b_q4nx` reuses `llama32_1b`'s.
- `fused_decode/fused_decode_qwen.py` + `models/qwen2.5-3b.h` — the 36-layer fused decode, plus the kernel changes it needs (Q4_0 signed-int4 in `q4_k.h`, QKV bias in `rope.cc`, head_dim 128 attention).
- `fused_decode/qwen_prefill_to_decode.py` — the KV hand-off and generation loop.

## Quant path: Q4_0, not Q4NX

Qwen2.5-3B has no pre-quantized 4-bit bundle, and its NPU kernels are built with `-DQ4_0` — a symmetric signed-int4 codec (`w = q*scale`, `q ∈ [-8,7]`, `scale = amax/8`, per 32-element group along the reduction dim), not the affine Q4NX codec the Llama Q4NX examples read. So this quantizes the full-precision HF checkpoint directly, which is also strictly more accurate than requantizing someone else's 4-bit weights. Layer-0 error is rel L2 ~0.095–0.098 on every projection. QKV bias is carried as bf16 (it is not quantized).

Prefill and decode share one quantizer, so they see bit-identical weight values and the prefill's KV cache is a valid decode input.

## Hand-off

A slice, not a shuffle: prefill K/V are `[ctx, 256]` seq-major head-major and the decode wants `[ATTN_L, 256]` at the K and V region offsets — same element order. Seeding from the **last** `ATTN_L` prefill rows keeps RoPE consistent, since RoPE is absolute and a cached entry carries the roping of the position it was computed at.

## Results (NPU2, quiet box)

| gate | result |
|---|---|
| First token, `"The capital of France is"`, 36 layers | argmax 12095 = `" Paris"` |
| Warm TTFT @ seq_len 2048 | 4.17 s |
| NPU prefill -> NPU fused decode, no host reference | coherent text, 9.54 tok/s device-only |

The cross-check that the hand-off is correct: the decode's first token equals the prefill's own argmax.

## Known weak point

Decode throughput. Layers do not pipeline (3.9 ms/layer × 36) and the full weight set streams per token. That is a follow-up, not addressed here.

## Notes

No lit tests yet — the example downloads a 3B checkpoint and compiles its own kernels, so wiring it into CI is deliberately left as a follow-up rather than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)