### PR TITLE
[programming_examples] Give the Qwen Q4_0 example the build path and CI gates its Q4NX siblings have

### DIFF
--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -301,6 +301,28 @@ KVBLK = 16 * KVPC_DH  # 2048 one 16-key K (or V) block per CU
 ATTN_L = int(_os.environ.get("ATTN_L", "32"))
 ATTN_ROUNDS = (ATTN_L + 15) // 16
 
+# Attn kernel linkage. Same mechanism as the Llama driver (fused_decode.py): the
+# attn_qk/attn_kv kernels are linked as LLVM IR (.ll) rather than objects, so they
+# can be llvm-linked and INLINED into the core (kernels built alwaysinline via
+# -DDECODE_INLINE_ATTN). This is upstream mlir-aie's func-level inline-kernel API:
+# the kernel func.func declaration carries link_with = "<name>.ll" together with
+# link_with_mode = "merge", which aiecc's aie-assign-core-link-files pass routes
+# into the core's link_merge_files -> llvm-link merges the alwaysinline body into
+# the core module before opt/llc (no surviving func.call, no object link).
+# air-to-aie copies the decl's discardable attrs onto the lowered AIE func.func,
+# so setting link_with_mode here is all that is needed. The attn HERDS carry no
+# link_with at all -- the linkage comes from the kernel func each core calls.
+_ATTN_EXT = ".ll"  # fixed config: inline-attn merge-mode (.ll) is the only decode path
+_ATTN_MERGE = _ATTN_EXT == ".ll"  # emit link_with_mode="merge" for the inline path
+
+
+def _set_attn_link(op, base):
+    """Attach the kernel link_with (+ link_with_mode="merge" for the .ll inline path)."""
+    op.attributes["link_with"] = StringAttr.get(base + _ATTN_EXT)
+    if _ATTN_MERGE:
+        op.attributes["link_with_mode"] = StringAttr.get("merge")
+
+
 # ---- reference-mirroring KV-cache + attn config (ported from fused_decode.py, the proven
 # Llama AIR design, re-parameterized for Qwen 1x8x1 / DH=128 / 2 CUs on col 7). ----
 # The whole rope->q-broadcast(mem_6_1)->attn->attn-o(mem_6_1)->xnorm loopclose and the
@@ -625,17 +647,17 @@ def build_module():
             ([aq_l1, ak_l1, m_l1, c_l1, as_l1, i32, i32], []),
             visibility="private",
         )
-        attn_qk_blk.attributes["link_with"] = StringAttr.get("attn_qk.o")
+        _set_attn_link(attn_qk_blk, "attn_qk")
         attn_kv_blk = FuncOp(
             "attn_kv_blk",
             ([as_l1, av_l1, y_l1, lden_l1, i32, i32], []),
             visibility="private",
         )
-        attn_kv_blk.attributes["link_with"] = StringAttr.get("attn_kv.o")
+        _set_attn_link(attn_kv_blk, "attn_kv")
         attn_kv_fin = FuncOp(
             "attn_kv_fin", ([y_l1, lden_l1, ao_l1], []), visibility="private"
         )
-        attn_kv_fin.attributes["link_with"] = StringAttr.get("attn_kv.o")
+        _set_attn_link(attn_kv_fin, "attn_kv")
 
         # ---- channels (two-hop, mirroring the reference) ----
         channel_decl("toX", size=[1])  # host -> X memtile (col 1)
@@ -2217,10 +2239,12 @@ def run():
     art = backend.compile(
         module, output_binary_name="decode_qwen", insts="decode_qwen.insts.bin"
     )
-    # Stamp the flag next to the artifact. The Qwen decode has no Makefile build,
-    # so nothing else can stop qwen_prefill_to_decode from feeding a dual-layout
-    # weight stream to a single-channel xclbin (or vice versa) -- which produces
-    # silent garbage rather than an error. The runner checks this file.
+    # Stamp the flag next to the artifact. The Makefile's own build stamp
+    # (llms/qwen25_3b_q4/.decode_build_flags) only guards the BUILD; this one
+    # guards the RUN, so that driving the builder directly cannot leave
+    # qwen_prefill_to_decode feeding a dual-layout weight stream to a
+    # single-channel xclbin (or vice versa) -- silent garbage rather than an
+    # error. The runner checks this file; keep it one `KEY=VALUE` line.
     with open("decode_qwen.flags", "w") as _f:
         _f.write(f"W_DUAL_CHAN={W_DUAL_CHAN}\n")
     print(

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -5,8 +5,8 @@
 # End-to-end Qwen2.5-3B on NPU2 with NO REFERENCE MODEL anywhere in the loop --
 # every token comes from the NPU prefill and the NPU fused decode, never from a
 # host copy of the model. What DOES still run on the host each token is the
-# final RMSNorm + LM-head projection (`lg = ... @ emb.T` below) and the argmax:
-# the 36 transformer layers are on device, the last projection is not. Moving it
+# final RMSNorm + LM-head projection (`_logits` below) and the argmax: the 36
+# transformer layers are on device, the last projection is not. Moving it
 # on-device is a performance item, not a correctness one -- the decode's own
 # hidden state is what feeds it.
 #
@@ -32,11 +32,21 @@
 # keeps RoPE consistent -- RoPE is absolute, so a cached entry carries the
 # roping of the position it was computed at.
 #
+# The generation loop lives in `QwenFusedDecoder`, not in main(), so the shared
+# verify subsystem can drive it one token at a time: `seed_kv()` + `dispatch()`
+# are the same two entry points llama32_1b_q4nx's FusedDecoder exposes, which is
+# what llms/qwen25_3b_q4/verify_adapter.py binds to. main() is a thin CLI over it.
+#
 #   cd programming_examples/llms/qwen25_3b_q4
-#   python3 qwen25_3b_q4_prefill.py --dump-kv /tmp/kv.npz --prompt "..."
+#   make compile-decode          # kernels + decode_qwen.xclbin
+#   make gen                     # prefill -> hand-off -> N_GEN tokens
+#
+# or by hand:
+#
+#   python3 qwen25_3b_q4_prefill.py --dump-kv /tmp/kv.npz --prompt "<32+ tokens>"
 #   cd ../../fused_decode
 #   QWEN_NLAYERS=36 python3 fused_decode_qwen.py      # 36-layer xclbin
-#   python3 qwen_prefill_to_decode.py --kv /tmp/kv.npz --n-gen 20
+#   QWEN_NLAYERS=36 python3 qwen_prefill_to_decode.py --kv /tmp/kv.npz --n-gen 16
 import argparse
 import os
 import sys
@@ -79,6 +89,189 @@ def pack_layer(hf, ap, k):
     )
 
 
