### PR TITLE
[AIR] Bound the shim feed burst so it cannot outrun the DMA task queue

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -2853,6 +2853,9 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       }
     });
 
+    // Bound how far one shim feed channel may run ahead of its siblings.
+    boundShimFeedBursts(module);
+
     // Repair dominance after the reordering above. Every hoist here moves a
     // configure task or an RTP write past other ops, and a runtime access
     // pattern brings along the small arith chain that narrows a sequence
@@ -2926,6 +2929,183 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     module.walk([](xilinx::AIE::DeviceOp device) {
       device->removeAttr(kMultiIterLaunchAttr);
       device->removeAttr(kNumLaunchItersAttr);
+    });
+  }
+
+  // Bound how far one shim MM2S feed channel may run ahead of its siblings, and
+  // how many tasks it may have in flight at once.
+  //
+  // Feeds come out of the conversion channel-major -- every task for A, then
+  // every task for B -- because that is the order the channels' puts appear in,
+  // and nothing bounds how many one channel may have outstanding. A shim
+  // channel absorbs only a few: its DMA task queue (4 entries on AIE2) plus
+  // whatever the L2 consumer is double-buffering. Measured on a 2x2 herd GEMM,
+  // <= 6 tasks in flight on one channel completes and >= 7 hangs, independent
+  // of the output drain's structure, the launch count, and the dtype
+  // (Xilinx/mlir-air#1822).
+  //
+  // Two things are wrong, and both need fixing:
+  //
+  //   - Channel-major order lets A consume the whole budget before B is fed at
+  //     all, so the cores wait on a B chunk that was never sent. Interleaving
+  //     the burst round-robin fixes that, and costs nothing.
+  //
+  //   - The overflow itself is per channel and absolute: a push past what the
+  //     channel holds is dropped, not deferred. A perfect A/B/A/B weave at 16
+  //     deep still hangs, so interleaving alone is not a fix. Capping each
+  //     channel's in-flight set -- await task i-limit before starting task i --
+  //     is what actually removes the deadlock.
+  //
+  // Only bursts that exceed the limit are touched. A design whose channels were
+  // already short-run keeps its emission order and its await structure byte for
+  // byte, which is what keeps this off the hot path of the tuned LLM decoders.
+  void boundShimFeedBursts(ModuleOp module) {
+    // Per-channel tasks in flight that a shim channel absorbs without the
+    // control program blocking on the push: the AIE2 shim DMA task queue depth.
+    // The measured limit is 6 (queue + an L2 ping-pong); staying at the queue
+    // depth alone keeps the bound independent of what the consumer buffers.
+    constexpr unsigned burstLimit = 4;
+
+    module.walk([&](AIE::RuntimeSequenceOp seq) {
+      if (seq.getBody().empty())
+        return;
+      auto device = seq->getParentOfType<AIE::DeviceOp>();
+      if (!device)
+        return;
+
+      // A feed whose position is already load-bearing is left alone, and fences
+      // the burst it sits in: `air.runtime_hoist` was deliberately moved to the
+      // front, the paced/coalesced feeds are bounded by
+      // synthesizeDoubleBufferedAwaits, and the append-barrier feeds carry a
+      // write-after-write ordering the dependence graph cannot express.
+      auto isReorderable = [&](AIEX::DMAConfigureTaskForOp cfg) {
+        for (StringRef a :
+             {air::attrs::RuntimeHoist, air::attrs::PreserveShimDmaOrder,
+              air::attrs::CoalescedShimFeed, air::attrs::AppendBarrier,
+              air::attrs::AwaitAppends})
+          if (cfg->hasAttr(a))
+            return false;
+        auto allocOp = AIE::ShimDMAAllocationOp::getForSymbol(
+            device, cfg.getAlloc().getLeafReference().getValue());
+        return allocOp && allocOp.getChannelDir() == AIE::DMAChannelDir::MM2S;
+      };
+
+      struct Unit {
+        AIEX::DMAConfigureTaskForOp cfg;
+        Operation *start;
+        StringRef chan;
+      };
+
+      SmallVector<Block *> blocks;
+      seq.getBody().walk([&](Block *b) { blocks.push_back(b); });
+      for (Block *blk : blocks) {
+        SmallVector<Unit> run;
+        SmallVector<Operation *> staleFrees;
+
+        // Lay the burst back down just before `fence`, round-robin over the
+        // channels it feeds, then cap each channel's in-flight set. Each
+        // channel keeps its own relative order -- the consumer ring depends on
+        // it -- so the weave only changes how the channels are interleaved with
+        // each other. A single-channel burst has nothing to weave and just gets
+        // the cap.
+        auto flush = [&](Operation *fence) {
+          if (run.size() < 2 || !fence)
+            return;
+          llvm::MapVector<StringRef, SmallVector<Unit>> byChan;
+          for (const Unit &u : run)
+            byChan[u.chan].push_back(u);
+          unsigned deepest = 0;
+          for (auto &kv : byChan)
+            deepest = std::max<unsigned>(deepest, kv.second.size());
+          if (deepest <= burstLimit)
+            return; // already within what a channel absorbs; leave as emitted.
+          for (unsigned i = 0; i < deepest; i++)
+            for (auto &kv : byChan) {
+              if (i >= kv.second.size())
+                continue;
+              const Unit &u = kv.second[i];
+              u.cfg->moveBefore(fence);
+              u.start->moveBefore(fence);
+            }
+          // Interleaving alone is not enough. It does bound how far one channel
+          // runs ahead, but the overflow is per channel and absolute: a push
+          // past what the channel can hold is dropped, not deferred, so the
+          // chunk is simply never sent. Measured with a perfect A/B/A/B weave
+          // at 16 deep, the design still hangs. So cap each channel's in-flight
+          // set as well: before starting task i, await the token from task
+          // i-burstLimit, which cannot have retired any later than that.
+          for (auto &kv : byChan) {
+            SmallVector<Unit> &chan = kv.second;
+            for (unsigned i = burstLimit; i < chan.size(); i++) {
+              AIEX::DMAConfigureTaskForOp older = chan[i - burstLimit].cfg;
+              // An MM2S task issues no completion token by default, so there
+              // would be nothing to wait on.
+              older.setIssueToken(true);
+              OpBuilder b(chan[i].start);
+              AIEX::DMAAwaitTaskOp::create(b, chan[i].start->getLoc(),
+                                           older.getResult());
+              // An await also frees the BD, so the fire-and-free this task was
+              // given at conversion would now be a second release. Erase those
+              // only once the block walk is done -- a free sits after the
+              // burst, so erasing it here would pull the ground out from under
+              // the iterator.
+              for (auto *u : older.getResult().getUsers())
+                if (isa<AIEX::DMAFreeTaskOp>(u))
+                  staleFrees.push_back(u);
+            }
+          }
+        };
+
+        // Walk the block, growing a run of reorderable feeds. Anything that is
+        // not such a feed and is not pure ends it: an await, a free, an RTP
+        // write, a lock set, a PDI load -- each is an ordering point, and a
+        // burst only exists between them. Pure ops (the arith chain narrowing a
+        // runtime length or offset) are transparent; moving a feed above its
+        // operands is repaired by the rematerialization pass below, which is
+        // there for exactly this.
+        for (Operation &o : llvm::make_early_inc_range(*blk)) {
+          if (auto cfg = dyn_cast<AIEX::DMAConfigureTaskForOp>(&o)) {
+            Operation *start = nullptr;
+            for (auto *u : cfg.getResult().getUsers()) {
+              if (!isa<AIEX::DMAStartTaskOp>(u) || u->getBlock() != blk)
+                continue;
+              if (start) { // more than one start: not a plain single-shot feed
+                start = nullptr;
+                break;
+              }
+              start = u;
+            }
+            if (start && isReorderable(cfg)) {
+              run.push_back(
+                  {cfg, start, cfg.getAlloc().getLeafReference().getValue()});
+              continue;
+            }
+            flush(&o);
+            run.clear();
+            continue;
+          }
+          if (isa<AIEX::DMAStartTaskOp>(&o)) {
+            // The start of a feed already in the run travels with its configure
+            // and does not break the burst; any other start does.
+            bool owned =
+                llvm::any_of(run, [&](const Unit &u) { return u.start == &o; });
+            if (owned)
+              continue;
+            flush(&o);
+            run.clear();
+            continue;
+          }
+          if (isMemoryEffectFree(&o))
+            continue;
+          flush(&o);
+          run.clear();
+        }
+        if (blk->mightHaveTerminator())
+          flush(blk->getTerminator());
+        run.clear();
+        for (Operation *f : staleFrees)
+          f->erase();
+      }
     });
   }
 

