### PR TITLE
[programming_examples] Follow FastFlowLM's Q4NX re-export instead of pinning around it

### DIFF
--- a/programming_examples/fused_decode/kernels/q4_k.h
+++ b/programming_examples/fused_decode/kernels/q4_k.h
@@ -6,10 +6,21 @@
 #include "aie_kernel_utils.h"
 #include "model_spec.h"
 
-// Two quant layouts: Q4NX (unsigned int4 + per-group min, the default / Llama
-// path) selected when Q4_0 is NOT defined; Q4_0 (signed int4, scale-only, no
-// min -- the Qwen2.5 path) selected when Q4_0 IS defined. The Q4_0 form takes 3
-// args (no b_col_reduce_buffer, since there is no +min term).
+// Two quant layouts, both produced on the host by _requant_q4k and unrelated to
+// how the weight bundle on disk was encoded:
+//
+//   default (Llama path)     unsigned int4 + per-group min: w = scale*q + min,
+//                            so c += (q*b)*scale then c += min*sum(b).
+//   Q4_0 (Qwen2.5 path)      signed int4, scale-only, no min. Selected by
+//                            defining Q4_0; takes 3 args, since with no +min
+//                            term there is no b_col_reduce_buffer.
+//
+// The first layout used to be called "Q4NX" here. That name is taken: it is the
+// safetensors dtype of the OLDER FastFlowLM bundle encoding, whose dequant is
+// SUBTRACTIVE (w = scale*(q - zero)) -- the opposite of the additive form
+// above. The additive form matches the newer "I8" bundle dtype instead. Naming
+// the layout after either bundle codec invites reading the algebra backwards,
+// so it is named after what it is.
 #ifndef Q4_0
 template <int M, int N>
 void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c,

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_weights.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_weights.py
@@ -101,8 +101,14 @@ _ODD = _EVEN + 1
 class Q4nxModel:
     """mmap + parse a model.q4nx safetensors file; vectorized Q4NX dequant.
 
-    Identical codec/loader to the llama example; Gemma-specific accessors add the
-    4-norm (1+w) fold, qk-norm weights, dual-theta rope LUT, and embed scale."""
+    Same codec as the llama example, but NOT the same header: this bundle is
+    I8-packed, so `shape` is [n_blocks, bytes_per_block] and `dequant` takes the
+    logical (M, K) from the caller instead of reading it off the header. See
+    llama32_1b_q4nx_weights.Q4nxModel for both conventions -- that loader now
+    handles either, and this fork should fold into it.
+
+    Gemma-specific accessors add the 4-norm (1+w) fold, qk-norm weights,
+    dual-theta rope LUT, and embed scale."""
 
     def __init__(self, model):
         import json

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_weights.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_weights.py
@@ -101,14 +101,12 @@ _ODD = _EVEN + 1
 class Q4nxModel:
     """mmap + parse a model.q4nx safetensors file; vectorized Q4NX dequant.
 
-    Same codec as the llama example, but NOT the same header: this bundle is
-    I8-packed, so `shape` is [n_blocks, bytes_per_block] and `dequant` takes the
-    logical (M, K) from the caller instead of reading it off the header. See
-    llama32_1b_q4nx_weights.Q4nxModel for both conventions -- that loader now
-    handles either, and this fork should fold into it.
-
-    Gemma-specific accessors add the 4-norm (1+w) fold, qk-norm weights,
-    dual-theta rope LUT, and embed scale."""
+    This bundle has only ever been I8-packed, so `shape` is
+    [n_blocks, bytes_per_block] and `dequant` takes the logical (M, K) from the
+    caller. llama32_1b_q4nx_weights.Q4nxModel now handles that header too, plus
+    the older Q4NX one; the codec half of this class duplicates it and could
+    fold in. Kept separate here because the accessors below are Gemma-specific:
+    the 4-norm (1+w) fold, qk-norm weights, dual-theta rope LUT, embed scale."""
 
     def __init__(self, model):
         import json
@@ -137,7 +135,7 @@ class Q4nxModel:
         return v.astype(np.float32).reshape(self._hdr[name]["shape"])
 
     def dequant(self, name, M, K):
