### PR TITLE
[programming_examples] Correct why the Qwen path differs: device format, not bundle

### DIFF
--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -30,6 +30,30 @@ the instruction stream for any `L`, byte-identical to a native per-L build.
 | `proj_qmm_pack.py` | numpy Q4NX block packer + dequant reference |
 | `kernels/` | Peano decode kernel sources (`proj_qmm`, `rms_residual`, `glu`, `rope`, `attn_qk`, `attn_kv`, headers) |
 | `models/` | model spec headers |
+| `fused_decode_qwen.py` | The Qwen2.5-3B variant of the builder (see below) |
+| `qwen25_3b_requant.py` | Q4_0 quantizer + weight cache for the Qwen decode |
+| `qwen_prefill_to_decode.py` | Hands `llms/qwen25_3b_q4`'s prefill KV to the Qwen decode |
+
+### Why Qwen has its own builder
+
+`fused_decode.py` covers Llama-3.2-1B/3B and Gemma3-4B, selected by
+`DECODE_MODEL`. Qwen2.5-3B is a separate file because its **on-device weight
+format differs**, not because its weights are packaged differently:
+
+| | Llama / Gemma | Qwen2.5 |
+|---|---|---|
+| device format | unsigned int4 **+ per-group min** | signed int4, **scale only** |
+| dequant | `w = scale*q + min` | `w = q*scale` |
+| kernel build | (default) | `-DQ4_0` |
+
+Both come from `kernels/q4_k.h`, which carries the two forms under `#ifndef
+Q4_0`. This mirrors FastFlowLM, whose own Qwen design sets `#define Q4_0` in
+`models/qwen2_3b.h` while its Llama and Gemma designs leave it undefined.
+
+The weight *bundles* are uniform: every FastFlowLM `model.q4nx` is the same
+per-block affine encoding regardless of model. That is why `llms/qwen25_3b_q4`
+quantizes the fp checkpoint directly rather than reading a bundle -- an affine
+bundle re-quantized into the symmetric device form would quantize twice.
 
 ## Reproducibility (toolchain)
 

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -47,8 +47,10 @@ format differs**, not because its weights are packaged differently:
 | kernel build | (default) | `-DQ4_0` |
 
 Both come from `kernels/q4_k.h`, which carries the two forms under `#ifndef
-Q4_0`. This mirrors FastFlowLM, whose own Qwen design sets `#define Q4_0` in
-`models/qwen2_3b.h` while its Llama and Gemma designs leave it undefined.
+Q4_0`; in-tree the switch is set by [`models/qwen2.5-3b.h`](models/qwen2.5-3b.h).
+This mirrors FastFlowLM, whose own Qwen design sets `#define Q4_0` in its
+`Qwen2_5/decoding_3b/models/qwen2_3b.h` while its Llama and Gemma designs leave
+it undefined.
 
 The weight *bundles* are uniform: every FastFlowLM `model.q4nx` is the same
 per-block affine encoding regardless of model. That is why `llms/qwen25_3b_q4`

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -31,8 +31,9 @@ workload ~30% slower.
 What differs for Qwen is the **on-device** format, not the weight bundle.
 FastFlowLM ships Qwen2.5-3B as a `model.q4nx` bundle in the same per-block
 affine encoding as Llama and Gemma (`w = scale*q + min`, unsigned nibbles,
-32x256 blocks). But their Qwen decode design sets `#define Q4_0`
-(`models/qwen2_3b.h`), which switches the kernel to a **symmetric signed-int4**
+32x256 blocks). But their Qwen decode design sets `#define Q4_0` (their
+`Qwen2_5/decoding_3b/models/qwen2_3b.h`), which switches the kernel to a
+**symmetric signed-int4**
 form (`w = q*scale`, `q ∈ [-8,7]`, `scale = amax/8`, per 32-element group along
 the reduction dim). The AIR port mirrors that, so its kernels are built
 `-DQ4_0` too.

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -28,13 +28,21 @@ workload ~30% slower.
 
 ## Quant codec: Q4_0, not Q4NX
 
-The Llama example reads an already-4-bit `model.q4nx` bundle whose codec is
-per-block **affine** quant (`w = scale*(q - min)`, unsigned nibbles). Qwen2.5-3B
-has no such bundle, and its NPU kernels are built with `-DQ4_0` — a
-**symmetric signed-int4** codec (`w = q*scale`, `q ∈ [-8,7]`, `scale = amax/8`,
-per 32-element group along the reduction dim). So this example quantizes the
-full-precision HF checkpoint directly, which is also strictly more accurate
-than re-quantizing someone else's 4-bit weights.
+What differs for Qwen is the **on-device** format, not the weight bundle.
+FastFlowLM ships Qwen2.5-3B as a `model.q4nx` bundle in the same per-block
+affine encoding as Llama and Gemma (`w = scale*q + min`, unsigned nibbles,
+32x256 blocks). But their Qwen decode design sets `#define Q4_0`
+(`models/qwen2_3b.h`), which switches the kernel to a **symmetric signed-int4**
+form (`w = q*scale`, `q ∈ [-8,7]`, `scale = amax/8`, per 32-element group along
+the reduction dim). The AIR port mirrors that, so its kernels are built
+`-DQ4_0` too.
+
+That mismatch is why this example ignores the bundle and quantizes the
+full-precision HF checkpoint directly. For Llama and Gemma the bundle and the
+device agree — affine to affine, same groups, same 4 bits — so the host
+dequant/requant round-trip lands back on the same grid. Symmetric cannot
+represent an offset range, so feeding it affine 4-bit weights would quantize
+twice and lose more than starting from fp does.
 
 The quantizer is `fused_decode/qwen25_3b_requant.requant_q4_0` — the same
 function that builds the fused-decode Qwen weight cache — so **the prefill and

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
@@ -6,13 +6,20 @@
 # Mirrors llama32_1b_q4nx_weights.Q4nxModel, with two deltas that follow from
 # the model rather than from a choice:
 #
