### PR TITLE
[AIR] Give host readbacks their own shim channel and tile, and drop 3 more shim_col pins

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -139,6 +139,20 @@ struct allocation_info_t {
   Operation *otherSideLTO = nullptr;
   std::vector<int32_t> dma_id;
   std::vector<Operation *> memcpyOps;
+  // True when the shim is this flow's DESTINATION (S2MM), i.e. a readback whose
+  // data leaves for host DDR. `otherSideLTO`/`col` then describe the PRODUCER
+  // core, because the real far side is off-chip and has no column. Bucketing on
+  // a producer column is wrong -- it says nothing about where a transfer should
+  // leave the array, and it forces every readback out of a herd onto that
+  // herd's column. That is how three llama-1b readbacks plus the feeds to the
+  // same cores landed on one shim tile and one channel, which does not route.
+  // A readback is therefore steered to the nearest free shim LTO holding no
+  // other readback, instead of to its producer's bucket. See the readback
+  // handling in ShimDMAAllocator::allocNewDmaChannel.
+  //
+  // Declared last on purpose: several sites aggregate-initialize this struct
+  // positionally, so a field inserted earlier silently shifts them.
+  bool isHostReadback = false;
   bool valid();
   AIE::TileLike getDmaTile();
   bool foundAlloc(AIE::TileLike tile);

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2064,14 +2064,26 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   // on the pinned column -- otherwise a col-less (or off-column) bucket LTO
   // would capture this flow on the non-packet/dedicated paths and silently
   // drop the pin.
-  // Does `lt` already carry a packet readback from a DIFFERENT channel decl?
+  // Does `lt` already carry a PACKET readback from a DIFFERENT channel decl?
+  // Packet matters: only packet flows time-multiplex a shim channel, so only
+  // they can collapse onto one. A circuit readback holds a channel of its own
+  // and sharing a tile with it is ordinary packing. Same decl is excluded too
+  // -- its sub-channels are one logical transfer and are meant to multiplex.
   auto hostsOtherPacketReadback = [&](AIE::LogicalTileOp lt) {
     for (auto &t : llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs)) {
       if (t.dma_tile.getOperation() != lt.getOperation() || !t.isHostReadback)
         continue;
-      if (declOf(t.memcpyOps.empty() ? nullptr : t.memcpyOps.front()) !=
+      if (declOf(t.memcpyOps.empty() ? nullptr : t.memcpyOps.front()) ==
           thisDecl)
-        return true;
+        continue;
+      for (auto o : t.memcpyOps) {
+        auto mc = dyn_cast_if_present<air::MemcpyInterface>(o);
+        if (!mc)
+          continue;
+        auto ct = air::getChannelType(mc);
+        if (succeeded(ct) && ct.value() == "npu_dma_packet")
+          return true;
+      }
     }
     return false;
   };
@@ -2100,7 +2112,8 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
       }
     return -1;
   };
-  // Nearest LTO to the producer that is free and holds no other readback.
+  // Nearest LTO to the producer that has a free channel and carries no packet
+  // readback from another decl (same-decl sub-channels may still share it).
   // Distance still matters -- picking purely the emptiest tile scatters
   // readbacks away from their producers and cost ~1.8% decode throughput on
   // llama-1b. Rank by (distance from the producer column, channels used).

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1869,6 +1869,10 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   AIE::DMAChannelDir dir =
       isMM2S.value() ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
 
+  // The shim receiving (S2MM) means this flow ends off-chip: a readback to host
+  // DDR. `otherSide`/`col` then describe the PRODUCER core, not a destination.
+  bool isHostReadback = !isMM2S.value();
+
   // Check if allocating for a packet flow (packet flow supports channel time
   // multiplexing at the shim DMA level)
   bool isPacketFlowOp = false;
@@ -1939,6 +1943,17 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   // on the (saturated) producer column.
   if (shimColPin >= 0)
     bucketCol = shimColPin;
+  // Channel declaration behind a memcpy, or null. Sub-channels of one bundled
+  // decl (e.g. @outD [2,2]) share it; independent channels do not.
+  auto declOf = [](Operation *op) -> Operation * {
+    auto chanIf = dyn_cast_if_present<air::ChannelInterface>(op);
+    if (!chanIf)
+      return nullptr;
+    auto decl = getChannelDeclarationThroughSymbol(chanIf);
+    return decl ? decl.getOperation() : nullptr;
+  };
+  Operation *thisDecl = declOf(memcpyOp.getOperation());
+
   auto sameBucket = [&](const allocation_info_t &t) {
     int tCol = bucketColFor(t.col, t.otherSideLTO);
     if (bucketCol >= 0 && tCol >= 0)
@@ -2007,6 +2022,19 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
             break;
           }
         }