-        """A Q4NX tensor dequantized to float32 [M, K] (w = scale*(q - min)).
+        """A Q4NX tensor dequantized to float32 [M, K] (w = scale*q + min).
 
         The Gemma bundle stores each Q4NX tensor block-major as [nb, block_bytes]
         (nb = (M/32)*(K/256), block = 256 scales + 256 mins + 32*256 nibbles =

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -123,11 +123,15 @@ def _ensure_requant_cache(fd):
     from llama32_1b_q4nx_prefill import MODEL_DEFAULT
     import q4nx_requant
 
-    rc = rc or os.path.join(_Q4NX_CACHE, "requant.npz")
+    src = os.environ.get("Q4NX_MODEL_SOURCE", MODEL_DEFAULT)
+    if not rc:
+        # Key on the bundle so a warm cache cannot outlive a Hub re-export
+        # (FastFlowLM re-encoded every NPU2 bundle on 2026-08-04).
+        from llama32_1b_q4nx_weights import Q4nxModel
+
+        rc = os.path.join(_Q4NX_CACHE, f"requant_{Q4nxModel(src).fingerprint()}.npz")
     if not os.path.exists(rc):
-        q4nx_requant.build_requant_cache(
-            os.environ.get("Q4NX_MODEL_SOURCE", MODEL_DEFAULT), fd, rc
-        )
+        q4nx_requant.build_requant_cache(src, fd, rc)
     os.environ["Q4NX_DECODE_WEIGHTS_NPZ"] = rc
     return rc
 

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -99,15 +99,19 @@ def resolve_q4nx_model(model):
             return p
     # treat as an HF repo id
     from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
 
     rev = _PINNED_Q4NX_REVISION.get(model)
     try:
         return hf_hub_download(model, "model.q4nx", revision=rev)
-    except Exception:
-        # Offline with a cache that predates the current revision: an offline
-        # runner pinned to a snapshot keeps working rather than failing to
-        # resolve. Both encodings decode correctly (the older one just
-        # reconstructs less faithfully), so an older snapshot is usable.
+    except LocalEntryNotFoundError:
+        # The Hub is unreachable (offline, or no network) AND the revision it
+        # would resolve to is not cached. That is the one case where an older
+        # cached snapshot is the right answer: a runner whose cache predates
+        # the re-export keeps working instead of failing to resolve, and both
+        # encodings decode correctly -- the older one just reconstructs less
+        # faithfully. A 404, a gated repo or an auth failure raises a different
+        # error and is left to propagate rather than silently served stale.
         if rev is not None:
             raise
         cached = _any_cached_snapshot(model)

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -69,24 +69,26 @@ _EVEN = np.array(
 _ODD = _EVEN + 1
 
 
-# Pinned model.q4nx revisions for the known FastFlowLM repos. The Hub bundles are
-# periodically re-packed to newer Q4NX block layouts (e.g. a 4096-i16/block form)
-# that this loader's codec (2560 i16/block; see proj_qmm_pack) does not parse, so
-# a bare `hf_hub_download` of the latest revision breaks with a reshape error.
-# Pin the last revision that matches the codec above. Custom repo ids / local
-# paths are always used as-is (unpinned).
-_PINNED_Q4NX_REVISION = {
-    "FastFlowLM/Llama-3.2-1B-NPU2": "d0c7f84ac9c5cf796db0fc8255afac42592d9db3",
-    "FastFlowLM/Llama-3.2-3B-NPU2": "790271a87c7bb8158e52e9684a586a496d1fb1c9",
-}
+# FastFlowLM re-exported every NPU2 bundle to the I8 packed encoding on
+# 2026-08-04 (all four repos within 20 minutes of each other). Those revisions
+# are the ones to use: decoded with the additive dequant below they reproduce
+# the reference bf16 weights to cosine ~0.997 with matching standard deviation,
+# whereas the older Q4NX-encoded revisions reconstruct to only 0.87 - 0.99 with
+# a standard deviation off by up to 13x. So nothing is pinned: take whatever the
+# repo currently serves, and let the codec be detected from the header.
+#
+# Old revisions remain reachable, so pinning one is still possible for a
+# bisect -- Llama-3.2-1B-NPU2 was d0c7f84a and Llama-3.2-3B-NPU2 was 790271a8
+# before the re-export -- but they are the worse weights, not a safe harbour.
+_PINNED_Q4NX_REVISION = {}
 
 
 def resolve_q4nx_model(model):
     """Resolve `model` to a local model.q4nx path. `model` may be an HF repo id
     (contains '/'), a directory containing model.q4nx, or a direct file path.
 
-    For a known FastFlowLM repo id, a compatible revision is pinned (see
-    `_PINNED_Q4NX_REVISION`); other repo ids download their latest revision."""
+    Repo ids download their current revision; `_PINNED_Q4NX_REVISION` can pin
+    one for a bisect (empty by default, see above)."""
     import os
 
     if os.path.isfile(model):
@@ -104,7 +106,26 @@ def resolve_q4nx_model(model):
 
 
 class Q4nxModel:
-    """mmap + parse a model.q4nx safetensors file; vectorized Q4NX dequant."""
+    """mmap + parse a model.q4nx safetensors file; vectorized Q4NX dequant.
+
+    HEADER CONVENTIONS. FastFlowLM ships quantized projections under two
+    different safetensors headers, and they are not distinguishable by shape
+    alone -- only by `dtype`:
+
+      dtype "Q4NX": shape is the LOGICAL [M, K] (e.g. [3072, 3072]). The block
+                    count is derived as (M/ROW_BLOCK)*(K/COL_BLOCK).
+      dtype "I8":   shape is the PACKED [n_blocks, bytes_per_block] (e.g.
+                    [1152, 5120]). The logical [M, K] is NOT recoverable from
+                    the header -- n_blocks is a single product of the two --
+                    so the caller must supply it.
+
+    Both describe the same bytes; the bundles were simply re-exported. As of
+    2026-08 the 1B bundle is Q4NX and the 3B / Gemma3-4B bundles are I8, and a
+    repo can switch between snapshots (FastFlowLM/Llama-3.2-3B-NPU2 did, on
+    2026-08-05). Reading an I8 header as logical yields a wrong block count and
+    a reshape error, so `dequant` dispatches on `dtype` and callers that may
+    meet an I8 bundle must pass `M`/`K`.
+    """
 
     def __init__(self, model):
         import json
@@ -112,8 +133,19 @@ class Q4nxModel:
         path = resolve_q4nx_model(model)
         self._mm = np.memmap(path, dtype=np.uint8, mode="r")
         hlen = int(np.frombuffer(self._mm[:8].tobytes(), dtype="<u8")[0])
-        self._hdr = json.loads(self._mm[8 : 8 + hlen].tobytes())
+        self._hdr_bytes = self._mm[8 : 8 + hlen].tobytes()
+        self._hdr = json.loads(self._hdr_bytes)
         self._base = 8 + hlen
+
+    def fingerprint(self):
+        """Short digest of the safetensors header. It changes whenever the Hub
+        re-exports the bundle -- encoding, block layout, or tensor set -- so a
+        derived cache keyed on it cannot silently outlive the weights it was
+        built from (the 2026-08-04 Q4NX -> I8 re-export is exactly that case).
+        Hashes the header only, never the multi-GB payload."""
+        import hashlib
+
+        return hashlib.sha256(self._hdr_bytes).hexdigest()[:8]
 
     def _raw_i16(self, name):
         o0, o1 = self._hdr[name]["data_offsets"]
@@ -132,11 +164,36 @@ class Q4nxModel:
         )
         return v.astype(np.float32).reshape(self._hdr[name]["shape"])
 
-    def dequant(self, name):
-        """A Q4NX tensor [M, K] dequantized to float32 (w = scale*(q - min))."""
-        M, K = self._hdr[name]["shape"]
+    def dims(self, name):
+        """Logical (M, K) of a quantized tensor, or None for an I8 header."""
+        e = self._hdr[name]
+        return tuple(e["shape"]) if e.get("dtype") == "Q4NX" else None
+
+    def dequant(self, name, M=None, K=None):
+        """A Q4NX tensor [M, K] dequantized to float32 (w = scale*(q - min)).
+
+        `M`/`K` are required for an I8-header bundle and cross-checked against
+        the header for a Q4NX one (see the class docstring).
+        """
+        hdr_dims = self.dims(name)
+        if hdr_dims is None:
+            if M is None or K is None:
+                raise ValueError(
+                    f"{name}: I8-packed header {self._hdr[name]['shape']} does not "
+                    "carry the logical shape; pass M/K from the model config"
+                )
+        else:
+            if M is not None and (M, K) != hdr_dims:
+                raise ValueError(f"{name}: caller says {(M, K)}, header {hdr_dims}")
+            M, K = hdr_dims
         nbi, nbj = M // ROW_BLOCK, K // COL_BLOCK
         nb = nbi * nbj
+        got = self._hdr[name]["shape"][0] if hdr_dims is None else nb
+        if got != nb:
+            raise ValueError(
+                f"{name}: header holds {got} blocks but (M/{ROW_BLOCK})*(K/{COL_BLOCK})"
+                f" = {nb} for [M, K] = {[M, K]}"
+            )
         i16 = self._raw_i16(name).reshape(nb, BLOCK_BF16)
         sc = (
             i16[:, 0:256]
@@ -163,9 +220,14 @@ class Q4nxModel:
         q = np.zeros((nb, ROW_BLOCK, COL_BLOCK), np.float32)
         q[:, _EVEN, :] = lo
         q[:, _ODD, :] = hi
-        w = np.repeat(sc.transpose(0, 2, 1), GROUP, axis=2) * (
-            q - np.repeat(mn.transpose(0, 2, 1), GROUP, axis=2)
-        )
+        scale = np.repeat(sc.transpose(0, 2, 1), GROUP, axis=2)
+        offset = np.repeat(mn.transpose(0, 2, 1), GROUP, axis=2)
+        # The two codecs also differ in the dequant itself, not just the header:
+        # Q4NX subtracts an unscaled zero point, I8 (GGUF Q4_1) adds an already
+        # scaled offset (offset/scale ~ -7.4), matching the AIR kernel q4_k.h
+        # (c += (q*b)*scale; c += min*sum(b)). Using the wrong one yields weights
+        # of plausible magnitude that decode to garbage, so it must follow dtype.
+        w = scale * (q - offset) if hdr_dims is not None else scale * q + offset
         return (
             w.reshape(nbi, nbj, ROW_BLOCK, COL_BLOCK)
             .transpose(0, 2, 1, 3)
@@ -182,11 +244,31 @@ class Q4nxModel:
         "down": "mlp.down_proj",
     }
 
-    def layer_weights(self, k):
-        """Dequantized bf16 GEMM input-B [K, out] per projection for layer k."""
+    # Logical (out, K) per projection, needed for an I8-packed header whose
+    # shape is [n_blocks, bytes_per_block]. These are the Llama-3.2-1B dims; a
+    # caller with different ones passes its own to layer_weights().
+    _PROJ_DIMS = {
+        "q": (DQ, D),
+        "k": (DK, D),
+        "v": (DV, D),
+        "o": (D, DQ),
+        "up": (INTER, D),
+        "gate": (INTER, D),
+        "down": (D, INTER),
+    }
+
+    def layer_weights(self, k, dims=None):
+        """Dequantized bf16 GEMM input-B [K, out] per projection for layer k.
+
+        `dims` maps a projection key to its logical (out, K), and is required
+        for an I8-header bundle whose dims differ from Llama-3.2-1B's (see the
+        class docstring); it defaults to _PROJ_DIMS.
+        """
+        dims = dims or self._PROJ_DIMS
         out = {}
         for nm, t in self._PROJ.items():
-            wt = self.dequant(f"model.layers.{k}.{t}.weight")  # [out, K]
+            M, K = (dims or {}).get(nm, (None, None))
+            wt = self.dequant(f"model.layers.{k}.{t}.weight", M, K)  # [out, K]
             out[nm] = np.ascontiguousarray(wt.T, dtype=bfloat16)  # [K, out]
         return out
 

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -15,6 +15,7 @@
 #                    | down(2048x8192) ], each Q4NX-reordered (pairs of row-
 #                    blocks interleaved column-by-column).
 #   rms_w  = [ input_layernorm(2048) | post_attention_layernorm(2048) | 0-pad ]
+import os
 import sys
 from pathlib import Path
 
@@ -58,10 +59,11 @@ def _bf(a):
 # The Q4NX model ships as a single safetensors file `model.q4nx` on the Hub
 # (repo FastFlowLM/Llama-3.2-1B-NPU2) with standard HF tensor names: per-layer
 # {q,k,v,o,gate,up,down}_proj (Q4NX), input/post_attention_layernorm + norm +
-# embed_tokens (bf16), and lm_head (Q4NX). The Q4NX storage codec is a per-block
-# affine quant `w = scale * (q - min)` (scale/min bf16 per 32-col group), 32x256
-# blocks in plain (row-block, col-block) order. This loader mmaps the file,
-# parses the safetensors header, and vectorized-dequantizes each tensor.
+# embed_tokens (bf16), and lm_head. The quantized tensors are per-block 4-bit
+# affine, 32x256 blocks with a bf16 scale/offset per 32-col group, in plain
+# (row-block, col-block) order, under one of two headers/dequants -- see
+# Q4nxModel. This loader mmaps the file, parses the safetensors header, and
+# vectorized-dequantizes each tensor.
 _G = ROW_BLOCK // PARALLEL  # row groups per block (2)
 _EVEN = np.array(
     [g * PARALLEL + 2 * k for g in range(_G) for k in range(PARALLEL // 2)]
@@ -89,8 +91,6 @@ def resolve_q4nx_model(model):
 
     Repo ids download their current revision; `_PINNED_Q4NX_REVISION` can pin
     one for a bisect (empty by default, see above)."""
-    import os
-
     if os.path.isfile(model):
         return model
     if os.path.isdir(model):
@@ -100,9 +100,38 @@ def resolve_q4nx_model(model):
     # treat as an HF repo id
     from huggingface_hub import hf_hub_download
 
-    return hf_hub_download(
-        model, "model.q4nx", revision=_PINNED_Q4NX_REVISION.get(model)
+    rev = _PINNED_Q4NX_REVISION.get(model)
+    try:
+        return hf_hub_download(model, "model.q4nx", revision=rev)
+    except Exception:
+        # Offline with a cache that predates the current revision: an offline
+        # runner pinned to a snapshot keeps working rather than failing to
+        # resolve. Both encodings decode correctly (the older one just
+        # reconstructs less faithfully), so an older snapshot is usable.
+        if rev is not None:
+            raise
+        cached = _any_cached_snapshot(model)
+        if cached is None:
+            raise
+        return cached
+
+
+def _any_cached_snapshot(model):
+    """Path to the most recently fetched cached model.q4nx for `model`."""
+    import glob
+
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    hits = glob.glob(
+        os.path.join(
+            HF_HUB_CACHE,
+            "models--" + model.replace("/", "--"),
+            "snapshots",
+            "*",
+            "model.q4nx",
+        )
     )
+    return max(hits, key=os.path.getmtime) if hits else None
 
 
 class Q4nxModel:

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_weights.py
@@ -119,12 +119,12 @@ class Q4nxModel:
                     the header -- n_blocks is a single product of the two --
                     so the caller must supply it.
 
-    Both describe the same bytes; the bundles were simply re-exported. As of
-    2026-08 the 1B bundle is Q4NX and the 3B / Gemma3-4B bundles are I8, and a
-    repo can switch between snapshots (FastFlowLM/Llama-3.2-3B-NPU2 did, on
-    2026-08-05). Reading an I8 header as logical yields a wrong block count and
-    a reshape error, so `dequant` dispatches on `dtype` and callers that may
-    meet an I8 bundle must pass `M`/`K`.
+    The two are not interchangeable encodings of the same bytes: the dequant
+    differs as well (see `dequant`), and the I8 re-export is the more faithful
+    of the two. Every FastFlowLM NPU2 repo currently serves I8; the Q4NX form
+    survives only in pre-2026-08-04 snapshots. Reading an I8 header as logical
+    yields a wrong block count and a reshape error, so `dequant` dispatches on
+    `dtype` and callers that may meet an I8 bundle must pass `M`/`K`.
     """
 
     def __init__(self, model):
@@ -170,10 +170,11 @@ class Q4nxModel:
         return tuple(e["shape"]) if e.get("dtype") == "Q4NX" else None
 
     def dequant(self, name, M=None, K=None):
-        """A Q4NX tensor [M, K] dequantized to float32 (w = scale*(q - min)).
+        """A quantized tensor dequantized to float32 [M, K].
 
         `M`/`K` are required for an I8-header bundle and cross-checked against
-        the header for a Q4NX one (see the class docstring).
+        the header for a Q4NX one (see the class docstring), which also selects
+        the dequant: Q4NX subtracts, I8 adds.
         """
         hdr_dims = self.dims(name)
         if hdr_dims is None:
@@ -188,11 +189,13 @@ class Q4nxModel:
             M, K = hdr_dims
         nbi, nbj = M // ROW_BLOCK, K // COL_BLOCK
         nb = nbi * nbj
-        got = self._hdr[name]["shape"][0] if hdr_dims is None else nb
-        if got != nb:
+        if hdr_dims is None and self._hdr[name]["shape"][0] != nb:
+            # The only cross-check available for an I8 header: caller dims that
+            # disagree with the block count would otherwise reshape-fail deep
+            # inside the unpack, or silently succeed on a transposed pair.
             raise ValueError(
-                f"{name}: header holds {got} blocks but (M/{ROW_BLOCK})*(K/{COL_BLOCK})"
-                f" = {nb} for [M, K] = {[M, K]}"
+                f"{name}: header holds {self._hdr[name]['shape'][0]} blocks but "
+                f"(M/{ROW_BLOCK})*(K/{COL_BLOCK}) = {nb} for [M, K] = {[M, K]}"
             )
         i16 = self._raw_i16(name).reshape(nb, BLOCK_BF16)
         sc = (
@@ -267,7 +270,7 @@ class Q4nxModel:
         dims = dims or self._PROJ_DIMS
         out = {}
         for nm, t in self._PROJ.items():
-            M, K = (dims or {}).get(nm, (None, None))
+            M, K = dims.get(nm, (None, None))
             wt = self.dequant(f"model.layers.{k}.{t}.weight", M, K)  # [out, K]
             out[nm] = np.ascontiguousarray(wt.T, dtype=bfloat16)  # [K, out]
         return out

--- a/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
+++ b/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
@@ -68,14 +68,25 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
         fd.UNI_LM,
     )
 
+    # Logical (out, K) per projection. An I8-packed bundle header carries only
+    # the block count, so the caller has to supply this (Q4nxModel docstring).
+    # Take it from `fd`, not from Q4nxModel's 1B default table: this function
+    # requantizes whichever model `fd` was configured for, and a mismatched
+    # table would reshape a 3B tensor as a 1B one.
+    dims = {
+        "q": (fd.DQ, fd.K),
+        "k": (fd.DK, fd.K),
+        "v": (fd.DV, fd.K),
+        "o": (fd.K, fd.DQ),
+        "up": (fd.GLU_OUT, fd.K),
+        "gate": (fd.GLU_OUT, fd.K),
+        "down": (fd.K, fd.GLU_OUT),
+    }
+
     W_all, RMS_in, RMS_post = [], [], []
     for k in range(n_layers):
-        # Dims come from the loader's table: an I8-packed bundle header carries
-        # the block count, not the logical [out, K] (Q4nxModel docstring).
         R = {
-            nm: qm_model.dequant(
-                f"model.layers.{k}.{t}.weight", *Q4nxModel._PROJ_DIMS[nm]
-            )
+            nm: qm_model.dequant(f"model.layers.{k}.{t}.weight", *dims[nm])
             for nm, t in _PROJ.items()
         }
         qm = [None] * NPH

--- a/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
+++ b/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
@@ -70,8 +70,12 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
 
     W_all, RMS_in, RMS_post = [], [], []
     for k in range(n_layers):
+        # Dims come from the loader's table: an I8-packed bundle header carries
+        # the block count, not the logical [out, K] (Q4nxModel docstring).
         R = {
-            nm: qm_model.dequant(f"model.layers.{k}.{t}.weight")
+            nm: qm_model.dequant(
+                f"model.layers.{k}.{t}.weight", *Q4nxModel._PROJ_DIMS[nm]
+            )
             for nm, t in _PROJ.items()
         }
         qm = [None] * NPH

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -151,13 +151,19 @@ _compile_decode_build:
 
 ## Run unified inference
 run:
+	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && python3 $(DRIVER) \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
-## Run with detailed profiling breakdown
+## Run with detailed profiling breakdown. --no-eos-stop so throughput is averaged
+## over the full N_TOKENS budget: the default prompt answers in ~7 tokens, and a
+## 7-sample average is dominated by the first (cold) dispatch. Mirrors
+## llama32_1b_q4nx, whose profile target has carried this since it was written.
 profile:
+	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && python3 $(DRIVER) \
-		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
+		--run-only --n-tokens $(N_TOKENS) --profile --no-eos-stop \
+		--prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat REPL
 chat:

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
@@ -97,6 +97,7 @@ def generate_stream(
     stream=True,
     prefiller=None,
     min_prefill=None,
+    stop_on_eos=True,
 ):
     """Consume the prompt, then generate greedily.
 
@@ -129,7 +130,7 @@ def generate_stream(
     t1 = time.perf_counter()
     for step in range(n_tokens):
         nxt = int(np.argmax(logits))
-        if nxt in EOS_IDS:
+        if stop_on_eos and nxt in EOS_IDS:
             break
         gen.append(nxt)
         if stream:
@@ -253,6 +254,12 @@ if __name__ == "__main__":
         help="use the batched NPU prefill only for prompts at least this long "
         f"(default {PREFILL_MIN_TOKENS}; shorter prompts decode faster token-by-token)",
     )
+    parser.add_argument(
+        "--no-eos-stop",
+        action="store_true",
+        help="keep generating past EOS (use with --profile so the decode rate is "
+        "measured over the full --n-tokens)",
+    )
     parser.add_argument("--interactive", action="store_true")
     args = parser.parse_args()
 
@@ -281,7 +288,12 @@ if __name__ == "__main__":
     prefiller = build_prefiller(args, prompt_len=len(ids))
     print(f"\nPrompt: {args.prompt}\n")
     gen, t_prompt, t_gen = generate_stream(
-        dec, tokenizer, ids, args.n_tokens, prefiller=prefiller
+        dec,
+        tokenizer,
+        ids,
+        args.n_tokens,
+        prefiller=prefiller,
+        stop_on_eos=not args.no_eos_stop,
     )
     if args.profile:
         npt, ngt = max(len(ids), 1), max(len(gen), 1)

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_weights.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_weights.py
@@ -23,12 +23,29 @@ for _p in (str(_LLMS), str(_LLAMA1B_Q4NX), str(_LLAMA3B), str(_HERE)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from llama32_1b_q4nx_weights import Q4nxModel  # noqa: E402  (shape-agnostic)
+# Dimension-agnostic, but NOT header-agnostic: the loader needs the logical
+# [out, K] for an I8-packed bundle, which is what this model ships.
+from llama32_1b_q4nx_weights import Q4nxModel  # noqa: E402
 from llama32_3b_weights import (  # noqa: E402
     LlamaConfig,
     LayerWeights,
     LlamaWeights,
 )
+
+
+def _proj_dims(c):
+    """Logical (out, K) per projection, for I8-packed Q4NX headers."""
+    dq = c.n_heads * c.head_dim
+    dkv = c.n_kv_heads * c.head_dim
+    return {
+        "q": (dq, c.emb_dim),
+        "k": (dkv, c.emb_dim),
+        "v": (dkv, c.emb_dim),
+        "o": (c.emb_dim, dq),
+        "gate": (c.hidden_dim, c.emb_dim),
+        "up": (c.hidden_dim, c.emb_dim),
+        "down": (c.emb_dim, c.hidden_dim),
+    }
 
 
 def load_q4nx_weights(model_source, config=None):
@@ -41,6 +58,8 @@ def load_q4nx_weights(model_source, config=None):
     if config is None:
         config = LlamaConfig()
 
+    # The 3B bundle carries I8-packed headers, which do not encode the logical
+    # [out, K] -- supply it (Q4nxModel docstring).
     qm = Q4nxModel(model_source)
     embed, norm, lm_head = qm.embed_norm_lmhead()  # (tied: lm_head is embed)
     embed = np.asarray(embed, bfloat16)
@@ -49,7 +68,7 @@ def load_q4nx_weights(model_source, config=None):
 
     layers = []
     for k in range(config.n_layers):
-        w = qm.layer_weights(k)  # {q,k,v,o,up,gate,down}, each [K, out] bf16
+        w = qm.layer_weights(k, _proj_dims(config))  # each [K, out] bf16
         rms_in, rms_post = qm.layer_rms(k)
         layers.append(
             LayerWeights(

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -83,19 +83,24 @@ def load_fd(model_type="LLAMA_3_2_3B"):
 
 def ensure_requant_cache(model_source, fd, n_layers, wcache_dir=None, verbose=True):
     """Return the q4k-cascade requant cache path, building it ONCE if missing. Keyed by
-    (n_layers, VOCAB_I2) -- the lm_head pack depends on VOCAB_I2, so a stale chunk size must
-    not be silently reused. A pre-versioning legacy file (VOCAB_I2-agnostic) is adopted once
-    under the versioned name."""
+    (n_layers, VOCAB_I2, bundle fingerprint): the lm_head pack depends on VOCAB_I2, so a
+    stale chunk size must not be silently reused, and the fingerprint ties the cache to the
+    exact model.q4nx it was requantized from. Without it a warm cache survives a Hub
+    re-export -- the machine keeps the old weights while a fresh one builds from the new
+    bundle, same code, different numbers.
+
+    Legacy unfingerprinted files are NOT adopted: they cannot be attributed to a bundle, and
+    the pre-2026-08-04 Q4NX-encoded weights they were built from reconstruct measurably worse
+    than the current ones. They are left in place, and the new cache is built alongside.
+    """
     from q4nx_requant import build_requant_cache
+    from llama32_1b_q4nx_weights import Q4nxModel
 
     wc = Path(wcache_dir) if wcache_dir else (_HERE / ".decode_wcache")
     wc.mkdir(parents=True, exist_ok=True)
-    cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}.npz"
-    legacy = wc / f"q4nx_3b_decode_L{n_layers}.npz"
+    fp = Q4nxModel(model_source).fingerprint()
+    cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}_{fp}.npz"
     if cache.exists():
