### PR TITLE
[CI] Serialize NPU access in the python test suite

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -172,3 +172,24 @@ jobs:
 
           popd
           rm -rf build_assert
+
+      # A wedged NPU surfaces in userspace only as "DRM_IOCTL_AMDXDNA_EXEC_CMD
+      # IOCTL failed (err=-5)", which says nothing about why the context could
+      # not be created. The kernel log carries the actual cascade -- a command
+      # timeout, then "Bad message ID"/"Channel in bad state" on the firmware
+      # mailbox, then aie2_ctx_connect() failing, and in the worst case
+      # "aie2_smu_start: Access power failed", after which the driver can no
+      # longer probe the device and the runner needs a power cycle. Dump it so
+      # the next occurrence is diagnosable from the CI log alone.
+      - name: NPU diagnostics on failure
+        if: failure()
+        run: |
+          echo "::group::amdxdna kernel log"
+          journalctl -k --no-pager 2>/dev/null | grep -i amdxdna | tail -60 || \
+            echo "(kernel log unavailable)"
+          echo "::endgroup::"
+          echo "::group::device state"
+          ls -l /dev/accel/ 2>&1 || true
+          source /opt/xilinx/xrt/setup.sh >/dev/null 2>&1 || true
+          xrt-smi examine 2>&1 | sed -n '/Device(s) Present/,$p' || true
+          echo "::endgroup::"

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -184,12 +184,36 @@ jobs:
       - name: NPU diagnostics on failure
         if: failure()
         run: |
+          # Report "journalctl did not work" and "journalctl worked but the
+          # device never logged" as distinct outcomes -- they point at opposite
+          # conclusions, and collapsing them into one message would mislead
+          # whoever reads this next. Checked explicitly rather than via a
+          # pipeline's exit status, which depends on `pipefail` being set.
           echo "::group::amdxdna kernel log"
-          journalctl -k --no-pager 2>/dev/null | grep -i amdxdna | tail -60 || \
-            echo "(kernel log unavailable)"
+          if klog=$(journalctl -k --no-pager 2>&1); then
+            hits=$(printf '%s\n' "$klog" | grep -i amdxdna | tail -60 || true)
+            if [ -n "$hits" ]; then
+              printf '%s\n' "$hits"
+            else
+              echo "(journalctl read OK; no amdxdna entries -- the driver never"
+              echo " logged a fault, so look elsewhere than a wedged device)"
+            fi
+          else
+            echo "(kernel log unavailable; journalctl said:)"
+            printf '%s\n' "$klog" | head -3
+          fi
           echo "::endgroup::"
+
+          # A missing /dev/accel is the severe signature: the driver could not
+          # probe the device at all (typically "aie2_smu_start: Access power
+          # failed"), and the runner needs a power cycle -- a module reload
+          # will not bring it back.
           echo "::group::device state"
-          ls -l /dev/accel/ 2>&1 || true
+          if [ -e /dev/accel ]; then
+            ls -l /dev/accel/ || true
+          else
+            echo "/dev/accel MISSING -- driver failed to probe; runner needs a power cycle"
+          fi
           source /opt/xilinx/xrt/setup.sh >/dev/null 2>&1 || true
           xrt-smi examine 2>&1 | sed -n '/Device(s) Present/,$p' || true
           echo "::endgroup::"

--- a/python/test/lit.cfg.py
+++ b/python/test/lit.cfg.py
@@ -97,7 +97,18 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
                 model = str(m.group(4))
             print(f"\tmodel: '{model}'")
             config.available_features.add("ryzen_ai")
-            run_on_npu = f"{config.air_src_root}/utils/run_on_npu.sh"
+            # Serialize hardware access. Concurrent hwctx creation on a single
+            # NPU can time out a command, which takes down the driver/firmware
+            # mailbox ("Bad message ID", "Channel in bad state"). Every later
+            # aie2_ctx_connect() then fails, the context is marked
+            # CTX_STATE_DEAD, and all subsequent submits -- in this process and
+            # in every process after it -- return -EIO ("DRM_IOCTL_AMDXDNA_
+            # EXEC_CMD IOCTL failed (err=-5)"). The device does not recover on
+            # its own; it needs a power cycle. test/lit.cfg.py takes the same
+            # lock, and the two must stay in agreement.
+            run_on_npu = (
+                f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+            )
             if model in ["npu1", "Phoenix"]:
                 run_on_npu1 = run_on_npu
                 config.available_features.add("ryzen_ai_npu1")

