### PR TITLE
[AIR] Fold an over-limit shim BD stride into base offsets

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1865,20 +1865,46 @@ LogicalResult unrollIllegalStrideDim(airrt::DmaMemcpyNdOp memcpy_op,
   // Folding costs one descriptor per entry of the folded dim.
   if (*constWrap > AIE2_STRIDE_UNROLL_LIMIT)
     return success();
+  // generateAwaitsFromWaitAllOps matches waits to configure tasks FIFO per
+  // channel -- the Nth wait for a channel awaits the Nth config for it. This
+  // rewrite turns one config into `wrap` of them without adding waits, so on a
+  // channel that already carries a wait the pairing shifts and the wait lands
+  // on the first piece while the rest go unawaited. Leave those alone: a
+  // silently under-synchronised transfer is far worse than an unfolded one.
+  if (auto metadata = memcpy_op->getAttrOfType<FlatSymbolRefAttr>("metadata")) {
+    bool channelIsWaited = false;
+    if (auto func = memcpy_op->getParentOfType<func::FuncOp>())
+      func.walk([&](AIEX::NpuDmaWaitOp wait) {
+        if (wait.getSymbol() == metadata.getValue())
+          channelIsWaited = true;
+      });
+    if (channelIsWaited)
+      return success();
+  }
 
+  // The op's !airrt.event is optional and, unlike tileIllegalWrapDim (which
+  // rewrites in place), this replaces the op -- so the result has to be
+  // carried across. The pieces are issued in program order on one channel, so
+  // the last one completing implies all of them have; give it the event and
+  // let it stand in for the original. This mirrors how coalesceShimDmaOrder
+  // redirects the event tokens of the ops it merges away.
+  SmallVector<Type> eventTy(memcpy_op->getResultTypes());
+  airrt::DmaMemcpyNdOp lastOp;
   for (int64_t k = 0; k < *constWrap; k++) {
     SmallVector<OpFoldResult> newOffsets(offsets), newWraps(wraps),
         newStrides(strides);
     newOffsets[i] = builder.getI64IntegerAttr(*constOff + k);
     newWraps[i] = builder.getI64IntegerAttr(1);
-    auto newOp = airrt::DmaMemcpyNdOp::create(
-        builder, loc, SmallVector<Type>{}, memcpy_op.getId(), memcpy_op.getX(),
-        memcpy_op.getY(), memcpy_op.getMemref(), newOffsets, newWraps,
-        newStrides);
+    bool isLast = k + 1 == *constWrap;
+    lastOp = airrt::DmaMemcpyNdOp::create(
+        builder, loc, isLast ? eventTy : SmallVector<Type>{}, memcpy_op.getId(),
+        memcpy_op.getX(), memcpy_op.getY(), memcpy_op.getMemref(), newOffsets,
+        newWraps, newStrides);
     // Ordering/barrier markers must ride along on every piece, or the split
     // silently drops the append barrier and the shim order constraint.
-    newOp->setAttrs(memcpy_op->getDiscardableAttrDictionary());
+    lastOp->setAttrs(memcpy_op->getDiscardableAttrDictionary());
   }
+  memcpy_op->replaceAllUsesWith(lastOp);
   memcpy_op.erase();
   folded = true;
   return success();

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1776,6 +1776,141 @@ static void coalesceShimDmaOrder(ModuleOp module) {
   }
 }
 
