### PR TITLE
[programming_examples] qwen decode handoff: read via bo.map(), not bo.read()

### DIFF
--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -251,9 +251,10 @@ class QwenFusedDecoder:
         self.x_bo.sync(FR)
         self.kv_bo.sync(FR)
 
-        # Zero-copy view into the BO (the shared infra's readback idiom): bo.read()
-        # returns a buffer whose stride metadata is pyxrt-build dependent, and on
-        # some runners it comes back non-contiguous, which np.frombuffer rejects.
+        # Read through the mapped BO, not bo.read(): read() returns a buffer whose
+        # stride metadata is pyxrt-build dependent, and where it comes back
+        # non-contiguous np.frombuffer rejects it. (frombuffer is a view; the
+        # .astype below is where the copy happens.)
         h = np.frombuffer(self.x_bo.map(), dtype=bfloat16, count=self.X).astype(
             np.float32
         )[m.XO_RMSIN : m.XO_RMSIN + m.K]

--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -251,13 +251,16 @@ class QwenFusedDecoder:
         self.x_bo.sync(FR)
         self.kv_bo.sync(FR)
 
-        h = np.frombuffer(self.x_bo.read(self.X * 2, 0), dtype=bfloat16).astype(
+        # Zero-copy view into the BO (the shared infra's readback idiom): bo.read()
+        # returns a buffer whose stride metadata is pyxrt-build dependent, and on
+        # some runners it comes back non-contiguous, which np.frombuffer rejects.
+        h = np.frombuffer(self.x_bo.map(), dtype=bfloat16, count=self.X).astype(
             np.float32
         )[m.XO_RMSIN : m.XO_RMSIN + m.K]
         logits = self._logits(h)
 
         # Take this token's K/V (device wrote slot L-1) and slide the window.
-        kvo = np.frombuffer(self.kv_bo.read(self.KVN * 2, 0), dtype=bfloat16).astype(
+        kvo = np.frombuffer(self.kv_bo.map(), dtype=bfloat16, count=self.KVN).astype(
             np.float32
         )
         for k in range(NL):


### PR DESCRIPTION
The `qwen25_3b_q4` verify lit added in #1789 fails on the perf runner:

```
qwen_prefill_to_decode.py:254 in dispatch
    h = np.frombuffer(self.x_bo.read(self.X * 2, 0), dtype=bfloat16)
ValueError: ndarray is not C-contiguous
```

Same root cause as #1788's gemma fix: pyxrt's `read()` returns an array whose stride metadata is build-dependent, and where it comes back non-contiguous the consumer rejects it. Only the consumer differs — `np.frombuffer` raises *"not C-contiguous"* where `.view()` raised *"last axis must be contiguous"* — so the error text does not resemble the earlier one, which is why the grep I did while fixing #1788 (for the `.read().view()` chain) missed it.

Both readbacks in `dispatch()` (`x_bo` and `kv_bo`) move to the `np.frombuffer(bo.map(), count=...)` idiom the llama and gemma designs already use.

The path is not new. #1789 gave this example its first `run_npu2_verify.lit`, so CI exercises it for the first time — new coverage surfacing a latent bug rather than causing one. The prefill half was already passing (`*** PARIS ***`, `argmax=12095`); it is the decode handoff that trips.

## Verification

On NPU2 (Ryzen AI 9 HX 370), full `clean` → `compile-decode` → `verify`, with `FileCheck` run against the lit:

```
[qwen_q4_prefill] *** PARIS ***
[qwen_q4_prefill] first-token argmax=279 (' the')
generated : ' the city. Paris. The tower is called the Eiffel Tower, after'
### exit=0 ###

FileCheck PASSED — all CHECK lines matched in order
```

## Not fixed here

Six other `bo.read()` consumers remain:

- `matrix_vector_multiplication/handwritten_pingpong_reference/run_{la,ld,la_2tile,ld_2tile}.py`
- `matrix_vector_multiplication/int4_q4nx/harness/time_elf{,_runlist}.py`

None are lit-covered, so they are latent in exactly the way this one was — the next to bite when someone adds coverage. A sweep wants its own change, together with a way to actually exercise them; shipping six unverified edits alongside a verified one seemed the wrong trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)