### PR TITLE
[fused_decode] Retire the Peano NOINLINE attn workaround (58.8 -> 63.2 tok/s)

### DIFF
--- a/programming_examples/fused_decode/kernels/attn_kv.cc
+++ b/programming_examples/fused_decode/kernels/attn_kv.cc
@@ -10,7 +10,9 @@
 // loop. Peano only, always built with -DDECODE_INLINE_ATTN.
 // The Peano NOINLINE workaround is retired here too -- see attn_qk.cc for the
 // defect history, the evidence that it no longer reproduces, and the numbers.
-// ATTN_PEANO_NOINLINE=1 restores it.
+// Compiling with -DATTN_PEANO_NOINLINE restores it (the guard tests only
+// whether the macro is defined, so the value is irrelevant and it must be a
+// compile define, not a make variable).
 #if defined(__chess__) || !defined(ATTN_PEANO_NOINLINE)
 #define ATTN_HOT inline __attribute__((always_inline))
 #else

--- a/programming_examples/fused_decode/kernels/attn_kv.cc
+++ b/programming_examples/fused_decode/kernels/attn_kv.cc
@@ -8,12 +8,10 @@
 // Hot-path inlining (see attn_qk.cc): tuned functions + entry wrappers are
 // always_inline'd so the .ll kernel is llvm-merged into AIR's per-block scf.for
 // loop. Peano only, always built with -DDECODE_INLINE_ATTN.
-// Peano (llvm-aie) spills the online-softmax attention's many live BFP16 matrix
-// accumulators, and a residual cross-regfile spill/reload defect corrupts /
-// deadlocks the inlined attn (the reference implementation). Keep the hot attn
-// helpers (attn_fv/calculate_l/_attn_qk/update) NOINLINE on Peano so each stays
-// a bounded-register function; chess schedules the inlined form correctly.
-#if defined(__chess__)
+// The Peano NOINLINE workaround is retired here too -- see attn_qk.cc for the
+// defect history, the evidence that it no longer reproduces, and the numbers.
+// ATTN_PEANO_NOINLINE=1 restores it.
+#if defined(__chess__) || !defined(ATTN_PEANO_NOINLINE)
 #define ATTN_HOT inline __attribute__((always_inline))
 #else
 #define ATTN_HOT __attribute__((noinline))

--- a/programming_examples/fused_decode/kernels/attn_qk.cc
+++ b/programming_examples/fused_decode/kernels/attn_qk.cc
@@ -10,12 +10,40 @@
 // so the .ll kernel is llvm-merged into AIR's per-block scf.for loop (no
 // per-block call ABI). Peano only, always built with -DDECODE_INLINE_ATTN (see
 // the chatbot Makefile).
