### PR TITLE
[AIR] Don't hand a loop's iter-arg init a token defined in its body

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -449,9 +449,17 @@ private:
     // Check memref deps
     if (auto defop = operand.getDefiningOp<air::ExecuteOp>()) {
       // addNewAsyncDepToGraph<T>(defop.getResult(0), op);
+      if (!definingOpDominatesSink(defop.getOperation(), op.getOperation()))
+        return;
       op.addAsyncDependency(defop.getAsyncToken());
     }
   }
+
+  // Whether def's results are usable at sink. The sink is not always a user of
+  // the memref: traceDependencyFromScfForOp sinks into the wait_all it inserts
+  // for an scf.for's iter_arg init, which sits outside the loop, so a memref
+  // allocated in the loop body reaches here without dominating it.
+  bool definingOpDominatesSink(Operation *def, Operation *sink);
 
   // If sink op and operand's use are under the same scope
   void pushDepsAtCurrentScope(mlir::Value operand, air::AsyncOpInterface op,

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -3105,6 +3105,16 @@ void dependencyTracer::getPartialMemrefFromOp(
   llvm::append_range(sink_op_scalar_outs, *writeAccessedScalars);
 }
 
+bool dependencyTracer::definingOpDominatesSink(Operation *def,
+                                               Operation *sink) {
+  // AIR regions are single-block, so proper dominance reduces to: some
+  // ancestor of sink lives in def's block, and def precedes it.
+  Operation *sinkAncestor = def->getBlock()->findAncestorOpInBlock(*sink);
+  if (!sinkAncestor || sinkAncestor == def)
+    return false;
+  return def->isBeforeInBlock(sinkAncestor);
+}
+
 // Add dependency edge
 void dependencyTracer::addDependencyBetweenOps(Operation *source,
                                                Operation *sink) {

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_loop_local_alloc.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_loop_local_alloc.mlir
@@ -1,0 +1,78 @@
+//===- air_split_l2_memref_loop_local_alloc.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1" --split-input-file | FileCheck %s
+
+// An L2 buffer allocated inside the loop that streams it (the weight-feed shape:
+// one alloc per trip, filled by a get, drained by one put per destination tile).
+// Splitting it re-traces the loop's dependencies, which inserts a wait_all for
+// the iter_arg init OUTSIDE the loop; the sub-allocs live inside. The re-trace
+// must not hand that wait_all a token defined in the loop body, or the pass
+// emits `operand #0 does not dominate this use` and fails.
+
+// The pass failing the verifier produces no output at all, so CHECK-LABEL
+// alone guards the dominance bug. The rest asserts it did the work: both
+// sub-allocs stay inside the loop, one per destination tile, and the 5120
+// buffer is gone.
+// CHECK-LABEL: func.func @loop_local_alloc_splits
+// CHECK: scf.for
+// CHECK: memref.alloc() : memref<2560xbf16, 1 : i32>
+// CHECK: memref.alloc() : memref<2560xbf16, 1 : i32>
+// CHECK-NOT: memref<5120xbf16, 1 : i32>
+
+air.channel @inW [1]
+air.channel @wL2ToL1 [1, 2]
+func.func @loop_local_alloc_splits(%arg0: memref<5120xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg1) in (%arg2=%c1) args(%arg3=%arg0) : memref<5120xbf16> attributes {id = 1 : i32} {
+    %c0 = arith.constant 0 : index
+    %c1_0 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c5120 = arith.constant 5120 : index
+    %1 = scf.for %arg4 = %c0 to %c4 step %c1_0 iter_args(%arg5 = %c0) -> (index) {
+      scf.yield %arg5 : index
+    }
+    %2 = air.segment @segment_0 async {
+      %c0_1 = arith.constant 0 : index
+      %c1_2 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c4_3 = arith.constant 4 : index
+      %3 = air.wait_all async
+      %4 = scf.for %arg4 = %c0_1 to %c4_3 step %c1_2 iter_args(%arg5 = %3) -> (!air.async.token) {
+        %async_token, %results = air.execute -> (memref<5120xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<5120xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<5120xbf16, 1 : i32>
+        }
+        %6 = air.channel.get async [%arg5, %async_token]  @inW[%c0_1] (%results[] [] []) {id = 1 : i32} : (memref<5120xbf16, 1 : i32>)
+        %7 = air.channel.put async [%6]  @wL2ToL1[%c0_1, %c0_1] (%results[0] [2560] [1]) {id = 2 : i32} : (memref<5120xbf16, 1 : i32>)
+        %8 = air.channel.put async [%6]  @wL2ToL1[%c0_1, %c1_2] (%results[2560] [2560] [1]) {id = 3 : i32} : (memref<5120xbf16, 1 : i32>)
+        %async_token_4 = air.execute [%8, %7] {
+          memref.dealloc %results : memref<5120xbf16, 1 : i32>
+        }
+        %9 = air.wait_all async [%7, %8]
+        scf.yield %9 : !air.async.token
+      }
+      %5 = air.herd @herd_0 async tile (%arg4, %arg5) in (%arg6=%c1_2, %arg7=%c2) attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c0_5 = arith.constant 0 : index
+        %c1_6 = arith.constant 1 : index
+        %c4_7 = arith.constant 4 : index
+        %6 = scf.for %arg8 = %c0_5 to %c4_7 step %c1_6 iter_args(%arg9 = %c0_5) -> (index) {
+          %async_token, %results = air.execute -> (memref<2560xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<2560xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<2560xbf16, 2 : i32>
+          }
+          %7 = air.channel.get async [%async_token]  @wL2ToL1[%arg4, %arg5] (%results[] [] []) {id = 4 : i32} : (memref<2560xbf16, 2 : i32>)
+          %async_token_8 = air.execute [%7] {
+            memref.dealloc %results : memref<2560xbf16, 2 : i32>
+          }
+          scf.yield %arg9 : index
+        }
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
`air-split-l2-memref` emitted SSA-invalid IR on the qwen decode pattern:

```
error: operand #0 does not dominate this use
Error: pass failed: func.func(air-split-l2-memref{max-launch-channels-mm2s=16 max-launch-channels-s2mm=16})
```

Found while investigating the second defect noted in #1794, which masks this one (qwen pins every L2 alloc, so those allocs no longer reach `partitionMemref`) without fixing it.

### Cause

`partitionMemref` ends by re-tracing each mutated loop through `traceDependencyFromScfForOp`. That helper first calls `assignEmptyWaitAllAtScfForIterArg`, which creates an `air.wait_all` **before** the loop — carrying the loop's own location, which is why the error is reported at the `scf.for` — and installs it as the iter-arg init. It then re-traces every async child op in the body against that wait_all as the sink.

Two paths add edges, and only one checked ordering:

- `pushDepsAtCurrentScope` goes through `addDependencyBetweenOps`, which guards on block membership and `isBeforeInBlock`.
- `traceDefiningOpAsDep` had **no check at all** — any memref defined by an `air.execute` handed its token straight to the sink.

So a buffer allocated inside the loop body fed a wait_all sitting outside it.

That asymmetry is why only qwen tripped it. Its weight feed allocates the L2 buffer inside the streaming loop — one alloc per trip, filled by a get, drained by one put per destination tile — so the sub-allocs land in the body. The llama and gemma split candidates sit at segment top level and dominate the init wait_all trivially.

### Fix

Add `definingOpDominatesSink` and consult it in `traceDefiningOpAsDep`. AIR regions are single-block, so proper dominance reduces to: an ancestor of the sink lives in def's block, and def precedes it.

New test `air_split_l2_memref_loop_local_alloc.mlir` covers the loop-local weight-feed shape. It fails on the current tree with the identical `operand #0 does not dominate this use` and passes with this change.

### The guard is inert everywhere else

A file-based probe counting rejections found **0** across all four q4nx decode designs compiled end to end, and **0** across the whole lit suite — while firing **24 times** on the failing input, all on `air.wait_all` sinks. The other two `traceDependencyFromOp` callers sink into the actual memref user, where dominance holds by SSA validity.

### Verification (NPU2, CI toolchain)

- `check-air-mlir` **487/487** (486 baseline + the new test)
- `conv2d_14x14` PASS, `xrt/48` PASS
- `xrt/50` **4/4 PASS at 218 buffers / 292 locks**, matching stock (this test's compiler output is nondeterministic run to run, so the comparison is on order-insensitive counts over repeated runs)
- 1b / 3b / gemma / qwen `make verify` PASS, with the decode templates deleted first so nothing was skipped
- All **7 production decode `insts.bin` byte-identical** to the pre-change builds — no perf impact

### Still open in this pass

The launch-cap guard waives itself when the single-channel side has no launch-level endpoints ("splitting is free at the launch level"). Free with respect to the one resource it models is not free — that is the memtile-to-compute case, where the whole cost lands on the memtile. Repairing it properly needs a memtile BD-occupancy model, since endpoints do not map 1:1 to blocks (see `getRepeatCounts`). Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
