### PR TITLE
[fused_decode] Q4_0: replace peano's int4 sign emulation with the xor bias

### DIFF
--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -52,6 +52,33 @@ This mirrors FastFlowLM, whose own Qwen design sets `#define Q4_0` in its
 `Qwen2_5/decoding_3b/models/qwen2_3b.h` while its Llama and Gemma designs leave
 it undefined.
 
+### The Q4_0 branch splits again, on the toolchain
+
+Only the Q4_0 side has a *signed* nibble to decode, and only chess can do it
+directly: `aie::to_float(vector<int4>)` on peano folds to zero and the whole
+matmul is dead-code-eliminated. So under `#if defined(__chess__)` the two
+backends compile **different source** from this one file -- worth knowing before
+concluding that a peano and a chess build of "the same kernel" should cost the
+same.
+
+The peano side loads the nibbles as `uint4` and sign-corrects them itself, under
+`Q4_SFIX_MODE`:
+
+| | how | inner-loop body |
+|---|---|---|
+| `1` (default) | xor bias: `(u ^ 8) - 8 == q`, the xor done on the packed bytes since `0x88` flips both nibbles | 140 bundles |
+| `0` | compare/select: `select(f, f - 16, f >= 8)` | 355 bundles |
+| `2` | no sign fix at all -- **numerically wrong**, for attributing static cost only | 121 bundles |
+| | (chess, for reference) | 142 bundles |
+
+Mode 0 is only 64 bundles of compare and select; the rest of its cost is spill
+traffic, because keeping four `vector<float,128>` and two broadcast constants
+live at once is well past the register file. That body runs 8x2 per 32x256
+weight block, and an AIE2P core issues about one bundle per cycle, so the
+difference is most of the projection: it moved the qwen2.5-3B decode intercept
+from 81.1 to 32.6 ms/token. `aie::bit_xor` on a `vector<uint4>` segfaults
+peano's frontend, which is why the xor is applied a byte at a time.
+
 The weight *bundles* are uniform: every FastFlowLM `model.q4nx` is the same
 per-block affine encoding regardless of model. That is why `llms/qwen25_3b_q4`
 quantizes the fp checkpoint directly rather than reading a bundle -- an affine

--- a/programming_examples/fused_decode/kernels/q4_k.h
+++ b/programming_examples/fused_decode/kernels/q4_k.h
@@ -21,6 +21,19 @@
 // above. The additive form matches the newer "I8" bundle dtype instead. Naming
 // the layout after either bundle codec invites reading the algebra backwards,
 // so it is named after what it is.
+
+// How the Q4_0 path sign-corrects a nibble when peano is the backend:
+//   1  xor bias, (u ^ 8) - 8    (default)
+//   0  compare/select, select(f, f - 16, f >= 8)
+//   2  no sign fix at all -- NUMERICALLY WRONG, static-cost attribution only
+// Defaulted here rather than at the use site because the preprocessor has no
+// scope: defining it inside the function body would still leak to the rest of
+// the translation unit, just less visibly. See the block above its use for what
+// the modes cost and why the emulation exists at all.
+#ifndef Q4_SFIX_MODE
+#define Q4_SFIX_MODE 1
+#endif
+
 #ifndef Q4_0
 template <int M, int N>
 void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c,