-// Peano (llvm-aie) spills the online-softmax attention's many live BFP16 matrix
-// accumulators, and a residual cross-regfile spill/reload defect corrupts /
-// deadlocks the inlined attn (the reference implementation). Keep the hot attn
-// helpers (attn_fv/calculate_l/_attn_qk/update) NOINLINE on Peano so each stays
-// a bounded-register function; chess schedules the inlined form correctly.
-#if defined(__chess__)
+// Peano used to need the hot helpers (attn_fv/calculate_l/_attn_qk/update)
+// NOINLINE: it spills the online-softmax attention's many live BFP16 matrix
+// accumulators, and a cross-regfile spill/reload defect corrupted / deadlocked
+// the inlined form, so each helper was kept a bounded-register function.
+//
+// That defect no longer reproduces on llvm-aie f4a72c27 (measured 2026-08-14).
+// The inlined form still exercises the same path -- inlining raises ACC2048
+// allocation pressure 35 -> 192 in this file and does emit cross-regfile
+// spill/reload -- and is correct: `make verify` PASS 2/2 for llama32_1b_q4nx
+// with NPU output bit-identical to the NOINLINE build (same divergence steps,
+// token ids, top-5 sets).
+//
+// NOINLINE is not free. These helpers run once per 16-token KV block (~2048
+// invocations per token at ctx 2048), and each call carries a prologue that
+// saves/restores callee-saved accumulators. That is a per-block cost, so it
+// shows up in the context SLOPE, not the intercept -- llama-3.2-1B decode:
+//
+//   NOINLINE       13.230 + 1.899*(ctx/1k) ms   17.03 ms @2k  58.8 tok/s
+//   always_inline  13.267 + 1.278*(ctx/1k) ms   15.82 ms @2k  63.2 tok/s
+//   (chess         13.050 + 1.249*(ctx/1k) ms   15.55 ms @2k  64.3 tok/s)
+//
+// No model is known to still need the workaround. All four users of this
+// engine build inlined; accumulator pressure / stack spills per kernel are
+//
+//   MODEL_TYPE      attn_qk ACC2048/spills   attn_kv ACC2048/spills
+//   LLAMA_3_2_1B          192 / 16                194 / 16   <- verify-gated
+//   LLAMA_3_2_3B          149 /  8                193 / 16
+//   GEMMA3_4B              61 /  2                234 /  8
+//   QWEN2_5_3B             41 /  0                141 /  0
+//
+// LLAMA_3_2_1B ties for the most spills, so the gated config is the worst case
+// for the defect this workaround guarded. 3B / gemma / qwen still want their
+// own `make verify`. ATTN_PEANO_NOINLINE=1 restores the old form if one bites.
+#if defined(__chess__) || !defined(ATTN_PEANO_NOINLINE)
 #define ATTN_HOT inline __attribute__((always_inline))
 #else
 #define ATTN_HOT __attribute__((noinline))

--- a/programming_examples/fused_decode/kernels/attn_qk.cc
+++ b/programming_examples/fused_decode/kernels/attn_qk.cc
@@ -42,7 +42,10 @@
 //
 // LLAMA_3_2_1B ties for the most spills, so the gated config is the worst case
 // for the defect this workaround guarded. 3B / gemma / qwen still want their
-// own `make verify`. ATTN_PEANO_NOINLINE=1 restores the old form if one bites.
+// own `make verify`. Compiling with -DATTN_PEANO_NOINLINE restores the old form
+// if one bites -- the guard tests only whether the macro is DEFINED, so any
+// value works and a bare make variable of that name will not reach the
+// compiler; it has to be passed as a -D (e.g. via the kernel CXXFLAGS).
 #if defined(__chess__) || !defined(ATTN_PEANO_NOINLINE)
 #define ATTN_HOT inline __attribute__((always_inline))
 #else


### PR DESCRIPTION
## Summary

The fused-decode attention hot helpers (`attn_fv` / `calculate_l` / `_attn_qk` / `update`)
were `always_inline` under Chess but `NOINLINE` under Peano:

```c
#if defined(__chess__)
#define ATTN_HOT inline __attribute__((always_inline))
#else
#define ATTN_HOT __attribute__((noinline))
#endif
```

The `NOINLINE` was a correctness workaround: Peano spills the online-softmax attention's
many live BFP16 matrix accumulators, and a cross-regfile spill/reload defect corrupted or
deadlocked the inlined form, so each helper was kept a bounded-register function.

**That defect no longer reproduces on llvm-aie `f4a72c27`.** This PR retires the
workaround, keeping an `ATTN_PEANO_NOINLINE=1` escape hatch.

## Why it was expensive

These helpers run **once per 16-token KV block** — ~2048 invocations per generated token at
ctx 2048 (128 blocks × 16 layers). `NOINLINE` makes each a real call, and the expensive
part is the ABI, not the branch: these functions use the accumulator file heavily, so every
call carries a prologue that saves and restores callee-saved accumulators.

Because the block count scales with context, this lands on the context **slope**, not the
intercept. Measured on NPU2, llama-3.2-1B, `bench_decode`, at two context points:

| build | ctx 1024 | ctx 2048 | intercept | slope ms/1k |
|---|---|---|---|---|
| `NOINLINE` (before) | 15.129 | 17.028 | 13.230 | **1.899** |
| `always_inline` (after) | 14.545 | **15.823** | 13.267 | **1.278** |
| _(Chess, for reference)_ | 14.300 | 15.549 | 13.050 | 1.249 |

