### PR TITLE
[programming_examples] Fix the llvm-link version rule: <23, not equals Peano's

### DIFF
--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "  make clean            Remove kernels + templates"
 	@echo ""
 	@echo "Consumed by the llama32_1b_q4nx LLM e2e (make chat / make gen there)."
-	@echo "Weight-free build; needs an llvm-link on PATH matching Peano's LLVM major"
+	@echo "Weight-free build; needs an llvm-link on PATH from LLVM <23"
 	@echo "-- see README.md Reproducibility."
 
 ## Build the fused decode: Peano kernels + two templates (decode_L2048 + decode_L2047
@@ -57,10 +57,11 @@ help:
 ## (e.g. the llama32_1b_q4nx verify + profile lits) thus pay the cost at most once.
 ##
 ## REPRODUCIBILITY (toolchain): the inline-attn merge path shells out to an EXTERNAL
-## `llvm-link` (resolved from PATH). Its LLVM major MUST EQUAL Peano's. A newer (>=23)
-## llvm-link upgrades the llvm.lifetime intrinsic to the no-size form and Peano opt then
-## rejects the merged IR ("Broken module found"); an OLDER one links quietly and silently
-## miscompiles the attn kernels into fluent garbage. The preflight aborts early on either.
+## `llvm-link` (resolved from PATH), which must be PRE-LIFETIME-CHANGE, i.e. LLVM < 23.
+## A >=23 llvm-link upgrades the llvm.lifetime intrinsic to the no-size form and Peano
+## opt then rejects the merged IR ("Broken module found"). The preflight aborts on it.
+## This is the same rule the lit harness gates on (lit.cfg.py, feature llvm_link_pre23);
+## the two MUST agree -- see the preflight comment below.
 compile-decode:
 	@if [ -f $(srcdir)/decode_L2048.xclbin ] && [ -f $(srcdir)/decode_L2048.insts.bin ] \
 	    && [ -f $(srcdir)/decode_L2047.xclbin ] && [ -f $(srcdir)/decode_L2047.insts.bin ]; then \
@@ -70,26 +71,34 @@ compile-decode:
 	fi
 
 ## Shared preflight for every inline-attn decode build. Any model driving this
-## engine (llms/*_q4nx) must run it rather than copy it: the rule below has been
-## tightened once already, and a stale copy silently reintroduces the miscompile.
+## engine (llms/*_q4nx) must run it rather than copy it, so the rule lives in
+## exactly one place.
+##
+## The rule is LLVM < 23, and it must stay identical to the `llvm_link_pre23`
+## feature in programming_examples/lit.cfg.py. Every decode e2e lit test
+## (llama32_1b_q4nx, llama32_3b_q4nx, gemma3_4b_q4nx) is REQUIRES-gated on that
+## feature, and lit will shim ANY <23 llvm-link it finds on PATH to the front --
+## with no regard for Peano's major. If this preflight is stricter than lit, lit
+## marks such a test supported, runs it, and the test hard-fails right here,
+## which is the exact outcome the feature exists to avoid.
 preflight-llvm-link:
-	@echo ">>> preflight: llvm-link must match Peano's LLVM major for the inline-attn merge"
-	@# Must EQUAL Peano's major, not merely be <23: a >=23 llvm-link rewrites
-	@# llvm.lifetime.* to the no-size form and Peano opt rejects the module (loud),
-	@# but an OLDER one (e.g. LLVM 20) links without complaint and silently
-	@# miscompiles the attn kernels -- the decode then runs at full speed and emits
-	@# fluent garbage, which no build-time check catches.
+	@echo ">>> preflight: llvm-link must be LLVM <23 (pre-lifetime-change) for the inline-attn merge"
+	@# A >=23 llvm-link rewrites llvm.lifetime.* to the no-size form, which Peano
+	@# opt then rejects outright ("Broken module found") -- loud, at build time.
+	@# Peano's own major is reported below for context only; it is NOT the gate.
 	@LLVM_LINK=$$(command -v llvm-link || true); \
 	  PEANO_CLANG="$(PEANO_INSTALL_DIR)/bin/clang"; \
 	  if [ -z "$(PEANO_INSTALL_DIR)" ] || [ ! -x "$$PEANO_CLANG" ]; then \
 	    echo "ERROR: PEANO_INSTALL_DIR does not point at a Peano install (no $$PEANO_CLANG)"; exit 1; fi; \
 	  PEANO_VER=$$($$PEANO_CLANG --version | grep -oE 'clang version [0-9]+' | grep -oE '[0-9]+' | head -1); \
-	  if [ -z "$$LLVM_LINK" ]; then echo "ERROR: no llvm-link on PATH (need LLVM $$PEANO_VER, matching Peano)"; exit 1; fi; \
+	  if [ -z "$$LLVM_LINK" ]; then echo "ERROR: no llvm-link on PATH (need LLVM <23)"; exit 1; fi; \
 	  VER=$$($$LLVM_LINK --version | grep -oE 'version [0-9]+' | grep -oE '[0-9]+' | head -1); \