-        return str(cache)
-    if legacy.exists():
-        os.replace(str(legacy), str(cache))  # one-time migration; never re-requant
         return str(cache)
     if verbose:
         print(


### PR DESCRIPTION
FastFlowLM re-exported every NPU2 `model.q4nx` bundle on 2026-08-04, switching
the quantized-projection encoding from `Q4NX` to `I8`. The two are different
codecs, not two spellings of one, and the loader here only understood the old
one — so it pinned the examples to pre-re-export revisions to keep working.
Those pinned revisions are the *worse* weights. This follows the re-export
instead of pinning around it.

## The two encodings

They are distinguishable only by the safetensors `dtype`; the shapes do not
give it away.

| | `Q4NX` | `I8` |
|---|---|---|
| header `shape` | logical `[M, K]` | packed `[n_blocks, bytes_per_block]` |
| dequant | `w = scale * (q - zero)` | `w = scale * q + min` (GGUF Q4_1) |

The I8 header does not carry the logical `[M, K]` — `n_blocks` is a single
product — so callers that may meet one must supply it. `dequant` dispatches on
`dtype` for both the reshape and the arithmetic; picking the wrong dequant
yields weights of plausible magnitude that decode to garbage.

The additive form matches what the AIR kernel already does (`q4_k.h`:
`c += (q*b)*scale; c += min*sum(b)`).

## Why the re-exported weights are the ones to use

Reconstruction vs the HF bf16 checkpoint, 15 tensors per model
(`q/k/o/gate/down` at three layers spread through the stack):

| model | revision | codec | cos min | cos mean | std vs ref |
|---|---|---|---|---|---|
| Llama-3.2-1B | `7bb88fcd` (current) | I8 | 0.99671 | 0.99718 | matches to 4 dp |
| Llama-3.2-1B | `d0c7f84a` (**pinned on main**) | Q4NX | 0.94545 | 0.98199 | up to **10x** off |
| Llama-3.2-3B | `2003cdb1` (current) | I8 | 0.99645 | 0.99715 | matches to 4 dp |
| Llama-3.2-3B | `790271a8` (**pinned on main**) | Q4NX | 0.86759 | 0.97258 | up to **13x** off |

The worst cases are the attention projections of layer 0 — `q_proj` on 3B
reconstructs at cosine 0.868 with a standard deviation 13x the reference.

## Changes

- **Unpin.** `_PINNED_Q4NX_REVISION` is now empty; repo ids resolve to whatever
  the Hub currently serves and the codec is detected from the header. The map is
  kept (with the two old hashes recorded in the comment) so a revision can still
  be pinned for a bisect.
- **Both headers, both codecs** in `Q4nxModel.dequant`, with a block-count
  cross-check so a caller/​header dim mismatch is a named error rather than a
  reshape failure deep in the unpack.
- **`fingerprint()`** — a short digest of the safetensors header — keys the
  derived requant caches (1B and 3B). Without it a warm cache outlives a Hub
  re-export: the machine that already has one keeps decoding the old weights
  while a fresh machine builds from the new bundle, same code, different
  numbers. Legacy unfingerprinted caches are left in place rather than adopted,
  since they cannot be attributed to a bundle.
- **`build_requant_cache` takes the projection dims from `fd`**, the
  fused_decode module it is requantizing for, instead of `Q4nxModel`'s
  Llama-1B default table. The 3B decode path was feeding 3072-wide tensors
  through 2048-wide dims; the new cross-check caught it.

The Gemma loader keeps its own copy of the codec (it has only ever seen I8, and
its accessors are Gemma-specific), with a note that the halves could fold
together now that the shared loader handles both headers.

## Validation (NPU2)

- Host weight-load gate: all three examples load with the current bundles,
  correct shapes, no non-finite or all-zero tensors.
- `llama32_1b_q4nx`: `make verify` **PASS 2/2** (top-k token set vs HF bf16).
- `llama32_3b_q4nx`: `make verify` **PASS 2/2**.
- `gemma3_4b_q4nx`: `make verify` **PASS** (first-token argmax 9079 " Paris").

## Note for the nightly runner

The perf runner serves weights from a warm offline HF cache. With the pins gone
these examples resolve `main`; if that cache holds only the pre-re-export
snapshot they will keep using it (correctly — the loader handles both), just
without the accuracy gain. Refreshing the cached revision is a runner-side
follow-up, not a code change.
