### PR TITLE
[programming_examples] Close the three gaps that let the gemma decode bug hide

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -85,7 +85,10 @@ jobs:
           source air-venv/bin/activate
           # Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles
           # xrt/50_multi_launch_attention and xrt/48_triton_matmul_ver4_strix_4x4_bf16_output
-          # on NPU2 (NaN outputs). Revert once fixed upstream.
+          # on NPU2 (NaN outputs). It also takes out every Qwen LLM example --
+          # llms/qwen25_{0_5b,1_5b,3b} (bf16) fail their top-k gate and
+          # llms/qwen25_3b_q4 (Q4_0) returns NaN logits -- so re-check those four
+          # alongside the two xrt tests before reverting. Revert once fixed upstream.
           python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       - name: Build and test mlir-air

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -109,7 +109,10 @@ jobs:
           source air-venv/bin/activate
           # Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles
           # xrt/50_multi_launch_attention and xrt/48_triton_matmul_ver4_strix_4x4_bf16_output
-          # on NPU2 (NaN outputs). Revert once fixed upstream.
+          # on NPU2 (NaN outputs). It also takes out every Qwen LLM example --
+          # llms/qwen25_{0_5b,1_5b,3b} (bf16) fail their top-k gate and
+          # llms/qwen25_3b_q4 (Q4_0) returns NaN logits -- so re-check those four
+          # alongside the two xrt tests before reverting. Revert once fixed upstream.
           python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
       # The fused-decode inline-attn merge (programming_examples/fused_decode, used

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -28,7 +28,7 @@ equals full causal), so for the Paris gate it is not yet wired; dual-theta + per
 qk-norm ARE wired (they affect every position).
 
 Run:
-  python3 gemma3_4b_q4nx_inference.py                 # Paris gate (greedy, first token 9079)
+  python3 gemma3_4b_q4nx_inference.py                 # Paris gate (greedy, PARIS_GREEDY)
   python3 gemma3_4b_q4nx_inference.py --prompt "The capital of France is" --n-tokens 12
   python3 gemma3_4b_q4nx_inference.py --numpy-prefill # numpy-oracle prefill instead
 """
@@ -49,6 +49,12 @@ MODEL_DEFAULT = os.environ.get("Q4NX_MODEL_SOURCE", "FastFlowLM/Gemma3-4B-NPU2")
 # <bos> + "The capital of France is"  (Gemma3 tokenizer); numpy ref -> 9079 " Paris".
 PARIS_PROMPT = [2, 818, 5279, 529, 7001, 563]
 PARIS_FIRST = 9079
+# Greedy continuation at the gate shape (`make verify` runs --n-tokens 9). The gate
+# checks this, not just PARIS_FIRST: a decode that starts right and then drifts is a
+# real failure mode here -- a stale decode template yields a correct first token and
+# fluent garbage after it, which a first-token gate passes. Greedy, so deterministic;
+# re-record from `make run` if a deliberate numerics change moves it.
+PARIS_GREEDY = [9079, 236761, 108, 50429, 563, 496, 4185, 3988, 573, 1610]
 EOS_IDS = (1, 106)  # <eos>, <end_of_turn>
 _Q4NX_CACHE = os.path.expanduser("~/.cache/q4nx_gemma")
 
@@ -406,6 +412,30 @@ def generate(prompt, n_tokens, model=MODEL_DEFAULT, greedy=True, numpy_prefill=F
     return gen_ids
 
 
+def _first_diff(got, want):
+    """Index of the first differing token, or the length of the shorter run."""
+    for i, (g, w) in enumerate(zip(got, want)):
+        if g != w:
+            return i
+    return min(len(got), len(want))
+
+
+def _paris_verdict(gen_ids):
+    """Lines to print for the Paris gate. The two misses are separated because they
+    point at different halves: the first token comes out of the prefill, the rest
+    out of the decode loop."""
+    n = min(len(gen_ids), len(PARIS_GREEDY))
+    if not gen_ids or gen_ids[0] != PARIS_FIRST:
+        return [f"*** MISS *** first token {gen_ids[:1]}, expected [{PARIS_FIRST}]"]
+    if gen_ids[:n] != PARIS_GREEDY[:n]:
+        return [
+            f"*** MISS *** decode drifted at token {_first_diff(gen_ids, PARIS_GREEDY)}",
+            f"    expected {PARIS_GREEDY[:n]}",
+            f"    got      {gen_ids[:n]}",
+        ]
+    return ["*** PARIS ***"]
+
+
 def _detok(ids, model=MODEL_DEFAULT):
     try:
         from transformers import AutoTokenizer
@@ -448,9 +478,8 @@ def main():
     print(f"[inference] gen ids: {gen_ids}")
     print(f"[inference] TEXT: {_detok(gen_ids, args.model)!r}")
     if prompt == PARIS_PROMPT:
-        print(
-            "*** PARIS ***" if gen_ids and gen_ids[0] == PARIS_FIRST else "*** MISS ***"
-        )
+        for line in _paris_verdict(gen_ids):
+            print(line)
 
 
 if __name__ == "__main__":

--- a/programming_examples/llms/gemma3_4b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/gemma3_4b_q4nx/run_npu2_verify.lit
@@ -1,11 +1,15 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
-// GEMMA3-4B Q4NX end-to-end correctness gate: greedy first-token argmax.
+// GEMMA3-4B Q4NX end-to-end correctness gate: greedy token sequence.
 // Runs the batched AIR prefill (which produces the first token and the KV seed)
 // followed by the fused on-device decode (34 layers + tied LM head in one
-// dispatch) for "The capital of France is", and PASSes iff the first greedy
-// token is 9079 (" Paris") -- matching FastFlowLM's Gemma3 NPU output.
+// dispatch) for "The capital of France is", and PASSes iff the greedy tokens
+// match PARIS_GREEDY -- first token 9079 (" Paris"), matching FastFlowLM's
+// Gemma3 NPU output, plus the continuation. The continuation is load-bearing:
+// the first token comes out of the prefill, so gating on it alone leaves the
+// whole decode loop untested (a stale decode template passes it, then emits
+// fluent garbage).
 //
 // This is the Q4NX analogue of the other examples' `make verify` vs HF bf16
 // (which does not apply here: greedy-token parity against the reference

--- a/programming_examples/llms/llama32_1b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_1b_q4nx/Makefile
@@ -172,9 +172,13 @@ gen:
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --greedy --n-tokens 12
 
-## Remove all build artifacts, kernel/weight caches, and verify reports. (Decode
-## templates live in the fused_decode example; run `make -C ../../fused_decode clean`.)
+## Remove all build artifacts, kernel/weight caches, and verify reports. Also cleans
+## the fused_decode example, because this one's decode templates live THERE: leaving
+## them makes the next `compile-decode` a no-op (it skips when both are present), so
+## `clean && compile-decode` would verify whatever binaries ran last -- including
+## another model's, or ones built by a different compiler.
 clean:
 	rm -rf $(BUILD_DIR) $(srcdir)/_q4nx_* $(srcdir)/.wcache 2>/dev/null || true
 	rm -rf $(srcdir)/../verify/reports 2>/dev/null || true
-	@echo "Build dirs, caches and verify/reports/ removed. Rebuild with 'make compile'."
+	@$(MAKE) --no-print-directory -C $(FUSED_DECODE) clean
+	@echo "Build dirs, caches, verify/reports/ and decode templates removed. Rebuild with 'make compile'."

--- a/programming_examples/llms/shared/infra/cache.py
+++ b/programming_examples/llms/shared/infra/cache.py
@@ -4,6 +4,7 @@
 """Kernel compilation cache, profiling, and air_project utilities."""
 
 import json
+import os
 import shutil
 import time
 from pathlib import Path
@@ -339,19 +340,63 @@ class KernelCache:
         if self.verbose:
             print(f"  [KernelCache] {msg}")
 
+    def _toolchain_id(self):
+        """Identity of the toolchain that produced the cached ELFs.
+
+        Entries are keyed on kernel name alone, so without this a cache built by
+        a different mlir-air or Peano is served silently -- the failure mode is a
+        run that "passes" on binaries nobody rebuilt.
+        """
+        ids = {}
+        for dist in ("llvm-aie", "mlir_aie"):
+            try:
+                from importlib.metadata import version
+
+                ids[dist] = version(dist)
+            except Exception:
+                ids[dist] = "?"
+        # Peano and mlir-air are routinely used from a path rather than a wheel
+        # (local builds, extracted nightlies), where the dist version says
+        # nothing. Stamp the binaries themselves.
+        for key, path in (
+            (
+                "peano_clang",
+                Path(os.environ.get("PEANO_INSTALL_DIR", "")) / "bin/clang",
+            ),
+            (
+                "aie_opt",
+                Path(os.environ.get("MLIR_AIE_INSTALL_DIR", "")) / "bin/aie-opt",
+            ),
+        ):
+            try:
+                st = path.stat()
+                ids[key] = f"{st.st_size}:{int(st.st_mtime)}"
+            except OSError:
+                ids[key] = "missing"
+        try:
+            import air
+
+            libs = sorted((Path(air.__file__).parent / "_mlir_libs").glob("_air*.so"))
+            st = libs[0].stat()
+            ids["air_lib"] = f"{st.st_size}:{int(st.st_mtime)}"
+        except Exception:
+            ids["air_lib"] = "?"
+        return ids
+
     def _save_manifest(self):
         """Save artifact metadata so --run-only can reconstruct artifacts."""
-        manifest = {}
+        entries = {}
         for name, art in self.artifacts.items():
-            manifest[name] = {
+            entries[name] = {
                 "output_binary": str(art.output_binary),
                 "kernel": art.kernel,
                 "insts": str(art.insts) if art.insts else None,
             }
+        manifest = {"_toolchain": self._toolchain_id(), "entries": entries}
         manifest_path = self.cache_dir / self.MANIFEST_FILE
         with open(manifest_path, "w") as f:
             json.dump(manifest, f, indent=2)
-        self._log(f"Saved manifest with {len(manifest)} entries")
+        self._log(f"Saved manifest with {len(entries)} entries")
 
     def load_manifest(self):
         """Load artifact metadata from a previous compilation.