+// AIE2 shim BDs encode each dimension's stride in a 20-bit field, so a stride
+// above AIE2_STRIDE_UPPER_BOUND cannot be expressed at all. Unlike an illegal
+// wrap, an illegal stride cannot be tiled away: splitting the dim leaves the
+// stride unchanged.
+//
+// It CAN be turned into base offsets. A dim (wrap W, stride S) contributes the
+// address set {(off + k) * S : k in [0, W)}, so the transfer is equivalent to W
+// separate BDs that drop the dim and fold its contribution into the base:
+//   offset_k = offset + (off + k) * S
+// Same bytes, same addresses, same order, same channel -- only the descriptor
+// count changes, by a factor of W.
+//
+// That is only worth doing when W is small, which is the case this exists for:
+// a KV cache laid out region-major strides its per-group dim by
+// ATTN_MAXL*REGION_W, which crosses the 20-bit field once the context is long
+// enough, while the dim itself stays tiny (one entry per KV group). A large W
+// is left alone rather than silently exploding the runtime sequence.
+const int AIE2_STRIDE_UNROLL_LIMIT = 16;
+
+// Index of the outermost dim whose stride exceeds the hardware field, or
+// std::nullopt. Dims of wrap 1 are ignored: they contribute a single address
+// and the stride is dead, so the BD builder drops them.
+static std::optional<unsigned>
+findIllegalStrideDim(SmallVector<OpFoldResult> wraps,
+                     SmallVector<OpFoldResult> strides) {
+  for (unsigned i = 0; i < strides.size(); i++) {
+    auto s = getConstantIntValue(strides[i]);
+    auto w = getConstantIntValue(wraps[i]);
+    if (s && w && *s > AIE2_STRIDE_UPPER_BOUND && *w > 1)
+      return i;
+  }
+  return std::nullopt;
+}
+
+bool violatesAIE2StrideLimit(airrt::DmaMemcpyNdOp dma) {
+  return findIllegalStrideDim(dma.getMixedLengths(), dma.getMixedStrides())
+      .has_value();
+}
+
+// Replace one over-strided dim with `wrap` copies of the transfer, each
+// carrying that dim's address contribution in its own base offset.
+//
+// The rewrite is in place, not a rank reduction: DmaToNpuPattern indexes the
+// wrap-and-stride lists as a fixed rank-4 layout. Instead the dim is set to
+// wrap 1 with offset (off + k), which
+//   - keeps the rank, and
+//   - keeps the address, because that pattern computes the BD base as
+//     sum(offsets[i] * strides[i]) -- so (off + k) * S lands in the base
+//     exactly as the strided walk would have reached it, and
+//   - drops the dim from the BD, because a middle dim of size 1 fails the
+//     `size > 1 || i == 3 || (use4thDimInBd && i > 0)` test that decides which
+//     dims become BDDimLayout entries. The over-limit stride is therefore never
+//     encoded.
+// The last point is what makes this legal, so it is checked rather than
+// assumed: only a middle dim of a BD that does not use the 4th dim qualifies.
+LogicalResult unrollIllegalStrideDim(airrt::DmaMemcpyNdOp memcpy_op,
+                                     bool &folded) {
+  auto loc = memcpy_op->getLoc();
+  OpBuilder builder(memcpy_op);
+  SmallVector<OpFoldResult> offsets = memcpy_op.getMixedOffsets();
+  SmallVector<OpFoldResult> wraps = memcpy_op.getMixedLengths();
+  SmallVector<OpFoldResult> strides = memcpy_op.getMixedStrides();
+
+  folded = false;
+  auto dim = findIllegalStrideDim(wraps, strides);
+  if (!dim)
+    return success();
+  unsigned i = *dim;
+
+  auto constOff = getConstantIntValue(offsets[i]);
+  auto constWrap = getConstantIntValue(wraps[i]);
+  auto constStride = getConstantIntValue(strides[i]);
+  auto outerStride =
+      strides.empty() ? std::nullopt : getConstantIntValue(strides[0]);
+  // Everything below is a REASON NOT TO FOLD, never a reason to fail. A large
+  // airrt-level stride does not by itself mean the emitted BD is illegal --
+  // later steps still reshape the access pattern -- so an op this rewrite
+  // cannot help is left exactly as it was, and downstream decides. Erroring
+  // here instead would reject transfers that compiled fine before this existed.
+  if (!constOff || !constWrap || !constStride || !outerStride)
+    return success();
+  // Only a middle dim of a BD whose 4th dim is unused is dropped once its wrap
+  // becomes 1; anywhere else the over-limit stride would still be encoded.
+  if (strides.size() != AIE2_DIM_COUNT || i == 0 || i + 1 == strides.size() ||
+      *outerStride != 0)
+    return success();
+  // Folding costs one descriptor per entry of the folded dim.
+  if (*constWrap > AIE2_STRIDE_UNROLL_LIMIT)
+    return success();
+
+  for (int64_t k = 0; k < *constWrap; k++) {
+    SmallVector<OpFoldResult> newOffsets(offsets), newWraps(wraps),
+        newStrides(strides);
+    newOffsets[i] = builder.getI64IntegerAttr(*constOff + k);
+    newWraps[i] = builder.getI64IntegerAttr(1);
+    auto newOp = airrt::DmaMemcpyNdOp::create(
+        builder, loc, SmallVector<Type>{}, memcpy_op.getId(), memcpy_op.getX(),
+        memcpy_op.getY(), memcpy_op.getMemref(), newOffsets, newWraps,
+        newStrides);
+    // Ordering/barrier markers must ride along on every piece, or the split
+    // silently drops the append barrier and the shim order constraint.
+    newOp->setAttrs(memcpy_op->getDiscardableAttrDictionary());
+  }
+  memcpy_op.erase();
+  folded = true;
+  return success();
+}
+
+LogicalResult enforceAIE2StrideLimit(ModuleOp module) {
+  // One pass peels one dim; a transfer with several illegal strides needs
+  // several. Iterate to a fixpoint, bounded by the dim count.
+  for (unsigned round = 0; round < AIE2_DIM_COUNT; round++) {
+    SmallVector<airrt::DmaMemcpyNdOp> targets;
+    module.walk([&](func::FuncOp f) {
+      f.walk([&](airrt::DmaMemcpyNdOp dma) {
+        if (violatesAIE2StrideLimit(dma))
+          targets.push_back(dma);
+      });
+    });
+    if (targets.empty())
+      return success();
+    bool changed = false;
+    for (auto op : targets) {
+      bool folded = false;
+      if (failed(unrollIllegalStrideDim(op, folded)))
+        return failure();
+      changed |= folded;
+    }
+    // Nothing left that this rewrite can help with; the rest is downstream's.
+    if (!changed)
+      return success();
+  }
+  return success();
+}
+
 LogicalResult enforceAIE2WrapLimit(ModuleOp module) {
   // Identify airrt.dma_memcpy_nd ops that violate the AIE2 wrap size
   // constraint.
@@ -1918,6 +2053,13 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
 
     // Enforce AIE2 hardware constraints.
     if (failed(enforceAIE2WrapLimit(module))) {
+      signalPassFailure();
+      return;
+    }
+
+    // After wrap tiling, since tiling can introduce a new outer dim whose
+    // stride is the product of the tiled ones.
+    if (failed(enforceAIE2StrideLimit(module))) {
       signalPassFailure();
       return;
     }

--- a/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
@@ -1,0 +1,79 @@
+//===- unroll_illegal_stride.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// A shim BD encodes each dim's stride in a 20-bit field (max 1048576). A dim
+// whose stride exceeds it cannot be tiled away -- splitting the dim leaves the
+// stride unchanged -- but if its wrap is small the transfer is equivalent to
+// `wrap` BDs that fold the dim into their base offset.
+//
+// This is the region-major KV-cache append shape: the per-group dim strides by
+// ATTN_MAXL*REGION_W, which crosses the field once the context is long enough,
+// while the dim itself stays at one entry per KV group. Here stride 4194304
+// (= 16384 * 256) with wrap 2 becomes two contiguous 256-element BDs whose
+// offsets differ by exactly that stride (16383 and 16383 + 4194304).
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 16383 len = 256 sizes = [256] strides = [1])
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 4210687 len = 256 sizes = [256] strides = [1])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<268435456xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c16383_i64 = arith.constant 16383 : i64
+    %c4194304_i64 = arith.constant 4194304 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c16383_i64], [%c1_i64, %c1_i64, %c2_i64, %c256_i64], [%c0_i64, %c0_i64, %c4194304_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// A legal stride is left alone: the pass must be inert below the limit, so a
+// build that does not need it is bit-identical to one from before the pass
+// existed. Stride 1048576 is exactly at the bound and stays one strided BD.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 0 len = 512 sizes = [2, 256] strides = [1048576, 1])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<268435456xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c1048576_i64 = arith.constant 1048576 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c2_i64, %c256_i64], [%c0_i64, %c0_i64, %c1048576_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
@@ -77,3 +77,40 @@ module {
     return
   }
 }