+def _check_w_dual_chan_stamp(xclbin):
+    """Refuse a weight layout the xclbin was not built for.
+
+    The xclbin's layout is set by W_DUAL_CHAN at BUILD time; pack_layer uses the
+    CURRENT module value. A mismatch is silent garbage, so refuse. The stamp sits
+    next to the xclbin it describes. An UNREADABLE stamp is just as unsafe as a
+    mismatched one (an xclbin built before the stamp existed has an unknown
+    layout), so that is refused too rather than assumed compatible."""
+    want = int(getattr(m, "W_DUAL_CHAN", 0))
+    stamp = os.path.splitext(xclbin)[0] + ".flags"
+    try:
+        with open(stamp) as f:
+            got = int(f.read().strip().split("=")[1])
+    except (OSError, IndexError, ValueError):
+        got = None
+    if got is None:
+        raise SystemExit(
+            f"cannot read the W_DUAL_CHAN build stamp {stamp}, so the weight "
+            f"layout of {xclbin} is unknown and packing for "
+            f"W_DUAL_CHAN={want} may silently produce garbage. Rebuild with "
+            f"QWEN_NLAYERS=.. W_DUAL_CHAN={want} python3 fused_decode_qwen.py"
+        )
+    if got != want:
+        raise SystemExit(
+            f"{xclbin} was built with W_DUAL_CHAN={got} but this run "
+            f"packs weights for W_DUAL_CHAN={want}. Rebuild the xclbin with the "
+            f"same setting (QWEN_NLAYERS=.. W_DUAL_CHAN={want} python3 "
+            f"fused_decode_qwen.py) or re-run with W_DUAL_CHAN={got}."
+        )
+
+
+class QwenFusedDecoder:
+    """One-dispatch-per-token Qwen2.5-3B decode over the fused NPU superkernel.
+
+    Owns the resident BOs, the token-invariant Q4_0 weight stream and the host
+    sliding KV window. Two entry points, matching llama32_1b_q4nx's FusedDecoder
+    so the shared verify Runner contract can bind to either:
+
+        seed_kv(K, V, ctx)      seed the window from a prefill's KV cache
+        dispatch(token, pos)    one token -> logits [VOCAB]
+
+    Construction packs 36 layers of Q4_0 weights on the host (~1 min) and writes
+    them to the device once; they never change again.
+    """
+
+    def __init__(self, xclbin="decode_qwen.xclbin", insts="decode_qwen.insts.bin"):
+        self.NL = m.NLAYERS
+        # ATTN_MAXL is the decode's fixed context window: the device attends over
+        # exactly this many slots and appends at slot ATTN_MAXL-1.
+        self.ATTN_MAXL = m.ATTN_L
+        assert m.REGION_W == m.DK, (m.REGION_W, m.DK)
+        _check_w_dual_chan_stamp(xclbin)
+
+        hf = qr.HFModel()
+        aperm = qr.attn_out_perm(m)
+        # Kept for the host-side final RMSNorm + LM head (tied embeddings).
+        self.emb = hf.bf16("model.embed_tokens.weight")
+        self.norm = hf.bf16("model.norm.weight")
+
+        L, NL = self.ATTN_MAXL, self.NL
+        self.X = max(m.X_CHUNKS * 2 * m.COL_BLOCK, NL * m.XLAYER)
+        self.WSZ = NL * m.W_LAYER
+        self.KVL = m.N_ATTN_CU * 2 * m.ATTN_ROUNDS * m.KVBLK
+        self.KVN = NL * self.KVL
+        self.YN = max(m.DEST_TOTAL * m.PAYLOAD, m.K + m.DQ)
+
+        print(f"[handoff] packing Q4_0 weights for {NL} layers...", flush=True)
+        self.xd = np.zeros(self.X, bfloat16)
+        wd = np.empty(self.WSZ, np.int16)
+        for k in range(NL):
+            b = k * m.XLAYER
+            wd[k * m.W_LAYER : (k + 1) * m.W_LAYER] = pack_layer(hf, aperm, k)
+            self.xd[b + m.XO_ROPE + m.DH : b + m.XO_ROPE + m.ROPE_W] = np.concatenate(
+                [hf.bf16(f"model.layers.{k}.{t}.bias") for t in qr._BIAS]
+            ).astype(bfloat16)
+            self.xd[b + m.XO_RMSW : b + m.XO_RMSW + m.K] = hf.bf16(
+                f"model.layers.{k}.input_layernorm.weight"
+            ).astype(bfloat16)
+            self.xd[b + m.XO_RMSW2 : b + m.XO_RMSW2 + m.K] = hf.bf16(
+                f"model.layers.{k}.post_attention_layernorm.weight"
+            ).astype(bfloat16)
+
+        dev = xrt.device(0)
+        xb = xrt.xclbin(xclbin)
+        dev.register_xclbin(xb)
+        hwc = xrt.hw_context(dev, xb.get_uuid())
+        self.kern = xrt.kernel(
+            hwc,
+            [q for q in xb.get_kernels() if "MLIR_AIE" in q.get_name()][0].get_name(),
+        )
+        g_, HO = self.kern.group_id, xrt.bo.host_only
+        self.x_bo = xrt.bo(dev, self.X * 2, HO, g_(3))
+        self.w_bo = xrt.bo(dev, self.WSZ * 2, HO, g_(4))
+        self.kv_bo = xrt.bo(dev, self.KVN * 2, HO, g_(5))
+        self.y_bo = xrt.bo(dev, self.YN * 2, HO, g_(6))
+        self._insts = np.fromfile(insts, dtype=np.uint32)
+        self.ib = xrt.bo(dev, self._insts.nbytes, xrt.bo.cacheable, g_(1))
+        self.ib.write(self._insts, 0)
+        self.ib.sync(TO)
+        self.w_bo.write(wd.view(np.uint16), 0)
+        self.w_bo.sync(TO)  # weights are token-invariant
+
+        # Host sliding KV window, [NL, ATTN_MAXL, DK]. seed_kv() fills it.
+        self.Kc = np.zeros((NL, L, m.DK), np.float32)
+        self.Vc = np.zeros((NL, L, m.DK), np.float32)
+        self.dev_ms = 0.0  # accumulated device dispatch time
+
+    def seed_kv(self, K, V, ctx):
+        """Seed the window with the LAST ATTN_MAXL positions of a prefill's KV.
+
+        K/V are [n_layers, ctx, DK]. RoPE is absolute, so a cached entry carries
+        the roping of the position it was computed at -- taking the tail keeps
+        the window's positions contiguous with the next token's."""
+        L = self.ATTN_MAXL
+        if ctx < L:
+            raise SystemExit(
+                f"prompt gave {ctx} tokens, decode window ATTN_L={L}. The decode "
+                f"seeds its window with the last {L} prefill positions, so the "
+                f"prompt must be at least that long (or rebuild with a smaller "
+                f"ATTN_L)."
+            )
+        assert K.shape == (self.NL, ctx, m.DK), (K.shape, (self.NL, ctx, m.DK))
+        self.Kc[:] = K[:, ctx - L :, :]
+        self.Vc[:] = V[:, ctx - L :, :]
+
+    def _logits(self, h):
+        """Host final RMSNorm + tied LM head over the decode's hidden state."""
+        return (h / np.sqrt((h * h).mean() + 1e-6) * self.norm) @ self.emb.T
+
+    def dispatch(self, token, pos):
+        """One fused decode dispatch: token at absolute position `pos` -> logits.
+
+        Also slides the KV window by one, consuming the K/V the device just
+        appended at slot ATTN_MAXL-1, so consecutive calls chain."""
+        L, NL, KVL = self.ATTN_MAXL, self.NL, self.KVL
+        lut = qr.rope_lut(pos, m.DH).astype(bfloat16)
+        for k in range(NL):
+            self.xd[k * m.XLAYER + m.XO_ROPE : k * m.XLAYER + m.XO_ROPE + m.DH] = lut
+        self.xd[m.XO_RMSIN : m.XO_RMSIN + m.K] = np.asarray(
+            self.emb[token], np.float32
+        ).astype(bfloat16)
+        kvd = np.zeros(self.KVN, bfloat16)
+        for k in range(NL):
+            kvd[k * KVL :][: L * m.REGION_W] = self.Kc[k].astype(bfloat16).ravel()
+            kvd[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W] = (
+                self.Vc[k].astype(bfloat16).ravel()
+            )
+        self.x_bo.write(self.xd.view(np.uint16), 0)
+        self.x_bo.sync(TO)
+        self.kv_bo.write(kvd.view(np.uint16), 0)
+        self.kv_bo.sync(TO)
+
+        t0 = time.time()
+        st = self.kern(
+            3, self.ib, self._insts.size, self.x_bo, self.w_bo, self.kv_bo, self.y_bo
+        ).wait(20000)
+        self.dev_ms += (time.time() - t0) * 1e3
+        if "COMPLETED" not in str(st):
+            raise RuntimeError(f"decode dispatch pos{pos} state={st}")
+        self.x_bo.sync(FR)
+        self.kv_bo.sync(FR)
+
+        h = np.frombuffer(self.x_bo.read(self.X * 2, 0), dtype=bfloat16).astype(
+            np.float32
+        )[m.XO_RMSIN : m.XO_RMSIN + m.K]
+        logits = self._logits(h)
+
+        # Take this token's K/V (device wrote slot L-1) and slide the window.
+        kvo = np.frombuffer(self.kv_bo.read(self.KVN * 2, 0), dtype=bfloat16).astype(
+            np.float32
+        )
+        for k in range(NL):
+            newk = kvo[k * KVL :][: L * m.REGION_W].reshape(L, m.REGION_W)[L - 1]
+            newv = kvo[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W].reshape(
+                L, m.REGION_W
+            )[L - 1]
+            self.Kc[k] = np.roll(self.Kc[k], -1, 0)
+            self.Kc[k][L - 2], self.Kc[k][L - 1] = newk, 0
+            self.Vc[k] = np.roll(self.Vc[k], -1, 0)
+            self.Vc[k][L - 2], self.Vc[k][L - 1] = newv, 0
+        return logits
+
+
 def main():
     ap_ = argparse.ArgumentParser(description="Qwen2.5-3B NPU prefill -> NPU decode")
     ap_.add_argument("--kv", default="/tmp/qwen_prefill_kv.npz", help="--dump-kv file")
@@ -89,151 +282,33 @@ def main():
     ap_.add_argument("--insts", default="decode_qwen.insts.bin")
     args = ap_.parse_args()
 
-    NL, L = m.NLAYERS, m.ATTN_L
+    NL = m.NLAYERS
     z = np.load(args.kv)
     ids = [int(t) for t in z["ids"]]
     ctx = int(z["ctx"])
     kp = z["k"].view(bfloat16).astype(np.float32)  # [n_layers, ctx, DK]
     vp = z["v"].view(bfloat16).astype(np.float32)
     assert kp.shape == (NL, ctx, m.DK), f"prefill KV {kp.shape} != {(NL, ctx, m.DK)}"
-    assert m.REGION_W == m.DK, (m.REGION_W, m.DK)
-    assert ctx >= L, f"prompt gave {ctx} tokens, decode window ATTN_L={L}"
+
+    dec = QwenFusedDecoder(xclbin=args.xclbin, insts=args.insts)
     print(
-        f"[handoff] prefill KV: {NL} layers x {ctx} tokens; "
-        f"seeding the last ATTN_L={L} positions ({ctx - L}..{ctx - 1})",
+        f"[handoff] prefill KV: {NL} layers x {ctx} tokens; seeding the last "
+        f"ATTN_L={dec.ATTN_MAXL} positions ({ctx - dec.ATTN_MAXL}..{ctx - 1})",
         flush=True,
     )
+    dec.seed_kv(kp, vp, ctx)
 
     from transformers import AutoTokenizer
 
     tok = AutoTokenizer.from_pretrained(qr.HF_REPO)