@@ -300,9 +313,7 @@ inline void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c) {
         //
         // Only this Q4_0 branch has a sign fix at all -- Q4NX nibbles are
         // unsigned -- so nothing outside the Q4_0 models is affected.
-#ifndef Q4_SFIX_MODE
-#define Q4_SFIX_MODE 1
-#endif
+        // Q4_SFIX_MODE is defaulted at the top of this file.
         const aie::vector<float, pr * 8> k_eight =
             aie::broadcast<float, pr * 8>(8.0f);
 #if Q4_SFIX_MODE == 0

--- a/programming_examples/fused_decode/kernels/q4_k.h
+++ b/programming_examples/fused_decode/kernels/q4_k.h
@@ -270,9 +270,47 @@ inline void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c) {
         aie::vector<float, pr * 8> a_cc_f32_3 = aie::to_float(a_cc_3, 0);
 #else
         // Peano's aie-api folds aie::to_float(vector<int4>) to zero (signed
-        // int4 unsupported) -> the whole matmul gets DCE'd. Load as uint4
-        // (works on peano) and sign-correct the 2's-complement nibble (v>=8 ->
-        // v-16) to match chess's to_float(int4).
+        // int4 unsupported) -> the whole matmul gets DCE'd. So the nibbles are
+        // loaded as uint4 and sign-corrected here, two ways:
+        //
+        //   Q4_SFIX_MODE 1 (default) -- XOR-BIAS. (u ^ 8) - 8 == q over the
+        //     whole signed-int4 range, so one integer xor and one float
+        //     subtract do the job. The xor runs on the PACKED bytes (0x88
+        //     flips bit 3 of both nibbles at once) because peano's aie-api has
+        //     no uint4 bit_xor -- aie::bit_xor on a vector<uint4> segfaults
+        //     the frontend.
+        //
+        //   Q4_SFIX_MODE 0 -- the original compare/select (v >= 8 -> v - 16).
+        //     Same values, but the select's operands keep four float<128>
+        //     vectors and two broadcast constants live at once, which is far
+        //     past the register file, and peano spills the difference.
+        //
+        // Measured, aie2p -O2, inner-loop body of this function:
+        //
+        //   mode      bundles   vlda   vst   vge   vsel
+        //   0             355    226    23    32     32
+        //   1             140     33     4     0      0
+        //   (chess)       142      4     0     0      0
+        //
+        // The body runs 8x2 per 32x256 block, and the core issues ~1 bundle
+        // per cycle, so those 215 bundles were 68% of the whole qwen2.5-3B
+        // projection: mode 1 took its decode intercept from 81.10 ms to
+        // 32.40 ms per token (measured, 36 layers, NPU2). See
+        // Q4_SFIX_MODE 2 in the A/B note below for how that was attributed.
+        //
+        // Only this Q4_0 branch has a sign fix at all -- Q4NX nibbles are
+        // unsigned -- so nothing outside the Q4_0 models is affected.
+#ifndef Q4_SFIX_MODE
+#define Q4_SFIX_MODE 1
+#endif
+        const aie::vector<float, pr * 8> k_eight =
+            aie::broadcast<float, pr * 8>(8.0f);
+#if Q4_SFIX_MODE == 0
+        const aie::vector<float, pr * 8> k_sixteen =
+            aie::broadcast<float, pr * 8>(16.0f);
+#endif
+
+#if Q4_SFIX_MODE == 0
         aie::vector<uint4, pr * 8> u_cc_0 =
             aie::load_v<pr * 8>((uint4 *)qs_ptr);
         qs_ptr += pr * 4;
@@ -285,14 +323,35 @@ inline void _qmm_q4k_bf16(const q4k_block_t *A, const bf16 *B, float *c) {
         aie::vector<uint4, pr * 8> u_cc_3 =
             aie::load_v<pr * 8>((uint4 *)qs_ptr);
         qs_ptr += pr * 4;
-        const aie::vector<float, pr * 8> k_sixteen =
-            aie::broadcast<float, pr * 8>(16.0f);
-        const aie::vector<float, pr * 8> k_eight =
-            aie::broadcast<float, pr * 8>(8.0f);
         auto sfix = [&](aie::vector<uint4, pr * 8> uv) {
           aie::vector<float, pr * 8> f = aie::to_float(uv, 0);
           return aie::select(f, aie::sub(f, k_sixteen), aie::ge(f, k_eight));
         };
+#else
+        const aie::vector<uint8, pr * 4> k_88 =
+            aie::broadcast<uint8, pr * 4>((uint8)0x88);
+        auto ldx = [&]() {
+          aie::vector<uint8, pr * 4> raw = aie::load_v<pr * 4>(qs_ptr);
+          qs_ptr += pr * 4;
+          return aie::bit_xor(raw, k_88).template cast_to<uint4>();
+        };
+        aie::vector<uint4, pr * 8> u_cc_0 = ldx();
+        aie::vector<uint4, pr * 8> u_cc_1 = ldx();
+        aie::vector<uint4, pr * 8> u_cc_2 = ldx();
+        aie::vector<uint4, pr * 8> u_cc_3 = ldx();
+#if Q4_SFIX_MODE == 2
+        // A/B BOUND ONLY -- NUMERICALLY WRONG. Drops the -8 so the body's
+        // static bundle count says what is left after the xor is paid for
+        // (113 bundles). Never ship; objdump/bench only.
+        auto sfix = [&](aie::vector<uint4, pr * 8> uv) {
+          return aie::to_float(uv, 0);
+        };
+#else
+        auto sfix = [&](aie::vector<uint4, pr * 8> uv) {
+          return aie::sub(aie::to_float(uv, 0), k_eight);
+        };
+#endif
+#endif
         aie::vector<float, pr * 8> a_cc_f32_0 = sfix(u_cc_0);
         aie::vector<float, pr * 8> a_cc_f32_1 = sfix(u_cc_1);
         aie::vector<float, pr * 8> a_cc_f32_2 = sfix(u_cc_2);

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -42,8 +42,8 @@ AIEOPT_DIR     := $(shell realpath $(dir $(shell which aie-opt))/..)
 # apart are built so DecodeInstsGen can calibrate the per-token L slope. Any
 # prompt up to LBUILD works -- there is no minimum.
 #
-# 2048 matches the three Llama/Gemma Q4NX decodes. It costs 2.7 ms/token against
-# a 256 build (85.4 vs 82.7 ms/tok, same box and power mode, 16-token `make gen`,
+# 2048 matches the three Llama/Gemma Q4NX decodes. It costs 2.5 ms/token against
+# a 256 build (35.5 vs 33.0 ms/tok, same box and power mode, 16-token `make gen`,
 # byte-identical output), because the readback streams the padded ATTN_MAXL --
 # `make compile-decode-dynseq` removes exactly that.
 LBUILD      ?= 2048
@@ -61,6 +61,17 @@ W_DUAL_CHAN ?= 1
 # Llama build only by -DMODEL_TYPE=QWEN2_5_3B.
 NONATTN_KERNELS := proj_qmm rms_residual glu rope   # object .o, -O2
 ATTN_LL_KERNELS := attn_qk attn_kv                  # inline .ll only, -O1 (merge-linked)
+
+# Extra kernel defines, as in fused_decode/Makefile -- read that file's header
+# for what these are for. The other three Q4NX examples delegate their kernel
+# builds to it and so inherit the hook; this Makefile compiles its own kernels
+# (it drives fused_decode_qwen.py rather than fused_decode.py) and had dropped
+# it. Empty by default, so the shipped path is byte-identical. Example:
+#     make compile-decode NONATTN_EXTRA=-DQ4_SFIX_MODE=0
+# rebuilds against the pre-xor-bias int4 sign fix, which is how the 2.4x in
+# README.md's decode table was measured on one box in one session.
+ATTN_EXTRA      ?=
+NONATTN_EXTRA   ?=
 PEANO_KBASE     := -std=c++20 --target=aie2p-none-unknown-elf \
   -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-deprecated-declarations \
   -DNDEBUG -DMODEL_TYPE=QWEN2_5_3B -D__AIE_API_AIE_ADF_HPP__ \
@@ -69,12 +80,18 @@ PEANO_KBASE     := -std=c++20 --target=aie2p-none-unknown-elf \
 DECODE_ENV      := QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$(ATTN_L) W_DUAL_CHAN=$(W_DUAL_CHAN)
 
 # Build-flag stamp for the idempotent skip. Every variable below changes either the
-# xclbin's dataflow or its DDR weight layout, so a warm build made with different
-# settings must NOT be silently reused. (Distinct from the builder's own
-# decode_qwen.flags, which records W_DUAL_CHAN for the *runtime* packer check and
-# whose single-line format the hand-off parses.)
+# xclbin's dataflow, its DDR weight layout or its core ELFs, so a warm build made
+# with different settings must NOT be silently reused. (Distinct from the builder's
+# own decode_qwen.flags, which records W_DUAL_CHAN for the *runtime* packer check
+# and whose single-line format the hand-off parses.)
+#
+# The kernel defines are in the stamp for the same reason the rest are: without
+# them `make compile-decode NONATTN_EXTRA=...` would find the templates present,
+# skip the build and hand back the PREVIOUS kernels -- an A/B that silently
+# measures the same binary twice.
 DECODE_STAMP := $(srcdir)/.decode_build_flags
-DECODE_FLAGS := MODEL_TYPE=QWEN2_5_3B NLAYERS=$(N_LAYERS) LBUILD=$(LBUILD) W_DUAL_CHAN=$(W_DUAL_CHAN)
+DECODE_FLAGS := MODEL_TYPE=QWEN2_5_3B NLAYERS=$(N_LAYERS) LBUILD=$(LBUILD) W_DUAL_CHAN=$(W_DUAL_CHAN) \
+                ATTN_EXTRA=$(ATTN_EXTRA) NONATTN_EXTRA=$(NONATTN_EXTRA)
 
 # End-to-end generation demo. The only bound now is the cache cap: the prompt
 # plus the generated tokens must fit in LBUILD positions. There is no minimum --
@@ -145,10 +162,10 @@ compile-decode-dynseq:
 	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
 	@echo ">>> qwen non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
 	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
-	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) $(NONATTN_EXTRA) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
 	@echo ">>> qwen attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
 	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
-	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) $(ATTN_EXTRA) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> qwen dynseq template decode_dyn_L$(LBUILD)"
 	@cd $(DEC) && QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$(LBUILD) W_DUAL_CHAN=$(W_DUAL_CHAN) \
