### PR TITLE
[AIR] Let the ping-pong labeler decline unsafe loops itself

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -83,7 +83,10 @@ jobs:
       - name: Get llvm-aie
         run: |
           source air-venv/bin/activate
-          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          # Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles
+          # xrt/50_multi_launch_attention and xrt/48_triton_matmul_ver4_strix_4x4_bf16_output
+          # on NPU2 (NaN outputs). Revert once fixed upstream.
+          python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       - name: Build and test mlir-air
         run: |

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -107,7 +107,10 @@ jobs:
       - name: Get llvm-aie
         run: |
           source air-venv/bin/activate
-          python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          # Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles
+          # xrt/50_multi_launch_attention and xrt/48_triton_matmul_ver4_strix_4x4_bf16_output
+          # on NPU2 (NaN outputs). Revert once fixed upstream.
+          python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       # The fused-decode inline-attn merge (programming_examples/fused_decode, used
       # by llama32_1b_q4nx) shells out to an `llvm-link` resolved from PATH, and it

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6163,7 +6163,7 @@ public:
     // row-block iteration) is expressed by air.refeed_count=N. The producing
     // core writes the buffer once and the DMA's count-free self-loop BD
     // re-reads it; the single core-side release must free N read-tokens so the
-    // BD fires N times. The count reaches the put via air-fold-refeed-loops,
+    // BD fires N times. The count reaches the put via air-annotate-refeed,
     // which runs at the head of the pipeline and collapses the N-trip loop the
     // front end writes; by the time air-to-aie sees the put the loop is gone
     // and N is on the op.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1613,9 +1613,97 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
   // iteration -- the K fills are sequential overwrites; doubling the buffer
   // doesn't decouple them and the downstream ping-pong transform miscompiles.
   // `allocsOut`, if non-null, receives the matched allocs on success.