--- a/python/test/torch_mlir_e2e/matmul.py
+++ b/python/test/torch_mlir_e2e/matmul.py
@@ -118,11 +118,11 @@ for t in dtypes:
     for s in sizes:
         print(f"running test for {t} and {s}")
         num_tests = num_tests + 1
-        try:
-            passed = passed + run_test(t, s)
-        except Exception as e:
-            print("test failed:", e)
-            pass
+        # Deliberately not wrapped in try/except: a swallowed exception here
+        # let this test report PASS while every submit was returning -EIO, so
+        # a dead NPU looked like a two-test failure instead of a whole-suite
+        # one. Let it propagate, the way mul.py and relu.py do.
+        passed = passed + run_test(t, s)
 
 if passed != num_tests:
     print(f"failed. {passed}/{num_tests}")


### PR DESCRIPTION
`check-air-python` has been taking down the npu1 runner. It runs
`torch_mlir_e2e/{mul,relu,matmul}.py` concurrently under lit, and unlike
`test/lit.cfg.py` it never took the `/tmp/npu.lock` that exists precisely to keep
two processes off the device at once.

Concurrent hwctx creation on one 4-column Phoenix times a command out. The
driver's recovery then corrupts the firmware mailbox, and from the kernel log the
cascade is:

```
aie2_dump_ctx: ... out_fence: unsignaled      <- command timed out, TDR fires
xdna_mailbox: Bad message ID 0x80000000
xdna_mailbox: Unexpected ret -22, disable irq
xdna_mailbox: Channel in bad state
xdna_send_msg_wait: Send message failed, ret -32
aie2_load_hwctx: create context failed, ret -32
part_ctx_start: ctx.304476.1 connect failed, err -32
rq_submit_enter_slow: ctx.304476.1 fatal error
aie2_cmd_submit: Submit enter failed, ret -5
```

Once the mailbox is down every `aie2_ctx_connect()` fails, the context is marked
`CTX_STATE_DEAD`, and `aie2_rq_submit_enter()` returns `-EIO` to every later
submit -- in that process and in every process after it. Userspace sees only
`DRM_IOCTL_AMDXDNA_EXEC_CMD IOCTL failed (err=-5)`. The device does not recover
on its own, and if the driver also loses the SMU (`aie2_smu_start: Access power
failed`) it can no longer even probe, so the runner needs a power cycle rather
than a module reload.

This is why the failure moved around: whichever suite ran after the device died
took the blame. Most days that was `check-air-python` in the *next* job; on Aug 11
it was all 45 npu1 tests in `test/xrt`.

The race is old, but it was masked by slow compiles -- mul/relu/matmul took
290s/171s/128s, so their hardware phases rarely overlapped. Since the mlir-aie
LLVM 23->24 bump (#1778) the suite finishes in ~13s total, so all three now hit
the device at once and collide almost every run. Taking the lock costs ~40s of
wall time and removes the contention.

### Reproduction

On a Phoenix part, running the three tests concurrently gives `err=-5` on the
first round, after which a *sequential* run also gets `err=-5` and stays broken
(still failing 5 minutes later; a module reload did not recover it). Two things
that do **not** reproduce it, so they can be ruled out:

- a single `SIGKILL` mid-hardware-execution -- the driver cleans up fine
- steady-state concurrency -- 4 processes, 115k iterations each, clean

so it is specifically concurrent context create/teardown.

### Also in this PR

- Drops `matmul.py`'s `try/except`. It swallowed the exception and has no CHECK
  lines, so it reported PASS while every submit returned `-EIO` -- a dead NPU
  looked like a two-test failure instead of a whole-suite one.
- Adds a failure-only diagnostics step dumping the amdxdna kernel log and device
  state. Everything above came from `journalctl` on a local part; CI has never
  shown us any of it, which is why this read as a compiler regression for a week.

### Verifying

The runner needs a power cycle before the first run, or the job will fail on a
still-wedged device and tell us nothing. The signal to look for is
`check-air-python` reporting `Testing Time: ~40s` instead of `~13s` -- that is
positive proof the lock is in effect rather than a lucky non-overlapping run.

### What this does not fix

It removes the contention that starts the cascade; it does not make the driver
resilient to it. If something else ever times a command out on that part, the
same mailbox collapse can happen. That is an upstream amdxdna robustness issue.
The diagnostics step is what will tell us if that is what we are looking at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)