### PR TITLE
[AIR] Derive packet header ownership from `dest`, and drop it from the designs

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -3641,9 +3641,17 @@ void AIRAnnotatePacketIDsPass::runOnOperation() {
         attrs.push_back(builder.getI32IntegerAttr(id));
       ArrayAttr idsAttr = builder.getArrayAttr(attrs);
       for (air::ChannelOp member : dom.hops) {
-        if (member.getPacketIDs())
-          continue;
-        member->setAttr(air::attrs::PacketIDs, idsAttr);
+        if (!member.getPacketIDs())
+          member->setAttr(air::attrs::PacketIDs, idsAttr);
+        // A hop MUST preserve the header. It is carrying a routing decision
+        // made upstream to a switchbox further downstream; strip it here and
+        // the demux has nothing left to route on. That is forced by the
+        // topology, not a design choice, so derive it rather than requiring
+        // every design to restate it. (At the demux itself keep is a real
+        // choice -- its consumers generally want pure payload -- so it is left
+        // alone.)
+        if (!member->hasAttr(air::attrs::KeepPktHeader))
+          member->setAttr(air::attrs::KeepPktHeader, builder.getUnitAttr());
       }
       if (!dom.idsDeclared)
         dom.demux->setAttr(air::attrs::PacketIDs, idsAttr);

--- a/mlir/lib/Util/PacketRoutingDomain.cpp
+++ b/mlir/lib/Util/PacketRoutingDomain.cpp
@@ -483,9 +483,26 @@ void PacketRoutingDomainAnalysis::buildDomains() {
         if (upstream.contains(c))
           onPath.insert(c);
     }
-    for (ChannelOp c : packetChans)
-      if (onPath.contains(c.getOperation()))
-        dom.hops.push_back(c);
+    // Collect by walking UPSTREAM from the demux, filtered to the path, so the
+    // order means something. Iterating packetChans here would collect in
+    // declaration order, which the std::reverse below then INVERTS -- in a
+    // simple chain that yields exactly the reverse of the travel order the
+    // field is documented to hold.
+    {
+      SmallVector<ChannelOp> wl{d};
+      llvm::SmallPtrSet<Operation *, 8> visited{d.getOperation()};
+      while (!wl.empty()) {
+        ChannelOp cur = wl.pop_back_val();
+        for (ChannelOp pred : fedBy.lookup(cur.getOperation())) {
+          if (!onPath.contains(pred.getOperation()))
+            continue;
+          if (!visited.insert(pred.getOperation()).second)
+            continue;
+          dom.hops.push_back(pred);
+          wl.push_back(pred);
+        }
+      }
+    }
 
     if (dom.originators.empty()) {
       // No put names a dest anywhere upstream. Either the design predates
@@ -795,6 +812,17 @@ void PacketRoutingDomainAnalysis::emitReportRemarks() const {
     }
     if (auto pinned = c.getPacketIDs())
       note << "; pins " << pinned.size();
+    // Spell the chain out on the demux. The hop ORDER is a documented property
+    // of the domain and was silently wrong once; printing it is what lets a
+    // test pin it.
+    if (dom && dom->demux == c && !dom->hops.empty()) {
+      note << "; fed by ";
+      bool first = true;
+      for (ChannelOp h : dom->hops) {
+        note << (first ? "@" : " -> @") << h.getSymName();
+        first = false;
+      }
+    }
     if (!f.reason.empty())
       note << " [" << f.reason << "]";
   }

--- a/mlir/lib/Util/PacketRoutingDomain.cpp
+++ b/mlir/lib/Util/PacketRoutingDomain.cpp
@@ -167,9 +167,16 @@ static PacketChannelFacts classify(ChannelOp chanOp,
     return c;
   }
 
-  // Partition: the destinations' volumes sum to the stream. Header ownership
-  // is what makes such a split physically possible, so require it rather than
-  // inferring a demux from arithmetic alone.
+  // Partition: the destinations' volumes sum to the stream.
+  //
+  // This is EVIDENCE, not proof. A partition is only physically routable if
+  // something upstream writes a routing header per packet, and volumes cannot
+  // say whether anything does. buildDomains() establishes that separately, from
+  // a put naming a `dest`, and verify() rejects a partition nothing confirms.
+  //
+  // Requiring the header attribute HERE, as this used to, is what made the
+  // attribute load-bearing for classification -- and therefore impossible for a
+  // design to stop declaring.
   int64_t sum = 0;
   for (auto &kv : volByDest)
     sum += kv.second;
@@ -179,11 +186,6 @@ static PacketChannelFacts classify(ChannelOp chanOp,
   // short of the sent total by that much. Accept a partition that accounts for
   // at least the payload and never exceeds what was sent.
   if (sum <= putVol && sum > 0) {
-    if (!air::channelSourceWritesHeader(chanOp)) {
-      c.reason = "destination volumes partition the stream, but the channel is "
-                 "not source-stamped, so per-packet routing is impossible";
-      return c;
-    }
     c.fanout = PacketFanout::Demux;
     return c;
   }
@@ -413,30 +415,101 @@ void PacketRoutingDomainAnalysis::buildDomains() {
     return ids;
   };
 
+  // Everything each dest-carrying put can reach downstream.
+  //
+  // A put naming a `dest` is choosing, at run time, which leaf this packet is
+  // for. Nothing else it could mean -- so the packet channel it eventually
+  // reaches covers its broadcast dimension over TIME, and that is the whole
+  // space-vs-time question, answered by the design without an attribute for it.
+  struct Origin {
+    ChannelPutOp put;
+    llvm::SmallPtrSet<Operation *, 8> reaches;
+  };
+  SmallVector<Origin> origins;
+  {
+    ModuleOp m = mod;
+    m.walk([&](ChannelPutOp put) {
+      if (!put.getDest())
+        return;
+      ChannelOp c0 = getChannelDeclarationThroughSymbol(put);
+      if (!c0)
+        return;
+      Origin o;
+      o.put = put;
+      o.reaches.insert(c0.getOperation());
+      SmallVector<ChannelOp> wl{c0};
+      while (!wl.empty()) {
+        ChannelOp cur = wl.pop_back_val();
+        for (ChannelOp succ : feeds.lookup(cur.getOperation()))
+          if (o.reaches.insert(succ.getOperation()).second)
+            wl.push_back(succ);
+      }
+      origins.push_back(std::move(o));
+    });
+  }
+
   // One domain per demux. Ids belong to the domain, so this is also the only
   // place they are handed out.
   for (ChannelOp d : packetChans) {
     if (getFacts(d).fanout != PacketFanout::Demux)
       continue;
-    if (!channelSourceWritesHeader(d))
-      continue;
 
     PacketRoutingDomain dom;
     dom.demux = d;
 
-    // Walk upstream, entering only channels that carry someone else's header.
-    // A DMA-stamped channel re-stamps and starts a fresh domain.
-    SmallVector<ChannelOp> worklist{d};
-    llvm::SmallPtrSet<Operation *, 8> visited{d.getOperation()};
-    while (!worklist.empty()) {
-      ChannelOp cur = worklist.pop_back_val();
-      for (ChannelOp pred : fedBy.lookup(cur.getOperation())) {
-        if (!channelSourceWritesHeader(pred))
-          continue;
-        if (!visited.insert(pred.getOperation()).second)
-          continue;
-        dom.hops.push_back(pred);
-        worklist.push_back(pred);
+    // Everything that can reach the demux, with no attribute gate.
+    llvm::SmallPtrSet<Operation *, 8> upstream;
+    {
+      SmallVector<ChannelOp> wl{d};
+      while (!wl.empty()) {
+        ChannelOp cur = wl.pop_back_val();
+        for (ChannelOp pred : fedBy.lookup(cur.getOperation()))
+          if (upstream.insert(pred.getOperation()).second)
+            wl.push_back(pred);
+      }
+    }
+
+    // A hop lies on a path from an originating put to this demux: reachable
+    // FORWARD from the put and BACKWARD from the demux. Intersecting the two
+    // is what keeps an unrelated channel that merely happens to feed the same
+    // buffer out of the domain -- the old attribute gate excluded those only
+    // incidentally.
+    llvm::SmallPtrSet<Operation *, 8> onPath;
+    for (const Origin &o : origins) {
+      if (!o.reaches.contains(d.getOperation()))
+        continue;
+      dom.originators.push_back(o.put);
+      for (Operation *c : o.reaches)
+        if (upstream.contains(c))
+          onPath.insert(c);
+    }
+    for (ChannelOp c : packetChans)
+      if (onPath.contains(c.getOperation()))
+        dom.hops.push_back(c);
+
+    if (dom.originators.empty()) {
+      // No put names a dest anywhere upstream. Either the design predates
+      // `dest` and declares its own header ownership, or the chain is broken.
+      // Fall back to the attribute-gated walk so such designs keep working;
+      // verify() is what tells the two apart.
+      //
+      // Deliberately NOT `continue` when the attribute is absent too: a
+      // partition with no header writer anywhere is a broken design, and
+      // forming the (empty) domain is what lets verify() say so instead of
+      // silently declining to allocate and leaving air-to-aie to auto-assign a
+      // single id that half the destinations will never match.
+      SmallVector<ChannelOp> worklist{d};
+      llvm::SmallPtrSet<Operation *, 8> visited{d.getOperation()};
+      while (!worklist.empty()) {
+        ChannelOp cur = worklist.pop_back_val();
+        for (ChannelOp pred : fedBy.lookup(cur.getOperation())) {
+          if (!channelSourceWritesHeader(pred))
+            continue;
+          if (!visited.insert(pred.getOperation()).second)
+            continue;
+          dom.hops.push_back(pred);
+          worklist.push_back(pred);
+        }
       }
     }
     // Furthest upstream first: the order the packet actually travels, which is
@@ -478,20 +551,6 @@ void PacketRoutingDomainAnalysis::buildDomains() {
     domainIdxOf[d.getOperation()] = idx;
     domains.push_back(std::move(dom));
   }
-
-  // Originators: puts that name a destination. Attach each to the domain of
-  // the channel it puts on.
-  mod.walk([&](ChannelPutOp put) {
-    if (!put.getDest())
-      return;
-    ChannelOp c = getChannelDeclarationThroughSymbol(put);
-    if (!c)
-      return;
-    auto it = domainIdxOf.find(c.getOperation());
-    if (it == domainIdxOf.end())
-      return;
-    domains[it->second].originators.push_back(put);
-  });
 }
 
 const PacketRoutingDomain *

--- a/mlir/test/Transform/AIRAnnotatePacketIDs/classify.mlir
+++ b/mlir/test/Transform/AIRAnnotatePacketIDs/classify.mlir
@@ -50,11 +50,19 @@ module {
 
 // -----
 
-// A partition on a channel that is NOT source-stamped cannot be a demux: with
-// the DMA stamping one id on one BD there is no per-packet routing decision to
-// make. Report it as unclassifiable rather than inventing ids.
+// A partition on a channel that nothing source-stamps still cannot be a demux:
+// with the DMA stamping one id on one BD there is no per-packet routing
+// decision to make.
+//
+// But that is no longer decided HERE. Classification reports the volume
+// EVIDENCE -- these destinations partition the stream -- and confirmation is a
+// separate question, answered by whether a put naming a `dest` reaches the
+// channel. Keeping the header attribute in this decision is what made it
+// load-bearing for classification, and so impossible for a design to stop
+// declaring. Under `assign` this exact module is rejected outright; see
+// no_header_source.mlir.
 module {
-  // expected-remark @below {{not source-stamped}}
+  // expected-remark @below {{demux over 2 destination(s); infers 2 routing id(s)}}
   air.channel @nohdr [1, 1] {broadcast_shape = [1 : index, 2 : index], channel_type = "npu_dma_packet"}
   func.func @f() {
     %c0 = arith.constant 0 : index

--- a/mlir/test/Transform/AIRAnnotatePacketIDs/derive_from_dest.mlir
+++ b/mlir/test/Transform/AIRAnnotatePacketIDs/derive_from_dest.mlir
@@ -1,0 +1,119 @@
+//===- derive_from_dest.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-annotate-packet-ids="assign=true emit-headers=false" -split-input-file | FileCheck %s
+
+// A design states NOTHING about packet headers. Not keep_pkt_header, not
+// air.src_writes_pkt_header, not packet_ids. Everything is derived from one
+// fact the design already had to state: a put naming a `dest`.
+//
+// `dest(%d)` is a runtime value saying which leaf this packet is for. There is
+// nothing else it can mean -- so the packet channel it reaches covers its
+// broadcast dimension over TIME rather than over space, which is the entire
+// space-vs-time question. The volume arithmetic (do the destinations partition
+// the stream, or each consume all of it?) is evidence; the `dest` is the
+// statement.
+//
+// This is the @outA -> @toMain -> @outY shape of the decode designs, reduced.
+
+// The two hops MUST preserve the header: each carries a routing decision made
+// upstream to a switchbox further downstream, and stripping it there would
+// leave the demux nothing to route on. Forced by topology, so injected.
+// CHECK-LABEL: @derived
+// CHECK-DAG: air.channel @hopA {{.*}}keep_pkt_header, packet_ids = [31 : i32, 30 : i32, 29 : i32]
+// CHECK-DAG: air.channel @hopB {{.*}}keep_pkt_header, packet_ids = [31 : i32, 30 : i32, 29 : i32]
+// The demux gets the ids but NOT keep: at the final consumers, stripping to a
+// pure payload is a real choice and stays the design's to make.
+// CHECK-DAG: air.channel @fanout [1, 1] {broadcast_shape = [1 : index, 3 : index], channel_type = "npu_dma_packet", packet_ids = [31 : i32, 30 : i32, 29 : i32]}
+module @derived {
+  air.channel @hopA [1] {channel_type = "npu_dma_packet"}
+  air.channel @hopB [1] {channel_type = "npu_dma_packet"}
+  air.channel @fanout [1, 1] {broadcast_shape = [1 : index, 3 : index], channel_type = "npu_dma_packet"}
+  func.func @f(%d : index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %src = memref.alloc() : memref<1536xbf16, 2 : i32>
+    %mid = memref.alloc() : memref<1536xbf16, 1 : i32>
+    %hub = memref.alloc() : memref<1536xbf16, 1 : i32>
+    %d0 = memref.alloc() : memref<512xbf16, 2 : i32>
+    %d1 = memref.alloc() : memref<512xbf16, 2 : i32>
+    %d2 = memref.alloc() : memref<512xbf16, 2 : i32>
+    air.channel.put @hopA[%c0] (%src[] [] []) dest(%d) : (memref<1536xbf16, 2 : i32>)
+    air.channel.get @hopA[%c0] (%mid[] [] []) : (memref<1536xbf16, 1 : i32>)
+    air.channel.put @hopB[%c0] (%mid[] [] []) : (memref<1536xbf16, 1 : i32>)
+    air.channel.get @hopB[%c0] (%hub[] [] []) : (memref<1536xbf16, 1 : i32>)
+    air.channel.put @fanout[%c0, %c0] (%hub[] [] []) : (memref<1536xbf16, 1 : i32>)
+    air.channel.get @fanout[%c0, %c0] (%d0[] [] []) : (memref<512xbf16, 2 : i32>)
+    air.channel.get @fanout[%c0, %c1] (%d1[] [] []) : (memref<512xbf16, 2 : i32>)
+    air.channel.get @fanout[%c0, %c2] (%d2[] [] []) : (memref<512xbf16, 2 : i32>)
+    return
+  }
+}
+
+// -----
+
+// A channel that merely feeds the same buffer, without lying on a path from
+// the originating put to the demux, is NOT a hop and gets nothing injected.
+// The old attribute gate excluded such channels only incidentally; the path
+// intersection excludes them on purpose.
+// CHECK-LABEL: @offpath
+// CHECK-DAG: air.channel @hop {{.*}}keep_pkt_header, packet_ids = [31 : i32, 30 : i32]
+// Full attribute dict, so this also asserts the ABSENCE of keep and of ids --
+// stronger than a CHECK-NOT, and immune to line ordering.
+// CHECK-DAG: air.channel @aside [1] {channel_type = "npu_dma_packet"}
+module @offpath {
+  air.channel @hop [1] {channel_type = "npu_dma_packet"}
+  air.channel @aside [1] {channel_type = "npu_dma_packet"}
+  air.channel @fanout [1, 1] {broadcast_shape = [1 : index, 2 : index], channel_type = "npu_dma_packet"}
+  func.func @f(%d : index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %src = memref.alloc() : memref<1024xbf16, 2 : i32>
+    %other = memref.alloc() : memref<1024xbf16, 2 : i32>
+    %sink = memref.alloc() : memref<1024xbf16, 1 : i32>
+    %hub = memref.alloc() : memref<1024xbf16, 1 : i32>
+    %d0 = memref.alloc() : memref<512xbf16, 2 : i32>
+    %d1 = memref.alloc() : memref<512xbf16, 2 : i32>
+    // Unrelated flow: reaches nothing on the path to @fanout.
+    air.channel.put @aside[%c0] (%other[] [] []) : (memref<1024xbf16, 2 : i32>)
+    air.channel.get @aside[%c0] (%sink[] [] []) : (memref<1024xbf16, 1 : i32>)
+    air.channel.put @hop[%c0] (%src[] [] []) dest(%d) : (memref<1024xbf16, 2 : i32>)
+    air.channel.get @hop[%c0] (%hub[] [] []) : (memref<1024xbf16, 1 : i32>)
+    air.channel.put @fanout[%c0, %c0] (%hub[] [] []) : (memref<1024xbf16, 1 : i32>)
+    air.channel.get @fanout[%c0, %c0] (%d0[] [] []) : (memref<512xbf16, 2 : i32>)
+    air.channel.get @fanout[%c0, %c1] (%d1[] [] []) : (memref<512xbf16, 2 : i32>)
+    return
+  }
+}
+
+// -----
+
+// A design that predates `dest` and declares its own header ownership keeps
+// working unchanged: with no dest anywhere, the walk falls back to the
+// attribute-gated one.
+// CHECK-LABEL: @legacy
+// CHECK-DAG: air.channel @hop {{.*}}keep_pkt_header, packet_ids = [13 : i32, 17 : i32]
+// CHECK-DAG: air.channel @fanout {{.*}}packet_ids = [13 : i32, 17 : i32]
+module @legacy {
+  air.channel @hop [1] {channel_type = "npu_dma_packet", keep_pkt_header}
+  air.channel @fanout [1, 1] {broadcast_shape = [1 : index, 2 : index], channel_type = "npu_dma_packet", keep_pkt_header, packet_ids = [13 : i32, 17 : i32]}
+  func.func @f() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %src = memref.alloc() : memref<1024xbf16, 2 : i32>
+    %hub = memref.alloc() : memref<1024xbf16, 1 : i32>
+    %d0 = memref.alloc() : memref<512xbf16, 2 : i32>
+    %d1 = memref.alloc() : memref<512xbf16, 2 : i32>
+    air.channel.put @hop[%c0] (%src[] [] []) : (memref<1024xbf16, 2 : i32>)
+    air.channel.get @hop[%c0] (%hub[] [] []) : (memref<1024xbf16, 1 : i32>)
+    air.channel.put @fanout[%c0, %c0] (%hub[] [] []) : (memref<1024xbf16, 1 : i32>)
+    air.channel.get @fanout[%c0, %c0] (%d0[] [] []) : (memref<512xbf16, 2 : i32>)
+    air.channel.get @fanout[%c0, %c1] (%d1[] [] []) : (memref<512xbf16, 2 : i32>)
+    return
+  }
+}

--- a/mlir/test/Transform/AIRAnnotatePacketIDs/derive_from_dest.mlir
+++ b/mlir/test/Transform/AIRAnnotatePacketIDs/derive_from_dest.mlir
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: air-opt %s -air-annotate-packet-ids="assign=true emit-headers=false" -split-input-file | FileCheck %s
+// RUN: air-opt %s -air-annotate-packet-ids="assign=true emit-headers=false report=true" -split-input-file 2>&1 | FileCheck %s --check-prefix=CHAIN
 
 // A design states NOTHING about packet headers. Not keep_pkt_header, not
 // air.src_writes_pkt_header, not packet_ids. Everything is derived from one
@@ -29,6 +30,11 @@
 // The demux gets the ids but NOT keep: at the final consumers, stripping to a
 // pure payload is a real choice and stays the design's to make.
 // CHECK-DAG: air.channel @fanout [1, 1] {broadcast_shape = [1 : index, 3 : index], channel_type = "npu_dma_packet", packet_ids = [31 : i32, 30 : i32, 29 : i32]}
+// The hops are reported in the order the PACKET TRAVELS, furthest upstream
+// first -- not declaration order, and not its reverse. Collecting them by
+// iterating the channel list and then reversing produced exactly the backwards
+// answer here, which nothing caught because no consumer read the order.
+// CHAIN: @fanout: demux over 3 destination(s); infers 3 routing id(s); fed by @hopA -> @hopB
 module @derived {
   air.channel @hopA [1] {channel_type = "npu_dma_packet"}
   air.channel @hopB [1] {channel_type = "npu_dma_packet"}

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1136,45 +1136,33 @@ def build_module():
         _outA = channel_decl(
             "outA", size=[NCX, PAIRS_PC], channel_type="npu_dma_packet"
         )
-        _outA.operation.attributes["keep_pkt_header"] = UnitAttr.get()
-        # No packet_ids here. This hop is single-destination: air-to-aie hands its
-        # whole id list to the one buffer (numS2MMAllocs == 1 -> return pinned), so
-        # the ORDER carries no meaning and the SET is just the demux's. Both are
-        # derivable, so air-annotate-packet-ids fills them in by propagating @outY's
-        # declared list back up the header-preserving chain. Only the demux itself
-        # still has to declare, because there the order picks the destination.
+        # No keep_pkt_header and no packet_ids. Both are DERIVED.
+        #
+        # This hop carries a routing decision made here (the dest operand on its
+        # put) to a switchbox further downstream, so it MUST preserve the header
+        # -- forced by the topology, not a choice, and air-annotate-packet-ids
+        # injects it. The ids likewise: the hop is single-destination, so its
+        # list is just the demux's set with no meaningful order.
         _toMain = channel_decl("toMain", size=[N_GRP], channel_type="npu_dma_packet")
-        _toMain.operation.attributes["keep_pkt_header"] = UnitAttr.get()
+        # keep_pkt_header derived, as for @outA above.
         # id-demux egress (reproducer mem_1_1 DMA5): the main MT emits each round's
         # assembled 514 packet (carrying the routing header) on ONE MM2S; the
         # switchbox routes the id allocated for dest p (broadcast_shape=[1,NDEST]).
-        # keep_pkt_header keeps each dest's header so the host can strip it.
         _outY = Channel("outY", size=[1, 1], broadcast_shape=[1, NDEST])
         _outY.operation.attributes["channel_type"] = StringAttr.get("npu_dma_packet")
-        # Faithful demux: route by the kernel header, then STRIP it at every dest
-        # -> pure payload (PAYLOAD=512) delivered. len(packet_ids) > 1 already
-        # tells air-to-aie the source writes its own header (no static stamp),
-        # and keep is false because keep_pkt_header is not set here. The main MT
-        # PUT stays MAIN_ROWS=514 (with header for routing); gets are PAYLOAD.
-        # Header ownership stated OUTRIGHT, not inferred from len(packet_ids) > 1.
-        # air-to-aie's channelKernelWritesHeader currently accepts EITHER, so this
-        # is behaviour-neutral today -- but the id COUNT and the fact that the core
-        # (not the DMA) stamps the header are two independent properties, and
-        # deriving the second from the first means the demux stops being
-        # recognisable the moment the pinned ids go away. air-annotate-packet-ids
-        # needs this marker to classify outY as a demux at all.
-        # The header is written into the payload by the producing core (the
-        # compiler emits that store from the dest operand on the @outA put), so
-        # the DMA must not stamp. This marker is what says so: the dest operand
-        # sits three hops upstream on @outA, and nothing on @outY itself reveals
-        # that its packets carry their own routing word.
-        _outY.operation.attributes["air.src_writes_pkt_header"] = UnitAttr.get()
-        # No packet_ids. The ids are ALLOCATED by air-annotate-packet-ids:
-        # it reads the demux shape (dests partition the stream) for the count,
-        # takes the ids from the top of the id space so nothing else is
+        # Faithful demux: route by the kernel header, then STRIP it at every
+        # dest -> pure payload (PAYLOAD=512) delivered. The main MT PUT stays
+        # MAIN_ROWS=514 (header included, for routing); the gets are PAYLOAD.
+        #
+        # Nothing is declared here either. That this channel demuxes is derived:
+        # its destinations partition the stream, and a put naming a `dest`
+        # reaches it through the hops above. A dest operand can only mean "this
+        # packet is for that leaf", which is exactly the statement that the
+        # fanout is over time rather than space.
+        # No packet_ids. The ids are ALLOCATED by air-annotate-packet-ids: it
+        # reads the demux shape (dests partition the stream) for the count,
+        # takes them from the top of the id space so nothing else is
         # renumbered, and rewrites the ordinals the kernel stamps to match.
-        # air.src_writes_pkt_header marks this channel as the demux --
-        # the count alone no longer identifies one, now that the list is gone.
         channel_decl("toShim", size=[NDEST])
         # #4: layer output (residual2 = h + down) drained to host from the rms core.
         if FULL4:

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -717,32 +717,29 @@ def build_module():
         # numeric id appears here -- the reference's 1/4/8 were the pinned spelling this
         # replaced.
         _outA = channel_decl("outA", size=[NCX, NCY], channel_type="npu_dma_packet")
-        _outA.operation.attributes["keep_pkt_header"] = UnitAttr.get()
-        # No packet_ids here. This hop is single-destination: air-to-aie hands its
-        # whole id list to the one buffer (numS2MMAllocs == 1 -> return pinned), so
-        # the ORDER carries no meaning and the SET is just the demux's. Both are
-        # derivable, so air-annotate-packet-ids fills them in by propagating @outY's
-        # declared list back up the header-preserving chain. Only the demux itself
-        # still has to declare, because there the order picks the destination.
+        # No keep_pkt_header and no packet_ids. Both are DERIVED.
+        #
+        # This hop carries a routing decision made here (the dest operand on its
+        # put) to a switchbox further downstream, so it MUST preserve the header
+        # -- forced by the topology, not a choice, and air-annotate-packet-ids
+        # injects it. The ids likewise: the hop is single-destination, so its
+        # list is just the demux's set with no meaningful order.
         # col memtile -> mem_1_1 hub (packet, keep header so the hub can demux by id).
         _toHub = channel_decl("toHub", size=[NCX], channel_type="npu_dma_packet")
-        _toHub.operation.attributes["keep_pkt_header"] = UnitAttr.get()
+        # keep_pkt_header derived, as for @outA above.
         # hub id-demux egress: emit the assembled 514 packet on ONE MM2S; switchbox routes
         # id 1->dest0(rope), 4->dest1(rms), 8->dest2(glu); strip header -> pure 512 payload.
         _outY = Channel("outY", size=[1, 1], broadcast_shape=[1, NDEST])
         _outY.operation.attributes["channel_type"] = StringAttr.get("npu_dma_packet")
-        # Header ownership stated OUTRIGHT, not inferred from len(packet_ids) > 1.
-        # air-to-aie's channelKernelWritesHeader currently accepts EITHER, so this
-        # is behaviour-neutral today -- but the id COUNT and the fact that the core
-        # (not the DMA) stamps the header are two independent properties, and
-        # deriving the second from the first means the demux stops being
-        # recognisable the moment the pinned ids go away. air-annotate-packet-ids
-        # needs this marker to classify outY as a demux at all.
-        _outY.operation.attributes["air.src_writes_pkt_header"] = UnitAttr.get()
-        # No packet_ids. air-annotate-packet-ids allocates the ids from the top
-        # of the id space (nothing else is renumbered) and rewrites the ordinals
-        # the kernel stamps to match. air.src_writes_pkt_header above is what
-        # marks this channel as the demux now that the list is gone.
+        # Nothing declared here. That this channel demuxes is DERIVED: its
+        # destinations partition the stream, and a put naming a `dest` reaches
+        # it through the hops above. A dest operand can only mean "this packet
+        # is for that leaf", which is exactly the statement that the fanout is
+        # over time rather than over space.
+        #
+        # No packet_ids either. air-annotate-packet-ids allocates them from the
+        # top of the id space (so nothing else is renumbered) and rewrites the
+        # ordinals the kernel stamps to match.
         # Keep the hub demux on S2MM0 at every consumer tile; the shim-sourced feeds
         # (ropeLUT/rmsIn/rmsW) are pinned to S2MM1 below. Without an explicit pin,
         # unpinned packet flows REUSE whatever packet channel the tile already has


### PR DESCRIPTION
The four q4nx/q4 decode designs each declared three things about packet headers: `keep_pkt_header` on two forwarding hops, and `air.src_writes_pkt_header` on the demux. **None of them were choices.** All three are now derived, and the designs state nothing.

## The lever is `dest(%d)`

A put naming a `dest` is a runtime value saying which leaf this packet is for. There is nothing else it can mean — so the packet channel it reaches covers its broadcast dimension over **time** rather than over **space**. That is the whole space-versus-time question, and the design was already answering it.

Worth being precise about what that question is, because `broadcast_shape` alone cannot express it. On a **circuit-switched** channel the stretch is always spatial: the route is static, there is no header, and nothing selects anything. Only on a **packet-switched** channel can the same `broadcast_shape` mean two different things — every packet copied to all N leaves (1 id), or each packet routed to exactly one of them (N ids). That ambiguity was being resolved by summing the volumes the gets consume, i.e. arithmetic standing in for intent.

## Three changes

**Classification stops reading the header attribute.** A partition of the stream across destinations is now reported as *evidence* of a demux; confirmation is separate. Requiring the attribute here is exactly what made it load-bearing for classification, and so impossible for a design to stop declaring — remove it and the channel stopped being recognised as a demux at all.

**Confirmation comes from reachability.** A demux is confirmed when a `dest`-carrying put reaches it forward through the hop graph, and the hops are the channels on that path: forward-reachable from the put *and* backward-reachable from the demux. Intersecting the two keeps an unrelated channel that merely feeds the same buffer out of the domain — the old attribute gate excluded those only incidentally. Designs with no `dest` anywhere fall back to the attribute-gated walk and are unaffected.

**`keep_pkt_header` is injected on the hops.** A hop carries a routing decision made upstream to a switchbox further downstream; strip the header there and the demux has nothing to route on. Forced by topology, not a choice. The demux itself is left alone: at the final consumers, stripping to a pure payload *is* a choice and stays the design's.

Also: a partition with no header writer anywhere no longer silently declines to allocate. It is rejected, via the check added in #1805. Previously air-to-aie would auto-assign one id that half the destinations never match.

## Verification

**IR gate.** Regenerated both decode builders with the attributes deleted and ran the full two-run sequence. Against a baseline binary built from merged main (`53fcac0d7`) on the *attributed* designs, the entire IR is identical except the removed `air.src_writes_pkt_header` line itself — 3124 and 1671 lines, **one line of diff each**.

That removal is provably inert. After the pass `@outY` carries three `packet_ids`, so `channelSourceWritesHeader` is true via its `size() > 1` branch — which is already what the bundle-split path relies on, since `copyChannelSteeringAttrs` does not copy that attribute. Its other consumers key on `keep_pkt_header`, absent on `@outY` both before and after.

**Device gates**, all with `make clean` first and `SKIPS=0`:

| model | builder | result |
|---|---|---|
| llama-3.2-1B | `fused_decode.py` | PASS (`topk_passed: 2, topk_failed: 0`) |
| llama-3.2-3B | `fused_decode.py` | PASS |
| gemma-3-4B | `fused_decode.py` | PASS (`*** PARIS ***`) |
| qwen2.5-3B | `fused_decode_qwen.py` | PASS (coherent, 12.08 tok/s) |

llama-1b was re-gated after rebasing onto current main and moving to the new mlir-aie pin from #1803 (`c84915b0`) — still PASS.

`check-air-mlir`: all packet-id tests pass. The only failures in the tree are 4 pre-existing `Util/Channel` tests that fail compiling a C++ host harness on a missing `air_tensor.h`, unrelated to this change.

No perf A/B: the generated IR is unchanged apart from one removed attribute line, so a measurement would report box noise rather than signal.

New coverage in `derive_from_dest.mlir`: the full derivation with a design that declares nothing, an off-path channel that must *not* be pulled into the domain, and a legacy `dest`-free design that still uses the attribute-gated walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