+  // The transform duplicates exactly the allocs directly in `forOp`'s body;
+  // every other memref the body touches stays single. Two things break under
+  // that, and together they cover what designs used to opt out of by hand.
+  //
+  // (1) An alloc that would be duplicated must be dead on entry to the body.
+  // If the first access reads it, the value flows from one iteration into the
+  // next, and splitting it across the two instances gives each parity its own
+  // half of the accumulation. A channel.get filling the whole buffer is a
+  // definite write; an opaque callee may read, so it disqualifies.
+  // (Loop-carried accumulators reach this pass sunk into the body by
+  // air-fuse-alloc-dealloc, so they look per-iteration until you ask who
+  // touches them first.)
+  //
+  // (2) A memref that stays single must not be reachable by an op whose
+  // effects are unknown. A herd block argument is shared with the herd's
+  // other tiles under a handshake taken once per body, so a second write
+  // inside one handshake races it, and an opaque callee may be that writer.
+  // Ops that do model their effects are left alone: a read-only use is fine.
+  static bool isUnsafeToDuplicate(scf::ForOp forOp) {
+    // Each air.execute wraps a single memref.alloc and yields it as the
+    // non-token result at index 1 (see AIR.td and HoistMemallocInForPattern).
+    // Map both spellings to the bare alloc result so one buffer counts once.
+    llvm::DenseMap<Value, Value> aliasToCanonical;
+    for (auto exec : forOp.getOps<air::ExecuteOp>())
+      for (auto alloc : exec.getOps<memref::AllocOp>()) {
+        Value canonical = alloc->getResult(0);
+        aliasToCanonical[canonical] = canonical;
+        if (exec->getNumResults() >= 2)
+          aliasToCanonical[exec->getResults()[1]] = canonical;
+      }
+
+    auto isDefiniteWrite = [](Operation *op, Value v) {
+      if (auto get = dyn_cast<air::ChannelGetOp>(op))
+        return get.getMemref() == v;
+      auto effects = dyn_cast<MemoryEffectOpInterface>(op);
+      if (!effects)
+        return false;
+      return !effects.getEffectOnValue<MemoryEffects::Read>(v) &&
+             effects.getEffectOnValue<MemoryEffects::Write>(v).has_value();
+    };
+
+    bool unsafe = false;
+    llvm::SmallPtrSet<Value, 8> firstAccessSeen;
+    forOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      // Neither allocating, freeing, nor yielding a buffer out of the
+      // air.execute that produced it is an access to its contents.
+      if (isa<memref::AllocOp, memref::DeallocOp>(op) ||
+          op->hasTrait<OpTrait::IsTerminator>())
+        return WalkResult::advance();
+      for (auto operand : op->getOperands()) {
+        if (!isa<MemRefType>(operand.getType()))
+          continue;
+        if (auto it = aliasToCanonical.find(operand);
+            it != aliasToCanonical.end()) {
+          if (firstAccessSeen.insert(it->second).second &&
+              !isDefiniteWrite(op, operand))
+            unsafe = true;
+          continue;
+        }
+        auto blockArg = dyn_cast<BlockArgument>(operand);
+        if (blockArg && isa<air::HerdOp>(blockArg.getOwner()->getParentOp()) &&
+            !isa<MemoryEffectOpInterface>(op))
+          unsafe = true;
+      }
+      return unsafe ? WalkResult::interrupt() : WalkResult::advance();
+    });
+    return unsafe;
+  }
+
   static bool isPingPongCandidate(scf::ForOp forOp, StringRef omitMemorySpace,
                                   SmallVectorImpl<Operation *> *allocsOut) {
     if (forOp->hasAttr("unroll"))
+      return false;
+    // Labeling a loop unrolls its body by 2, which duplicates a nested loop
+    // and everything that loop allocates per trip. So an unsafe loop anywhere
+    // in the region tree disqualifies the enclosing candidate, exactly as the
+    // air.disable_ping_pong opt-out below does -- rejecting only the inner
+    // loop would instead release the outer one, which
+    // hasLabelableNestedFor had been suppressing, and duplicate a bigger
+    // buffer at a worse level.
+    if (isUnsafeToDuplicate(forOp))
+      return false;
+    bool nestedUnsafe = false;
+    forOp.getBody()->walk([&](scf::ForOp inner) -> WalkResult {
+      if (isUnsafeToDuplicate(inner)) {
+        nestedUnsafe = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (nestedUnsafe)
       return false;
     // User-facing opt-out: an scf.for in the candidate's region tree
     // (including the candidate itself) carrying `air.disable_ping_pong`
@@ -1667,63 +1755,6 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
           exec && exec->getNumResults() >= 2)
         aliasToCanonical[exec->getResults()[1]] = canonical;
     }
-
-    // The transform duplicates exactly the candidate allocs; every other
-    // memref the body touches stays single. Two rejections follow from that,
-    // and together they cover the cases designs used to opt out of by hand.
-    //
-    // (1) A candidate alloc must be dead on entry to the body. If the first
-    // access reads it, the value flows from one iteration into the next, and
-    // splitting it across the two instances gives each parity its own half of
-    // the accumulation. A channel.get filling the whole buffer is a definite
-    // write; an opaque callee may read, so it disqualifies. (Loop-carried
-    // accumulators reach this pass sunk into the body by
-    // air-fuse-alloc-dealloc, so they look per-iteration until you ask who
-    // touches them first.)
-    //
-    // (2) A memref that stays single must not be reachable by an op whose
-    // effects are unknown. A herd block argument is shared with the herd's
-    // other tiles under a handshake taken once per body, so a second write
-    // inside one handshake races it -- and an opaque callee may be that
-    // writer. Ops that do model their effects are left alone, since a
-    // read-only use is harmless.
-    auto isDefiniteWrite = [](Operation *op, Value v) {
-      if (auto get = dyn_cast<air::ChannelGetOp>(op))
-        return get.getMemref() == v;
-      auto effects = dyn_cast<MemoryEffectOpInterface>(op);
-      if (!effects)
-        return false;
-      return !effects.getEffectOnValue<MemoryEffects::Read>(v) &&
-             effects.getEffectOnValue<MemoryEffects::Write>(v).has_value();
-    };
-    bool unsafeToDuplicate = false;
-    llvm::SmallPtrSet<Value, 8> firstAccessSeen;
-    forOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      // Neither allocating, freeing, nor yielding a buffer out of the
-      // air.execute that produced it is an access to its contents.
-      if (isa<memref::AllocOp, memref::DeallocOp>(op) ||
-          op->hasTrait<OpTrait::IsTerminator>())
-        return WalkResult::advance();
-      for (auto operand : op->getOperands()) {
-        if (!isa<MemRefType>(operand.getType()))
-          continue;
-        if (auto it = aliasToCanonical.find(operand);
-            it != aliasToCanonical.end()) {
-          if (firstAccessSeen.insert(it->second).second &&
-              !isDefiniteWrite(op, operand))
-            unsafeToDuplicate = true;
-          continue;
-        }
-        auto blockArg = dyn_cast<BlockArgument>(operand);
-        if (blockArg && isa<air::HerdOp>(blockArg.getOwner()->getParentOp()) &&
-            !isa<MemoryEffectOpInterface>(op))
-          unsafeToDuplicate = true;
-      }
-      return unsafeToDuplicate ? WalkResult::interrupt()
-                               : WalkResult::advance();
-    });
-    if (unsafeToDuplicate)
-      return false;
 
     // Reject if any candidate alloc has >1 channel.get/iter, or if any
     // intervening loop has a non-static trip count (can't bound the count).

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1668,6 +1668,60 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
         aliasToCanonical[exec->getResults()[1]] = canonical;
     }
 