@@ -171,12 +188,12 @@ _compile_decode_build:
 	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
 	@echo ">>> qwen non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
 	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
-	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) $(NONATTN_EXTRA) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
 	@echo ">>> qwen attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
 	@# Merge-linked INTO the core (mlir-aie #3399), not object-linked: the builder
 	@# tags the kernel decls link_with="<name>.ll" + link_with_mode="merge".
 	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
-	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) $(ATTN_EXTRA) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@# Two templates one L apart, into THIS example's dir. They must not land in
 	@# $(DEC): DecodeInstsGen discovers templates by scanning for decode_L*, so a

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -16,16 +16,19 @@ relationship `llama32_1b_q4nx` has to `llama32_1b`); this example supplies the
 |---|---|
 | First token, `"The capital of France is"`, 36 layers on NPU2 | **argmax 12095 = `" Paris"`** — PASS |
 | Warm TTFT @ seq_len=2048 | **4.17 s** (491 tok/s prefill), NPU-dispatch 4.17 s, host 5 ms |
-| End-to-end NPU prefill -> NPU fused decode, 36 layers, no reference model | coherent text, **12.2 tok/s** device-only decode |
+| End-to-end NPU prefill -> NPU fused decode, 36 layers, no reference model | coherent text, **30.3 tok/s** device-only decode (`LBUILD=256`; 28.2 at the 2048 default) |
 | Top-k token-set inclusion vs HF bf16 (`make verify-full`) | **8/8 prompts PASS** (shared prompt file) — the CI gate |
 
 The 36 transformer layers run on the NPU for both prefill and decode. The final
 RMSNorm + LM-head projection and the argmax still run on the host each decode
 token; moving them on-device is a performance item, not a correctness one.
 