+        // Never collapse two INDEPENDENT readbacks onto one shim packet
+        // channel. A readback ends off-chip, so its bucket key is the producer
+        // core's column -- which says nothing about where the transfer should
+        // leave the array, and lands every readback out of a herd in the same
+        // bucket. Packet reuse then puts them on one channel: llama-1b's
+        // appendK, appendV and layerOut all became (2,0) S2MM 0, which the
+        // pathfinder cannot route, and which air.shim_col was pinning apart by
+        // hand. Sub-channels of ONE bundled decl still multiplex -- that is a
+        // single logical transfer and is what the packing exists for.
+        if (isHostReadback && t.isHostReadback &&
+            declOf(t.memcpyOps.empty() ? nullptr : t.memcpyOps.front()) !=
+                thisDecl)
+          continue;
         // Never collapse onto a channel that hosts a dedicated flow.
         if (tPacket && !t.containsDedicatedChannel()) {
           packetLT = lt;
@@ -2036,19 +2064,90 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
   // on the pinned column -- otherwise a col-less (or off-column) bucket LTO
   // would capture this flow on the non-packet/dedicated paths and silently
   // drop the pin.
-  AIE::LogicalTileOp tileLT = nullptr;
-  walkBucketLTOs([&](AIE::LogicalTileOp lt) {
-    if (shimColPin >= 0) {
-      auto ltCol = lt.tryGetCol();
-      if (!ltCol || (int)*ltCol != shimColPin)
-        return false;
-    }
-    if ((int)channelsUsedOn(lt).size() < shim_dma_channels) {
-      tileLT = lt;
-      return true;
+  // Does `lt` already carry a packet readback from a DIFFERENT channel decl?
+  auto hostsOtherPacketReadback = [&](AIE::LogicalTileOp lt) {
+    for (auto &t : llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs)) {
+      if (t.dma_tile.getOperation() != lt.getOperation() || !t.isHostReadback)
+        continue;
+      if (declOf(t.memcpyOps.empty() ? nullptr : t.memcpyOps.front()) !=
+          thisDecl)
+        return true;
     }
     return false;
-  });
+  };
+
+  // A readback ends off-chip, so it has no column affinity at all: its bucket
+  // key is the PRODUCER's column, which only says where the data came from.
+  // Restricting it to that bucket puts every readback out of a herd on one
+  // shim tile -- llama-1b's appendK/appendV/layerOut -- which does not route,
+  // and is what air.shim_col was pinning apart by hand. Give it the SPARSEST
+  // existing shim LTO with a free channel instead, so readbacks spread over
+  // tiles the design already owns.
+  //
+  // Spreading this way rather than by opening a fresh LTO per readback is
+  // deliberate: the AIR pipeline runs aie-place-tiles with
+  // merge-logical-tiles=false, so every LTO costs a whole shim tile and NPU2
+  // only has 8. One-LTO-per-readback needs 9 for this design and fails to
+  // place. Joining another column's existing bucket is exactly what a
+  // shim_col pin achieves (appendK pinned to col 3 shares the inKV LTO).
+  // Bucket column of an LTO, from any allocation that owns it, or -1.
+  auto ltoBucketCol = [&](AIE::LogicalTileOp lt) {
+    for (auto &t : llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs))
+      if (t.dma_tile.getOperation() == lt.getOperation()) {
+        int c = bucketColFor(t.col, t.otherSideLTO);
+        if (c >= 0)
+          return c;
+      }
+    return -1;
+  };
+  // Nearest LTO to the producer that is free and holds no other readback.
+  // Distance still matters -- picking purely the emptiest tile scatters
+  // readbacks away from their producers and cost ~1.8% decode throughput on
+  // llama-1b. Rank by (distance from the producer column, channels used).
+  auto spreadShimLTO = [&]() -> AIE::LogicalTileOp {
+    AIE::LogicalTileOp best = nullptr;
+    std::pair<int, int> bestKey = {std::numeric_limits<int>::max(),
+                                   std::numeric_limits<int>::max()};
+    llvm::SmallPtrSet<Operation *, 8> seen;
+    for (auto &t : llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs)) {
+      auto lt = dyn_cast<AIE::LogicalTileOp>(t.dma_tile.getOperation());
+      if (!lt || lt.getTileType() != AIE::AIETileType::ShimNOCTile)
+        continue;
+      if (!seen.insert(lt.getOperation()).second)
+        continue;
+      if (hostsOtherPacketReadback(lt))
+        continue;
+      int used = (int)channelsUsedOn(lt).size();
+      if (used >= shim_dma_channels)
+        continue;
+      int ltCol = ltoBucketCol(lt);
+      int dist = (ltCol < 0 || col < 0) ? shim_dma_channels
+                                        : std::abs(ltCol - (int)col);
+      std::pair<int, int> key = {dist, used};
+      if (key < bestKey) {
+        best = lt;
+        bestKey = key;
+      }
+    }
+    return best;
+  };
+
+  AIE::LogicalTileOp tileLT = nullptr;
+  if (shimColPin < 0 && isPacketFlowOp && isHostReadback)
+    tileLT = spreadShimLTO();
+  if (!tileLT)
+    walkBucketLTOs([&](AIE::LogicalTileOp lt) {
+      if (shimColPin >= 0) {
+        auto ltCol = lt.tryGetCol();
+        if (!ltCol || (int)*ltCol != shimColPin)
+          return false;
+      }
+      if ((int)channelsUsedOn(lt).size() < shim_dma_channels) {
+        tileLT = lt;
+        return true;
+      }
+      return false;
+    });
   // Broadcast fallback: reuse the sparsest existing shim LTO across all
   // buckets before opening a new one.
   if (!tileLT && isBroadcastL3Put && !isPacketFlowOp) {
@@ -2168,10 +2267,13 @@ FailureOr<air::allocation_info_t> air::ShimDMAAllocator::allocNewDmaChannel(
            t.dma_channel == baseRes->dma_channel;
   };
   for (auto &t : llvm::concat<allocation_info_t>(mm2s_allocs, s2mm_allocs)) {
-    if (matchesReturned(t))
+    if (matchesReturned(t)) {
       t.otherSideLTO = otherSideOp;
+      t.isHostReadback = isHostReadback;
+    }
   }
   baseRes->otherSideLTO = otherSideOp;
+  baseRes->isHostReadback = isHostReadback;
   return baseRes;
 }
 

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1087,14 +1087,16 @@ def build_module():
             # cache is streamed back per CU (inKV) into a readback memtile that
             # re-blocks into per-block toK/toV.
             if KV_APPEND:
-                # the reference-faithful: rope K/V -> shim col3 (K) / col4 (V) S2MM -> DDR,
-                # mirroring reference pkt14/15. PACKET (not circuit) so the append
-                # can leave rope on its 2nd MM2S and fan to distinct cols. TWO
-                # channels (one per col) because air.shim_col pins a single col
-                # per channel DECL (compiler reads it from the decl). Pinning
-                # cols 3/4 (attention CU cols; readback reuses them on MM2S) keeps
-                # the append OFF rope's own col2 (whose congestion deadlocks the
-                # front-end).
+                # the reference-faithful: rope K/V -> shim S2MM -> DDR, mirroring
+                # reference pkt14/15. PACKET (not circuit) so the append can leave
+                # rope on its 2nd MM2S and fan to distinct cols. TWO channel DECLS
+                # so the allocator can place them independently -- one decl's
+                # sub-channels are treated as a single logical transfer and may
+                # share a shim channel, which is the opposite of what is wanted
+                # here. The columns are no longer pinned: the allocator spreads
+                # independent packet readbacks over distinct shim tiles, keeping
+                # the append off rope's own col2 (whose congestion deadlocks the
+                # front-end) without air.shim_col.
                 _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
                 _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
                     T.i32(), 1
@@ -1565,9 +1567,9 @@ def build_module():
                             # (2) READ BACK the whole cache per CU (inKV, strided) for the flash
                             # block loop. = the reference _receive + _move.
                             def _emit_append(_kbase=_kbase):
-                                # K -> shim col3 S2MM, V -> shim col4 S2MM (attention CU cols;
-                                # cols pinned on the appendK/appendV channel DECLS via
-                                # air.shim_col). air-annotate-append-barrier derives the
+                                # K and V each drain to a shim S2MM; the allocator
+                                # picks distinct shim tiles for the two decls.
+                                # air-annotate-append-barrier derives the
                                 # append->readback ordering from the RAW on the shared DDR
                                 # cache: these gets write it, the readback below reads it.
                                 if KV_REGION:

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1096,16 +1096,10 @@ def build_module():
                 # the append OFF rope's own col2 (whose congestion deadlocks the
                 # front-end).
                 _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