--- a/mlir/test/Conversion/AIRRtToNpu/shim_feed_burst_bound.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/shim_feed_burst_bound.mlir
@@ -1,0 +1,133 @@
+//===- shim_feed_burst_bound.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu %s | FileCheck %s
+
+// A shim MM2S channel absorbs 6 tasks in flight (its DMA task queue plus an L2
+// ping-pong); past that a push is dropped rather than deferred and the design
+// deadlocks (Xilinx/mlir-air#1822). Runtime-loop tiling unrolls the feed puts,
+// so a burst can be far deeper than that, and the conversion emits it
+// channel-major: every task for A, then every task for B.
+//
+// Two channels x 6 feeds each, so both exceed the limit of 4. The burst comes
+// back woven A/B/A/B -- if it stayed channel-major, the pacing awaits below
+// could never retire, because B would not be fed until A had drained -- and
+// each channel is capped at 4 in flight by awaiting task i-4 before starting
+// task i. The awaited config gains issue_token (an MM2S task issues no
+// completion token by default) and loses its fire-and-free, which an await
+// would otherwise double.
+
+// CHECK-LABEL: aie.runtime_sequence @burst
+// The weave: the first four of each channel start back to back, unpaced.
+// CHECK: %[[A0:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: issue_token = true
+// CHECK: aiex.dma_start_task(%[[A0]])
+// CHECK: %[[B0:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: issue_token = true
+// CHECK: aiex.dma_start_task(%[[B0]])
+// CHECK: %[[A1:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: aiex.dma_start_task(%[[A1]])
+// CHECK: %[[B1:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: aiex.dma_start_task(%[[B1]])
+// CHECK: %[[A2:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: aiex.dma_start_task(%[[A2]])
+// CHECK: %[[B2:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: aiex.dma_start_task(%[[B2]])
+// CHECK: %[[A3:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: aiex.dma_start_task(%[[A3]])
+// CHECK: %[[B3:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: aiex.dma_start_task(%[[B3]])
+// The fifth of each channel is the first that must wait: it may not start until
+// the task four back has retired.
+// CHECK: %[[A4:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: aiex.dma_await_task(%[[A0]])
+// CHECK: aiex.dma_start_task(%[[A4]])
+// CHECK: %[[B4:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: aiex.dma_await_task(%[[B0]])
+// CHECK: aiex.dma_start_task(%[[B4]])
+// CHECK: %[[A5:.*]] = aiex.dma_configure_task_for @chanA
+// CHECK: aiex.dma_await_task(%[[A1]])
+// CHECK: aiex.dma_start_task(%[[A5]])
+// CHECK: %[[B5:.*]] = aiex.dma_configure_task_for @chanB
+// CHECK: aiex.dma_await_task(%[[B1]])
+// CHECK: aiex.dma_start_task(%[[B5]])
+// An awaited task is freed by its await, so it must not also be freed here.
+// CHECK-NOT: aiex.dma_free_task(%[[A0]])
+// CHECK-NOT: aiex.dma_free_task(%[[B0]])
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %shim_noc_tile_1_0 = aie.tile(1, 0)
+    aie.shim_dma_allocation @chanA(%shim_noc_tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @chanB(%shim_noc_tile_1_0, MM2S, 0)
+  } {sym_name = "burst_seg"}
+  airrt.module_metadata{}
+  func.func @burst(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %p = airrt.segment_load "burst_seg" : i64
+    %0 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %1 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %2 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %3 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %4 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %5 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %6 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %7 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %8 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %9 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %10 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %11 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @chanB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    airrt.wait_all %0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11
+    return
+  }
+}
+
+// -----
+
+// A burst that already fits stays exactly as emitted: no weave, no awaits, no
+// issue_token. Three feeds per channel, under the limit of 4.
+
+// CHECK-LABEL: aie.runtime_sequence @short_burst
+// CHECK-NOT: issue_token
+// CHECK-NOT: aiex.dma_await_task
+// CHECK: %[[S0:.*]] = aiex.dma_configure_task_for @shortA
+// CHECK: aiex.dma_start_task(%[[S0]])
+// CHECK: %[[S1:.*]] = aiex.dma_configure_task_for @shortA
+// CHECK: aiex.dma_start_task(%[[S1]])
+// CHECK: %[[S2:.*]] = aiex.dma_configure_task_for @shortA
+// CHECK: aiex.dma_start_task(%[[S2]])
+// CHECK: %[[T0:.*]] = aiex.dma_configure_task_for @shortB
+// CHECK: aiex.dma_start_task(%[[T0]])
+module {
+  aie.device(npu1) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %shim_noc_tile_1_0 = aie.tile(1, 0)
+    aie.shim_dma_allocation @shortA(%shim_noc_tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @shortB(%shim_noc_tile_1_0, MM2S, 0)
+  } {sym_name = "short_seg"}
+  airrt.module_metadata{}
+  func.func @short_burst(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %p = airrt.segment_load "short_seg" : i64
+    %0 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %1 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %2 = airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortA} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %3 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %4 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %5 = airrt.dma_memcpy_nd(%c3_i32, %c0_i64, %c0_i64, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @shortB} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    airrt.wait_all %0, %1, %2, %3, %4, %5
+    return
+  }
+}

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -14,6 +14,7 @@ import air.compiler.util
 # This was previously done as a side effect of importing aircc.main.
 from air.dialects import air as _air_dialect  # noqa: F401
 