+    // The transform duplicates exactly the candidate allocs; every other
+    // memref the body touches stays single. Two rejections follow from that,
+    // and together they cover the cases designs used to opt out of by hand.
+    //
+    // (1) A candidate alloc must be dead on entry to the body. If the first
+    // access reads it, the value flows from one iteration into the next, and
+    // splitting it across the two instances gives each parity its own half of
+    // the accumulation. A channel.get filling the whole buffer is a definite
+    // write; an opaque callee may read, so it disqualifies. (Loop-carried
+    // accumulators reach this pass sunk into the body by
+    // air-fuse-alloc-dealloc, so they look per-iteration until you ask who
+    // touches them first.)
+    //
+    // (2) A memref that stays single must not be written by the body. A herd
+    // block argument is shared with the herd's other tiles under a handshake
+    // taken once per body; running the body twice per handshake races it.
+    auto isDefiniteWrite = [](Operation *op, Value v) {
+      if (auto get = dyn_cast<air::ChannelGetOp>(op))
+        return get.getMemref() == v;
+      auto effects = dyn_cast<MemoryEffectOpInterface>(op);
+      if (!effects)
+        return false;
+      return !effects.getEffectOnValue<MemoryEffects::Read>(v) &&
+             effects.getEffectOnValue<MemoryEffects::Write>(v).has_value();
+    };
+    bool unsafeToDuplicate = false;
+    llvm::SmallPtrSet<Value, 8> firstAccessSeen;
+    forOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      // Neither allocating, freeing, nor yielding a buffer out of the
+      // air.execute that produced it is an access to its contents.
+      if (isa<memref::AllocOp, memref::DeallocOp>(op) ||
+          op->hasTrait<OpTrait::IsTerminator>())
+        return WalkResult::advance();
+      for (auto operand : op->getOperands()) {
+        if (!isa<MemRefType>(operand.getType()))
+          continue;
+        if (auto it = aliasToCanonical.find(operand);
+            it != aliasToCanonical.end()) {
+          if (firstAccessSeen.insert(it->second).second &&
+              !isDefiniteWrite(op, operand))
+            unsafeToDuplicate = true;
+          continue;
+        }
+        auto blockArg = dyn_cast<BlockArgument>(operand);
+        if (blockArg && isa<air::HerdOp>(blockArg.getOwner()->getParentOp()) &&
+            !isa<MemoryEffectOpInterface>(op))
+          unsafeToDuplicate = true;
+      }
+      return unsafeToDuplicate ? WalkResult::interrupt()
+                               : WalkResult::advance();
+    });
+    if (unsafeToDuplicate)
+      return false;
+
     // Reject if any candidate alloc has >1 channel.get/iter, or if any
     // intervening loop has a non-static trip count (can't bound the count).
     //

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -1681,9 +1681,12 @@ struct LabelScfForLoopForPingPongPattern : public OpRewritePattern<scf::ForOp> {
     // air-fuse-alloc-dealloc, so they look per-iteration until you ask who
     // touches them first.)
     //
-    // (2) A memref that stays single must not be written by the body. A herd
-    // block argument is shared with the herd's other tiles under a handshake
-    // taken once per body; running the body twice per handshake races it.
+    // (2) A memref that stays single must not be reachable by an op whose
+    // effects are unknown. A herd block argument is shared with the herd's
+    // other tiles under a handshake taken once per body, so a second write
+    // inside one handshake races it -- and an opaque callee may be that
+    // writer. Ops that do model their effects are left alone, since a
+    // read-only use is harmless.
     auto isDefiniteWrite = [](Operation *op, Value v) {
       if (auto get = dyn_cast<air::ChannelGetOp>(op))
         return get.getMemref() == v;

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -3310,8 +3310,9 @@ static air::ChannelPutOp matchRefeedLoop(Operation *loopOp, Block *body,
   // The async dependency is exempt from the invariance check: it is the carried
   // token, a block argument by construction, re-spliced when the loop is
   // erased.
-  llvm::SmallPtrSet<Value, 2> deps(llvm::from_range,
-                                   put.getAsyncDependencies());
+  llvm::SmallPtrSet<Value, 2> deps;
+  deps.insert(put.getAsyncDependencies().begin(),
+              put.getAsyncDependencies().end());
   for (auto operand : put->getOperands()) {
     if (deps.contains(operand))
       continue;

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_unsafe_to_duplicate.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_unsafe_to_duplicate.mlir
@@ -152,3 +152,58 @@ func.func @herd_without_shared_arg(%shared: memref<32xbf16, 2>) {
   }
   return
 }
+
+// -----
+
+// Labeling a loop unrolls its body by 2, which duplicates a nested loop and
+// whatever that loop allocates per trip. So an unsafe inner loop disqualifies
+// the outer candidate as well. Rejecting only the inner one would instead
+// release the outer, which the deepest-qualifying-loop rule had been
+// suppressing, and duplicate a bigger buffer at a worse level.
+
+// CHECK-LABEL: @nested_unsafe_disqualifies_outer
+// CHECK-NOT: hoist_alloc
+// CHECK-NOT: unroll
+air.channel @c4 [1, 1]
+air.channel @c5 [1, 1]
+func.func private @accum(memref<64xbf16, 2>, memref<16xf32, 2>)
+func.func @nested_unsafe_disqualifies_outer() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %t = air.wait_all async
+  %outer = scf.for %i = %c0 to %c4 step %c1 iter_args(%tok = %t) -> (!air.async.token) {
+    %tok0, %big = air.execute [%tok] -> (memref<4096xbf16, 2>) {
+      %alloc = memref.alloc() : memref<4096xbf16, 2>
+      air.execute_terminator %alloc : memref<4096xbf16, 2>
+    }
+    %g = air.channel.get async [%tok0] @c4[] (%big[] [] []) : (memref<4096xbf16, 2>)
+    %inner = scf.for %j = %c0 to %c8 step %c1 iter_args(%itok = %g) -> (!air.async.token) {
+      %tok1, %buf = air.execute [%itok] -> (memref<64xbf16, 2>) {
+        %alloc = memref.alloc() : memref<64xbf16, 2>
+        air.execute_terminator %alloc : memref<64xbf16, 2>
+      }
+      %tok2, %acc = air.execute -> (memref<16xf32, 2>) {
+        %alloc = memref.alloc() : memref<16xf32, 2>
+        air.execute_terminator %alloc : memref<16xf32, 2>
+      }
+      %g2 = air.channel.get async [%tok1] @c5[] (%buf[] [] []) : (memref<64xbf16, 2>)
+      %tok3 = air.execute [%g2, %tok2] {
+        func.call @accum(%buf, %acc) : (memref<64xbf16, 2>, memref<16xf32, 2>) -> ()
+      }
+      %tok4 = air.execute [%tok3] {
+        memref.dealloc %buf : memref<64xbf16, 2>
+      }
+      %tok5 = air.execute [%tok3] {
+        memref.dealloc %acc : memref<16xf32, 2>
+      }
+      scf.yield %tok4 : !air.async.token
+    }
+    %tok6 = air.execute [%inner] {
+      memref.dealloc %big : memref<4096xbf16, 2>
+    }
+    scf.yield %tok6 : !air.async.token
+  }
+  return
+}

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_unsafe_to_duplicate.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/label_ping_pong_unsafe_to_duplicate.mlir
@@ -1,0 +1,154 @@
+//===- label_ping_pong_unsafe_to_duplicate.mlir ----------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-label-scf-for-to-ping-pong --split-input-file | FileCheck %s
+
+// The transform duplicates exactly the allocs it labels; every other memref the
+// body touches stays single. These two shapes break under that, so the labeler
+// declines them instead of making the design opt out by hand.
+
+// Positive control: the alloc is filled by a channel.get before the callee sees
+// it, so nothing carries into the next iteration. Labeled.
+
+// CHECK-LABEL: @dead_on_entry
+// CHECK: memref.alloc() {hoist_alloc = true} : memref<64xbf16, 2>
+// CHECK: } {unroll = 2 : i32}
+air.channel @c0 [1, 1]
+func.func private @use(memref<64xbf16, 2>)
+func.func @dead_on_entry() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %t = air.wait_all async
+  %r = scf.for %i = %c0 to %c8 step %c1 iter_args(%tok = %t) -> (!air.async.token) {
+    %tok0, %buf = air.execute [%tok] -> (memref<64xbf16, 2>) {
+      %alloc = memref.alloc() : memref<64xbf16, 2>
+      air.execute_terminator %alloc : memref<64xbf16, 2>
+    }
+    %g = air.channel.get async [%tok0] @c0[] (%buf[] [] []) : (memref<64xbf16, 2>)
+    %tok1 = air.execute [%g] {
+      func.call @use(%buf) : (memref<64xbf16, 2>) -> ()
+    }
+    %tok2 = air.execute [%tok1] {
+      memref.dealloc %buf : memref<64xbf16, 2>
+    }
+    scf.yield %tok2 : !air.async.token
+  }
+  return
+}
+
+// -----
+
+// An opaque callee reaches the alloc first, so it may read what the previous
+// iteration left there. Duplicating it would give each parity its own half of
+// the accumulation. (Accumulators arrive here sunk into the body by
+// air-fuse-alloc-dealloc, which is why they look per-iteration.)
+
+// CHECK-LABEL: @live_across_iterations
+// CHECK-NOT: hoist_alloc
+// CHECK-NOT: unroll
+air.channel @c1 [1, 1]
+func.func private @accumulate(memref<64xbf16, 2>, memref<16xf32, 2>)
+func.func @live_across_iterations() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %t = air.wait_all async
+  %r = scf.for %i = %c0 to %c8 step %c1 iter_args(%tok = %t) -> (!air.async.token) {
+    %tok0, %buf = air.execute [%tok] -> (memref<64xbf16, 2>) {
+      %alloc = memref.alloc() : memref<64xbf16, 2>
+      air.execute_terminator %alloc : memref<64xbf16, 2>
+    }
+    %tok1, %acc = air.execute -> (memref<16xf32, 2>) {
+      %alloc = memref.alloc() : memref<16xf32, 2>
+      air.execute_terminator %alloc : memref<16xf32, 2>
+    }
+    %g = air.channel.get async [%tok0] @c1[] (%buf[] [] []) : (memref<64xbf16, 2>)
+    %tok2 = air.execute [%g, %tok1] {
+      func.call @accumulate(%buf, %acc) : (memref<64xbf16, 2>, memref<16xf32, 2>) -> ()
+    }
+    %tok3 = air.execute [%tok2] {
+      memref.dealloc %buf : memref<64xbf16, 2>
+    }
+    %tok4 = air.execute [%tok2] {
+      memref.dealloc %acc : memref<16xf32, 2>
+    }
+    scf.yield %tok3 : !air.async.token
+  }
+  return
+}
+
+// -----
+
+// The score buffer enters as a herd argument, so it is shared with the herd's
+// other tiles and the transform leaves it single. The handshake around it is
+// taken once per body; running the body twice per handshake races it.
+
+// CHECK-LABEL: @writes_shared_herd_arg
+// CHECK-NOT: hoist_alloc
+// CHECK-NOT: unroll
+air.channel @c2 [1, 1]
+func.func private @score(memref<64xbf16, 2>, memref<32xbf16, 2>)
+func.func @writes_shared_herd_arg(%shared: memref<32xbf16, 2>) {
+  %c1 = arith.constant 1 : index
+  air.herd @h tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%s=%shared) : memref<32xbf16, 2> {
+    %h0 = arith.constant 0 : index
+    %h1 = arith.constant 1 : index
+    %h8 = arith.constant 8 : index
+    %t = air.wait_all async
+    %r = scf.for %i = %h0 to %h8 step %h1 iter_args(%tok = %t) -> (!air.async.token) {
+      %tok0, %buf = air.execute [%tok] -> (memref<64xbf16, 2>) {
+        %alloc = memref.alloc() : memref<64xbf16, 2>
+        air.execute_terminator %alloc : memref<64xbf16, 2>
+      }
+      %g = air.channel.get async [%tok0] @c2[] (%buf[] [] []) : (memref<64xbf16, 2>)
+      %tok1 = air.execute [%g] {
+        func.call @score(%buf, %s) : (memref<64xbf16, 2>, memref<32xbf16, 2>) -> ()
+      }
+      %tok2 = air.execute [%tok1] {
+        memref.dealloc %buf : memref<64xbf16, 2>
+      }
+      scf.yield %tok2 : !air.async.token
+    }
+  }
+  return
+}
+
+// -----
+
+// Same herd, same loop, but the callee only sees the per-iteration buffer. The
+// herd wrapper by itself is not what disqualifies the case above.
+
+// CHECK-LABEL: @herd_without_shared_arg
+// CHECK: memref.alloc() {hoist_alloc = true} : memref<64xbf16, 2>
+// CHECK: } {unroll = 2 : i32}
+air.channel @c3 [1, 1]
+func.func private @local(memref<64xbf16, 2>)
+func.func @herd_without_shared_arg(%shared: memref<32xbf16, 2>) {
+  %c1 = arith.constant 1 : index
+  air.herd @h tile (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%s=%shared) : memref<32xbf16, 2> {
+    %h0 = arith.constant 0 : index
+    %h1 = arith.constant 1 : index
+    %h8 = arith.constant 8 : index
+    %t = air.wait_all async
+    %r = scf.for %i = %h0 to %h8 step %h1 iter_args(%tok = %t) -> (!air.async.token) {
+      %tok0, %buf = air.execute [%tok] -> (memref<64xbf16, 2>) {
+        %alloc = memref.alloc() : memref<64xbf16, 2>
+        air.execute_terminator %alloc : memref<64xbf16, 2>
+      }
+      %g = air.channel.get async [%tok0] @c3[] (%buf[] [] []) : (memref<64xbf16, 2>)
+      %tok1 = air.execute [%g] {
+        func.call @local(%buf) : (memref<64xbf16, 2>) -> ()
+      }
+      %tok2 = air.execute [%tok1] {
+        memref.dealloc %buf : memref<64xbf16, 2>
+      }
+      scf.yield %tok2 : !air.async.token
+    }
+  }
+  return
+}

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -113,8 +113,8 @@ _compile_decode_build: preflight-llvm-link
 	@echo ">>> template decode_L2048 (+ L2047 slope ref) [region-major KV + fire-and-free readback + inline attn]"
 	@# The two same-ATTN_MAXL builds (L2048 + L2047) calibrate the L-slope so DecodeInstsGen can
 	@# patch any context length in [1, 2048] into one template at runtime (recompile-free decode).
