### PR TITLE
[programming_examples] Decode staircase: run each token on the smallest KV window

### DIFF
--- a/programming_examples/fused_decode/.gitignore
+++ b/programming_examples/fused_decode/.gitignore
@@ -18,3 +18,6 @@ air.elf
 # build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
 .decode_flags
 decode_qwen.flags
+
+# Staircase window manifest (which ATTN_MAXL pairs this dir holds).
+.decode_windows

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -74,6 +74,8 @@ help:
 ## opt then rejects the merged IR ("Broken module found"). The preflight aborts on it.
 ## This is the same rule the lit harness gates on (lit.cfg.py, feature llvm_link_pre23);
 ## the two MUST agree -- see the preflight comment below.
+LBUILD ?= 2048
+LREF   := $(shell echo $$(($(LBUILD) - 1)))
 DECODE_FLAGS_STAMP := $(srcdir)/.decode_flags
 DECODE_FLAGS       := W_DUAL_CHAN=$(W_DUAL_CHAN)
 
@@ -117,6 +119,23 @@ preflight-llvm-link:
 	    echo "ERROR: llvm-link is LLVM $$VER; the inline-attn merge needs LLVM <23"; \
 	    echo "       (see README Reproducibility for how to fetch one)"; exit 1; fi
 
+## Staircase templates: one pair per ATTN_MAXL window. Each token dispatches on the
+## smallest window covering the current context, so a short context streams
+## proportionally less KV. Writes $(DECODE_WINDOWS_STAMP) so the driver can reject a
+## directory whose templates do not match what was built.
+WINDOWS ?= 64 128 256 512 1024 2048
+DECODE_WINDOWS_STAMP := $(srcdir)/.decode_windows
+
+compile-decode-windows:
+	@for W in $(WINDOWS); do \
+	  echo ">>> staircase window ATTN_MAXL=$$W"; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build LBUILD=$$W \
+	    || exit 1; \
+	done
+	@echo "$(WINDOWS)" > $(DECODE_WINDOWS_STAMP)
+	@echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP)
+	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with --staircase."
+
 _compile_decode_build: preflight-llvm-link
 	@echo ">>> non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
 	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
@@ -132,13 +151,13 @@ _compile_decode_build: preflight-llvm-link
 	@# patch any context length in [1, 2048] into one template at runtime (recompile-free decode).
 	@# The block loop is single-buffered: air-label-scf-for-to-ping-pong declines it, because the
 	@# running max and accumulator are live across blocks. Turbo for ~50 tok/s.
-	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=2048 python3 $(DECODE_DRIVER) >/tmp/decode_L2048.log 2>&1; \
-	  if [ -f decode.xclbin ]; then mv -f decode.xclbin decode_L2048.xclbin; mv -f decode.insts.bin decode_L2048.insts.bin; \
-	  else echo "decode_L2048 FAILED (see /tmp/decode_L2048.log)"; exit 1; fi
-	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=2047 python3 $(DECODE_DRIVER) >/tmp/decode_L2047.log 2>&1; \
-	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin decode_L2047.insts.bin; mv -f decode.xclbin decode_L2047.xclbin; \
-	  else echo "decode_L2047 FAILED (see /tmp/decode_L2047.log)"; exit 1; fi
-	@echo "Decode build complete: decode_L2048 + decode_L2047 templates."
+	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/decode_L$(LBUILD).log 2>&1; \
+	  if [ -f decode.xclbin ]; then mv -f decode.xclbin decode_L$(LBUILD).xclbin; mv -f decode.insts.bin decode_L$(LBUILD).insts.bin; \
+	  else echo "decode_L$(LBUILD) FAILED (see /tmp/decode_L$(LBUILD).log)"; exit 1; fi
+	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/decode_L$(LREF).log 2>&1; \
+	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin decode_L$(LREF).insts.bin; mv -f decode.xclbin decode_L$(LREF).xclbin; \
+	  else echo "decode_L$(LREF) FAILED (see /tmp/decode_L$(LREF).log)"; exit 1; fi
+	@echo "Decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."
 
 ## Remove compiled kernels + decode templates.
 clean:

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -134,7 +134,7 @@ compile-decode-windows:
 	done
 	@echo "$(WINDOWS)" > $(DECODE_WINDOWS_STAMP)
 	@echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP)
-	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with --staircase."
+	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with DECODE_STAIRCASE=1."
 
 _compile_decode_build: preflight-llvm-link
 	@echo ">>> non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -57,6 +57,72 @@ per-block affine encoding regardless of model. That is why `llms/qwen25_3b_q4`
 quantizes the fp checkpoint directly rather than reading a bundle -- an affine
 bundle re-quantized into the symmetric device form would quantize twice.
 
+## Decode staircase: one template per KV window (opt-in)
+
+The compiled KV readback streams `ATTN_MAXL` positions **whatever the real context length
+is**. `RB_ROUNDS` (default `ceil(ATTN_L/16)`) feeds the outer size of the readback nd-DMA
+and is a build constant, so a template built at `ATTN_MAXL=2048` moves the whole padded
+cache on every token -- 224 MiB/token on the 3B -- to use 7 MiB of it at L=50. The core
+does skip fully-masked far blocks, but only *after* the DMA has hauled them from DDR:
+masking saves compute, not bandwidth.
+
+`DecodeInstsGen` cannot patch this away. It recovers per-word slopes by diffing two builds,
+and `ceil(L/16)` is a step function whose calibration points (e.g. 2047 and 2048) sit in
+the same step, so the readback count never appears among its L-dependent words.
+
+The staircase builds a template pair **per window** and dispatches each token on the
+smallest one covering the current L. At the same L, an `ATTN_MAXL=64` build and a 2048
+build differ in only 500 of 70,648 instruction words -- all `ATTN_MAXL`-scaled shim-NOC BD
+sizes, strides and offsets.
+
+### Using it
+
+```bash
+# once: builds a pair per window (default 64 128 256 512 1024 2048)
+make -C ../llms/llama32_1b_q4nx compile-decode-windows
+
+DECODE_STAIRCASE=1 make -C ../llms/llama32_1b_q4nx chat     # 1B, gemma3_4b_q4nx
+make -C ../llms/llama32_3b_q4nx chat ... --staircase        # 3B uses a CLI flag
+```
+
+`WINDOWS="64 512 2048"` overrides the set. Off by default: with a single template the
+behaviour and the code path are unchanged, and `staircase=True` against a one-window
+directory is identical to off.
+
+Measured over 300 greedy tokens from an empty cache, token stream **identical** to the
+single-window baseline in every case:
+
+| model | baseline | staircase | |
+|---|---|---|---|
+| `llama32_1b_q4nx` | 53.00 tok/s | 58.61 | **1.106x** |
+| `llama32_3b_q4nx` | 22.20 tok/s | 24.45 | **1.101x** |
+| `gemma3_4b_q4nx` | 15.41 tok/s | 18.55 | **1.204x** |
+
+The saving is `(1 - L/ATTN_MAXL) x` the full readback cost -- ~10% at short context, ~5%
+typical, and 0 once the context fills the window. Gemma gains most: 34 layers at head_dim
+256 is the largest padded cache.
+
+### How a window switch stays cheap
+
+Host-only BOs stay valid across an xclbin/hw_context swap, so every window's kernel is
+created once up front and a switch is kernel selection plus a KV re-space -- **no weight
+re-upload**. The cache is region-major on `ATTN_MAXL*REGION_W`, so changing window re-lays
+each region's live prefix (`respace_kv` in `decode_staircase.py`); the cost is proportional
+to the live positions, and a crossing happens exactly when that prefix is small (~33 ms,
+three crossings per 300 tokens).
+
+Templates are discovered by scanning a directory, and the staircase makes multi-window
+directories normal rather than a mistake, so the build writes a `.decode_windows` manifest
+and `DecodeInstsGen` rejects a directory whose calibrated set does not match it. A stray
+pair fails loudly instead of silently changing which window is selected.
+
+### Not applicable to `fused_decode_qwen.py`
+
+Qwen's decode is a sliding window of exactly `ATTN_L`: `seed_kv` fills it with the *last*
+`ATTN_L` positions, the hand-off asserts `ctx >= ATTN_L`, and the kernel appends at slot
+`ATTN_L-1`. The cache is fully occupied at every step, so there is no padding to stop
+streaming at any window size -- nothing for the staircase to reclaim.
+
 ## Dual-MM2S weight feed (`W_DUAL_CHAN`, on by default)
 
 Batch-1 decode is a weight-streaming problem: every token reads every weight once,

--- a/programming_examples/fused_decode/decode_insts_gen.py
+++ b/programming_examples/fused_decode/decode_insts_gen.py
@@ -79,7 +79,32 @@ class DecodeInstsGen:
                 Ls=Ls,
                 xclbin=os.path.join(artifact_dir, f"decode_L{base_L}.xclbin"),
             )
