### PR TITLE
[programming_examples] Feed decode weights on both shim MM2S channels per column

### DIFF
--- a/programming_examples/fused_decode/.gitignore
+++ b/programming_examples/fused_decode/.gitignore
@@ -14,3 +14,7 @@ build_chess/
 air.mlir
 air.elf
 .decode_build_model
+
+# build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
+.decode_flags
+decode_qwen.flags

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -34,8 +34,9 @@ PEANO_KBASE    := -std=c++20 --target=aie2p-none-unknown-elf \
 # DECODE_GOLDEN=1 enables the post-attention-RMS decode path (a boolean flag; no
 # weight files are read at build time -- the compile is weight-free).
 # W_DUAL_CHAN=1 feeds each proj column's weights on BOTH of its shim MM2S channels
-# (@inW even fan steps / @inW2 odd) instead of ch0 only. It also changes the DDR
-# cascade order, so any consumer must pack its weights with the SAME flag -- the
+# (@inW0c{cx} takes the low half of the column's cascade rows, @inW1c{cx} the high
+# half) instead of ch0 only. It also changes the DDR cascade order, so any
+# consumer must pack its weights with the SAME flag -- the
 # llms/*_q4nx drivers read it from the environment and key their requant cache on
 # it. Inherited from the environment so a consumer can set it once for both the
 # build and the run.

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -33,7 +33,15 @@ PEANO_KBASE    := -std=c++20 --target=aie2p-none-unknown-elf \
   -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
 # DECODE_GOLDEN=1 enables the post-attention-RMS decode path (a boolean flag; no
 # weight files are read at build time -- the compile is weight-free).
-DECODE_ENV     := VOCAB_CHUNK_I2=14 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1
+# W_DUAL_CHAN=1 feeds each proj column's weights on BOTH of its shim MM2S channels
+# (@inW even fan steps / @inW2 odd) instead of ch0 only. It also changes the DDR
+# cascade order, so any consumer must pack its weights with the SAME flag -- the
+# llms/*_q4nx drivers read it from the environment and key their requant cache on
+# it. Inherited from the environment so a consumer can set it once for both the
+# build and the run.
+W_DUAL_CHAN    ?= 1
+DECODE_ENV     := VOCAB_CHUNK_I2=14 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1 \
+                  W_DUAL_CHAN=$(W_DUAL_CHAN)
 
 .PHONY: help compile-decode _compile_decode_build preflight-llvm-link clean
 
@@ -52,9 +60,12 @@ help:
 ## Build the fused decode: Peano kernels + two templates (decode_L2048 + decode_L2047
 ## slope ref). ~15 min. Weight-free (runtime BOs), like the prefill compile.
 ##
-## Idempotent: if both templates are already present, skip (the ~15 min build only
-## runs once). `make clean` forces a rebuild. Consumers that call this repeatedly
-## (e.g. the llama32_1b_q4nx verify + profile lits) thus pay the cost at most once.
+## Idempotent: if both templates are already present AND were built with the
+## current W_DUAL_CHAN setting, skip (the ~15 min build only runs once). `make clean`
+## forces a rebuild. Consumers that call this repeatedly (e.g. the llama32_1b_q4nx
+## verify + profile lits) thus pay the cost at most once. The .decode_flags stamp
+## exists because W_DUAL_CHAN changes the DDR weight layout: a warm template built
+## with the other setting would silently be fed the wrong blocks.
 ##
 ## REPRODUCIBILITY (toolchain): the inline-attn merge path shells out to an EXTERNAL
 ## `llvm-link` (resolved from PATH), which must be PRE-LIFETIME-CHANGE, i.e. LLVM < 23.
@@ -62,12 +73,17 @@ help:
 ## opt then rejects the merged IR ("Broken module found"). The preflight aborts on it.
 ## This is the same rule the lit harness gates on (lit.cfg.py, feature llvm_link_pre23);
 ## the two MUST agree -- see the preflight comment below.
+DECODE_FLAGS_STAMP := $(srcdir)/.decode_flags
+DECODE_FLAGS       := W_DUAL_CHAN=$(W_DUAL_CHAN)
+
 compile-decode:
 	@if [ -f $(srcdir)/decode_L2048.xclbin ] && [ -f $(srcdir)/decode_L2048.insts.bin ] \
-	    && [ -f $(srcdir)/decode_L2047.xclbin ] && [ -f $(srcdir)/decode_L2047.insts.bin ]; then \
-	  echo "Decode templates already built (decode_L2048 + decode_L2047); skipping. Run 'make clean' to force a rebuild."; \
+	    && [ -f $(srcdir)/decode_L2047.xclbin ] && [ -f $(srcdir)/decode_L2047.insts.bin ] \
+	    && [ "`cat $(DECODE_FLAGS_STAMP) 2>/dev/null`" = "$(DECODE_FLAGS)" ]; then \
+	  echo "Decode templates already built (decode_L2048 + decode_L2047, $(DECODE_FLAGS)); skipping. Run 'make clean' to force a rebuild."; \
 	else \
-	  $(MAKE) -f $(srcdir)/Makefile _compile_decode_build; \
+	  $(MAKE) -f $(srcdir)/Makefile _compile_decode_build \
+	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
 	fi
 
 ## Shared preflight for every inline-attn decode build. Any model driving this