+import functools
 import numpy as np
 import os
 import shutil
@@ -91,6 +92,22 @@ class XRTCompileArtifact:
         self.txn_header = txn_header
 
 
+@functools.lru_cache(maxsize=1)
+def _ert_completed_state():
+    """The `ERT_CMD_STATE_COMPLETED` enumerator, or None if unavailable.
+
+    pyxrt is imported lazily -- it is needed for load(), not for compile() -- so
+    this cannot be resolved at module scope. Cached because `_check_run_state`
+    runs inside the timed region of a perf-iteration loop.
+    """
+    try:
+        import pyxrt
+
+        return getattr(pyxrt.ert_cmd_state, "ERT_CMD_STATE_COMPLETED", None)
+    except ImportError:
+        return None
+
+
 def _check_run_state(state):
     """Raise unless the kernel run completed.
 
@@ -100,16 +117,9 @@ def _check_run_state(state):
     sees a partially written buffer with no indication anything went wrong. A
     device-side deadlock then reads as a numerical failure (Xilinx/mlir-air#1822).
     """
-    # pyxrt is imported lazily -- it is needed for load(), not for compile() --
-    # so resolve the enum here rather than at module scope.
-    try:
-        import pyxrt
-
-        completed = getattr(pyxrt.ert_cmd_state, "ERT_CMD_STATE_COMPLETED", None)
-    except ImportError:
-        completed = None
     # Older bindings return None from wait(); treat an unavailable status as "no
     # status" rather than inventing a failure.