-	@# The block loop is always single-buffered (air.disable_ping_pong, unconditional in
-	@# fused_decode.py); without it the KV ring misaligns -> garbage continuation. Turbo for ~50 tok/s.
+	@# The block loop is single-buffered: air-label-scf-for-to-ping-pong declines it, because the
+	@# running max and accumulator are live across blocks. Turbo for ~50 tok/s.
 	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=2048 python3 $(DECODE_DRIVER) >/tmp/decode_L2048.log 2>&1; \
 	  if [ -f decode.xclbin ]; then mv -f decode.xclbin decode_L2048.xclbin; mv -f decode.insts.bin decode_L2048.insts.bin; \
 	  else echo "decode_L2048 FAILED (see /tmp/decode_L2048.log)"; exit 1; fi

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -117,7 +117,8 @@ make gen         # prefill+decode Paris gate -> *** PARIS ***
 
 Per-kernel `-O` is load-bearing (encoded in the Makefile): `proj_qmm` / `rms_residual` /
 `glu` / `rope` at `-O2`; `attn_qk` / `attn_kv` at `-O1` (a `-O2` do-while deadlock; and
-`rope` at `-O1` miscompiles). The rolled 128-block decode loop is always single-buffered
-(`air.disable_ping_pong`, unconditional in `fused_decode.py`) to keep the KV ring aligned.
+`rope` at `-O1` miscompiles). The rolled 128-block decode loop is single-buffered:
+`air-label-scf-for-to-ping-pong` declines it, because the running max and accumulator are
+live across blocks and the score buffer is shared with the kv tile.
 Enable turbo for ~50 tok/s:
 `xrt-smi configure -d <BDF> --pmode turbo`.

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -409,9 +409,8 @@ def _set_attn_link(op, base):
 
 # The attention block loop is a compile-time ATTN_ROUNDS (=ceil(ATTN_MAXL/16)) loop; the kernel
 # masks/skips blocks beyond the runtime RTP-L so one ATTN_MAXL build serves every L. That loop is
