### PR TITLE
Bump mlir-aie to 1.4.1.dev46+g687ff97 (LLVM 23 -> 24)

### DIFF
--- a/.github/workflows/buildAIRWheels.yml
+++ b/.github/workflows/buildAIRWheels.yml
@@ -254,9 +254,9 @@ jobs:
             if [ x"$ENABLE_RTTI" == x"OFF" ]; then
               NO_RTTI="-no-rtti"
               NO_RTTI_UNDERSCORE="_no_rtti"
-              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
+              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2/"
             else
-              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
+              MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/"
             fi
 
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
@@ -331,7 +331,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/ \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-4' || 'latest-wheels-no-rtti-2' }}/ \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 
@@ -434,9 +434,9 @@ jobs:
           NO_RTTI_UNDERSCORE=""
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
             NO_RTTI_UNDERSCORE="_no_rtti"
-            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
+            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2/"
           else
-            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/"
+            MLIR_AIE_WHEELS_URL="https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/"
           fi
 
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
@@ -528,7 +528,7 @@ jobs:
             ```bash
             pip install 'mlir_air[aie]' \
               -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-air-wheels' || 'latest-air-wheels-no-rtti' }} \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/ \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/${{ matrix.ENABLE_RTTI == 'ON' && 'latest-wheels-4' || 'latest-wheels-no-rtti-2' }}/ \
               -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
             ```
 

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -78,7 +78,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 
       - name: Get llvm-aie
         run: |

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -75,7 +75,7 @@ jobs:
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           echo "mlir-aie wheel version: $MLIR_AIE_VERSION"
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 
       - name: Get cmakeModules
         run: |

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -93,7 +93,7 @@ jobs:
           source air-venv/bin/activate
           MLIR_AIE_VERSION=$(utils/clone-mlir-aie.sh --get-wheel-version)
           pip install mlir_aie==$MLIR_AIE_VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 
       - name: Get llvm-aie
         run: |
@@ -106,7 +106,7 @@ jobs:
       # llvm.lifetime.{start,end} to the no-size form and Peano opt (LLVM 21) then
       # rejects the merged module ("immarg operand has non-immediate parameter").
       # Neither toolchain on this runner provides one -- the llvm-aie wheel ships
-      # clang/opt/llc but no llvm-link, and the pinned mlir distro is LLVM 23 -- so
+      # clang/opt/llc but no llvm-link, and the pinned mlir distro is LLVM 24 -- so
       # the q4nx verify+profile lits reported UNSUPPORTED and the model silently
       # vanished from perf.json.
       #

--- a/docs/aircc.md
+++ b/docs/aircc.md
@@ -32,7 +32,8 @@ optional arguments:
   --host-target host_target
                         Target architecture of the host program
   --shared              Generate a shared library (.so) instead of the default of a static library (.a)
-  -xbridge              pass --xbridge to aiecc, otherwise pass --no-xbridge
+  -xbridge              pass --xbridge to aiecc; otherwise nothing is passed and
+                        aiecc uses its default Peano backend
 ```
 
 ```

--- a/docs/buildingRyzenLin.md
+++ b/docs/buildingRyzenLin.md
@@ -71,7 +71,7 @@ For the no-RTTI variant, point both find-links at the no-RTTI pages so pip resol
 ```bash
 pip install 'mlir_air[aie]' \
   -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
-  -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
+  -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
   -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 ```
 

