### PR TITLE
[AIR] Derive air.refeed_count from the loop instead of hand-writing it

### DIFF
--- a/mlir/include/air/Dialect/AIR/AIRDialect.h
+++ b/mlir/include/air/Dialect/AIR/AIRDialect.h
@@ -62,14 +62,11 @@ constexpr StringLiteral TileDmaChannel = "air.tile_dma_channel";
 constexpr StringLiteral MemtileDmaChannelMin = "air.memtile_dma_channel_min";
 constexpr StringLiteral DedicatedDmaChannel = "air.dedicated_dma_channel";
 // Single-buffer count-free re-broadcast: N (>= 1) re-sends of one resident
-// buffer per production. Authoritative carrier is the air.channel declaration;
-// read via air::getRefeedCount. Verified on air.channel.
+// buffer per production. Carried on the air.channel declaration, on a channel
+// put/get, or on the source memref.alloc of a memtile producer; read via
+// air::getRefeedCount. Written by air-annotate-refeed from a re-feed loop's
+// trip count, not by the front end. Verified on air.channel and on put/get.
 constexpr StringLiteral RefeedCount = "air.refeed_count";
-// Opt-in front-end marker (unit attr) on an scf.for / affine.for whose body is
-// a single loop-invariant air.channel.put: the loop re-sends one resident
-// buffer once per iteration. The air-annotate-refeed pass reads its trip count
-// into attrs::RefeedCount on the channel and collapses the loop.
-constexpr StringLiteral RefeedLoop = "air.refeed_loop";
 // User-pinned packet routing ids on an air.channel (channel_type
 // "npu_dma_packet"). One packet_flow per id: N ids to a single dest converge on
 // one buffer for a downstream demux hop; N ids to N dests route dest i with

--- a/mlir/include/air/Transform/Passes.td
+++ b/mlir/include/air/Transform/Passes.td
@@ -1041,20 +1041,47 @@ def AIRFuseChannels: Pass<"air-fuse-channels", "ModuleOp"> {
 }
 
 def AIRAnnotateRefeedPass: Pass<"air-annotate-refeed", "ModuleOp"> {
-  let summary = "Lower opt-in re-feed loops to air.refeed_count on the channel";
+  let summary = "Derive air.refeed_count from a re-feed loop's trip count";
   let constructor = "xilinx::air::createAIRAnnotateRefeedPass()";
   let description = [{
-    Opt-in producer for the single-buffer count-free re-broadcast primitive.
-    An scf.for / affine.for tagged with the 'air.refeed_loop' unit attribute,
-    whose body is a single loop-invariant air.channel.put, expresses "re-send
-    one resident buffer once per iteration". This pass reads the loop's static
-    trip count N into 'air.refeed_count' on the put's channel declaration and
-    collapses the loop to the single put. Loops that do not match the safe shape
-    (non-constant trip count, body other than one invariant put, or loop-carried
-    values) are left unchanged. Not part of the default pipeline: the marker
-    asserts the re-feed semantics the front-end intends.
+    Producer for the single-buffer count-free re-broadcast primitive. A
+    producer that re-sends ONE resident buffer N times per production is
+    written as an N-trip scf.for / affine.for around a single air.channel.put:
+
+    ```mlir
+    scf.for %i = %c0 to %c6 step %c1 {
+      air.channel.put @xnorm[] (%buf[] [] [])
+    }
+    ```
+
+    The body does nothing but the put, so nothing rewrites the source between
+    sends, and no data operand depends on the induction variable, so every send
+    reads the same bytes. That is a re-broadcast, not N productions, and the two
+    lower differently: N productions get a ping-pong twin buffer whose pong slot
+    is never filled (the fill sits outside the loop), and a one-deep credit
+    handshake that lets the producer overwrite the source while the last send is
+    still in flight.
+
+    This pass recognizes the shape, erases the loop, and records the trip count
+    as air.refeed_count on the carrier air-to-aie reads for that producer: the
+    source memref.alloc for a memtile (L2) producer, whose count primes the
+    fill/drain rendezvous on the buffer, and the put itself for a core (L1) one,
+    whose count scales the core-side release. Counts landing on one carrier add,
+    since the count is drains-enabled-per-fill.
+
+    Loops that do not match -- dynamic trip count, more than one put, a body op
+    with side effects, an induction-variable-dependent operand, or an async put
+    with a dependency other than the carried token -- are left unchanged, which
+    is their pre-existing N-productions meaning. An L2 source whose alloc is not
+    recoverable is an error rather than a silent miscompile: the count would
+    have no carrier the memtile lock allocator reads.
+
+    Runs at the head of the pipeline, before any other AIR pass. That placement
+    is load-bearing: air-opt-memtile-dma-bds folds such a loop into its single
+    BD and drops the trip count, which silently loses the re-sends.
   }];
 }