-    hf = qr.HFModel()
-    aperm = qr.attn_out_perm(m)
-    emb = hf.bf16("model.embed_tokens.weight")
-    norm = hf.bf16("model.norm.weight")
-
-    # Host KV window, seeded from the prefill (no reference model involved).
-    Kc = np.ascontiguousarray(kp[:, ctx - L :, :])
-    Vc = np.ascontiguousarray(vp[:, ctx - L :, :])
-
-    X = max(m.X_CHUNKS * 2 * m.COL_BLOCK, NL * m.XLAYER)
-    WSZ = NL * m.W_LAYER
-    KVL = m.N_ATTN_CU * 2 * m.ATTN_ROUNDS * m.KVBLK
-    KVN = NL * KVL
-    YN = max(m.DEST_TOTAL * m.PAYLOAD, m.K + m.DQ)
-
-    # The xclbin's weight layout is set by W_DUAL_CHAN at BUILD time; pack_layer
-    # below uses the CURRENT module value. A mismatch is silent garbage, so refuse.
-    # The stamp sits next to the xclbin it describes. An UNREADABLE stamp is just
-    # as unsafe as a mismatched one (an xclbin built before the stamp existed has
-    # an unknown layout), so that is refused too rather than assumed compatible.
-    _want = int(getattr(m, "W_DUAL_CHAN", 0))
-    _stamp = os.path.splitext(args.xclbin)[0] + ".flags"
-    try:
-        with open(_stamp) as _f:
-            _got = int(_f.read().strip().split("=")[1])
-    except (OSError, IndexError, ValueError):
-        _got = None
-    if _got is None:
-        raise SystemExit(
-            f"cannot read the W_DUAL_CHAN build stamp {_stamp}, so the weight "
-            f"layout of {args.xclbin} is unknown and packing for "
-            f"W_DUAL_CHAN={_want} may silently produce garbage. Rebuild with "
-            f"QWEN_NLAYERS=.. W_DUAL_CHAN={_want} python3 fused_decode_qwen.py"
-        )
-    if _got != _want:
-        raise SystemExit(
-            f"{args.xclbin} was built with W_DUAL_CHAN={_got} but this run "
-            f"packs weights for W_DUAL_CHAN={_want}. Rebuild the xclbin with the "
-            f"same setting (QWEN_NLAYERS=.. W_DUAL_CHAN={_want} python3 "
-            f"fused_decode_qwen.py) or re-run with W_DUAL_CHAN={_got}."
-        )
-
-    print(f"[handoff] packing Q4_0 weights for {NL} layers...", flush=True)
-    xd = np.zeros(X, bfloat16)
-    wd = np.empty(WSZ, np.int16)
-    for k in range(NL):
-        b = k * m.XLAYER
-        wd[k * m.W_LAYER : (k + 1) * m.W_LAYER] = pack_layer(hf, aperm, k)
-        xd[b + m.XO_ROPE + m.DH : b + m.XO_ROPE + m.ROPE_W] = np.concatenate(
-            [hf.bf16(f"model.layers.{k}.{t}.bias") for t in qr._BIAS]
-        ).astype(bfloat16)
-        xd[b + m.XO_RMSW : b + m.XO_RMSW + m.K] = hf.bf16(
-            f"model.layers.{k}.input_layernorm.weight"
-        ).astype(bfloat16)
-        xd[b + m.XO_RMSW2 : b + m.XO_RMSW2 + m.K] = hf.bf16(
-            f"model.layers.{k}.post_attention_layernorm.weight"
-        ).astype(bfloat16)
-
-    dev = xrt.device(0)
-    xb = xrt.xclbin(args.xclbin)
-    dev.register_xclbin(xb)
-    hwc = xrt.hw_context(dev, xb.get_uuid())
-    kern = xrt.kernel(
-        hwc, [q for q in xb.get_kernels() if "MLIR_AIE" in q.get_name()][0].get_name()
-    )
-    g_, HO = kern.group_id, xrt.bo.host_only
-    x_bo = xrt.bo(dev, X * 2, HO, g_(3))
-    w_bo = xrt.bo(dev, WSZ * 2, HO, g_(4))
-    kv_bo = xrt.bo(dev, KVN * 2, HO, g_(5))
-    y_bo = xrt.bo(dev, YN * 2, HO, g_(6))
-    insts = np.fromfile(args.insts, dtype=np.uint32)
-    ib = xrt.bo(dev, insts.nbytes, xrt.bo.cacheable, g_(1))
-    ib.write(insts, 0)
-    ib.sync(TO)
-    w_bo.write(wd.view(np.uint16), 0)
-    w_bo.sync(TO)  # weights are token-invariant
 
     out_ids = []
     cur = ids[-1]
     pos = ctx - 1  # re-run the last prompt token to produce the first logit
-    dev_ms = 0.0
     t_all = time.time()
     for step in range(args.n_gen):
-        lut = qr.rope_lut(pos, m.DH).astype(bfloat16)
-        for k in range(NL):
-            xd[k * m.XLAYER + m.XO_ROPE : k * m.XLAYER + m.XO_ROPE + m.DH] = lut
-        xd[m.XO_RMSIN : m.XO_RMSIN + m.K] = np.asarray(emb[cur], np.float32).astype(
-            bfloat16
-        )
-        kvd = np.zeros(KVN, bfloat16)
-        for k in range(NL):
-            kvd[k * KVL :][: L * m.REGION_W] = Kc[k].astype(bfloat16).ravel()
-            kvd[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W] = (
-                Vc[k].astype(bfloat16).ravel()
-            )
-        x_bo.write(xd.view(np.uint16), 0)
-        x_bo.sync(TO)
-        kv_bo.write(kvd.view(np.uint16), 0)
-        kv_bo.sync(TO)
-
-        t0 = time.time()
-        st = kern(3, ib, insts.size, x_bo, w_bo, kv_bo, y_bo).wait(20000)
-        dev_ms += (time.time() - t0) * 1e3
-        if "COMPLETED" not in str(st):
-            print("DISPATCH FAILED:", st)
-            return 1
-        x_bo.sync(FR)
-        kv_bo.sync(FR)
-
-        h = np.frombuffer(x_bo.read(X * 2, 0), dtype=bfloat16).astype(np.float32)[
-            m.XO_RMSIN : m.XO_RMSIN + m.K
-        ]
-        lg = (h / np.sqrt((h * h).mean() + 1e-6) * norm) @ emb.T
-        nxt = int(np.argmax(lg))
+        nxt = int(np.argmax(dec.dispatch(cur, pos)))
         out_ids.append(nxt)
-
-        # Take this token's K/V (device wrote slot L-1) and slide the window.
-        kvo = np.frombuffer(kv_bo.read(KVN * 2, 0), dtype=bfloat16).astype(np.float32)
-        for k in range(NL):
-            newk = kvo[k * KVL :][: L * m.REGION_W].reshape(L, m.REGION_W)[L - 1]
-            newv = kvo[k * KVL + m.NGRP * m.REGION_STRIDE :][: L * m.REGION_W].reshape(
-                L, m.REGION_W
-            )[L - 1]
-            Kc[k] = np.roll(Kc[k], -1, 0)
-            Kc[k][L - 2], Kc[k][L - 1] = newk, 0
-            Vc[k] = np.roll(Vc[k], -1, 0)
-            Vc[k][L - 2], Vc[k][L - 1] = newv, 0
         cur = nxt
         pos += 1
         print(f"  [{step:2d}] {nxt:6d} {tok.decode([nxt])!r}", flush=True)
@@ -243,9 +318,15 @@ def main():
     print("\nprompt    :", repr(tok.decode(ids)))
     print("generated :", repr(tok.decode(out_ids)))
     print(
-        f"\n{len(out_ids)} tokens | device {dev_ms/n:.1f} ms/tok "
-        f"({1000/(dev_ms/n):.2f} tok/s device-only) | end-to-end {wall/n:.2f} s/tok"
+        f"\n{len(out_ids)} tokens | device {dec.dev_ms/n:.1f} ms/tok "
+        f"({1000/(dec.dev_ms/n):.2f} tok/s device-only) | end-to-end {wall/n:.2f} s/tok"
     )
+    # Machine-readable lines for llms/bench/extract_perf.py (TOKS_LABEL_RE and
+    # CTX_RE). The human line above does not parse: its TOKS_RE alternative needs
+    # "tok/s" immediately before the closing paren, and ours is followed by
+    # "device-only".
+    print(f"Tokens/second: {1000/(dec.dev_ms/n):.2f}")
+    print(f"prompt_len: {ctx}")
     return 0
 
 

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -325,8 +325,14 @@ def main():
     # CTX_RE). The human line above does not parse: its TOKS_RE alternative needs
     # "tok/s" immediately before the closing paren, and ours is followed by
     # "device-only".
+    #
+    # The dashboard's "Context" column sits next to the decode throughput, so
+    # report the depth that throughput was actually measured at: this decode
+    # attends over a FIXED window of ATTN_MAXL slots every token, no matter how
+    # long the prompt was. Printing ctx would overstate it for any prompt longer
+    # than the window (the prefill saw those tokens; the decode never does).
     print(f"Tokens/second: {1000/(dec.dev_ms/n):.2f}")