-Measured 2026-08-06 on a quiet NPU2 box (load < 0.1). Verify the box is idle
-before trusting any timing here — a busy host makes this DDR-bandwidth-bound
-workload ~30% slower.
+Prefill measured 2026-08-06, decode re-measured 2026-08-18, both on a quiet
+(load < 0.1) **AMD Ryzen AI 7 350 (Krackan Point)**, XRT 2.21.75. Verify the box
+is idle before trusting any timing here — a busy host makes this
+DDR-bandwidth-bound workload ~30% slower. The part matters as much as the load:
+"NPU2" spans more than one array configuration, so a number from another NPU2
+box is not comparable to these.
 
 ## Quant codec: Q4_0, not Q4NX
 
@@ -175,16 +178,22 @@ slope. The default is **2048**, matching the three Llama/Gemma Q4NX decodes.
 Measured: prompt *"The capital city of France is called Paris, ... that stands
 right in the middle of"* -> *" the city. It is called the Eiffel Tower, and it
 was built"*. Same box and power mode, 16-token `make gen`, output byte-identical
-at both caps:
+in all four cells:
 
-| `LBUILD` | device |
-|---|---|
-| 256 | 82.7 ms/token |
-| 2048 | 85.4 ms/token |
+| `LBUILD` | device | `NONATTN_EXTRA=-DQ4_SFIX_MODE=0` |
+|---|---|---|
+| 256 | **33.0 ms/token** (30.3 tok/s) | 81.8 ms/token (12.2 tok/s) |
+| 2048 | **35.5 ms/token** (28.2 tok/s) | 84.2 ms/token (11.9 tok/s) |
 
-The 2.7 ms is the padded readback: the KV nd-DMA streams `ATTN_MAXL` positions
-whatever the real context is. `make compile-decode-dynseq` takes the block count
-off the runtime scalar instead and removes it.
+The 2.5 ms between the caps is the padded readback: the KV nd-DMA streams
+`ATTN_MAXL` positions whatever the real context is. `make
+compile-decode-dynseq` takes the block count off the runtime scalar instead and
+removes it.
+
+The right-hand column is the same design built against the pre-xor-bias int4
+sign fix (see [`kernels/q4_k.h`](../../fused_decode/kernels/q4_k.h)), measured in
+the same session on the same box so the 2.4x is not a cross-box comparison. It
+is also what this table used to report.
 
 ## Files
 


