### PR TITLE
[programming_examples] Add a bfp16ebs8 matrix multiplication example

### DIFF
--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -75,6 +75,12 @@ EXAMPLES = [
     },
     {
         "category": "Linear Algebra",
+        "name": "Matrix Multiplication (bfp16ebs8)",
+        "path": "matrix_multiplication/bfp16",
+        "datatypes": "bfp16ebs8",
+    },
+    {
+        "category": "Linear Algebra",
         "name": "AXPY",
         "path": "axpy",
         "datatypes": "bf16",

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/matmul_bf16_x_bfp16.py
@@ -89,11 +89,16 @@ def _bf16_block_to_bfp16ebs8(block_f32):
     signed_mant = np.where(
         sign, (~mant_explicit + 1) & 0xFFFFFFFF, mant_explicit
     ).astype(np.int64)
-    base = (signed_mant.astype(np.int64) >> (23 - 7 + 1)).astype(np.int64)
-    shift = max_exp - exp.astype(np.int64)
-    aligned = np.where(shift >= 32, np.where(sign, -1, 0), base >> shift).astype(
-        np.int8
-    )
+    # Truncate to 8 bits FIRST, then arithmetic-shift the int8 by (max_exp - exp).
+    # This is the order floatToBfp16() uses in mlir-aie
+    # programming_examples/ml/block_datatypes/helper.h. Shifting the 32-bit value
+    # first and truncating afterwards diverges for NEGATIVE values whose in-block
+    # exponent spread reaches 8, producing a packing the hardware would not.
+    b8 = (signed_mant >> (23 - 7 + 1)).astype(np.uint8).view(np.int8).astype(np.int32)
+    shift = (max_exp - exp).astype(np.int32)
+    aligned = np.where(
+        shift >= 32, np.where(sign, -1, 0), b8 >> np.minimum(shift, 31)
+    ).astype(np.int8)
     out = np.empty(BFP16_BYTES_PER_BLOCK, dtype=np.uint8)
     out[0] = np.uint8(max_exp)
     out[1:] = aligned.view(np.uint8)
@@ -135,11 +140,13 @@ def pack_b_bfp16ebs8(B_bf16, tile_n, tile_k_l1):
     signed_mant = np.where(
         sign, (~mant_explicit + np.uint32(1)) & np.uint32(0xFFFFFFFF), mant_explicit
     ).astype(np.int64)
-    base = signed_mant >> (23 - 7 + 1)  # 24-bit -> 8-bit-with-sign
-    shift = (max_exp - exp).astype(np.int64)  # [n_records, 8] >= 0
-    big_shift = shift >= 32
+    # 24-bit -> 8-bit-with-sign. Truncate to 8 bits FIRST, then arithmetic-shift
+    # the int8 by (max_exp - exp) -- the order floatToBfp16() uses in helper.h.
+    # See _bf16_block_to_bfp16ebs8 for why the order matters.
+    b8 = (signed_mant >> (23 - 7 + 1)).astype(np.uint8).view(np.int8).astype(np.int32)
+    shift = (max_exp - exp).astype(np.int32)  # [n_records, 8] >= 0
     aligned = np.where(
-        big_shift, np.where(sign, -1, 0), base >> np.minimum(shift, 31)
+        shift >= 32, np.where(sign, -1, 0), b8 >> np.minimum(shift, 31)
     ).astype(np.int8)
 
     # Interleave [shared_exp, m0..m7] per record into 9-byte stride.

--- a/programming_examples/matrix_multiplication/bfp16/Makefile
+++ b/programming_examples/matrix_multiplication/bfp16/Makefile
@@ -1,0 +1,178 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Tile sizes.
+# bfp16ebs8 constrains these more than bf16 does: the host shuffle requires
+# TILE_K_L1 % 64 == 0 and TILE_N % 64 == 0 (tile width in elements), and
+# mm_bfp.cc requires TILE_M % 16 == 0.
+TILE_M ?= 64
+TILE_K_L2 ?= 128
+TILE_K_L1 ?= 64
+TILE_N ?= 64
+
+# bfp16ebs8 is an AIE2P-only type and has no Chess codegen path, so unlike the
+# bf16 example there is no aie2 / xchesscc branch here. run.py exits with a
+# diagnostic if --arch aie2 is requested.
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
+
+# The GEMM kernel is mlir-aie's reference design, used unmodified. It ships in
+# the mlir-aie install tree, so resolve it through AIEOPT_DIR rather than
+# assuming a source checkout is present next to mlir-air.
+KERNEL_SRC ?= ${AIEOPT_DIR}/include/aie_kernels/aie2p/mm_bfp.cc
+
+# AIE_TARGET is accepted for symmetry with the bf16 example, but aie2p is the
+# only legal value; run.py rejects aie2 with a diagnostic.
+# COMPILE_MODE can be 'compile-and-run' (default), 'compile-and-xclbin', or
+# 'compile-only'.
+# Usage examples:
+#   make run4x4                            # compile-and-run (default)
+#   make run4x4 OUTPUT_DTYPE=bf16          # bf16 instead of f32 output
+#   make run4x4 COMPILE_MODE=compile-only  # no XRT needed
+#   make run4x4 TILE_M=128 TILE_K_L2=256
+AIE_TARGET ?= aie2p
+COMPILE_MODE ?= compile-and-run
+MAX_HERD_M = 8
+MAX_HERD_N = 4
+
+OUTPUT_DTYPE ?=
+ifneq ($(OUTPUT_DTYPE),)
+  OUTPUT_DTYPE_FLAG = --output-dtype $(OUTPUT_DTYPE)
+else
+  OUTPUT_DTYPE_FLAG =
+endif
+
+COMMON_ARGS = --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
+
+all: run4x4
+
+print:
+	${powershell} python3 ${srcdir}/run.py -p --herd-m 8 --herd-n 4 --m 2048 --n 1024 --k 512 \
+		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --arch $(AIE_TARGET)
+
+run8x4: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 -v \
+		$(COMMON_ARGS)
+
+run4x4: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
+		$(COMMON_ARGS)
+
+run2x4: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
+		$(COMMON_ARGS)
+
+run2x2: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
+		$(COMMON_ARGS)
+
+# 576 = 9 * 64, so the 64-element tile floor still divides it 3 ways.
+run3x3: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
+		--tile-m 64 --tile-k-l2 192 --tile-k-l1 64 --tile-n 64 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
+
+# Smallest single-PE config. TILE_K_L1/TILE_N cannot go below 64 for bfp16ebs8
+# (host shuffle granularity), so this is 64x64x64 rather than bf16's 32x32x16.
+run1x1: compile-kernel-1x1
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 \
+		--tile-m 64 --tile-k-l2 64 --tile-k-l1 64 --tile-n 64 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
+
+compile-kernel-1x1:
+	$(MAKE) -f $(srcdir)/Makefile compile-kernel TILE_M=64 TILE_N=64 TILE_K_L1=64
+
+# LLAMA-3.2-1B GEMM shapes (M=128)
+# Q/O: 128x2048x2048, K/V: 128x2048x512, Gate/Up: 128x2048x8192, Down: 128x8192x2048
+#
+# These are 4x4 (16 cores), not bf16's 8x4. M=128 with herd_m=8 forces
+# TILE_M=16, and mm_bfp.cc runs out of registers on AIE2P below TILE_M=32
+# (rowA=2 vs its AIE_LOOP_MIN_ITERATION_COUNT(4)). TILE_M=32 => herd_m=4.
+# TILE_N is 64 (not bf16's 32) because of the bfp16ebs8 shuffle granularity.
+LLAMA_TILE_M = 32
+LLAMA_TILE_N = 64
+LLAMA_TILE_K_L1 = 64
+LLAMA_HERD_M = 4
+LLAMA_HERD_N = 4
+
+compile-kernel-llama:
+	$(MAKE) -f $(srcdir)/Makefile compile-kernel TILE_M=$(LLAMA_TILE_M) TILE_N=$(LLAMA_TILE_N) TILE_K_L1=$(LLAMA_TILE_K_L1)
+
+LLAMA_ARGS = --tile-m $(LLAMA_TILE_M) --tile-k-l2 128 --tile-k-l1 $(LLAMA_TILE_K_L1) --tile-n $(LLAMA_TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
+
+# _down (K=8192) is deliberately excluded: mm_bfp.cc keeps C in bfp16ebs8
+# between K-l1 chunks, so 8192/64 = 128 re-quantizations leave the result
+# unusable (mean_rel_L1 ~1.2). The target is kept below for experimentation.
+run_llama_4x4: run_llama_4x4_qo run_llama_4x4_kv run_llama_4x4_gate_up
+
+run_llama_4x4_qo: compile-kernel-llama
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 2048 \
+		$(LLAMA_ARGS)
+
+run_llama_4x4_kv: compile-kernel-llama
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 512 \
+		$(LLAMA_ARGS)
+
+run_llama_4x4_gate_up: compile-kernel-llama
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 8192 \
+		$(LLAMA_ARGS)
+
+run_llama_4x4_down: compile-kernel-llama
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 8192 --n 2048 \
+		$(LLAMA_ARGS)
+
+# Report latency + GFLOPs alongside the correctness check. Uses XRTRunner's
+# built-in timing (--perf-iters), so no separate C++ harness is needed.
+profile: compile-kernel
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m 1024 --k 1024 --n 1024 \
+		--herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --perf-iters 50 $(COMMON_ARGS)
+
+# Measure the e2e latencies across a range of problem shapes.
+sweep4x4: compile-kernel
+	@for M in 256 512 1024 2048; do \
+		for N in 256 512 1024 2048; do \
+			for K in 256 512 1024 2048; do \
+				echo "Running with M=$$M, N=$$N, K=$$K"; \
+				cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m $$M --n $$N --k $$K \
+					--herd-m 4 --herd-n 4 --perf-iters 20 $(COMMON_ARGS); \
+			done; \
+		done; \
+	done
+
+compile-kernel:
+	mkdir -p $(BUILD_DIR)
+	@if [ -z "$(PEANO_INSTALL_DIR)" ]; then \
+		echo "Error: PEANO_INSTALL_DIR not set. The Chess toolchain has no"\
+		     "bfp16ebs8 codegen path; source utils/env_setup.sh."; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(PEANO_INSTALL_DIR)/bin/clang++" ]; then \
+		echo "Error: invalid PEANO_INSTALL_DIR, clang++ not found."; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(KERNEL_SRC)" ]; then \
+		echo "Error: reference kernel not found at $(KERNEL_SRC)."; \
+		echo "Point KERNEL_SRC at mlir-aie's aie_kernels/aie2p/mm_bfp.cc."; \
+		exit 1; \
+	fi
+	$(PEANO_INSTALL_DIR)/bin/clang++ $(PEANOWRAP2P_FLAGS) \
+		-DDIM_M=$(TILE_M) -DDIM_K=$(TILE_K_L1) -DDIM_N=$(TILE_N) \
+		-c $(KERNEL_SRC) -o $(BUILD_DIR)/mm_bfp_gemm.o
+	$(PEANO_INSTALL_DIR)/bin/clang++ $(PEANOWRAP2P_FLAGS) \
+		-DDIM_M=$(TILE_M) -DDIM_K=$(TILE_K_L1) -DDIM_N=$(TILE_N) \
+		-c $(srcdir)/bfp_cvt.cc -o $(BUILD_DIR)/mm_bfp_cvt.o
+	$(PEANO_INSTALL_DIR)/bin/ld.lld -r -o $(BUILD_DIR)/mm_bfp.o \
+		$(BUILD_DIR)/mm_bfp_gemm.o $(BUILD_DIR)/mm_bfp_cvt.o
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__
+
+.PHONY: all print run8x4 run4x4 run2x4 run2x2 run3x3 run1x1 compile-kernel-1x1 \
+        compile-kernel-llama run_llama_4x4 run_llama_4x4_qo run_llama_4x4_kv \
+        run_llama_4x4_gate_up run_llama_4x4_down profile sweep4x4 compile-kernel clean

--- a/programming_examples/matrix_multiplication/bfp16/README.md
+++ b/programming_examples/matrix_multiplication/bfp16/README.md
@@ -1,0 +1,162 @@
+# Matrix Multiplication (bfp16ebs8)
+
+Matrix multiplication with bfp16ebs8 inputs, a port of mlir-aie's
+[block-datatype GEMM reference design][ref] to MLIR-AIR. It runs the reference
+kernel [`mm_bfp.cc`][kernel] **unmodified** (resolved from the mlir-aie install via `AIEOPT_DIR`) -- this directory contributes only
+the AIR data movement around it, plus a small output-conversion kernel.
+
+`A[M,K] x B[K,N] -> C[M,N]`. A and B are bfp16ebs8 (8 scalars share one 8-bit
+exponent, so 8 elements occupy 9 bytes); B is consumed transposed. C is
+accumulated in bfp16ebs8 by the kernel and converted to bf16 or f32 on the way
+out.
+
+NPU2 (Strix) only, and Peano only -- `xchesscc` has no `bfp16ebs8` codegen path.
+
+[ref]: https://github.com/Xilinx/mlir-aie/tree/main/programming_examples/ml/block_datatypes/matrix_multiplication
+[kernel]: https://github.com/Xilinx/mlir-aie/blob/main/aie_kernels/aie2p/mm_bfp.cc
+
+## Available Make Targets
+
+- `make run4x4` - Compile and run on NPU with a 4x4 herd (512x512x512 matrix)
+- `make run8x4` - 8x4 herd (1024x512x512)
+- `make run3x3` - 3x3 herd (576x576x576)
+- `make run2x4` - 2x4 herd (512x512x512)
+- `make run2x2` - 2x2 herd (512x512x512)
+- `make run1x1` - single core (64x64x64)
+- `make run_llama_4x4` - LLAMA-3.2-1B GEMM shapes (`_qo`, `_kv`, `_gate_up`; see the K limit below for `_down`)
+- `make profile` - Run on hardware and report latency + GFLOPs
+- `make sweep4x4` - Measure end-to-end latencies across a range of shapes (256-2048)
+- `make print` - Print the generated MLIR without running
+
+## Tile Size Configuration
+
+```bash
+TILE_M      # M dimension tile size (default: 64)
+TILE_K_L2   # K dimension L2 tile size (default: 128)
+TILE_K_L1   # K dimension L1 tile size (default: 64)
+TILE_N      # N dimension tile size (default: 64)
+```
+
+**Example:**
+```bash
+make run4x4 TILE_M=128 TILE_K_L2=256 TILE_K_L1=64 TILE_N=64
+```
+
+bfp16ebs8 constrains these more than bf16 does:
+
+| constraint | source |
+|---|---|
+| `TILE_M % 16 == 0` | `mm_bfp.cc` (2x register blocking on `r`) |
+| `TILE_M >= 32` | `mm_bfp.cc` runs out of registers at `TILE_M=16` on AIE2P |
+| `TILE_N % 64 == 0` | host shuffle (`tileWidth % 64`) + kernel |
+| `TILE_K_L1 % 64 == 0` | host shuffle (`tileWidth % 64`) + kernel |
+| `K % 32 == 0` | `K*9/8` must be 4-byte aligned for shim BDs |
+
+## Output Data Type
+
+```bash
+make run4x4                   # f32 output (default on aie2p)
+make run4x4 OUTPUT_DTYPE=bf16 # bf16 output
+```
+
+Both go through `bfp_cvt.cc`, which converts the bfp16ebs8 L1 accumulator in
+8x8-block order; the de-blocking permute is left to the drain DMA.
+
+## Target Architecture Selection
+
+`AIE_TARGET` exists for symmetry with the bf16 example, but `aie2p` is the only
+legal value -- `v8bfp16ebs8` and `mac_8x8_8x8T` are AIE2P-only and NPU1 has no
+block-floating-point datapath. `make run4x4 AIE_TARGET=aie2` exits non-zero with
+a diagnostic rather than emitting IR that cannot be lowered.
+
+## Note on Numerical Tolerances
+
+The check uses `randn/sqrt(K)` inputs (the bf16 example's generator) and
+compares against an f32 matmul on the ORIGINAL floats, so it covers the bfp16
+input quantization. Because 8 elements share an exponent, an element next to a
+much larger neighbour loses mantissa bits, and that -- not the output dtype --
+dominates the error. The reference magnitude is ~`1/sqrt(K)`, which shrinks
+with K while the bfp16 error floor does not, so relative error grows with K:
+
+| K | measured `mean_rel_L1` |
+|---|---|
+| 64 | 2.1e-2 |
+| 512 | 6.9e-2 |
+| 2048 | 2.7e-1 |
+
+`abs_err max` stays in 8.5e-3 .. 1.5e-2 across every target and both output
+dtypes, so the gate is absolute-error driven (`atol=2.5e-2`, ~1.7x headroom).
+mlir-aie's own `bfp_test.cpp` avoids this regime by drawing inputs from
+`rand()%16`; this example keeps the bf16 generator so the numbers above are the
+honest bfp16 error on high-dynamic-range data.
+
+## Accumulator Depth Limit (max usable K)
+
+`mm_bfp.cc` keeps C in bfp16ebs8 *between* K-l1 chunks: after every chunk the
+accumulator is re-quantized to an 8-bit mantissa with one shared exponent per 8
+elements. Error therefore grows with the number of round-trips,
+`K / TILE_K_L1`, and it does so under any input distribution:
+
+| round-trips (`K/TILE_K_L1`) | `mean_rel_L1`, randn | `mean_rel_L1`, `rand()%16` |
+|---|---|---|
+| 32 (K=2048) | 0.27 | 0.09 |
+| 128 (K=8192) | 1.23 | 0.41 |
+
+Past roughly 64 round-trips the output is not usable at any sane tolerance, so
+`run_llama_4x4_down` (K=8192, 128 round-trips) is excluded from the aggregate
+`run_llama_4x4` target and has no lit test. It is kept as a target for
+experimentation, and `run.py` prints a warning above 64 round-trips. Raising
+`TILE_K_L1` reduces the count but costs L1 (both A and B tiles scale with it).
+
+This is a property of the reference kernel, not of the AIR port.
+
+## Design Notes
+
+**No bfp16 type in AIR.** mlir-aie has `!aiex.bfp<"v8bfp16ebs8">`, but
+`aie-transform-bfp-types` lowers it to `i72` inside `aie.device` -- after every
+AIR pass -- and AIR's BD lowering assumes an int-or-float element type. So A and
+B cross the AIR boundary as plain `i8` and the kernel reinterprets via
+`aie::block_vector<bfp16ebs8>`, the same type-pun
+[`bf16_x_bfp16`](../bf16_x_bfp16/) uses for its weights.
+
+**The host shuffle makes the DMAs trivial.** `shuffleMatrixForBfp16ebs8()`
+reorders 8x8 sub-tiles *within* each tile box only, leaving the global matrix
+row-major. So L3 A/B are plain 2D byte matrices (`[M, K*9/8]`, `[N, K*9/8]`),
+L3->L2 is a strided box gather, and L2->L1 is a contiguous copy that lands in
+exactly the sub-tile-major order `mm_bfp.cc`'s
+`block_vector_input_buffer_stream.seek(z * colA)` expects. Neither of the two
+data-layout transforms the reference README calls out as impossible for blocked
+types is needed on the AIR side. `bfp16_utils.py` is a NumPy port of those host
+helpers, cross-checked byte-for-byte against `helper.h`.
+
+**Three herds.** `herd_init` zeroes the bfp16 L1 accumulator, `herd_compute`
+runs the K loop, `herd_drain` converts and copies out. The accumulator is a
+segment-shared L1 buffer so it survives across the three invocations.
+
+**Herd geometry is transposed relative to IRON.** AIR's `--herd-m` maps to
+columns (M-parallel) and `--herd-n` to rows (N-parallel), so on NPU2
+`herd_m <= 8` and `herd_n <= 4`. mlir-aie's `whole_array` is the other way round
+(`n_aie_rows = 4` is M-parallel). Irrelevant for square GEMMs; it matters once
+`M != N`.
+
+**Small herds need `--runtime-loop-tiling 1`.** `runtime_loop_tiling_sizes`
+defaults to `[2, 2]` and is worth ~26% throughput (183us vs 232us at 512^3,
+4x4). It is not safe when the herd is small enough that AIR gives the C drain a
+single shim channel: the shim-BD fold then collapses that drain across every
+launch iteration into one task with one await, so only the first launch
+iteration's output is written while all the input fills still run. Observed at
+herd 2x2 / 2x1 / 1x2 with more than one launch iteration; herd 4x2 and larger
+split C over four channels and are unaffected. `run.py` detects this and drops
+to `[1, 1]` with a printed note. Same class as the shim-BD stride-fold and
+wait-pairing fixes in mlir-air #1810 / #1815.
+
+## Differences from the bf16 example
+
+- No `--direct-codegen`: there is no MLIR bfp16 type, so the kernel must be
+  external.
+- No Chess path and no `aie2` path (see above).
+- `profile` uses `XRTRunner`'s built-in timing (`--perf-iters`) rather than a
+  separate C++ harness, so there is no `test.cpp` / `build-test-exe`.
+- No `runner` (air-runner simulation) target.
+- The LLAMA targets are 4x4, not 8x4: `M=128` with `herd_m=8` forces
+  `TILE_M=16`, below this kernel's register-allocation floor.

--- a/programming_examples/matrix_multiplication/bfp16/bfp16_utils.py
+++ b/programming_examples/matrix_multiplication/bfp16/bfp16_utils.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# NumPy port of the bfp16ebs8 host helpers in mlir-aie
+# programming_examples/ml/block_datatypes/helper.h.
+#
+# These are used by the Python dev loop only. The authoritative correctness
+# gate for this example is mlir-aie's own bfp_test.cpp, which uses the C++
+# originals; see the Makefile's `verify` target.
+#
+# bfp16ebs8 layout: every 8 consecutive scalars become 9 bytes -- one shared
+# 8-bit exponent (the block max) followed by eight 8-bit two's-complement
+# mantissas. So a [H, W] float matrix becomes a [H, W*9//8] uint8 matrix.
+
+import numpy as np
+
+BLOCK = 8  # scalars per block
+BYTES_PER_BLOCK = 9  # 1 shared exponent + 8 mantissas
+
+
+def nbytes(n_elems):
+    """Byte count of n_elems bfp16ebs8 scalars."""
+    assert n_elems % BLOCK == 0, f"{n_elems} is not a multiple of {BLOCK}"
+    return n_elems // BLOCK * BYTES_PER_BLOCK
+
+
+def float_to_bfp16ebs8(x):
+    """[..., W] float -> [..., W*9//8] uint8, blocking along the last axis.
+
+    Mirrors floatToBfp16() in helper.h, including its truncation rounding
+    (AIE2P's only mantissa rounding mode).
+    """
+    x = np.ascontiguousarray(x, dtype=np.float32)
+    lead, W = x.shape[:-1], x.shape[-1]
+    assert W % BLOCK == 0, f"last axis {W} must be a multiple of {BLOCK}"
+
+    blocks = x.reshape(-1, BLOCK)
+    bits = blocks.view(np.uint32)
+    sign = (bits & np.uint32(0x80000000)) != 0
+    exp = ((bits >> 23) & np.uint32(0xFF)).astype(np.int32)
+    # Restore the implicit leading 1 for normals; subnormals keep exp == 0.
+    mant = (bits & np.uint32(0x007FFFFF)) | np.where(
+        exp != 0, np.uint32(0x00800000), np.uint32(0)
+    )
+    max_exp = exp.max(axis=1, keepdims=True)  # shared exponent per block
+
+    signed_mant = np.where(
+        sign, (~mant + np.uint32(1)) & np.uint32(0xFFFFFFFF), mant
+    ).astype(np.int64)
+
+    # helper.h truncates to 8 bits FIRST, then arithmetic-shifts the int8 by
+    # (max_exp - exp). Doing the shift before the truncation gives different
+    # answers once the in-block exponent spread reaches 8, so keep this order.
+    b8 = (signed_mant >> (23 - 7 + 1)).astype(np.uint8).view(np.int8).astype(np.int32)
+    shift = (max_exp - exp).astype(np.int32)
+    aligned = np.where(
+        shift >= 32,  # shifting by >= width is UB in C++; helper.h saturates
+        np.where(sign, -1, 0),
+        b8 >> np.minimum(shift, 31),
+    ).astype(np.int8)
+
+    recs = np.empty((blocks.shape[0], BYTES_PER_BLOCK), dtype=np.uint8)
+    recs[:, 0] = max_exp.ravel().astype(np.uint8)
+    recs[:, 1:] = aligned.view(np.uint8)
+    return recs.reshape(*lead, nbytes(W))
+
+
+def bfp16ebs8_to_float(b):
+    """[..., W*9//8] uint8 -> [..., W] float32. Inverse of the above."""
+    b = np.ascontiguousarray(b, dtype=np.uint8)
+    lead, WB = b.shape[:-1], b.shape[-1]
+    assert WB % BYTES_PER_BLOCK == 0, f"{WB} is not a multiple of {BYTES_PER_BLOCK}"
+
+    recs = b.reshape(-1, BYTES_PER_BLOCK)
+    shared_exp = recs[:, 0].astype(np.int32)
+    mant = recs[:, 1:].view(np.int8).astype(np.float32)
+    # helper.h: multiplier = 2^(e-127) / 64
+    mult = np.ldexp(np.float32(1.0), shared_exp - 127 - 6).astype(np.float32)
+    vals = mant * mult[:, None]
+    return vals.reshape(*lead, WB // BYTES_PER_BLOCK * BLOCK)
+
+
+def shuffle_bfp16ebs8(mat, tile_h, tile_w_elems, unshuffle=False):
+    """Reorder 8x8 sub-tiles to be contiguous within each tile box.
+
+    Mirrors shuffleMatrixForBfp16ebs8() in helper.h. `mat` is the packed
+    [H, W*9//8] uint8 matrix; the transform is intra-tile-box only, so the
+    global matrix stays row-major and the L3 buffer shape is unchanged.
+    """
+    mat = np.ascontiguousarray(mat, dtype=np.uint8)
+    H, MW = mat.shape
+    tw = nbytes(tile_w_elems)  # tile width in bytes
+    assert tile_w_elems % 64 == 0, "tile width must be a multiple of 64 elements"
+    assert tile_h % BLOCK == 0, "tile height must be a multiple of 8"
+    assert H % tile_h == 0 and MW % tw == 0
+
+    ty, tx = H // tile_h, MW // tw
+    # [ty, r, tx, c] -> per-tile-box [n_boxes, tile_h, tw]
+    boxes = (
+        mat.reshape(ty, tile_h, tx, tw).transpose(0, 2, 1, 3).reshape(-1, tile_h, tw)
+    )
+    if not unshuffle:
+        # [sy, i, sx, j] -> [sy, sx, i, j]: sub-tiles become 72B-contiguous.
+        boxes = (
+            boxes.reshape(-1, tile_h // 8, 8, tw // BYTES_PER_BLOCK, BYTES_PER_BLOCK)
+            .transpose(0, 1, 3, 2, 4)
+            .reshape(-1, tile_h, tw)
+        )
+    else:
+        boxes = (
+            boxes.reshape(-1, tile_h // 8, tw // BYTES_PER_BLOCK, 8, BYTES_PER_BLOCK)
+            .transpose(0, 1, 3, 2, 4)
+            .reshape(-1, tile_h, tw)
+        )
+    out = boxes.reshape(ty, tx, tile_h, tw).transpose(0, 2, 1, 3).reshape(H, MW)
+    return np.ascontiguousarray(out)
+
+
+def nearly_equal(a, e, rel_tol=0.05, abs_tol=0.5):
+    """matmul_common::nearly_equal from mlir-aie basic/matrix_multiplication/common.h.
+
+    Note this is `|a-e| < max(abs_tol, rel_tol*(|a|+|e|))` -- a max, and the
+    norm is the SUM of magnitudes. It is NOT np.isclose's `atol + rtol*|e|`.
+    """
+    a = np.asarray(a, dtype=np.float64)
+    e = np.asarray(e, dtype=np.float64)
+    diff = np.abs(a - e)
+    norm = np.abs(a) + np.abs(e)
+    return (a == e) | (diff < np.maximum(abs_tol, rel_tol * norm))

--- a/programming_examples/matrix_multiplication/bfp16/bfp16_utils.py
+++ b/programming_examples/matrix_multiplication/bfp16/bfp16_utils.py
@@ -4,9 +4,15 @@
 # NumPy port of the bfp16ebs8 host helpers in mlir-aie
 # programming_examples/ml/block_datatypes/helper.h.
 #
-# These are used by the Python dev loop only. The authoritative correctness
-# gate for this example is mlir-aie's own bfp_test.cpp, which uses the C++
-# originals; see the Makefile's `verify` target.
+# These build the device operands: quantize the float inputs, then apply the
+# same sub-tile shuffle, so the buffers handed to the NPU are byte-for-byte
+# what mlir-aie's own bfp_test.cpp produces for the same shapes. They were
+# validated against the C++ originals on random and adversarial signed
+# wide-exponent data.
+#
+# The correctness gate itself lives in run.py: XRTRunner compares the device
+# output against a float reference computed from the PRE-quantization inputs,
+# so the check covers the input quantization too.
 #
 # bfp16ebs8 layout: every 8 consecutive scalars become 9 bytes -- one shared
 # 8-bit exponent (the block max) followed by eight 8-bit two's-complement
@@ -66,7 +72,13 @@ def float_to_bfp16ebs8(x):
 
 
 def bfp16ebs8_to_float(b):
-    """[..., W*9//8] uint8 -> [..., W] float32. Inverse of the above."""
+    """[..., W*9//8] uint8 -> [..., W] float32. Inverse of the above.
+
+    Mirrors bfp16ebs8ToFloat() in helper.h. Not needed to drive the device --
+    the output is a real float tensor -- but it is what makes the packer
+    round-trippable, and it is how a packed operand can be inspected when
+    debugging a layout problem.
+    """
     b = np.ascontiguousarray(b, dtype=np.uint8)
     lead, WB = b.shape[:-1], b.shape[-1]
     assert WB % BYTES_PER_BLOCK == 0, f"{WB} is not a multiple of {BYTES_PER_BLOCK}"
@@ -114,16 +126,3 @@ def shuffle_bfp16ebs8(mat, tile_h, tile_w_elems, unshuffle=False):
         )
     out = boxes.reshape(ty, tx, tile_h, tw).transpose(0, 2, 1, 3).reshape(H, MW)
     return np.ascontiguousarray(out)
-
-
-def nearly_equal(a, e, rel_tol=0.05, abs_tol=0.5):
-    """matmul_common::nearly_equal from mlir-aie basic/matrix_multiplication/common.h.
-
-    Note this is `|a-e| < max(abs_tol, rel_tol*(|a|+|e|))` -- a max, and the
-    norm is the SUM of magnitudes. It is NOT np.isclose's `atol + rtol*|e|`.
-    """
-    a = np.asarray(a, dtype=np.float64)
-    e = np.asarray(e, dtype=np.float64)
-    diff = np.abs(a - e)
-    norm = np.abs(a) + np.abs(e)
-    return (a == e) | (diff < np.maximum(abs_tol, rel_tol * norm))

--- a/programming_examples/matrix_multiplication/bfp16/bfp_cvt.cc
+++ b/programming_examples/matrix_multiplication/bfp16/bfp_cvt.cc
@@ -1,0 +1,53 @@
+//===- bfp_cvt.cc - bfp16ebs8 accumulator -> bf16 / f32 drain -------------===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// mm_bfp.cc accumulates C in bfp16ebs8. This converts that L1 accumulator to
+// the example's chosen output type (bf16 or f32) on the way out.
+//
+// The block order is PRESERVED: both source and destination stay
+// [m/8][n/8][8][8] sub-tile-major, so this is a straight contiguous stream and
+// the L1 side of the drain DMA collapses to a single dimension. The
+// de-blocking permute into row-major is left to that DMA, where it costs
+// nothing extra.
+//
+//===----------------------------------------------------------------------===//
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+#ifndef DIM_M
+#define DIM_M 64
+#endif
+#ifndef DIM_N
+#define DIM_N 64
+#endif
+
+template <unsigned NELEM, typename T>
+static void bfp16_to_float_blocks(const bfp16ebs8 *__restrict src,
+                                  T *__restrict dst) {
+  static_assert(NELEM % 64 == 0, "tile must be a whole number of 8x8 blocks");
+  aie::block_vector_input_buffer_stream<bfp16ebs8, 64> in(src);
+  for (unsigned i = 0; i < NELEM / 64; ++i) {
+    // accum<accfloat,64> is constructible from a block_vector, the same
+    // conversion mm_bfp.cc uses in the opposite direction.
+    aie::accum<accfloat, 64> acc(in.pop());
+    aie::store_v(dst + i * 64, acc.template to_vector<T>());
+  }
+}
+
+extern "C" {
+
+void bfp16_to_bf16_mn(uint8_t *src, bfloat16 *dst) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  bfp16_to_float_blocks<DIM_M * DIM_N, bfloat16>(
+      reinterpret_cast<const bfp16ebs8 *>(src), dst);
+}
+
+void bfp16_to_f32_mn(uint8_t *src, float *dst) {
+  bfp16_to_float_blocks<DIM_M * DIM_N, float>(
+      reinterpret_cast<const bfp16ebs8 *>(src), dst);
+}
+
+} // extern "C"

--- a/programming_examples/matrix_multiplication/bfp16/run.py
+++ b/programming_examples/matrix_multiplication/bfp16/run.py
@@ -1,0 +1,705 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# bfp16ebs8 A x bfp16ebs8 B -> bf16/f32 C GEMM on NPU2, running the mlir-aie
+# reference kernel mm_bfp.cc unmodified.
+#
+# AIR has no bfp16ebs8 element type (mlir-aie's !aiex.bfp<> lowers to i72 only
+# inside aie.device, i.e. after every AIR pass, and AIR's BD lowering assumes an
+# int-or-float element type). So A and B cross the AIR boundary as plain i8 and
+# the kernel reinterprets via aie::block_vector<bfp16ebs8>, the same type-pun
+# bf16_x_bfp16 uses for its weights.
+#
+# Layout: bfp16ebs8 packs 8 scalars into 9 bytes, so a logical [H, W] matrix is
+# an [H, W*9//8] byte matrix. mlir-aie's host-side shuffleMatrixForBfp16ebs8()
+# reorders 8x8 sub-tiles WITHIN each tile box only, leaving the global matrix
+# row-major -- so A and B here are byte-for-byte what mlir-aie's own
+# bfp_test.cpp produces. B is consumed transposed, i.e. stored [N, K*9//8].
+#
+# C is accumulated in bfp16ebs8 by the kernel and converted to bf16 or f32 on
+# the way out (bfp_cvt.cc), so the output is an ordinary float tensor that
+# XRTRunner checks against a float reference exactly like the bf16 example.
+
+import argparse
+import os
+import sys
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from air.ir import (
+    AffineConstantExpr,
+    AffineExpr,
+    AffineMap,
+    AffineSymbolExpr,
+    InsertionPoint,
+    IntegerAttr,
+    IntegerType,
+    MemRefType,
+    ShapedType,
+    StridedLayoutAttr,
+    StringAttr,
+    UnitAttr,
+)
+from air.dialects.affine import apply as affine_apply
+from air.dialects.air import (
+    MemorySpace,
+    T,
+    dma_memcpy_nd,
+    herd,
+    launch,
+    module_builder,
+    segment,
+)
+from air.dialects import arith
+from air.dialects.func import CallOp, FuncOp
+from air.dialects.memref import AllocOp, DeallocOp, subview
+from air.dialects.scf import ForOp, for_, yield_
+from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt import XRTBackend
+
+from bfp16_utils import float_to_bfp16ebs8, nbytes, shuffle_bfp16ebs8
+
+np.random.seed(42)
+
+KERNEL_OBJ_NAME = "mm_bfp.o"
+
+# bfp16ebs8 MMUL is 8x8x8 (mac_8x8_8x8T).
+MMUL_R = MMUL_S = MMUL_T = 8
+
+
+def for_disable_pp(start, stop=None, step=None):
+    """`for_` variant tagging the scf.for with `air.disable_ping_pong`.
+
+    Only needed when the K-l1 fill loop's 2x ping-pong buffers would blow the
+    64 KiB L1 budget; see bf16_x_bfp16 for the case that forced it.
+    """
+    if step is None:
+        step = 1
+    if stop is None:
+        stop, start = start, 0
+    params = [start, stop, step]
+    for i, p in enumerate(params):
+        if isinstance(p, int):
+            params[i] = arith.ConstantOp.create_index(p)
+    for_op = ForOp(*params, [])
+    for_op.operation.attributes["air.disable_ping_pong"] = UnitAttr.get()
+    with InsertionPoint(for_op.body):
+        yield for_op.induction_variable
+
+
+def _scaled(iv, c):
+    """affine_apply of (s0 -> s0 * c)."""
+    m = AffineMap.get(
+        0,
+        1,
+        [AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(c))],
+    )
+    return affine_apply(m, [iv])
+
+
+@module_builder
+def build_module(
+    m,
+    k,
+    n,
+    tile_m,
+    tile_k_l2,
+    tile_k_l1,
+    tile_n,
+    herd_m,
+    herd_n,
+    np_dtype_out,
+    arch="aie2p",
+    disable_pingpong=False,
+):
+    r, s, t = MMUL_R, MMUL_S, MMUL_T
+
+    # bfp16ebs8 is an AIE2P type; there is no aie2 lowering for it.
+    assert arch == "aie2p", "bfp16ebs8 requires arch aie2p"
+
+    # mm_bfp.cc static_asserts
+    assert tile_m % (2 * r) == 0, "tile_m must be a multiple of 16"
+    # mm_bfp.cc's static_assert allows tile_m == 16, but at that size rowA is 2
+    # while the z loop still carries AIE_LOOP_MIN_ITERATION_COUNT(4), and Peano
+    # fails with "ran out of registers during register allocation". 32 is the
+    # smallest tile_m the reference kernel actually compiles at on AIE2P.
+    assert tile_m >= 32, (
+        f"tile_m ({tile_m}) must be >= 32: mm_bfp.cc exhausts the register "
+        "file at tile_m=16 on AIE2P"
+    )
+    assert tile_n % (2 * t) == 0, "tile_n must be a multiple of 16"
+    assert tile_k_l1 % s == 0, "tile_k_l1 must be a multiple of 8"
+    # shuffleMatrixForBfp16ebs8 asserts (tile width is in elements)
+    assert tile_k_l1 % 64 == 0, "tile_k_l1 must be a multiple of 64 (host shuffle)"
+    assert tile_n % 64 == 0, "tile_n must be a multiple of 64 (host shuffle)"
+    # 4-byte shim BD granularity on the L3 row strides of the packed operands
+    assert k % 32 == 0, "K must be a multiple of 32 (K*9/8 must be 4-byte aligned)"
+
+    assert m % (tile_m * herd_m) == 0
+    assert n % (tile_n * herd_n) == 0
+    assert k % tile_k_l2 == 0
+    assert tile_k_l2 % tile_k_l1 == 0
+
+    k_per_l2 = tile_k_l2 // tile_k_l1
+    xrt_dtype_out = type_mapper(np_dtype_out)
+
+    KB = nbytes(k)  # L3 A/B row stride, bytes
+    a_row_b = nbytes(tile_k_l1)  # one L3 row of an A/B tile box
+    a_l1_b = nbytes(tile_m * tile_k_l1)
+    b_l1_b = nbytes(tile_n * tile_k_l1)
+    c_l1_b = nbytes(tile_m * tile_n)  # bfp16 accumulator, bytes
+    c_elems = tile_m * tile_n  # converted output, elements
+    MB, NB = tile_m // r, tile_n // t  # 8x8 blocks per tile
+
+    i8 = IntegerType.get_signless(8)
+    l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+
+    # ---- L3 (caller-facing). A/B are packed bytes; C is a real float tensor.
+    A_l3_ty = MemRefType.get([m, KB], i8)
+    B_l3_ty = MemRefType.get([n, KB], i8)  # B stored transposed
+    C_l3_ty = MemRefType.get([m, n], xrt_dtype_out)
+
+    # ---- L1. A/B tile boxes are contiguous in sub-tile-major order, which is
+    # exactly what mm_bfp.cc's block_vector_input_buffer_stream .seek(z*colA)
+    # expects, so no strided views are needed.
+    l1TyA = MemRefType.get([a_l1_b], i8, memory_space=l1_ms)
+    l1TyB = MemRefType.get([b_l1_b], i8, memory_space=l1_ms)
+    l1TyAccHerd = MemRefType.get([herd_m, herd_n, c_l1_b], i8, memory_space=l1_ms)
+    l1TyOutHerd = MemRefType.get(
+        [herd_m, herd_n, c_elems], xrt_dtype_out, memory_space=l1_ms
+    )
+    acc_sv_layout = StridedLayoutAttr.get(
+        ShapedType.get_dynamic_size(), [herd_n * c_l1_b, c_l1_b, 1]
+    )
+    out_sv_layout = StridedLayoutAttr.get(
+        ShapedType.get_dynamic_size(), [herd_n * c_elems, c_elems, 1]
+    )
+    l1TyAccSub = MemRefType.get(
+        [1, 1, c_l1_b], i8, memory_space=l1_ms, layout=acc_sv_layout
+    )
+    l1TyOutSub = MemRefType.get(
+        [1, 1, c_elems], xrt_dtype_out, memory_space=l1_ms, layout=out_sv_layout
+    )
+
+    # ---- External kernel decls. mm_bfp.cc + bfp_cvt.cc are linked into one .o.
+    def _extern(name, arg_tys):
+        f = FuncOp(name, (arg_tys, []), visibility="private")
+        f.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
+        f.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+        return f
+
+    zero_func = _extern("zero_kernel", [l1TyAccSub])
+    matmul_func = _extern("matmul_vectorized_bfp16", [l1TyA, l1TyB, l1TyAccSub])
+    cvt_name = "bfp16_to_bf16_mn" if np_dtype_out == bfloat16 else "bfp16_to_f32_mn"
+    cvt_func = _extern(cvt_name, [l1TyAccSub, l1TyOutSub])
+
+    @FuncOp.from_py_func(A_l3_ty, B_l3_ty, C_l3_ty)
+    def matmul_bfp16(arg0, arg1, arg2):
+        launch_size = [m // (tile_m * herd_m), n // (tile_n * herd_n)]
+
+        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
+        def launch_body(ivx, ivy, sx, sy, l3_a, l3_b, l3_c):
+            @segment(name="matmul_seg", operands=[ivx, ivy, l3_a, l3_b, l3_c])
+            def segment_body(ivx_s, ivy_s, l3_a_s, l3_b_s, l3_c_s):
+                l2TyA = MemRefType.get(
+                    [herd_m, k_per_l2, a_l1_b], i8, memory_space=l2_ms
+                )
+                l2TyB = MemRefType.get(
+                    [herd_n, k_per_l2, b_l1_b], i8, memory_space=l2_ms
+                )
+                l2TyC = MemRefType.get(
+                    [herd_m, herd_n, tile_m, tile_n], xrt_dtype_out, memory_space=l2_ms
+                )
+
+                l2_a = AllocOp(l2TyA, [], [])
+                l2_b = AllocOp(l2TyB, [], [])
+                l2_c = AllocOp(l2TyC, [], [])
+                # Segment-shared so the accumulator survives across the
+                # zero / compute / drain herd invocations.
+                l1_acc = AllocOp(l1TyAccHerd, [], [])
+                l1_out = AllocOp(l1TyOutHerd, [], [])
+
+                off_x_rows = _scaled(ivx_s, tile_m * herd_m)  # A/C row offset
+                off_y_rows = _scaled(ivy_s, tile_n * herd_n)  # B row offset
+                off_y_cols = _scaled(ivy_s, tile_n * herd_n)  # C column offset
+
+                # ---- Herd #1: zero the bfp16 L1 accumulator.
+                @herd(name="herd_0", sizes=[herd_m, herd_n], operands=[l1_acc])
+                def herd_init(tx, ty, _sx, _sy, acc):
+                    CallOp(
+                        zero_func,
+                        [
+                            subview(
+                                acc,
+                                offsets=[tx, ty, 0],
+                                sizes=[1, 1, c_l1_b],
+                                strides=[1, 1, 1],
+                            )
+                        ],
+                    )
+
+                # ---- Segment-level K-l2 loop.
+                for i in for_(0, k // tile_k_l2):
+                    k_off_b = _scaled(i, nbytes(tile_k_l2))
+
+                    # L3 -> L2: gather tile boxes. The two innermost dims
+                    # (tile_m, a_row_b) flatten into the contiguous destination.
+                    dma_memcpy_nd(
+                        l2_a,
+                        l3_a_s,
+                        src_offsets=[0, 0, off_x_rows, k_off_b],
+                        src_sizes=[herd_m, k_per_l2, tile_m, a_row_b],
+                        src_strides=[tile_m * KB, a_row_b, KB, 1],
+                    )
+                    dma_memcpy_nd(
+                        l2_b,
+                        l3_b_s,
+                        src_offsets=[0, 0, off_y_rows, k_off_b],
+                        src_sizes=[herd_n, k_per_l2, tile_n, a_row_b],
+                        src_strides=[tile_n * KB, a_row_b, KB, 1],
+                    )
+
+                    # ---- Herd #2: accumulate over the K-l1 chunks.
+                    @herd(
+                        name="herd_0",
+                        sizes=[herd_m, herd_n],
+                        operands=[l1_acc, l2_a, l2_b],
+                    )
+                    def herd_compute(tx, ty, _sx, _sy, acc, a2, b2):
+                        a1 = AllocOp(l1TyA, [], [])
+                        b1 = AllocOp(l1TyB, [], [])
+                        loop = for_disable_pp if disable_pingpong else for_
+                        for j in loop(0, k_per_l2):
+                            dma_memcpy_nd(
+                                a1,
+                                a2,
+                                src_offsets=[tx, j, 0],
+                                src_sizes=[1, 1, a_l1_b],
+                                src_strides=[k_per_l2 * a_l1_b, a_l1_b, 1],
+                            )
+                            dma_memcpy_nd(
+                                b1,
+                                b2,
+                                src_offsets=[ty, j, 0],
+                                src_sizes=[1, 1, b_l1_b],
+                                src_strides=[k_per_l2 * b_l1_b, b_l1_b, 1],
+                            )
+                            CallOp(
+                                matmul_func,
+                                [
+                                    a1,
+                                    b1,
+                                    subview(
+                                        acc,
+                                        offsets=[tx, ty, 0],
+                                        sizes=[1, 1, c_l1_b],
+                                        strides=[1, 1, 1],
+                                    ),
+                                ],
+                            )
+                            yield_([])
+                        DeallocOp(a1)
+                        DeallocOp(b1)
+
+                    yield_([])
+
+                # ---- Herd #3: convert bfp16 -> output dtype, then drain.
+                @herd(
+                    name="herd_0",
+                    sizes=[herd_m, herd_n],
+                    operands=[l1_acc, l1_out, l2_c],
+                )
+                def herd_drain(tx, ty, _sx, _sy, acc, out, c2):
+                    CallOp(
+                        cvt_func,
+                        [
+                            subview(
+                                acc,
+                                offsets=[tx, ty, 0],
+                                sizes=[1, 1, c_l1_b],
+                                strides=[1, 1, 1],
+                            ),
+                            subview(
+                                out,
+                                offsets=[tx, ty, 0],
+                                sizes=[1, 1, c_elems],
+                                strides=[1, 1, 1],
+                            ),
+                        ],
+                    )
+                    # L1 (8x8-block order) -> L2 (row-major). Nesting is
+                    # [m_b, n_b, m_i, n_i] so the L1 side is a single
+                    # contiguous run and only the L2 side needs the permute.
+                    dma_memcpy_nd(
+                        c2,
+                        out,
+                        dst_offsets=[tx, ty, 0, 0, 0, 0],
+                        dst_sizes=[1, 1, MB, NB, r, t],
+                        dst_strides=[
+                            herd_n * c_elems,
+                            c_elems,
+                            r * tile_n,
+                            t,
+                            tile_n,
+                            1,
+                        ],
+                        src_offsets=[tx, ty, 0, 0, 0, 0],
+                        src_sizes=[1, 1, MB, NB, r, t],
+                        src_strides=[
+                            herd_n * c_elems,
+                            c_elems,
+                            NB * r * t,
+                            r * t,
+                            t,
+                            1,
+                        ],
+                    )
+
+                # ---- L2 -> L3.
+                dma_memcpy_nd(
+                    l3_c_s,
+                    l2_c,
+                    dst_offsets=[0, off_x_rows, 0, off_y_cols],
+                    dst_sizes=[herd_m, tile_m, herd_n, tile_n],
+                    dst_strides=[tile_m * n, n, tile_n, 1],
+                    src_offsets=[0, 0, 0, 0],
+                    src_sizes=[herd_m, tile_m, herd_n, tile_n],
+                    src_strides=[herd_n * c_elems, tile_n, c_elems, 1],
+                )
+
+                DeallocOp(l2_a)
+                DeallocOp(l2_b)
+                DeallocOp(l2_c)
+                DeallocOp(l1_acc)
+                DeallocOp(l1_out)
+
+
+def pack_operands(A, B, tile_m, tile_k_l1, tile_n):
+    """Float A[M,K], B[K,N] -> the packed+shuffled device buffers.
+
+    Byte-for-byte what mlir-aie's bfp_test.cpp builds: quantize with
+    floatToBfp16(), then shuffleMatrixForBfp16ebs8() with the per-core tile
+    box. B is quantized transposed because the kernel consumes it that way.
+    """
+    A_dev = shuffle_bfp16ebs8(float_to_bfp16ebs8(A), tile_m, tile_k_l1)
+    B_dev = shuffle_bfp16ebs8(
+        float_to_bfp16ebs8(np.ascontiguousarray(B.T)), tile_n, tile_k_l1
+    )
+    return A_dev, B_dev
+
+
+if __name__ == "__main__":
+    # Default values.
+    M = 512
+    K = 512
+    N = 512
+    TILE_M = 64
+    TILE_K_L2 = 128
+    TILE_K_L1 = 64
+    TILE_N = 64
+    HERD_M = 4
+    HERD_N = 4
+    OUTPUT_DATATYPE = bfloat16
+
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Builds, runs, and tests the bfp16ebs8 matmul example",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-p",
+        "--print-module-only",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--m", type=int, default=M, help="M dimension size in a (MxK) * (KxN) matmul"
+    )
+    parser.add_argument(
+        "--k", type=int, default=K, help="K dimension size in a (MxK) * (KxN) matmul"
+    )
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=N,
+        help="N dimension size in a (MxK) * (KxN) matmul",
+    )
+    parser.add_argument(
+        "--tile-m", type=int, default=TILE_M, help="M dimension size of each L1 tile"
+    )
+    parser.add_argument(
+        "--tile-k-l2",
+        type=int,
+        default=TILE_K_L2,
+        help="K dimension size of each L2 tile",
+    )
+    parser.add_argument(
+        "--tile-k-l1",
+        type=int,
+        default=TILE_K_L1,
+        help="K dimension size of each L1 tile",
+    )
+    parser.add_argument(
+        "--tile-n", type=int, default=TILE_N, help="N dimension size of each L1 tile"
+    )
+    parser.add_argument(
+        "--herd-m",
+        type=int,
+        default=HERD_M,
+        help="Number of L1 tiles along the M dimension",
+    )
+    parser.add_argument(
+        "--herd-n",
+        type=int,
+        default=HERD_N,
+        help="Number of L1 tiles along the N dimension",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-only", "compile-and-xclbin", "compile-and-run"],
+        dest="compile_mode",
+        default="compile-and-run",
+        help="Configure compilation mode: compile-only (no XRT, no xclbin), compile-and-xclbin (requires XRT, generates xclbin), or compile-and-run (requires XRT, generates xclbin and runs)",
+    )
+    parser.add_argument(
+        "--arch",
+        type=str,
+        choices=["aie2", "aie2p"],
+        default="aie2p",
+        help="Target AIE architecture (aie2p only; bfp16ebs8 is an AIE2P type)",
+    )
+    parser.add_argument(
+        "--output-dtype",
+        type=str,
+        choices=["bf16", "f32"],
+        default=None,
+        dest="output_dtype",
+        help="Override output data type (default: f32 for aie2p)",
+    )
+    parser.add_argument(
+        "--disable-pingpong",
+        action="store_true",
+        dest="disable_pingpong",
+        help="Tag the K-l1 fill loop with air.disable_ping_pong when the 2x "
+        "ping-pong buffers would exceed the 64 KiB L1 budget",
+    )
+    parser.add_argument(
+        "--runtime-loop-tiling",
+        type=int,
+        default=None,
+        dest="runtime_loop_tiling",
+        help="Tile factor for the runtime launch loop (default: auto -- 2, or 1 "
+        "for small herds, see the note in the source)",
+    )
+    parser.add_argument(
+        "--perf-iters",
+        type=int,
+        default=0,
+        dest="perf_iters",
+        help="If >0, time the kernel over this many iters (after 10 warmup) and "
+        "print Latency + GFLOPs in addition to the correctness check",
+    )
+    args = parser.parse_args()
+
+    # bfp16ebs8 (v8bfp16ebs8 / mac_8x8_8x8T) exists only on AIE2P. There is no
+    # aie2 fallback -- neither the type nor the MMUL intrinsic is available, and
+    # xchesscc has no bfp16ebs8 codegen path either. Fail loudly rather than
+    # emitting IR that cannot be lowered.
+    if args.arch != "aie2p":
+        print(
+            f"Error: --arch {args.arch} is not supported by this example.",
+            file=sys.stderr,
+        )
+        print(
+            "bfp16ebs8 (v8bfp16ebs8) and its mac_8x8_8x8T MMUL are AIE2P-only; "
+            "NPU1/aie2 has no block-floating-point datapath. Re-run with "
+            "--arch aie2p on an NPU2 (Strix) device.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # aie2p defaults to f32 output for better precision.
+    # Can be overridden with --output-dtype.
+    if args.output_dtype == "bf16":
+        pass  # keep default bfloat16
+    elif args.output_dtype == "f32":
+        OUTPUT_DATATYPE = np.float32
+    elif args.arch == "aie2p":
+        OUTPUT_DATATYPE = np.float32
+
+    # bfp16ebs8 kernels are Peano-only; xchesscc has no codegen path for them.
+    if args.compile_mode != "compile-only" and not os.environ.get("PEANO_INSTALL_DIR"):
+        print(
+            "Error: PEANO_INSTALL_DIR environment variable is not set.",
+            file=sys.stderr,
+        )
+        print(
+            "Peano is required for bfp16ebs8; the Chess toolchain has no "
+            "bfp16ebs8 codegen path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Runtime launch-loop tiling. [2, 2] batches the per-launch DMA task
+    # triplets and is worth ~26% throughput (183us vs 232us at 512^3 / 4x4).
+    #
+    # It is NOT safe on small herds: when the herd is small enough that AIR
+    # gives the C drain a single shim channel, the shim-BD fold collapses that
+    # drain across every launch iteration into one task with one await, so only
+    # the first launch iteration's output is ever written while all the input
+    # fills still run. Observed at herd 2x2 / 2x1 / 1x2 with more than one
+    # launch iteration (herd 4x2 and larger split C over 4 channels and are
+    # fine). Same class as the shim-BD stride-fold / wait-pairing fixes in
+    # mlir-air #1810 and #1815. Override with --runtime-loop-tiling.
+    n_launch = (args.m // (args.tile_m * args.herd_m)) * (
+        args.n // (args.tile_n * args.herd_n)
+    )
+    n_cores = args.herd_m * args.herd_n
+    if args.runtime_loop_tiling is not None:
+        runtime_loop_tiling_sizes = [args.runtime_loop_tiling] * 2
+    elif n_launch > 1 and n_cores < 8:
+        runtime_loop_tiling_sizes = [1, 1]
+        print(
+            f"note: herd {args.herd_m}x{args.herd_n} ({n_cores} cores) with "
+            f"{n_launch} launch iterations -- using runtime_loop_tiling_sizes="
+            "[1, 1]; [2, 2] drops all but the first launch iteration's output "
+            "on herds this small. Override with --runtime-loop-tiling."
+        )
+    else:
+        runtime_loop_tiling_sizes = [2, 2]
+
+    # mm_bfp.cc keeps C in bfp16ebs8 between K-l1 chunks, re-quantizing the
+    # accumulator to an 8-bit mantissa with a shared exponent on every chunk.
+    # Error therefore grows with the number of round-trips, K/tile_k_l1,
+    # independently of the input distribution (measured mean_rel_L1 at
+    # M=128,N=2048: 32 round-trips -> 0.27 randn / 0.09 integer; 128
+    # round-trips -> 1.23 randn / 0.41 integer). Past ~64 round-trips the
+    # result is not usable at any sane tolerance.
+    n_roundtrips = args.k // args.tile_k_l1
+    if n_roundtrips > 64:
+        print(
+            f"warning: K/tile_k_l1 = {n_roundtrips} accumulator round-trips. "
+            "mm_bfp.cc re-quantizes C to bfp16ebs8 on every K-l1 chunk, so this "
+            "shape will lose too much precision to pass the check. Raise "
+            "--tile-k-l1 or use a shallower K.",
+            file=sys.stderr,
+        )
+
+    mlir_module = build_module(
+        args.m,
+        args.k,
+        args.n,
+        args.tile_m,
+        args.tile_k_l2,
+        args.tile_k_l1,
+        args.tile_n,
+        args.herd_m,
+        args.herd_n,
+        OUTPUT_DATATYPE,
+        args.arch,
+        args.disable_pingpong,
+    )
+
+    if args.print_module_only:
+        print(mlir_module)
+        exit(0)
+
+    # Variance-normalized inputs following PyTorch's
+    # random_matrix_with_scaled_reduction_dim: randn / sqrt(K). This keeps
+    # output variance ~1 regardless of K, so relative tolerance behaves
+    # consistently across matrix sizes. Same generator as the bf16 example.
+    scale = 1.0 / np.sqrt(args.k)
+    input_a = (np.random.randn(args.m, args.k) * scale).astype(np.float32)
+    input_b = (np.random.randn(args.k, args.n) * scale).astype(np.float32)
+
+    if args.compile_mode == "compile-and-run":
+        # Device operands are the bfp16ebs8-quantized, sub-tile-shuffled bytes.
+        packed_a, packed_b = pack_operands(
+            input_a, input_b, args.tile_m, args.tile_k_l1, args.tile_n
+        )
+
+        # Full reference: f32 matmul over the whole output, cast to the output
+        # dtype. Computing the reference from the ORIGINAL floats (not the
+        # de-quantized operands) means the check covers the bfp16 input
+        # quantization too, which is what mlir-aie's bfp_test.cpp does.
+        reference = (input_a @ input_b).astype(OUTPUT_DATATYPE)
+
+        # Tolerances are sized to the kernel's measured worst-case error.
+        #
+        # bfp16ebs8 shares one 8-bit exponent across 8 elements, so an element
+        # sitting in a block with a much larger neighbour loses mantissa bits.
+        # On Gaussian inputs that is the dominant error term -- it comes from
+        # quantizing A and B, not from the output dtype, which is why bf16 and
+        # f32 output need the same tolerance here.
+        #
+        # The check is therefore absolute-error driven: with randn/sqrt(K)
+        # inputs the reference has std ~1/sqrt(K), which shrinks with K while
+        # the bfp16 error floor does not, so mean_rel_L1 grows with K
+        # (measured: 2.1e-2 at K=64, 6.9e-2 at K=512, 2.7e-1 at K=2048).
+        # Measured abs_err max across every Makefile target and both output
+        # dtypes is 8.5e-3 .. 1.5e-2, so atol below leaves ~1.7x headroom.
+        #
+        # For reference, mlir-aie's own bfp_test.cpp sidesteps this by drawing
+        # inputs from rand()%16 ("limiting to 16 to avoid precision loss
+        # issues") -- integers of similar magnitude share an exponent almost
+        # losslessly. This example keeps the bf16 example's randn/sqrt(K)
+        # generator instead, so the numbers above are the honest bfp16 error
+        # on high-dynamic-range data.
+        test_rtol, test_atol = 5e-2, 2.5e-2
+
+        ###### Compile and test
+        runner_kwargs = {
+            "verbose": args.verbose,
+            "omit_while_true_loop": False,
+            "runtime_loop_tiling_sizes": runtime_loop_tiling_sizes,
+            "stack_size": 2048,
+            "report_precision": True,
+            "n_perf_iters": args.perf_iters,
+            "perf_flops": (
+                (2.0 * args.m * args.k * args.n) if args.perf_iters > 0 else None
+            ),
+        }
+
+        runner = XRTRunner(**runner_kwargs, instance_name="matmul_bfp16")
+        exit(
+            runner.run_test(
+                mlir_module,
+                inputs=[packed_a, packed_b],
+                expected_outputs=[reference],
+                rtol=test_rtol,
+                atol=test_atol,
+            )
+        )
+
+    elif args.compile_mode == "compile-and-xclbin":
+        ###### Compile and generate xclbin (requires XRT, no execution)
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            runtime_loop_tiling_sizes=runtime_loop_tiling_sizes,
+            stack_size=2048,
+        )
+        module_function = backend.compile(mlir_module)
+        backend.unload()
+
+    elif args.compile_mode == "compile-only":
+        ###### Compile only (without XRT dependencies)
+        backend = XRTBackend(
+            verbose=args.verbose,
+            target_device="npu2",
+            output_format="none",
+            omit_while_true_loop=False,
+            runtime_loop_tiling_sizes=runtime_loop_tiling_sizes,
+            stack_size=2048,
+        )
+        module_function = backend.compile(mlir_module)
+        backend.unload()
+
+        print("Compilation completed successfully!")
+        sys.exit(0)

--- a/programming_examples/matrix_multiplication/bfp16/run_npu1_unsupported_arch.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu1_unsupported_arch.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// bfp16ebs8 (v8bfp16ebs8 / mac_8x8_8x8T) is an AIE2P-only datapath. Requesting
+// aie2 must fail with a diagnostic rather than emitting IR that cannot lower.
+// Host-only check: no device and no Peano needed.
+//
+// RUN: mkdir -p test_npu1_unsupported_arch
+// RUN: cd test_npu1_unsupported_arch
+// RUN: not python3 %S/run.py --arch aie2 --compile-mode compile-only 2>&1 | FileCheck %s
+// CHECK: Error: --arch aie2 is not supported
+// CHECK: AIE2P-only

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_llama_4x4_kv_peano.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_llama_4x4_kv_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_llama_4x4_kv_peano
+// RUN: cd test_npu2_llama_4x4_kv_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_llama_4x4_kv PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_llama_4x4_qo_peano.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_llama_4x4_qo_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_llama_4x4_qo_peano
+// RUN: cd test_npu2_llama_4x4_qo_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run_llama_4x4_qo PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_peano
+// RUN: cd test_npu2_peano
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run4x4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_1x1.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_1x1.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_peano_1x1
+// RUN: cd test_npu2_peano_1x1
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run1x1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_8x4.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_8x4.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_peano_8x4
+// RUN: cd test_npu2_peano_8x4
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run8x4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_bf16_output.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu2_makefile_peano_bf16_output.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_peano_bf16_output
+// RUN: cd test_npu2_peano_bf16_output
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run4x4 OUTPUT_DTYPE=bf16 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR AIE_TARGET=aie2p | FileCheck %s
+// CHECK: PASS!


### PR DESCRIPTION
Ports mlir-aie's [block-datatype GEMM reference design](https://github.com/Xilinx/mlir-aie/tree/main/programming_examples/ml/block_datatypes/matrix_multiplication) to MLIR-AIR. The compute kernel is mlir-aie's [`aie_kernels/aie2p/mm_bfp.cc`](https://github.com/Xilinx/mlir-aie/blob/main/aie_kernels/aie2p/mm_bfp.cc), used **unmodified** and resolved from the mlir-aie install via `AIEOPT_DIR`; this example contributes the AIR data movement around it plus a small output-conversion kernel.

A and B are bfp16ebs8 (8 scalars share one 8-bit exponent, so 8 elements occupy 9 bytes); B is consumed transposed. C is accumulated in bfp16ebs8 by the kernel and converted to bf16 or f32 on the way out.

Two commits, independent and separable if reviewers prefer:
1. a bug fix in the existing `bf16_x_bfp16` packer, found while porting;
2. the new example.

### Why the `i8` type-pun

AIR has no bfp16ebs8 element type. mlir-aie's `!aiex.bfp<>` lowers to `i72`, but `aie-transform-bfp-types` runs inside `aie.device` — after every AIR pass — and AIR's BD lowering assumes an int-or-float element type. So A and B cross the AIR boundary as plain `i8` and the kernel reinterprets via `aie::block_vector<bfp16ebs8>`, the same type-pun `bf16_x_bfp16` already uses for its weights.

### Why the data movement stays simple

`shuffleMatrixForBfp16ebs8()` reorders 8x8 sub-tiles *within* each tile box only, leaving the global matrix row-major. L3 A/B are therefore plain 2D byte matrices, L3→L2 is a strided box gather, and L2→L1 is a contiguous copy landing in exactly the sub-tile-major order the kernel expects. Neither of the two data-layout transforms the reference README calls out as impossible for blocked types is needed on the AIR side. `bfp16_utils.py` is a NumPy port of the host helpers, cross-checked byte-for-byte against `helper.h`.

### Conventions

Layout, targets and CLI follow the `bf16` example: `run.py` entry point, defaults in the `__main__` block, `XRTRunner.run_test` for the check, named per-herd Make targets, `--arch` / `--output-dtype` / `--compile-mode` / `--perf-iters`.

### bfp16ebs8-specific constraints (all enforced with diagnostics)

- **AIE2P only.** `--arch aie2` exits non-zero: `v8bfp16ebs8` and `mac_8x8_8x8T` are AIE2P-only and NPU1 has no block-floating-point datapath. Peano only; `xchesscc` has no bfp16ebs8 codegen path.
- **`TILE_N`, `TILE_K_L1` multiples of 64** (host shuffle granularity); **`K` a multiple of 32** so `K*9/8` stays 4-byte aligned for shim BDs.
- **`TILE_M >= 32`.** `mm_bfp.cc`'s `static_assert` permits 16, but at that size `rowA` is 2 while the z loop still carries `AIE_LOOP_MIN_ITERATION_COUNT(4)` and Peano fails register allocation. This is why the LLAMA targets are 4x4 rather than 8x4 — `M=128` with `herd_m=8` would force `TILE_M=16`.
- **Accumulator depth.** `mm_bfp.cc` re-quantizes C to bfp16ebs8 between K-l1 chunks, so accuracy degrades with `K/TILE_K_L1` under any input distribution:

  | round-trips | `mean_rel_L1` randn | `mean_rel_L1` `rand()%16` |
  |---|---|---|
  | 32 (K=2048) | 0.27 | 0.09 |
  | 128 (K=8192) | 1.23 | 0.41 |

  `run.py` warns past 64 round-trips, and `run_llama_4x4_down` (K=8192) is excluded from the aggregate target. This is a property of the reference kernel, not of the port.

### One AIR issue worked around here

Small herds need `runtime_loop_tiling_sizes=[1, 1]`. When the herd is small enough that AIR gives the C drain a single shim channel, the shim-BD fold collapses that drain across every launch iteration into one task with one await, so only the first launch iteration's output is written while all the input fills still run. Observed at herd 2x2 / 2x1 / 1x2 with more than one launch iteration; 4x2 and larger split C over four channels and are unaffected. Evidence is the generated runtime sequence — 1 configure / 1 await for herd 2x2 versus 8 / 8 for herd 4x2, with 16 A-fills and 16 B-fills in both. Not ping-pong (`air.disable_ping_pong` changes nothing).

`run.py` detects the case and drops to `[1, 1]` with a printed note, since `[2, 2]` is worth ~26% throughput elsewhere (183us vs 232us at 512^3, 4x4). Looks related to the shim-BD stride-fold / wait-pairing work in #1810 and #1815; I am investigating the root cause separately and will file it on its own.

### Testing

Validated on NPU2 across every Make target and both output dtypes (16/16 combinations PASS): `run1x1`, `run2x2`, `run2x4`, `run4x4`, `run8x4`, `run3x3`, `run_llama_4x4_qo`, `run_llama_4x4_kv`, each with f32 and bf16 output. `run_llama_4x4_gate_up` also passes. Tolerances are sized from measurement (`atol=2.5e-2` against a worst observed `abs_err` of 1.5e-2). `sweep4x4` is provided but has not been run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)