### PR TITLE
[programming_examples] gemma3_4b_q4nx: read decode logits via bo.map()

### DIFF
--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -298,11 +298,12 @@ class FusedDecoder:
         ).wait(60000)
         _voc_n = self.UNI_LM * self.VP
         self.y_bo.sync(FROM, _voc_n * 2, self.decode_y * 2)
-        yv = (
-            self.y_bo.read(_voc_n * 2, self.decode_y * 2)
-            .view(self.bf16)
-            .astype(np.float32)
-        )
+        # Zero-copy view into the BO (the shared infra's readback idiom): bo.read()
+        # returns a buffer whose stride metadata is pyxrt-build dependent, and
+        # .view() on it raises on some runners.
+        yv = np.frombuffer(
+            self.y_bo.map(), dtype=self.bf16, count=_voc_n, offset=self.decode_y * 2
+        ).astype(np.float32)
         if not str(st).endswith("COMPLETED"):
             raise RuntimeError(f"decode dispatch pos{p} state={st}")
         return yv[: self.VOCAB_SIZE]


### PR DESCRIPTION
The fused decode read its vocab logits back with `y_bo.read(n, off).view(bfloat16)`. pyxrt's `read()` returns an array whose stride metadata is build-dependent, and where it comes back non-contiguous numpy refuses the 1->2 byte view:

```
File "gemma3_4b_q4nx_inference.py", line 303, in dispatch
    .view(self.bf16)
ValueError: To change to a dtype of a different size, the last axis must be contiguous
```

Switch to the `np.frombuffer(bo.map(), ...)` idiom the sibling designs already use — `llama32_1b_q4nx` adopted it in #1770 and `llama32_3b_q4nx` carries it in `q4nx_decode_3b.py`. This example landed a day after #1770 and was written from the pre-fix copy, so it kept the old form. Both BOs are constructed identically (`xrt.bo(dev, ny*2, host_only, g(6))`), so the idiom transplants directly.

## Why it surfaced now

It stayed latent because the decode template failed to build on the perf runner — `'aie.packet_flow' op packet flow source (4, 1) DMA0 could not be routed to destination (2, 1) DMA0` — so the line never executed. #1784's `DOWN_PCOL` change fixed that routing; the nightly then reached the first decode dispatch and raised here instead. Placement fix revealed it, did not cause it.

## Verification

On NPU2 (Ryzen AI 9 HX 370) at `b40eb7a11`, built against the pinned toolchain from #1785 (mlir_aie `1.4.1.dev58+gf501f21`, llvm-aie `21.0.0.2026080601+f4a72c27`), with decode templates and prefill ELFs rebuilt from source:

| model | gate | result |
|---|---|---|
| `gemma3_4b_q4nx` | Paris argmax | PASS — `' Paris.\n\nParis is a global center for art'` |
| `llama32_1b_q4nx` | top-k vs HF bf16 | PASS 2/0 |
| `llama32_3b_q4nx` | top-k vs HF bf16 | PASS 2/0 |
| `qwen25_3b_q4` | Paris argmax | PASS — `argmax=12095` |

Note the remaining nightly failures (`qwen25_0_5b`, `qwen25_1_5b`, `qwen25_3b`) are unrelated to this change — they are the LLVM 22 Peano regression that #1785 pins around. Confirmed by holding mlir-air fixed and varying only Peano: `qwen25_0_5b` verify FAILs on `22.0.0.2026081201` and PASSes on the pinned `21.0.0.2026080601`.

One follow-up for whoever reverts that pin: its comment cites `xrt/50_multi_launch_attention` and `xrt/48_triton_matmul_ver4_strix_4x4_bf16_output`, but Peano 22 also breaks all four qwen models. Worth re-checking those too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)