+
+// -----
+
+// A channel that already carries a wait is left alone. generateAwaitsFromWaitAllOps
+// pairs waits to configure tasks FIFO per channel, so splitting one config into
+// several without adding waits would leave the wait on the first piece and the
+// rest unawaited. Not folding keeps the transfer correctly synchronized; the
+// over-limit stride is then downstream's problem, as everywhere else here.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 16383 len = 512 sizes = [2, 256] strides = [4194304, 1])
+// CHECK: aiex.dma_await_task
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<268435456xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c16383_i64 = arith.constant 16383 : i64
+    %c4194304_i64 = arith.constant 4194304 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c16383_i64], [%c1_i64, %c1_i64, %c2_i64, %c256_i64], [%c0_i64, %c0_i64, %c4194304_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
+    airrt.wait_all %0
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride_limit.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride_limit.mlir
@@ -1,0 +1,40 @@
+//===- unroll_illegal_stride_limit.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+
+// Folding an over-limit stride into base offsets costs one descriptor per entry
+// of the folded dim, so a large wrap is NOT folded -- 64 descriptors is worse
+// than the problem. The op is then left exactly as it was: this rewrite is an
+// opportunity, not a gate, and must never fail a build that compiled before it
+// existed. Whether the resulting BD is legal is downstream's call.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 0 len = 16384 sizes = [64, 256] strides = [4194304, 1])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<268435456xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c4194304_i64 = arith.constant 4194304 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c64_i64, %c256_i64], [%c0_i64, %c0_i64, %c4194304_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
+    return
+  }
+}