+    completed = _ert_completed_state()
     if state is None or completed is None or state == completed:
         return
     raise AirBackendError(f"NPU kernel run did not complete: {state}")

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -91,6 +91,30 @@ class XRTCompileArtifact:
         self.txn_header = txn_header
 
 
+def _check_run_state(state):
+    """Raise unless the kernel run completed.
+
+    `wait2()` and `wait()` return an ert_cmd_state rather than raising, so a run
+    the driver timed out or aborted is otherwise indistinguishable from a
+    successful one: the output BOs get synced back and returned, and the caller
+    sees a partially written buffer with no indication anything went wrong. A
+    device-side deadlock then reads as a numerical failure (Xilinx/mlir-air#1822).
+    """
+    # pyxrt is imported lazily -- it is needed for load(), not for compile() --
+    # so resolve the enum here rather than at module scope.
+    try:
+        import pyxrt
+
+        completed = getattr(pyxrt.ert_cmd_state, "ERT_CMD_STATE_COMPLETED", None)
+    except ImportError:
+        completed = None
+    # Older bindings return None from wait(); treat an unavailable status as "no
+    # status" rather than inventing a failure.
+    if state is None or completed is None or state == completed:
+        return
+    raise AirBackendError(f"NPU kernel run did not complete: {state}")
+
+
 class XRTBackend(AirBackend):
     """Main entry-point for the xrt based AIR backend."""
 
