### PR TITLE
[programming_examples] Fingerprint the air extension via __path__, not __file__

### DIFF
--- a/programming_examples/llms/shared/infra/cache.py
+++ b/programming_examples/llms/shared/infra/cache.py
@@ -373,14 +373,21 @@ class KernelCache:
                 ids[key] = f"{st.st_size}:{int(st.st_mtime)}"
             except OSError:
                 ids[key] = "missing"
+        # `air` is a namespace package, so __file__ is None -- go through
+        # __path__. The compiled extension is what the passes live in, and it is
+        # the piece that moves on an mlir-air rebuild.
         try:
             import air
 
-            libs = sorted((Path(air.__file__).parent / "_mlir_libs").glob("_air*.so"))
-            st = libs[0].stat()
-            ids["air_lib"] = f"{st.st_size}:{int(st.st_mtime)}"
-        except Exception:
-            ids["air_lib"] = "?"
+            roots = [Path(p) / "_mlir_libs" for p in air.__path__]
+            libs = sorted(l for r in roots for l in r.glob("_air*.so"))
+            if not libs:
+                raise FileNotFoundError("no _air*.so under air/_mlir_libs")
+            ids["air_lib"] = ";".join(
+                f"{l.name}:{l.stat().st_size}:{int(l.stat().st_mtime)}" for l in libs
+            )
+        except Exception as e:
+            ids["air_lib"] = f"?({type(e).__name__})"
         return ids
 
     def _save_manifest(self):

--- a/programming_examples/llms/shared/infra/cache.py
+++ b/programming_examples/llms/shared/infra/cache.py
@@ -380,12 +380,16 @@ class KernelCache:
             import air
 
             roots = [Path(p) / "_mlir_libs" for p in air.__path__]
-            libs = sorted(l for r in roots for l in r.glob("_air*.so"))
+            libs = sorted(lib for r in roots for lib in r.glob("_air*.so"))
             if not libs:
                 raise FileNotFoundError("no _air*.so under air/_mlir_libs")
-            ids["air_lib"] = ";".join(
-                f"{l.name}:{l.stat().st_size}:{int(l.stat().st_mtime)}" for l in libs
-            )
+            # One stat per file: two calls could straddle a rebuild and pair a
+            # stale size with a fresh mtime, giving a stamp that matches neither.
+            stamps = []
+            for lib in libs:
+                st = lib.stat()
+                stamps.append(f"{lib.name}:{st.st_size}:{int(st.st_mtime)}")
+            ids["air_lib"] = ";".join(stamps)
         except Exception as e:
             ids["air_lib"] = f"?({type(e).__name__})"
         return ids


### PR DESCRIPTION
Follow-up to #1790: the toolchain fingerprint it added never captured mlir-air.

`air` is a namespace package, so `air.__file__` is `None`. `Path(None)` raises `TypeError`, the bare `except Exception` swallowed it, and the field degraded to a constant `"?"`:

```
air.__file__ : None
air.__path__ : ['.../build_ci/python/air']
_air*.so     : ['_air.cpython-313-...so', '_airRt.cpython-313-...so']   # they do exist
```

So the fingerprint only ever tracked Peano and mlir-aie. The mlir-air half — the one that matters most for local iteration, since the passes live in that extension — did nothing: rebuild mlir-air and the ELF cache stayed valid, so a run could serve binaries built by different passes. That is precisely the case the fingerprint was added for; `llama32_1b_q4nx` verified pre-#1784 binaries during the #1788 investigation.

Fix: go through `air.__path__` and stamp every `_air*.so`. Also record the exception type rather than a bare `"?"`, so a future silent degradation is visible in the manifest instead of indistinguishable from "not installed".

## Verification

```
llvm-aie    = 21.0.0.2026080601+f4a72c27
mlir_aie    = 1.4.1.dev58+gf501f21
peano_clang = 225824:1786572805
aie_opt     = 209850976:1786554749
air_lib     = _air.cpython-313-...so:328904:1786578386;_airRt.cpython-313-...so:292056:1786578386
```

Invalidation round-trip, touching the extension to simulate an mlir-air rebuild:

```
same toolchain      -> True   (want True)
after mlir-air bump -> False  (want False)
restored            -> True   (want True)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)