-# ALWAYS single-buffered (air.disable_ping_pong, set unconditionally below): ping-pong would
-# unroll-by-2 + 1-remainder over a 3-buffer toK/toV ring whose remainder reads the wrong buffer vs
-# the DMA rotation -> misaligned KV -> coherent first token then garbage chat.
+# single-buffered: air-label-scf-for-to-ping-pong declines it because the running max and
+# accumulator are live across blocks and the score buffer is shared with the kv tile.
 # DECODE_RB_ROUNDS overrides the shim KV-readback nd-DMA outer block count (default ATTN_ROUNDS).
 # Used to (a) locate the readback-count word in insts.bin by diffing two builds, and (b) let the
 # host patch it to ceil(L/16) per token so the shim pushes exactly what the runtime core consumes.
@@ -2271,9 +2270,6 @@ def build_module():
                                     # 1-remainder over a 3-buffer toK ring whose remainder reads
                                     # the wrong buffer vs the DMA rotation -> misaligned KV ->
                                     # garbage chat. Single-buffer is aligned.
-                                    _blk.owner.owner.attributes[
-                                        "air.disable_ping_pong"
-                                    ] = UnitAttr.get()
                                     a_k = AllocOp(ak_l1, [], [])
                                     ChannelGet("toK", a_k, indices=[idx(_c)])
                                     blk_c = arith.index_cast(i32, _blk)