+        self._check_declared_windows(artifact_dir)
         self.select(max_L)
+
+    # Build stamp naming the ATTN_MAXL windows a directory is meant to hold, written by
+    # `make compile-decode-windows`.
+    WINDOWS_STAMP = ".decode_windows"
+
+    def _check_declared_windows(self, artifact_dir):
+        """Reject a directory whose calibrated windows differ from what the build declared.
+
+        Templates are discovered by scanning, so a leftover pair from an unrelated build
+        otherwise changes which window is selected -- silently, and the symptom is a
+        plausible-looking but wrong generation rather than an error.
+        """
+        stamp = os.path.join(artifact_dir, self.WINDOWS_STAMP)
+        if not os.path.exists(stamp):
+            return  # nothing declared (single-template tree) -- nothing to check
+        with open(stamp) as f:
+            want = sorted(int(t) for t in f.read().split())
+        have = self.calibrated_windows()
+        if have != want:
+            raise RuntimeError(
+                f"decode templates in {artifact_dir} do not match {self.WINDOWS_STAMP}: "
+                f"declared ATTN_MAXL {want}, found calibrated {have}. Remove strays or "
+                f"re-run `make compile-decode-windows`."
+            )
 
     def select(self, max_L=None):
         """Pick the active template: smallest calibrated ATTN_MAXL >= max_L (or the largest
@@ -122,13 +147,38 @@ class DecodeInstsGen:
 
     def insts_for_L(self, L):
         """uint32 insts stream for context length L on the active template (1 <= L <= ATTN_MAXL)."""
-        if not (1 <= L <= self.active_maxl):
-            raise ValueError(f"L={L} out of range for ATTN_MAXL={self.active_maxl}")
-        t = self._t
+        return self.insts_for(self.active_maxl, L)
+
+    def insts_for(self, maxl, L):
+        """uint32 insts stream for L on the `maxl` template, leaving the active one alone.
+
+        A staircase driver holds every window at once and picks per token, so it needs
+        the streams without the select()/active_maxl round trip.
+        """
+        t = self.templates[maxl]
+        if t["slope"] is None:
+            raise KeyError(f"template ATTN_MAXL={maxl} is not calibrated")
+        if not (1 <= L <= maxl):
+            raise ValueError(f"L={L} out of range for ATTN_MAXL={maxl}")
         out = t["base"].astype(np.int64)
         ld = t["slope"] != 0
         out[ld] = t["base"][ld].astype(np.int64) + (L - t["base_L"]) * t["slope"][ld]
         return out.astype(np.uint32)
+
+    def calibrated_windows(self):
+        """Calibrated ATTN_MAXL windows, ascending."""
+        return sorted(m for m, t in self.templates.items() if t["slope"] is not None)
+
+    def window_for_L(self, L):
+        """Smallest calibrated window that can serve context length L.
+
+        The compiled KV readback streams ATTN_MAXL positions regardless of L, so the
+        smallest covering window is also the cheapest one to run at.
+        """
+        for m in self.calibrated_windows():
+            if m >= L:
+                return m
+        raise KeyError(f"no calibrated window covers L={L}")
 
     def xclbin_for_maxl(self, m):
         return self.templates[m]["xclbin"]

--- a/programming_examples/fused_decode/decode_staircase.py
+++ b/programming_examples/fused_decode/decode_staircase.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Shared machinery for the decode staircase: run each token on the smallest KV window.
+
+The compiled KV readback streams ATTN_MAXL positions whatever the real context length is
+(`RB_ROUNDS` feeds the outer size of the readback nd-DMA and is a build constant), so a
+2048-window template moves the whole padded cache per token even at L=50. Building a
+template pair per ATTN_MAXL and dispatching on the smallest one covering L removes the
+difference.
+
+Every model's decoder keeps its own BO set and dispatch; what lives here is the part that
+must not diverge between them -- the window bookkeeping and the KV re-space.
+"""
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+
+class KVGeometry:
+    """Region-major KV cache shape.
+
+    Per layer: NGRP K regions then NGRP V regions, each ATTN_MAXL*REGION_W elements, with
+    position p at p*REGION_W inside its region. `lreg_max` sizes the BO, which is allocated
+    for the largest window and shared by all of them.
+    """
+
+    def __init__(self, n_layers, kvsz_tok, region_w, ngrp, lreg_max):
+        self.n_layers = int(n_layers)
+        self.kvsz_tok = int(kvsz_tok)
+        self.region_w = int(region_w)
+        self.ngrp = int(ngrp)
+        self.lreg_max = int(lreg_max)
+
+    def lreg(self, maxl):
+        return maxl * self.kvsz_tok
+
+    @property
+    def n_regions(self):
+        return 2 * self.ngrp
+
+
+def resolve_windows(gen, staircase):
+    """Windows to hold open: every calibrated one, or just the active one when off."""
+    return gen.calibrated_windows() if staircase else [gen.attn_maxl]
+
+
+def open_windows(dev, xrt, gen, windows, kernel_match="MLIR_AIE"):
+    """One hw_context + kernel per window, all opened up front.
+
+    Host-only BOs are host memory registered with the device rather than bound to a
+    context slot, so one BO set stays valid on every window's kernel; that is what keeps a
+    switch to a kernel swap instead of a multi-GB weight re-upload. Returns
+    {maxl: (ctx, kernel)} -- the context is kept in the tuple so it outlives the kernel.
+    """
+    out = {}
+    for m in windows:
+        xb = xrt.xclbin(gen.xclbin_for_maxl(m))
+        dev.register_xclbin(xb)
+        ctx = xrt.hw_context(dev, xb.get_uuid())
+        xk = [k for k in xb.get_kernels() if kernel_match in k.get_name()][0]
+        out[m] = (ctx, xrt.kernel(ctx, xk.get_name()))
+    return out
+
+
+def make_insts_states(gen, xrt, dev, group_id, windows):
+    """Per-window instruction stream: base, L-slope, host buffer and its own cacheable BO.
+
+    `lo`/`hi` bound the L-dependent words so a per-token patch can rewrite and sync just
+    that slice. `primed` tracks whether the full base stream has been written yet.
+    """
+    st = {}
+    for m in windows:
+        i1 = gen.insts_for(m, 1)
+        i2 = gen.insts_for(m, 2)
+        ld = np.where(i1 != i2)[0]
+        st[m] = dict(
+            ld=ld,
+            lo=int(ld.min()),
+            hi=int(ld.max()) + 1,
+            base=i1[ld].astype(np.int64),
+            slope=i2[ld].astype(np.int64) - i1[ld].astype(np.int64),
+            buf=i1.astype(np.uint32).copy(),
+            size=int(i1.size),
+            ib=xrt.bo(dev, i1.nbytes, xrt.bo.cacheable, group_id),
+            primed=False,
+        )
+    return st
+
+
+def patch_insts(state, L, xrt, to_dir):
+    """Write the L-dependent words of `state` into its BO and return the stream length.
+
+    The base stream is written whole once; afterwards only the [lo:hi] slice is rewritten
+    and synced.
+    """
+    state["buf"][state["ld"]] = (state["base"] + (L - 1) * state["slope"]).astype(
+        np.uint32
+    )
+    if not state["primed"]:
+        state["ib"].write(state["buf"], 0)
+        state["ib"].sync(to_dir)
+        state["primed"] = True
+    else:
+        lo, hi = state["lo"], state["hi"]
+        state["ib"].write(state["buf"][lo:hi], lo * 4)
+        state["ib"].sync(to_dir, (hi - lo) * 4, lo * 4)
+    return state["size"]
+
+
+def respace_kv(kvc, geom, old_maxl, new_maxl, live, xrt):
+    """Re-lay the `live` filled positions from one window's KV layout into another's.
+
+    Region stride is ATTN_MAXL*REGION_W, so changing window re-spaces the regions while
+    each region's live prefix is unchanged. Gathered to a compact temp first, so growing
+    and shrinking are both safe. Cost is proportional to `live`, and a crossing happens
+    exactly when `live` is small.
+
+    Reads back from the device: the kernel appends each token's K/V in place, so any host
+    mirror of the cache is stale after the first dispatch.
+    """
+    if old_maxl == new_maxl or live <= 0:
+        return
+    TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+    FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
+    R, NR = geom.region_w, geom.n_regions
+    kvc.sync(FROM)
+    src = np.frombuffer(kvc.map(), dtype=bfloat16, count=geom.n_layers * geom.lreg_max)
+    dst = np.zeros(geom.n_layers * geom.lreg_max, dtype=bfloat16)
+    n = live * R
+    for lay in range(geom.n_layers):
+        so = lay * geom.lreg(old_maxl)
+        do = lay * geom.lreg(new_maxl)
+        for r in range(NR):
+            dst[do + r * new_maxl * R : do + r * new_maxl * R + n] = src[
+                so + r * old_maxl * R : so + r * old_maxl * R + n
+            ]
+    kvc.write(dst.view(np.int16), 0)
+    kvc.sync(TO)