@@ -126,5 +142,6 @@ _compile_decode_build: preflight-llvm-link
 ## Remove compiled kernels + decode templates.
 clean:
 	rm -f $(srcdir)/*.o $(srcdir)/*.ll $(srcdir)/decode.xclbin $(srcdir)/decode.insts.bin \
-	      $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
+	      $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin \
+	      $(DECODE_FLAGS_STAMP) 2>/dev/null || true
 	@echo "Kernels and decode templates removed. Rebuild with 'make compile-decode'."

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -57,6 +57,45 @@ per-block affine encoding regardless of model. That is why `llms/qwen25_3b_q4`
 quantizes the fp checkpoint directly rather than reading a bundle -- an affine
 bundle re-quantized into the symmetric device form would quantize twice.
 
+## Dual-MM2S weight feed (`W_DUAL_CHAN`, on by default)
+
+Batch-1 decode is a weight-streaming problem: every token reads every weight once,
+with no reuse. Each proj column's weights are therefore fed on **both** of that
+column's shim MM2S channels rather than ch0 alone, following FastFlowLM. Set
+`W_DUAL_CHAN=0` to fall back to the single-channel feed; the flag reaches both the
+build and the run (the DDR weight layout changes with it), and every consumer keys
+its requant cache and its `.decode_flags` template stamp on it, so the two can
+never silently disagree.
+
+Three things make it work, all mirroring FLM's `mem_C_1`:
+
+| | what | why |
+|---|---|---|
+| split axis | **spatial**, by cascade pair -- ch0 feeds rows 2/3, ch1 rows 4/5, on two independent lock cycles | a *temporal* split (alternating fan steps) gives every core one MM2S chain alternating between both channels' buffers, couples the two shim channels at every step, and deadlocks |
+| shim placement | per-column channels `@inW{0,1}c{cx}`, each pinned with `air.shim_col` | a `[NCX]` bundle cannot express a per-index column; unpinned, the extra flows steal the rms/rope column and silently violate *its* `air.shim_col` |
+| X memtile | on the hub column (`XMT_PCOL = MAIN_PCOL`) | FLM has **no** memtile in column 2. Leaving the 16-way X broadcast there alongside the shim feeds and both cores makes the pathfinder fail outright once the weight flows double |
+
+The DDR side is a pure permutation of the packed cascade
+(`pack_q4k_cascade(dual_chan=True)`), so each channel still reads one contiguous
+1-D run -- a strided feed cannot, because a 10240-element fan step exceeds the AIE2
+per-dim wrap limit and only a contiguous BD gets the wide `buffer_length` register.
+
+Measured on Strix (quiet box, `make profile N_TOKENS=64`, 3 runs each; the nightly
+dashboard numbers come from the Krackan Point runner instead):
+
+| model | single-channel | dual-channel | |
+|---|---|---|---|
+| Llama-3.2-1B | 46.2 tok/s | 52.3 tok/s | **1.13x** |
+| Llama-3.2-3B | 18.8 tok/s | 22.5 tok/s | **1.20x** |
+| Gemma3-4B | 15.2 tok/s | 17.1 tok/s | **1.12x** |
+| Qwen2.5-3B | 105.1 ms/tok | 105.5 ms/tok | none |
+
+Qwen gains nothing, and that is expected: it streams 1.91 GB/token at ~105 ms =
+**18.2 GB/s**, while the Llama-1B design already sustains 35.7 GB/s on four
+channels. Qwen's decode is not weight-bandwidth-bound (its layers do not
+pipeline), so doubling the channels cannot help. Check GB/s before assuming the
+feed is the bottleneck.
+
 ## Reproducibility (toolchain)
 
 `make compile-decode` merges an inline attention kernel into the core via an **external

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -324,21 +324,28 @@ GRP_PCOL = (
 # hub must NOT sit on a proj col. Put it on col 2, the X-broadcast memtile (5 free S2MM)
 # -- exactly FLM, whose hub mem_1_1 IS its X-broadcast memtile.
 # W_DUAL_CHAN=1: drive each proj column's weight stream on BOTH of its shim MM2S
-# channels (@inW = even fan steps, @inW2 = odd fan steps) instead of ch0 only.
-# Decode at batch 1 is ~92% weight streaming, and the reference feeds 2 MM2S per
-# weight column while we feed 1; the per-column bandwidth gap (10.2 vs 14.4 GB/s
-# on the SAME physical columns) says the column is not saturated by one channel.
+# channels (@inW0c{cx} and @inW1c{cx}) instead of ch0 only. Decode at batch 1 is
+# ~92% weight streaming, and the reference feeds 2 MM2S per weight column while we
+# feed 1; the per-column bandwidth gap (10.2 vs 14.4 GB/s on the SAME physical
+# columns) says the column is not saturated by one channel.
 #
-# The even/odd split is what makes both channels carry weights CONCURRENTLY: the
-# memtile drains the fan in a strict order, so a first-half/second-half split
-# would just run one channel then the other. It requires the host weight array to
-# be packed with pack_q4k_cascade(dual_chan=True), which lays each column's slab
-# out as [even steps | odd steps] so both channels feed contiguous 1D runs (a
-# strided even/odd feed cannot be one shim task -- the 10240-element fan step
-# exceeds the AIE2 per-dim wrap limit -- and would also lose the
-# air.coalesced_shim_feed cross-channel phase barrier). Exported so the weight
-# packers (llms/*_q4nx requant) key their cascade order and their cache off the
-# same flag as the build.
+# The split is SPATIAL, by cascade pair: channel 0 carries the low half of the
+# column's rows (cy 0..NCY/2-1) for every fan step, channel 1 the high half. Each
+# channel therefore feeds a DISJOINT set of cores through its own fan ring, so the
+# two run concurrently without ever being ordered against each other -- this is
+# FLM's layout (mem_C_1 takes shim ch0 on S2MM4 and ch1 on S2MM5, two independent
+# lock cycles). Each channel also reads one contiguous DDR run, so both stay single
+# 1D shim BDs and keep the air.coalesced_shim_feed cross-channel phase barrier.
+#
+# Do NOT split temporally (even/odd fan steps) instead: that makes every core's
+# MM2S BD chain alternate between the two channels' buffers, coupling the channels
+# at every step -- measured to deadlock on device. A temporal feed also cannot be a
+# single shim task, since the 10240-element fan step exceeds the AIE2 per-dim wrap
+# limit and only a contiguous 1D BD gets the wide buffer_length register.
+#
+# Requires the host weight array packed with pack_q4k_cascade(dual_chan=True).
+# Exported so the weight packers (llms/*_q4nx requant) key their cascade order and
+# their cache off the same flag as the build.
 W_DUAL_CHAN = int(_os.environ.get("W_DUAL_CHAN", "1"))
 
 

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -323,14 +323,50 @@ GRP_PCOL = (
 # 4 separate per-lead egress on 0-3, mirroring FLM mem_C_1 -- NO packet-merge), so the
 # hub must NOT sit on a proj col. Put it on col 2, the X-broadcast memtile (5 free S2MM)
 # -- exactly FLM, whose hub mem_1_1 IS its X-broadcast memtile.
+# W_DUAL_CHAN=1: drive each proj column's weight stream on BOTH of its shim MM2S
+# channels (@inW = even fan steps, @inW2 = odd fan steps) instead of ch0 only.
+# Decode at batch 1 is ~92% weight streaming, and the reference feeds 2 MM2S per
+# weight column while we feed 1; the per-column bandwidth gap (10.2 vs 14.4 GB/s
+# on the SAME physical columns) says the column is not saturated by one channel.
+#
+# The even/odd split is what makes both channels carry weights CONCURRENTLY: the
+# memtile drains the fan in a strict order, so a first-half/second-half split
+# would just run one channel then the other. It requires the host weight array to
+# be packed with pack_q4k_cascade(dual_chan=True), which lays each column's slab
+# out as [even steps | odd steps] so both channels feed contiguous 1D runs (a
+# strided even/odd feed cannot be one shim task -- the 10240-element fan step
+# exceeds the AIE2 per-dim wrap limit -- and would also lose the
+# air.coalesced_shim_feed cross-channel phase barrier). Exported so the weight
+# packers (llms/*_q4nx requant) key their cascade order and their cache off the
+# same flag as the build.
+W_DUAL_CHAN = int(_os.environ.get("W_DUAL_CHAN", "1"))
+
+
+def _wname(ci, cx):
+    """Weight channel name: the single @inW bundle when W_DUAL_CHAN is off, else
+    the per-column, shim-col-pinned channel for shim channel ci of column cx."""
+    return f"inW{ci}c{cx}" if W_DUAL_CHAN else "inW"
+
+
 MAIN_PCOL = 2 if MODEL["PAIR_ROWS"] == 1 else 1  # phys col of the main memtile
 # Faithful X-feed (reproducer core_2_2): the rms producer core
 # (tile_2_2, col2) normalizes raw X once and re-feeds it via an output-lock release
-# of N (= REFEED) into a 512 x_buffer (col2 memtile) that broadcasts 256-blocks to
-# the 16 proj cores. (the reference puts x_buffer on col1/mem_1_1, but col1 congestion makes
-# AIR's weight-fan MM2S a repeat_count BD; the golden uses col2, kept here.)
-RMS_PCOL = 2  # rms producer core + X memtile column
-XMT_PCOL = RMS_PCOL
+# of N (= REFEED) into a 512 x_buffer that broadcasts 256-blocks to the 16 proj
+# cores. (An older note here claimed col-1 congestion forced that x_buffer onto
+# col 2, away from the reference's mem_1_1. That is STALE: with W_DUAL_CHAN the
+# x_buffer sits on mem_1_1 exactly like the reference, and it has to -- see
+# XMT_PCOL below.)
+RMS_PCOL = 2  # rms producer core column
+# X-broadcast memtile column. W_DUAL_CHAN follows FLM and puts it on the MAIN/hub
+# memtile (mem_1_1) instead of col 2: FLM has NO memtile in column 2 at all -- that
+# column holds only the shim rms/rope feeds and the rms/rope cores -- and broadcasts
+# X from mem_1_1 DMA:4 to all 16 proj cores. Keeping the X memtile on col 2 while
+# also doubling the weight flows makes the pathfinder fail outright (it cannot even
+# route the one-hop rms->X xnorm packet flow tile_2_2 DMA1 -> mem_2_1 DMA0), because
+# col 2 would carry the shim feeds, both cores, AND a 16-way broadcast hub.
+# Overridable so the floorplan move can be A/B-tested independently of the
+# channel split (XMT_PCOL=1 with W_DUAL_CHAN=0 isolates the placement effect).
+XMT_PCOL = int(_os.environ.get("XMT_PCOL", MAIN_PCOL if W_DUAL_CHAN else RMS_PCOL))
 # Column of the glu-down memtile, the third producer converging on @xnorm (the
 # other two are the o-proj memtile on col 5 and the rms core itself). Distinct
 # from col 5 either way, so the convergence never merges o+down onto one MM2S
@@ -543,6 +579,7 @@ VOCAB_PER_COL = VOCAB_I2 * PAIR_ROWS * NCY * NBJ  # blocks/col per chunk
 # LM_HEAD=1 builds the vocab-mode sequence (IS_ATTN=0); default 0 = decode.
 LM_HEAD = int(_os.environ.get("LM_HEAD", "0"))
 
+
 # ===== UNIFIED single-launch decode+lm_head (one PDI, no multi-launch) =====
 # UNIFIED=1: ONE air.launch in for_(0, UNI_DEC+UNI_LM); per-wave arm =
 # (iv<UNI_DEC)?1:0 drives the herds' on-core index_switch AND a launch-scope
@@ -578,6 +615,10 @@ NBI_PH = [I2P[p] * PAIR_ROWS * NCX * NCY for p in range(NPH)]  # [96, 64, 512, 6
 PER_COL_PH = [(NBI_PH[p] // NCX) * NBJ_PH[p] for p in range(NPH)]  # per-phase NBJ
 W_FAN_STEPS = sum(pc // NCY for pc in PER_COL_PH)  # per col, all phases
 W_TOTAL_BLOCKS = sum(NBI_PH[p] * NBJ_PH[p] for p in range(NPH))  # packed q4k blocks
+if W_DUAL_CHAN:
+    # The split is spatial (each shim channel owns half the column's cores), so
+    # the only requirement is an even core count per column.
+    assert NCY % 2 == 0, f"W_DUAL_CHAN needs an even NCY (got {NCY})"
 # X 256-blocks the cores consume across all phases: per core per phase = I2*2
 # row-blocks, each reading NBJ_PH[p] 256-blocks of that phase's K. The X memtile
 # relays this many (matched put/get sizes -> balanced count-free ring, no deadlock).
@@ -759,7 +800,12 @@ def build_module():
         # X memtile = reproducer x_buffer: 512 (2 blocks) so the producer re-feed +
         # broadcast has the same slack as the reference; the proj cores' 256 ring chops it.
         xmt_l2 = MemRefType.get([2 * COL_BLOCK], bf16, memory_space=l2)
-        wfan_l2 = MemRefType.get([NCY * BLOCK_BF16], bf16, memory_space=l2)
+        # One fan get. W_DUAL_CHAN halves it: each shim channel feeds its own
+        # ring covering half the column's cores (FLM's w_buffer[0:5120] /
+        # w_buffer[5120:10240] split).
+        wfan_l2 = MemRefType.get(
+            [(NCY // (2 if W_DUAL_CHAN else 1)) * BLOCK_BF16], bf16, memory_space=l2
+        )
         grp_l2 = MemRefType.get([GRP_ROWS], bf16, memory_space=l2)
         main_l2 = MemRefType.get([MAIN_ROWS], bf16, memory_space=l2)
         relay_l2 = MemRefType.get(
@@ -979,7 +1025,29 @@ def build_module():
                 channel_decl("inKV", size=[N_ATTN_CU])
         channel_decl("attnO", size=[N_ATTN_CU])
         # W: host (per col) -> group memtile -> NCY cores.
-        channel_decl("inW", size=[NCX])
+        if W_DUAL_CHAN:
+            # PER-COLUMN channels, each PINNED to its own shim column, rather than
+            # one [NCX] bundle. Two reasons:
+            #   1. Both of a column's shim MM2S channels must sit on THAT column's
+            #      shim tile (that is the whole point -- 2x the per-column weight
+            #      bandwidth). The default placement does not guarantee it: adding
+            #      the second set of flows makes AIR hand shim col 2 to the col-1
+            #      weights and push the rms/rope feed (air.shim_col = RMS_PCOL) to
+            #      col 1, i.e. it silently violates that pin and swaps two
+            #      hand-placed columns.
+            #   2. air.shim_col is a per-DECL attribute, so a [NCX] bundle cannot
+            #      express "index k belongs on column PCOL[k]".
+            # This reproduces FLM's map exactly: shim col C ch0+ch1 -> mem_C_1 for
+            # C in PCOL, and shim col 2 -> the rms/rope tiles, with no cross-column
+            # weight route at all.
+            for _wc in range(NCX):
+                for _nm in (_wname(0, _wc), _wname(1, _wc)):
+                    _wch = channel_decl(_nm, size=[1])
+                    _wch.operation.attributes["air.shim_col"] = IntegerAttr.get(
+                        T.i32(), PCOL[_wc]
+                    )
+        else:
+            channel_decl("inW", size=[NCX])
         _wL2 = channel_decl("wL2ToL1", size=[NCX, NCY])
         _wL2.operation.attributes["air.shared_resident_ring"] = UnitAttr.get()
         # Output: leads -> group MT -> main MT -> id-demux egress.
@@ -1086,6 +1154,80 @@ def build_module():
 
                 blk = BLOCK_BF16
                 wstep = NCY * blk  # 10240 = one fan get
+
+                def _feed_wcol(_cx, _cbase, nsteps):
+                    """One proj column's weight slab for one phase.
+
+                    Single-channel (default): TWO contiguous puts on @inW so the
+                    shim-dma coalescer merges+tags them (air.coalesced_shim_feed =
+                    the cross-channel phase barrier); a single put would skip
+                    coalescing and lose that barrier.
+
+                    W_DUAL_CHAN: the slab is packed [low-row half | high-row half]
+                    (see pack_q4k_cascade(dual_chan=True)), so channel 0 takes the
+                    first half of the column -- every fan step's cy 0..NCY/2-1
+                    blocks -- and channel 1 the second. Each is still one contiguous
+                    run, and each is still fed as two puts so BOTH keep their
+                    coalesced tag and both appear in the phase group. A phase group
+                    is the 2*NCX distinct channels; the next phase's repeat opens a
+                    new group (AIRRtToNpuPass phase-barrier grouping).
+
+                    `_cx` is a Python int when W_DUAL_CHAN (per-column channels), and
+                    the scf.parallel bundle IV otherwise.
+                    """
+                    nch = 2 if W_DUAL_CHAN else 1
+                    cstep = wstep // nch  # this channel's per-step share
+                    span = nsteps * cstep  # elements per channel
+                    half = (nsteps // 2) * cstep  # step-aligned inner split
+                    for ci in range(nch):
+                        base = _cbase if ci == 0 else arith.addi(_cbase, idx(span))
+                        ch = _wname(ci, _cx)
+                        ix = [idx(0)] if W_DUAL_CHAN else [_cx]
+                        ChannelPut(
+                            ch,
+                            W,
+                            indices=ix,
+                            offsets=[base],
+                            sizes=[half],
+                            strides=[1],
+                        )
+                        ChannelPut(
+                            ch,
+                            W,
+                            indices=ix,
+                            offsets=[arith.addi(base, idx(half))],
+                            sizes=[span - half],
+                            strides=[1],
+                        )
+
+                def _feed_wcols(_wcol0, _colspan, nsteps):
+                    """Fan the phase's weight slab over the NCX proj columns.
+
+                    W_DUAL_CHAN uses per-column pinned channels, so the column index
+                    has to be a Python constant -> plain unrolled loop. Otherwise the
+                    bundle index must be an scf.parallel IV (canonical form; a
+                    temporal scf.for over a bundle index is a verifier error), and
+                    air-to-aie spatially unrolls it to the same per-column feeds.
+                    """
+                    if W_DUAL_CHAN:
+                        for _cxi in range(NCX):
+                            _cbase = (
+                                _wcol0 + _cxi * _colspan
+                                if isinstance(_wcol0, int)
+                                else arith.addi(_wcol0, idx(_cxi * _colspan))
+                            )
+                            if isinstance(_cbase, int):
+                                _cbase = idx(_cbase)
+                            _feed_wcol(_cxi, _cbase, nsteps)
+                        return
+                    _w0 = idx(_wcol0) if isinstance(_wcol0, int) else _wcol0
+                    for _cx in parallel_(NCX):
+                        _feed_wcol(
+                            _cx,
+                            arith.addi(_w0, arith.muli(_cx, idx(_colspan))),
+                            nsteps,
+                        )
+
                 for _layer in range(NLAYERS if a_iv is None else 1):
                     _wbase = _lb(W_LAYER)  # weights slab for this layer
                     _rbase = _lb(RMS_LAYER)  # rms weights slab for this layer
@@ -1191,27 +1333,7 @@ def build_module():
                             # coalescer merges+tags them (see the decode feed).
                             assert VOCAB_PER_COL % NCY == 0
                             _colspan = VOCAB_PER_COL * blk
-                            _half = _colspan // 2
-                            for _cx in parallel_(NCX):
-                                _cbase = arith.addi(
-                                    _vwb, arith.muli(_cx, idx(_colspan))
-                                )
-                                ChannelPut(
-                                    "inW",
-                                    W,
-                                    indices=[_cx],
-                                    offsets=[_cbase],
-                                    sizes=[_half],
-                                    strides=[1],
-                                )
-                                ChannelPut(
-                                    "inW",
-                                    W,
-                                    indices=[_cx],
-                                    offsets=[arith.addi(_cbase, idx(_half))],
-                                    sizes=[_colspan - _half],
-                                    strides=[1],
-                                )
+                            _feed_wcols(_vwb, _colspan, VOCAB_PER_COL // NCY)
                             # ATTENTION FULLY GATED OFF in vocab (gate-off 2026-07-15b):
                             # the 8 attn cores' bodies index_switch to an empty idle case
                             # in vocab, and every launch-scope attn channel (ropeLUT,
@@ -1456,36 +1578,17 @@ def build_module():
                                 per_col = PER_COL_PH[p]
                                 assert per_col % NCY == 0
                                 _colspan = per_col * blk
-                                _half = _colspan // 2
                                 # Spatial fan over the NCX proj columns: the bundle index
                                 # @inW[cx] must be an scf.parallel IV (canonical form; a
                                 # temporal scf.for over a bundle index is a verifier error).
-                                # Each column is one contiguous DDR block fed as TWO halves
-                                # so the shim-dma coalescer merges+tags them
-                                # (air.coalesced_shim_feed = the cross-channel phase barrier);
-                                # a single put would skip coalescing and lose that barrier.
+                                # Each column is one contiguous DDR block; _feed_wcol
+                                # emits it as TWO halves per shim channel so the
+                                # coalescer merges+tags them (air.coalesced_shim_feed =
+                                # the cross-channel phase barrier) -- a single put would
+                                # skip coalescing and lose that barrier.
                                 # air-to-aie spatially unrolls this to the per-column feeds.
                                 _wcol0 = _lo(_wbase, woff)  # _wbase + woff (col 0 base)
-                                for _cx in parallel_(NCX):
-                                    _cbase = arith.addi(
-                                        _wcol0, arith.muli(_cx, idx(_colspan))
-                                    )
-                                    ChannelPut(
-                                        "inW",
-                                        W,
-                                        indices=[_cx],
-                                        offsets=[_cbase],
-                                        sizes=[_half],
-                                        strides=[1],
-                                    )
-                                    ChannelPut(
-                                        "inW",
-                                        W,
-                                        indices=[_cx],
-                                        offsets=[arith.addi(_cbase, idx(_half))],
-                                        sizes=[_colspan - _half],
-                                        strides=[1],
-                                    )
+                                _feed_wcols(_wcol0, _colspan, per_col // NCY)
                                 woff += NCX * per_col * blk
                                 if MULTIBLK and p == 0:
                                     _emit_append()
@@ -1639,28 +1742,54 @@ def build_module():
                     # ===== weight fan: per col MT peels NCY blocks/(i,j) -> cores ==
                     # Phase-agnostic flat ring (reproducer single w_buffer): W_FAN_STEPS
                     # = total (i,j) steps across all phases; each get fans NCY cy.
+                    #
+                    # W_DUAL_CHAN emits ONE SUCH RING PER SHIM CHANNEL, each owning a
+                    # disjoint half of the column's cores -- @inW drives cy 0..NCY/2-1,
+                    # @inW2 drives the rest. This is FLM's mem_C_1 exactly: shim ch0 on
+                    # S2MM4 -> w_buffer[0:5120] -> MM2S0/1 -> rows 2/3, shim ch1 on
+                    # S2MM5 -> w_buffer[5120:] -> MM2S2/3 -> rows 4/5, on two
+                    # INDEPENDENT lock cycles. A SPATIAL split is what makes the two
+                    # channels usable: they share no consumer, so neither is ever
+                    # ordered against the other.
+                    #
+                    # A temporal split (@inW even fan steps / @inW2 odd) was tried and
+                    # DEADLOCKS the first decode dispatch: it gives every core a single
+                    # MM2S BD chain alternating between both channels' buffers, so the
+                    # two shim channels are cross-coupled at every fan step. FLM has no
+                    # such edge. Do not reintroduce it.
+                    _fan_groups = (
+                        [(0, 0, NCY // 2), (1, NCY // 2, NCY)]
+                        if W_DUAL_CHAN
+                        else [(0, 0, NCY)]
+                    )
                     for cx in range(NCX):
-                        for _ in for_(idx(0), idx(W_FAN_STEPS), idx(1)):
-                            wf = AllocOp(wfan_l2, [], [])
-                            wf.operation.attributes["air.memtile_col"] = (
-                                IntegerAttr.get(T.i32(), PCOL[cx])
-                            )
-                            wf.operation.attributes["air.no_split"] = UnitAttr.get()
-                            ChannelGet("inW", wf, indices=[idx(cx)])
-                            for cy in range(NCY):
-                                # 1D fixed-offset read (reproducer w_buffer MM2S
-                                # shape) so AIR detects the 2-buffer rotation ->
-                                # count-free next_bd ring (NOT a repeat_count BD).
-                                ChannelPut(
-                                    "wL2ToL1",
-                                    wf,
-                                    indices=[idx(cx), idx(cy)],
-                                    offsets=[cy * BLOCK_BF16],
-                                    sizes=[BLOCK_BF16],
-                                    strides=[1],
+                        for _ci, _cy0, _cy1 in _fan_groups:
+                            _wch = _wname(_ci, cx)
+                            for _ in for_(idx(0), idx(W_FAN_STEPS), idx(1)):
+                                wf = AllocOp(wfan_l2, [], [])
+                                wf.operation.attributes["air.memtile_col"] = (
+                                    IntegerAttr.get(T.i32(), PCOL[cx])
                                 )
-                            DeallocOp(wf)
-                            yield_([])
+                                wf.operation.attributes["air.no_split"] = UnitAttr.get()
+                                ChannelGet(
+                                    _wch,
+                                    wf,
+                                    indices=[idx(0) if W_DUAL_CHAN else idx(cx)],
+                                )
+                                for cy in range(_cy0, _cy1):
+                                    # 1D fixed-offset read (reproducer w_buffer MM2S
+                                    # shape) so AIR detects the 2-buffer rotation ->
+                                    # count-free next_bd ring (NOT a repeat_count BD).
+                                    ChannelPut(
+                                        "wL2ToL1",
+                                        wf,
+                                        indices=[idx(cx), idx(cy)],
+                                        offsets=[(cy - _cy0) * BLOCK_BF16],
+                                        sizes=[BLOCK_BF16],
+                                        strides=[1],
+                                    )
+                                DeallocOp(wf)
+                                yield_([])
 
                     # ===== output assembly + id-demux egress (count-free ring) =====
                     # ONE for_ loop over all rounds -> count-free next_bd rings (NOT

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -101,6 +101,25 @@ PROJ_ROW0 = 2  # physical row of grid ty=0
 # memtile on a column SEPARATE from its hub (col2 vs col1); QWEN_XMT_COL overrides for
 # the loopclose bisect.
 XMT_COL = int(_os.environ.get("QWEN_XMT_COL", "1"))
+
+# W_DUAL_CHAN=1: feed each proj column's weights on BOTH of its shim MM2S channels
+# instead of ch0 only, following FLM (its mem_C_1 takes shim ch0 on S2MM4 ->
+# w_buffer[0:5120] -> MM2S0/1 -> rows 2/3, and shim ch1 on S2MM5 -> w_buffer[5120:]
+# -> MM2S2/3 -> rows 4/5, on two INDEPENDENT lock cycles). The split is SPATIAL, by
+# cascade pair: each channel owns a disjoint half of the column's cores, so the two
+# are never ordered against each other. It also changes the DDR cascade order, so the
+# packer must run with the same flag (qwen25_3b_requant reads fd.W_DUAL_CHAN).
+# Qwen already has its X memtile on the hub column (XMT_COL=1), which is the
+# placement the llama engine had to move to before its dual feed would route.
+W_DUAL_CHAN = int(_os.environ.get("W_DUAL_CHAN", "1"))
+
+
+def _wname(ci, cx):
+    """Weight channel: the single @inW bundle when the flag is off, else the
+    per-column shim-col-pinned channel for shim channel ci of proj column cx."""
+    return f"inW{ci}c{cx}" if W_DUAL_CHAN else "inW"
+
+
 # X memtile get granularity (one packet per BD on the @xnorm packet channel).
 XCH = 2 * COL_BLOCK
 # attn-o (ph1 X) refeed memtile column. Default 6 (next to attn col 7), but that makes
@@ -517,7 +536,11 @@ def build_module():
 
         # ---- L2 memtile staging buffers ----
         xmt_l2 = MemRefType.get([2 * COL_BLOCK], bf16, memory_space=l2)  # 512
-        wfan_l2 = MemRefType.get([NCY * BLOCK_BF16], bf16, memory_space=l2)  # 4*2560
+        # one fan get; W_DUAL_CHAN halves it (each shim channel feeds its own ring
+        # covering half the column's cores -- FLM's w_buffer[0:5120]/[5120:] split).
+        wfan_l2 = MemRefType.get(
+            [(NCY // (2 if W_DUAL_CHAN else 1)) * BLOCK_BF16], bf16, memory_space=l2
+        )
         # per-col gather (reference y_buffer<130> = 2 hdr + 4x32; keeps core0's pkt header).
         col_l2 = MemRefType.get([2 + NCY * ROW_BLOCK], bf16, memory_space=l2)  # 130
         # hub gather (reference y_buffer<514> = 2 hdr + 4x128; keeps col0's pkt header).
@@ -625,7 +648,20 @@ def build_module():
             "inX", size=[1, 1], broadcast_shape=[NCX, NCY]
         )  # Xmt -> 16 cores
         _inX.operation.attributes["air.shared_resident_ring"] = UnitAttr.get()
-        channel_decl("inW", size=[NCX])  # host -> per-col W memtile
+        if W_DUAL_CHAN:
+            # Per-column channels PINNED to their own shim column. air.shim_col is a
+            # per-DECL attribute, so a [NCX] bundle cannot express "index k lives on
+            # column PROJ_COL0+k"; without the pin the extra flows perturb the whole
+            # hand-placed shim map (on the llama engine they stole the rms/rope
+            # column outright, silently violating ITS air.shim_col).
+            for _wc in range(NCX):
+                for _ci in range(2):
+                    _wch = channel_decl(_wname(_ci, _wc), size=[1])
+                    _wch.operation.attributes["air.shim_col"] = IntegerAttr.get(
+                        i32, PROJ_COL0 + _wc
+                    )
+        else:
+            channel_decl("inW", size=[NCX])  # host -> per-col W memtile
         channel_decl("wL2ToL1", size=[NCX, NCY])  # W memtile -> col cores
         # proj core egress is a PACKET flow (the reference: packet_flow(1/4/8) tile_C_r -> mem_C_1,
         # keep_pkt_header). The kernel-written id (flush_hdr @y+14) rides the packet so the
@@ -985,29 +1021,43 @@ def build_module():
 
                 def _feed_w_phase(p):
                     span_p = _RB[p] * _NJ[p] * STEP_BF16
-                    hp = span_p // 2
+                    nch = 2 if W_DUAL_CHAN else 1
+                    # per-channel share of this (col, phase) slab. W_DUAL_CHAN: the
+                    # packer laid the slab out [low-row half | high-row half], so
+                    # channel ci reads one contiguous run at cbase + ci*span_c.
+                    span_c = span_p // nch
+                    hp = span_c // 2
                     for cx in range(NCX):
                         cbase = (
                             _pbase[p] + cx * span_p
                             if W_PHASE_MAJOR
                             else cx * colspan + _woff[p]
                         )
-                        ChannelPut(
-                            "inW",
-                            W,
-                            indices=[idx(cx)],
-                            offsets=[_wo(cbase)],
-                            sizes=[idx(hp)],
-                            strides=[idx(1)],
-                        )
-                        ChannelPut(
-                            "inW",
-                            W,
-                            indices=[idx(cx)],
-                            offsets=[_wo(cbase + hp)],
-                            sizes=[idx(span_p - hp)],
-                            strides=[idx(1)],
-                        )
+                        for ci in range(nch):
+                            ch = _wname(ci, cx)
+                            # index built per put (not hoisted) so the flag-off IR stays
+                            # byte-identical: the original emitted one constant per put.
+                            wix = lambda: [idx(0) if W_DUAL_CHAN else idx(cx)]
+                            base = cbase + ci * span_c
+                            # two contiguous puts per channel so the shim coalescer
+                            # merges+tags them (air.coalesced_shim_feed); a single put
+                            # would skip coalescing and lose the phase barrier.
+                            ChannelPut(
+                                ch,
+                                W,
+                                indices=wix(),
+                                offsets=[_wo(base)],
+                                sizes=[idx(hp)],
+                                strides=[idx(1)],
+                            )
+                            ChannelPut(
+                                ch,
+                                W,
+                                indices=wix(),
+                                offsets=[_wo(base + hp)],
+                                sizes=[idx(span_c - hp)],
+                                strides=[idx(1)],
+                            )
 
                 # SPLIT THE WEIGHT FEED AROUND THE KV READBACK (mirror Llama's runtime
                 # sequence). The 4 phase groups are CONTIGUOUS in DDR per column, so the
@@ -1232,25 +1282,44 @@ def build_module():
                         _x_feed(_xsrc, X_CHUNKS)
 
                     # --- weight fan: per-col memtile peels NCY blocks/step -> cores ---
+                    # W_DUAL_CHAN emits ONE ring PER SHIM CHANNEL, each owning a
+                    # disjoint half of the column's cores (FLM's mem_C_1: ch0 -> rows
+                    # 2/3, ch1 -> rows 4/5, two independent lock cycles). A SPATIAL
+                    # split is what makes both channels usable -- they share no
+                    # consumer, so neither is ever ordered against the other. Do NOT
+                    # split temporally (alternating fan steps): that gives every core
+                    # one MM2S chain alternating between both channels' buffers and
+                    # deadlocks (proven on the llama engine).
+                    _fan_groups = (
+                        [(0, 0, NCY // 2), (1, NCY // 2, NCY)]
+                        if W_DUAL_CHAN
+                        else [(0, 0, NCY)]
+                    )
                     for cx in range(NCX):
-                        for _ in for_(idx(0), idx(W_FAN_STEPS), idx(1)):
-                            wf = AllocOp(wfan_l2, [], [])
-                            wf.operation.attributes["air.memtile_col"] = (
-                                IntegerAttr.get(T.i32(), PROJ_COL0 + cx)
-                            )
-                            wf.operation.attributes["air.no_split"] = UnitAttr.get()
-                            ChannelGet("inW", wf, indices=[idx(cx)])
-                            for cy in range(NCY):
-                                ChannelPut(
-                                    "wL2ToL1",
-                                    wf,
-                                    indices=[idx(cx), idx(cy)],
-                                    offsets=[cy * BLOCK_BF16],
-                                    sizes=[BLOCK_BF16],
-                                    strides=[1],
+                        for _ci, _cy0, _cy1 in _fan_groups:
+                            _wch = _wname(_ci, cx)
+                            for _ in for_(idx(0), idx(W_FAN_STEPS), idx(1)):
+                                wf = AllocOp(wfan_l2, [], [])
+                                wf.operation.attributes["air.memtile_col"] = (
+                                    IntegerAttr.get(T.i32(), PROJ_COL0 + cx)
                                 )
-                            DeallocOp(wf)
-                            yield_([])
+                                wf.operation.attributes["air.no_split"] = UnitAttr.get()
+                                ChannelGet(
+                                    _wch,
+                                    wf,
+                                    indices=[idx(0) if W_DUAL_CHAN else idx(cx)],
+                                )
+                                for cy in range(_cy0, _cy1):
+                                    ChannelPut(
+                                        "wL2ToL1",
+                                        wf,
+                                        indices=[idx(cx), idx(cy)],
+                                        offsets=[(cy - _cy0) * BLOCK_BF16],
+                                        sizes=[BLOCK_BF16],
+                                        strides=[1],
+                                    )
+                                DeallocOp(wf)
+                                yield_([])
 
                     # --- egress gather (mirror the reference/Llama _egress): BOTH hops INTERLEAVED
                     # in ONE round loop so they pipeline across tiles. SEPARATE put-loop
@@ -2138,6 +2207,12 @@ def build_module():
 
 def run():
     module = build_module()
+
+    # Emit-only hook (mirrors fused_decode.py): dump the built AIR MLIR and stop
+    # before the expensive NPU compile, so a no-op refactor can be byte-diffed.
+    if _os.environ.get("FUSED_DECODE_EMIT_ONLY"):
+        print(str(module))
+        return 0
     backend = XRTBackend(
         omit_while_true_loop=False,
         output_format="xclbin",
@@ -2155,7 +2230,15 @@ def run():
     art = backend.compile(
         module, output_binary_name="decode_qwen", insts="decode_qwen.insts.bin"
     )
-    print(f"[qwen_decode] emitted {art.output_binary} + {art.insts}")
+    # Stamp the flag next to the artifact. The Qwen decode has no Makefile build,
+    # so nothing else can stop qwen_prefill_to_decode from feeding a dual-layout
+    # weight stream to a single-channel xclbin (or vice versa) -- which produces
+    # silent garbage rather than an error. The runner checks this file.
+    with open("decode_qwen.flags", "w") as _f:
+        _f.write(f"W_DUAL_CHAN={W_DUAL_CHAN}\n")
+    print(
+        f"[qwen_decode] emitted {art.output_binary} + {art.insts} (W_DUAL_CHAN={W_DUAL_CHAN})"
+    )
     return 0
 
 

--- a/programming_examples/fused_decode/proj_qmm_pack.py
+++ b/programming_examples/fused_decode/proj_qmm_pack.py
@@ -57,7 +57,9 @@ def pack_q4k_block(q, scale, mn):
     return arr
 
 
-def pack_q4k_cascade(q, scale, mn, NCX, NCY, core_major=False, iter_major=False):
+def pack_q4k_cascade(
+    q, scale, mn, NCX, NCY, core_major=False, iter_major=False, dual_chan=False
+):
     """Pack an [M, K] q4 weight matrix in the memtile-cascade STREAM order
     [cx][i][j][cy], where each element is one 32x256 q4k block (BLOCK_BF16).
 
@@ -77,6 +79,21 @@ def pack_q4k_cascade(q, scale, mn, NCX, NCY, core_major=False, iter_major=False)
     -- while each core emits ONE contiguous packet (one header), a core-major
     layout where every Y BD is a plain linear transfer.
 
+    dual_chan=True (the two-MM2S-per-column weight feed): the column's stream is
+    split SPATIALLY, by cascade pair -- the low half of the rows (cy 0..NCY/2-1) is
+    emitted for every fan step, then the high half. This is FLM's layout: its
+    mem_C_1 takes shim ch0 on S2MM4 (writing w_buffer[0:5120], drained by MM2S0/1 to
+    rows 2/3) and shim ch1 on S2MM5 (w_buffer[5120:10240], drained by MM2S2/3 to
+    rows 4/5), with two INDEPENDENT lock cycles. Each channel therefore owns a
+    disjoint set of cores and never has to be ordered against the other; each also
+    reads one contiguous DDR run, so both stay single 1D shim BDs (a strided feed
+    cannot: the innermost dim exceeds the AIE2 per-dim wrap limit, and only a
+    contiguous 1D BD gets the wide buffer_length register).
+
+    Do NOT split temporally (even/odd fan steps) instead: that makes every core's
+    MM2S BD chain alternate between the two channels' buffers, which couples the two
+    shim channels at every step and deadlocks on device.
+
     Returns int16 [NCX*nbi_pc*nbj*NCY * BLOCK_BF16] = [nbi*nbj * BLOCK_BF16].
     """
     M, K = q.shape
@@ -85,28 +102,39 @@ def pack_q4k_cascade(q, scale, mn, NCX, NCY, core_major=False, iter_major=False)
     n_cores = NCX * NCY
     assert nbi % n_cores == 0, "row-blocks must split evenly across cores"
     nbi_pc = nbi // n_cores
+    steps = [(i, j) for i in range(nbi_pc) for j in range(nbj)]
+    # Per-column emission order: (step, cy) by default; dual_chan hoists the row
+    # half (the shim channel) outermost so each channel's share is contiguous.
+    if dual_chan:
+        assert NCY % 2 == 0, f"dual_chan needs an even NCY (got {NCY})"
+        order = [
+            (i, j, cy)
+            for h in range(2)
+            for (i, j) in steps
+            for cy in range(h * (NCY // 2), (h + 1) * (NCY // 2))
+        ]
+    else:
+        order = [(i, j, cy) for (i, j) in steps for cy in range(NCY)]
     blocks = []
     for cx in range(NCX):
-        for i in range(nbi_pc):
-            for j in range(nbj):
-                for cy in range(NCY):
-                    if iter_major:
-                        # iteration-major: rb = i*(NCX*NCY) + cx*NCY + cy.
-                        # iteration i owns a contiguous 16-row-block span, so the
-                        # natural QKV[M] emerges (Q=i0..3, K=i4, V=i5) and the
-                        # rope split sees K at rows 2048..2559 directly.
-                        gi = i * (NCX * NCY) + cx * NCY + cy
-                    elif core_major:
-                        gi = (cx * NCY + cy) * nbi_pc + i  # contiguous per core
-                    else:
-                        gi = cx * (NCY * nbi_pc) + i * NCY + cy  # global row-block
-                    rs, cs = gi * ROW_BLOCK, j * COL_BLOCK
-                    gs = j * (COL_BLOCK // GROUP)
-                    blocks.append(
-                        pack_q4k_block(
-                            q[rs : rs + ROW_BLOCK, cs : cs + COL_BLOCK],
-                            scale[rs : rs + ROW_BLOCK, gs : gs + N_GROUPS],
-                            mn[rs : rs + ROW_BLOCK, gs : gs + N_GROUPS],
-                        )
-                    )
+        for i, j, cy in order:
+            if iter_major:
+                # iteration-major: rb = i*(NCX*NCY) + cx*NCY + cy.
+                # iteration i owns a contiguous 16-row-block span, so the
+                # natural QKV[M] emerges (Q=i0..3, K=i4, V=i5) and the
+                # rope split sees K at rows 2048..2559 directly.
+                gi = i * (NCX * NCY) + cx * NCY + cy
+            elif core_major:
+                gi = (cx * NCY + cy) * nbi_pc + i  # contiguous per core
+            else:
+                gi = cx * (NCY * nbi_pc) + i * NCY + cy  # global row-block
+            rs, cs = gi * ROW_BLOCK, j * COL_BLOCK
+            gs = j * (COL_BLOCK // GROUP)
+            blocks.append(
+                pack_q4k_block(
+                    q[rs : rs + ROW_BLOCK, cs : cs + COL_BLOCK],
+                    scale[rs : rs + ROW_BLOCK, gs : gs + N_GROUPS],
+                    mn[rs : rs + ROW_BLOCK, gs : gs + N_GROUPS],
+                )
+            )
     return np.concatenate(blocks)

--- a/programming_examples/fused_decode/qwen25_3b_requant.py
+++ b/programming_examples/fused_decode/qwen25_3b_requant.py
@@ -125,7 +125,7 @@ def requant_q4_0(Wm, group=GROUP):
     return q.reshape(M, Kc).view(np.uint8), sc
 
 
-def pack_q4k_cascade_fast(q, scale, NCX, NCY):
+def pack_q4k_cascade_fast(q, scale, NCX, NCY, dual_chan=False):
     """Vectorized iteration-major cascade pack; == proj_qmm_pack.pack_q4k_cascade
     (iter_major=True) with all-zero mins, but packs every block at once.
 
@@ -171,6 +171,16 @@ def pack_q4k_cascade_fast(q, scale, NCX, NCY):
     cy = np.arange(NCY)[None, None, None, :]
     gi = np.broadcast_to(i * n_cores + cx * NCY + cy, (NCX, nbi_pc, nbj, NCY))
     gj = np.broadcast_to(j, (NCX, nbi_pc, nbj, NCY))
+    if dual_chan:
+        # Two-MM2S-per-column weight feed: hoist the ROW HALF (= the shim channel)
+        # to just inside cx, so each column's slab is [low-row half | high-row half]
+        # and each channel reads one contiguous DDR run. Matches FLM's mem_C_1
+        # (shim ch0 -> S2MM4 -> rows 2/3, shim ch1 -> S2MM5 -> rows 4/5) and the
+        # llama engine's pack_q4k_cascade(dual_chan=True).
+        assert NCY % 2 == 0, f"dual_chan needs an even NCY (got {NCY})"
+        sh = (NCX, nbi_pc, nbj, 2, NCY // 2)
+        gi = gi.reshape(sh).transpose(0, 3, 1, 2, 4)
+        gj = gj.reshape(sh).transpose(0, 3, 1, 2, 4)
     return blocks[gi.ravel(), gj.ravel()].reshape(-1)
 
 
@@ -244,6 +254,9 @@ def build_requant_cache(fd, cache_path, model=HF_REPO, n_layers=None, verbose=Tr
     hf = HFModel(model)
     aperm = attn_out_perm(fd)
     NCX, NCY, NPH, K = fd.NCX, fd.NCY, fd.NPH, fd.K
+    # Dual-MM2S weight feed: keyed off the SAME flag the decode was built with,
+    # so the cascade order can never disagree with the xclbin.
+    DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
     RB, NJ = fd._RB, fd._NJ
     DQ, DK, DV = fd.DQ, fd.DK, fd.DV
     INTER = fd.INTERMEDIATE
@@ -272,7 +285,10 @@ def build_requant_cache(fd, cache_path, model=HF_REPO, n_layers=None, verbose=Tr
         )
         ph[DP] = requant_q4_0(_pad_cols(R["down"], INTER))
         w = np.concatenate(
-            [pack_q4k_cascade_fast(*ph[p], NCX, NCY) for p in range(NPH)]
+            [
+                pack_q4k_cascade_fast(*ph[p], NCX, NCY, dual_chan=DUAL)
+                for p in range(NPH)
+            ]
         )
         assert w.size == W_LAYER, (w.size, W_LAYER)
         W_all.append(w)

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -124,15 +124,26 @@ def main():
 
     # The xclbin's weight layout is set by W_DUAL_CHAN at BUILD time; pack_layer
     # below uses the CURRENT module value. A mismatch is silent garbage, so refuse.
+    # The stamp sits next to the xclbin it describes. An UNREADABLE stamp is just
+    # as unsafe as a mismatched one (an xclbin built before the stamp existed has
+    # an unknown layout), so that is refused too rather than assumed compatible.
     _want = int(getattr(m, "W_DUAL_CHAN", 0))
+    _stamp = os.path.splitext(args.xclbin)[0] + ".flags"
     try:
-        with open("decode_qwen.flags") as _f:
+        with open(_stamp) as _f:
             _got = int(_f.read().strip().split("=")[1])
     except (OSError, IndexError, ValueError):
         _got = None
-    if _got is not None and _got != _want:
+    if _got is None:
         raise SystemExit(
-            f"decode_qwen.xclbin was built with W_DUAL_CHAN={_got} but this run "
+            f"cannot read the W_DUAL_CHAN build stamp {_stamp}, so the weight "
+            f"layout of {args.xclbin} is unknown and packing for "
+            f"W_DUAL_CHAN={_want} may silently produce garbage. Rebuild with "
+            f"QWEN_NLAYERS=.. W_DUAL_CHAN={_want} python3 fused_decode_qwen.py"
+        )
+    if _got != _want:
+        raise SystemExit(
+            f"{args.xclbin} was built with W_DUAL_CHAN={_got} but this run "
             f"packs weights for W_DUAL_CHAN={_want}. Rebuild the xclbin with the "
             f"same setting (QWEN_NLAYERS=.. W_DUAL_CHAN={_want} python3 "
             f"fused_decode_qwen.py) or re-run with W_DUAL_CHAN={_got}."

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -67,8 +67,15 @@ def pack_layer(hf, ap, k):
         qr._interleave_chunks(su, sg, m.PAYLOAD),
     )
     ph[m.DOWN_PHASE] = qr.requant_q4_0(qr._pad_cols(R["down"], m.INTERMEDIATE))
+    # dual_chan must match the flag the decode xclbin was BUILT with: it reorders
+    # the cascade so each of a column's two shim channels reads a contiguous run.
     return np.concatenate(
-        [qr.pack_q4k_cascade_fast(*ph[p], m.NCX, m.NCY) for p in range(m.NPH)]
+        [
+            qr.pack_q4k_cascade_fast(
+                *ph[p], m.NCX, m.NCY, dual_chan=bool(getattr(m, "W_DUAL_CHAN", 0))
+            )
+            for p in range(m.NPH)
+        ]
     )
 
 
@@ -114,6 +121,22 @@ def main():
     KVL = m.N_ATTN_CU * 2 * m.ATTN_ROUNDS * m.KVBLK
     KVN = NL * KVL
     YN = max(m.DEST_TOTAL * m.PAYLOAD, m.K + m.DQ)
+
+    # The xclbin's weight layout is set by W_DUAL_CHAN at BUILD time; pack_layer
+    # below uses the CURRENT module value. A mismatch is silent garbage, so refuse.
+    _want = int(getattr(m, "W_DUAL_CHAN", 0))
+    try:
+        with open("decode_qwen.flags") as _f:
+            _got = int(_f.read().strip().split("=")[1])
+    except (OSError, IndexError, ValueError):
+        _got = None
+    if _got is not None and _got != _want:
+        raise SystemExit(
+            f"decode_qwen.xclbin was built with W_DUAL_CHAN={_got} but this run "
+            f"packs weights for W_DUAL_CHAN={_want}. Rebuild the xclbin with the "
+            f"same setting (QWEN_NLAYERS=.. W_DUAL_CHAN={_want} python3 "
+            f"fused_decode_qwen.py) or re-run with W_DUAL_CHAN={_got}."
+        )
 
     print(f"[handoff] packing Q4_0 weights for {NL} layers...", flush=True)
     xd = np.zeros(X, bfloat16)

--- a/programming_examples/llms/gemma3_4b_q4nx/.gitignore
+++ b/programming_examples/llms/gemma3_4b_q4nx/.gitignore
@@ -26,3 +26,6 @@ air.insts.bin
 # Golden / weight caches produced at runtime (external data; see README.md).
 *.npz
 diag_cache/
+
+# build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
+.decode_flags

--- a/programming_examples/llms/gemma3_4b_q4nx/Makefile
+++ b/programming_examples/llms/gemma3_4b_q4nx/Makefile
@@ -71,6 +71,15 @@ PROMPT_ARG := $(if $(PROMPT),--prompt "$(PROMPT)",)
 MODEL_SOURCE ?= FastFlowLM/Gemma3-4B-NPU2
 export Q4NX_MODEL_SOURCE := $(MODEL_SOURCE)
 
+# Dual-MM2S weight feed for the fused decode (fused_decode/fused_decode.py).
+# ON by default. The BUILD and the RUN must agree -- the flag selects both the
+# shim channel split and the DDR weight cascade order -- so export it here and let
+# it reach the delegated decode build AND the inference driver. The requant cache
+# is keyed on it, so flipping it needs no manual cache purge.
+W_DUAL_CHAN ?= 1
+export W_DUAL_CHAN
+
+
 .PHONY: help compile compile-prefill compile-decode _compile_decode_build prefill \
         run ask verify verify-paris profile profile-prefill gen clean
 
@@ -104,12 +113,20 @@ help:
 ## Skips when both templates are already present, matching fused_decode's
 ## compile-decode. The guard is keyed on the LBUILD-encoded filenames, so a build
 ## at a different LBUILD is never silently reused.
+# W_DUAL_CHAN changes the DDR weight layout, so a warm template built with the
+# other setting must NOT be reused -- it would be fed the wrong blocks and produce
+# silent garbage. The stamp makes the skip below flag-aware.
+DECODE_FLAGS_STAMP := $(srcdir)/.decode_flags
+DECODE_FLAGS       := W_DUAL_CHAN=$(W_DUAL_CHAN)
+
 compile-decode:
 	@if [ -f $(srcdir)/decode_L$(LBUILD).xclbin ] && [ -f $(srcdir)/decode_L$(LBUILD).insts.bin ] \
-	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ]; then \
-	  echo "Gemma decode templates already built (decode_L$(LBUILD) + decode_L$(LREF)); skipping. Run 'make clean' to force a rebuild."; \
+	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ] \
+	    && [ "`cat $(DECODE_FLAGS_STAMP) 2>/dev/null`" = "$(DECODE_FLAGS)" ]; then \
+	  echo "Gemma decode templates already built (decode_L$(LBUILD) + decode_L$(LREF), $(DECODE_FLAGS)); skipping. Run 'make clean' to force a rebuild."; \
 	else \
-	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build \
+	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
 	fi
 
 _compile_decode_build:
@@ -198,6 +215,7 @@ gen: run
 ## link Gemma objects.
 clean:
 	rm -f $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
+	rm -f $(DECODE_FLAGS_STAMP) 2>/dev/null || true
 	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
 	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
 	rm -rf $(srcdir)/build_peano $(srcdir)/build_chess $(srcdir)/__pycache__ \

--- a/programming_examples/llms/gemma3_4b_q4nx/README.md
+++ b/programming_examples/llms/gemma3_4b_q4nx/README.md
@@ -42,6 +42,11 @@ Divergences from Llama are parametric, host-side, or compile flags — see
 | prefill (TTFT) | **4.5 s** at CTX=2048 (452 tok/s); 4.50 s on-device, 29 ms host |
 | decode | **12.5 tok/s** (80 ms/token), ATTN_MAXL=2048, 64 tokens |
 
+> Decode streams each proj column's weights on **both** of that column's shim
+> MM2S channels (`W_DUAL_CHAN`, on by default) — see
+> [fused_decode/README.md](../../fused_decode/README.md#dual-mm2s-weight-feed-w_dual_chan-on-by-default).
+> The decode figure above predates that change and is therefore conservative.
+
 Prefill runs at a fixed padded context (`CTX`), so its cost is roughly constant
 in prompt length rather than proportional to it. Measure it with
 `make profile-prefill`. Per-op on-device split at CTX=2048:

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -61,7 +61,11 @@ def _ensure_requant_cache(fd, model):
         return rc
     import gemma3_4b_q4nx_requant as rq
 
-    rc = rc or os.path.join(_Q4NX_CACHE, "requant.npz")
+    # W_DUAL_CHAN reorders the cascade (even/odd fan steps for the two-MM2S
+    # weight feed), so it gets its own cache entry -- a warm single-channel
+    # cache would feed the dual-channel xclbin the wrong blocks.
+    _w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
+    rc = rc or os.path.join(_Q4NX_CACHE, f"requant{_w2}.npz")
     if not os.path.exists(rc):
         rq.build_requant_cache(model, fd, rc)
     os.environ["Q4NX_GEMMA_DECODE_NPZ"] = rc

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -61,9 +61,10 @@ def _ensure_requant_cache(fd, model):
         return rc
     import gemma3_4b_q4nx_requant as rq
 
-    # W_DUAL_CHAN reorders the cascade (even/odd fan steps for the two-MM2S
-    # weight feed), so it gets its own cache entry -- a warm single-channel
-    # cache would feed the dual-channel xclbin the wrong blocks.
+    # W_DUAL_CHAN reorders the cascade (the two-MM2S weight feed splits it by
+    # cascade pair into [low-row half | high-row half]), so it gets its own cache
+    # entry -- a warm single-channel cache would feed the dual-channel xclbin the
+    # wrong blocks.
     _w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
     rc = rc or os.path.join(_Q4NX_CACHE, f"requant{_w2}.npz")
     if not os.path.exists(rc):

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_requant.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_requant.py
@@ -57,6 +57,11 @@ def build_requant_cache(model, fd, cache_path, verbose=True):
     GLU_CHUNK, W_LAYER = fd.GLU_CHUNK, fd.W_LAYER
     VP, VPF, UNI_LM = fd.VOCAB_SIZE_PADDED, fd.VOCAB_SIZE_PADDED_FULL, fd.UNI_LM
     n_layers = fd.UNI_DEC
+    # Dual-MM2S weight feed: the decode splits each column's slab across the
+    # column's two shim channels, which needs the cascade laid out as
+    # [even fan steps | odd fan steps]. Keyed off the SAME flag the decode was
+    # built with (fd.W_DUAL_CHAN) so the pack can never disagree with the xclbin.
+    DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
     PROJ = qm_model._PROJ  # {nm: (suffix, out, in)}
 
     def _dq(k, nm):
@@ -77,7 +82,9 @@ def build_requant_cache(model, fd, cache_path, verbose=True):
         W_all.append(
             np.concatenate(
                 [
-                    fd.pack_q4k_cascade(*qm[p], NCX, NCY, iter_major=True)
+                    fd.pack_q4k_cascade(
+                        *qm[p], NCX, NCY, iter_major=True, dual_chan=DUAL
+                    )
                     for p in range(NPH)
                 ]
             )
@@ -104,6 +111,7 @@ def build_requant_cache(model, fd, cache_path, verbose=True):
             NCX,
             NCY,
             iter_major=True,
+            dual_chan=DUAL,
         )
         for w in range(UNI_LM)
     ]

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_requant.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_requant.py
@@ -58,8 +58,8 @@ def build_requant_cache(model, fd, cache_path, verbose=True):
     VP, VPF, UNI_LM = fd.VOCAB_SIZE_PADDED, fd.VOCAB_SIZE_PADDED_FULL, fd.UNI_LM
     n_layers = fd.UNI_DEC
     # Dual-MM2S weight feed: the decode splits each column's slab across the
-    # column's two shim channels, which needs the cascade laid out as
-    # [even fan steps | odd fan steps]. Keyed off the SAME flag the decode was
+    # column's two shim channels by cascade pair, which needs the cascade laid out
+    # as [low-row half | high-row half]. Keyed off the SAME flag the decode was
     # built with (fd.W_DUAL_CHAN) so the pack can never disagree with the xclbin.
     DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
     PROJ = qm_model._PROJ  # {nm: (suffix, out, in)}

--- a/programming_examples/llms/llama32_1b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_1b_q4nx/Makefile
@@ -41,6 +41,14 @@ export Q4NX_CACHE_DIR := $(srcdir)/$(BUILD_DIR)/q4nx_kernel_cache_$(CTX)
 # CTX % 512 != 0). This is the headline ~0.93s TTFT prefill path.
 export TEMPORAL_CAUSAL_SKIP := 1
 
+# Dual-MM2S weight feed for the fused decode (see fused_decode/fused_decode.py).
+# The BUILD and the RUN must agree -- the flag selects both the shim channel split
+# and the weight cascade order -- so export it here and let it reach both the
+# delegated `compile-decode` and the inference driver. The requant cache is keyed
+# on it, so flipping it does not need a manual cache purge.
+W_DUAL_CHAN ?= 1
+export W_DUAL_CHAN
+
 # Unified prefill+decode inference driver (run/profile/chat/gen/ask/compile).
 DRIVER := $(srcdir)/llama32_1b_q4nx_inference.py
 # Prefill engine (weight-integrity Paris gate + the CTX prefill latency sweep).

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -50,6 +50,12 @@ every context length.
   prompt length (the prefill processes the full padded `seq_len` each call).
 - **Decode**: ~**50 tok/s** end-to-end at turbo (single MAX_L=2048 template).
 
+> Decode streams each proj column's weights on **both** of that column's shim
+> MM2S channels (`W_DUAL_CHAN`, on by default) — see
+> [fused_decode/README.md](../../fused_decode/README.md#dual-mm2s-weight-feed-w_dual_chan-on-by-default).
+> The decode figure below predates that change and is therefore conservative.
+
+
 ## Prerequisites
 
 1. **MLIR-AIR base environment** — AMD NPU2, Peano (`PEANO_INSTALL_DIR`),

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -129,9 +129,10 @@ def _ensure_requant_cache(fd):
         # (FastFlowLM re-encoded every NPU2 bundle on 2026-08-04).
         from llama32_1b_q4nx_weights import Q4nxModel
 
-        # The dual-MM2S weight feed reorders the cascade (even/odd fan steps), so
-        # it needs its own cache entry -- a warm single-channel cache would feed
-        # the wrong blocks. Key on the flag too so both layouts can coexist.
+        # The dual-MM2S weight feed reorders the cascade (split by cascade pair
+        # into [low-row half | high-row half]), so it needs its own cache entry --
+        # a warm single-channel cache would feed the wrong blocks. Key on the flag
+        # too so both layouts can coexist.
         _w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
         rc = os.path.join(
             _Q4NX_CACHE, f"requant_{Q4nxModel(src).fingerprint()}{_w2}.npz"

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -129,7 +129,13 @@ def _ensure_requant_cache(fd):
         # (FastFlowLM re-encoded every NPU2 bundle on 2026-08-04).
         from llama32_1b_q4nx_weights import Q4nxModel
 
-        rc = os.path.join(_Q4NX_CACHE, f"requant_{Q4nxModel(src).fingerprint()}.npz")
+        # The dual-MM2S weight feed reorders the cascade (even/odd fan steps), so
+        # it needs its own cache entry -- a warm single-channel cache would feed
+        # the wrong blocks. Key on the flag too so both layouts can coexist.
+        _w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
+        rc = os.path.join(
+            _Q4NX_CACHE, f"requant_{Q4nxModel(src).fingerprint()}{_w2}.npz"
+        )
     if not os.path.exists(rc):
         q4nx_requant.build_requant_cache(src, fd, rc)
     os.environ["Q4NX_DECODE_WEIGHTS_NPZ"] = rc

--- a/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
+++ b/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
@@ -61,6 +61,11 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
     G, NCX, NCY, NPH, K = fd.GROUP, fd.NCX, fd.NCY, fd.NPH, fd.K
     OP, GP, DP = fd.OPROJ_PHASE, fd.GLU_PHASE, fd.DOWN_PHASE
     GLU_CHUNK, W_LAYER = fd.GLU_CHUNK, fd.W_LAYER
+    # Dual-MM2S weight feed: the decode splits each column's slab across the
+    # column's two shim channels, which needs the cascade laid out as
+    # [even fan steps | odd fan steps]. Keyed off the SAME flag the decode was
+    # built with (fd.W_DUAL_CHAN) so the pack can never disagree with the xclbin.
+    DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
     VP, VPF, VOCAB, UNI_LM = (
         fd.VOCAB_SIZE_PADDED,
         fd.VOCAB_SIZE_PADDED_FULL,
@@ -99,7 +104,9 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
         W_all.append(
             np.concatenate(
                 [
-                    fd.pack_q4k_cascade(*qm[p], NCX, NCY, iter_major=True)
+                    fd.pack_q4k_cascade(
+                        *qm[p], NCX, NCY, iter_major=True, dual_chan=DUAL
+                    )
                     for p in range(NPH)
                 ]
             )
@@ -124,6 +131,7 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
             NCX,
             NCY,
             iter_major=True,
+            dual_chan=DUAL,
         )
         for w in range(UNI_LM)
     ]

--- a/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
+++ b/programming_examples/llms/llama32_1b_q4nx/q4nx_requant.py
@@ -62,8 +62,8 @@ def build_requant_cache(model, fd, cache_path, n_layers=16, verbose=True):
     OP, GP, DP = fd.OPROJ_PHASE, fd.GLU_PHASE, fd.DOWN_PHASE
     GLU_CHUNK, W_LAYER = fd.GLU_CHUNK, fd.W_LAYER
     # Dual-MM2S weight feed: the decode splits each column's slab across the
-    # column's two shim channels, which needs the cascade laid out as
-    # [even fan steps | odd fan steps]. Keyed off the SAME flag the decode was
+    # column's two shim channels by cascade pair, which needs the cascade laid out
+    # as [low-row half | high-row half]. Keyed off the SAME flag the decode was
     # built with (fd.W_DUAL_CHAN) so the pack can never disagree with the xclbin.
     DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
     VP, VPF, VOCAB, UNI_LM = (

--- a/programming_examples/llms/llama32_3b_q4nx/.gitignore
+++ b/programming_examples/llms/llama32_3b_q4nx/.gitignore
@@ -31,3 +31,6 @@ decode_L*.xclbin
 decode_L*.insts.bin
 decode.xclbin
 decode.insts.bin
+
+# build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
+.decode_flags

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -38,6 +38,15 @@ MODEL    ?= instruct
 MODEL_SOURCE ?= FastFlowLM/Llama-3.2-3B-NPU2
 export Q4NX_MODEL_SOURCE := $(MODEL_SOURCE)
 
+# Dual-MM2S weight feed for the fused decode (fused_decode/fused_decode.py).
+# ON by default. The BUILD and the RUN must agree -- the flag selects both the
+# shim channel split and the DDR weight cascade order -- so export it here and let
+# it reach the delegated decode build AND the inference driver. The requant cache
+# is keyed on it, so flipping it needs no manual cache purge.
+W_DUAL_CHAN ?= 1
+export W_DUAL_CHAN
+
+
 DRIVER := $(srcdir)/llama32_3b_q4nx_inference.py
 # The fused per-token decode engine is a SEPARATE reusable example (one dispatch =
 # 28 layers + LM head); this Makefile drives it with the 3B model selection and
@@ -119,12 +128,20 @@ compile:
 ## ~15 min, skipped when both are already present. Weight-free; needs an llvm-link
 ## from LLVM <23 (the fused_decode preflight enforces it). The driver loads
 ## the templates from here at run time.
+# W_DUAL_CHAN changes the DDR weight layout, so a warm template built with the
+# other setting must NOT be reused -- it would be fed the wrong blocks and produce
+# silent garbage. The stamp makes the skip below flag-aware.
+DECODE_FLAGS_STAMP := $(srcdir)/.decode_flags
+DECODE_FLAGS       := W_DUAL_CHAN=$(W_DUAL_CHAN)
+
 compile-decode:
 	@if [ -f $(srcdir)/decode_L$(LBUILD).xclbin ] && [ -f $(srcdir)/decode_L$(LBUILD).insts.bin ] \
-	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ]; then \
-	  echo "3B decode templates already built (decode_L$(LBUILD) + decode_L$(LREF)); skipping. Run 'make clean' to force a rebuild."; \
+	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ] \
+	    && [ "`cat $(DECODE_FLAGS_STAMP) 2>/dev/null`" = "$(DECODE_FLAGS)" ]; then \
+	  echo "3B decode templates already built (decode_L$(LBUILD) + decode_L$(LREF), $(DECODE_FLAGS)); skipping. Run 'make clean' to force a rebuild."; \
 	else \
-	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build \
+	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
 	fi
 
 _compile_decode_build:
@@ -216,6 +233,7 @@ gen:
 ## the lit tests run `clean` before every gate. Delete it by hand to force a re-pack.
 clean:
 	rm -f $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
+	rm -f $(DECODE_FLAGS_STAMP) 2>/dev/null || true
 	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
 	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
 	rm -rf $(BUILD_DIR) $(srcdir)/__pycache__ $(srcdir)/_q4nx_cache_seq* 2>/dev/null || true

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -37,6 +37,11 @@ eps=1e-5, tied embeddings (lm_head = embed_tokens). Q4NX codec: 32×256 blocks,
   dispatch per token. FastFlowLM's own 3B decode measures ~19.6 tok/s on the same
   machine.
 
+> Decode streams each proj column's weights on **both** of that column's shim
+> MM2S channels (`W_DUAL_CHAN`, on by default) — see
+> [fused_decode/README.md](../../fused_decode/README.md#dual-mm2s-weight-feed-w_dual_chan-on-by-default).
+> The decode figure above predates that change and is therefore conservative.
+
 Both measured at turbo: `xrt-smi configure -d <BDF> --pmode turbo`.
 
 ## Prerequisites

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -99,9 +99,10 @@ def ensure_requant_cache(model_source, fd, n_layers, wcache_dir=None, verbose=Tr
     wc = Path(wcache_dir) if wcache_dir else (_HERE / ".decode_wcache")
     wc.mkdir(parents=True, exist_ok=True)
     fp = Q4nxModel(model_source).fingerprint()
-    # W_DUAL_CHAN reorders the cascade (even/odd fan steps for the two-MM2S weight
-    # feed), so it is part of the key: a warm single-channel cache would feed the
-    # dual-channel xclbin the wrong blocks.
+    # W_DUAL_CHAN reorders the cascade (the two-MM2S weight feed splits it by
+    # cascade pair into [low-row half | high-row half]), so it is part of the key:
+    # a warm single-channel cache would feed the dual-channel xclbin the wrong
+    # blocks.
     w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
     cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}{w2}_{fp}.npz"
     if cache.exists():

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -99,7 +99,11 @@ def ensure_requant_cache(model_source, fd, n_layers, wcache_dir=None, verbose=Tr
     wc = Path(wcache_dir) if wcache_dir else (_HERE / ".decode_wcache")
     wc.mkdir(parents=True, exist_ok=True)
     fp = Q4nxModel(model_source).fingerprint()
-    cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}_{fp}.npz"
+    # W_DUAL_CHAN reorders the cascade (even/odd fan steps for the two-MM2S weight
+    # feed), so it is part of the key: a warm single-channel cache would feed the
+    # dual-channel xclbin the wrong blocks.
+    w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
+    cache = wc / f"q4nx_3b_decode_L{n_layers}_v{fd.VOCAB_I2}{w2}_{fp}.npz"
     if cache.exists():
         return str(cache)
     if verbose:


### PR DESCRIPTION
## Why

Batch-1 decode is a weight-streaming problem: every token reads every weight exactly once, with no reuse, so tok/s tracks weight bandwidth almost 1:1. The fused decode drove each proj column's weights on **one** shim MM2S channel; FastFlowLM drives **two**. On the same four physical columns FLM pulls 14.35 GB/s per column where we pulled 10.16 — the column was not saturated.

## What

Feed each proj column on both of its MM2S channels. `W_DUAL_CHAN` is on by default; set it to `0` for the previous single-channel feed.

Three things are required, all mirroring FLM's `mem_C_1`:

| | what | why |
|---|---|---|
| split axis | **spatial**, by cascade pair — ch0 feeds rows 2/3, ch1 rows 4/5, on two independent lock cycles | a *temporal* split (alternating fan steps) gives every core one MM2S chain alternating between both channels' buffers, couples the two shim channels at every step, and deadlocks the first dispatch |
| shim placement | per-column channels `@inW{0,1}c{cx}` carrying `air.shim_col` | a `[NCX]` bundle cannot express a per-index column; unpinned, the extra flows take the rms/rope column and silently violate *its* `air.shim_col` pin |
| X memtile | on the hub column (`XMT_PCOL = MAIN_PCOL`) | FLM has **no** memtile in column 2. Leaving a 16-way broadcast hub there alongside the shim feeds and both cores makes the pathfinder fail outright once the weight flows double |

The DDR side is a pure permutation of the packed cascade (`pack_q4k_cascade(dual_chan=True)`), so each channel still reads one contiguous 1-D run. A strided feed cannot: a 10240-element fan step exceeds the AIE2 per-dim wrap limit, and only a contiguous BD gets the wide `buffer_length` register.

The flag changes the DDR weight layout, so build and run must agree. Consumers key their requant cache and their `.decode_flags` template stamp on it; the Qwen decode, which has no Makefile build, stamps the artifact instead and its runner refuses a mismatch rather than producing silent garbage.

## Measured (Strix, quiet box, `make profile N_TOKENS=64`, 3 runs each)

| model | single-channel | dual-channel | |
|---|---|---|---|
| Llama-3.2-1B | 46.2 tok/s | 52.3 tok/s | **1.13x** |
| Llama-3.2-3B | 18.8 tok/s | 22.5 tok/s | **1.20x** |
| Gemma3-4B | 15.2 tok/s | 17.1 tok/s | **1.12x** |
| Qwen2.5-3B | 105.1 ms/tok | 105.5 ms/tok | none |

Qwen is unchanged, as expected: it streams 1.91 GB/token at ~105 ms = **18.2 GB/s**, against the 1B design's 35.7 GB/s on four channels. Its decode is not weight-bandwidth-bound (its layers do not pipeline), so more channels cannot help. It is enabled there for uniformity and is correctness-verified.

The nightly LLM dashboard is rendered from CI's `perf.json` on the Krackan Point runner, so it will pick these up on that hardware without hand-edited numbers.

## Testing

- `llama32_1b_q4nx`: `make verify-full` 8/8, and **byte-identical greedy token ids** vs the single-channel build at short and ~1170-token context (same weights, same kernels, only DMA routing differs, so output must match exactly).
- `llama32_3b_q4nx`: `make verify` PASS on both arms.
- `gemma3_4b_q4nx`: Paris gate PASS on both arms, identical generated text.
- Qwen2.5-3B: identical generated text both ways; first token matches the prefill argmax.
- With `W_DUAL_CHAN=0` the emitted AIR is **byte-identical to before this change** for all four model configs (llama-3.2-1b/3b, gemma3-4b, Qwen), and `pack_q4k_cascade(dual_chan=False)` byte-matches the previous packer — so the fallback path is a provable no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)