@@ -2300,9 +2296,6 @@ def build_module():
                                     # REQUIRED single-buffer (see _qk_body): keeps toV/toK
                                     # consumption aligned with the DMA rotation (no unroll-by-2
                                     # remainder desync -> no misaligned KV).
-                                    _blk.owner.owner.attributes[
-                                        "air.disable_ping_pong"
-                                    ] = UnitAttr.get()
                                     a_v = AllocOp(av_l1, [], [])
                                     ChannelGet("toV", a_v, indices=[idx(_c)])
                                     blk_c = arith.index_cast(i32, _blk)
@@ -2951,8 +2944,6 @@ def build_module():
                             # drained K-block. Total x-sends = VOCAB_RNDS, drain blocks =
                             # VOCAB_RNDS*PAYLOAD/K. rms recompute per round is negligible vs
                             # the vocab GEMV (matches the reference re-running rms per row-block).
-                            # air.disable_ping_pong keeps single-buffer rings (a_xnl / a_v
-                            # reused; fill==drain, trivially aligned; lm_head not perf-crit).
                             a_v = AllocOp(rms_l1, [], [])
                             _voc_blks_2k = VOCAB_RNDS * PAYLOAD // K
                             _xn_per_blk = K // PAYLOAD  # = VOCAB_RNDS // _voc_blks_2k
@@ -2965,13 +2956,7 @@ def build_module():
                                 f"{_xn_per_blk}"
                             )
                             for _rv in for_(idx(0), idx(_voc_blks_2k), idx(1)):
-                                _rv.owner.owner.attributes["air.disable_ping_pong"] = (
-                                    UnitAttr.get()
-                                )
                                 for _xr in for_(idx(0), idx(_xn_per_blk), idx(1)):