--- a/programming_examples/fused_decode/decode_staircase.py
+++ b/programming_examples/fused_decode/decode_staircase.py
@@ -41,8 +41,17 @@ class KVGeometry:
 
 
 def resolve_windows(gen, staircase):
-    """Windows to hold open: every calibrated one, or just the active one when off."""
-    return gen.calibrated_windows() if staircase else [gen.attn_maxl]
+    """Windows to hold open: the staircase up to the active one, or just the active one.
+
+    `gen.attn_maxl` is what `DecodeInstsGen.select(max_L)` already resolved to -- the
+    smallest calibrated window covering the caller's reach. Anything above it can never be
+    selected for L <= that reach, so opening it would only cost init time and an unused
+    hw_context. With `max_L=None` the active window is the largest and the full staircase
+    is kept.
+    """
+    if not staircase:
+        return [gen.attn_maxl]
+    return [m for m in gen.calibrated_windows() if m <= gen.attn_maxl]
 
 
 def open_windows(dev, xrt, gen, windows, kernel_match="MLIR_AIE"):
@@ -58,8 +67,14 @@ def open_windows(dev, xrt, gen, windows, kernel_match="MLIR_AIE"):
         xb = xrt.xclbin(gen.xclbin_for_maxl(m))
         dev.register_xclbin(xb)
         ctx = xrt.hw_context(dev, xb.get_uuid())
-        xk = [k for k in xb.get_kernels() if kernel_match in k.get_name()][0]
-        out[m] = (ctx, xrt.kernel(ctx, xk.get_name()))
+        xks = [k for k in xb.get_kernels() if kernel_match in k.get_name()]
+        if not xks:
+            raise RuntimeError(
+                f"no kernel matching {kernel_match!r} in "
+                f"{gen.xclbin_for_maxl(m)} (found: "
+                f"{[k.get_name() for k in xb.get_kernels()]})"
+            )
+        out[m] = (ctx, xrt.kernel(ctx, xks[0].get_name()))
     return out
 
 

--- a/programming_examples/llms/gemma3_4b_q4nx/.gitignore
+++ b/programming_examples/llms/gemma3_4b_q4nx/.gitignore
@@ -29,3 +29,6 @@ diag_cache/
 
 # build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
 .decode_flags
+
+# Staircase window manifest (which ATTN_MAXL pairs this dir holds).
+.decode_windows

--- a/programming_examples/llms/gemma3_4b_q4nx/Makefile
+++ b/programming_examples/llms/gemma3_4b_q4nx/Makefile
@@ -129,6 +129,21 @@ compile-decode:
 	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
 	fi
 
+## Staircase templates: one pair per ATTN_MAXL window; each token dispatches on the
+## smallest one covering the context. Writes $(DECODE_WINDOWS_STAMP) so a stray pair is
+## rejected at load rather than silently changing which window is selected.
+WINDOWS ?= 64 128 256 512 1024 2048
+DECODE_WINDOWS_STAMP := $(srcdir)/.decode_windows
+
+compile-decode-windows:
+	@for W in $(WINDOWS); do \
+	  echo ">>> staircase window ATTN_MAXL=$$W"; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build LBUILD=$$W \
+	    || exit 1; \
+	done
+	@echo "$(WINDOWS)" > $(DECODE_WINDOWS_STAMP)
+	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with DECODE_STAIRCASE=1."
+
 _compile_decode_build:
 	@# Delegate the llvm-link version preflight to the engine that owns it rather
 	@# than keeping a copy here: the rule (LLVM <23) must stay in one place, in

--- a/programming_examples/llms/gemma3_4b_q4nx/README.md
+++ b/programming_examples/llms/gemma3_4b_q4nx/README.md
@@ -218,6 +218,22 @@ The rms tile's DMA layout depends on a compute-tile allocator rule
 the sublayer result twice per dispatch beside once-per-dispatch norm weights,
 and such unequal-multiplicity flows must not share one S2MM BD chain.
 
+## Decode staircase (opt-in, ~1.1-1.2x)
+
+The decode template streams `ATTN_MAXL` KV positions per token regardless of the real
+context length, so a 2048-window build wastes most of that readback at short context.
+Building one template pair per window and dispatching each token on the smallest covering
+window recovers it, with a token stream identical to the single-window baseline.
+
+```bash
+make compile-decode-windows      # once; WINDOWS="64 512 2048" to override the set
+DECODE_STAIRCASE=1 make run
+```
+
+Off by default. See
+[`programming_examples/fused_decode/README.md`](../../fused_decode/README.md) for the
+mechanism, the measurements and the `.decode_windows` manifest guard.
+
 ## Key Files
 
 | file | role |

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -84,6 +84,19 @@ def _ensure_requant_cache(fd, model):
 # specializer) is imported from fused_decode/ but scans this dir for the templates.
 _DECODE_DIR = Path(os.environ.get("Q4NX_GEMMA_DECODE_DIR", str(_HERE)))
 
+# decode_staircase lives in fused_decode/, which joins sys.path in _pick_decode_gen;
+# imported lazily and cached for the methods that need it.
+_stair = None
+
+
+def _load_stair():
+    global _stair
+    if _stair is None:
+        import decode_staircase
+
+        _stair = decode_staircase
+    return _stair
+
 
 def _pick_decode_gen(dec_dir, max_L=None):
     sys.path.insert(0, str(_DEC))