@@ -678,16 +702,16 @@ class XRTBackend(AirBackend):
                     # after n_warmup_iters warmup runs (buffer sync excluded).
                     for _ in range(self.n_warmup_iters):
                         run.start()
-                        run.wait2()
+                        _check_run_state(run.wait2())
                     t0 = time.perf_counter()
                     for _ in range(self.n_perf_iters):
                         run.start()
-                        run.wait2()
+                        _check_run_state(run.wait2())
                     t1 = time.perf_counter()
                     self.last_latency_us = (t1 - t0) / self.n_perf_iters * 1e6
                 else:
                     run.start()
-                    run.wait2()
+                    _check_run_state(run.wait2())
 
                 for i in range(len(args)):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
@@ -777,15 +801,23 @@ class XRTBackend(AirBackend):
                     # n_perf_iters after n_warmup_iters warmup runs (buffer sync
                     # excluded — matches the C++ test-harness timing range).
                     for _ in range(self.n_warmup_iters):
-                        self.kernel(3, self.bo_instr, len(self.instr_v), *bos).wait()
+                        _check_run_state(
+                            self.kernel(
+                                3, self.bo_instr, len(self.instr_v), *bos
+                            ).wait()
+                        )
                     t0 = time.perf_counter()
                     for _ in range(self.n_perf_iters):
-                        self.kernel(3, self.bo_instr, len(self.instr_v), *bos).wait()
+                        _check_run_state(
+                            self.kernel(
+                                3, self.bo_instr, len(self.instr_v), *bos
+                            ).wait()
+                        )
                     t1 = time.perf_counter()
                     self.last_latency_us = (t1 - t0) / self.n_perf_iters * 1e6
                 else:
                     h = self.kernel(3, self.bo_instr, len(self.instr_v), *bos)
-                    h.wait()
+                    _check_run_state(h.wait())
 
                 for i in range(len(args)):
                     bos[i].sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)


### PR DESCRIPTION
Fixes #1822.

`air-opt-shim-dma-bds` tiles the shim `scf.for` nest by `--air-runtime-loop-tiling-sizes` and unrolls the tiled inner loops, so the number of feed puts emitted back to back is the tile volume times the per-iteration feed count. `airrt-to-npu` then emits that run **channel-major** — every task for A, then every task for B — with nothing bounding how many one channel may have in flight.