@@ -367,7 +412,16 @@ class KernelCache:
         with open(manifest_path) as f:
             manifest = json.load(f)
 
-        for name, info in manifest.items():
+        # A pre-_toolchain manifest cannot be shown to match, so treat it as cold
+        # rather than trusting it.
+        if manifest.get("_toolchain") != self._toolchain_id():
+            print(
+                "  [KernelCache] toolchain changed since this cache was built; "
+                "recompiling (delete the cache dir to silence this)"
+            )
+            return False
+
+        for name, info in manifest["entries"].items():
             binary_path = info["output_binary"]
             if not Path(binary_path).exists():
                 print(f"  WARNING: cached binary not found: {binary_path}")

--- a/programming_examples/llms/shared/infra/cache.py
+++ b/programming_examples/llms/shared/infra/cache.py
@@ -357,19 +357,19 @@ class KernelCache:
                 ids[dist] = "?"
         # Peano and mlir-air are routinely used from a path rather than a wheel
         # (local builds, extracted nightlies), where the dist version says
-        # nothing. Stamp the binaries themselves.
-        for key, path in (
-            (
-                "peano_clang",
-                Path(os.environ.get("PEANO_INSTALL_DIR", "")) / "bin/clang",
-            ),
-            (
-                "aie_opt",
-                Path(os.environ.get("MLIR_AIE_INSTALL_DIR", "")) / "bin/aie-opt",
-            ),
+        # nothing. Stamp the binaries themselves. An unset root is "unset", not a
+        # relative "bin/clang" -- that would stat whatever sits under the caller's
+        # cwd and make the fingerprint depend on where the run started.
+        for key, root_var, rel in (
+            ("peano_clang", "PEANO_INSTALL_DIR", "bin/clang"),
+            ("aie_opt", "MLIR_AIE_INSTALL_DIR", "bin/aie-opt"),
         ):
+            root = os.environ.get(root_var, "")
+            if not root:
+                ids[key] = "unset"
+                continue
             try:
-                st = path.stat()
+                st = (Path(root) / rel).stat()
                 ids[key] = f"{st.st_size}:{int(st.st_mtime)}"
             except OSError:
                 ids[key] = "missing"

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -52,7 +52,8 @@ export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 # Install llvm-aie
 # Temp pin: the LLVM 22 nightly (22.0.0.2026081201+046b11f9) miscompiles two NPU2 e2e
-# tests (NaN outputs). Keep in step with .github/workflows/. Revert once fixed upstream.
+# tests and every Qwen LLM example (NaN outputs) -- see .github/workflows/ for the
+# revert checklist. Keep in step with them. Revert once fixed upstream.
 python3 -m pip install --upgrade --force-reinstall "llvm-aie==21.0.0.2026080601+f4a72c27" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 PEANO_INSTALL_DIR="$(python3 -m pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 echo "WHL_LLVM_AIE DIR: $PEANO_INSTALL_DIR"


### PR DESCRIPTION
The gemma readback bug fixed in #1788 sat latent through four nightlies. Three separate holes let it, and each is fixed here. Companion to #1789, which covers the fourth gap (qwen25_3b_q4's missing build path and CI gates) — the two are disjoint.

## 1. Gemma's gate only checked token 0

`make verify` generates 9 tokens and compared just `gen_ids[0]` — which comes out of the **prefill**, so the decode loop the gate exists to cover was untested. The known failure mode here is exactly a decode that starts right and then drifts: a stale decode template yields a correct first token and fluent garbage after it, which the old gate passes.

Now gates on the full greedy sequence, with the two misses separated because they point at different halves:

```
*** MISS *** first token [4242], expected [9079]        <- prefill / weights / KV seed
*** MISS *** decode drifted at token 1                  <- decode loop
    expected [9079, 236761, 108, 50429, ...]
    got      [9079, 111, 222, 333]
```

Greedy, so deterministic. The recorded sequence is identical across repeated runs and across `b40eb7a11` → `a6ac5dd12`, which included #1786's decode weight-feed change — so it is stable across a real code change, not just run to run.

## 2. The ELF cache was not keyed on the compiler

`shared/infra/cache.py` keyed manifest entries on kernel **name** alone, so a cache built by a different mlir-air or Peano was served without complaint — a run that "passes" on binaries nobody rebuilt. This bit the #1788 investigation directly.

Now records a toolchain fingerprint; a mismatch, or a pre-fingerprint manifest, is treated as cold with a printed reason. Peano and mlir-air are routinely used from a path rather than a wheel (local builds, extracted nightlies), so the fingerprint stamps the binaries as well as the dist versions.

## 3. `llama32_1b_q4nx`'s `clean` missed the templates it consumes

Its decode templates live in `fused_decode/`, whose `compile-decode` skips when both are present — so the lit's `clean && compile-decode` was a no-op onto whatever ran last. Not hypothetical: during the #1788 investigation it verified **pre-#1784 binaries**, passing on stale artifacts. Now delegates to the `fused_decode` clean, matching what the gemma and 3B targets already do to that shared dir.

## Also: widen the #1785 Peano pin comment

It cites `xrt/50_multi_launch_attention` and `xrt/48_triton_matmul_ver4_strix_4x4_bf16_output`. LLVM 22 also breaks every Qwen LLM example — `llms/qwen25_{0_5b,1_5b,3b}` fail their top-k gate and `llms/qwen25_3b_q4` returns NaN logits. Whoever reverts that pin needs the full checklist. Confirmed by holding mlir-air fixed and varying only Peano.

## Verification

- **Cache fingerprint round-trip:** same toolchain → loads; changed Peano → invalidates with reason; legacy manifest → invalidates.
- **`llama32_1b_q4nx clean`:** confirmed it now removes the shared `decode_L2047/L2048`.
- **Gate branches**, all six, including right-first-token-then-drift (the case the old gate passed):

```
[ok] exact golden sequence            -> *** PARIS ***
[ok] short but matching prefix        -> *** PARIS ***
[ok] stale-template: right 1st, drift -> *** MISS *** decode drifted at token 1
[ok] drift late (token 7)             -> *** MISS *** decode drifted at token 7
[ok] wrong first token (prefill)      -> *** MISS *** first token [4242], expected [9079]
[ok] empty output                     -> *** MISS *** first token [], expected [9079]
```

The verdict logic is factored into `_paris_verdict()` so it is testable without hardware. The end-to-end `make verify` re-run on NPU2 is queued behind another session's use of the device; the golden sequence itself was captured from hardware runs earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)