@@ -98,7 +111,7 @@ class FusedDecoder:
     The weight + KV BOs are uploaded once; the kernel appends each new token's K/V in place.
     """
 
-    def __init__(self, model=MODEL_DEFAULT, max_L=None):
+    def __init__(self, model=MODEL_DEFAULT, max_L=None, staircase=False):
         import importlib.util
         import numpy as np
         from ml_dtypes import bfloat16
@@ -111,7 +124,12 @@ class FusedDecoder:
         self.gw = gw
 
         self.gen = _pick_decode_gen(_DECODE_DIR, max_L)
-        self.ATTN_MAXL = self.gen.attn_maxl
+        _load_stair()
+        # Staircase: hold every calibrated ATTN_MAXL window and dispatch each token on the
+        # smallest one covering L (the readback streams ATTN_MAXL positions regardless).
+        # Off by default -- one window, identical to the single-template path.
+        self.windows = _stair.resolve_windows(self.gen, staircase)
+        self.ATTN_MAXL = max(self.windows)
         self.maxL = min(int(max_L), self.ATTN_MAXL) if max_L else self.ATTN_MAXL
 
         # DECODE_MODEL / geometry env must be set BEFORE importing fused_decode.py (its
@@ -197,12 +215,9 @@ class FusedDecoder:
         # ONE xclbin + ONE self-contained BO set (weight BO uploaded once)
         self.dev = xrt.device(0)
         TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
-        xb = xrt.xclbin(self.gen.xclbin)
-        self.dev.register_xclbin(xb)
-        self._ctx = xrt.hw_context(self.dev, xb.get_uuid())
-        self._xb = xb
-        xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
-        self.kern = xrt.kernel(self._ctx, xk.get_name())
+        self._kern = _stair.open_windows(self.dev, xrt, self.gen, self.windows)
+        self.cur_maxl = self.ATTN_MAXL
+        self.kern = self._kern[self.cur_maxl][1]
         g = self.kern.group_id
         HO = xrt.bo.host_only
         self.x_bo = xrt.bo(self.dev, self.K * 2, HO, g(3))
@@ -210,16 +225,32 @@ class FusedDecoder:
         self.r_bo = xrt.bo(self.dev, self._RMS_SIZE * 2, HO, g(5))
         self.y_bo = xrt.bo(self.dev, self.ny * 2, HO, g(6))
         self.kvc = xrt.bo(self.dev, self.UNI_DEC * self.LREG * 2, HO, g(7))
-        self.ib = xrt.bo(self.dev, self.gen.base.nbytes, xrt.bo.cacheable, g(1))
+        self._ist = _stair.make_insts_states(
+            self.gen, xrt, self.dev, g(1), self.windows
+        )
+        self._geom = _stair.KVGeometry(
+            self.UNI_DEC, self.KVSZ_TOK, self.REGION_W, self.NGRP, self.LREG
+        )
+        self._use_window(self.cur_maxl)
         self.w_bo.write(self.Wv16, 0)
         self.w_bo.sync(TO)
         self.KV = np.zeros((self.UNI_DEC, self.LREG), dtype=bfloat16)
+
+    def _use_window(self, m):
+        """Point the active kernel / insts state at window `m` (no KV movement)."""
+        self._st = self._ist[m]
+        self.cur_maxl = m
+        self.kern = self._kern[m][1]
+        self.ib = self._st["ib"]
 
     def seed_kv(self, fk, fv, P):
         """Place the numpy-prefill K/V (fk/fv: [UNI_DEC,P,DK_TOT_A]) into the device KV cache
         region-major, then prefetch to the device (before the timed decode loop)."""
         np = self.np
-        RW, RS, NG = self.REGION_W, self.REGION_STRIDE, self.NGRP
+        if len(self.windows) > 1:
+            self._use_window(self.gen.window_for_L(P + 1))
+        RW, NG = self.REGION_W, self.NGRP
+        RS = self.cur_maxl * RW
         self.KV[:] = 0
         for Lyr in range(self.UNI_DEC):
             for gi in range(NG):
@@ -230,10 +261,11 @@ class FusedDecoder:
                     :
                 ] = fv[Lyr, :P, gi * RW : (gi + 1) * RW].astype(self.bf16)
         TO = self.xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        _lreg = self._geom.lreg(self.cur_maxl)
         for Lyr in range(self.UNI_DEC):
-            boff = Lyr * self.LREG * 2
-            self.kvc.write(self.KV[Lyr].view(np.int16), boff)
-            self.kvc.sync(TO, self.LREG * 2, boff)
+            boff = Lyr * _lreg * 2
+            self.kvc.write(self.KV[Lyr, :_lreg].view(np.int16), boff)
+            self.kvc.sync(TO, _lreg * 2, boff)
         self._kv_dirty = False
 
     def _rope_slab(self, p):
@@ -256,26 +288,13 @@ class FusedDecoder:
         FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
         L = p + 1
         # insts: write full stream once, then patch only the L-dependent [lo:hi] slice.
-        if not hasattr(self, "_ld"):
-            i1 = self.gen.insts_for_L(1)
-            i2 = self.gen.insts_for_L(2)
-            ld = np.where(i1 != i2)[0]
-            self._ld = ld
-            self._ld_lo = int(ld.min())
-            self._ld_hi = int(ld.max()) + 1
-            self._ld_base = i1[ld].astype(np.int64)
-            self._ld_slope = i2[ld].astype(np.int64) - i1[ld].astype(np.int64)
-            self._insts_buf = i1.astype(np.uint32).copy()
-            self._insts_size = int(i1.size)
-            self.ib.write(self._insts_buf, 0)
-            self.ib.sync(TO)
-        self._insts_buf[self._ld] = (self._ld_base + (L - 1) * self._ld_slope).astype(
-            np.uint32
-        )
-        _lo, _hi = self._ld_lo, self._ld_hi
-        self.ib.write(self._insts_buf[_lo:_hi], _lo * 4)
-        self.ib.sync(TO, (_hi - _lo) * 4, _lo * 4)
-        insts_size = self._insts_size
+        if len(self.windows) > 1:
+            _w = self.gen.window_for_L(L)
+            if _w != self.cur_maxl:
+                # `p` positions are live; this token's K/V is appended by the dispatch.
+                _stair.respace_kv(self.kvc, self._geom, self.cur_maxl, _w, p, xrt)
+                self._use_window(_w)
+        insts_size = _stair.patch_insts(self._st, L, xrt, TO)
         # KV uploaded once (seed), then device-resident (kernel appends in place).
         if getattr(self, "_kv_dirty", True):
             packed = np.ascontiguousarray(self.KV).reshape(-1)
@@ -377,7 +396,11 @@ def generate(prompt, n_tokens, model=MODEL_DEFAULT, greedy=True, numpy_prefill=F
     # Machine-readable line for bench/extract_perf.py (nightly LLM dashboard).
     print(f"Time to first token (TTFT): {ttft:.3f}s", flush=True)
 
-    dec = FusedDecoder(model=model, max_L=P + n_tokens)
+    dec = FusedDecoder(
+        model=model,
+        max_L=P + n_tokens,
+        staircase=os.environ.get("DECODE_STAIRCASE") == "1",
+    )
     n_eff = min(n_tokens, dec.ATTN_MAXL - P)
     if n_eff <= 0:
         print(f"[inference] P={P} >= ATTN_MAXL={dec.ATTN_MAXL}; abort")

--- a/programming_examples/llms/llama32_1b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_1b_q4nx/Makefile
@@ -63,7 +63,7 @@ VERIFY_RUNNER = $(srcdir)/../verify/verify_runner.py
 RUNNER_ADAPTER = llama32_1b_q4nx.verify_adapter
 
 .PHONY: help compile run profile chat verify verify-full diagnosis clean \
-        compile-decode profile-prefill verify-paris ask gen
+        compile-decode compile-decode-windows profile-prefill verify-paris ask gen
 
 help:
 	@echo "============================================================"
@@ -108,6 +108,10 @@ compile:
 ## Reproducibility). The inference driver loads its templates at run time.
 compile-decode:
 	$(MAKE) -C $(FUSED_DECODE) compile-decode
+
+## Staircase templates (one pair per ATTN_MAXL window); run with DECODE_STAIRCASE=1.
+compile-decode-windows:
+	$(MAKE) -C $(FUSED_DECODE) compile-decode-windows
 
 ## Run unified inference (NPU prefill + fused NPU decode).
 run:

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -151,6 +151,22 @@ Options: `--temperature 0.7 --top-k 5 --top-p 0.9`, `--rep-penalty`, `--seed`,
 `--system "..."`, `--n-tokens N`, `--no-eos-stop`. Enable turbo for ~50 tok/s:
 `xrt-smi configure -d <BDF> --pmode turbo`.
 
+## Decode staircase (opt-in, ~1.1-1.2x)
+
+The decode template streams `ATTN_MAXL` KV positions per token regardless of the real
+context length, so a 2048-window build wastes most of that readback at short context.
+Building one template pair per window and dispatching each token on the smallest covering
+window recovers it, with a token stream identical to the single-window baseline.
+
+```bash
+make compile-decode-windows      # once; WINDOWS="64 512 2048" to override the set
+DECODE_STAIRCASE=1 make chat
+```
+
+Off by default. See
+[`programming_examples/fused_decode/README.md`](../../fused_decode/README.md) for the
+mechanism, the measurements and the `.decode_windows` manifest guard.
+
 ## Correctness
 
 `make verify` runs the shared `verify/` top-k token-set inclusion gate (k=5,

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -39,6 +39,27 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 _PE = _HERE.parent.parent  # programming_examples
 _DEC = _PE / "fused_decode"  # standalone fused superkernel decode example
+
+# decode_staircase lives in fused_decode/, which only joins sys.path when a decoder is
+# constructed, so it is imported lazily and cached here for the methods that need it.
+_stair = None
+
+
+def _staircase_on():
+    """Multi-window decode (smallest ATTN_MAXL covering L). Env so every entry point --
+    CLI, verify adapter, lit -- opts in the same way."""
+    return os.environ.get("DECODE_STAIRCASE") == "1"
+
+
+def _load_stair():
+    global _stair
+    if _stair is None:
+        import decode_staircase
+
+        _stair = decode_staircase
+    return _stair
+
+
 # Tokenizer: a local Llama-3.2-1B tokenizer dir if present, else fall back to the
 # HF checkpoint (base/instruct share one tokenizer) so `make run`/`profile` work
 # without a hand-set Q4NX_TOKENIZER_DIR — same source the other llms/ examples use.
@@ -241,7 +262,7 @@ class FusedDecoder:
     xclbin, one BO set; the weight + KV BOs are uploaded once and the kernel appends each new
     token's K/V in place."""
 
-    def __init__(self, max_L=None):
+    def __init__(self, max_L=None, staircase=False):
         HF = (
             _ensure_paris_golden()
         )  # embed/norm from model.q4nx (single source) if not provided
@@ -251,6 +272,7 @@ class FusedDecoder:
         import pyxrt as xrt
 
         sys.path.insert(0, str(_DEC))
+        _load_stair()
         self.np = np
         self.bf16 = bfloat16
         self.xrt = xrt
@@ -258,7 +280,11 @@ class FusedDecoder:
         # kernel skips masked blocks and single-buffers the block loop, so it serves every L in
         # [1, 2048] via an RTP-L + append insts patch (the reference one-MAX_L design).
         self.gen = _pick_decode_gen(_DEC, max_L)
-        self.ATTN_MAXL = self.gen.attn_maxl
+        # Staircase: hold every calibrated ATTN_MAXL window and dispatch each token on the
+        # smallest one covering L (the readback streams ATTN_MAXL positions regardless).
+        # Off by default -- one window, identical to the single-template path.
+        self.windows = _stair.resolve_windows(self.gen, staircase)
+        self.ATTN_MAXL = max(self.windows)
         self.maxL = min(int(max_L), self.ATTN_MAXL) if max_L else self.ATTN_MAXL
 
         # decode-module constants at DECODE_GOLDEN_L=ATTN_MAXL -- the LREG/ny geometry must