-    print(f"prompt_len: {ctx}")
+    print(f"prompt_len: {dec.ATTN_MAXL}")
     return 0
 
 

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -521,9 +521,11 @@ LLM_HF_MODELS = {
     "qwen25_0_5b": "Qwen/Qwen2.5-0.5B",
     "qwen25_1_5b": "Qwen/Qwen2.5-1.5B",
     "qwen25_3b": "Qwen/Qwen2.5-3B",
-    # Q4_0-quantized straight from the bf16 checkpoint (no pre-quantized Qwen
-    # bundle exists), so it points at the same repo as the bf16 example above
-    # rather than at a FastFlowLM NPU2 bundle like the Llama/Gemma Q4NX rows.
+    # Q4_0-quantized on the host straight from an upstream bf16 checkpoint (no
+    # pre-quantized Qwen bundle exists), so this points at a Qwen repo rather
+    # than at a FastFlowLM NPU2 bundle like the Llama/Gemma Q4NX rows. It is the
+    # Instruct variant -- the example's own default (MODEL_DEFAULT in
+    # qwen25_3b_q4_prefill.py) -- not the base repo the qwen25_3b row above uses.
     "qwen25_3b_q4": "Qwen/Qwen2.5-3B-Instruct",
     "qwen3_0_6b": "Qwen/Qwen3-0.6B",
     "qwen3_1_7b": "Qwen/Qwen3-1.7B",

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -521,6 +521,10 @@ LLM_HF_MODELS = {
     "qwen25_0_5b": "Qwen/Qwen2.5-0.5B",
     "qwen25_1_5b": "Qwen/Qwen2.5-1.5B",
     "qwen25_3b": "Qwen/Qwen2.5-3B",
+    # Q4_0-quantized straight from the bf16 checkpoint (no pre-quantized Qwen
+    # bundle exists), so it points at the same repo as the bf16 example above
+    # rather than at a FastFlowLM NPU2 bundle like the Llama/Gemma Q4NX rows.
+    "qwen25_3b_q4": "Qwen/Qwen2.5-3B-Instruct",
     "qwen3_0_6b": "Qwen/Qwen3-0.6B",
     "qwen3_1_7b": "Qwen/Qwen3-1.7B",
     "qwen3_4b": "Qwen/Qwen3-4B",

--- a/programming_examples/llms/qwen25_3b_q4/.gitignore
+++ b/programming_examples/llms/qwen25_3b_q4/.gitignore
@@ -5,3 +5,7 @@ build_*/
 *.o
 *.xclbin
 *.log
+
+# Fused-decode build stamp + the prefill->decode KV hand-off cache (`make gen`).
+.decode_build_flags
+.kv_handoff.npz

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -1,11 +1,21 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 #
-# Qwen2.5-3B Q4_0 prefill on NPU2 (MLIR-AIR).
+# Qwen2.5-3B Q4_0 on NPU2 (MLIR-AIR): op-by-op prefill + the fused
+# single-dispatch decode.
 #
-#   make compile   — build/cache the prefill ELFs (no weights, no NPU dispatch)
-#   make run       — prefill "The capital of France is" -> expect " Paris"
-#   make bench     — warm TTFT at BENCH_L (default 2048)
+# Same driver contract as the other Q4NX examples (llama32_1b_q4nx,
+# llama32_3b_q4nx, gemma3_4b_q4nx): compile/compile-decode are weight-free
+# builds, run/gen/bench dispatch on the NPU.
+#
+#   make compile         — build/cache the prefill ELFs (no weights, no NPU dispatch)
+#   make compile-decode  — build the fused decode kernels + decode_qwen.xclbin
+#   make run             — prefill "The capital of France is" -> expect " Paris"
+#   make gen             — end-to-end: NPU prefill -> KV hand-off -> NPU fused decode
+#   make bench           — warm TTFT at BENCH_L (default 2048)
+#
+# Config: 36 layers, emb=2048, 16 heads / 2 KV heads (GQA group 8), head_dim=128,
+#         hidden=11008, vocab=151936, rope_theta=1e6, tied lm_head.
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -16,24 +26,156 @@ MODEL    ?= Qwen/Qwen2.5-3B-Instruct
 
 PREFILL := $(srcdir)/qwen25_3b_q4_prefill.py
 
-.PHONY: help compile run bench weights clean
+# ---- fused decode (the shared programming_examples/fused_decode engine) ----
+# Qwen drives its own builder (fused_decode_qwen.py) rather than fused_decode.py's
+# DECODE_MODEL switch: its attention topology is 2 CUs of 1x8x1 on column 7 at
+# DH=128, not the Llama/Gemma layout. Everything else -- the kernels, the
+# inline-attn merge, the llvm-link preflight -- is shared.
+DEC            := $(srcdir)/../../fused_decode
+DECODE_DRIVER  := $(DEC)/fused_decode_qwen.py
+HANDOFF        := $(DEC)/qwen_prefill_to_decode.py
+AIEOPT_DIR     := $(shell realpath $(dir $(shell which aie-opt))/..)
+
+# Decode context window. The device always appends this token's K/V at slot
+# ATTN_L-1 and attends over all ATTN_L slots, so the host keeps a sliding window
+# of exactly this many positions (see qwen_prefill_to_decode.py). The prompt fed
+# to `make gen` must therefore tokenize to at least ATTN_L tokens.
+ATTN_L      ?= 32
+# W_DUAL_CHAN feeds each proj column's weights on BOTH of its shim MM2S channels
+# and reorders the DDR cascade accordingly, so the build and the weight packer
+# must agree. The builder stamps decode_qwen.flags and the hand-off refuses a
+# mismatch; this variable is what keeps the two in sync from one place.
+W_DUAL_CHAN ?= 1
+
+# Per-kernel -O is LOAD-BEARING (see fused_decode/Makefile): proj_qmm/rms_residual/
+# glu/rope MUST be -O2 (rope.cc at -O1 miscompiles -> the decode HANGS on device);
+# attn_qk/attn_kv MUST be -O1 (a -O2 attn do-while deadlock). Qwen differs from the
+# Llama build only by -DMODEL_TYPE=QWEN2_5_3B.
+NONATTN_KERNELS := proj_qmm rms_residual glu rope   # object .o, -O2
+ATTN_LL_KERNELS := attn_qk attn_kv                  # inline .ll only, -O1 (merge-linked)
+PEANO_KBASE     := -std=c++20 --target=aie2p-none-unknown-elf \
+  -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-deprecated-declarations \
+  -DNDEBUG -DMODEL_TYPE=QWEN2_5_3B -D__AIE_API_AIE_ADF_HPP__ \
+  -I $(AIEOPT_DIR)/include -I $(DEC)/kernels -I $(DEC)/models \
+  -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+DECODE_ENV      := QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$(ATTN_L) W_DUAL_CHAN=$(W_DUAL_CHAN)
+
+# Build-flag stamp for the idempotent skip. Every variable below changes either the
+# xclbin's dataflow or its DDR weight layout, so a warm build made with different
+# settings must NOT be silently reused. (Distinct from the builder's own
+# decode_qwen.flags, which records W_DUAL_CHAN for the *runtime* packer check and
+# whose single-line format the hand-off parses.)
+DECODE_STAMP := $(srcdir)/.decode_build_flags
+DECODE_FLAGS := MODEL_TYPE=QWEN2_5_3B NLAYERS=$(N_LAYERS) ATTN_L=$(ATTN_L) W_DUAL_CHAN=$(W_DUAL_CHAN)
+
+# End-to-end generation demo. Prompt length is bounded on BOTH sides by the
+# window: below ATTN_L the hand-off cannot seed it (`ctx >= ATTN_L` asserts),
+# and above ATTN_L the head of the prompt slides out of context, so a much
+# longer prompt visibly degrades the continuation. 32 Qwen2.5 BPE tokens at the
+# default ATTN_L=32 -- see verify_prompts.txt for the same reasoning applied to
+# the correctness gate. Resize if you change ATTN_L.
+N_GEN      ?= 16
+GEN_PROMPT ?= The capital city of France is called Paris, and the most famous landmark in the entire world is probably the very tall iron tower that stands right in the middle of
+KV_NPZ     ?= $(srcdir)/.kv_handoff.npz
+
+# ---- shared verify subsystem (programming_examples/llms/verify/) ----
+VERIFY_RUNNER  := $(srcdir)/../verify/verify_runner.py
+RUNNER_ADAPTER := qwen25_3b_q4.verify_adapter
+# This example's own prompt file: every line must be >= ATTN_L tokens, which the
+# shared verify/prompts/*.txt lines are not. See verify_prompts.txt for why.
+VERIFY_PROMPTS := $(srcdir)/verify_prompts.txt
+MODEL_CHOICE   ?= instruct
+MAX_PROMPTS    ?= 2
+
+.PHONY: help compile compile-decode _compile_decode_build run gen dump-kv bench \
+        weights verify verify-topk verify-topk-full verify-paris diagnosis \
+        profile clean
 
 help:
-	@echo "Qwen2.5-3B Q4_0 prefill (MLIR-AIR, NPU2)"
-	@echo "  make compile   build/cache the prefill ELFs (CI-runnable, no weights)"
-	@echo "  make run       prefill gate: 'The capital of France is' -> ' Paris'"
-	@echo "  make bench     warm TTFT at BENCH_L=$(BENCH_L)"
-	@echo "  make weights   quant-error report for layer 0"
+	@echo "============================================================"
+	@echo " Qwen2.5-3B Q4_0 on NPU2 (MLIR-AIR)"
+	@echo "============================================================"
+	@echo ""
+	@echo "  make compile         Build/cache the prefill ELFs (CI-runnable, no weights)"
+	@echo "  make compile-decode  Build the fused decode (kernels + decode_qwen.xclbin, no weights)"
+	@echo "  make run             Prefill gate: 'The capital of France is' -> ' Paris'"
+	@echo "  make gen             End-to-end NPU prefill -> KV hand-off -> NPU fused decode"
+	@echo "  make bench           Warm prefill TTFT at BENCH_L=$(BENCH_L)"
+	@echo "  make weights         Q4_0 quant-error report for layer 0 (no NPU)"
+	@echo ""
+	@echo "Correctness:"
+	@echo "  make verify          CI gate: prefill argmax (12095 ' Paris') + a full fused-decode generation"
+	@echo "  make verify-paris    Fast prefill-only weight-integrity smoke (no decode build)"
+	@echo "  make verify-topk     Top-k token-set gate vs HF bf16 (informational; 2/5 prompts pass today)"
+	@echo "  make verify-topk-full  Same over every prompt in verify_prompts.txt"
+	@echo "  make diagnosis       Single-prompt lens through the shared runner (informational)"
+	@echo "  make profile         Perf capture (prefill TTFT + decode tok/s) for bench/extract_perf.py"
+	@echo ""
+	@echo "Options (override with make VAR=value):"
+	@echo "  N_LAYERS=$(N_LAYERS)        Transformer layers (prefill and decode)"
+	@echo "  ATTN_L=$(ATTN_L)           Decode context window (>= prompt length for gen)"
+	@echo "  W_DUAL_CHAN=$(W_DUAL_CHAN)        Two-MM2S-channel weight feed per proj column"
+	@echo "  N_GEN=$(N_GEN)            Tokens generated by 'make gen'"
 
 ## Build/cache the prefill ELFs and exit. No weights, no NPU dispatch.
 compile:
 	cd $(srcdir) && python3 $(PREFILL) --compile-only \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS)
 
-## First-token gate.
+## Build the fused Qwen decode: the Peano kernels (QWEN2_5_3B) + decode_qwen.xclbin.
+## Weight-free (everything is a runtime BO), like `make compile`.
+##
+## Idempotent: skipped when the xclbin, its instruction stream and a matching
+## build-flag stamp are all present. `make clean` forces a rebuild.
+compile-decode:
+	@if [ -f $(DEC)/decode_qwen.xclbin ] && [ -f $(DEC)/decode_qwen.insts.bin ] \
+	    && [ "`cat $(DECODE_STAMP) 2>/dev/null`" = "$(DECODE_FLAGS)" ]; then \
+	  echo "Qwen decode already built ($(DECODE_FLAGS)); skipping. Run 'make clean' to force a rebuild."; \
+	else \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build \
+	    && echo "$(DECODE_FLAGS)" > $(DECODE_STAMP); \
+	fi
+
+_compile_decode_build:
+	@# Delegate the llvm-link version preflight to the engine that owns it rather
+	@# than keeping a copy here: the rule (LLVM <23) must stay in one place, in
+	@# sync with lit.cfg.py's llvm_link_pre23 feature that gates this example's
+	@# lit tests (fused_decode/Makefile: preflight-llvm-link).
+	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
+	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
+	@echo ">>> qwen non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
+	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	@echo ">>> qwen attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
+	@# Merge-linked INTO the core (mlir-aie #3399), not object-linked: the builder
+	@# tags the kernel decls link_with="<name>.ll" + link_with_mode="merge".
+	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
+	@echo ">>> qwen decode xclbin ($(DECODE_FLAGS))"
+	@cd $(DEC) && $(DECODE_ENV) python3 $(DECODE_DRIVER) >/tmp/qwen_decode_L$(ATTN_L).log 2>&1; \
+	  if [ -f decode_qwen.xclbin ] && [ -f decode_qwen.insts.bin ]; then \
+	    grep -h '\[qwen_decode\] emitted' /tmp/qwen_decode_L$(ATTN_L).log; \
+	  else echo "decode_qwen FAILED (see /tmp/qwen_decode_L$(ATTN_L).log)"; \
+	    tail -30 /tmp/qwen_decode_L$(ATTN_L).log; exit 1; fi
+	@echo "Qwen decode build complete: decode_qwen.xclbin + decode_qwen.insts.bin."
+
+## First-token gate: prefill "The capital of France is"; PASS iff argmax == 12095.
 run:
 	cd $(srcdir) && python3 $(PREFILL) \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL)
