### PR TITLE
[AIR] Make air-split-l2-memref pick a deterministic channel order

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1535,7 +1535,7 @@ private:
       SmallVector<air::ChannelPutOp> &puts,
       SmallVector<air::ChannelGetOp> &gets, int memrefDim, Operation *allocOp,
       llvm::MapVector<air::ChannelInterface, infoEntryTy> &opToSplitInfoMap);
-  FailureOr<llvm::DenseMap<memref::AllocOp, memrefSplitInfoTy>>
+  FailureOr<llvm::MapVector<memref::AllocOp, memrefSplitInfoTy>>
   getTargetMemrefAllocs(
       func::FuncOp func,
       llvm::MapVector<air::ChannelInterface, infoEntryTy> &opToSplitInfoMap);
@@ -2088,7 +2088,7 @@ std::optional<int> AIRSplitL2MemrefForBufferConstraintPass::getMemrefSplitDim(
 
 // Get a vector of allocs whose memrefs require splitting; label the single
 // split dimension with split factor, split_type and affine_map (if any).
-FailureOr<llvm::DenseMap<memref::AllocOp, memrefSplitInfoTy>>
+FailureOr<llvm::MapVector<memref::AllocOp, memrefSplitInfoTy>>
 AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
     func::FuncOp func,
     llvm::MapVector<air::ChannelInterface, infoEntryTy> &opToSplitInfoMap) {
@@ -2104,7 +2104,10 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
   // Condition to split a memref: detected multiple-in-single-out or
   // single-in-multiple-out channel patterns. Such pattern is represented via
   // the memref being accessed by multiple unique channel puts/gets.
-  llvm::DenseMap<memref::AllocOp, memrefSplitInfoTy> targetMemrefsToInfoMap;
+  // MapVector, not DenseMap: STEP 3 iterates this and mints a fresh channel
+  // name per entry, so a pointer-hashed order would rename channels
+  // differently run to run and change the physical shim assignment.
+  llvm::MapVector<memref::AllocOp, memrefSplitInfoTy> targetMemrefsToInfoMap;
 
   // Launch-level endpoint cap state. Each approved split multiplies the
   // post-split endpoint count on the single-channel-side symbol. Track those

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_deterministic_order.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_deterministic_order.mlir
@@ -1,0 +1,89 @@
+//===- air_split_l2_memref_deterministic_order.mlir ------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="tiles-per-l2-tile=1" --split-input-file | FileCheck %s
+
+// Two splittable L2 buffers in one func. The pass mints one fresh channel name
+// per buffer, so the name each buffer gets is decided by the order the pass
+// walks them. That order used to come from a DenseMap keyed by the alloc op,
+// i.e. from heap addresses, so the two buffers swapped names between processes
+// -- and since the names drive aie.shim_dma_allocation, so did the physical
+// shim port assignment.
+//
+// The two buffers split by different factors (2 and 4), so the minted sizes
+// tell them apart: walk order pins @channel_0 (from the 2-way buffer, declared
+// first) ahead of @channel_1 (the 4-way one). A single alloc cannot catch this
+// -- one entry has no order to get wrong.
+// CHECK: air.channel @channel_0 [2, 1]
+// CHECK: air.channel @channel_1 [4, 1]
+// CHECK-LABEL: func.func @two_allocs_keep_walk_order
+// CHECK: memref.alloc() : memref<2560xbf16, 1 : i32>
+// CHECK: memref.alloc() : memref<3072xbf16, 1 : i32>
+// CHECK-NOT: memref<5120xbf16, 1 : i32>
+// CHECK-NOT: memref<12288xbf16, 1 : i32>
+
+air.channel @inA [1]
+air.channel @inB [1]
+air.channel @aL2ToL1 [1, 2]
+air.channel @bL2ToL1 [1, 4]
+func.func @two_allocs_keep_walk_order(%arg0: memref<5120xbf16>, %arg1: memref<12288xbf16>) {
+  %c1 = arith.constant 1 : index
+  %0 = air.launch async (%arg2) in (%arg3=%c1) args(%arg4=%arg0, %arg5=%arg1) : memref<5120xbf16>, memref<12288xbf16> attributes {id = 1 : i32} {
+    %1 = air.segment @segment_0 async {
+      %c0 = arith.constant 0 : index
+      %c1_0 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c3 = arith.constant 3 : index
+      %c4 = arith.constant 4 : index
+      // Buffer A: 2 destination tiles -> split factor 2.
+      %async_token, %results = air.execute -> (memref<5120xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<5120xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<5120xbf16, 1 : i32>
+      }
+      %2 = air.channel.get async [%async_token]  @inA[%c0] (%results[] [] []) {id = 1 : i32} : (memref<5120xbf16, 1 : i32>)
+      %3 = air.channel.put async [%2]  @aL2ToL1[%c0, %c0] (%results[0] [2560] [1]) {id = 2 : i32} : (memref<5120xbf16, 1 : i32>)
+      %4 = air.channel.put async [%2]  @aL2ToL1[%c0, %c1_0] (%results[2560] [2560] [1]) {id = 3 : i32} : (memref<5120xbf16, 1 : i32>)
+      %async_token_0 = air.execute [%3, %4] {
+        memref.dealloc %results : memref<5120xbf16, 1 : i32>
+      }
+      // Buffer B: 4 destination tiles -> split factor 4.
+      %async_token_1, %results_1 = air.execute -> (memref<12288xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<12288xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<12288xbf16, 1 : i32>
+      }
+      %5 = air.channel.get async [%async_token_1]  @inB[%c0] (%results_1[] [] []) {id = 4 : i32} : (memref<12288xbf16, 1 : i32>)
+      %6 = air.channel.put async [%5]  @bL2ToL1[%c0, %c0] (%results_1[0] [3072] [1]) {id = 5 : i32} : (memref<12288xbf16, 1 : i32>)
+      %7 = air.channel.put async [%5]  @bL2ToL1[%c0, %c1_0] (%results_1[3072] [3072] [1]) {id = 6 : i32} : (memref<12288xbf16, 1 : i32>)
+      %8 = air.channel.put async [%5]  @bL2ToL1[%c0, %c2] (%results_1[6144] [3072] [1]) {id = 7 : i32} : (memref<12288xbf16, 1 : i32>)
+      %9 = air.channel.put async [%5]  @bL2ToL1[%c0, %c3] (%results_1[9216] [3072] [1]) {id = 8 : i32} : (memref<12288xbf16, 1 : i32>)
+      %async_token_2 = air.execute [%6, %7, %8, %9] {
+        memref.dealloc %results_1 : memref<12288xbf16, 1 : i32>
+      }
+      %10 = air.herd @herd_a async tile (%arg6, %arg7) in (%arg8=%c1_0, %arg9=%c2) attributes {id = 2 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %async_token_3, %results_3 = air.execute -> (memref<2560xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<2560xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<2560xbf16, 2 : i32>
+        }
+        %11 = air.channel.get async [%async_token_3]  @aL2ToL1[%arg6, %arg7] (%results_3[] [] []) {id = 9 : i32} : (memref<2560xbf16, 2 : i32>)
+        %async_token_4 = air.execute [%11] {
+          memref.dealloc %results_3 : memref<2560xbf16, 2 : i32>
+        }
+      }
+      %12 = air.herd @herd_b async tile (%arg6, %arg7) in (%arg8=%c1_0, %arg9=%c4) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 4 : i64} {
+        %async_token_5, %results_5 = air.execute -> (memref<3072xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<3072xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<3072xbf16, 2 : i32>
+        }
+        %13 = air.channel.get async [%async_token_5]  @bL2ToL1[%arg6, %arg7] (%results_5[] [] []) {id = 10 : i32} : (memref<3072xbf16, 2 : i32>)
+        %async_token_6 = air.execute [%13] {
+          memref.dealloc %results_5 : memref<3072xbf16, 2 : i32>
+        }
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
`air-split-l2-memref` collected the allocs it was going to split into a
`llvm::DenseMap<memref::AllocOp, memrefSplitInfoTy>`. That key is an op wrapper,
so the map hashes the underlying `Operation*` and iteration follows heap
addresses, which differ from one process to the next.

STEP 3 walks that map and mints a fresh channel name per entry via
`air::createChannelName`, so two compiles of the same input handed the split L2
buffers each other's names. Channel names feed `aie.shim_dma_allocation`, so the
*physical* shim port assignment moved with them — the same `air_channel_N` landed
on `(0,0) S2MM 0` in one build and `(0,0) MM2S 1` in the next.

Observed on `llms/llama32_1b_q4nx`'s `rms_gemms_rope`: compiling the identical
module twice on one install produced different `placed.air.mlir`,
`aie.air.mlir` and `npu.air.mlir`, first diverging at
`pass_025_after_func.func_air-split-l2-memref.mlir`, with everything downstream
inheriting it. One of those draws hung on device
(`ERT_CMD_STATE_TIMEOUT`), which is how this surfaced.

The map is filled from an in-order `func.walk`, so insertion order is already the
order we want — only the container discarded it. `MapVector` keeps it, and
matches every other map in this pass (`opToSplitInfoMap`, `infoEntryMap`,
`MM2SChannels`/`S2MMChannels`); the `DenseMap` was the lone outlier and the only
unordered container the pass iterates.

## Test

`air_split_l2_memref_deterministic_order.mlir` puts two splittable L2 buffers in
one func with different split factors (2 and 4) so the minted channel sizes tell
them apart. A single alloc cannot catch this — one entry has no order to get
wrong, which is why the existing cases never did.

Against the pre-fix `DenseMap` build the new test fails on most runs; six
invocations of the same binary on the same input gave:

```
@channel_0 [4, 1] @channel_1 [2, 1]
@channel_0 [4, 1] @channel_1 [2, 1]
@channel_0 [4, 1] @channel_1 [2, 1]
@channel_0 [2, 1] @channel_1 [4, 1]
@channel_0 [4, 1] @channel_1 [2, 1]
@channel_0 [2, 1] @channel_1 [4, 1]
```

With the fix it is `[2, 1]` then `[4, 1]` every time.

## Verification

`check-air-mlir` 506/520. Three fresh compiles of `rms_gemms_rope` now agree
byte-for-byte at all three stages (`placed` `62daf6f8`, `aie` `af4aae49`, `npu`
`d1645ea2`).

On the four Q4/Q4NX LLMs (NPU2, `llvm-aie 21.0.0.2026080601+f4a72c27`):

* **Decode — unchanged.** `decode_L64`/`decode_L63` `insts.bin` byte-identical
  before and after for llama32_1b_q4nx (`ca22e34f`/`90476fc2`), llama32_3b_q4nx
  (`6bb9a5f7`/`1112be9b`), gemma3_4b_q4nx (`459e2be7`/`c28ab3de`) and
  qwen25_3b_q4 (`84d8c54a`/`068fcac7`). The decode path does not exercise this
  pass.
* **Prefill correctness.** First-token argmax unchanged: llama-1B/3B `12366`,
  gemma `9079`, qwen `12095`.
* **Prefill perf.** Prefill *is* affected, so both ELF sets were built and kept,
  then alternated on an idle box (three rounds each, σ ≈ 0.003 s on a fixed
  build):

  | model | before | after |
  |---|---|---|
  | llama32_1b_q4nx | 0.982 / 0.979 / 0.981 s | 0.980 / 0.972 / 0.977 s |
  | llama32_3b_q4nx | 2.668 / 2.658 / 2.668 s | 2.668 / 2.665 / 2.672 s |
  | gemma3_4b_q4nx  | 4.068 / 4.078 / 4.055 s | 3.892 / 3.876 / 4.034 s |
  | qwen25_3b_q4    | 4.300 / 4.398 / 4.356 s | 4.323 / 4.311 / 4.272 s |

  Flat within noise; gemma ~3% faster.

Note this pins the order rather than preserving a previous output — there wasn't
one to preserve, since the pass was emitting one of 2^n orderings at random.

🤖 Generated with [Claude Code](https://claude.com/claude-code)