### PR DESCRIPTION
Qwen2.5-3B Q4_0 decode was spending most of its projection undoing a
toolchain limitation. Fixing it takes the decode intercept from **81.1 to
32.6 ms/token**, 2.4x on the shipped `make gen` configuration.

## What was wrong

`kernels/q4_k.h`'s Q4_0 template splits on `#if defined(__chess__)`, so the two
backends compile *different source* from that one file. Chess decodes the signed
nibble with `aie::to_float(int4)`. Peano cannot — its aie-api folds that to zero
and the whole matmul is dead-code-eliminated — so the peano branch loaded the
nibbles as `uint4` and sign-corrected them with `select(f, f - 16, f >= 8)`.

That select keeps four `vector<float,128>` and two broadcast constants live at
once, well past the register file, and peano spills the difference. Inner-loop
body of `_qmm_q4k_bf16<32,256>`, aie2p `-O2`:

| build | bundles | vlda | vst | vge | vsel |
|---|---|---|---|---|---|
| peano, compare/select | 355 | 226 | 23 | 32 | 32 |
| peano, xor bias | **140** | 33 | 4 | 0 | 0 |
| chess | 142 | 4 | 0 | 0 | 0 |

Only 64 of the 215 bundles removed are the compare and select themselves. The
rest is the spill traffic they caused. Reproduce with
`llvm-objdump -dr --section=.text.<sym>` and the `.LBB` / `.L_LEnd`
zero-overhead-loop bounds — no hardware needed.

## The fix

`(u ^ 8) - 8 == q` over the whole signed-int4 range, so one xor and one float
subtract do the same job. It is an identity, not an approximation: it holds for
all 16 values, and the byte-level form holds for all 256 bytes.

The xor is applied to the *packed* bytes — `0x88` flips bit 3 of both nibbles —
because `aie::bit_xor` on a `vector<uint4>` segfaults peano's frontend.

`Q4_SFIX_MODE` selects: `1` = xor bias (default), `0` = the old compare/select,
`2` = no sign fix at all (numerically **wrong**, for attributing static cost
only, alongside the existing `proj_qmm_pass256` / `proj_qmm_fill_x` instruments).

## Measured

The body runs 8x2 per 32x256 weight block and an AIE2P core issues about one
bundle per cycle, so this was most of the projection. Ryzen AI 7 350 (Krackan
Point), 36 layers, 16-token `make gen`, output byte-identical in all four cells:

| `LBUILD` | before | after |
|---|---|---|
| 256 | 81.8 ms/token | **33.0 ms/token** |
| 2048 | 84.2 ms/token | **35.5 ms/token** |

Two-point fit over ctx 1k–8k: intercept **81.07 -> 32.57 ms/token**, slope
4.586 -> 4.556 ms/1k. The win is entirely intercept — the slope is a KV-path
property and is untouched — so it decays with context: 2.31x at 1k, 1.71x at 8k,
1.08x at 128k.

Both columns were measured in one session on one box through the
`NONATTN_EXTRA` hook this PR restores, so the comparison is not across boxes.

## Scope

`Q4_0` comes from `models/qwen2.5-3b.h` and `qwen25_3b_q4` is its only user.
Q4NX nibbles are unsigned and have no sign fix at all, so no Llama or Gemma
example is affected. The chess branch is untouched (recompiled clean via
`xchesscc_wrapper aie2p`). Prefill is unaffected — it does not use this kernel.

## Correctness

| Gate | Result |
|---|---|
| `make verify` (top-k token set vs HF bf16, 2 prompts x 32 tokens, k=5) | **2/2 PASS** |
| `make verify-full` (8 prompts) | **8/8 PASS** |
| Prefill first-token argmax | **12095 `" Paris"`** |
| `make gen` x 4 configurations | output byte-identical |

## Also: the kernel-define hooks

Restores `ATTN_EXTRA` / `NONATTN_EXTRA` to the `qwen25_3b_q4` Makefile. The
other three Q4NX examples delegate their kernel builds to
`fused_decode/Makefile` and inherit the hooks; this one compiles its own kernels
(it drives `fused_decode_qwen.py`) and had dropped them, so a flag A/B was not
expressible without editing the header.

The extras also go into the build stamp. Without that,
`make compile-decode NONATTN_EXTRA=...` finds the templates present, skips the
build and hands back the previous kernels — an A/B that silently measures the
same binary twice.

Empty by default, so the shipped path is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)