-                _apK.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                    T.i32(), ATTN_COL_GROUPS[0][0]
-                )
                 _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
                     T.i32(), 1
                 )
                 _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
-                _apV.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                    T.i32(), ATTN_COL_GROUPS[1][0]
-                )
                 _apV.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
                     T.i32(), 1
                 )
@@ -1167,7 +1161,6 @@ def build_module():
         # #4: layer output (residual2 = h + down) drained to host from the rms core.
         if FULL4:
             _lo = channel_decl("layerOut", size=[1])
-            _lo.operation.attributes["air.shim_col"] = IntegerAttr.get(T.i32(), 5)
             if KV_APPEND:
                 # Keep layerOut on rms MM2S0 (circuit) so xnorm (pinned to MM2S1)
                 # does not share/flip it to packet. See xnorm pin above.


### PR DESCRIPTION
A shim readback ends off-chip, so `allocateL3` hands the allocator the **producer
core's** tile and column as the flow's "other side":

```cpp
auto mm2sTile = f.MM2S_alloc[0].getDmaTile();
shim_dma_alloc.allocNewDmaChannel(memcpyOpIf, mm2sTile,
                                  mm2sTile.tryGetCol().value_or(-1), ...);
```

Herds are placed before `air-to-aie`, so that column is concrete and every readback
out of a herd keys on it. Two things then collapse: the bucket already holds the
**feeds into those same cores**, so the readback joins them; and the packet path
reuses "the bucket's existing packet channel", so independent readbacks land on one
channel. llama-3.2-1B put `appendK`, `appendV` and `layerOut` on **(2,0) S2MM 0** —
one tile, one channel — and the pathfinder then could not route an unrelated flow,
`air_xnorm`, out of column 2:

```
'aie.packet_flow' op packet flow source (2, 2) DMA1 could not be routed to
destination (1, 1) DMA2
```

`air.shim_col` was pinning that apart by hand. #1803 kept 3 pins per design for
exactly this reason, having measured they were the only ones that changed anything.

## Fix

Both scoped to packet readbacks on unpinned channels:

- don't reuse a packet channel that already hosts a readback from a **different**
  channel decl (sub-channels of one bundled decl still multiplex — `@outD [2,2]`
  needs that);
- steer the readback to the nearest free shim LTO holding no other readback, ranked
  by (distance from the producer column, channels used), instead of to its
  producer's bucket.

Reusing an existing LTO rather than opening one per readback is deliberate: the
pipeline runs `aie-place-tiles{merge-logical-tiles=false}`, so every LTO costs a
whole shim tile and NPU2 has 8. One-LTO-per-readback wants 9 here and fails to
place. Joining another column's bucket is exactly what a pin did (`appendK` pinned
to col 3 shared the `inKV` LTO).

**No mlir-aie change is needed.** An earlier version made the placer's column choice
congestion-aware; reverting it produced identical placement, because the reused LTOs
take their column from their own buckets and the readback never drives a placement
decision.

## The compiler change is a no-op on everything that exists today

Pinned flows bypass all of it. With the pins still in place the llama-3.2-1B decode
templates rebuild **byte-identical** (insts md5 `6d6ae12e` / `2eb3876a`) and all 19
shim allocations are unchanged.

## Measured on NPU2 — pins on vs pins off, 5 reps each

| model | verify | tok/s | TTFT |
|---|---|---|---|
| llama32_1b_q4nx | PASS | 50.16 → 50.00 (−0.3%) | 952 → 938 ms |
| llama32_3b_q4nx | PASS | 21.85 → 21.38 (−2.2%) | 1880 → 1940 ms |
| gemma3_4b_q4nx | PASS | 17.10 → 16.70 (−2.3%) | 4000 → 4079 ms |
| qwen25_3b_q4 | PASS | 11.79 (pins untouched) | 4236 ms |

`check-air-mlir` 505 passed, 0 failed.

The ~2% on 3b and gemma is the cost of the compiler's column choice versus the
hand-tuned 3/4/5, and is accepted here: the pins were unmaintainable and blocked any
new unpinned design. Recovering it likely means preferring a column already carrying
the same DDR buffer's traffic — which is why 3/4/5 were good — and is left for
follow-up.

`fused_decode_qwen.py` keeps its pins; it is a separate file needing its own
validation, and its `ropeLUT` pin has a documented circuit→packet interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
