### PR TITLE
Bump mlir-aie to 1.4.1.dev58+gf501f21

### DIFF
--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6463,12 +6463,12 @@ public:
         if (!channel_head) {
           channel_head = start_bb;
           auto b = OpBuilder::atBlockBegin(channel_head);
-          startOp =
-              AIE::DMAStartOp::create(b, loc, dir, chan, rep, first_bd, end_bb);
+          startOp = AIE::DMAStartOp::create(b, loc, dir, chan, rep,
+                                            /*pad_value*/ 0, first_bd, end_bb);
         } else {
           auto b = OpBuilder::atBlockBegin(start_bb);
           startOp = AIE::DMAStartOp::create(
-              b, loc, dir, chan, rep, first_bd,
+              b, loc, dir, chan, rep, /*pad_value*/ 0, first_bd,
               channel_head->getTerminator()->getSuccessor(1));
           channel_head->getTerminator()->setSuccessor(start_bb, 1);
           channel_head = start_bb;

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=687ff971b6524260814aade8e0fba33b047fba02
-WHEEL_VERSION=1.4.1.dev46+g687ff97
+export HASH=f501f215b5e772b7fba38df35b79251d1de64b97
+WHEEL_VERSION=1.4.1.dev58+gf501f21
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
Unblocks the nightly LLM perf benchmark, red since the LLVM 23 -> 24 bump (#1778). The two `q4nx` decode models failed to compile, and behind that failure sat a second defect that hung the decode on hardware. Both are fixed upstream and this pin picks them up.

## What this pulls in

- **mlir-aie #3528** — LLVM 24 prints a `float`/`half` constant as a short decimal whenever it round-trips in the narrow type; Peano's parser still demands exact representability and rejected it. This is the visible nightly failure:
  ```
  opt: peano-linked_seg_core_4_5.ll:32:102: error: floating point constant invalid for type
  @activation_lut_ab = ... [float -0.000000e+00, float -3.236090e-03, ...
  ```
- **mlir-aie #3533** — the post-link downgrade stripped `, align N` from the merged module, demoting the inline attention kernel's `aie::linear_approx` LUT from `align 64` to `align 4`. That wedged the decode with `ERT_CMD_STATE_TIMEOUT` at token 7. It was invisible in the nightly only because the compile error above landed first.

LLVM is unchanged (`56bcc1871734`, DATETIME `2026080106`), so `clone-llvm.sh` needs no edit.

## Source change required by the bump

mlir-aie #3512 wired `pad_value` to hardware and moved it onto the DMA channel, adding an operand to `DMAStartOp`. The two 7-argument `DMAStartOp::create` calls in `AIRToAIEPass.cpp` no longer match any overload, so they now pass `/*pad_value*/ 0`, matching what mlir-aie's own callers (`AIEObjectFifoStatefulTransform`, `AIELowerMemcpy`) do.

## Validation

`ninja` builds clean against mlir-aie at `f501f215b5e`.

The two fixes were validated on NPU2 hardware before they landed upstream — `llama32_1b_q4nx` and `llama32_3b_q4nx` both go from the failure above to `[verify] PASS` (`topk_passed: 2, topk_failed: 0` each) on the top-k-vs-HF-bf16 gate.

**Not yet re-run against this exact wheel.** That validation used a locally patched `aiecc` on top of the old pin; this wheel is ten commits ahead and includes #3512 above and #3514 (fail on incomplete packet-flow routing), neither of which has been exercised on the q4nx path. I'm running the two verify gates against the published wheel now and will post the result here before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)