A shim channel absorbs 6: its DMA task queue (4 entries on AIE2) plus an L2 ping-pong. A push past that is dropped rather than deferred, so the chunk is never sent, its consumer never advances, and the design deadlocks. The host times out at the driver's ~6.1 s deadline and — because the run status was discarded — got a partially written buffer back as if it had succeeded.

The tiling factor alone flips it (2x2 herd, 16 launch iterations, one feed task per iteration per channel):

| `runtime_loop_tiling_sizes` | tile volume | in flight / channel | before | after |
|---|---|---|---|---|
| `[1,1]` | 1 | 1 | 2.8 ms, 100% | 3.8 ms, 100% |
| `[2,2]` | 4 | 4 | 3.1 ms, 100% | 2.4 ms, 100% |
| `[4,4]` | 16 | 16 | **6092 ms, 37.5%** | **2.1 ms, 100%** |

Sweeping in-flight depth directly, the boundary is exactly 6: ≤ 6 completes, ≥ 7 hangs, independent of the output drain's structure, the output dtype and the launch count.

## Where the fix goes, and why

After the wrap-stride fold, which normally re-collapses the unrolled copies into one multi-D BD — that is why this is rare in practice, and why clamping the tile volume inside `air-opt-shim-dma-bds` would be the wrong move: that pass runs *before* the fold, so it cannot tell whether the copies it is about to create will survive, and clamping there would pessimize the majority of designs the fold rescues to protect the minority it does not. `airrt-to-npu` is the first point that knows the true post-fold count.

Two things are needed there, and both are load-bearing:

- **Interleave** the burst round-robin over the channels it feeds. Channel-major order otherwise lets A consume the whole budget before B is fed at all, and the awaits below could then never retire. Interleaving alone is **not** a fix — a perfect A/B/A/B weave at 16 deep still hangs, because the overflow is per channel and absolute.
- **Cap** each channel's in-flight set: await task `i-4` before starting task `i`. The awaited config gains `issue_token` (an MM2S task issues no completion token by default) and loses the fire-and-free that an await would double.

Only bursts that exceed the limit are touched. Feeds whose position is already load-bearing — `air.runtime_hoist`, `air.preserve_shim_dma_order`, `air.coalesced_shim_feed`, the append-barrier pair — fence a burst rather than joining it, so this never overlaps the pacing added in #1810.

## Also: check the run completion status

`wait2()` / `wait()` return an `ert_cmd_state` rather than raising, so a timed-out run was indistinguishable from a successful one: the output BOs were synced back and returned. That is why the deadlock above presented as wrong numbers instead of an error, and it cost real debugging time. A timeout now raises `AirBackendError`. Verified by reverting the compiler fix and re-running the hanging configuration: `AirBackendError: NPU kernel run did not complete: ert_cmd_state.ERT_CMD_STATE_TIMEOUT`.

## Testing

- Every previously hanging configuration passes, including `[4,4]` and 7 / 8 / 16 in flight — 12 device configurations across shape, `TILE_K_L2`, `K`, tiling factor and drain structure.
- `check-air-mlir` 504 pass (the 5 failures are pre-existing and unrelated — none invokes `airrt-to-npu`); `check-air-python` 10 pass.
- New lit test covers both directions: a two-channel burst over the limit comes back woven with depth-4 awaits, `issue_token` set on the awaited configs and their frees dropped; a burst that already fits is left exactly as emitted.
- **Inert on the tuned LLM decoders.** It fires on none of the four q4/q4nx models' builds — llama-3.2-1B, llama-3.2-3B, gemma3-4B, qwen2.5-3B, prefill and decode, at context 2048 and 16384 — so `insts.bin` comes out byte-identical with the pass on and off, and all four `make verify` gates pass. Byte-identical instructions are a stronger no-regression argument than a throughput measurement on a shared machine.

## Open

The limit is 4 (the queue depth) while the measured absorption is 6; the conservative number keeps the bound independent of what the consumer buffers. Single-channel bursts are capped too, on the same reasoning, but no design in tree exercises that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