### PR DESCRIPTION
## Summary

A shim BD encodes each dimension's stride in a 20-bit field, so a stride above
`AIE2_STRIDE_UPPER_BOUND` (1048576) cannot be expressed and `aie.dma_bd` rejects it.
`AIRRtToNpuPass` already legalizes an illegal **wrap** (`violatesAIE2WrapLimit` /
`tileIllegalWrapDim`) but had nothing for an illegal **stride**, and tiling cannot help:
splitting a dim leaves its stride unchanged.

Such a dim can become base offsets instead. A dim (wrap `W`, stride `S`) covers the
addresses `{(off + k) * S : k in [0, W)}`, so the transfer is equivalent to `W` copies
that each carry one `k` in their own base.

The rewrite is **in place, not a rank reduction**, because `DmaToNpuPattern` indexes the
wrap-and-stride lists as a fixed rank-4 layout. The dim is set to wrap 1 with offset
`(off + k)`, which:

- keeps the rank;
- keeps the address, since that pattern derives the BD base from `sum(offsets[i] * strides[i])`;
- drops the dim from the BD, because a middle dim of size 1 fails the
  `size > 1 || i == 3 || (use4thDimInBd && i > 0)` test that selects `BDDimLayout` entries.

The oversized stride is therefore never encoded. That last step is what makes this legal,
so it is checked rather than assumed: only a middle dim of a BD with an unused 4th dim
qualifies.

## This is an opportunity, not a gate

Every "cannot fold" path leaves the op untouched. An airrt-level stride above the field
does not by itself mean the emitted BD is illegal — later steps still reshape the access
pattern — so ops this rewrite cannot help are passed through and downstream decides.

An earlier version of this patch raised an error there and **regressed the Llama-3.2-1B
prefill**, whose `o_ffn` kernel carries a dim-1 stride of 2097152 and compiled fine
before. A wrap above `AIE2_STRIDE_UNROLL_LIMIT` (16) is also left alone: folding it would
emit one descriptor per entry, which is worse than the problem.

## What it unblocks

This is what capped context length in the fused decode. The region-major KV cache strides
its per-group dim by `ATTN_MAXL*REGION_W`, which crosses the field above ctx 8k
(llama-3.2-1B) and 4k (llama-3.2-3B, gemma3-4b), while the dim itself is one entry per KV
group — always wrap 2, so the fold costs 2 descriptors per layer per K/V, **+4%** on a
772-BD sequence.

Decode latency on NPU2, llama-3.2-1B, built at `ATTN_MAXL = ctx`:

| ctx | ms | tok/s | Δms per 1k |
|---|---|---|---|
| 1k | 15.173 | 65.91 | — |
| 2k | 17.023 | 58.74 | 1.850 |
| 4k | 20.725 | 48.25 | 1.851 |
| 8k | 28.175 | 35.49 | 1.862 ← previous ceiling |
| 16k | 43.040 | 23.23 | 1.858 |
| 32k | 72.728 | 13.75 | 1.855 |
| 64k | 132.076 | 7.57 | 1.855 |
| 128k | 250.958 | 3.98 | 1.858 |

The model's full 128k context now builds and runs, and the slope holds at 1.85–1.86 ms/1k
across a 128× range — the extra descriptors cost nothing measurable. Also measured at 16k
on llama-3.2-3B (110.214 ms, 56 BDs folded) and gemma3-4b (99.087 ms, 68 folded).

Above 8k the remaining limit is not the compiler: 3B and gemma **build** at 128k and fail
in XRT host-memory allocation (14.0 / 17.0 GiB KV BOs, `mmap ... err=-11`). qwen2.5-3B was
never affected — its KV-append dim has wrap 1 (`NGRP=1`), so the stride was already dead.

## Validation

- `check-air-mlir`: 494 pass, 0 unexpected
- two new lit tests: the fold, the leave-alone-when-wrap-is-large case, and an
  at-the-bound case proving the pass is inert below the limit
- **no effect below the limit**: shipped llama-3.2-1B decode templates rebuild
  byte-identically (insts md5 `c17c55f2`), 64-token greedy id sequence unchanged
  (`350f4a6049dd`), `make verify` PASS 2/2
- 16k built natively produces insts byte-identical to a hand-edited-IR prototype, and runs
  at 43.009 ms / 23.25 tok/s
- the previously regressed llama-3.2-1B prefill runs again
- `clang-format` clean

Latency figures come from `bench_decode`, which uses synthetic weights — it is not a
numerical gate. Contexts above 8k are therefore latency-validated only; verifying numerics
there additionally needs a prefill engine built beyond `seq_len=2048`. Below the limit the
pass is provably inert, so the shipped configurations are fully covered by the gates above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