**58.8 → 63.2 tok/s at ctx 2048.** Inlining removes 96% of the slope excess over Chess and
leaves the intercept unchanged (13.230 → 13.267), which confirms the cost was per-block
rather than a general code-quality difference. The residual 0.27 ms at ctx 2048 is 79%
intercept and is unrelated to this change.

## Correctness

`make verify` (top-5 token-set inclusion vs HF bf16, 2 prompts × 32 tokens) **PASS 2/2**
for `llama32_1b_q4nx`, both before and after.

Stronger than pass/pass — the NPU output is **bit-identical** between the two builds:

| | prompt 0 | prompt 1 |
|---|---|---|
| divergence step | 0 = 0 | 12 = 12 |
| chosen token id | 323 = 323 | 1176 = 1176 |
| top-5 set | identical | identical |
| rank in ref | 3 = 3 | 3 = 3 |

The inlined form still exercises the path the workaround guarded — inlining raises ACC2048
allocation pressure 35 → 192 in `attn_qk` and does emit cross-regfile spill/reload traffic —
and is correct. So this is the defect being fixed upstream, not the code sneaking past it.

## Coverage: the other three models

Four models share this engine. All four compile inlined. Accumulator pressure and stack
spills per kernel, and gate status:

| MODEL_TYPE | `attn_qk` ACC2048 / spills | `attn_kv` ACC2048 / spills | gated |
|---|---|---|---|
| LLAMA_3_2_1B | 192 / **16** | 194 / **16** | ✅ `make verify` PASS 2/2, output bit-identical |
| LLAMA_3_2_3B | 149 / 8 | 193 / **16** | ✅ `make verify` PASS 2/2, output bit-identical |
| GEMMA3_4B | 61 / 2 | **234** / 8 | ✗ not gated |
| QWEN2_5_3B | 41 / 0 | 141 / **0** | ✗ not gated |

The two gated models are the two with the highest spill counts (16 each in `attn_kv`), so
the worst cases for the specific defect this workaround guarded are covered. For 3B the
decode templates were force-rebuilt (`09ccddaf47ca` → `65b69e6e194e`) and A/B'd against the
prior noinline templates: identical divergence steps (9, 1), identical chosen tokens
(6617, 320), identical top-5 sets and ranks.

Gemma and Qwen are **not** gated here, for structural reasons rather than a result:

- `gemma3_4b_q4nx`'s `verify` target is `verify: run` — it runs the model, it is not the
  token-set inclusion gate — and its HF reference (`google/gemma-3-4b-it`) was not
  available locally.
- `qwen25_3b_q4`'s target is `verify: run gen`, and its own Makefile comment describes the
  token-set gate as "Informational today".

Qwen carries the least risk of the four on this axis: inlined it spills **zero** in both
kernels, and inlining actually removes 6 spills from its `attn_kv`. Gemma has the highest
raw ACC2048 pressure (234) but fewer spills (8) — a different axis, and the one I'd want
covered before relying on this for gemma.

`ATTN_PEANO_NOINLINE=1` restores the old form per-model if one of them bites.

## Related

The underlying Peano limitation is worth reporting upstream separately:
`AIE2PRegisterInfo::getLargestLegalSuperClass` is marked `// TODO: This implimentation is
not complete` and has cases for ACC512/VEC512 → the 39-register
`spill_vec512_to_composite` pool, but no case for ACC1024/ACC2048. `ACC2048` therefore has
5 allocatable registers (`dm0-4`) and no relocation class, so over-pressure values go
straight to a stack slot. It buys no measurable performance on its own (verified: removing
336 of 352 accumulator spills in `rms_residual` changed decode latency by 0), but it is the
ceiling on how much accumulator pressure Peano can absorb — which is the resource this PR
spends.

Latency figures come from `bench_decode`, which uses synthetic weights and is not a
numerical gate; `make verify` above is the correctness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
