### PR TITLE
[AIR] Don't fold a shim BD stride under a dim that still walks

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -2053,6 +2053,16 @@ LogicalResult unrollIllegalStrideDim(airrt::DmaMemcpyNdOp memcpy_op,
   // Folding costs one descriptor per entry of the folded dim.
   if (*constWrap > AIE2_STRIDE_UNROLL_LIMIT)
     return success();
+  // The pieces are issued back to back, so an enclosing dim that still walks is
+  // traversed inside each piece instead of around them: (d,k) order becomes
+  // (k,d). Same addresses, different arrival order, which an S2MM consumer
+  // synchronising on locks reads as corrupt data. A stride-0 repeat counts --
+  // it revisits the same addresses, so only the order distinguishes it. Only
+  // fold when every enclosing dim is degenerate, which is the shape this exists
+  // for: the KV append is wrap 1 outside the folded dim.
+  for (unsigned d = 0; d < i; d++)
+    if (getConstantIntValue(wraps[d]).value_or(0) != 1)
+      return success();
   // generateAwaitsFromWaitAllOps matches waits to configure tasks FIFO per
   // channel -- the Nth wait for a channel awaits the Nth config for it. This
   // rewrite turns one config into `wrap` of them, so the channel needs `wrap`

--- a/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/unroll_illegal_stride.mlir
@@ -173,3 +173,41 @@ module {
     return
   }
 }
+
+// -----
+
+// A dim outside the folded one that still walks blocks the fold. The pieces are
+// issued back to back, so that dim ends up traversed inside each piece instead
+// of around them -- (d,k) order becomes (k,d). Same addresses, different arrival
+// order, which an S2MM consumer synchronising on locks reads as corrupt data.
+// Here dim 0 is a stride-0 repeat of wrap 2: it revisits the same addresses, so
+// order is the only thing that distinguishes it. Shape taken from the
+// llama-3.2-1B int4 bfp16 prefill, which this silently miscompiled.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK: aie.dma_bd(%arg0 : memref<268435456xbf16> offset = 0 len = 589824 sizes = [2, 384, 768] strides = [1179648, 768, 1])
+
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, S2MM, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<268435456xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c384_i64 = arith.constant 384 : i64
+    %c768_i64 = arith.constant 768 : i64
+    %c1179648_i64 = arith.constant 1179648 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c2_i64, %c2_i64, %c384_i64, %c768_i64], [%c0_i64, %c1179648_i64, %c768_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<268435456xbf16>) : !airrt.event
+    airrt.wait_all %0
+    return
+  }
+}


### PR DESCRIPTION
Fixes the nightly LLM benchmark, red since d0e522bb (#1810):
`llms/qwen25_{1_5b,3b,3b_q4}` stopped compiling, and
`llms/llama32_1b_int4` verify-prefill bfp16 started answering `'endi'`
instead of `' Paris'`. #1810 exposed the designs, but the defect is older
than the wait pairing it changed.

## Cause

`unrollIllegalStrideDim` replaces one dim with `wrap` copies of the transfer,
each carrying that dim's contribution in its own base. The pieces are issued
back to back, so any **enclosing** dim that still walks is traversed inside each
piece instead of around them: `(d,k)` order becomes `(k,d)`. Identical address
set, different arrival order — which an S2MM consumer synchronising on locks
reads as corrupt data. A stride-0 repeat counts: it revisits the same addresses,
so order is the only thing distinguishing it.

#1806 checked `*outerStride != 0` but never `outerWrap != 1`, so a transfer
whose outer dim is a stride-0 repeat passed, and the fold ran under a live dim:

| design | `wraps` | fold dim | result |
|---|---|---|---|
| decode KV append | `[1,1,2,256]` | 2 | sound — what the fold exists for |
| int4 bfp16 prefill | `[2,2,384,768]` | 1 | reordered → miscompile |
| qwen prefill | `[2,16,128,64]` | 1 | reordered → BD overflow |

The qwen case surfaces as a compile error rather than bad data only because the
fold is `wrap=16` there: sixteen configs stay live until one wait point, so tile
(0,0) needs 64 of its 16 BDs. Same root cause, louder symptom.

## Fix

Reject the fold when any enclosing dim is non-degenerate — 10 lines. The KV
append is wrap 1 outside the folded dim, so it is unaffected.

## Why not revert #1810

Reverting restores qwen and int4 but breaks #1810's own target: llama-1b q4nx
decode at ctx 16k then fails to build with
`'aie.dma_bd' op Stride 1 exceeds the [1:1048576] range`. Measured, not assumed.
This guard keeps both working.

## Verification

Measured on NPU2, all on one build:

| check | result |
|---|---|
| `fused_decode` ctx 16384 | builds |
| `llms/qwen25_3b` compile | clean |
| `llms/llama32_1b_int4` verify-prefill bfp16 | **PASS**, overlap 9/10, argmax match (was 0/10, Pearson r = -0.8347) |
| `check-air-mlir` | 505 passed, 0 failed |

New lit case built from the real int4 shape, asserting the transfer stays
unfolded.

A full `nightlyPerfBenchmark.yml` run has been dispatched against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