-                                    _xr.owner.owner.attributes[
-                                        "air.disable_ping_pong"
-                                    ] = UnitAttr.get()
                                     CallOp(_rms_final, [a_xnl, a_xl, a_wl, _arm])
                                     # Each vocab round emits x ONCE: VOCAB_RNDS
                                     # distinct puts give VOCAB_RNDS broadcasts,

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -124,7 +124,7 @@ def refeed(n, emit):
     """Re-send ONE resident buffer n times: an n-trip scf.for around a single
     air.channel.put. The body holds nothing but the put and no operand depends
     on the induction variable, so this is a re-broadcast, not n productions --
-    air-fold-refeed-loops recognizes the shape, collapses the loop, and derives
+    air-annotate-refeed recognizes the shape, collapses the loop, and derives
     the count for the lock init. n <= 1 emits the bare put."""
     if n <= 1:
         emit()
@@ -2936,7 +2936,7 @@ def build_module():
                             # AcquireGreaterEqual(N) unsatisfiable -> DEADLOCK, forcing the
                             # 9-wave split (2*I2<=63). Here we mirror the reference: re-normalize + put
                             # xnorm PER ROUND (a_xnl is rewritten each round, so this is n
-                            # productions and air-fold-refeed-loops leaves it alone). The
+                            # productions and air-annotate-refeed leaves it alone). The
                             # sends are INTERLEAVED with the outY->layerOut relay (this ONE
                             # rms core both produces x and relays logits, unlike the reference's split
                             # tiles) so the producer never serializes ahead of the drain and
@@ -2963,7 +2963,7 @@ def build_module():
                                     # matching the X memtile's VOCAB_RNDS*(K/(2*
                                     # COL_BLOCK)) gets. This loop re-runs rms into
                                     # a_xnl every trip, so it is n productions, not