-#   1. CODEC. The Llama path reads an already-4-bit `model.q4nx` bundle whose
-#      codec is per-block AFFINE quant (w = scale*(q - min), unsigned nibbles).
-#      Qwen2.5-3B has no such bundle; its NPU kernels are built with -DQ4_0, a
-#      SYMMETRIC signed-int4 codec (w = q*scale, q in [-8,7], scale = amax/8,
-#      per 32-element group along the reduction dim). So this loader quantizes
-#      the full-precision HF checkpoint directly -- which is also strictly more
-#      accurate than re-quantizing someone else's 4-bit weights.
+#   1. CODEC. What differs is the ON-DEVICE format, not the bundle. FastFlowLM
+#      ships Qwen2.5-3B as a `model.q4nx` bundle in the same per-block AFFINE
+#      encoding as Llama and Gemma (w = scale*q + min, unsigned nibbles), but
+#      their Qwen decode design sets `#define Q4_0` (models/qwen2_3b.h), which
+#      switches the kernel to a SYMMETRIC signed-int4 form (w = q*scale, q in
+#      [-8,7], scale = amax/8, per 32-element group along the reduction dim).
+#      The AIR port mirrors that and builds its kernels -DQ4_0.
+#
+#      So the bundle's codec and the device's disagree, and this loader
+#      quantizes the full-precision HF checkpoint directly instead. For Llama
+#      and Gemma the two agree (affine to affine, same groups, same 4 bits), so
+#      their dequant/requant round-trip lands back on the same grid; symmetric
+#      cannot represent an offset range, so re-quantizing affine 4-bit weights
+#      into it would quantize twice and lose more than starting from fp.
 #
 #      The quantizer is `qwen25_3b_requant.requant_q4_0`, the same function the
 #      fused_decode Qwen weight cache uses, so the prefill and the fused decode

--- a/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
+++ b/programming_examples/llms/qwen25_3b_q4/qwen25_3b_q4_weights.py
@@ -9,8 +9,9 @@
 #   1. CODEC. What differs is the ON-DEVICE format, not the bundle. FastFlowLM
 #      ships Qwen2.5-3B as a `model.q4nx` bundle in the same per-block AFFINE
 #      encoding as Llama and Gemma (w = scale*q + min, unsigned nibbles), but
-#      their Qwen decode design sets `#define Q4_0` (models/qwen2_3b.h), which
-#      switches the kernel to a SYMMETRIC signed-int4 form (w = q*scale, q in
+#      their Qwen decode design sets `#define Q4_0` (FastFlowLM's
+#      Qwen2_5/decoding_3b/models/qwen2_3b.h), which switches the kernel to a
+#      SYMMETRIC signed-int4 form (w = q*scale, q in
 #      [-8,7], scale = amax/8, per 32-element group along the reduction dim).
 #      The AIR port mirrors that and builds its kernels -DQ4_0.
 #


### PR DESCRIPTION
Two places said Qwen2.5-3B "has no such bundle" as the reason its example
quantizes the full-precision HF checkpoint instead of reading a `model.q4nx`.
It has one: FastFlowLM ships it in
`FLM_Xclbin/Qwen2_5/decoding_3b/q4nx_files/Qwen2.5-3B-NPU2/model.q4nx`, in the
same per-block affine encoding as every other `model.q4nx`.

## What actually differs

The **on-device** format, one layer below the bundle. FastFlowLM's own Qwen
decode sets `#define Q4_0` in `models/qwen2_3b.h`; their Llama and Gemma
designs leave it undefined. The AIR port mirrors that, so `kernels/q4_k.h`
carries both forms under `#ifndef Q4_0`:

| | Llama / Gemma | Qwen2.5 |
|---|---|---|
| device format | unsigned int4 + per-group min | signed int4, scale only |
| dequant | `w = scale*q + min` | `w = q*scale` |
| kernel build | (default) | `-DQ4_0` |

So bundle and device agree for Llama and Gemma and disagree only for Qwen.
That is the real reason `llms/qwen25_3b_q4` starts from fp: symmetric cannot
represent an offset range, so an affine 4-bit bundle re-quantized into it
quantizes twice, whereas Llama/Gemma round-trip affine to affine, same groups
and same 4 bits, and land back on the same grid.

The conclusion those texts drew was right; only the premise was wrong.

## Also

- Both described the affine form subtractively (`w = scale*(q - min)`). That is
  the older bundle encoding's dequant, not the one in use.
- `fused_decode/README.md` documented none of this, and its Files table omitted
  the three Qwen files that live in that directory
  (`fused_decode_qwen.py`, `qwen25_3b_requant.py`, `qwen_prefill_to_decode.py`).
  Both are fixed, so the fused_decode-vs-fused_decode_qwen split is explained
  where the two files actually sit.

Documentation and comments only; no code changes.

Best read after #1780, which is what makes the current bundles' additive
dequant the one in use.