@@ -326,12 +352,9 @@ class FusedDecoder:
         # ONE xclbin + ONE self-contained BO set (weight BO uploaded once)
         self.dev = xrt.device(0)
         TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
-        xb = xrt.xclbin(self.gen.xclbin)
-        self.dev.register_xclbin(xb)
-        self._ctx = xrt.hw_context(self.dev, xb.get_uuid())
-        self._xb = xb
-        xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
-        self.kern = xrt.kernel(self._ctx, xk.get_name())
+        self._kern = _stair.open_windows(self.dev, xrt, self.gen, self.windows)
+        self.cur_maxl = self.ATTN_MAXL
+        self.kern = self._kern[self.cur_maxl][1]
         g = self.kern.group_id
         HO = xrt.bo.host_only
         self.x_bo = xrt.bo(self.dev, self.K * 2, HO, g(3))
@@ -339,19 +362,35 @@ class FusedDecoder:
         self.r_bo = xrt.bo(self.dev, self._RMS_SIZE * 2, HO, g(5))
         self.y_bo = xrt.bo(self.dev, self.ny * 2, HO, g(6))
         self.kvc = xrt.bo(self.dev, 16 * self.LREG * 2, HO, g(7))
-        self.ib = xrt.bo(self.dev, self.gen.base.nbytes, xrt.bo.cacheable, g(1))
+        self._ist = _stair.make_insts_states(
+            self.gen, xrt, self.dev, g(1), self.windows
+        )
+        self._geom = _stair.KVGeometry(
+            16, self.KVSZ_TOK, self.REGION_W, self.NGRP, self.LREG
+        )
+        self._use_window(self.cur_maxl)
         self.w_bo.write(self.Wv16, 0)
         self.w_bo.sync(TO)
         # Per-layer KV cache, flat [LREG], laid out region-major (the reference quadrants):
         # [K_g0 | K_g1 | V_g0 | V_g1], each region ATTN_MAXL*REGION_W = REGION_STRIDE.
         self.KV = np.zeros((16, self.LREG), dtype=bfloat16)
 
+    def _use_window(self, m):
+        """Point the active kernel / insts state at window `m` (no KV movement)."""
+        self._st = self._ist[m]
+        self.cur_maxl = m
+        self.kern = self._kern[m][1]
+        self.ib = self._st["ib"]
+
     def seed_kv(self, fk, fv, P):
         """Place the prefill K/V (fk/fv: [16,P,DK_TOT_A]) into the device KV cache in the layout
         the loaded xclbin expects, then prefetch it to the device (before the timed decode loop).
         """
         np = self.np
-        RW, RS, NG = self.REGION_W, self.REGION_STRIDE, self.NGRP
+        if len(self.windows) > 1:
+            self._use_window(self.gen.window_for_L(P + 1))
+        RW, NG = self.REGION_W, self.NGRP
+        RS = self.cur_maxl * RW
         self.KV[:] = 0
         # Region-major (the reference layout): scatter each group's K (resp V) into its contiguous region.
         # fk[Lyr] is [P, DK_TOT_A] = [g0 K(RW) | g1 K(RW) | ...]; region g slot pos = g*RS+pos*RW.
@@ -368,10 +407,11 @@ class FusedDecoder:
         # kernel appends new tokens in-place). Region-major seeded slots are scattered across the
         # 4 regions, so upload the whole per-layer slab (one-time, off the timer).
         TO = self.xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        _lreg = self._geom.lreg(self.cur_maxl)
         for Lyr in range(16):
-            boff = Lyr * self.LREG * 2
-            self.kvc.write(self.KV[Lyr].view(np.int16), boff)
-            self.kvc.sync(TO, self.LREG * 2, boff)
+            boff = Lyr * _lreg * 2
+            self.kvc.write(self.KV[Lyr, :_lreg].view(np.int16), boff)
+            self.kvc.sync(TO, _lreg * 2, boff)
         self._kv_dirty = False  # already uploaded; dispatch skips it
 
     def dispatch(self, tok, p):
@@ -392,26 +432,13 @@ class FusedDecoder:
         # (RTP-L + append/readback offsets, located by diffing two builds). Write the full
         # 780KB stream ONCE, then each token overwrite only the changed [lo:hi] range and
         # sync just that slice -- avoids re-writing/re-syncing the whole cacheable BO.
-        if not hasattr(self, "_ld"):
-            i1 = self.gen.insts_for_L(1)
-            i2 = self.gen.insts_for_L(2)
-            ld = np.where(i1 != i2)[0]
-            self._ld = ld
-            self._ld_lo = int(ld.min())
-            self._ld_hi = int(ld.max()) + 1
-            self._ld_base = i1[ld].astype(np.int64)
-            self._ld_slope = i2[ld].astype(np.int64) - i1[ld].astype(np.int64)
-            self._insts_buf = i1.astype(np.uint32).copy()
-            self._insts_size = int(i1.size)
-            self.ib.write(self._insts_buf, 0)
-            self.ib.sync(TO)  # base written once
-        self._insts_buf[self._ld] = (self._ld_base + (L - 1) * self._ld_slope).astype(
-            np.uint32
-        )
-        _lo, _hi = self._ld_lo, self._ld_hi
-        self.ib.write(self._insts_buf[_lo:_hi], _lo * 4)
-        self.ib.sync(TO, (_hi - _lo) * 4, _lo * 4)
-        insts_size = self._insts_size
+        if len(self.windows) > 1:
+            _w = self.gen.window_for_L(L)
+            if _w != self.cur_maxl:
+                # `p` positions are live; this token's K/V is appended by the dispatch.
+                _stair.respace_kv(self.kvc, self._geom, self.cur_maxl, _w, p, xrt)
+                self._use_window(_w)
+        insts_size = _stair.patch_insts(self._st, L, xrt, TO)
         _t_insts = _tk() - _a
         _a = _tk()
         # KV cache is uploaded ONCE (seeded prefill positions) then left device-resident:
@@ -600,7 +627,7 @@ def generate(
 
     # ONE decode xclbin serves L in [1, ATTN_MAXL]; the decoder picks the template that covers
     # the requested reach (rt<M> for short, compile-time L<M> up to 2048). Cap at its ATTN_MAXL.
-    dec = FusedDecoder(P + n_tokens)
+    dec = FusedDecoder(P + n_tokens, staircase=_staircase_on())
     attn_maxl = dec.ATTN_MAXL
     n_eff = min(n_tokens, attn_maxl - P)
     if n_eff <= 0:
@@ -726,8 +753,8 @@ class Session:
             f"[session] prefill resident ({time.perf_counter() - t0:.2f}s); building decode...",
             flush=True,
         )
-        self.dec = (
-            FusedDecoder()
+        self.dec = FusedDecoder(
+            staircase=_staircase_on()
         )  # largest available decode context, resident (weights + xclbin)
         self.attn_maxl = self.dec.ATTN_MAXL
         # Warmup: one throwaway prefill so the FIRST user turn is warm (~1.07s) instead of the

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -766,8 +766,13 @@ class Session:
             [128000]
         )  # 1-token dummy, padded to seq_len -> warms the full path
         self.prefiller.clear_context()
+        _win = (
+            f", staircase windows={self.dec.windows}"
+            if len(self.dec.windows) > 1
+            else ""
+        )
         print(
-            f"[session] ready: prefill+decode resident (ATTN_MAXL={self.attn_maxl}, "
+            f"[session] ready: prefill+decode resident (ATTN_MAXL={self.attn_maxl}{_win}, "
             f"weights preloaded, warmup {time.perf_counter() - t_w:.2f}s).",
             flush=True,
         )
