### PR TITLE
[programming_examples] Bump mlir-aie and drop 38 derivable air.shim_col pins

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -884,7 +884,8 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
           /*sizes=*/ValueRange{}, /*strides=*/ValueRange{},
           /*static_sizes=*/nullptr, /*static_strides=*/nullptr,
           /*pad_dimensions=*/nullptr, /*bd_id=*/nullptr, pktAttr,
-          /*burst_length=*/nullptr, /*offset_parameter=*/nullptr,
+          /*burst_length=*/nullptr, /*iteration=*/nullptr,
+          /*offset_parameter=*/nullptr,
           /*offset_state_table_idx=*/nullptr, /*next_bd_id=*/nullptr);
     } else if (dynOffsetI32) {
       // Only the address moves. Build the descriptor exactly as the static path

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -138,7 +138,7 @@ Three things make it work, all mirroring FLM's `mem_C_1`:
 | | what | why |
 |---|---|---|
 | split axis | **spatial**, by cascade pair -- ch0 feeds rows 2/3, ch1 rows 4/5, on two independent lock cycles | a *temporal* split (alternating fan steps) gives every core one MM2S chain alternating between both channels' buffers, couples the two shim channels at every step, and deadlocks |
-| shim placement | per-column channels `@inW{0,1}c{cx}`, each pinned with `air.shim_col` | a `[NCX]` bundle cannot express a per-index column; unpinned, the extra flows steal the rms/rope column and silently violate *its* `air.shim_col` |
+| shim placement | per-column channels `@inW{0,1}c{cx}`, columns derived | a `[NCX]` bundle cannot express a per-index column, so the channels stay separate; the column itself is not stated -- each feeds an L2 buffer pinned with `air.memtile_col`, and the tile placer puts the shim in the column of the memtile it feeds |
 | X memtile | on the hub column (`XMT_PCOL = MAIN_PCOL`) | FLM has **no** memtile in column 2. Leaving the 16-way X broadcast there alongside the shim feeds and both cores makes the pathfinder fail outright once the weight flows double |
 
 The DDR side is a pure permutation of the packed cascade

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1006,14 +1006,8 @@ def build_module():
         # Debug configs keep the original circuit + dedicated-channel rmsX.
         if FULL4:
             _rx = channel_decl("rmsX", size=[1], channel_type="npu_dma_packet")
-            _rx.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                T.i32(), RMS_PCOL
-            )
         else:
             _rx = channel_decl("rmsX", size=[1])
-            _rx.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                T.i32(), RMS_PCOL
-            )
             _rx.operation.attributes["air.dedicated_dma_channel"] = UnitAttr.get()
         _rw = channel_decl("rmsW", size=[1])
         if POST_RMS:
@@ -1028,7 +1022,6 @@ def build_module():
             # (rmsW = [input | post_attn], rmsW2 = [pre_ffn | post_ffn], each 2K) so the
             # rms tile's S2MM0 carries only {rmsX, rmsW, rmsW2, o-proj/down} = 4 packet
             # ids (a compute-tile S2MM port demuxes at most 4). No rmsW3/rmsW4 channels.
-        _rw.operation.attributes["air.shim_col"] = IntegerAttr.get(T.i32(), RMS_PCOL)
         _rw.operation.attributes["air.dedicated_dma_channel"] = UnitAttr.get()
         # FAITHFUL convergent X feed (reproducer x_buffer DMA:3): ONE channel
         # carries BOTH the rmsnorm'd token X (phases 0..2) and the GLU-output X
@@ -1126,26 +1119,15 @@ def build_module():
         channel_decl("attnO", size=[N_ATTN_CU])
         # W: host (per col) -> group memtile -> NCY cores.
         if W_DUAL_CHAN:
-            # PER-COLUMN channels, each PINNED to its own shim column, rather than
-            # one [NCX] bundle. Two reasons:
-            #   1. Both of a column's shim MM2S channels must sit on THAT column's
-            #      shim tile (that is the whole point -- 2x the per-column weight
-            #      bandwidth). The default placement does not guarantee it: adding
-            #      the second set of flows makes AIR hand shim col 2 to the col-1
-            #      weights and push the rms/rope feed (air.shim_col = RMS_PCOL) to
-            #      col 1, i.e. it silently violates that pin and swaps two
-            #      hand-placed columns.
-            #   2. air.shim_col is a per-DECL attribute, so a [NCX] bundle cannot
-            #      express "index k belongs on column PCOL[k]".
-            # This reproduces FLM's map exactly: shim col C ch0+ch1 -> mem_C_1 for
-            # C in PCOL, and shim col 2 -> the rms/rope tiles, with no cross-column
-            # weight route at all.
+            # PER-COLUMN channels rather than one [NCX] bundle, so that both of a
+            # column's shim MM2S channels sit on THAT column's shim tile -- the
+            # whole point is 2x the per-column weight bandwidth. The columns are
+            # not stated here: each channel feeds an L2 buffer the allocator
+            # already buckets by column, and AIRToAIE stamps that bucket column
+            # on the shim tile it opens.
             for _wc in range(NCX):
                 for _nm in (_wname(0, _wc), _wname(1, _wc)):
-                    _wch = channel_decl(_nm, size=[1])
-                    _wch.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                        T.i32(), PCOL[_wc]
-                    )
+                    channel_decl(_nm, size=[1])
         else:
             channel_decl("inW", size=[NCX])
         _wL2 = channel_decl("wL2ToL1", size=[NCX, NCY])

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -700,17 +700,13 @@ def build_module():
         )  # Xmt -> 16 cores
         _inX.operation.attributes["air.shared_resident_ring"] = UnitAttr.get()
         if W_DUAL_CHAN:
-            # Per-column channels PINNED to their own shim column. air.shim_col is a
-            # per-DECL attribute, so a [NCX] bundle cannot express "index k lives on
-            # column PROJ_COL0+k"; without the pin the extra flows perturb the whole
-            # hand-placed shim map (on the llama engine they stole the rms/rope
-            # column outright, silently violating ITS air.shim_col).
+            # Per-column channels rather than one [NCX] bundle, so each column's
+            # two shim MM2S channels land on that column's shim tile. The column
+            # itself is not stated: the W memtile these feed is already bucketed
+            # by column, and AIRToAIE stamps that bucket column on the shim tile.
             for _wc in range(NCX):
                 for _ci in range(2):
-                    _wch = channel_decl(_wname(_ci, _wc), size=[1])
-                    _wch.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                        i32, PROJ_COL0 + _wc
-                    )
+                    channel_decl(_wname(_ci, _wc), size=[1])
         else:
             channel_decl("inW", size=[NCX])  # host -> per-col W memtile
         channel_decl("wL2ToL1", size=[NCX, NCY])  # W memtile -> col cores

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=f501f215b5e772b7fba38df35b79251d1de64b97
-WHEEL_VERSION=1.4.1.dev58+gf501f21
+export HASH=c84915b0680fbbc43ec47d9c74caf0967b8bac18
+WHEEL_VERSION=1.4.2.dev14+gc84915b
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
Bumps mlir-aie to `c84915b0` (Xilinx/mlir-aie#3551) and removes the 38 `air.shim_col` pins that fix makes unnecessary.

### Why the pins existed

The tile placer resolved a flow's destination columns by walking *past* a memtile to the cores behind it, even when the memtile's own column was already known. A memtile serves several unrelated flows, so that returns the union of every column it touches. A shim feeding a memtile pinned to col 1 saw destinations spanning cols 0, 1, 2, 5, 6 and 7 — mean 2.96 — and was placed on **col 3**, a cross-column flow.

`air.shim_col` was pinning those back by hand. mlir-aie#3551 has the placer use the endpoint's known column, so it derives them instead.

### Which pins came out — measured, not assumed

Each design was compiled twice, with pins honoured and with pins ignored, and per-flow shim placement diffed. All four agree: **exactly three pins per design change anything.** Those stay:

| design | kept | what happens without them |
|---|---|---|
| 1b / 3b / gemma | `appendK`, `appendV`, `layerOut` | pinned to cols 3/4/5; all three collapse onto `2:S2MM0` — same tile *and* channel |
| qwen | `appendK`, `appendV`, `ropeLUT` | 7→1 and 0→1 |

The remaining 12 spread readback flows across columns, which the compiler has no rule for. That is genuine placement, not a workaround, so it stays.

### The bump

`HASH` and `WHEEL_VERSION` move together — `c84915b0` is the merge commit, `1.4.2.dev14+gc84915b` is the wheel CI installs for it. That the wheel actually carries the fix was checked directly rather than inferred: on the fix's own test case the old wheel places the shim on col 4 and the new one on col 1.

### Verification

All on NPU2 against the **new wheel**, not the from-source mlir-aie used while #3551 was in flight.

**Gate** — pins present vs pins removed, same toolchain, same base: **0 shim-placement diffs, 0 hw-op diffs** on all four designs. The 34–46 residual lines are only the removed attribute text on the channel declarations.

**Performance** — all 7 production decode `insts.bin` **byte-identical** between the two arms.

**Correctness** — llama-3.2-1b PASS, llama-3.2-3b PASS, gemma3-4b PARIS 16.98 tok/s, qwen2.5-3b PARIS argmax 12095, 12.20 tok/s. Templates deleted before each build.

**Regression net** — `check-air-mlir` 492/492, `conv2d_14x14` PASS, `xrt/48` PASS, `xrt/50` 4/4 PASS at its stock 218 buffers / 292 locks.

### Note on the remaining `air.memtile_col`

This does not reduce the need for `air.memtile_col`; if anything it deepens it. The derived shim column now *comes from* the memtile's pinned column, so that attribute is load-bearing for this mechanism. Retiring it would need the memtile placed before the shim that feeds it (mlir-aie#3551 notes that ordering gap) plus an L2 placement cost model. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Supersedes #1798

#1798 was a keep-current bump to `1.4.2.dev8+gdd18668`. `dd18668` is an ancestor of `c84915b0` (`ahead_by=6, behind_by=0`), so this PR contains all of it — mlir-aie#3547 (`aievec.neg` → LLVM), #3538, #3532, #3530, #3536 — plus six more commits, including two non-trivial ObjectFIFO changes (#3298 fully-dynamic ObjectFIFO + new unrolling pass, #3377 lock-ID allocation moved out of the ObjectFIFO pass) and the placer fix this PR is built on (#3551). The regression net above ran against `c84915b0`, so those are covered.

Note #1798 carried npu1 (Phoenix) validation that this PR does not — the work here was done on npu2 only, so npu1 coverage rests on CI's `amd8845hs` job.

Also: #3547 landing makes the `arith.negf` / `aievec.neg` note in `CLAUDE.md` stale; worth a follow-up.