-                                    # a re-broadcast, and air-fold-refeed-loops
+                                    # a re-broadcast, and air-annotate-refeed
                                     # leaves it alone.
                                     ChannelPut(
                                         "xnorm",

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -71,7 +71,7 @@ def refeed(n, emit):
     """Re-send ONE resident buffer n times: an n-trip scf.for around a single
     air.channel.put. The body holds nothing but the put and no operand depends
     on the induction variable, so this is a re-broadcast, not n productions --
-    air-fold-refeed-loops recognizes the shape, collapses the loop, and derives
+    air-annotate-refeed recognizes the shape, collapses the loop, and derives
     the count for the lock init. n <= 1 emits the bare put."""
     if n <= 1:
         emit()

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -425,11 +425,6 @@ ATTN_NOCOMPUTE = int(_os.environ.get("QWEN_ATTN_NOCOMPUTE", "0"))
 SKIP_QK = int(_os.environ.get("QWEN_SKIP_QK", "0")) or ATTN_NOCOMPUTE
 SKIP_KV = int(_os.environ.get("QWEN_SKIP_KV", "0")) or ATTN_NOCOMPUTE
 SKIP_KVFIN = int(_os.environ.get("QWEN_SKIP_KVFIN", "0")) or SKIP_KV
-# air.disable_ping_pong on the attn block loops forces the s/v/o handshake to
-# depth-1 (lock init 1). The reference's original double-buffers these (lock init 2, two
-# score buffers). QWEN_ATTN_PINGPONG=1 drops disable_ping_pong so AIR lowers the
-# depth-2 handshake reference uses (investigating the cross-tile-s deadlock).
-ATTN_PINGPONG = int(_os.environ.get("QWEN_ATTN_PINGPONG", "0"))
 # QWEN_SURROUND_NOCOMPUTE=1 (use ONLY with QWEN_ATTN=0): keep the ENTIRE base dataflow
 # (proj MVM + egress + X/weight feeds + rope/rms/glu channel gets+puts) but SKIP the
 # rope/rms/glu compute CallOps. COHERENT (not a header-skip): under ATTN=0/LOOPCLOSE=0
@@ -1838,10 +1833,6 @@ def build_module():
                         a_m = AllocOp(m_l1, [], [])
                         a_cc = AllocOp(c_l1, [], [])
                         for _blk in for_(idx(0), idx(ATTN_ROUNDS), idx(1)):
-                            if not ATTN_PINGPONG:
-                                _blk.owner.owner.attributes["air.disable_ping_pong"] = (
-                                    UnitAttr.get()
-                                )
                             a_k = AllocOp(ak_l1, [], [])
                             ChannelGet("toK", a_k, indices=[idx(cu)])
                             blk_c = arith.index_cast(i32, _blk)
@@ -1860,10 +1851,6 @@ def build_module():
                         a_l = AllocOp(lden_l1, [], [])
                         a_o = AllocOp(ao_l1, [], [])
                         for _blk in for_(idx(0), idx(ATTN_ROUNDS), idx(1)):
-                            if not ATTN_PINGPONG:
-                                _blk.owner.owner.attributes["air.disable_ping_pong"] = (
-                                    UnitAttr.get()
-                                )
                             a_v = AllocOp(av_l1, [], [])
                             ChannelGet("toV", a_v, indices=[idx(cu)])
                             blk_c = arith.index_cast(i32, _blk)

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -171,7 +171,8 @@ KV cache (`kv_view()`), and the prefill kernel cache is **seq_len-specific**
 **Decode** — the [`fused_decode`](../../fused_decode) example builds one fused xclbin (16 layers + LM
 head). The attention block loop reads `ceil(L/16)` KV blocks; blocks past `L` are
 skipped by the kernel so the online softmax is not contaminated, and the loop is
-always single-buffered (`air.disable_ping_pong`) to keep the KV ring aligned.
+single-buffered (`air-label-scf-for-to-ping-pong` declines it: the running max and
+accumulator are live across blocks).
 `decode_insts_gen.py` patches the per-token instruction words (RTP-L, KV-append
 offset) so one xclbin serves every `L`. The host performs embedding, sampling
 (`Sampler`: repetition/frequency penalties + temperature + top-k/top-p), chat

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -51,7 +51,9 @@ export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
 export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # Install llvm-aie
-python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+# Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles two NPU2 e2e
+# tests (NaN outputs). Keep in step with .github/workflows/. Revert once fixed upstream.
+python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"
 


### PR DESCRIPTION
`air-label-scf-for-to-ping-pong` duplicates exactly the allocs it marks `hoist_alloc`; every other memref the body touches stays single. It never checked that the loop tolerates that, so two shapes miscompiled, and the four Q4NX decode designs opted out by hand with 34 `air.disable_ping_pong` sites.

### The failure

1B at its production shape (`ATTN_ROUNDS=128`), attribute removed, old labeler: 832 differing hardware ops, `make verify` FAILs, diverging at step 1 on a token outside HF's top-5. Both defects are visible in the lowered attention core:

```mlir
scf.for %arg0 = 0 to 128 step 2 {
  call @attn_qk_blk(%buf11, %buf7,  %buf5, %buf6, %shared_l10, ...)
  call @attn_qk_blk(%buf11, %buf10, %buf9, %buf8, %shared_l10, ...)
```

1. **A loop-carried accumulator gets duplicated.** The running max (`%buf5`/`%buf9`) and accumulator (`%buf6`/`%buf8`) alternate, so even and odd blocks each keep half the accumulation. The front end allocates them *outside* the block loop; `air-fuse-alloc-dealloc` sinks them in, which is what makes them look per-iteration. Tracing the alloc position across the 50 pass dumps: pass 027 outside, pass 028 inside, labeling at pass 030.
2. **A shared buffer races.** `%shared_l10` is a single herd-argument buffer with one producer/consumer handshake per unrolled pair but two writes inside it, so block i+1 overwrites block i's scores before the kv tile reads them. Independent of the sink.

### The fix

Two rejections in `isPingPongCandidate`:

- A candidate alloc must be **dead on entry** — first access a definite write. A `channel.get` filling the buffer is; an opaque callee may read, so it disqualifies.
- A memref the transform leaves single must not be **reachable by an opaque op**. A herd block argument is shared with the herd's other tiles.

The attribute stays supported for designs that opt out for other reasons, e.g. `matmul_bf16_x_bfp16`'s L1 budget.

`label_ping_pong_unsafe_to_duplicate.mlir` has two negatives and two positive controls that isolate each check: case 2 differs from case 1 only by the accumulator, case 3 from case 4 only by whether the callee sees the herd argument.

### Front end

All 34 sites dropped, plus the now-dead `QWEN_ATTN_PINGPONG` flag and the stale prose. Compiled hardware is unchanged for gemma and qwen (0 differing hw ops, qwen 0 total diffs); the 1B and 3B differ only by the lm_head lock sequence, where ping-pong now engages and is fine.

### Verification

NPU2, each arm a full rebuild of compiler and driver from its own source state, three runs, turbo off:

| | correctness | tok/s shipped → final |
|---|---|---|
| 1B | `make verify` PASS 2/2 | 44.00 → 43.98 (−0.05%) |
| 3B | `make verify` PASS 2/2 | 20.12 → 20.15 (+0.13%) |
| gemma | Paris gate PASS | 15.23 → 15.21 (−0.13%) |

Every delta is below the within-arm spread (0.39 / 0.18 / 0.05) and they do not share a sign. `check-air-mlir`: 498 discovered, 484 passed, 0 failures.

### Not covered

- **Qwen has no run harness** — only its compiled IR was checked. The compiler change is not inert in general (it also halves ping-pong depth on the 1B's glu tile, which costs nothing measurable), so byte-identical IR against the unmodified driver rules out the driver edit mattering, not the compiler edit.
- **`AIRFuseAllocDeallocToLoopLike` still sinks loop-carried accumulators into loop bodies.** Check 1 stops ping-pong from acting on it, but the IR remains misleading for the next transform that reads it. Separate fix, wider blast radius.