+	  if [ -z "$$VER" ]; then \
+	    echo "ERROR: could not parse an LLVM major from '$$LLVM_LINK --version' (need LLVM <23)"; exit 1; fi; \
 	  echo "    llvm-link = $$LLVM_LINK (LLVM $$VER); Peano = LLVM $$PEANO_VER"; \
-	  if [ "$$VER" != "$$PEANO_VER" ]; then \
-	    echo "ERROR: llvm-link is LLVM $$VER but Peano is LLVM $$PEANO_VER; they must match"; \
-	    echo "       (see README Reproducibility for how to fetch a matching llvm-link)"; exit 1; fi
+	  if [ "$$VER" -ge 23 ]; then \
+	    echo "ERROR: llvm-link is LLVM $$VER; the inline-attn merge needs LLVM <23"; \
+	    echo "       (see README Reproducibility for how to fetch one)"; exit 1; fi
 
 _compile_decode_build: preflight-llvm-link
 	@echo ">>> non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -60,17 +60,38 @@ bundle re-quantized into the symmetric device form would quantize twice.
 ## Reproducibility (toolchain)
 
 `make compile-decode` merges an inline attention kernel into the core via an **external
-`llvm-link`** (resolved from `PATH`) whose **LLVM major must equal Peano's** (21 today).
-A newer (≥ 23) one rewrites the `llvm.lifetime` intrinsic to the no-size form, which
-Peano `opt` then rejects (`Broken module found`); an older one (e.g. the system LLVM 20)
-links without complaint and *silently miscompiles* the attention kernels — the decode
-runs at full speed and emits fluent garbage. Keep any mismatched LLVM's `bin` off `PATH`
-for this build; the Makefile preflight aborts early on either. Verify:
+`llvm-link`** (resolved from `PATH`), which must come from **LLVM < 23** — the last
+release series before the `llvm.lifetime` change. A ≥ 23 one rewrites that intrinsic to
+the no-size form, which Peano `opt` then rejects (`Broken module found`). Keep any such
+LLVM's `bin` off `PATH` for this build; the Makefile preflight aborts on it.
+
+This is the same rule the lit harness gates on (`llvm_link_pre23` in
+`programming_examples/lit.cfg.py`), and the two must stay in sync: every decode e2e test
+is `REQUIRES`-gated on that feature, so a preflight stricter than lit turns an
+UNSUPPORTED into a hard test failure. Verify:
 
 ```bash
-which llvm-link && llvm-link --version
-$PEANO_INSTALL_DIR/bin/clang --version   # majors must match
+which llvm-link && llvm-link --version   # major must be < 23
 ```
+
+The Peano wheel (`llvm-aie`) does **not** ship `llvm-link`, and the MLIR distro wheel's
+is too new (LLVM 24 today), so on a machine with neither you need to fetch one. Any
+`llvm-link` from an LLVM < 23 release works; without root, extracting the Debian
+packages is enough:
+
+```bash
+LLVM_V=21   # any < 23
+BASE=https://apt.llvm.org/$(lsb_release -cs)/pool/main/l/llvm-toolchain-$LLVM_V
+# grab the llvm-$LLVM_V and libllvm$LLVM_V .deb names from that index, then:
+dpkg-deb -x llvm-$LLVM_V*.deb   unpack/
+dpkg-deb -x libllvm$LLVM_V*.deb unpack/
+export LD_LIBRARY_PATH=$PWD/unpack/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+export PATH=$PWD/unpack/usr/lib/llvm-$LLVM_V/bin:$PATH
+```
+
+Prepend only a directory holding `llvm-link` itself — putting a full system
+`bin` ahead of the AIE toolchain shadows Peano's `clang`/`opt`/`llc`. (`lit.cfg.py`
+does exactly this, via a shim dir containing a single symlink.)
 
 Nothing compiled is committed — `make compile-decode` reproduces every kernel object,
 xclbin, and instruction stream from source (see `.gitignore`).

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -246,7 +246,7 @@ except Exception:
 #
 # Resolve it against the PATH the TESTS get (config.environment), not this
 # process's os.environ: the block above prepends config.llvm_tools_dir -- the
-# mlir distro, currently LLVM 23 -- ahead of the ambient PATH, so a usable
+# mlir distro, currently LLVM 24 -- ahead of the ambient PATH, so a usable
 # llvm-link further down the ambient PATH is shadowed inside the tests. Checking
 # os.environ instead reported "enabled" while the tests ran the distro's LLVM 23
 # and died in the fused_decode preflight.

--- a/programming_examples/llms/gemma3_4b_q4nx/Makefile
+++ b/programming_examples/llms/gemma3_4b_q4nx/Makefile
@@ -113,10 +113,10 @@ compile-decode:
 	fi
 
 _compile_decode_build:
-	@# Delegate the llvm-link/Peano version preflight to the engine that owns it
-	@# rather than keeping a copy here: an llvm-link older than Peano links quietly
-	@# and miscompiles the attn kernels into fluent garbage, and that rule has
-	@# already been tightened once (fused_decode/Makefile: preflight-llvm-link).
+	@# Delegate the llvm-link version preflight to the engine that owns it rather
+	@# than keeping a copy here: the rule (LLVM <23) must stay in one place, in
+	@# sync with lit.cfg.py's llvm_link_pre23 feature that gates this example's
+	@# lit tests (fused_decode/Makefile: preflight-llvm-link).
 	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
 	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
 	@echo ">>> gemma non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -62,20 +62,22 @@ every context length.
 ## Reproducibility (decode toolchain)
 
 `make compile-decode` merges an inline attention kernel into the core via an
-**external `llvm-link`** (resolved from `PATH`) whose **LLVM major must equal
-Peano's** (21 today). A newer (≥ 23) one rewrites the `llvm.lifetime` intrinsic to
-the no-size form, which Peano `opt` then rejects (`Broken module found`); an older
-one (e.g. the system LLVM 20) links without complaint and *silently miscompiles*
-the attention kernels — the decode runs at full speed and emits fluent garbage.
+**external `llvm-link`** (resolved from `PATH`), which must come from **LLVM < 23**.
+A ≥ 23 one rewrites the `llvm.lifetime` intrinsic to the no-size form, which Peano
+`opt` then rejects (`Broken module found`).
 
-So keep any mismatched LLVM's `bin` off `PATH` for the decode build. The
-`make compile-decode` preflight prints the resolved `llvm-link` and Peano's version
-and aborts early on any mismatch. Verify with:
+So keep any such LLVM's `bin` off `PATH` for the decode build. The
+`make compile-decode` preflight prints the resolved `llvm-link` and aborts on a
+≥ 23 one. Verify with:
 
 ```bash
-which llvm-link && llvm-link --version
-$PEANO_INSTALL_DIR/bin/clang --version   # majors must match
+which llvm-link && llvm-link --version   # major must be < 23
 ```
+
+Neither the Peano wheel nor the MLIR distro wheel provides a usable one (the former
+ships no `llvm-link`, the latter's is LLVM 24) — see
+[`fused_decode`](../../fused_decode) Reproducibility for how to fetch one without
+root.
 
 Nothing compiled is committed — `make compile` / `make compile-decode` reproduce
 every ELF, xclbin, and instruction stream from source (see `.gitignore`).

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -116,8 +116,8 @@ compile:
 
 ## Build the fused decode at the 3B geometry: Peano kernels (LLAMA_3_2_3B) + two
 ## same-ATTN_MAXL templates (decode_L$(LBUILD) + decode_L$(LREF)) into THIS dir.
-## ~15 min, skipped when both are already present. Weight-free; the llvm-link major
-## must equal Peano's (the fused_decode preflight enforces it). The driver loads
+## ~15 min, skipped when both are already present. Weight-free; needs an llvm-link
+## from LLVM <23 (the fused_decode preflight enforces it). The driver loads
 ## the templates from here at run time.
 compile-decode:
 	@if [ -f $(srcdir)/decode_L$(LBUILD).xclbin ] && [ -f $(srcdir)/decode_L$(LBUILD).insts.bin ] \
@@ -128,9 +128,8 @@ compile-decode:
 	fi
 
 _compile_decode_build:
-	@# Delegate the llvm-link/Peano version preflight to the engine that owns it:
-	@# an llvm-link older than Peano links quietly and miscompiles the attn kernels
-	@# into fluent garbage.
+	@# Delegate the llvm-link version preflight to the engine that owns it:
+	@# a >=23 llvm-link rewrites llvm.lifetime.* and Peano opt rejects the merge.
 	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
 	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
 	@echo ">>> 3B non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"


### PR DESCRIPTION
The fused_decode preflight required the external llvm-link's LLVM major to EQUAL Peano's, but the lit harness that gates every decode e2e test requires only <23 (lit.cfg.py, feature llvm_link_pre23). The two disagreed, and lit is the authority: it will shim ANY <23 llvm-link it finds on PATH to the front, with no regard for Peano's major. On a runner holding, say, LLVM 22, lit adds the feature, marks llama32_1b_q4nx / llama32_3b_q4nx / gemma3_4b_q4nx decode tests supported, runs them -- and they hard-fail in this preflight. That is precisely the outcome the feature exists to prevent ("report UNSUPPORTED rather than hard-fail").

Only the >=23 direction has a mechanism behind it: such an llvm-link rewrites llvm.lifetime.* to the no-size form and Peano opt rejects the merged IR. Keep that check, drop the equality, and state the rule in one place. Peano's major is still printed, for context rather than as a gate.

The error message also pointed at "README Reproducibility for how to fetch a matching llvm-link", which never said how. It does now -- the Peano wheel ships no llvm-link and the MLIR distro's is LLVM 24, so on a fresh machine fetching one is a required step, not a footnote.

Verified on NPU2 (Krackan, aie2p):
  - preflight passes on LLVM 21, rejects the distro's LLVM 24, and rejects an empty PATH;
  - a clean llama32_1b_q4nx decode rebuild completes through the patched preflight;
  - on this same tree, pre-patch, that decode passes the Paris gate at 48.3 tok/s. The post-patch re-run of the gate was blocked by unrelated NPU contention and is NOT claimed here; the patch changes only the version check and docs, not the build recipe.