+
+## Prefill GEN_PROMPT and dump the per-layer roped-K / biased-V hand-off cache.
+dump-kv:
+	cd $(srcdir) && python3 $(PREFILL) \
+		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL) \
+		--prompt "$(GEN_PROMPT)" --dump-kv $(KV_NPZ)
+
+## End-to-end: NPU prefill -> KV hand-off -> N_GEN tokens on the fused NPU decode.
+## No reference model in the loop; the decode's first token must equal the
+## prefill's own argmax, which is the cross-check that the hand-off is correct.
+gen: dump-kv
+	cd $(DEC) && $(DECODE_ENV) python3 $(HANDOFF) --kv $(KV_NPZ) --n-gen $(N_GEN)
 
 ## Warm TTFT benchmark (+ per-ELF profile).
 bench:
@@ -45,5 +187,72 @@ bench:
 weights:
 	cd $(srcdir) && python3 $(srcdir)/qwen25_3b_q4_weights.py --model $(MODEL)
 
+# ---- correctness gates ----
+#
+# WHY `verify` IS NOT THE TOP-K GATE HERE (it is for the Llama Q4NX examples).
+# The shared top-k gate demands that, at the first token where NPU and HF bf16
+# disagree, each side's pick is in the other's top-5. Measured on this design:
+# 2/5 prompts pass. The decode itself is sound -- `make gen` produces "the city.
+# Paris. The tower is called the Eiffel Tower, after" -- but greedy runs of a
+# Q4_0 36-layer model and a bf16 reference diverge early on open-ended
+# continuations, and near-ties there fall outside top-5. Gating CI on that would
+# be red, and loosening k or hand-picking prompts until it passed would make the
+# gate meaningless. So `verify` gates on two things that DO hold deterministically,
+# and the top-k path stays available (and honest) as `verify-topk`.
+# gemma3_4b_q4nx made the same call for the same reason.
+
+## CI correctness gate: prefill first-token argmax + a full fused-decode
+## generation. Between them these cover both halves on device:
+##   run  36 NPU prefill layers -> argmax 12095 (" Paris")
+##   gen  36 NPU decode layers, 16 one-dispatch tokens over the KV hand-off
+## `gen` is also the guard against an under-primed fill lock, i.e. a decode
+## deadlock -- the failure mode the refeed mechanism exists to prevent, and the
+## reason the other three Q4NX designs each have a decode gate.
+verify: run gen
+
+## Full production top-k token-set inclusion gate (NPU q4 vs HF bf16, k=5) via
+## the shared verify subsystem and verify_adapter.py. Informational today; see
+## the note above for why it is not the CI gate.
+##
+## DECODE_ENV is passed here too, not just to the build: fused_decode_qwen reads
+## QWEN_NLAYERS / ATTN_L / W_DUAL_CHAN from the environment at import and they
+## default to a 1-layer lowering check. Without them the runner would pack a
+## 1-layer weight stream for a 36-layer xclbin.
+verify-topk:
+	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --prompts-file $(VERIFY_PROMPTS) \
+		--model $(MODEL_CHOICE) --max-prompts $(MAX_PROMPTS)
+
+## Full-sweep variant of `make verify-topk` (every prompt in verify_prompts.txt).
+verify-topk-full:
+	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --prompts-file $(VERIFY_PROMPTS) \
+		--model $(MODEL_CHOICE)
+
+## Fast weight-integrity smoke: prefill only, no decode build required.
+## PASS iff the first-token argmax is 12095 (" Paris"). Alias for `make run`.
+verify-paris: run
+
+## Diagnosis lens (single prompt through the shared runner, informational).
+## The Q4_0 prefill does not expose per-layer ffn_out, so this reports the
+## token-level view rather than per-layer cosines.
+diagnosis:
+	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts single --prompt "$(GEN_PROMPT)" --model $(MODEL_CHOICE)
+
+## Perf capture for llms/bench/extract_perf.py: prefill TTFT + fused decode
+## throughput. `bench` prints "Time to first token (TTFT): X s" and `gen` prints
+## "Tokens/second: X"; extract_perf.py parses both.
+profile: bench gen
+
+## Remove this example's caches AND the QWEN2_5_3B-compiled kernels + decode
+## artifacts it writes into the shared fused_decode/ dir -- leaving those there
+## makes a later Llama or Gemma build silently link Qwen objects.
 clean:
-	rm -rf $(srcdir)/_q4_cache_seq* $(srcdir)/__pycache__
+	rm -rf $(srcdir)/_q4_cache_seq* $(srcdir)/__pycache__ 2>/dev/null || true
+	rm -f $(DECODE_STAMP) $(KV_NPZ) 2>/dev/null || true
+	rm -f $(DEC)/decode_qwen.xclbin $(DEC)/decode_qwen.insts.bin \
+	      $(DEC)/decode_qwen.flags 2>/dev/null || true
+	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
+	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
+	@echo "Qwen caches, decode artifacts and shared-dir kernels removed."

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -172,8 +172,12 @@ dump-kv:
 		--prompt "$(GEN_PROMPT)" --dump-kv $(KV_NPZ)
 
 ## End-to-end: NPU prefill -> KV hand-off -> N_GEN tokens on the fused NPU decode.
-## No reference model in the loop; the decode's first token must equal the
-## prefill's own argmax, which is the cross-check that the hand-off is correct.
+## No reference model in the loop. When the prompt fits the decode window
+## (len <= ATTN_L, which the default GEN_PROMPT is sized for) the decode's first
+## token equals the prefill's own argmax, and that is the cross-check that the
+## hand-off is exact. For a longer prompt the two legitimately differ: the
+## prefill attended over all of it, the decode only over the last ATTN_L
+## positions.
 gen: dump-kv
 	cd $(DEC) && $(DECODE_ENV) python3 $(HANDOFF) --kv $(KV_NPZ) --n-gen $(N_GEN)
 

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -16,7 +16,8 @@ relationship `llama32_1b_q4nx` has to `llama32_1b`); this example supplies the
 |---|---|
 | First token, `"The capital of France is"`, 36 layers on NPU2 | **argmax 12095 = `" Paris"`** — PASS |
 | Warm TTFT @ seq_len=2048 | **4.17 s** (491 tok/s prefill), NPU-dispatch 4.17 s, host 5 ms |