@@ -925,6 +930,11 @@ def interactive_chat(
                 sys.stdout.write(d)
                 sys.stdout.flush()
 
+        if len(sess.dec.windows) > 1:
+            print(
+                f"[chat] context {len(ids)} tok -> KV window {sess.dec.gen.window_for_L(len(ids) + 1)}",
+                flush=True,
+            )
         gen_ids = sess.run_turn(
             ids,
             temperature=temperature,

--- a/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_1b_q4nx/verify_adapter.py
@@ -80,6 +80,11 @@ def build_runner(
     return NpuRunner(max_seq=max_seq, tokenizer=tokenizer, lite_mode=lite_mode)
 
 
+def _stair_on():
+    """Multi-window decode opt-in; same env switch as the CLI."""
+    return os.environ.get("DECODE_STAIRCASE") == "1"
+
+
 class NpuRunner:
     """Adapter over the Q4NX fused prefill + one-xclbin decode.
 
@@ -100,7 +105,7 @@ class NpuRunner:
 
         self.prefiller = LlamaQ4nxPrefill(seq_len=max_seq, n_layers=_N_LAYERS)
         self.prefiller.load_weights(model=Q4NX_MODEL_SOURCE)
-        self.dec = FusedDecoder()
+        self.dec = FusedDecoder(staircase=_stair_on())
         self.attn_maxl = self.dec.ATTN_MAXL
         self._P = 0
 

--- a/programming_examples/llms/llama32_3b_q4nx/.gitignore
+++ b/programming_examples/llms/llama32_3b_q4nx/.gitignore
@@ -34,3 +34,6 @@ decode.insts.bin
 
 # build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
 .decode_flags
+
+# Staircase window manifest (which ATTN_MAXL pairs this dir holds).
+.decode_windows

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -96,6 +96,7 @@ help:
 	@echo "Quick start:"
 	@echo "  make compile          Compile prefill ELFs (~4 min, one-time; no weights)"
 	@echo "  make compile-decode   Decode templates, built into this dir (~15 min, no weights)"
+	@echo "  make compile-decode-windows  Staircase: one template pair per ATTN_MAXL ($(WINDOWS)); ~1.11x decode"
 	@echo "  make run              Run inference ($(N_TOKENS) tokens)"
 	@echo "  make chat             Interactive chat REPL (streaming output)"
 	@echo "  make profile          Run with profiling breakdown"
@@ -143,6 +144,26 @@ compile-decode:
 	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build \
 	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
 	fi
+
+## Staircase templates: one pair per ATTN_MAXL window. The compiled KV readback streams
+## ATTN_MAXL positions whatever the real context length is, so running each token on the
+## smallest covering window moves proportionally less DDR per token (measured 1.11x over
+## 300 tokens, token stream bit-identical). Run the driver with --staircase to use them.
+## Writes $(DECODE_WINDOWS_STAMP) so the driver can reject a directory whose templates do
+## not match what was built -- template discovery is a directory scan, and a stray pair
+## silently changes which window is selected.
+WINDOWS ?= 64 128 256 512 1024 2048
+DECODE_WINDOWS_STAMP := $(srcdir)/.decode_windows
+
+compile-decode-windows:
+	@for W in $(WINDOWS); do \
+	  echo ">>> staircase window ATTN_MAXL=$$W"; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build LBUILD=$$W \
+	    || exit 1; \
+	done
+	@echo "$(WINDOWS)" > $(DECODE_WINDOWS_STAMP)
+	@echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP)
+	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with --staircase."
 
 _compile_decode_build:
 	@# Delegate the llvm-link version preflight to the engine that owns it:
@@ -233,7 +254,7 @@ gen:
 ## the lit tests run `clean` before every gate. Delete it by hand to force a re-pack.
 clean:
 	rm -f $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
-	rm -f $(DECODE_FLAGS_STAMP) 2>/dev/null || true
+	rm -f $(DECODE_FLAGS_STAMP) $(DECODE_WINDOWS_STAMP) 2>/dev/null || true
 	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
 	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
 	rm -rf $(BUILD_DIR) $(srcdir)/__pycache__ $(srcdir)/_q4nx_cache_seq* 2>/dev/null || true

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -159,6 +159,22 @@ shape-agnostic `Q4nxModel` reader (from the 1B Q4NX example) and assembles the
 dequantized bf16 matrices into the `llama32_3b` `LlamaWeights` container; every
 stage downstream of weight loading is the bf16 `llama32_3b` driver, unchanged.
 
+## Decode staircase (opt-in, ~1.1-1.2x)
+
+The decode template streams `ATTN_MAXL` KV positions per token regardless of the real
+context length, so a 2048-window build wastes most of that readback at short context.
+Building one template pair per window and dispatching each token on the smallest covering
+window recovers it, with a token stream identical to the single-window baseline.
+
+```bash
+make compile-decode-windows      # once; WINDOWS="64 512 2048" to override the set
+make chat ... --staircase
+```
+
+Off by default. See
+[`programming_examples/fused_decode/README.md`](../../fused_decode/README.md) for the
+mechanism, the measurements and the `.decode_windows` manifest guard.
+
 ## Key Files
 
 | Path | Purpose |

--- a/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_3b_q4nx/llama32_3b_q4nx_inference.py
@@ -183,7 +183,12 @@ def build_decoder(args) -> FusedDecode3B:
             f"first (or pass --templates)."
         )
     print(f"\nLoading Q4NX weights ({args.model_source}) + decode templates ...")
-    return FusedDecode3B(args.model_source, args.templates, model_type=MODEL_TYPE)
+    return FusedDecode3B(
+        args.model_source,
+        args.templates,
+        model_type=MODEL_TYPE,
+        staircase=args.staircase,
+    )
 
 
 def repl(dec, tokenizer, args, prefiller=None):
@@ -233,6 +238,12 @@ if __name__ == "__main__":
         type=str,
         default=TEMPLATES_DEFAULT,
         help="directory holding decode_L<N>.{xclbin,insts.bin} builds",
+    )
+    parser.add_argument(
+        "--staircase",
+        action="store_true",
+        help="run each token on the smallest calibrated ATTN_MAXL window covering the "
+        "current context, instead of always the largest (needs multi-window templates)",
     )
     parser.add_argument(
         "--no-prefill",

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -170,7 +170,14 @@ class FusedDecode3B:
     The KV cache is device-resident and grown in place -- no CPU attention, no re-upload.
     """
 
-    def __init__(self, model_source, templates, model_type="LLAMA_3_2_3B", max_L=None):
+    def __init__(
+        self,
+        model_source,
+        templates,
+        model_type="LLAMA_3_2_3B",
+        max_L=None,
+        staircase=False,
+    ):
         import pyxrt as xrt
 
         self.xrt = xrt
@@ -198,7 +205,15 @@ class FusedDecode3B:
         from decode_insts_gen import DecodeInstsGen
 
         self.gen = DecodeInstsGen(str(templates), max_L=max_L)
-        self.ATTN_MAXL = self.gen.attn_maxl
+        # Staircase: hold every calibrated ATTN_MAXL window and run on the smallest one
+        # covering the current L. The compiled KV readback streams ATTN_MAXL positions
+        # whatever L is, so a smaller window moves proportionally fewer DDR bytes/token.
+        # Off by default -- one window, byte-identical to the single-template path.
+        self.windows = (
+            self.gen.calibrated_windows() if staircase else [self.gen.attn_maxl]
+        )
+        # BOs and the rope table are sized for the largest window and shared by all.
+        self.ATTN_MAXL = max(self.windows)
         self.rope_cos, self.rope_sin = llama3_rope(self.ATTN_MAXL, self.DH)
 
         RMS_LAYER = fd.RMS_LAYER
@@ -212,15 +227,22 @@ class FusedDecode3B:
             [np.concatenate([RMS_in[k], RMS_post[k]]) for k in range(self.N_LAYERS)]
         )
 
-        # XRT: one xclbin + one resident BO set (weights uploaded once)
+        # XRT: one kernel per window + ONE resident BO set (weights uploaded once).
+        # Host-only BOs are host memory registered with the device, not bound to a
+        # hw_context slot, so the same set is valid on every window's kernel -- which is
+        # what makes a window switch cheap (no 2 GB weight re-upload).
         self.dev = xrt.device(0)
         self.TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
         self.FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
-        xb = xrt.xclbin(self.gen.xclbin)
-        self.dev.register_xclbin(xb)
-        ctx = xrt.hw_context(self.dev, xb.get_uuid())
-        xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
-        self.kern = xrt.kernel(ctx, xk.get_name())
+        self._kern = {}
+        for m in self.windows:
+            xb = xrt.xclbin(self.gen.xclbin_for_maxl(m))
+            self.dev.register_xclbin(xb)
+            c = xrt.hw_context(self.dev, xb.get_uuid())
+            xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
+            self._kern[m] = (c, xrt.kernel(c, xk.get_name()))  # tuple keeps ctx alive
+        self.cur_maxl = self.ATTN_MAXL
+        self.kern = self._kern[self.cur_maxl][1]
         g = self.kern.group_id
         HO = xrt.bo.host_only
         self.x_bo = xrt.bo(self.dev, self.K * 2, HO, g(3))
@@ -228,7 +250,6 @@ class FusedDecode3B:
         self.r_bo = xrt.bo(self.dev, RMS_SIZE * 2, HO, g(5))
         self.y_bo = xrt.bo(self.dev, self.ny * 2, HO, g(6))
         self.kvc = xrt.bo(self.dev, self.N_LAYERS * self.LREG * 2, HO, g(7))
-        self.ib = xrt.bo(self.dev, self.gen.base.nbytes, xrt.bo.cacheable, g(1))
 
         self.w_bo.write(Wv16, 0)
         self.w_bo.sync(self.TO)
@@ -240,22 +261,73 @@ class FusedDecode3B:
         self.r_bo.sync(self.TO)
         self.rms_lut_off = int(rms_slabs.size)
 
-        # insts base + the L-dependent word slope (RTP-L + KV-append offsets), from two builds.
-        i1 = self.gen.insts_for_L(1)
-        i2 = self.gen.insts_for_L(2)
-        self.ld = np.where(i1 != i2)[0]
-        self.ld_base = i1[self.ld].astype(np.int64)
-        self.ld_slope = i2[self.ld].astype(np.int64) - i1[self.ld].astype(np.int64)
-        self.insts_buf = i1.astype(np.uint32).copy()
-        self.insts_size = int(i1.size)
-        self.ib.write(self.insts_buf, 0)
-        self.ib.sync(self.TO)
+        # Per window: insts base + the L-dependent word slope (RTP-L + KV-append
+        # offsets, from that window's two builds) and its own instruction BO.
+        self._ist = {}
+        for m in self.windows:
+            i1 = self.gen.insts_for(m, 1)
+            i2 = self.gen.insts_for(m, 2)
+            ld = np.where(i1 != i2)[0]
+            ib = xrt.bo(self.dev, i1.nbytes, xrt.bo.cacheable, g(1))
+            self._ist[m] = dict(
+                ld=ld,
+                base=i1[ld].astype(np.int64),
+                slope=i2[ld].astype(np.int64) - i1[ld].astype(np.int64),
+                buf=i1.astype(np.uint32).copy(),
+                size=int(i1.size),
+                ib=ib,
+            )
+        self._use_window(self.cur_maxl)
+
+    def _use_window(self, m):
+        """Point the active kernel / insts state at window `m` (no KV movement)."""
+        st = self._ist[m]
+        self.cur_maxl = m
+        self.kern = self._kern[m][1]
+        self.ib = st["ib"]
+        self.ld, self.ld_base, self.ld_slope = st["ld"], st["base"], st["slope"]
+        self.insts_buf, self.insts_size = st["buf"], st["size"]
+
+    def _cur_lreg(self, maxl=None):
+        """KV elements per layer at window `maxl` (default: the active window)."""
+        return (self.cur_maxl if maxl is None else maxl) * self.fd.KVSZ_TOK
+
+    def _respace_kv(self, old_maxl, new_maxl, live):
+        """Re-lay the `live` filled positions from one window's KV layout into another's.
+
+        The cache is region-major with region_stride = ATTN_MAXL*REGION_W, so changing
+        window re-spaces the regions while each region's live prefix is unchanged.
+        Gathered to a compact temp first, so growing and shrinking are both safe. Cost
+        is proportional to `live`, and a crossing happens exactly when `live` is small.
+        """
+        if old_maxl == new_maxl or live <= 0:
+            return
+        fd = self.fd
+        R, NR = fd.REGION_W, 2 * fd.NGRP
+        self.kvc.sync(self.FROM)
+        src = np.frombuffer(
+            self.kvc.map(), dtype=bfloat16, count=self.N_LAYERS * self.LREG
+        )
+        dst = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
+        n = live * R
+        for lay in range(self.N_LAYERS):
+            so = lay * self._cur_lreg(old_maxl)
+            do = lay * self._cur_lreg(new_maxl)
+            for r in range(NR):
+                s = so + r * old_maxl * R
+                d = do + r * new_maxl * R
+                dst[d : d + n] = src[s : s + n]
+        self.kvc.write(dst.view(np.int16), 0)
+        self.kvc.sync(self.TO)
 
     def reset_kv(self):
         """Zero the device-resident KV cache (start a fresh sequence)."""
         KV = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
         self.kvc.write(KV.view(np.int16), 0)
         self.kvc.sync(self.TO)
+        # A fresh sequence starts at L=1, so drop back to the cheapest window.
+        if getattr(self, "_ist", None):
+            self._use_window(self.windows[0])
 
     def seed_kv(self, k_layers, v_layers):
         """Seed the device KV cache from a prefill (the warm-start handoff).
@@ -274,12 +346,17 @@ class FusedDecode3B:
             raise RuntimeError(
                 f"prefill ctx {ctx} exceeds decode ATTN_MAXL {self.ATTN_MAXL}"
             )
-        region_stride = self.ATTN_MAXL * fd.REGION_W
+        # Seed straight into the layout of the window the first decode step will use
+        # (L = ctx+1), so no re-space is needed on the very first dispatch.
+        if len(self.windows) > 1:
+            self._use_window(self.gen.window_for_L(ctx + 1))
+        region_stride = self.cur_maxl * fd.REGION_W
+        lreg = self._cur_lreg()
         buf = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
         for L in range(self.N_LAYERS):
             kL = np.asarray(k_layers[L], bfloat16).reshape(ctx, -1)
             vL = np.asarray(v_layers[L], bfloat16).reshape(ctx, -1)
-            base = L * self.LREG
+            base = L * lreg
             for gi in range(fd.NGRP):
                 cols = slice(gi * fd.REGION_W, (gi + 1) * fd.REGION_W)
                 kreg = base + gi * region_stride
@@ -294,6 +371,12 @@ class FusedDecode3B:
         """One decode step at context length L=p+1: patch insts for L, feed embed[tok] +
         the position-p rope LUT, run the fused decode, return the vocab logits."""
         L = p + 1
+        if len(self.windows) > 1:
+            w = self.gen.window_for_L(L)
+            if w != self.cur_maxl:
+                # `p` positions are live; this token's K/V is appended by the dispatch.
+                self._respace_kv(self.cur_maxl, w, p)
+                self._use_window(w)
         self.insts_buf[self.ld] = (self.ld_base + (L - 1) * self.ld_slope).astype(
             np.uint32
         )

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -25,6 +25,9 @@ for _p in (str(_PROG), str(_LLMS), str(_DEC), str(_1B), str(_HERE)):
         sys.path.insert(0, _p)
 
 
+import decode_staircase as stair  # noqa: E402  (needs the sys.path above)
+
+
 def llama3_rope(
     n_pos,
     dim,
@@ -209,9 +212,7 @@ class FusedDecode3B:
         # covering the current L. The compiled KV readback streams ATTN_MAXL positions
         # whatever L is, so a smaller window moves proportionally fewer DDR bytes/token.
         # Off by default -- one window, byte-identical to the single-template path.
-        self.windows = (
-            self.gen.calibrated_windows() if staircase else [self.gen.attn_maxl]
-        )
+        self.windows = stair.resolve_windows(self.gen, staircase)
         # BOs and the rope table are sized for the largest window and shared by all.
         self.ATTN_MAXL = max(self.windows)
         self.rope_cos, self.rope_sin = llama3_rope(self.ATTN_MAXL, self.DH)
@@ -234,13 +235,7 @@ class FusedDecode3B:
         self.dev = xrt.device(0)
         self.TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
         self.FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
-        self._kern = {}
-        for m in self.windows:
-            xb = xrt.xclbin(self.gen.xclbin_for_maxl(m))
-            self.dev.register_xclbin(xb)
-            c = xrt.hw_context(self.dev, xb.get_uuid())
-            xk = [k for k in xb.get_kernels() if "MLIR_AIE" in k.get_name()][0]
-            self._kern[m] = (c, xrt.kernel(c, xk.get_name()))  # tuple keeps ctx alive
+        self._kern = stair.open_windows(self.dev, xrt, self.gen, self.windows)
         self.cur_maxl = self.ATTN_MAXL
         self.kern = self._kern[self.cur_maxl][1]
         g = self.kern.group_id
@@ -263,62 +258,22 @@ class FusedDecode3B:
 
         # Per window: insts base + the L-dependent word slope (RTP-L + KV-append
         # offsets, from that window's two builds) and its own instruction BO.
-        self._ist = {}
-        for m in self.windows:
-            i1 = self.gen.insts_for(m, 1)
-            i2 = self.gen.insts_for(m, 2)
-            ld = np.where(i1 != i2)[0]
-            ib = xrt.bo(self.dev, i1.nbytes, xrt.bo.cacheable, g(1))
-            self._ist[m] = dict(
-                ld=ld,
-                base=i1[ld].astype(np.int64),
-                slope=i2[ld].astype(np.int64) - i1[ld].astype(np.int64),
-                buf=i1.astype(np.uint32).copy(),
-                size=int(i1.size),
-                ib=ib,
-            )
+        self._ist = stair.make_insts_states(self.gen, xrt, self.dev, g(1), self.windows)
+        self._geom = stair.KVGeometry(
+            self.N_LAYERS, KVSZ_TOK, fd.REGION_W, fd.NGRP, self.LREG
+        )
         self._use_window(self.cur_maxl)
 
     def _use_window(self, m):
         """Point the active kernel / insts state at window `m` (no KV movement)."""
-        st = self._ist[m]
+        self._st = self._ist[m]
         self.cur_maxl = m
         self.kern = self._kern[m][1]
-        self.ib = st["ib"]
-        self.ld, self.ld_base, self.ld_slope = st["ld"], st["base"], st["slope"]
-        self.insts_buf, self.insts_size = st["buf"], st["size"]
-
-    def _cur_lreg(self, maxl=None):
-        """KV elements per layer at window `maxl` (default: the active window)."""
-        return (self.cur_maxl if maxl is None else maxl) * self.fd.KVSZ_TOK
+        self.ib = self._st["ib"]
 
     def _respace_kv(self, old_maxl, new_maxl, live):
-        """Re-lay the `live` filled positions from one window's KV layout into another's.
-
-        The cache is region-major with region_stride = ATTN_MAXL*REGION_W, so changing
-        window re-spaces the regions while each region's live prefix is unchanged.
-        Gathered to a compact temp first, so growing and shrinking are both safe. Cost
-        is proportional to `live`, and a crossing happens exactly when `live` is small.
-        """
-        if old_maxl == new_maxl or live <= 0:
-            return
-        fd = self.fd
-        R, NR = fd.REGION_W, 2 * fd.NGRP
-        self.kvc.sync(self.FROM)
-        src = np.frombuffer(
-            self.kvc.map(), dtype=bfloat16, count=self.N_LAYERS * self.LREG
-        )
-        dst = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
-        n = live * R
-        for lay in range(self.N_LAYERS):
-            so = lay * self._cur_lreg(old_maxl)
-            do = lay * self._cur_lreg(new_maxl)
-            for r in range(NR):
-                s = so + r * old_maxl * R
-                d = do + r * new_maxl * R
-                dst[d : d + n] = src[s : s + n]
-        self.kvc.write(dst.view(np.int16), 0)
-        self.kvc.sync(self.TO)
+        """Move the `live` filled positions into window `new_maxl`'s KV layout."""
+        stair.respace_kv(self.kvc, self._geom, old_maxl, new_maxl, live, self.xrt)
 
     def reset_kv(self):
         """Zero the device-resident KV cache (start a fresh sequence)."""
@@ -351,7 +306,7 @@ class FusedDecode3B:
         if len(self.windows) > 1:
             self._use_window(self.gen.window_for_L(ctx + 1))
         region_stride = self.cur_maxl * fd.REGION_W
-        lreg = self._cur_lreg()
+        lreg = self._geom.lreg(self.cur_maxl)
         buf = np.zeros(self.N_LAYERS * self.LREG, dtype=bfloat16)
         for L in range(self.N_LAYERS):
             kL = np.asarray(k_layers[L], bfloat16).reshape(ctx, -1)
@@ -377,11 +332,7 @@ class FusedDecode3B:
                 # `p` positions are live; this token's K/V is appended by the dispatch.
                 self._respace_kv(self.cur_maxl, w, p)
                 self._use_window(w)
-        self.insts_buf[self.ld] = (self.ld_base + (L - 1) * self.ld_slope).astype(
-            np.uint32
-        )
-        self.ib.write(self.insts_buf, 0)
-        self.ib.sync(self.TO)
+        self.insts_size = stair.patch_insts(self._st, L, self.xrt, self.TO)
         x0 = np.asarray(self.embed[tok], bfloat16)
         h = self.DH // 2
         lut = np.empty(self.DH, dtype=bfloat16)

--- a/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/llama32_3b_q4nx/verify_adapter.py
@@ -79,7 +79,13 @@ class FusedDecodeRunner:
     name = "npu-q4nx-3b-fused-decode"
 
     def __init__(self, model_source, templates, max_seq):
-        self._dec = FusedDecode3B(model_source, templates)
+        # DECODE_STAIRCASE=1 gates the multi-window (per-token smallest ATTN_MAXL) path;
+        # needs a directory built by `make compile-decode-windows`.
+        self._dec = FusedDecode3B(
+            model_source,
+            templates,
+            staircase=os.environ.get("DECODE_STAIRCASE") == "1",
+        )
         if max_seq > self._dec.ATTN_MAXL:
             raise RuntimeError(
                 f"max_seq {max_seq} exceeds decode ATTN_MAXL {self._dec.ATTN_MAXL}"


### PR DESCRIPTION
## What

The fused decode's KV readback streams `ATTN_MAXL` positions whatever the real context
length is. `RB_ROUNDS` (default `ceil(ATTN_L/16)`) feeds the outer size of the readback
nd-DMA and is a build constant, so a 2048-window template moves the whole padded cache
every token — 224 MiB/token on the 3B — to use 7 MiB of it at L=50.

`DecodeInstsGen` cannot patch that away: it recovers per-word slopes by diffing two
builds, `ceil(L/16)` is a step function, and its calibration points (2047, 2048) sit in
the same step, so the readback count never appears among its 448 L-dependent words.

This builds a template pair per `ATTN_MAXL` window and dispatches each token on the
smallest one covering L. Diffing an `ATTN_MAXL=64` build against a 2048 build at the same
L, only **500 of 70,648 words differ (0.7%)** — all `ATTN_MAXL`-scaled shim-NOC BD sizes,
strides and offsets.

**Off by default.** With one window loaded the behaviour and the code path are unchanged.

## How

Host-only BOs stay valid across an xclbin/hw_context swap, so every window's kernel is
created once up front and a switch is kernel selection plus a KV re-space — no weight
re-upload. The cache is region-major on `ATTN_MAXL*REGION_W`, so a window change re-lays
each region's live prefix; a crossing happens exactly when that prefix is small (~33 ms,
three crossings per 300 tokens).

Shared mechanics live in `fused_decode/decode_staircase.py` so `respace_kv` — the only
piece with real correctness surface — exists once rather than per model.

`.decode_windows` records which windows a directory holds and is checked at load.
Template discovery is a directory scan, and the staircase makes multi-window directories
normal, so a stray pair must fail loudly rather than silently change which window is
selected.

## Results

300 greedy tokens from an empty cache, same template directory, only the flag differing.
Token stream **identical** to the single-window baseline in every case:

| model | baseline | staircase | speedup |
|---|---|---|---|
| `llama32_1b_q4nx` | 53.00 tok/s | 58.61 | **1.106x** |
| `llama32_3b_q4nx` | 22.20 tok/s | 24.45 | **1.101x** |
| `gemma3_4b_q4nx` | 15.41 tok/s | 18.55 | **1.204x** |

Gemma gains most: 34 layers at head_dim 256 is the largest padded cache.

The saving is `(1 - L/2048) x 4.77 ms` on the 3B, so ~10% at short context, ~5% typical,
0 at a full window.

## Verification

| gate | baseline | staircase |
|---|---|---|
| `llama32_3b_q4nx` `make verify` (top-k token set vs HF bf16) | PASS 2/0 | PASS 2/0 |
| `llama32_1b_q4nx` `make verify` | PASS 2/0 | PASS 2/0 |
| `gemma3_4b_q4nx` `make gen` (Paris) | `*** PARIS ***` | identical ids |
| `qwen25_3b_q4` `make gen` (untouched, regression check) | 12.15 tok/s, coherent (README: 12.2) | n/a |

Both paths are bit-exact run to run, which is what makes token equality a valid gate here.

All five window crossings exercised with identical output: 64->128, 128->256, 256->512 in
the benchmark; 512->1024 (`windows_used=[(505,512),(512,1024)]`) and 1024->2048
(`[(1022,1024),(1024,2048)]`) through the 1B chat path.

## Usage

    make -C programming_examples/llms/llama32_1b_q4nx compile-decode-windows
    DECODE_STAIRCASE=1 make -C programming_examples/llms/llama32_1b_q4nx chat

`llama32_3b_q4nx` uses a `--staircase` CLI flag instead of the env var; worth unifying if
reviewers prefer.

## Notes for reviewers

- **`qwen25_3b_q4` is deliberately not covered** — nothing to reclaim, not a missing
  mechanism. Its decode is a sliding window of exactly `ATTN_L`: `seed_kv` fills it with
  the last `ATTN_L` positions, the hand-off asserts `ctx >= ATTN_L`, and the kernel
  appends at slot `ATTN_L-1`. The cache is fully occupied at every step, so there is no
  padding to stop streaming at any window size.
- **Pre-existing hazard this makes fire more often:** llama and qwen compile the same
  kernel object filenames (`proj_qmm.o`, `rope.o`, `attn_qk.ll`, ...) into
  `programming_examples/fused_decode/`, with qwen using `-DQ4_0`. A window build now runs
  that compile once per window, so it clobbers whichever flavour was there last. Existing
  xclbins embed their kernels so runs are unaffected, and each Makefile rebuilds them, but
  it is worth separating those object paths.
- The staircase captures roughly two thirds of the available win. The remainder needs a
  runtime-valued BD size, which is blocked on AIR (non-constant wraps/strides are declined
  rather than propagated; the launch loop is unrolled before the sequence is emitted;
  `aircc` has no C++/TXN-builder output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)