+
 
 def AIREnforceChannelFifoOrder: Pass<"air-enforce-channel-fifo-order", "ModuleOp"> {
   let summary = "Serialize same-channel async ops to preserve FIFO order";
@@ -1768,5 +1795,6 @@ def AIRMergeUnrolledDevices : Pass<"air-merge-unrolled-devices", "ModuleOp"> {
     ```
   }];
 }
+
 
 #endif // AIR_CONVERSION_PASSES

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6163,9 +6163,10 @@ public:
     // row-block iteration) is expressed by air.refeed_count=N. The producing
     // core writes the buffer once and the DMA's count-free self-loop BD
     // re-reads it; the single core-side release must free N read-tokens so the
-    // BD fires N times. (The N>1 loop the front-end emits is canonicalized away
-    // before air-to-aie, so the count is carried on the channel/put, not
-    // inferred from a loop.)
+    // BD fires N times. The count reaches the put via air-fold-refeed-loops,
+    // which runs at the head of the pipeline and collapses the N-trip loop the
+    // front end writes; by the time air-to-aie sees the put the loop is gone
+    // and N is on the op.
     if (UsesSemaphoreLocks && !tileInbound.value()) {
       int64_t n = 1;
       if (auto chanIf =

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -3260,7 +3260,139 @@ std::unique_ptr<Pass> createAIROverrideMemRefMemorySpacePass(
   return std::make_unique<AIROverrideMemRefMemorySpacePass>(options);
 }
 
-// Opt-in producer for air.refeed_count. See the pass description in Passes.td.
+// Producer for air.refeed_count. See the pass description in Passes.td.
+namespace {
+
+// The memref.alloc backing `v`, looking through the air.execute a bufferized
+// alloc is wrapped in after air-dependency.
+static memref::AllocOp getBackingAlloc(Value v) {
+  if (auto a = v.getDefiningOp<memref::AllocOp>())
+    return a;
+  auto exec = dyn_cast_if_present<air::ExecuteOp>(v.getDefiningOp());
+  if (!exec)
+    return nullptr;
+  // air.execute yields region results through air.execute_terminator; result 0
+  // is the async token, so memref result i is terminator operand i-1.
+  auto idx = cast<OpResult>(v).getResultNumber();
+  if (idx == 0)
+    return nullptr;
+  auto *term = exec.getRegion().front().getTerminator();
+  if (idx - 1 >= term->getNumOperands())
+    return nullptr;
+  return term->getOperand(idx - 1).getDefiningOp<memref::AllocOp>();
+}
+
+// A refeed loop re-sends ONE resident buffer N times. Its body does nothing but
+// the put, so nothing rewrites the source between sends, and no data operand
+// depends on the induction variable, so every send reads the same bytes.
+// Returns the put, or null if `loopOp` is not that shape.
+static air::ChannelPutOp matchRefeedLoop(Operation *loopOp, Block *body,
+                                         Value iv) {
+  // Pure ops are tolerated and hoisted with the put: a front end materializes
+  // the put's index constants at its own insertion point, i.e. inside the loop,
+  // and no canonicalizer need have run before this pass.
+  air::ChannelPutOp put = nullptr;
+  for (auto &op : body->without_terminator()) {
+    if (auto p = dyn_cast<air::ChannelPutOp>(&op)) {
+      if (put)
+        return nullptr; // more than one put: not a single re-broadcast
+      put = p;
+      continue;
+    }
+    if (!isMemoryEffectFree(&op))
+      return nullptr;
+    for (auto operand : op.getOperands())
+      if (operand.getParentBlock() == body)
+        return nullptr;
+  }
+  if (!put)
+    return nullptr;
+  // The async dependency is exempt from the invariance check: it is the carried
+  // token, a block argument by construction, re-spliced when the loop is
+  // erased.
+  llvm::SmallPtrSet<Value, 2> deps(llvm::from_range,
+                                   put.getAsyncDependencies());
+  for (auto operand : put->getOperands()) {
+    if (deps.contains(operand))
+      continue;
+    if (operand == iv)
+      return nullptr;
+    // A block argument of the body varies per trip (the induction variable or
+    // an iter arg). A value DEFINED in the body is one of the pure ops cleared
+    // above, which is hoisted along with the put, so it is fine.
+    if (operand.getParentBlock() == body && isa<BlockArgument>(operand))
+      return nullptr;
+  }
+  auto forOp = dyn_cast<scf::ForOp>(loopOp);
+  if (put.getAsyncToken()) {
+    // Async form: the loop must carry exactly the put's token and yield it,
+    // and the put must depend on nothing else, or hoisting drops an edge.
+    if (!forOp || forOp.getNumRegionIterArgs() != 1)
+      return nullptr;
+    auto yield = dyn_cast<scf::YieldOp>(body->getTerminator());
+    if (!yield || yield->getNumOperands() != 1 ||
+        yield->getOperand(0) != put.getResult(0))
+      return nullptr;
+    if (put.getAsyncDependencies().size() != 1 ||
+        put.getAsyncDependencies()[0] != forOp.getRegionIterArg(0))
+      return nullptr;
+  } else if (loopOp->getNumResults())
+    return nullptr; // loop-carried values with a non-async put
+  return put;
+}
+
+// The carrier air-to-aie reads for this producer, or failure if there is none.
+// The two lock mechanisms take it from different ops and must NOT be unified:
+// a memtile (L2) producer's count primes the fill/drain rendezvous on the
+// buffer, which AllocL2BuffersPattern propagates from the alloc, while a core
+// (L1) producer's count scales the core-side release, which
+// allocateCoreLocksPerMemcpyOp reads off the put.
+static FailureOr<Operation *> getRefeedCarrier(air::ChannelPutOp put) {
+  auto memrefTy = dyn_cast<MemRefType>(put.getSrcMemref().getType());
+  if (!memrefTy || !air::isL2(memrefTy))
+    return put.getOperation();
+  auto alloc = getBackingAlloc(put.getSrcMemref());
+  if (!alloc)
+    // Writing the count on the put would be silently ineffective here: the
+    // memtile mechanism only reads the buffer, so the fill lock would keep its
+    // default init and the array would deadlock on device. Refuse.
+    return put->emitOpError(
+        "re-feed loop over an L2 source whose memref.alloc is not "
+        "recoverable; air.refeed_count has no carrier the memtile lock "
+        "allocator reads");
+  return alloc.getOperation();
+}
+
+// Add this producer's re-send count to `carrier`, given what this run has
+// already attributed to `put`.
+//
+// Sibling loops over one resident buffer ADD: air-to-aie makes the fill release
+// the count once per fill, so draining it N1 then N2 times needs N1 + N2 drains
+// enabled. NESTED loops MULTIPLY: the walk is post-order, so folding the inner
+// loop hoists the put into the outer body, where it matches again -- the same
+// put re-folded means the two trip counts compose, M x N sends, not M + N.
+// Which case this is cannot be read off the carrier, only off whether this run
+// has folded a loop around THIS put before.
+static void accumulateRefeed(Operation *carrier, air::ChannelPutOp put,
+                             int64_t n,
+                             llvm::DenseMap<Operation *, int64_t> &perPut) {
+  auto it = perPut.find(put.getOperation());
+  int64_t prev = (it == perPut.end()) ? 0 : it->second;
+  int64_t updated = prev ? prev * n : n;
+  perPut[put.getOperation()] = updated;
+
+  int64_t onCarrier = 0;
+  if (auto a = carrier->getAttrOfType<IntegerAttr>(air::attrs::RefeedCount))
+    onCarrier = a.getInt();
+  // Replace this put's earlier contribution rather than adding to it.
+  int64_t total = std::max<int64_t>(onCarrier - prev, 0) + updated;
+  carrier->setAttr(
+      air::attrs::RefeedCount,
+      IntegerAttr::get(IntegerType::get(carrier->getContext(), 32), total));
+}
+
+} // namespace
+
 class AIRAnnotateRefeedPass
     : public air::impl::AIRAnnotateRefeedPassBase<AIRAnnotateRefeedPass> {
 public:
@@ -3271,14 +3403,16 @@ public:
 
 void AIRAnnotateRefeedPass::runOnOperation() {
   ModuleOp module = getOperation();
-  SmallVector<Operation *> markedLoops;
+  // Counts this run has attributed to each put, so a re-fold of the same put
+  // (a nest) composes rather than adds. See accumulateRefeed.
+  llvm::DenseMap<Operation *, int64_t> perPut;
+  SmallVector<Operation *> loops;
   module.walk([&](Operation *op) {
-    if (isa<scf::ForOp, affine::AffineForOp>(op) &&
-        op->hasAttr(air::attrs::RefeedLoop))
-      markedLoops.push_back(op);
+    if (isa<scf::ForOp, affine::AffineForOp>(op))
+      loops.push_back(op);
   });
 
-  for (Operation *loopOp : markedLoops) {
+  for (Operation *loopOp : loops) {
     Block *body = nullptr;
     Value iv;
     std::optional<int64_t> tripCount;
@@ -3292,58 +3426,39 @@ void AIRAnnotateRefeedPass::runOnOperation() {
       iv = afo.getInductionVar();
       tripCount = air::getStaticAffineForTripCountAsInt(afo);
     }
-
-    // Safe shape only: no loop-carried values, a static trip count >= 2, and a
-    // body of exactly one loop-invariant air.channel.put.
-    if (loopOp->getNumResults()) {
-      loopOp->emitWarning("air.refeed_loop: loop-carried values unsupported; "
-                          "left unchanged");
+    // A dynamic trip count cannot become a lock init; leave the loop alone.
+    if (!tripCount || *tripCount < 1)
       continue;
-    }
-    if (!tripCount || *tripCount < 2) {
-      loopOp->emitWarning("air.refeed_loop: non-constant or trivial trip "
-                          "count; left unchanged");
+    auto put = matchRefeedLoop(loopOp, body, iv);
+    if (!put)
       continue;
-    }
-    if (body->getOperations().size() != 2) {
-      loopOp->emitWarning("air.refeed_loop: body is not a single channel.put; "
-                          "left unchanged");
-      continue;
-    }
-    auto put = dyn_cast<air::ChannelPutOp>(&body->front());
-    if (!put) {
-      loopOp->emitWarning("air.refeed_loop: body is not a single channel.put; "
-                          "left unchanged");
-      continue;
-    }
-    Region &region = loopOp->getRegion(0);
-    bool invariant = llvm::all_of(put->getOperands(), [&](Value v) {
-      if (v == iv)
-        return false;
-      if (Operation *def = v.getDefiningOp())
-        return !region.isAncestor(def->getParentRegion());
-      return true;
-    });
-    if (!invariant) {
-      loopOp->emitWarning(
-          "air.refeed_loop: channel.put is not loop-invariant; left unchanged");
-      continue;
-    }
-    auto chan = air::getChannelDeclarationThroughSymbol(put);
-    if (!chan) {
-      loopOp->emitWarning(
-          "air.refeed_loop: channel declaration not found; left unchanged");
-      continue;
+    // Resolve the carrier BEFORE touching the IR, so a producer with no usable
+    // carrier fails with the loop still intact rather than half-transformed.
+    Operation *carrier = nullptr;
+    if (*tripCount > 1) {
+      auto resolved = getRefeedCarrier(put);
+      if (failed(resolved))
+        return signalPassFailure();
+      carrier = *resolved;
     }
 
-    // Record N = trip count on the channel declaration (authoritative carrier),
-    // then collapse the loop to its single put.
-    int64_t n =
-        std::max<int64_t>(air::getRefeedCount(chan.getOperation()), *tripCount);
-    OpBuilder builder(loopOp);
-    chan->setAttr(air::attrs::RefeedCount, builder.getI32IntegerAttr(n));
-    put->moveBefore(loopOp);
+    // Hoist the body out and splice the loop's incoming token into the put, so
+    // the one remaining put keeps the loop's place in the dependency graph. The
+    // pure ops move with it -- they are its operands.
+    SmallVector<Operation *> bodyOps;
+    for (auto &op : body->without_terminator())
+      bodyOps.push_back(&op);
+    for (auto *op : bodyOps)
+      op->moveBefore(loopOp);
+    if (put.getAsyncToken()) {
+      auto forOp = cast<scf::ForOp>(loopOp);
+      put.getAsyncDependenciesMutable().assign(forOp.getInitArgs()[0]);
+      forOp.getResult(0).replaceAllUsesWith(put.getResult(0));
+    }
     loopOp->erase();
+
+    if (carrier)
+      accumulateRefeed(carrier, put, *tripCount, perPut);
   }
 }
 

--- a/mlir/lib/Util/Util.cpp
+++ b/mlir/lib/Util/Util.cpp
@@ -1785,8 +1785,29 @@ LogicalResult air::foldForLoopNestAsExtendedSizesAndStrides(
     // Skip loops that don't affect the channel offset (stride=0).
     // LLVM 23's canonicalize no longer hoists loop-invariant channel ops,
     // so we skip them here when requested to avoid stride=0 DMA dimensions.
-    if (skipZeroStride && ind_var_factor == 0)
+    if (skipZeroStride && ind_var_factor == 0) {
+      // Dropping the dimension drops the repeat with it: an N-trip loop whose
+      // channel op does not use the induction variable performs N transfers,
+      // and the folded op performs one. That is a silent semantic change, so
+      // say so. A producer re-sending one resident buffer N times should reach
+      // here already collapsed by air-annotate-refeed, which records N as
+      // air.refeed_count instead of losing it.
+      int64_t droppedTrips = -1;
+      if (auto afo = dyn_cast_if_present<affine::AffineForOp>(o)) {
+        if (auto tc = getStaticAffineForTripCountAsInt(afo))
+          droppedTrips = *tc;
+      } else if (auto sfo = dyn_cast_if_present<scf::ForOp>(o)) {
+        if (auto tc = getStaticScfForTripCountAsInt(sfo))
+          droppedTrips = *tc;
+      }
+      if (droppedTrips > 1)
+        o->emitWarning("folding this loop into the DMA drops a repeat of ")
+            << droppedTrips
+            << ": the enclosed transfer does not use the induction variable, "
+               "so the fold keeps one transfer where the loop performed "
+            << droppedTrips;
       continue;
+    }
     int trip_count = -1;
     if (auto afo = dyn_cast_if_present<affine::AffineForOp>(o))
       trip_count = *getStaticAffineForTripCountAsInt(afo);

--- a/mlir/test/Transform/AIRMiscPasses/air_annotate_refeed.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_annotate_refeed.mlir
@@ -7,15 +7,14 @@
 
 // RUN: air-opt %s -air-annotate-refeed --split-input-file --verify-diagnostics | FileCheck %s
 
-// Opt-in producer: an scf.for tagged air.refeed_loop whose body is a single
-// loop-invariant channel.put is collapsed to one put, and its trip count is
-// recorded as air.refeed_count on the channel declaration (the authoritative
-// carrier the lock allocators read).
+// An N-trip loop whose body is nothing but a loop-invariant channel.put is a
+// re-broadcast, not N productions. It collapses to one put and N lands on the
+// carrier air-to-aie reads: the put itself for an L1 source, which is what the
+// core-side lock allocator picks up.
 
-// CHECK: air.channel @c0 [1, 1] {air.refeed_count = 4 : i32}
 // CHECK-LABEL: @scf_refeed
 // CHECK-NOT: scf.for
-// CHECK: air.channel.put @c0[] (%{{.*}}[] [] []) : (memref<64xi32, 2>)
+// CHECK: air.channel.put @c0[] (%{{.*}}[] [] []) {air.refeed_count = 4 : i32}
 air.channel @c0 [1, 1]
 func.func @scf_refeed(%m: memref<64xi32, 2>) {
   %c0 = arith.constant 0 : index
@@ -23,7 +22,7 @@ func.func @scf_refeed(%m: memref<64xi32, 2>) {
   %c1 = arith.constant 1 : index
   scf.for %i = %c0 to %c4 step %c1 {
     air.channel.put @c0[] (%m[] [] []) : (memref<64xi32, 2>)
-  } {air.refeed_loop}
+  }
   return
 }
 
@@ -31,70 +30,308 @@ func.func @scf_refeed(%m: memref<64xi32, 2>) {
 
 // affine.for variant.
 
-// CHECK: air.channel @c1 [1, 1] {air.refeed_count = 8 : i32}
 // CHECK-LABEL: @affine_refeed
 // CHECK-NOT: affine.for
-// CHECK: air.channel.put @c1[]
+// CHECK: air.channel.put @c1[]{{.*}}{air.refeed_count = 8 : i32}
 air.channel @c1 [1, 1]
 func.func @affine_refeed(%m: memref<64xi32, 2>) {
   affine.for %i = 0 to 8 {
     air.channel.put @c1[] (%m[] [] []) : (memref<64xi32, 2>)
-  } {air.refeed_loop}
+  }
   return
 }
 
 // -----
 
-// Existing air.refeed_count on the channel is raised to max(existing, N).
+// An L2 source puts the count on the backing memref.alloc instead: that is the
+// carrier AllocL2BuffersPattern propagates onto the buffer op, which is the
+// fill/drain rendezvous the memtile lock allocator reads.
 
-// CHECK: air.channel @c2 [1, 1] {air.refeed_count = 4 : i32}
-air.channel @c2 [1, 1] {air.refeed_count = 3 : i32}
-func.func @max_refeed(%m: memref<64xi32, 2>) {
+// CHECK-LABEL: @l2_carrier
+// CHECK: memref.alloc() {air.refeed_count = 4 : i32}
+// CHECK-NOT: scf.for
+// CHECK: air.channel.put
+// CHECK-NOT: air.refeed_count
+air.channel @c2 [1, 1]
+func.func @l2_carrier() {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c1 = arith.constant 1 : index
+  %buf = memref.alloc() : memref<64xi32, 1>
   scf.for %i = %c0 to %c4 step %c1 {
-    air.channel.put @c2[] (%m[] [] []) : (memref<64xi32, 2>)
-  } {air.refeed_loop}
+    air.channel.put @c2[] (%buf[] [] []) : (memref<64xi32, 1>)
+  }
+  memref.dealloc %buf : memref<64xi32, 1>
   return
 }
 
 // -----
 
-// Unsafe: the put offset depends on the induction variable (NOT invariant), so
-// the loop is left unchanged and no refeed_count is recorded.
+// Two re-feed loops draining the same resident L2 buffer ADD. air-to-aie makes
+// the fill release the count once per fill, so 3 drains plus 4 drains need 7
+// enabled -- not 12, which a multiplying accumulator would give.
 
-// CHECK: air.channel @c3 [1, 1]{{$}}
+// CHECK-LABEL: @counts_add
+// CHECK: memref.alloc() {air.refeed_count = 7 : i32}
+// CHECK-NOT: scf.for
+air.channel @c3 [1, 1]
+air.channel @c3b [1, 1]
+func.func @counts_add() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %buf = memref.alloc() : memref<64xi32, 1>
+  scf.for %i = %c0 to %c3 step %c1 {
+    air.channel.put @c3[] (%buf[] [] []) : (memref<64xi32, 1>)
+  }
+  scf.for %j = %c0 to %c4 step %c1 {
+    air.channel.put @c3b[] (%buf[] [] []) : (memref<64xi32, 1>)
+  }
+  memref.dealloc %buf : memref<64xi32, 1>
+  return
+}
+
+// -----
+
+// Nested re-feed loops COMPOSE. The walk is post-order, so the inner loop folds
+// first and hoists the put into the outer body, where it matches again. The
+// same put re-folded means M x N sends, not M + N -- priming the fill lock for
+// 7 when the buffer is drained 12 times under-primes it and deadlocks.
+
+// CHECK-LABEL: @nested_composes
+// CHECK: memref.alloc() {air.refeed_count = 12 : i32}
+// CHECK-NOT: scf.for
+air.channel @c3c [1, 1]
+func.func @nested_composes() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %buf = memref.alloc() : memref<64xi32, 1>
+  scf.for %i = %c0 to %c3 step %c1 {
+    scf.for %j = %c0 to %c4 step %c1 {
+      air.channel.put @c3c[] (%buf[] [] []) : (memref<64xi32, 1>)
+    }
+  }
+  memref.dealloc %buf : memref<64xi32, 1>
+  return
+}
+
+// -----
+
+// A nest and a sibling on one buffer: 2 x 3 sends plus 4 sends is 10 drains.
+
+// CHECK-LABEL: @nest_plus_sibling
+// CHECK: memref.alloc() {air.refeed_count = 10 : i32}
+// CHECK-NOT: scf.for
+air.channel @c3d [1, 1]
+air.channel @c3e [1, 1]
+func.func @nest_plus_sibling() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %buf = memref.alloc() : memref<64xi32, 1>
+  scf.for %i = %c0 to %c2 step %c1 {
+    scf.for %j = %c0 to %c3 step %c1 {
+      air.channel.put @c3d[] (%buf[] [] []) : (memref<64xi32, 1>)
+    }
+  }
+  scf.for %k = %c0 to %c4 step %c1 {
+    air.channel.put @c3e[] (%buf[] [] []) : (memref<64xi32, 1>)
+  }
+  memref.dealloc %buf : memref<64xi32, 1>
+  return
+}
+
+// -----
+
+// Async form: the loop carries the put's token. The hoisted put inherits the
+// loop's incoming dependency and takes over its uses, so no edge is dropped.
+
+// CHECK-LABEL: @async
+// CHECK: %[[T:.*]], %[[B:.*]] = air.execute
+// CHECK-NOT: scf.for
+// CHECK: %[[P:.*]] = air.channel.put async [%[[T]]]{{.*}}{air.refeed_count = 3 : i32}
+// CHECK: air.execute [%[[P]]]
+air.channel @c4 [1, 1]
+func.func @async() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %t, %buf = air.execute -> (memref<64xi32, 2>) {
+    %a = memref.alloc() : memref<64xi32, 2>
+    air.execute_terminator %a : memref<64xi32, 2>
+  }
+  %r = scf.for %i = %c0 to %c3 step %c1 iter_args(%tok = %t) -> (!air.async.token) {
+    %p = air.channel.put async [%tok] @c4[] (%buf[] [] []) : (memref<64xi32, 2>)
+    scf.yield %p : !air.async.token
+  }
+  %d = air.execute [%r] {
+    memref.dealloc %buf : memref<64xi32, 2>
+  }
+  return
+}
+
+// -----
+
+// Pure ops in the body are tolerated and hoisted with the put: a front end
+// materializes the put's index constants at its own insertion point, i.e.
+// inside the loop, and no canonicalizer need have run before this pass.
+
+// CHECK-LABEL: @pure_ops_in_body
+// CHECK-NOT: scf.for
+// CHECK: air.channel.put @c5[]{{.*}}{air.refeed_count = 5 : i32}
+air.channel @c5 [1, 1]
+func.func @pure_ops_in_body(%m: memref<64xi32, 2>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  scf.for %i = %c0 to %c5 step %c1 {
+    %z = arith.constant 0 : index
+    %n = arith.constant 64 : index
+    %s = arith.constant 1 : index
+    air.channel.put @c5[] (%m[%z] [%n] [%s]) : (memref<64xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// Not a re-broadcast: the put offset depends on the induction variable, so each
+// trip sends different bytes. Left unchanged.
+
 // CHECK-LABEL: @not_invariant
 // CHECK: scf.for
-air.channel @c3 [1, 1]
+// CHECK-NOT: air.refeed_count
+air.channel @c6 [1, 1]
 func.func @not_invariant(%m: memref<256xi32, 2>) {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c1 = arith.constant 1 : index
-  // expected-warning @+1 {{channel.put is not loop-invariant}}
   scf.for %i = %c0 to %c4 step %c1 {
-    air.channel.put @c3[] (%m[%i] [%c4] [%c1]) : (memref<256xi32, 2>)
-  } {air.refeed_loop}
+    air.channel.put @c6[] (%m[%i] [%c4] [%c1]) : (memref<256xi32, 2>)
+  }
   return
 }
 
 // -----
 
-// Unsafe: body is more than a single channel.put, so it is left unchanged.
+// Not a re-broadcast: two puts in the body. Left unchanged.
 
-// CHECK: air.channel @c4 [1, 1]{{$}}
-// CHECK-LABEL: @not_single_put
+// CHECK-LABEL: @two_puts
 // CHECK: scf.for
-air.channel @c4 [1, 1]
-func.func @not_single_put(%m: memref<64xi32, 2>, %n: memref<64xi32, 2>) {
+// CHECK-NOT: air.refeed_count
+air.channel @c7 [1, 1]
+func.func @two_puts(%m: memref<64xi32, 2>, %n: memref<64xi32, 2>) {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c1 = arith.constant 1 : index
-  // expected-warning @+1 {{body is not a single channel.put}}
   scf.for %i = %c0 to %c4 step %c1 {
-    air.channel.put @c4[] (%m[] [] []) : (memref<64xi32, 2>)
-    air.channel.put @c4[] (%n[] [] []) : (memref<64xi32, 2>)
-  } {air.refeed_loop}
+    air.channel.put @c7[] (%m[] [] []) : (memref<64xi32, 2>)
+    air.channel.put @c7[] (%n[] [] []) : (memref<64xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// Not a re-broadcast: the body rewrites the source between sends, so the loop
+// really is N productions. Left unchanged.
+
+// CHECK-LABEL: @rewritten_between_sends
+// CHECK: scf.for
+// CHECK: func.call @norm
+// CHECK-NOT: air.refeed_count
+air.channel @c8 [1, 1]
+func.func private @norm(memref<64xi32, 2>)
+func.func @rewritten_between_sends(%m: memref<64xi32, 2>) {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %c3 step %c1 {
+    func.call @norm(%m) : (memref<64xi32, 2>) -> ()
+    air.channel.put @c8[] (%m[] [] []) : (memref<64xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// A dynamic trip count cannot become a lock init. Left unchanged.
+
+// CHECK-LABEL: @dynamic_trip
+// CHECK: scf.for
+// CHECK-NOT: air.refeed_count
+air.channel @c9 [1, 1]
+func.func @dynamic_trip(%m: memref<64xi32, 2>, %ub: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %ub step %c1 {
+    air.channel.put @c9[] (%m[] [] []) : (memref<64xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// An async put carrying a dependency other than the loop's token would lose
+// that edge if hoisted. Left unchanged.
+
+// CHECK-LABEL: @extra_async_dep
+// CHECK: scf.for
+// CHECK-NOT: air.refeed_count
+air.channel @c10 [1, 1]
+func.func @extra_async_dep() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %t, %buf = air.execute -> (memref<64xi32, 2>) {
+    %a = memref.alloc() : memref<64xi32, 2>
+    air.execute_terminator %a : memref<64xi32, 2>
+  }
+  %u = air.wait_all async
+  %r = scf.for %i = %c0 to %c3 step %c1 iter_args(%tok = %t) -> (!air.async.token) {
+    %p = air.channel.put async [%tok, %u] @c10[] (%buf[] [] []) : (memref<64xi32, 2>)
+    scf.yield %p : !air.async.token
+  }
+  return
+}
+
+// -----
+
+// A trip count of one is a plain put: the loop goes, no count is recorded.
+
+// CHECK-LABEL: @single_trip
+// CHECK-NOT: scf.for
+// CHECK: air.channel.put
+// CHECK-NOT: air.refeed_count
+air.channel @c11 [1, 1]
+func.func @single_trip(%m: memref<64xi32, 2>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %c1 step %c1 {
+    air.channel.put @c11[] (%m[] [] []) : (memref<64xi32, 2>)
+  }
+  return
+}
+
+// -----
+
+// An L2 source whose memref.alloc is not recoverable (here a block argument)
+// has no carrier the memtile lock allocator reads. Writing the count on the put
+// would be silently ineffective and deadlock on device, so it is an error.
+
+air.channel @c12 [1, 1]
+func.func @l2_no_alloc(%m: memref<64xi32, 1>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %c4 step %c1 {
+    // expected-error @+1 {{air.refeed_count has no carrier the memtile lock allocator reads}}
+    air.channel.put @c12[] (%m[] [] []) : (memref<64xi32, 1>)
+  }
   return
 }

--- a/mlir/test/aircc/debug_ir.mlir
+++ b/mlir/test/aircc/debug_ir.mlir
@@ -14,10 +14,11 @@
 
 // Verify per-pass IR files are created
 // RUN: ls %t/debug_ir/pass_000_initial_input.mlir
-// RUN: ls %t/debug_ir/pass_001_after_air-rank-to-launch.mlir
-// RUN: ls %t/debug_ir/pass_002_after_air-insert-launch-around-herd.mlir
-// RUN: ls %t/debug_ir/pass_005_after_air-dependency.mlir
-// RUN: ls %t/debug_ir/pass_009_after_air-dma-to-channel.mlir
+// RUN: ls %t/debug_ir/pass_001_after_air-annotate-refeed.mlir
+// RUN: ls %t/debug_ir/pass_002_after_air-rank-to-launch.mlir
+// RUN: ls %t/debug_ir/pass_003_after_air-insert-launch-around-herd.mlir
+// RUN: ls %t/debug_ir/pass_006_after_air-dependency.mlir
+// RUN: ls %t/debug_ir/pass_010_after_air-dma-to-channel.mlir
 
 // Verify pass.log exists and has correct structure
 // RUN: FileCheck %s --input-file=%t/debug_ir/pass.log --check-prefix=LOG
@@ -25,10 +26,11 @@
 // Verbose output should show per-pass execution
 // CHECK: [DEBUG] Splitting pipeline into
 // CHECK: [PASS 000] Saved initial IR
-// CHECK: [PASS 001] air-rank-to-launch
-// CHECK: [PASS 002] air-insert-launch-around-herd
-// CHECK: [PASS 005] air-dependency
-// CHECK: [PASS 009] air-dma-to-channel
+// CHECK: [PASS 001] air-annotate-refeed
+// CHECK: [PASS 002] air-rank-to-launch
+// CHECK: [PASS 003] air-insert-launch-around-herd
+// CHECK: [PASS 006] air-dependency
+// CHECK: [PASS 010] air-dma-to-channel
 
 // Pass log should have checkpoints
 // LOG: MLIR-AIR Compilation Pass Log

--- a/programming_examples/fused_decode/.gitignore
+++ b/programming_examples/fused_decode/.gitignore
@@ -13,3 +13,4 @@ build_peano/
 build_chess/
 air.mlir
 air.elf
+.decode_build_model

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -120,6 +120,23 @@ from air.dialects.scf import for_, yield_, index_switch, ParallelOp, ReduceOp, I
 from air.backend.xrt import XRTBackend
 
 
+def refeed(n, emit):
+    """Re-send ONE resident buffer n times: an n-trip scf.for around a single
+    air.channel.put. The body holds nothing but the put and no operand depends
+    on the induction variable, so this is a re-broadcast, not n productions --
+    air-fold-refeed-loops recognizes the shape, collapses the loop, and derives
+    the count for the lock init. n <= 1 emits the bare put."""
+    if n <= 1:
+        emit()
+        return
+    c0 = arith.ConstantOp(IndexType.get(), 0).result
+    cn = arith.ConstantOp(IndexType.get(), n).result
+    c1 = arith.ConstantOp(IndexType.get(), 1).result
+    for _rf in for_(c0, cn, c1):
+        emit()
+        yield_([])
+
+
 def parallel_(n):
     """Spatial scf.parallel over [0, n) — the canonical form for a channel fan
     over a BUNDLE INDEX (@chan[iv]). air-to-aie spatially unrolls it to one
@@ -307,7 +324,7 @@ GRP_PCOL = (
 # hub must NOT sit on a proj col. Put it on col 2, the X-broadcast memtile (5 free S2MM)
 # -- exactly FLM, whose hub mem_1_1 IS its X-broadcast memtile.
 MAIN_PCOL = 2 if MODEL["PAIR_ROWS"] == 1 else 1  # phys col of the main memtile
-# Faithful X-feed (reproducer core_2_2 + air.refeed_count): the rms producer core
+# Faithful X-feed (reproducer core_2_2): the rms producer core
 # (tile_2_2, col2) normalizes raw X once and re-feeds it via an output-lock release
 # of N (= REFEED) into a 512 x_buffer (col2 memtile) that broadcasts 256-blocks to
 # the 16 proj cores. (the reference puts x_buffer on col1/mem_1_1, but col1 congestion makes
@@ -824,7 +841,7 @@ def build_module():
 
         # ---- channels ----
         # Faithful X-feed: host raw X (@xy) + rms weight (@rmsin) -> rms core ->
-        # xnorm (re-fed N times on-chip via air.refeed_count) -> X memtile (512) ->
+        # xnorm (re-fed N times on-chip, see refeed()) -> X memtile (512) ->
         # 256-block broadcast to all 16 cores. (reproducer core_2_2 + mem_1_1 x_buffer)
         # #4 (FULL4): rmsX is PACKET so it converges with the id4 demux (o-proj+down)
         # on the rms core's S2MM0 -- the reference's tile_2_2 DMA0 receives @xy(id0)+id4
@@ -875,18 +892,10 @@ def build_module():
             _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
                 T.i32(), 1
             )
-        # rms-X producer-side re-feed (mechanism 1): the rms core releases its
-        # output lock RMS_REFEED times. (The down_buffer producer re-broadcasts via
-        # its own counting-lock from air.refeed_count on its alloc -- mechanism 2 --
-        # and must NOT be multiplied by this channel count; air-to-aie skips the
-        # channel re-feed for memtile producers.)
-        _xn.operation.attributes["air.refeed_count"] = IntegerAttr.get(
-            T.i32(), XN_REFEED  # LOOPCLOSE: rms emits ONLY ph0 (6); ph1/ph2/ph3 memtile
-        )
-        # (FAITHFUL ph2): no toBufP2 / buf_ph2 channel -- the rms core now emits ph2 X
-        # = rmsnorm(x+oproj) directly on @xnorm with a PER-PUT air.refeed_count (32),
-        # the per-step single-channel re-feed (reproducer core_2_2 step2; AIRToAIE
-        # per-emission refeed override). ph0 uses the channel-level count (6).
+        # (FAITHFUL ph2): no toBufP2 / buf_ph2 channel -- the rms core emits ph2 X
+        # = rmsnorm(x+oproj) directly on @xnorm. Every re-feed on this channel is
+        # written as an n-trip loop around the put (see refeed()); the counts are
+        # XN_REFEED for ph0 and REFEED[GATEUP_PHASE] for ph2.
         # air.shared_resident_ring: the two per-v1 GEMV emit passes each re-read
         # this same broadcast X/W stream; mark so air-ping-pong-transform merges
         # the two sibling get-loops onto ONE 2-deep resident ring (reproducer's
@@ -1000,8 +1009,8 @@ def build_module():
         # GLU -> gluOut -> down memtile accumulate (8192). FAITHFUL: that 8192 is
         # fed back on-chip as the DOWN phase X by the down_buffer re-broadcasting it
         # DOWN_REFEED times into the convergent @xnorm channel (counting-lock-N on
-        # the down_buffer fill -- mechanism 2, set via air.refeed_count on the
-        # down_buffer alloc below), NOT drained to host.
+        # the down_buffer fill, derived from the DOWN_REFEED loop around the put
+        # below), NOT drained to host.
         channel_decl("gluOut", size=[1])
 
         def idx(v):
@@ -1215,7 +1224,7 @@ def build_module():
 
                         def _uni_dec():
                             # raw X (@xy) + rms weight (@rmsin) to the rms producer core; the
-                            # on-chip rms normalizes + re-feeds X via air.refeed_count. X is
+                            # on-chip rms normalizes + re-feeds X (see refeed()). X is
                             # in-place (offset 0 every layer -- the chained hidden state).
                             ChannelPut("rmsX", X, offsets=[0], sizes=[K], strides=[1])
                             if N_NORMS >= 4:
@@ -1546,7 +1555,7 @@ def build_module():
                     # fed back on-chip. The SAME inX broadcast carries both, in order.
                     #
                     # (1) rms-X: get the normed X (from the rms core, re-fed RMS_REFEED
-                    # times via @xnorm air.refeed_count) in 512 chunks -> broadcast
+                    # times over @xnorm) in 512 chunks -> broadcast
                     # 256-blocks. RMS_REFEED*(2048/512) gets. (reproducer core_2_2 +
                     # mem_1_1 x_buffer 512.)
                     def _feed_inX(src, total_chunks):
@@ -2429,13 +2438,9 @@ def build_module():
                             T.i32(), 5
                         )
                         omtb.operation.attributes["air.no_split"] = UnitAttr.get()
-                        # loop close: gathered o (2048) is ph1 o-proj X. As a MEMTILE
-                        # producer it re-broadcasts OPROJ_REFEED times (mechanism-2)
-                        # into the convergent @xnorm, AFTER ph0 (rms) and BEFORE ph2
-                        # (buf_ph2). Reference mem_5_1 o_buffer -> mem_1_1 x_buffer.
-                        omtb.operation.attributes["air.refeed_count"] = IntegerAttr.get(
-                            T.i32(), OPROJ_REFEED
-                        )
+                        # loop close: gathered o (2048) is ph1 o-proj X, re-broadcast
+                        # OPROJ_REFEED times into the convergent @xnorm, AFTER ph0 (rms)
+                        # and BEFORE ph2. Reference mem_5_1 o_buffer -> mem_1_1 x_buffer.
                         for c in range(N_ATTN_CU):
                             ChannelGet(
                                 "attnO",
@@ -2445,13 +2450,16 @@ def build_module():
                                 sizes=[idx(DQ_PER_CU)],
                                 strides=[idx(1)],
                             )
-                        ChannelPut(
-                            "xnorm",
-                            omtb,
-                            indices=[idx(0)],
-                            offsets=[idx(0)],
-                            sizes=[idx(N_ATTN_CU * DQ_PER_CU)],
-                            strides=[idx(1)],
+                        refeed(
+                            OPROJ_REFEED,
+                            lambda: ChannelPut(
+                                "xnorm",
+                                omtb,
+                                indices=[idx(0)],
+                                offsets=[idx(0)],
+                                sizes=[idx(N_ATTN_CU * DQ_PER_CU)],
+                                strides=[idx(1)],
+                            ),
                         )
                         DeallocOp(omtb)
 
@@ -2545,8 +2553,8 @@ def build_module():
 
                         # GLU output -> down memtile accumulate (8192). FAITHFUL: feed
                         # it back on-chip as the DOWN phase X, re-broadcast DOWN_REFEED
-                        # times into the convergent @xnorm. air.refeed_count on the
-                        # down_buffer ALLOC (mechanism 2) makes air-to-aie emit a
+                        # times into the convergent @xnorm. The DOWN_REFEED loop
+                        # around the put (see refeed()) makes air-to-aie emit a
                         # counting-lock-N on the fill (S2MM) side so the count-free MM2S
                         # re-reads the resident 8192 N times (reproducer down_buffer
                         # lock_5_1 init=4: one GLU fill -> 4 re-sends = the 4 down output
@@ -2560,9 +2568,6 @@ def build_module():
                             4,
                         )
                         db.operation.attributes["air.no_split"] = UnitAttr.get()
-                        db.operation.attributes["air.refeed_count"] = IntegerAttr.get(
-                            T.i32(), DOWN_REFEED
-                        )
                         for _s in for_(idx(0), idx(NGLU), idx(1)):
                             soff = arith.muli(_s, idx(GLU_HID))
                             ChannelGet(
@@ -2573,14 +2578,16 @@ def build_module():
                                 strides=[idx(1)],
                             )
                             yield_([])
-                        # re-broadcast the resident 8192 into the convergent X feed
-                        # (counting-lock-N from the alloc refeed_count above).
-                        ChannelPut(
-                            "xnorm",
-                            db,
-                            offsets=[0],
-                            sizes=[GLU_OUT],
-                            strides=[1],
+                        # re-broadcast the resident 8192 into the convergent X feed.
+                        refeed(
+                            DOWN_REFEED,
+                            lambda: ChannelPut(
+                                "xnorm",
+                                db,
+                                offsets=[0],
+                                sizes=[GLU_OUT],
+                                strides=[1],
+                            ),
                         )
                         DeallocOp(db)
 
@@ -2875,7 +2882,7 @@ def build_module():
 
                     # ===== rms producer core (reproducer core_2_2, tile_2_2) =====
                     # input-layernorm: raw X + rms weight -> normed X -> xnorm (re-fed
-                    # on-chip REFEED times via air.refeed_count -> the X memtile).
+                    # on-chip REFEED times, see refeed() -> the X memtile).
 
                     OPROJ_RNDS = PAIR_ROWS * I2P[1]  # 4 o-proj egress rounds
                     DOWN_RNDS = PAIR_ROWS * I2P[DOWN_PHASE]  # 4 down egress rounds
@@ -2918,17 +2925,17 @@ def build_module():
                                 ChannelGet("rmsW2", a_w2l, indices=[idx(0)])
                                 DeallocOp(a_w2l)
                             a_xnl = AllocOp(rms_l1, [], [])
-                            # the reference-FAITHFUL x re-broadcast (was air.refeed_count=VOCAB_RNDS).
+                            # the reference-FAITHFUL x re-broadcast (was one put x VOCAB_RNDS).
                             # the reference re-supplies x every vocab round through value-1 ping-pong
                             # rings and re-runs rms each persistent-loop iteration; the count
                             # lives in the loop + runtime, NEVER in a lock (all the reference lock
-                            # values are 1/2/4). Our old air.refeed_count baked N=VOCAB_RNDS
+                            # values are 1/2/4). Baking N=VOCAB_RNDS as a re-broadcast puts it
                             # into ONE producer-side credit lock; the AIE-ML lock is 7-bit
                             # (max +63, xaie_locks_aieml.c 0x7F), so N>63 (I2>=32) made
                             # AcquireGreaterEqual(N) unsatisfiable -> DEADLOCK, forcing the
                             # 9-wave split (2*I2<=63). Here we mirror the reference: re-normalize + put
-                            # xnorm PER ROUND (value-1; a_xnl is rewritten each round so AIR
-                            # does not canonicalize the puts back into refeed_count). The
+                            # xnorm PER ROUND (a_xnl is rewritten each round, so this is n
+                            # productions and air-fold-refeed-loops leaves it alone). The
                             # sends are INTERLEAVED with the outY->layerOut relay (this ONE
                             # rms core both produces x and relays logits, unlike the reference's split
                             # tiles) so the producer never serializes ahead of the drain and
@@ -2958,24 +2965,19 @@ def build_module():
                                         "air.disable_ping_pong"
                                     ] = UnitAttr.get()
                                     CallOp(_rms_final, [a_xnl, a_xl, a_wl, _arm])
-                                    _pl = ChannelPut(
+                                    # Each vocab round emits x ONCE: VOCAB_RNDS
+                                    # distinct puts give VOCAB_RNDS broadcasts,
+                                    # matching the X memtile's VOCAB_RNDS*(K/(2*
+                                    # COL_BLOCK)) gets. This loop re-runs rms into
+                                    # a_xnl every trip, so it is n productions, not
+                                    # a re-broadcast, and air-fold-refeed-loops
+                                    # leaves it alone.
+                                    ChannelPut(
                                         "xnorm",
                                         a_xnl,
                                         offsets=[0],
                                         sizes=[K],
                                         strides=[1],
-                                    )
-                                    # PER-PUT override of the channel-level
-                                    # air.refeed_count (XN_REFEED=6, meant for the
-                                    # decode ph0 path): each vocab round emits x
-                                    # ONCE (value-1, n=1 hits the n>1 guard in
-                                    # AIRToAIE -> no credit multiply). VOCAB_RNDS
-                                    # distinct puts give VOCAB_RNDS broadcasts,
-                                    # matching the X memtile's VOCAB_RNDS*(K/(2*
-                                    # COL_BLOCK)) gets. Without this the puts inherit
-                                    # refeed_count=6 -> over-broadcast.
-                                    _pl.operation.attributes["air.refeed_count"] = (
-                                        IntegerAttr.get(T.i32(), 1)
                                     )
                                     yield_([])
                                 ChannelGet(
@@ -3051,12 +3053,14 @@ def build_module():
                             )  # post-norm out (attn, then ffn)
                             g_h = AllocOp(rms_l1, [], [])
                             # step1: input_layernorm (g_wa lo) -> QKV X feed (ph0).
-                            # Single normalize + baked channel-level XN_REFEED, mirroring
-                            # llama (a per-round value-1 reput loop instead re-reads the
-                            # input buffer every iteration and doubles the S2MM0 BD ring).
+                            # Normalize once, then re-broadcast the resident result
+                            # XN_REFEED times.
                             CallOp(rms_norm_lo_aie, [g_xn, g_x, g_wa, _arm])
-                            ChannelPut(
-                                "xnorm", g_xn, offsets=[0], sizes=[K], strides=[1]
+                            refeed(
+                                XN_REFEED,
+                                lambda: ChannelPut(
+                                    "xnorm", g_xn, offsets=[0], sizes=[K], strides=[1]
+                                ),
                             )
                             # step2 (residual1): h = x + post_attention_norm(o_proj) [g_wa hi]
                             ChannelGet(
@@ -3073,11 +3077,11 @@ def build_module():
                             # step3: pre_feedforward_norm(h) [g_wb lo] -> GLU X feed (ph2).
                             # baked per-put refeed = GLU proj rounds that re-read X.
                             CallOp(rms_norm_lo_aie, [g_xn, g_h, g_wb, _arm])
-                            _p2 = ChannelPut(
-                                "xnorm", g_xn, offsets=[0], sizes=[K], strides=[1]
-                            )
-                            _p2.operation.attributes["air.refeed_count"] = (
-                                IntegerAttr.get(T.i32(), REFEED[GATEUP_PHASE])
+                            refeed(
+                                REFEED[GATEUP_PHASE],
+                                lambda: ChannelPut(
+                                    "xnorm", g_xn, offsets=[0], sizes=[K], strides=[1]
+                                ),
                             )
                             DeallocOp(g_xn)
                             # step4 (residual2): res2 = h + post_feedforward_norm(down) [g_wb hi].
@@ -3117,7 +3121,12 @@ def build_module():
                         # step1: input layernorm -> X feed (re-fed RMS_REFEED via xnorm)
                         a_xn = AllocOp(rms_l1, [], [])
                         CallOp(rms_norm_aie, [a_xn, a_x, a_w, _arm])
-                        ChannelPut("xnorm", a_xn, offsets=[0], sizes=[K], strides=[1])
+                        refeed(
+                            XN_REFEED,
+                            lambda: ChannelPut(
+                                "xnorm", a_xn, offsets=[0], sizes=[K], strides=[1]
+                            ),
+                        )
                         # a_w and a_xn are kept for the ph2 (gate-up) emission (step2).
                         if RMS_DEST < 0:
                             # debug configs: original single-step rms (no residual).
@@ -3147,23 +3156,22 @@ def build_module():
                             # = rmsnorm(residual1) = rmsnorm(x + o-proj), emitted
                             # AFTER o-proj (gates phase order) on the SAME @xnorm
                             # channel as ph0, REUSING a_xn (single y buffer), with
-                            # PER-PUT air.refeed_count = REFEED[ph2] (32). This is
-                            # the per-step single-channel re-feed (ph0 x6 via the
-                            # channel count, ph2 x32 via this per-put count) --
-                            # replaces the invented buf_ph2 memtile stand-in.
+                            # a REFEED[ph2]-trip (32) re-broadcast loop. This is
+                            # the per-step single-channel re-feed (ph0 x6, ph2 x32)
+                            # -- replaces the invented buf_ph2 memtile stand-in.
                             CallOp(
                                 rms_norm_aie,
                                 [a_xn, a_h, a_w2 if POST_RMS else a_w, _arm],
                             )
-                            _p2 = ChannelPut(
-                                "xnorm",
-                                a_xn,
-                                offsets=[0],
-                                sizes=[K],
-                                strides=[1],
-                            )
-                            _p2.operation.attributes["air.refeed_count"] = (
-                                IntegerAttr.get(T.i32(), REFEED[GATEUP_PHASE])
+                            refeed(
+                                REFEED[GATEUP_PHASE],
+                                lambda: ChannelPut(
+                                    "xnorm",
+                                    a_xn,
+                                    offsets=[0],
+                                    sizes=[K],
+                                    strides=[1],
+                                ),
                             )
                             DeallocOp(a_xn)
                             DeallocOp(a_w)

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -331,6 +331,17 @@ MAIN_PCOL = 2 if MODEL["PAIR_ROWS"] == 1 else 1  # phys col of the main memtile
 # AIR's weight-fan MM2S a repeat_count BD; the golden uses col2, kept here.)
 RMS_PCOL = 2  # rms producer core + X memtile column
 XMT_PCOL = RMS_PCOL
+# Column of the glu-down memtile, the third producer converging on @xnorm (the
+# other two are the o-proj memtile on col 5 and the rms core itself). Distinct
+# from col 5 either way, so the convergence never merges o+down onto one MM2S
+# ring. Gemma needs it ADJACENT to the X memtile: its per-column egress puts a
+# group memtile on every proj column AND lands the hub on the X column (
+# MAIN_PCOL == XMT_PCOL == 2), so a down->X route from col 4 crosses switches
+# that are already carrying the hub traffic and the pathfinder cannot complete
+# all three sources of the merge -- mlir-aie reports it as an incomplete
+# packet-flow routing (it used to drop the source silently). Llama's hub is on
+# col 1, clear of the X column, and routes fine from col 4.
+DOWN_PCOL = 3 if MODEL["PAIR_ROWS"] == 1 else 4
 
 # Phases (reproducer I2=[3,2,16,2], J2=[4,4,4,16], pkt=[1,4,8,4]). Phase 0 = QKV
 # (id1), phase 1 = o-proj (id4), phase 2 = gate-up MLP (id8), phase 3 = DOWN (id4).
@@ -2562,10 +2573,7 @@ def build_module():
                         # 8192 into 16x512 -> inX for ph3.
                         db = AllocOp(down_l2, [], [])
                         db.operation.attributes["air.memtile_col"] = IntegerAttr.get(
-                            # LOOPCLOSE: down on col4 (distinct from o on col5) so the
-                            # @xnorm convergence doesn't merge o+down onto one MM2S ring.
-                            T.i32(),
-                            4,
+                            T.i32(), DOWN_PCOL
                         )
                         db.operation.attributes["air.no_split"] = UnitAttr.get()
                         for _s in for_(idx(0), idx(NGLU), idx(1)):

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -66,6 +66,24 @@ from air.dialects import arith
 from air.dialects.scf import for_, yield_, index_switch, IfOp
 from air.backend.xrt import XRTBackend
 
+
+def refeed(n, emit):
+    """Re-send ONE resident buffer n times: an n-trip scf.for around a single
+    air.channel.put. The body holds nothing but the put and no operand depends
+    on the induction variable, so this is a re-broadcast, not n productions --
+    air-fold-refeed-loops recognizes the shape, collapses the loop, and derives
+    the count for the lock init. n <= 1 emits the bare put."""
+    if n <= 1:
+        emit()
+        return
+    c0 = arith.ConstantOp(IndexType.get(), 0).result
+    cn = arith.ConstantOp(IndexType.get(), n).result
+    c1 = arith.ConstantOp(IndexType.get(), 1).result
+    for _rf in for_(c0, cn, c1):
+        emit()
+        yield_([])
+
+
 # ============================ Qwen2.5-3B config =============================
 MODEL_DIM = 2048
 K = MODEL_DIM
@@ -95,7 +113,7 @@ OREF_COL = int(_os.environ.get("QWEN_OREF_COL", "6"))
 OREF_NOPUT = int(_os.environ.get("QWEN_OREF_NOPUT", "0"))
 # QWEN_OREF_VIA_RMS=1: the attn-o gather memtile does NOT feed @xnorm directly. It hands
 # the gathered o to the rms core over @orms, and the rms core re-emits it as ph1's X on
-# @xnorm (per-put air.refeed_count = OPROJ_REFEED). That makes the rms tile the ONLY
+# @xnorm (re-broadcast OPROJ_REFEED times). That makes the rms tile the ONLY
 # physical producer into the hub X ring -- exactly the shape that PASSES at NPH=2 when the
 # oref put is removed (QWEN_OREF_NOPUT=1) -- while keeping the real attn data. Isolates
 # "a second physical X producer starves ph0" from "the attn data itself starves ph0".
@@ -297,8 +315,8 @@ KV_APPEND = True  # rope writes this token's roped-K/raw-V into the DDR cache
 # All four converge (in phase-time order) on ONE npu_dma_packet channel @xnorm, read
 # by ONE count-free feed loop that broadcasts 256-blocks to the 16 proj cores (inX).
 # Each phase source re-broadcasts REFEED[p] = RB[p] times (rounds/phase): the rms core
-# via channel/per-put air.refeed_count, the attn-o + glu-down via memtile-alloc
-# air.refeed_count (mechanism 2). Mirrors fused_decode.py exactly, re-parameterized.
+# from the rms core, the attn-o + glu-down from their gather memtiles. Every
+# re-feed is an n-trip loop around the put. Mirrors fused_decode.py, re-parameterized.
 # QWEN_ATTN=0 = device-deadlock bisection: drop the whole attn subsystem (KV
 # staging + attn herd + o-gather), rope drains q to host, forces LOOPCLOSE off.
 # Isolates whether a device hang is in attn vs the base proj/surround.
@@ -535,7 +553,7 @@ def build_module():
         kvcomb_l2 = MemRefType.get([16 * REGION_W], bf16, memory_space=l2)  # 4096
         # X-loopclose refeed memtiles (reference mem_tile_6_1 role): attn-o (ph1 oproj X =
         # MODEL_DIM) and glu-down (ph3 down X = INTERMEDIATE) gathered then re-broadcast
-        # into the convergent @xnorm via air.refeed_count (mechanism 2).
+        # into the convergent @xnorm.
         oref_l2 = MemRefType.get([K], bf16, memory_space=l2)  # 2048 attn-o
         downref_l2 = MemRefType.get([INTERMEDIATE], bf16, memory_space=l2)  # 11264
 
@@ -720,12 +738,11 @@ def build_module():
             channel_decl("hostQ", size=[1])
         # ---- X-loopclose channels (Step 2c; reuse Llama convergent-xnorm) ----
         # ONE convergent packet channel carries all 4 phase X sources (rms ph0/ph2,
-        # attn-o ph1, glu-down ph3) into the X memtile, read by ONE feed loop. rms
-        # channel-level refeed = XN_REFEED (ph0); ph2/ph1/ph3 use per-put / memtile
-        # air.refeed_count. Pin the rms core's xnorm output to tile MM2S1 (layerOut
-        # keeps MM2S0) so the placer does not flip layerOut circuit->packet.
+        # attn-o ph1, glu-down ph3) into the X memtile, read by ONE feed loop. Every
+        # re-feed on it is written as an n-trip loop around the put (see refeed()).
+        # Pin the rms core's xnorm output to tile MM2S1 (layerOut keeps MM2S0) so the
+        # placer does not flip layerOut circuit->packet.
         _xn = channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
-        _xn.operation.attributes["air.refeed_count"] = IntegerAttr.get(i32, XN_REFEED)
         if OREF_2HOP:
             channel_decl("oref2", size=[1], channel_type="npu_dma_packet")
         if OREF_HOSTSRC:
@@ -750,10 +767,7 @@ def build_module():
             _orms = channel_decl("orms", size=[1], channel_type="npu_dma_packet")
             _orms.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 0)
         if PH1_XCHAN:
-            _xn2 = channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
-            _xn2.operation.attributes["air.refeed_count"] = IntegerAttr.get(
-                i32, OPROJ_REFEED
-            )
+            channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
         _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
         _rmsw = channel_decl("rmsW", size=[1])  # host rms weight -> rms core
         _rmsw.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
@@ -1361,28 +1375,27 @@ def build_module():
                                 # (x XN_REFEED) -> 5 packets vs 20 BDs (1:4 mismatch). The
                                 # working host-toX feed is 1:1 (20 puts of 512). Emit the same
                                 # 1:1 shape here, in ROUND-MAJOR order (r, then chunk) so the
-                                # X memtile sees c0,c1,c2,c3 per round; per-put refeed_count=1
-                                # overrides the channel-level count (getRefeedCount: an
-                                # explicit per-emission attr wins for ANY value, incl. 1).
+                                # X memtile sees c0,c1,c2,c3 per round. These are XN_REFEED
+                                # x (K/XCH) distinct puts, not a re-broadcast loop.
                                 for _xr in range(XN_REFEED):
                                     for _xc in range(K // XCH):
-                                        _pp = ChannelPut(
+                                        ChannelPut(
                                             "xnorm",
                                             a_xn,
                                             offsets=[idx(_xc * XCH)],
                                             sizes=[idx(XCH)],
                                             strides=[idx(1)],
                                         )
-                                        _pp.operation.attributes["air.refeed_count"] = (
-                                            IntegerAttr.get(i32, 1)
-                                        )
                             else:
-                                ChannelPut(
-                                    "xnorm",
-                                    a_xn,
-                                    offsets=[idx(0)],
-                                    sizes=[idx(K)],
-                                    strides=[idx(1)],
+                                refeed(
+                                    XN_REFEED,
+                                    lambda: ChannelPut(
+                                        "xnorm",
+                                        a_xn,
+                                        offsets=[idx(0)],
+                                        sizes=[idx(K)],
+                                        strides=[idx(1)],
+                                    ),
                                 )
                             if OREF_NOPUT and OPROJ_PHASE < NPH:
                                 # bisect stand-in for the muted oref as ph1's X source.
@@ -1393,15 +1406,15 @@ def build_module():
                                 # the core lock trace acquired the outY data lock before the
                                 # ph1 prod-acquire). Also makes the stand-in work at NPH>=3,
                                 # where the gate-up branch below is taken instead.
-                                _pa = ChannelPut(
-                                    "xnorm",
-                                    a_xn,
-                                    offsets=[idx(0)],
-                                    sizes=[idx(K)],
-                                    strides=[idx(1)],
-                                )
-                                _pa.operation.attributes["air.refeed_count"] = (
-                                    IntegerAttr.get(i32, OPROJ_REFEED)
+                                refeed(
+                                    OPROJ_REFEED,
+                                    lambda: ChannelPut(
+                                        "xnorm",
+                                        a_xn,
+                                        offsets=[idx(0)],
+                                        sizes=[idx(K)],
+                                        strides=[idx(1)],
+                                    ),
                                 )
                             if OREF_VIA_RMS and OPROJ_PHASE < NPH:
                                 # ph1 X = the attn-o handed over by the oref memtile. Placed
@@ -1443,15 +1456,15 @@ def build_module():
                                 )
                                 if not SURROUND_NOCOMPUTE:
                                     CallOp(rms_copy_aie, [a_xn, a_o])
-                                _po = ChannelPut(
-                                    "xnorm",
-                                    a_xn,
-                                    offsets=[idx(0)],
-                                    sizes=[idx(K)],
-                                    strides=[idx(1)],
-                                )
-                                _po.operation.attributes["air.refeed_count"] = (
-                                    IntegerAttr.get(i32, OPROJ_REFEED)
+                                refeed(
+                                    OPROJ_REFEED,
+                                    lambda: ChannelPut(
+                                        "xnorm",
+                                        a_xn,
+                                        offsets=[idx(0)],
+                                        sizes=[idx(K)],
+                                        strides=[idx(1)],
+                                    ),
                                 )
                                 DeallocOp(a_o)
                         a_op = None
@@ -1481,15 +1494,15 @@ def build_module():
                             # after its rms_norm (Llama's working cadence), not batched at the
                             # loop top.
                             CallOp(rms_norm_aie, [a_xn, a_h, a_w2, _one])
-                            _p2 = ChannelPut(
-                                "xnorm",
-                                a_xn,
-                                offsets=[idx(0)],
-                                sizes=[idx(K)],
-                                strides=[idx(1)],
-                            )
-                            _p2.operation.attributes["air.refeed_count"] = (
-                                IntegerAttr.get(i32, GATEUP_REFEED)
+                            refeed(
+                                GATEUP_REFEED,
+                                lambda: ChannelPut(
+                                    "xnorm",
+                                    a_xn,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
+                                ),
                             )
                             DeallocOp(a_xn)
                             DeallocOp(a_w)
@@ -1913,7 +1926,7 @@ def build_module():
                     # ===== X-loopclose refeed memtiles (reference mem_tile_6_1 role) =====
                     # attn-o (ph1 oproj X) + glu-down (ph3 down X) gathered into col-6
                     # memtiles and re-broadcast into the convergent @xnorm via
-                    # air.refeed_count on the alloc (mechanism 2). Convergence order:
+                    # an OPROJ_REFEED-trip loop around the put. Convergence order:
                     # rms ph0 -> o ph1 -> rms ph2 -> glu ph3.
                     # Phase-isolation: each refeed memtile serves ONE phase's X, so emit it
                     # only when that phase is built (else it gathers a producer output that
@@ -1937,10 +1950,6 @@ def build_module():
                         if OREF_NOCHAIN:
                             omtb.operation.attributes["air.no_chain_lock"] = (
                                 UnitAttr.get()
-                            )
-                        if not OREF_NOPUT and _oref_refeed_here:
-                            omtb.operation.attributes["air.refeed_count"] = (
-                                IntegerAttr.get(i32, OPROJ_REFEED)
                             )
                         if OREF_HOSTSRC:
                             ChannelGet(
@@ -1969,20 +1978,23 @@ def build_module():
                                 strides=[idx(1)],
                             )
                         elif not OREF_NOPUT:
-                            ChannelPut(
-                                (
-                                    "oref2"
-                                    if OREF_2HOP
-                                    else (
-                                        "orms"
-                                        if OREF_VIA_RMS
-                                        else ("xnorm2" if PH1_XCHAN else "xnorm")
-                                    )
+                            refeed(
+                                OPROJ_REFEED if _oref_refeed_here else 1,
+                                lambda: ChannelPut(
+                                    (
+                                        "oref2"
+                                        if OREF_2HOP
+                                        else (
+                                            "orms"
+                                            if OREF_VIA_RMS
+                                            else ("xnorm2" if PH1_XCHAN else "xnorm")
+                                        )
+                                    ),
+                                    omtb,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
                                 ),
-                                omtb,
-                                offsets=[idx(0)],
-                                sizes=[idx(K)],
-                                strides=[idx(1)],
                             )
                         DeallocOp(omtb)
                         if OREF_2HOP and not OREF_NOPUT:
@@ -1993,10 +2005,6 @@ def build_module():
                                 IntegerAttr.get(T.i32(), OREF2_COL)
                             )
                             omt2.operation.attributes["air.no_split"] = UnitAttr.get()
-                            if not OREF_VIA_RMS:
-                                omt2.operation.attributes["air.refeed_count"] = (
-                                    IntegerAttr.get(i32, OPROJ_REFEED)
-                                )
                             ChannelGet(
                                 "oref2",
                                 omt2,
@@ -2004,16 +2012,19 @@ def build_module():
                                 sizes=[idx(K)],
                                 strides=[idx(1)],
                             )
-                            ChannelPut(
-                                (
-                                    "orms"
-                                    if OREF_VIA_RMS
-                                    else ("xnorm2" if PH1_XCHAN else "xnorm")
+                            refeed(
+                                1 if OREF_VIA_RMS else OPROJ_REFEED,
+                                lambda: ChannelPut(
+                                    (
+                                        "orms"
+                                        if OREF_VIA_RMS
+                                        else ("xnorm2" if PH1_XCHAN else "xnorm")
+                                    ),
+                                    omt2,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(K)],
+                                    strides=[idx(1)],
                                 ),
-                                omt2,
-                                offsets=[idx(0)],
-                                sizes=[idx(K)],
-                                strides=[idx(1)],
                             )
                             DeallocOp(omt2)
                     if LOOPCLOSE and DOWN_PHASE < NPH:
@@ -2033,9 +2044,6 @@ def build_module():
                             T.i32(), 0
                         )
                         db.operation.attributes["air.no_split"] = UnitAttr.get()
-                        db.operation.attributes["air.refeed_count"] = IntegerAttr.get(
-                            i32, DOWN_REFEED
-                        )
                         # UNROLLED gather (constant offsets), not a rolled scf.for with
                         # an IV-derived offset. Rolled, the NGLU=22 gets lower to a BD ring
                         # whose wrap does not divide 22, so chunks are duplicated and
@@ -2086,12 +2094,15 @@ def build_module():
                                     strides=[idx(1)],
                                 )
                         else:
-                            ChannelPut(
-                                "xnorm",
-                                db,
-                                offsets=[idx(0)],
-                                sizes=[idx(INTERMEDIATE)],
-                                strides=[idx(1)],
+                            refeed(
+                                DOWN_REFEED,
+                                lambda: ChannelPut(
+                                    "xnorm",
+                                    db,
+                                    offsets=[idx(0)],
+                                    sizes=[idx(INTERMEDIATE)],
+                                    strides=[idx(1)],
+                                ),
                             )
                         DeallocOp(db)
 

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1036,7 +1036,16 @@ static LogicalResult runAieCompilation() {
   {
     raw_string_ostream os(placementPipeline);
     os << "builtin.module(";
-    os << "air-rank-to-launch";
+    // FIRST, before any other AIR pass sees the IR. A producer that re-sends
+    // one resident buffer N times is written as an N-trip loop around a single
+    // put; this collapses it and records N on the carrier air-to-aie reads.
+    // It has to run here rather than next to air-to-aie:
+    // air-opt-memtile-dma-bds erases such a loop (its body is one BD, so it
+    // looks like a redundant wrapper), which would silently drop the re-sends.
+    // Folding up front means every pass downstream sees exactly the IR it saw
+    // when the count was written by hand.
+    os << "air-annotate-refeed";
+    os << ",air-rank-to-launch";
     os << ",air-insert-launch-around-herd{insert-segment=true}";
     os << ",func.func(air-lower-herd-parallel)";
     os << ",scf-forall-to-parallel";


### PR DESCRIPTION
The four Q4NX LLM designs hand-wrote `air.refeed_count` at 15 sites to tell
air-to-aie "this producer re-sends ONE resident buffer N times per production".
The count is what primes the credit lock; without it the fill's
`AcquireGreaterEqual N` can never fire and the array deadlocks. This removes
those 15 sites and derives the count instead.

## Why it could not simply be inferred

Nothing in the lowered program carries N back out. The MM2S BD is an infinite
self-loop that drains credits one at a time, and the only two consumers of the
count in the whole compiler are lock-init sites. Solving the channel's token
balance does not recover it either: `@xnorm` has four producers and one
consumer loop, so it is one equation in four unknowns in all four models.

What N *can* be is stated structurally. An N-trip loop around a single put,
whose body holds nothing but the put and none of whose operands depend on the
induction variable, says exactly the same thing:

```mlir
scf.for %i = %c0 to %c6 step %c1 {
  air.channel.put @xnorm[] (%buf[] [] [])
}
```

Today that form lowers differently, and worse. It reads as N productions, so
the v2 chain-lock allocates a ping-pong twin whose pong slot is never filled,
and the credit handshake collapses to one deep -- the producer's next acquire
only proves N-1 sends landed, so it can overwrite the source while the last one
is still in flight.

## air-annotate-refeed

`AIRAnnotateRefeedPass` already existed for exactly this job (#1709), opt-in
behind an `air.refeed_loop` marker, writing the count to the channel
declaration. This extends it rather than adding a second pass beside it:

- **Carrier.** The channel declaration cannot express these designs: `@xnorm`
  has three producers with different counts. The count now goes on the source
  `memref.alloc` for a memtile producer -- the carrier `AllocL2BuffersPattern`
  propagates onto the buffer op, which is the fill/drain rendezvous the memtile
  lock allocator reads -- and on the put for a core producer, which is what
  `allocateCoreLocksPerMemcpyOp` reads. The two mechanisms must not be unified.
- **Accumulation distinguishes siblings from nests.** air-to-aie makes the fill
  release the count once per fill, so two producers draining one resident
  buffer N1 and N2 times need N1 + N2 drains enabled -- a sum, where the pass
  previously took a max. But nested loops compose: the walk is post-order, so
  folding an inner loop hoists the put into the outer body where it matches
  again, and M x N sends must not be recorded as M + N. Which case it is cannot
  be read off the carrier, only off whether this run already folded a loop
  around *that put*, so the pass tracks per-put contributions and replaces
  rather than adds when the same put re-folds. Under-priming the fill lock is
  the deadlock this whole mechanism exists to prevent.
- **Async form** (the loop carrying the put's token, allocs wrapped in
  `air.execute`) and **pure ops in the body** (a front end materializes the
  put's index constants inside the loop) are accepted; both were rejected
  before.
- **No longer opt-in.** The marker is gone, along with `air.refeed_loop`.
- An **L2 source whose alloc is not recoverable is an error**, not a silent
  wrong carrier: the count would land somewhere the memtile mechanism never
  reads, and the array would deadlock with no diagnostic. The carrier is
  resolved before any IR is touched, so that failure leaves the loop intact
  rather than half-transformed.
- `affine.for` support and the pass's location in `AIRMiscPasses.cpp` are kept.

### Why unconditional

#1709 made it opt-in deliberately, so the reversal needs an argument. For the
shape this pass matches -- a loop whose body is one put of a source nothing in
the loop writes -- folding is not merely equivalent, it is the only correct
lowering. The buffer is filled outside the loop, so a ping-pong twin's second
slot has no writer and never fills. Leaving the loop is what breaks. For a
buffer that is not a chain-lock candidate the fold changes the lock init from 1
to N, which batches credits the producer would otherwise take one at a time --
both correct, and the batched form is what protects the source from being
overwritten while the last send is in flight.

The cost of dropping the marker is that a loop that *nearly* matches now
silently stays a loop. That is its pre-existing meaning, so nothing regresses,
but a front end that meant a re-broadcast gets no warning. The mitigation is the
third commit below, which makes the downstream drop visible.

It runs **first** in aircc's pipeline. That placement is load-bearing:
`air-opt-memtile-dma-bds` folds such a loop into its single BD and drops the
trip count. Folding up front means every pass downstream sees exactly the IR it
saw when the count was hand-written.

The 15 front-end sites become `refeed()` loops. `air.refeed_count` no longer
appears in either `fused_decode.py` or `fused_decode_qwen.py`; it survives only
as a lowering artifact the compiler writes for itself.

## Second commit: gemma packet-flow routing

`gemma3_4b_q4nx` stopped compiling on the mlir-aie bump in #1782:

```
'aie.packet_flow' op packet flow source (4, 1) DMA0 could not be routed to
destination (2, 1) DMA0; the pathfinder produced an incomplete routing
```

This is independent of the refeed work -- it reproduces on pristine `main` at
778c9372 -- but `main` is currently broken for gemma, so it is fixed here.

Running both pathfinders over the identical pre-routing IR: the previously
installed mlir-aie (`db06374d`) routes all three `@xnorm` senders and lands
three arrivals on (2,1) DMA0, taking the col-5 sender down through the shim row
and the col-4 sender up through the compute row; the new pin cannot route it at
all. So it is a routing capability regression in `db06374d..f501f215`, not a
latent incomplete route that mlir-aie #3514's new diagnostic merely exposed.
The only router change in that range is mlir-aie #3472; that attribution is
from file-level inspection, not a bisect, and is worth reporting upstream
separately.

Gemma is the only model that strains this merge: its per-column egress lands a
group memtile on every proj column, which pushes `MAIN_PCOL` onto the X column
(`MAIN_PCOL == XMT_PCOL == 2`), so those detours thread switches already
carrying hub traffic. Llama keeps its hub on col 1 and routes from col 4 fine.
Putting the down memtile on the adjacent free col 3 when the hub shares the X
column restores a fully-routed design.

## Third commit: the silent drop, named

`foldForLoopNestAsExtendedSizesAndStrides` (`Util.cpp`) skips an enclosing loop
whose channel op does not use the induction variable, because under
`skipZeroStride` the resulting stride-0 dimension is not expressible. The
dimension goes and the repeat goes with it -- N transfers become one, with no
diagnostic. That is precisely how these re-feed loops used to die.

This warns instead of staying silent. It does not refuse the fold: refusing
would leave the loop in place and change codegen for every design that reaches
here, which wants its own change with the e2e suite behind it. No warning fires
on any of the four designs, since air-annotate-refeed collapses their loops
first.

## Validation

Compiled output IR through the **real aircc pipeline**, loop form vs the
attribute form on the same binaries -- zero differing `aie.lock`, `aie.buffer`,
`aie.dma_bd`, `aie.use_lock`, `aie.next_bd` or `aie.dma_start`:

| model | hw-op diffs | residual |
|---|---|---|
| llama32_1b_q4nx | 0 | 8 lines of unlowered `air.channel` metadata |
| llama32_3b_q4nx | 0 | 8 |
| gemma3_4b_q4nx | 0 | 8 |
| qwen (`fused_decode_qwen.py`) | 0 | 6 |

Re-run after the pass merge; unchanged.

NPU2 hardware, caches cleared and every xclbin rebuilt:

| model | `make verify` | perf (turbo) |
|---|---|---|
| llama32_1b_q4nx | PASS 2/2 | 47.49 / 48.61 / 47.71 tok/s (baseline 47.2) |
| llama32_3b_q4nx | PASS 2/2 | 20.50 / 20.54 / 20.45 tok/s (baseline 20.84), TTFT 2.07s |
| gemma3_4b_q4nx | PASS | 15.57 tok/s mean of 5 (baseline 15.5), TTFT 3.80-3.94s |

`check-air-mlir` clean, including 14 cases on the merged pass -- the six that
distinguish it from the version it extends (pure ops in the body, summing
accumulation, dynamic trip count, two puts, an extra async dependency, and the
unrecoverable-L2-alloc error), two for nesting (a 3x4 nest recording 12, and a
2x3 nest beside a 4-trip sibling recording 10), plus affine.for and both
carriers. The 3B attribute-form control also passes, confirming
the loop form is not carrying the result.

The correctness runs above are on this branch's build. The throughput figures
were taken in turbo on the immediately preceding build, which differs from this
one only by the unrelated commits it was stacked on -- a comment change in
`AIRToAIEPass.cpp` and a pass that is not in aircc's pipeline -- so the
generated AIE is the same; the machine has since dropped out of turbo, so they
are not re-measured here.

## Not covered

`fused_decode_qwen.py` has no end-to-end harness in-tree, so its 9 sites rest
on the IR gate alone -- and four of those are behind flags (`OREF_2HOP`,
`PH1_XCHAN`, `OREF_NOPUT`, `DOWN_PUT_SPLIT`) that are off in the shipped
config, so the gate does not reach them either.