-| End-to-end NPU prefill -> NPU fused decode, 36 layers, no reference model | coherent text, **9.54 tok/s** device-only decode |
+| End-to-end NPU prefill -> NPU fused decode, 36 layers, no reference model | coherent text, **12.2 tok/s** device-only decode |
+| Top-k token-set inclusion vs HF bf16 (`make verify-topk-full`) | 2/5 prompts — informational, not the CI gate ([why](#why-verify-is-not-the-top-k-gate-here)) |
 
 The 36 transformer layers run on the NPU for both prefill and decode. The final
 RMSNorm + LM-head projection and the argmax still run on the host each decode
@@ -72,10 +73,51 @@ QKV bias, no QK-norm.
 
 ```bash
 make compile          # build/cache the prefill ELFs (no weights, no NPU)
+make compile-decode   # build the fused decode kernels + decode_qwen.xclbin (no weights)
 make run              # first-token gate -> " Paris"
+make gen              # end-to-end: NPU prefill -> KV hand-off -> NPU fused decode
 make bench BENCH_L=2048   # warm TTFT + per-ELF profile
 make weights          # Q4_0 quant-error report, layer 0
 ```
+
+Correctness gates (CI runs these via `run_npu2_*.lit`):
+
+```bash
+make verify           # CI gate: prefill argmax 12095 + a full 16-token fused decode
+make verify-paris     # fast prefill-only weight-integrity smoke (no decode build)
+make verify-topk      # top-k token-set inclusion vs HF bf16 (informational, see below)
+```
+
+### Why `verify` is not the top-k gate here
+
+The Llama Q4NX examples gate on the shared top-k check: at the first token where
+NPU and HF bf16 disagree, each side's pick must be in the other's top-5. That
+path is fully wired up here — [`verify_adapter.py`](verify_adapter.py) binds the
+Q4_0 prefill and the fused decode to the shared runner contract — but it scores
+**2/5 prompts** today.
+
+That is not a broken decode. `make gen` produces
+*" the city. Paris. The tower is called the Eiffel Tower, after"*. What fails is
+strictness: a Q4_0 36-layer model and a bf16 reference free-running greedily
+diverge within a few tokens on open-ended continuations, and the near-ties at the
+divergence point fall outside top-5. Gating CI on that would be permanently red,
+and raising `k` or cherry-picking prompts until it passed would make the gate
+meaningless — so `make verify` gates on the prefill argmax plus a complete
+fused-decode generation, both deterministic, and the top-k number stays visible
+here. `gemma3_4b_q4nx` made the same call for the same reason.
+
+The decode gate is not just a liveness check: it is the guard against an
+under-primed fill lock (a decode deadlock), which is the failure mode the refeed
+mechanism exists to prevent and the reason the other three Q4NX designs each
+carry one.
+
+`verify-topk` uses this example's own [`verify_prompts.txt`](verify_prompts.txt)
+rather than the shared `verify/prompts/*.txt`, and every line there is 32–34
+tokens. The fused decode is a sliding window of exactly `ATTN_L` (=32): shorter
+prompts cannot seed it at all, and longer ones push the head of the prompt out of
+context so the NPU answers from a truncation the reference never sees (at 37
+tokens the gate fails because *"A graphics **processing** unit"* has already slid
+out).
 
 Weights are downloaded from HuggingFace on first use and cached under
 `~/.cache/huggingface/hub/`. Override with `--model` or
@@ -113,6 +155,8 @@ with the same Q4_0 codec, so the prefill's K/V are exactly what the decode's own
 rope core would have appended at those positions, and the hand-off is a slice
 (both sides are `[tokens, 256]` head-major) rather than a shuffle.
 
+`make compile-decode && make gen` drives the whole thing. By hand:
+
 ```bash
 python3 qwen25_3b_q4_prefill.py --dump-kv /tmp/kv.npz --prompt "<32+ tokens>"
 cd ../../fused_decode
@@ -120,10 +164,23 @@ QWEN_NLAYERS=36 python3 fused_decode_qwen.py           # 36-layer xclbin
 QWEN_NLAYERS=36 python3 qwen_prefill_to_decode.py --kv /tmp/kv.npz --n-gen 16
 ```
 
+`QWEN_NLAYERS` must be exported for **both** commands: `fused_decode_qwen` reads
+its geometry from the environment at import and defaults to 1 layer (a fast
+lowering check), so omitting it packs a 1-layer weight stream for a 36-layer
+xclbin.
+
+**Context window.** The decode attends over exactly `ATTN_L` (=32) slots and
+appends at slot `ATTN_L-1`, so the host keeps a sliding window of the last 32
+positions. The prompt must therefore be at least 32 tokens. A prompt longer than
+the window is truncated to its tail from the decode's point of view, which is
+also why the decode's first token need not equal the prefill's argmax when
+`ctx > ATTN_L`: the prefill attended over all `ctx` positions, the decode over
+the last 32. They agree exactly when `ctx == ATTN_L`, which is the cross-check
+the adapter warns on.
+
 Measured: prompt *"The capital city of France is called Paris, ... the very tall
 iron tower that stands right"* -> *" in the middle. The Eiffel Tower. The tower
-is 33"*, 104.8 ms/token device. The decode's first token equals the prefill's own
-argmax, which is the cross-check that the KV hand-off is correct.
+is 33"*, 104.8 ms/token device.
 
 ## Files
 
@@ -131,5 +188,8 @@ argmax, which is the cross-check that the KV hand-off is correct.
 |---|---|
 | `qwen25_3b_q4_weights.py` | Q4_0 requant/dequant loader → the `qwen25_3b` `LlamaWeights` container |
 | `qwen25_3b_q4_prefill.py` | `Qwen25Q4Prefill` — compile/preload/prefill/KV-cache/bench |
-| `Makefile` | compile / run / bench / weights / clean |
-| `../../fused_decode/qwen_prefill_to_decode.py` | KV hand-off + generation loop on the fused decode |
+| `Makefile` | compile / compile-decode / run / gen / verify / bench / weights / clean |
+| `verify_adapter.py` | Binds the prefill + fused decode to the shared `verify/` runner contract |
+| `verify_prompts.txt` | Prompts for `make verify` (>= ATTN_L tokens each; see above) |
+| `run_npu2_*.lit` | CI gates: prefill compile, decode compile, verify, profile |
+| `../../fused_decode/qwen_prefill_to_decode.py` | `QwenFusedDecoder` (KV hand-off + per-token dispatch) and its CLI |

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_compile.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_compile.lit
@@ -1,0 +1,18 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B Q4_0 prefill compile-only smoke test: builds the 7 prefill ELFs
+// (rms_qkv_bias_rope + flash_attn + o_res_norm + gate + up + swiglu + down_add)
+// plus the 19-partition lm_head GEMV through the AIR -> AIE -> aiecc -> Peano
+// pipeline. No NPU dispatch and no weight data (weights are runtime BOs), so
+// this is the signal CI can always give without HF credentials. Pairs with
+// run_npu2_compile_decode.lit (the fused decode half) and run_npu2_verify.lit
+// (end-to-end top-k correctness, gated on the weight data).
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_compile
+// RUN: cd test_peano_compile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Compilation passed.

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_compile_decode.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_compile_decode.lit
@@ -1,0 +1,30 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B fused decode compile smoke test: builds the QWEN2_5_3B Peano
+// kernels and the single-dispatch decode_qwen xclbin through the
+// AIR -> AIE -> aiecc -> Peano pipeline. Weights are runtime BOs, so this
+// compile needs no weight data (like the prefill's run_npu2_compile.lit).
+//
+// This is the only automated gate on fused_decode_qwen.py. It matters because
+// under-priming a fill lock is a deadlock, which is exactly the failure mode
+// the refeed mechanism exists to prevent: the three other Q4NX designs driven
+// by that engine each have a CI gate against it, and until this file existed
+// the Qwen one had none.
+//
+// The attn kernels are merge-linked as inline .ll (link_with_mode="merge"),
+// not object-linked, so the build needs a pre-change `llvm-link` (< LLVM 23)
+// on PATH -- hence llvm_link_pre23 below. The Makefile preflight aborts with a
+// clear message otherwise (fused_decode/Makefile: preflight-llvm-link).
+//
+// The name matches the check-programming-examples-llms-compile filter
+// ("llms/.*/run_npu2_compile"), as gemma3_4b_q4nx does with its second
+// compile lit.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_compile_decode
+// RUN: cd test_peano_compile_decode
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Qwen decode build complete

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_profile.lit
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B Q4_0 profiling: compile then profile on NPU2 (Q4_0 prefill + fused
+// decode), capturing TTFT + decode throughput into qwen25_3b_q4.perf.json via
+// bench/extract_perf.py (collected by the nightly LLM benchmark). Perf is
+// best-effort; this test gates only that profiling ran end to end. Correctness
+// is gated separately by run_npu2_verify.lit.
+//
+// `make profile` runs bench (warm prefill TTFT at BENCH_L) then gen (fused
+// decode). extract_perf.py reads TTFT from bench's
+// "Time to first token (TTFT): X s" and throughput from gen's
+// "Tokens/second: X" -- gen's human-readable "(X tok/s device-only)" line does
+// NOT parse, because TOKS_RE needs "tok/s" immediately before the paren.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct
+//
+// RUN: mkdir -p test_peano_profile
+// RUN: cd test_peano_profile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | tee profile.txt
+// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model qwen25_3b_q4 > qwen25_3b_q4.perf.json
+// RUN: FileCheck %s < qwen25_3b_q4.perf.json
+// CHECK: "model": "qwen25_3b_q4"
+// A parsed number, not just a well-formed file: if a driver's print format drifts
+// out of extract_perf.py's regexes the metric goes null and the published
+// benchmark row silently blanks while the test stays green.
+// CHECK: "ttft_ms": {{[0-9]}}
+// CHECK: "decode_tokens_per_sec": {{[0-9]}}
+// CHECK: "context_len": {{[0-9]}}

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
@@ -1,0 +1,43 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-3B Q4_0 end-to-end correctness gate on NPU2. Covers BOTH halves of
+// the design on device:
+//
+//   prefill  36 NPU layers on "The capital of France is" -> first-token argmax
+//            must be 12095 (" Paris"). A wrong weight layout, a dropped layer
+//            or a bad Q4_0 codec all move this token.
+//   decode   36 NPU layers, 16 one-dispatch tokens fed by the prefill's KV
+//            hand-off, greedy -> must reach the Eiffel Tower continuation.
+//            This is also the guard against an under-primed fill lock, i.e. a
+//            decode deadlock: that is the failure mode the refeed mechanism
+//            exists to prevent, and until this file existed the Qwen design was
+//            the one Q4NX design with no gate against it.
+//
+// NOT the shared top-k-vs-HF-bf16 gate the Llama Q4NX examples use. That path
+// is wired up here too (verify_adapter.py + `make verify-topk`) but 2/5 prompts
+// pass today: the decode is sound, yet greedy runs of a Q4_0 36-layer model and
+// a bf16 reference diverge early on open-ended continuations and the near-ties
+// there fall outside top-5. Gating CI on it would be red, and tuning k or
+// cherry-picking prompts until it passed would make the gate meaningless.
+// gemma3_4b_q4nx made the same call. See the Makefile's "correctness gates" note.
+//
+// Both checks are greedy with fixed weights and a fixed prompt, so they are
+// deterministic.
+//
+// Skips cleanly when HF_TOKEN is unset (weight + tokenizer downloads need it).
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct
+//
+// RUN: mkdir -p test_peano_verify
+// RUN: cd test_peano_verify
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-decode PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+//
+// Prefill half.
+// CHECK: first-token argmax=12095
+// CHECK: *** PARIS ***
+// Decode half: the greedy continuation, then a completed 16-token run.
+// CHECK: generated : ' the city. Paris. The tower is called the Eiffel Tower, after'
+// CHECK: 16 tokens | device

--- a/programming_examples/llms/qwen25_3b_q4/verify_adapter.py
+++ b/programming_examples/llms/qwen25_3b_q4/verify_adapter.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Verify adapter for the Q4_0 Qwen2.5-3B example.
+
+The NPU runs Q4_0 weights quantized straight from the HF bf16 checkpoint (no
+pre-quantized Qwen bundle exists); the reference is that same HF **bf16**
+checkpoint. The shared verify gate therefore compares NPU-q4 vs HF-bf16 (top-k
+token-set inclusion), the same NPU-vs-bf16 proxy the Llama Q4NX adapters use.
+
+Like `llama32_1b_q4nx`, the decode here is a fused superkernel rather than a
+per-op pipeline: prefill runs through `Qwen25Q4Prefill` and each decode step
+through the one-xclbin `QwenFusedDecoder` (extracted from
+`fused_decode/qwen_prefill_to_decode.py`), so this adapter drives those two
+components directly to satisfy the shared `prefill()` / `decode_step()` contract.
+
+PROMPT LENGTH IS A HARD CONSTRAINT HERE. The fused Qwen decode is a sliding
+window of exactly `ATTN_L` positions (32 by default): the device attends over all
+`ATTN_L` slots and appends at slot `ATTN_L-1`, so the window must be seeded with
+that many real prefill positions. Prompts shorter than `ATTN_L` cannot be run at
+all. The shared prompt files are far shorter than that, so this example ships its
+own `verify_prompts.txt` and its Makefile points `--prompts-file` at it.
+
+Pointed at via `--runner=qwen25_3b_q4.verify_adapter`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LLMS_DIR = _THIS_DIR.parent
+_VERIFY = _LLMS_DIR / "verify"
+_QWEN3B = _LLMS_DIR / "qwen25_3b"  # shared prefill builders + config
+_FUSED = _LLMS_DIR.parent / "fused_decode"  # QwenFusedDecoder
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_QWEN3B), str(_FUSED), str(_THIS_DIR)):
+    while _p in sys.path:
+        sys.path.remove(_p)
+    sys.path.insert(0, _p)
+
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+
+# The Q4_0 example is a requantization of the bf16 qwen25_3b architecture (36
+# layers, emb=2048, 16Q/2KV, head_dim=128); reuse its config so the shared
+# HfRunner sees the dims it needs.
+from qwen25_3b_weights import LlamaConfig  # noqa: E402
+
+MODEL_CHOICES = {
+    "base": "Qwen/Qwen2.5-3B",
+    "instruct": "Qwen/Qwen2.5-3B-Instruct",
+}
+DEFAULT_MODEL = "instruct"
+
+# Weight source for the NPU side. Unlike the Llama Q4NX examples this is not a
+# separate pre-quantized bundle: it is the same HF checkpoint, Q4_0-quantized on
+# the host by qwen25_3b_q4_weights (bit-identical to the codec the fused decode
+# packs with, which is what makes the KV hand-off exact).
+QWEN_Q4_MODEL_SOURCE = os.environ.get("QWEN_Q4_MODEL_SOURCE", "")
+
+_N_LAYERS = 36
+# Padded prefill length. The qwen25_3b GEMM registry shapes exist at M=2048, so
+# the whole prefill runs there (same constraint as the Llama Q4NX example).
+_SEQ_LEN = int(os.environ.get("QWEN_Q4_SEQ_LEN", "2048"))
+
+# fused_decode_qwen reads its geometry from the environment AT IMPORT, and
+# QWEN_NLAYERS defaults to 1 (a fast lowering check, not a real model). Left
+# unset, the decoder would pack a 1-layer weight stream for the 36-layer xclbin
+# `make compile-decode` builds -- which is silent garbage, not an error. The
+# Makefile targets export this; set it here too so a bare `verify_runner
+# --runner=qwen25_3b_q4.verify_adapter` cannot hit that trap.
+os.environ.setdefault("QWEN_NLAYERS", str(_N_LAYERS))
+
+
+def build_config():
+    return LlamaConfig(n_layers=_N_LAYERS)
+
+
+def resolve_model(model_choice_or_id: str) -> str:
+    return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
+
+
+def hf_reference(npu_model_name: str) -> str:
+    """Reference is the HF bf16 checkpoint (NPU q4 vs HF bf16)."""
+    return npu_model_name
+
+
+def build_runner(
+    model_name: str,
+    config,
+    max_seq: int,
+    tokenizer,
+    *,
+    npu_attn: bool = True,
+    lite_mode: bool = False,
+):
+    """Compile/load the Q4_0 prefill + the fused Qwen decode, return an NpuRunner."""
+    return NpuRunner(model_name=model_name, tokenizer=tokenizer, lite_mode=lite_mode)
+
+
+class NpuRunner:
+    """Adapter over the Q4_0 prefill + one-xclbin fused Qwen decode.
+
+    prefill() runs `Qwen25Q4Prefill` (full logits + per-layer roped-K / biased-V)
+    and seeds the decoder's sliding KV window; decode_step() dispatches one fused
+    token through `QwenFusedDecoder`. Mirrors the loop in
+    `fused_decode/qwen_prefill_to_decode.py:main`."""
+
+    name = "npu_q4"
+
+    def __init__(self, model_name: str, tokenizer, lite_mode: bool = False):
+        self.lite_mode = lite_mode
+        self._tokenizer = tokenizer
+
+        from qwen25_3b_q4_prefill import Qwen25Q4Prefill
+        import fused_decode_qwen as _fd
+        from qwen_prefill_to_decode import QwenFusedDecoder
+
+        # The prefill and the decode must agree on layer count or the KV
+        # hand-off is meaningless. Catch it here with a message that names the
+        # variable, rather than deep inside seed_kv's shape assert.
+        if _fd.NLAYERS != _N_LAYERS:
+            raise SystemExit(
+                f"fused decode was configured for {_fd.NLAYERS} layers but this "
+                f"adapter prefills {_N_LAYERS}. Export QWEN_NLAYERS={_N_LAYERS} "
+                f"(what the Makefile targets do) and make sure the xclbin was "
+                f"built with the same value."
+            )
+
+        self.prefiller = Qwen25Q4Prefill(seq_len=_SEQ_LEN, n_layers=_N_LAYERS)
+        self.prefiller.load_weights(model=QWEN_Q4_MODEL_SOURCE or model_name)
+        # The decode xclbin is built by `make compile-decode` into fused_decode/;
+        # QwenFusedDecoder resolves it relative to the CWD, so anchor it here
+        # rather than depending on where the runner was launched from.
+        self.dec = QwenFusedDecoder(
+            xclbin=str(_FUSED / "decode_qwen.xclbin"),
+            insts=str(_FUSED / "decode_qwen.insts.bin"),
+        )
+        self.attn_maxl = self.dec.ATTN_MAXL
+        self._P = 0
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        ids = [int(t) for t in prompt_tokens]
+        if len(ids) < self.attn_maxl:
+            raise SystemExit(
+                f"prompt is {len(ids)} tokens but the fused Qwen decode window is "
+                f"ATTN_L={self.attn_maxl}; it can only be seeded from a prompt at "
+                f"least that long. Use this example's verify_prompts.txt (what "
+                f"`make verify` passes via --prompts-file), or rebuild the decode "
+                f"with a smaller ATTN_L."
+            )
+        self.prefiller.clear_context()
+        logits = np.asarray(self.prefiller.prefill(ids), np.float32)
+        first = int(logits.argmax())
+        K = np.stack(
+            [
+                np.asarray(self.prefiller.kv_view(l)[0], np.float32)
+                for l in range(_N_LAYERS)
+            ]
+        )
+        V = np.stack(
+            [
+                np.asarray(self.prefiller.kv_view(l)[1], np.float32)
+                for l in range(_N_LAYERS)
+            ]
+        )
+        self._P = K.shape[1]
+        self.dec.seed_kv(K, V, self._P)
+
+        # Prime the device window. seed_kv leaves the last prompt position in
+        # slot ATTN_L-1, which is exactly the slot the device appends into, so
+        # the first real decode step would overwrite it. Re-run the last prompt
+        # token at its own absolute position (what the CLI loop's first
+        # iteration does): the device rewrites that slot with the same content
+        # and the slide then frees the slot for position P. After this,
+        # decode_step(token, P) lines up with the runner's `cur`.
+        prime = int(np.asarray(self.dec.dispatch(ids[-1], self._P - 1)).argmax())
+        if prime != first and self._P <= self.attn_maxl:
+            # The priming step recomputes the prefill's own last position, so the
+            # two should agree -- that is the documented cross-check that the KV
+            # hand-off is exact. It is only a valid comparison when the whole
+            # prompt fits the window: for a longer prompt the decode attends over
+            # the last ATTN_L positions while the prefill attended over all P, so
+            # they legitimately differ and this would be a false alarm.
+            # Not fatal either way; the verify gate itself is the real check.
+            print(
+                f"[verify] WARN: fused decode re-ran the last prompt token and "
+                f"chose {prime}, but the prefill chose {first}; the "
+                f"prefill->decode KV hand-off may be inexact.",
+                file=sys.stderr,
+            )
+
+        # The Q4_0 prefill doesn't expose per-layer ffn_out, so the diagnosis lens
+        # has no data. Return one empty dict per layer (len == n_layers) rather
+        # than an empty list: the diagnosis path indexes layer_intermediates[li]
+        # per layer, and `.get("ffn_out")` on an empty dict yields None, which the
+        # shared runner skips gracefully (an empty list would IndexError).
+        empty = np.empty((0,), dtype=np.float32)
+        return PrefillRecord(
+            layer_intermediates=[{} for _ in range(_N_LAYERS)],
+            final_hidden_normed=empty,
+            logits_at_pred=logits,
+            top1_token=first,
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        # `current_pos` is the absolute position of `input_token` (the runner
+        # passes len(prompt) for the first generated token), which is exactly
+        # what dispatch() wants. prefill() primed the window for it.
+        logits = np.asarray(
+            self.dec.dispatch(int(input_token), int(current_pos)), np.float32
+        )
+        return DecodeStepRecord(
+            lm_head_logits=logits,
+            top1_token=int(logits.argmax()),
+        )

--- a/programming_examples/llms/qwen25_3b_q4/verify_prompts.txt
+++ b/programming_examples/llms/qwen25_3b_q4/verify_prompts.txt
@@ -1,0 +1,35 @@
+# Prompts for `make verify` on llms/qwen25_3b_q4 (passed to the shared
+# verify_runner via --prompts-file).
+#
+# WHY THIS FILE EXISTS instead of verify/prompts/instruct.txt, and why every
+# line is sized to 32-34 tokens:
+#
+# The fused Qwen decode is a sliding window of exactly ATTN_L positions (32 by
+# default). The host seeds it with the LAST ATTN_L positions of the prefill, so
+# the prompt length has to sit in a narrow band:
+#
+#   < 32 tokens  the window cannot be seeded at all -- verify_adapter refuses
+#                with a clear message. (The shared prompt file's lines are 5-10
+#                tokens, so it is unusable here.)
+#   > 32 tokens  the head of the prompt falls outside the window, so the NPU
+#                answers from a truncated context while the HF bf16 reference
+#                sees the whole prompt. That measures context truncation, not
+#                NPU drift, and it is a real effect: at 37 tokens the gate fails
+#                because "A graphics *processing* unit" has already slid out and
+#                the NPU cannot rank " processing" where HF does.
+#
+# 32-34 keeps the comparison apples-to-apples (at most two leading tokens
+# truncated) while leaving a small margin above the hard 32-token floor, so a
+# tokenizer change does not turn the gate into a crash. If you raise ATTN_L,
+# resize these to match it.
+#
+# All are open-ended continuations (base-style), not questions: the runner calls
+# tokenizer.encode() directly and applies no chat template, so a bare question
+# would be scored as raw continuation anyway.
+#
+# One prompt per line. Lines starting with '#' or empty are ignored.
+The capital city of France is called Paris, and the most famous landmark in the entire world is probably the very tall iron tower that stands right in the middle of
+A graphics processing unit is a specialized electronic circuit that was originally designed to speed up the drawing of images on a screen, and today it is also widely used to
+When water is heated to one hundred degrees Celsius at normal atmospheric pressure it starts to boil and turns into steam, and this change of state is known to scientists as a
+The human heart is a muscular organ that pumps blood all around the body, and over the course of an average day it beats roughly one hundred thousand separate times, which
+The Earth travels around the Sun once every three hundred and sixty five days, and while it does that it also spins on its own axis once every twenty four hours, which


### PR DESCRIPTION
Of the four Q4NX designs, three (`llama32_1b_q4nx`, `llama32_3b_q4nx`, `gemma3_4b_q4nx`) carry lits, a verify gate and a dashboard row. `qwen25_3b_q4` carried none: no `.lit` files, Makefile targets stopping at `compile`/`run`/`bench`/`weights`, no `verify_adapter.py`, absent from `generate_readme.py`'s model map, and zero references across `.github/workflows/`. Its `make run` is a real gate (`EXPECT_FIRST = 12095`, `" Paris"`) that nothing ever invoked, and the decode half had no gate at all — under-priming a fill lock is a deadlock, which is exactly the failure mode the refeed mechanism exists to prevent.

Underneath sat a defect that blocked bolting a harness on: the decode linked its attention kernels as classic objects while the other three use the inline-`.ll` merge, so mirroring the sibling build rule produced artifacts this design could not link (`unable to find air_project/attn_kv.o`).

### Attn linkage

`fused_decode_qwen` now uses the same `_set_attn_link` mechanism as `fused_decode.py`: `link_with = "<name>.ll"` plus `link_with_mode = "merge"`, which aiecc routes into the core's `link_merge_files`. Confirmed on device:

- the attn cores' ld scripts no longer `INPUT()` an object (the proj cores still do);
- the per-block `attn_qk_blk`/`attn_kv_blk` calls are gone from the merged core IR;
- an A/B against a `.o`-linked build of the same xclbin generates **token-for-token identical** text at the same 82 ms/token — the change is numerically neutral.

### Build

`llms/qwen25_3b_q4` gains `compile-decode` (QWEN2_5_3B kernels + the `decode_qwen` xclbin, weight-free, idempotent behind a build-flag stamp), `gen`, and a `clean` that also removes the QWEN-compiled kernels this Makefile writes into the shared `fused_decode/` dir — gemma's Makefile documents why leaving them makes a later Llama build link Qwen objects. The llvm-link preflight is delegated to `fused_decode` rather than copied, so the rule stays in one place in sync with `lit.cfg.py`'s `llvm_link_pre23`.

### Gates

`qwen_prefill_to_decode`'s monolithic `main()` is factored into a `QwenFusedDecoder` exposing the same `seed_kv()`/`dispatch()` pair `llama32_1b_q4nx`'s `FusedDecoder` does, which is what lets `verify_adapter.py` bind to the shared verify subsystem; the CLI is now a thin wrapper and produces identical output. Four lits land, named so the existing `check-programming-examples-llms-{compile,verify,profile}` filters pick them up with no workflow change.

`make verify` gates on the prefill argmax plus a complete 16-token fused-decode generation, both deterministic, rather than on the shared top-k-vs-HF-bf16 check. That path is wired up (`verify_adapter.py`, `make verify-topk`) but scores **2/5 prompts**: the decode is sound — it produces *"the city. Paris. The tower is called the Eiffel Tower, after"* — yet a Q4_0 36-layer model and a bf16 reference free-running greedily diverge within a few tokens on open-ended continuations, and the near-ties there fall outside top-5. Gating CI on it would be permanently red, and raising `k` or cherry-picking prompts until it passed would make the gate meaningless. `gemma3_4b_q4nx` made the same call. The number is recorded in the README instead of hidden.

`verify_prompts.txt` exists because the decode is a sliding window of exactly `ATTN_L` (=32): shorter prompts cannot seed it, and longer ones push the prompt head out of context so the NPU answers from a truncation the reference never sees — at 37 tokens the gate fails because *"A graphics **processing** unit"* has already slid out. Every line is 32–34 tokens.

### Verification

On NPU2 with the pinned toolchain (mlir-aie `1.4.1.dev58+gf501f21`, llvm-aie `21.0.0.2026080601+f4a72c27`, llvm-link 20):

| Check | Result |
|---|---|
| `make compile` | `Compilation passed.` |
| `make run` (36 NPU prefill layers) | argmax **12095** — `*** PARIS ***` |
| `make compile-decode` | `decode_qwen.xclbin` + insts + flags, inline-attn merged |
| `make gen` (36 NPU decode layers) | *" the city. Paris. The tower is called the Eiffel Tower, after"*, 12.2 tok/s device |
| `make verify` | PASS (all four lit CHECK lines) |
| `make profile` → `extract_perf.py` | `ttft_ms 4177`, `decode_tokens_per_sec 12.17`, `context_len 32` |
| `make verify-topk-full` | 2/5 — informational, documented |

Note on scope: the analysis that prompted this reported the Qwen prefill producing NaN. That does not reproduce on the pinned toolchain — it was measured with Peano `22.0.0.2026081201`, a major ahead of the repo pin. On the pin the Paris gate passes.

The change is one coherent feature and lands as a single PR rather than split: the linkage change and the Makefile build target are mutually dependent (before the Makefile there was no build path for the Qwen kernels at all), so an intermediate commit would leave the design unbuildable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)