--- a/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
+++ b/mlir/lib/Dialect/AIR/IR/AIRDialect.cpp
@@ -925,7 +925,7 @@ void air::LaunchOp::getSuccessorRegions(
   if (point.isParent())
     regions.push_back(RegionSuccessor(&getBody()));
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 void air::LaunchOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands, SmallVectorImpl<InvocationBounds> &bounds) {
@@ -1327,7 +1327,7 @@ void air::RankOp::getSuccessorRegions(
   if (point.isParent())
     regions.push_back(RegionSuccessor(&getBody()));
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 void air::RankOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands, SmallVectorImpl<InvocationBounds> &bounds) {
@@ -1628,7 +1628,7 @@ void air::SegmentOp::getSuccessorRegions(
   if (point.isParent())
     regions.push_back(RegionSuccessor(&getBody()));
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 void air::SegmentOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands, SmallVectorImpl<InvocationBounds> &bounds) {
@@ -2038,7 +2038,7 @@ void air::HerdOp::getSuccessorRegions(
   if (point.isParent())
     regions.push_back(RegionSuccessor(&getBody()));
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 void air::HerdOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands, SmallVectorImpl<InvocationBounds> &bounds) {
@@ -3542,6 +3542,17 @@ air::ChannelPutOp::getTiledImplementation(OpBuilder &builder,
                                                              sizes, put);
 }
 
+// LLVM 24 added a second overload carrying per-dimension InnerTileAlignment
+// hints. The hints only mean something to pack/unpack ops, which relate a tile
+// size to an inner tile; a channel put has no such inner tile, so ignore them.
+// TableGen declares both overloads whenever the name is listed in
+// DeclareOpInterfaceMethods, so this has to be defined rather than inherited.
+FailureOr<TilingResult> air::ChannelPutOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
 LogicalResult air::ChannelPutOp::getResultTilePosition(
     OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
@@ -3665,6 +3676,14 @@ air::ChannelGetOp::getTiledImplementation(OpBuilder &builder,
       dyn_cast_if_present<air::ChannelInterface>(getOperation());
   return getTiledImplementationFromChanIf<air::ChannelGetOp>(builder, offsets,
                                                              sizes, get);
+}
+
+// See the ChannelPutOp overload above: the InnerTileAlignment hints are a
+// pack/unpack concept and carry no meaning for a channel get.
+FailureOr<TilingResult> air::ChannelGetOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
 }
 
 LogicalResult air::ChannelGetOp::getResultTilePosition(

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -32,8 +32,8 @@
 #   generic_decoding_layer/bringup/bringup_gen.cpp):
 #     1) dump inputs from this script: DECODE_BRINGUP_DUMP=/tmp/mb_dump python3.13 q4nx_decode.py
 #     2) aiecc air_project/input_with_addresses.mlir -> /tmp/T.{xclbin,insts.bin}
-#        (aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host
-#         --xclbin-kernel-name=MLIR_AIE --peano=$PEANO --no-xchesscc --no-xbridge)
+#        (aiecc.py --get-xclbin --get-npu-insts
+#         --xclbin-kernel-name=MLIR_AIE --peano=$PEANO)
 #     3) build harness: bringup/build_gen.sh ; run (LD_LIBRARY_PATH=xrt/lib:../host_common):
 #        INPLACE=1 BAKED_INSTS=/tmp/T.insts.bin ./bringup_gen.exe /tmp/mb_dump /tmp/T.xclbin
 #        env: INPLACE=1 (output in arg0), ZERO_SLOT=1 + DUMP_KVC=1 (clean KV-append verify vs

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -32,6 +32,37 @@ NPU_MODELS = {
 }
 
 
+def _find_peano_install_dir():
+    """Return the installed llvm-aie (Peano) directory, or "" if there is none.
+
+    The llvm-aie wheel unpacks to a top-level `llvm-aie` data directory. That is
+    not a legal module name, so it cannot be imported -- ask the distribution
+    where it landed instead, and fall back to scanning the site dirs for
+    installs whose metadata is missing or non-standard.
+    """
+    try:
+        import importlib.metadata
+
+        candidate = importlib.metadata.distribution("llvm-aie").locate_file("llvm-aie")
+        if os.path.isdir(candidate):
+            return os.path.abspath(candidate)
+    except Exception:
+        pass
+
+    import site, glob
+
+    site_dirs = list(site.getsitepackages())
+    try:
+        site_dirs.append(site.getusersitepackages())
+    except Exception:
+        pass
+    for site_dir in site_dirs:
+        for match in glob.glob(os.path.join(site_dir, "llvm-aie")):
+            if os.path.isdir(match):
+                return os.path.abspath(match)
+    return ""
+
+
 class XRTCompileArtifact:
     """A class encompassing information on the artifacts produced by compilation for the NPU/XRT"""
 
@@ -267,16 +298,30 @@ class XRTBackend(AirBackend):
                     f"Confining design to {self.num_device_cols} column(s) of {base_device} device: {target_device}"
                 )
 
-        import os, site, glob
-
-        # Try to get peano package dir from environment variable, fallback to site-packages
+        # Resolve the Peano (llvm-aie) install: an explicit PEANO_INSTALL_DIR wins,
+        # otherwise use the llvm-aie package, which the AIE backend installs as a
+        # dependency. Chess is only reached when neither is available.
         peano_package_dir = os.environ.get("PEANO_INSTALL_DIR", "")
 
-        if peano_package_dir and os.path.isdir(peano_package_dir):
+        if peano_package_dir and not os.path.isdir(peano_package_dir):
+            print(
+                "XRTBackend: PEANO_INSTALL_DIR is not a directory, ignoring it:",
+                peano_package_dir,
+            )
+            peano_package_dir = ""
+
+        if peano_package_dir:
             print(
                 "XRTBackend: llvm-aie package detected via PEANO_INSTALL_DIR:",
                 peano_package_dir,
             )
+        else:
+            peano_package_dir = _find_peano_install_dir()
+            if peano_package_dir:
+                print(
+                    "XRTBackend: llvm-aie package detected in site-packages:",
+                    peano_package_dir,
+                )
 
         # Determine output file extension based on output_format
         if self.output_format == "elf":
@@ -378,6 +423,11 @@ class XRTBackend(AirBackend):
                 aircc_options += ["--no-xchesscc"]
                 aircc_options += ["--no-xbridge"]
             else:
+                print(
+                    "XRTBackend: no llvm-aie (Peano) install found; falling back to "
+                    "the Chess toolchain, which needs Vitis AIE Essentials. Set "
+                    "PEANO_INSTALL_DIR or `pip install llvm-aie` to use Peano."
+                )
                 aircc_options += ["--xchesscc"]
                 aircc_options += ["--xbridge"]
 

--- a/test/airhost/26_air_beefmaker_extfn/run.lit
+++ b/test/airhost/26_air_beefmaker_extfn/run.lit
@@ -10,5 +10,5 @@
 // XFAIL: *
 // RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-to-aie="output-prefix=./ row-offset=2 col-offset=7" -o /dev/null
-// RUN: aiecc.py --no-xbridge aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
+// RUN: aiecc.py aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/airhost/26_air_beefmaker_extfn/run.lit
+++ b/test/airhost/26_air_beefmaker_extfn/run.lit
@@ -10,5 +10,9 @@
 // XFAIL: *
 // RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-to-aie="output-prefix=./ row-offset=2 col-offset=7" -o /dev/null
-// RUN: aiecc.py aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
+// The old aiecc defaulted to Chess for both compile and link, so a bare
+// --no-xbridge here meant "xchesscc to compile, Peano lld to link" (this test
+// REQUIRES a valid xchess license). Peano is the default now, so that asymmetric
+// request has to be spelled out.
+// RUN: aiecc.py --xchesscc --xbridge=false aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
 // RUN: %run_on_board %T/test.elf

--- a/test/xrt/05_extern_func/run_npu1_peano.lit
+++ b/test/xrt/05_extern_func/run_npu1_peano.lit
@@ -7,5 +7,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu1 row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu1% %python %S/run.py aie.xclbin

--- a/test/xrt/05_extern_func/run_npu2_peano.lit
+++ b/test/xrt/05_extern_func/run_npu2_peano.lit
@@ -12,5 +12,5 @@
 // RUN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/chess/beefmaker_kernel.cc
 // RUN: air-opt %S/air.mlir -air-dma-to-channel -canonicalize -air-dependency -air-to-aie="device=npu2_4col row-offset=2 col-offset=0" --aie-place-tiles -air-to-std -symbol-dce -airrt-to-npu -canonicalize -cse -o aie.mlir
-// RUN: aiecc.py --no-xchesscc --no-xbridge --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
+// RUN: aiecc.py --peano %PEANO_INSTALL_DIR --get-xclbin --get-npu-insts --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie.mlir
 // RUN: %run_on_npu2% %python %S/run.py aie.xclbin

--- a/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_chess.lit
@@ -6,8 +6,8 @@
 // RUN: cd test_npu1_chess
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu1_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
+++ b/test/xrt/23_ctrlpkt_config/run_npu2_peano.lit
@@ -7,8 +7,8 @@
 // UN: %python %S/aie.py
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: aiecc.py --no-xchesscc --no-xbridge --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=forward_0 --get-ctrlpkt --ctrlpkt-name=ctrlpkt.bin --ctrlpkt-dma-seq-name=ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie_run_seq.bin aie_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe -x base.xclbin -k MLIR_AIE -i aie_run_seq.bin -c ctrlpkt_dma_seq.bin -p ctrlpkt.bin -v 2

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu1_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
+++ b/test/xrt/24_ctrlpkt_config_2gemms_4x4/run_npu2_peano.lit
@@ -7,12 +7,12 @@
 // UN: export PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
 // UN: %PEANO_INSTALL_DIR/bin/clang++ --target=aie2p-none-unknown-elf %peano_flags -c %S/mm.cc -o mm.o
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/base.mlir -o base_overlay.mlir
-// UN: aiecc.py --device-name=base --no-xchesscc --no-xbridge --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
+// UN: aiecc.py --device-name=base --get-xclbin --xclbin-name=base.xclbin base_overlay.mlir
 // UN: %python %S/aie.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie.mlir -o aie_overlay.mlir
-// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x512_512xbf16__dispatch_0_matmul_512x512x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie1_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie1_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie1_run_seq.bin aie_overlay.mlir
 // UN: %python %S/aie2.py
 // UN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" aie2.mlir -o aie2_overlay.mlir
-// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --no-xchesscc --no-xbridge --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// UN: aiecc.py --device-name=matmul_512x1024_512xbf16__dispatch_0_matmul_512x1024x512_bf16_0 --get-ctrlpkt --ctrlpkt-name=aie2_ctrlpkt.bin --ctrlpkt-dma-seq-name=aie2_ctrlpkt_dma_seq.bin --get-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 // UN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %test_utils_flags %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // UN: %run_on_npu1% ./test.exe

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1251,8 +1251,14 @@ static LogicalResult runAieCompilation() {
     if (verbose)
       aieccCmd.push_back("--verbose");
 
-    aieccCmd.push_back(xchesscc ? "--xchesscc" : "--no-xchesscc");
-    aieccCmd.push_back(xbridge ? "--xbridge" : "--no-xbridge");
+    // Core backend. mlir-aie #3501 dropped aiecc's --no-xchesscc/--no-xbridge
+    // and made Peano the default, so the Peano case is now expressed by saying
+    // nothing. The two Chess flags imply each other unless both are stated, so
+    // an asymmetric request has to spell out the negative half explicitly.
+    if (xchesscc || xbridge) {
+      aieccCmd.push_back(xchesscc ? "--xchesscc" : "--xchesscc=false");
+      aieccCmd.push_back(xbridge ? "--xbridge" : "--xbridge=false");
+    }
     aieccCmd.push_back("--tmpdir=" + tmpDir.getValue());
 
     // Output format options. The mlir-aie v1.4.0 aiecc is a declarative
@@ -1556,8 +1562,10 @@ static LogicalResult runAieCompilation() {
       segAieccCmd.push_back(aieccDir.str().str());
       segAieccCmd.push_back("--no-aiesim");
       segAieccCmd.push_back("--compile-host");
-      segAieccCmd.push_back(xchesscc ? "--xchesscc" : "--no-xchesscc");
-      segAieccCmd.push_back(xbridge ? "--xbridge" : "--no-xbridge");
+      if (xchesscc || xbridge) {
+        segAieccCmd.push_back(xchesscc ? "--xchesscc" : "--xchesscc=false");
+        segAieccCmd.push_back(xbridge ? "--xbridge" : "--xbridge=false");
+      }
       segAieccCmd.push_back(aieccFile.str().str());
 
       if (failed(runCommand(segAieccCmd)))

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -40,7 +40,7 @@ echo "WHL_MLIR DIR: $WHL_MLIR_DIR"
 # Install mlir-aie from wheel
 pushd my_install
 MLIR_AIE_VERSION=$($(dirname ${SCRIPT_PATH})/clone-mlir-aie.sh --get-wheel-version)
-python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0/
+python3 -m pip install mlir_aie==$MLIR_AIE_VERSION -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 popd
 export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 echo "WHL_AIE DIR: $MLIR_AIE_INSTALL_DIR"

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -18,9 +18,9 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=46fcb339fb61119b337f973c7ca9e710a319fdd0
-DATETIME=2026071405
-WHEEL_VERSION=23.0.0.$DATETIME+${commithash:0:8}
+export commithash=56bcc1871734e6c375a254dec0ec74eb18d04a2e
+DATETIME=2026080106
+WHEEL_VERSION=24.0.0.$DATETIME+${commithash:0:8}
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=db06374df9bf83d9fc557001ca213368aed15788
-WHEEL_VERSION=1.4.0
+export HASH=687ff971b6524260814aade8e0fba33b047fba02
+WHEEL_VERSION=1.4.1.dev46+g687ff97
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
Moves the mlir-aie pin off the v1.4.0 tag and onto the rolling nightly wheel, which carries mlir-aie's LLVM bump from 23 to 24.

| | before | after |
|---|---|---|
| mlir-aie | `1.4.0` / `db06374d` | `1.4.1.dev46+g687ff97` / `687ff971` |
| LLVM (ROCm fork) | `23.0.0.2026071405+46fcb339` | `24.0.0.2026080106+56bcc187` |
| mlir_aie find-links | `expanded_assets/v1.4.0` | `latest-wheels-4` / `latest-wheels-no-rtti-2` |

v1.4.0 shipped both the RTTI and no-RTTI wheels from a single release page, so one find-links URL sufficed for both. The rolling releases are split, so the URLs move back to the two pages and the install snippets in the wheel release notes become matrix-aware instead of hardcoding the RTTI page for both variants.

## Porting

**1. `RegionSuccessor::parent()` was deleted in LLVM 24.** Branching back out of a region is now a successor targeting the parent operation, via the new `RegionSuccessor(Operation *)` constructor. Four `getSuccessorRegions` implementations in `AIRDialect.cpp` (Launch, Rank, Segment, Herd).

**2. `TilingInterface::getTiledImplementation` gained an `ArrayRef<InnerTileAlignment>` overload.** Both overloads share a source name, so listing the method in `DeclareOpInterfaceMethods` makes TableGen declare *both*; defining only the hint-less one left an undefined symbol at link time. `ChannelPutOp`/`ChannelGetOp` now define the hint-bearing overload as a forward to the hint-less one — the hints describe a pack/unpack inner tile, which a channel does not have.

**3. aiecc dropped `--no-xchesscc` / `--no-xbridge`** (mlir-aie #3501). Peano is now the default core backend, and each Chess flag implies the other unless both are stated. `aircc` therefore passes nothing at all for the Peano case, and spells out the negative half as `--<flag>=false` for an asymmetric request. The raw `aiecc.py` RUN lines in `05_extern_func`, `26_air_beefmaker_extfn` and the disabled `// UN:` ctrlpkt tests get the same treatment, as does the `-xbridge` entry in `docs/aircc.md`.

Also corrects a stale comment in the nightly benchmark workflow that described the pinned distro as LLVM 23. The LLVM-21 `llvm-link` that step extracts is pinned to a fixed wheel URL and is unaffected by this bump.

## Depends on mlir-aie #3509

This is the first mlir-aie build containing Xilinx/mlir-aie#3509, and the bump needs it. LLVM 24 moved `arith-expand`'s floating-point min/max expansion behind an option defaulting to false, which let scalar `arith.maxnumf` reach Peano as `llvm.maxnum` and abort `llc`:

```
LLVM ERROR: unable to legalize instruction: G_FMAXNUM (in function: core_3_2)
```

On any earlier wheel on this LLVM, `test/xrt/41_triton_softmax` does not build.

## Testing

Validated both against a source build of mlir-aie `687ff971` and against the released wheel installed through the normal `clone-mlir-aie.sh --get-wheel-version` + find-links path:

- `check-air-mlir` — 480 passed, 7 XFAIL, 0 failed
- `check-air-cpp` — passed
- `test/xrt` npu1 Peano on a Phoenix part — **33/33 passed**, from wiped build dirs
- `41_triton_softmax` additionally re-run end-to-end with the wheel's `aiecc` on hardware: PASS

Both release pages carry the full 8-wheel set (cp311–cp314 × manylinux/win) for the RTTI and no-RTTI variants, so the whole wheel matrix resolves this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
