### PR TITLE
[AIR] Revert the shim-BD stride fold's wait pairing (#1810)

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -2055,22 +2055,20 @@ LogicalResult unrollIllegalStrideDim(airrt::DmaMemcpyNdOp memcpy_op,
     return success();
   // generateAwaitsFromWaitAllOps matches waits to configure tasks FIFO per
   // channel -- the Nth wait for a channel awaits the Nth config for it. This
-  // rewrite turns one config into `wrap` of them, so the channel needs `wrap`
-  // waits or the pairing shifts: the original wait would land on the first
-  // piece, every later transfer on the channel would be awaited one slot
-  // early, and the tail pieces would go unawaited -- on an S2MM channel that
-  // is both a missed completion token and a BD that is never freed. Emit the
-  // extra waits alongside the extra configs so the 1:1 invariant survives.
-  //
-  // Only on a channel that is already waited: adding waits to a fire-and-
-  // forget channel would impose synchronisation the design never asked for.
-  StringRef waitedSym;
-  if (auto metadata = memcpy_op->getAttrOfType<FlatSymbolRefAttr>("metadata"))
+  // rewrite turns one config into `wrap` of them without adding waits, so on a
+  // channel that already carries a wait the pairing shifts and the wait lands
+  // on the first piece while the rest go unawaited. Leave those alone: a
+  // silently under-synchronised transfer is far worse than an unfolded one.
+  if (auto metadata = memcpy_op->getAttrOfType<FlatSymbolRefAttr>("metadata")) {
+    bool channelIsWaited = false;
     if (auto func = memcpy_op->getParentOfType<func::FuncOp>())
       func.walk([&](AIEX::NpuDmaWaitOp wait) {
         if (wait.getSymbol() == metadata.getValue())
-          waitedSym = metadata.getValue();
+          channelIsWaited = true;
       });
+    if (channelIsWaited)
+      return success();
+  }
 
   // The op's !airrt.event is optional and, unlike tileIllegalWrapDim (which
   // rewrites in place), this replaces the op -- so the result has to be
@@ -2093,26 +2091,6 @@ LogicalResult unrollIllegalStrideDim(airrt::DmaMemcpyNdOp memcpy_op,
     // Ordering/barrier markers must ride along on every piece, or the split
     // silently drops the append barrier and the shim order constraint.
     lastOp->setAttrs(memcpy_op->getDiscardableAttrDictionary());
-  }
-  // Where they go does not change the pairing -- FIFO orders waits among
-  // themselves, and anywhere after the pieces and before the transfer's own
-  // wait gives piece k the kth of these and the last piece the original wait.
-  // It does change when the awaits execute, so prefer the transfer's own wait:
-  // a design that deliberately waits late keeps the overlap it asked for
-  // instead of being synchronised early. Only in the same block, though -- a
-  // wait in a nested region (a per-iteration drain inside an scf.for, say)
-  // would multiply these by the trip count and unbalance the very pairing they
-  // exist to preserve. Falling back to right after the pieces is always valid:
-  // every piece dominates them, which the pairing's dominance guard requires.
-  if (!waitedSym.empty()) {
-    for (Operation *o = memcpy_op->getNextNode(); o; o = o->getNextNode())
-      if (auto wait = dyn_cast<AIEX::NpuDmaWaitOp>(o))
-        if (wait.getSymbol() == waitedSym) {
-          builder.setInsertionPoint(wait);
-          break;
-        }
-    for (int64_t k = 1; k < *constWrap; k++)
-      AIEX::NpuDmaWaitOp::create(builder, loc, waitedSym);
   }
   memcpy_op->replaceAllUsesWith(lastOp);
   memcpy_op.erase();

--- a/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
@@ -80,25 +80,15 @@ module {
 
 // -----
 
-// A channel that already carries a wait still folds, but the split has to carry
-// the synchronization with it. generateAwaitsFromWaitAllOps pairs waits to
-// configure tasks FIFO per channel, so turning one config into `wrap` of them
-// needs `wrap` waits: with only the original one the wait would land on the
-// first piece, every later transfer on the channel would be awaited one slot
-// early, and the tail pieces would go unawaited -- on this S2MM channel both a
-// missed completion token and a BD that is never freed.
-//
-// This is the shape the pass exists for -- the real KV append channels are
-// waited -- so check the whole chain: both pieces are configured, and both are
-// awaited, leaving no config unpaired.
+// A channel that already carries a wait is left alone. generateAwaitsFromWaitAllOps
+// pairs waits to configure tasks FIFO per channel, so splitting one config into
+// several without adding waits would leave the wait on the first piece and the
+// rest unawaited. Not folding keeps the transfer correctly synchronized; the
+// over-limit stride is then downstream's problem, as everywhere else here.
 
 // CHECK-LABEL: aie.device(npu1)
-// CHECK: %[[T0:.*]] = aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 16383 len = 256 sizes = [256] strides = [1])
-// CHECK: %[[T1:.*]] = aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 4210687 len = 256 sizes = [256] strides = [1])
-// CHECK-DAG: aiex.dma_await_task(%[[T0]])
-// CHECK-DAG: aiex.dma_await_task(%[[T1]])
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 16383 len = 512 sizes = [2, 256] strides = [4194304, 1])
+// CHECK: aiex.dma_await_task
 
 module {
   aie.device(npu1) {
@@ -121,55 +111,6 @@ module {
     %p = airrt.segment_load "forward_0" : i64
     %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c16383_i64], [%c1_i64, %c1_i64, %c2_i64, %c256_i64], [%c0_i64, %c0_i64, %c4194304_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
     airrt.wait_all %0
-    return
-  }
-}
-
-// -----
-
-// The extra waits go at the transfer's own wait, not straight after the pieces.
-// Placement does not change the FIFO pairing -- waits are ordered among
-// themselves, and anywhere after the pieces and before the original wait pairs
-// piece k with the kth new wait -- but it does change when the awaits execute.
-// A design that waits late should keep the overlap it asked for.
-//
-// Here an unrelated channel's transfer sits between the folded one and the
-// wait_all that covers both. The two extra awaits must land after that
-// channel's config, not before it.
-
-// CHECK-LABEL: aie.device(npu1)
-// CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aiex.dma_configure_task_for @airMemcpyId4
-// CHECK: aiex.dma_configure_task_for @airMemcpyId5
-// CHECK: aiex.dma_await_task
-// CHECK: aiex.dma_await_task
-// CHECK: aiex.dma_await_task
-
-module {
-  aie.device(npu1) {
-    %shim_noc_tile_0_0 = aie.tile(0, 0)
-    %shim_noc_tile_1_0 = aie.tile(1, 0)
-    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
-    aie.shim_dma_allocation @airMemcpyId5(%shim_noc_tile_1_0, S2MM, 0)
-  } {sym_name = "forward_0"}
-  airrt.module_metadata {
-    airrt.segment_metadata attributes {sym_name = "forward_0"} {
-      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
-    }
-  }
-  func.func @forward(%arg0: memref<268435456xbf16>, %arg1: memref<268435456xbf16>) {
-    %c0_i64 = arith.constant 0 : i64
-    %c1_i64 = arith.constant 1 : i64
-    %c2_i64 = arith.constant 2 : i64
-    %c256_i64 = arith.constant 256 : i64
-    %c16383_i64 = arith.constant 16383 : i64
-    %c4194304_i64 = arith.constant 4194304 : i64
-    %c4_i32 = arith.constant 4 : i32
-    %c5_i32 = arith.constant 5 : i32
-    %p = airrt.segment_load "forward_0" : i64
-    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c16383_i64], [%c1_i64, %c1_i64, %c2_i64, %c256_i64], [%c0_i64, %c0_i64, %c4194304_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
-    %1 = airrt.dma_memcpy_nd(%c5_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId5} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
-    airrt.wait_all %0, %1
     return
   }
 }


### PR DESCRIPTION
Reverts #1810. The nightly LLM benchmark went red at d0e522bb with four new
failures, all traceable to that commit. The fold itself (#1806) stays.

## Cause

#1806 refused to fold on a channel that already carries a wait, because
splitting one `airrt.dma_memcpy_nd` into `wrap` of them shifts the FIFO wait
pairing. #1810 replaced that refusal with hand-emitted `NpuDmaWaitOp`s.

But `enforceAIE2StrideLimit` runs at `AIRRtToNpuPass.cpp:2274` and
`generateAwaitsFromWaitAllOps` at `:2344`. The awaits derived from
`airrt.wait_all` do not exist yet when the fold counts them, and the fold does
not split the `wait_all` that produces them. The 1:1 invariant #1810 means to
preserve is computed against an incomplete picture, and the guard it removed was
the only thing keeping these designs off the path.

## Symptoms

Two distinct ones, both measured on NPU2, both gone at 13e02eb5:

| test | d0e522bb | 13e02eb5 |
|---|---|---|
| `llms/qwen25_3b` compile | BD overflow | pass |
| `llms/qwen25_1_5b` compile | BD overflow | pass |
| `llms/qwen25_3b_q4` compile | BD overflow | (shares the qwen prefill builder) |
| `llms/llama32_1b_int4` verify-prefill bfp16 | overlap 0/10, r = -0.8347, `'endi'` | overlap 9/10, r = 0.9938, `' Paris'` |

**Qwen** — the prefill folds a `wrap=16` dim (stride 1409024 = 128*11008) on four
shim channels. Sixteen configs stay live until one wait point, so tile (0,0)
needs 64 of its 16 BDs:

```
'aiex.dma_configure_task' op Too many simultaneously active buffer descriptors
on tile (0,0), which supports up to 16.
```

`AIE2_STRIDE_UNROLL_LIMIT` is 16 — a descriptor-count heuristic equal to the
entire per-tile budget, so it never fires.

**llama32_1b_int4** — folds `wrap=2`, the same shape #1810 was written for and
verified on. Compiles and runs, then answers `'endi'` instead of `' Paris'`.

That wrap=2 case is why this is a revert and not a tightened limit: bounding the
fold by BD cost would fix qwen and leave llama32_1b_int4 silently wrong.

## What this gives up

#1810's own target, the fused decode above ctx 4k/8k, which needs the fold on
waited channels. No CI test covers it — the nightly was green at 9b037828,
before either commit — so nothing regresses here. Re-landing it needs the wait
split to happen where the await set is final, with these two designs as gates.

## Verification

- `check-air-mlir`: 505 passed, 7 unsupported, 7 XFAIL, 0 failures.
- NPU2: `qwen25_3b` and `qwen25_1_5b` compile clean; `llama32_1b_int4`
  verify-prefill bfp16 PASS (overlap 9/10, r = 0.9938).
- The reverted tree is byte-identical to 13e02eb5 for both changed files.

Note: `llms/gemma3_4b_q4nx/run_npu2_verify.lit` is currently UNSUPPORTED on the
nightly runner (its bf16 reference `unsloth/gemma-3-4b-it` is not yet in the
runner's HF cache). Unrelated to this revert; needs a `downloadLLMWeights.yml`
dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Supersedes #1813 (opened from a fork, where the nightly workflow cannot be dispatched against it).
