### PR TITLE
Bump mlir-aie to 1.4.2.dev8+gdd18668

### DIFF
--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=f501f215b5e772b7fba38df35b79251d1de64b97
-WHEEL_VERSION=1.4.1.dev58+gf501f21
+export HASH=dd186682c7f5fcd49d42305f2abf6919702c4e1c
+WHEEL_VERSION=1.4.2.dev8+gdd18668
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
Routine pin refresh, eleven mlir-aie commits (`f501f21..dd18668`). No AIR source change is required — the tree builds clean against the new wheel as-is, which is the main thing this PR is here to prove.

LLVM is unchanged (`56bcc1871734`, DATETIME `2026080106`), so `clone-llvm.sh` needs no edit. Both `latest-wheels-4` and `latest-wheels-no-rtti-2` publish `1.4.2.dev8+gdd18668`, so the no-RTTI leg of the wheel matrix is covered.

Note the series moves 1.4.1 -> 1.4.2.

## What this pulls in

Nothing here targets a known AIR failure — this is a keep-current bump, not a fix. The functional changes:

- **mlir-aie #3547** — lower `aievec.neg` to LLVM for AIE2 and AIE2p.
- **mlir-aie #3538** — BD iteration support on `aie.dma_bd`.
- **mlir-aie #3532** (aie-rt) — zero the `p_memsz - p_filesz` gap when loading `PT_LOAD` segments, so `.bss` is actually cleared on ELF load.
- **mlir-aie #3530** — aie-rt pin moved to `8849e208` (`release/main_aig`), now tracked by Dependabot.
- **mlir-aie #3536** — hardware coverage for same-packet-id routing on npu1.

The rest are CI/infra and dependency bumps (#3518 clang-tidy, #3544, #3543, #3541, #3506, #3534).

## Validation

Built and tested locally against the published wheel, Phoenix/npu1:

| Suite | Result |
| --- | --- |
| `ninja` | clean, no API breakage |
| `check-air-mlir` | 492 passed, 7 XFAIL, 7 unsupported |
| `check-air-cpp` | 1/1 |
| `check-air-python` | 13 passed, 8 unsupported |
| `test/xrt` npu1+peano | 4/4 — `01_air_to_npu`, `05_extern_func`, `08_gemm_extern_vec`, `13_conv2d_i32` |
| `programming_examples` npu1+peano | 3/3 — `softmax`, `herd_dataflow` (mlir + python source) |

### Draft because the hardware coverage is a smoke set, not a sweep

The npu1 runs above are seven hand-picked tests, not the full 43-test `ryzen_ai_npu1 && peano` suite — the local Phoenix host is shared, so I kept the device footprint small. Nothing in this bump is npu2-specific, but nothing here has been run on npu2 either, and #3538 (`dma_bd` iteration) and #3532 (`PT_LOAD` zero-fill) are the two commits most likely to surface something a smoke set would miss. Leaving this as a draft until CI has run the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
