### PR TITLE
[CI] Sweep decode tok/s against context for the four fused-decode models

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -142,6 +142,12 @@ jobs:
           test -f /tmp/llmperf/perf.json \
             && echo "perf.json fetched" \
             || echo "no nightly perf artifact with perf.json available"
+          # sweep.json rides in the same artifact but is younger than perf.json,
+          # so an older nightly may have one and not the other. Its absence just
+          # drops the tok/s-vs-context table; the rest of the page still builds.
+          test -f /tmp/llmperf/sweep.json \
+            && echo "sweep.json fetched" \
+            || echo "no sweep.json in that artifact; context table omitted"
 
       # Pull the append-only time series from the durable `perf-history` branch
       # (accumulated by nightlyPerfBenchmark.yml). Best-effort: if the branch
@@ -173,6 +179,7 @@ jobs:
           python3 programming_examples/generate_readme.py \
             --section llm --base-url "$BASE" \
             --llm-perf /tmp/llmperf/perf.json \
+            --llm-sweep /tmp/llmperf/sweep.json \
             --output docs/llms/index.md
           python3 programming_examples/generate_perf_history.py \
             --embed --history /tmp/llmperf_history/history.ndjson \

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -23,6 +23,16 @@ on:
   schedule:
     - cron: '17 4 * * *'  # Daily at 04:17 (off-:00 to avoid CI fleet pile-up)
   workflow_dispatch:
+    inputs:
+      suites:
+        description: >-
+          Comma-separated lit suites to run: verify, profile, sweep. Defaults to
+          all three, which is what the schedule runs. Narrow it to iterate on one
+          suite without paying for the others -- a full run is ~4h, sweep alone is
+          ~25 min. A narrowed run does NOT publish (see below), because its
+          perf.json is partial by construction.
+        default: verify,profile,sweep
+        type: string
 
 defaults:
   run:
@@ -323,19 +333,29 @@ jobs:
 
           rc=0
           pushd build_assert
-          # Correctness gate (strict): red if any model's verify fails.
-          LIT_OPTS="--timeout 1800 --xunit-xml-output $OLDPWD/verify.xml" \
-            ninja check-programming-examples-llms-verify || rc=1
-          # Perf capture: writes <model>.perf.json under test/llms/<model>/.
-          LIT_OPTS="--timeout 1800" \
-            ninja check-programming-examples-llms-profile || rc=1
+          SUITES="${{ github.event.inputs.suites || 'verify,profile,sweep' }}"
+          echo "running suites: $SUITES"
+          want() { case ",$SUITES," in *",$1,"*) return 0;; *) return 1;; esac; }
+
+          if want verify; then
+            # Correctness gate (strict): red if any model's verify fails.
+            LIT_OPTS="--timeout 1800 --xunit-xml-output $OLDPWD/verify.xml" \
+              ninja check-programming-examples-llms-verify || rc=1
+          fi
+          if want profile; then
+            # Perf capture: writes <model>.perf.json under test/llms/<model>/.
+            LIT_OPTS="--timeout 1800" \
+              ninja check-programming-examples-llms-profile || rc=1
+          fi
           # Decode tok/s vs context, for the four fused-decode models: writes
           # <model>.sweep.json alongside. The profile capture above measures one
           # point at the profile prompt's ~6 tokens of context, which is the
           # flattering end of a ~12x range and cannot see a KV-path regression.
           # Each sweep is ~4-5 min (a template build per context).
-          LIT_OPTS="--timeout 3600" \
-            ninja check-programming-examples-llms-sweep || rc=1
+          if want sweep; then
+            LIT_OPTS="--timeout 3600" \
+              ninja check-programming-examples-llms-sweep || rc=1
+          fi
           popd
           exit $rc
 
@@ -465,7 +485,10 @@ jobs:
       # Best-effort: never reds the benchmark job. The nightly concurrency group
       # serializes runs, so there is no push race on the branch.
       - name: Append perf history
-        if: always() && hashFiles('perf.json') != ''
+        # Only from a FULL run. A suite-narrowed dispatch produces a perf.json
+        # that is partial by construction, and history.ndjson is append-only --
+        # a short row set there is indistinguishable from models disappearing.
+        if: always() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -552,7 +575,10 @@ jobs:
       # and the page only ever refreshed on an unrelated push to main. Best-
       # effort: never fails the benchmark job if the dispatch call errors.
       - name: Refresh docs page
-        if: always() && hashFiles('perf.json') != ''
+        # Full runs only, same reason: generateDocs picks the newest nightly
+        # artifact, so publishing a narrowed run would blank most of the
+        # dashboard until the next scheduled run repaired it.
+        if: always() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -329,6 +329,13 @@ jobs:
           # Perf capture: writes <model>.perf.json under test/llms/<model>/.
           LIT_OPTS="--timeout 1800" \
             ninja check-programming-examples-llms-profile || rc=1
+          # Decode tok/s vs context, for the four fused-decode models: writes
+          # <model>.sweep.json alongside. The profile capture above measures one
+          # point at the profile prompt's ~6 tokens of context, which is the
+          # flattering end of a ~12x range and cannot see a KV-path regression.
+          # Each sweep is ~4-5 min (a template build per context).
+          LIT_OPTS="--timeout 3600" \
+            ninja check-programming-examples-llms-sweep || rc=1
           popd
           exit $rc
 
@@ -428,6 +435,27 @@ jobs:
           recs.sort(key=lambda r: r["model"])
           json.dump(recs, open("perf.json", "w"), indent=2)
           print(json.dumps(recs, indent=2))
+
+          # Decode tok/s-vs-context sweeps, kept in their own file rather than
+          # folded into perf.json: a sweep is a curve, not a scalar, and
+          # history.ndjson's one-row-per-model shape cannot hold one. The four
+          # models that have a sweep are published from this file instead of the
+          # perf.json table (generate_readme.py drops them from the latter).
+          sweeps = []
+          for f in sorted(glob.glob("build_assert/test/llms/**/*.sweep.json", recursive=True)):
+              d = json.load(open(f))
+              d["runner"] = "amdryzenai5pro340"
+              d["toolchain"] = {
+                  "mlir_air_sha": air_sha,
+                  "mlir_aie_hash": aie_hash,
+                  "llvm_aie_version": peano_ver,
+              }
+              d["verify_status"] = vstatus.get(d["model"], "")
+              sweeps.append(d)
+          sweeps.sort(key=lambda r: r["model"])
+          json.dump(sweeps, open("sweep.json", "w"), indent=2)
+          print(f"{len(sweeps)} sweep(s):",
+                ", ".join(f"{s['model']}({len(s['points'])} pts)" for s in sweeps))
           PY
 
       # Append this run's datapoints to the durable `perf-history` branch so the
@@ -462,9 +490,21 @@ jobs:
             --perf perf.json \
             --history "$workdir/history.ndjson" \
             --run-id "${{ github.run_id }}"
+          # Sweeps go to their own series. Kept separate from history.ndjson so
+          # the existing one-row-per-model time series keeps its shape and its
+          # continuity -- every row in it predates the sweep and was taken at
+          # ~6 tokens of context, so folding curve points in would silently
+          # change what the plotted number means.
+          if [ -f sweep.json ]; then
+            python3 programming_examples/llms/bench/append_history.py \
+              --sweep sweep.json \
+              --history "$workdir/sweep_history.ndjson" \
+              --run-id "${{ github.run_id }}"
+          fi
           pushd "$workdir"
           if [ -n "$(git status --porcelain)" ]; then
             git add history.ndjson
+            [ -f sweep_history.ndjson ] && git add sweep_history.ndjson
             git commit -m "perf-history: nightly ${{ github.sha }} run ${{ github.run_id }}"
             git push origin HEAD:perf-history
           else
@@ -499,6 +539,7 @@ jobs:
           name: perf-${{ github.run_id }}
           path: |
             perf.json
+            sweep.json
             perf_out/
             verify.xml
 

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -162,4 +162,19 @@ add_lit_testsuite(check-programming-examples-llms-profile
 )
 set_target_properties(check-programming-examples-llms-profile PROPERTIES FOLDER "Tests")
 
+# LLM decode-throughput sweep: tok/s against context length, for the four
+# fused-decode models only (the others have no bench_decode path). The profile
+# suite above captures one point, at the profile prompt's ~6 tokens of context;
+# decode throughput is dominated by KV streaming and falls ~12x from 1k to 128k,
+# so that point cannot see a KV-path regression. This walks the axis.
+# Decode-only and synthetic — latency, never correctness. Sequential (-j1) for
+# the same NPU-OOM reason; driven by the nightly perf workflow.
+add_lit_testsuite(check-programming-examples-llms-sweep
+  "Running LLM decode tok/s-vs-context sweeps (fused-decode models, sequential)"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TEST_DEPENDS}
+  ARGS ${AIR_TEST_LIT_ARGS} -j1 --filter "llms/.*/run_npu2_sweep"
+)
+set_target_properties(check-programming-examples-llms-sweep PROPERTIES FOLDER "Tests")
+
 add_dependencies(check-all check-programming-examples)

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -570,7 +570,14 @@ def load_llm_sweeps(sweep_path):
         recs = json.loads(p.read_text())
     except (json.JSONDecodeError, OSError):
         return []
-    return recs or []
+    # The combined artifact is a list of per-model records. A single per-model
+    # <model>.sweep.json is a dict and is an easy thing to point this at by
+    # mistake; iterating one yields its keys as strings and blows up further
+    # down, so reject the shape here and just drop the table.
+    if not isinstance(recs, list):
+        print(f"warning: {p} is not a list of sweep records; ignoring it")
+        return []
+    return [r for r in recs if isinstance(r, dict)]
 
 
 def render_llm_sweep(recs, base_url=""):

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -586,9 +586,9 @@ def render_llm_sweep(recs, base_url=""):
     These four models are published here instead of in the single-point table:
     decode throughput is dominated by KV streaming and falls by more than 10x
     across this axis, so one number cannot represent them. A blank cell is a
-    context the model does not reach -- at 64k/128k the larger KV caches exceed
-    what XRT will pin as host memory -- which is a real ceiling worth showing
-    rather than a gap to hide.
+    context this runner did not reach, which at 64k/128k means XRT would not pin
+    enough host memory for the KV BO -- a property of the machine rather than of
+    the design, and worth showing rather than hiding.
     """
     if not recs:
         return ""
@@ -634,7 +634,7 @@ Verify column, which comes from the same nightly's `make verify`).
 {sep}
 {chr(10).join(rows)}
 
-— context not reached on this runner (the KV cache exceeds what XRT will pin as host memory)
+— context not reached on this runner (XRT would not pin enough host memory for the KV cache; the limit is the machine's, not the design's)
 """
 
 

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -554,7 +554,86 @@ def _llm_model_cell(model, base_url):
     return name_link
 
 
-def render_llm_benchmark(perf_path, base_url="", perf_history_link="perf-history.html"):
+def _ctx_label(n):
+    """1024 -> '1k', 131072 -> '128k'."""
+    return f"{n // 1024}k" if n and n % 1024 == 0 else str(n)
+
+
+def load_llm_sweeps(sweep_path):
+    """Read sweep.json (list of per-model tok/s-vs-context curves), or []."""
+    if not sweep_path:
+        return []
+    p = Path(sweep_path)
+    if not p.is_file():
+        return []
+    try:
+        recs = json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    return recs or []
+
+
+def render_llm_sweep(recs, base_url=""):
+    """Render decode tok/s against context length, one row per model.
+
+    These four models are published here instead of in the single-point table:
+    decode throughput is dominated by KV streaming and falls by more than 10x
+    across this axis, so one number cannot represent them. A blank cell is a
+    context the model does not reach -- at 64k/128k the larger KV caches exceed
+    what XRT will pin as host memory -- which is a real ceiling worth showing
+    rather than a gap to hide.
+    """
+    if not recs:
+        return ""
+
+    ctxs = sorted(
+        {
+            pt.get("context_len")
+            for d in recs
+            for pt in d.get("points", []) or []
+            if pt.get("context_len")
+        }
+    )
+    if not ctxs:
+        return ""
+
+    head = "| Model | " + " | ".join(_ctx_label(c) for c in ctxs) + " | Verify |"
+    sep = "|:------|" + "".join("------:|" for _ in ctxs) + ":------:|"
+
+    rows = []
+    for d in sorted(recs, key=lambda r: r.get("model", "")):
+        by_ctx = {pt.get("context_len"): pt for pt in d.get("points", []) or []}
+        cells = []
+        for c in ctxs:
+            pt = by_ctx.get(c) or {}
+            tps = pt.get("decode_tokens_per_sec")
+            cells.append(f"{tps:.2f}" if isinstance(tps, (int, float)) else "—")
+        verify = _VERIFY_EMOJI.get(d.get("verify_status", ""), "")
+        rows.append(
+            f'| {_llm_model_cell(d.get("model", ""), base_url)} | '
+            + " | ".join(cells)
+            + f" | {verify} |"
+        )
+
+    return f"""
+
+### Decode throughput vs context (tok/s)
+
+Steady-state decode, measured against KV-cache depth rather than at a single
+context. Decode-only and synthetic: latency, not correctness (correctness is the
+Verify column, which comes from the same nightly's `make verify`).
+
+{head}
+{sep}
+{chr(10).join(rows)}
+
+— context not reached on this runner (the KV cache exceeds what XRT will pin as host memory)
+"""
+
+
+def render_llm_benchmark(
+    perf_path, base_url="", perf_history_link="perf-history.html", sweep_recs=()
+):
     """Render the nightly LLM benchmark section from a perf.json file.
 
     `perf_path` is the JSON produced by nightlyPerfBenchmark.yml (a list of
@@ -577,8 +656,15 @@ def render_llm_benchmark(perf_path, base_url="", perf_history_link="perf-history
     def _fmt(v):
         return "—" if v is None else v
 
+    # Models with a sweep are published in the sweep table below instead; a
+    # single near-zero-context point next to a curve invites reading the two as
+    # comparable numbers, and they are not.
+    swept = {s.get("model") for s in (sweep_recs or ())}
+
     rows = []
     for d in sorted(recs, key=lambda r: r.get("model", "")):
+        if d.get("model") in swept:
+            continue
         m = d.get("metrics", {})
         verify = _VERIFY_EMOJI.get(d.get("verify_status", ""), "")
         rows.append(
@@ -616,6 +702,7 @@ def render_llm_benchmark(perf_path, base_url="", perf_history_link="perf-history
         if s
     )
 
+    _sweep_table = render_llm_sweep(sweep_recs, base_url=base_url)
     table = "\n".join(rows)
     return f"""\
 
@@ -629,6 +716,7 @@ End-to-end LLM inference performance on the AMD Ryzen AI (Krackan Point, NPU2) b
 
 \U0001f7e2 verify passed &nbsp; \U0001f534 verify failed &nbsp; ⚪ verify skipped &nbsp; — metric not captured (e.g. the model's profile run failed)
 
+{_sweep_table}
 \U0001f4c8 [Performance history over time]({perf_history_link}) — per-nightly TTFT and decode throughput plotted per model.
 
 _{provenance}_
@@ -686,7 +774,9 @@ python3 run.py --print-module-only  # print IR only
 """
 
 
-def generate_readme(base_url="", llm_perf_path=None, section="full"):
+def generate_readme(
+    base_url="", llm_perf_path=None, section="full", llm_sweep_path=None
+):
     """Generate dashboard content.
 
     section:
@@ -702,7 +792,10 @@ def generate_readme(base_url="", llm_perf_path=None, section="full"):
 
     if section == "llm":
         llm_section = render_llm_benchmark(
-            llm_perf_path, base_url=base_url, perf_history_link="perf-history.md"
+            llm_perf_path,
+            base_url=base_url,
+            perf_history_link="perf-history.md",
+            sweep_recs=load_llm_sweeps(llm_sweep_path),
         )
         return f"""\
 <!-- This file is auto-generated by generate_readme.py. Do not edit manually. -->
@@ -713,7 +806,9 @@ End-to-end decoder-only LLM inference (prefill + autoregressive decode) mapped t
 {llm_section}"""
 
     # section == "full" (legacy single-page dashboard)
-    llm_section = render_llm_benchmark(llm_perf_path, base_url=base_url)
+    llm_section = render_llm_benchmark(
+        llm_perf_path, base_url=base_url, sweep_recs=load_llm_sweeps(llm_sweep_path)
+    )
     return (
         _operator_dashboard(base_url=base_url) + llm_section + _getting_started_footer()
     )
@@ -741,6 +836,13 @@ if __name__ == "__main__":
         "absent or missing, the LLM benchmark section is omitted.",
     )
     parser.add_argument(
+        "--llm-sweep",
+        default=None,
+        help="Path to the nightly sweep.json (decode tok/s vs context). Models "
+        "present here are rendered as a curve and dropped from the single-point "
+        "table. Omitted when absent.",
+    )
+    parser.add_argument(
         "--section",
         choices=["full", "operators", "llm"],
         default="full",
@@ -750,7 +852,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     content = generate_readme(
-        base_url=args.base_url, llm_perf_path=args.llm_perf, section=args.section
+        base_url=args.base_url,
+        llm_perf_path=args.llm_perf,
+        section=args.section,
+        llm_sweep_path=args.llm_sweep,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(content)

--- a/programming_examples/llms/bench/append_history.py
+++ b/programming_examples/llms/bench/append_history.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-"""Append a nightly perf.json into the append-only history.ndjson time series.
+"""Append a nightly perf.json / sweep.json into an append-only ndjson series.
 
 The nightly LLM benchmark (nightlyPerfBenchmark.yml) produces a per-run
 `perf.json` (a list of per-model records). This flattens each record into one
@@ -11,8 +11,15 @@ Idempotent on run_id: if any row for this run_id already exists, nothing is
 appended, so re-running the *same* workflow run does not double-count. (A newly
 dispatched run gets a fresh run_id and is treated as new data, as intended.)
 
+The two series are kept in separate files. history.ndjson is one row per model
+per run and every row in it was taken at the profile prompt's ~6 tokens of
+context; sweep_history.ndjson is one row per (model, context) per run. Folding
+the sweep into the first would silently change what the plotted number means
+partway through the series, which reads as a step change that never happened.
+
 Usage:
-  python3 append_history.py --perf perf.json --history history.ndjson --run-id 123
+  python3 append_history.py --perf  perf.json  --history history.ndjson       --run-id 123
+  python3 append_history.py --sweep sweep.json --history sweep_history.ndjson --run-id 123
 """
 
 import argparse
@@ -42,6 +49,32 @@ def _flat_rows(recs, run_id):
         }
 
 
+def _flat_sweep_rows(recs, run_id):
+    """Yield one flat history row per (model, context) sweep point.
+
+    Points that did not produce a number are still emitted, with a null metric
+    and their status, so a context that starts failing is visible in the series
+    rather than the curve just getting shorter.
+    """
+    for d in recs:
+        tc = d.get("toolchain", {}) or {}
+        ts = d.get("timestamp_utc", "") or ""
+        for pt in d.get("points", []) or []:
+            yield {
+                "date": ts[:10],
+                "timestamp_utc": ts,
+                "run_id": run_id,
+                "air_sha": tc.get("mlir_air_sha", ""),
+                "aie_hash": tc.get("mlir_aie_hash", ""),
+                "peano": tc.get("llvm_aie_version", ""),
+                "model": d.get("model", ""),
+                "context_len": pt.get("context_len"),
+                "decode_tokens_per_sec": pt.get("decode_tokens_per_sec"),
+                "ms_per_token": pt.get("ms_per_token"),
+                "status": pt.get("status", ""),
+            }
+
+
 def _existing_run_ids(history_path):
     """Return the set of run_ids already recorded in history.ndjson.
 
@@ -65,7 +98,9 @@ def _existing_run_ids(history_path):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--perf", required=True, help="Path to the nightly perf.json")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--perf", help="Path to the nightly perf.json")
+    src.add_argument("--sweep", help="Path to the nightly sweep.json")
     ap.add_argument(
         "--history", required=True, help="Path to history.ndjson (created if absent)"
     )
@@ -81,26 +116,27 @@ def main():
     except ValueError:
         run_id = args.run_id
 
-    perf_path = Path(args.perf)
-    if not perf_path.is_file():
-        print(f"no perf.json at {perf_path}; nothing to append")
+    src_path = Path(args.perf or args.sweep)
+    flatten = _flat_rows if args.perf else _flat_sweep_rows
+    if not src_path.is_file():
+        print(f"no {src_path.name}; nothing to append")
         return 0
     try:
-        recs = json.loads(perf_path.read_text())
+        recs = json.loads(src_path.read_text())
     except (json.JSONDecodeError, OSError) as e:
-        # Best-effort: a missing/corrupt/partial perf.json should not crash the
-        # CI step (which is itself continue-on-error), just skip this run.
-        print(f"could not read {perf_path} ({e}); nothing to append")
+        # Best-effort: a missing/corrupt/partial input should not crash the CI
+        # step (which is itself continue-on-error), just skip this run.
+        print(f"could not read {src_path} ({e}); nothing to append")
         return 0
     if not recs:
-        print("perf.json is empty; nothing to append")
+        print(f"{src_path.name} is empty; nothing to append")
         return 0
 
     if run_id in _existing_run_ids(args.history):
         print(f"run {run_id} already in history; no change")
         return 0
 
-    rows = list(_flat_rows(recs, run_id))
+    rows = list(flatten(recs, run_id))
     hist = Path(args.history)
     hist.parent.mkdir(parents=True, exist_ok=True)
     with hist.open("a") as f:

--- a/programming_examples/llms/bench/bench_qwen_decode.py
+++ b/programming_examples/llms/bench/bench_qwen_decode.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Decode-latency bench for the qwen2.5-3B fused decode.
+
+bench_decode.exe cannot be reused: qwen binds 4 data BOs in a different order
+(x, w, kv, y -- no separate rms BO) than the llama/gemma path (x, w, rms, y, kv).
+Argument order and every BO size are taken verbatim from the production
+hand-off driver (fused_decode/qwen_prefill_to_decode.py:183-186, :245), so
+nothing here is hand-derived.
+
+Synthetic contents -- LATENCY ONLY, never a correctness gate, same caveat as
+bench_decode.cpp. Reports the device dispatch span (the comparable number) and,
+separately, the per-token host KV-window upload this design needs and the
+llama/gemma device-append design does not.
+"""
+
+import os, sys, time, importlib
+
+sys.path.insert(
+    0, str(__import__("pathlib").Path(__file__).resolve().parents[2] / "fused_decode")
+)
+ctx = int(sys.argv[1])
+nl = int(os.environ.get("QWEN_NLAYERS", "36"))
+d = sys.argv[2]
+iters = int(sys.argv[3]) if len(sys.argv) > 3 else 32
+warm = 8
+os.environ.update(ATTN_L=str(ctx), QWEN_NLAYERS=str(nl), W_DUAL_CHAN="1")
+import numpy as np, pyxrt as xrt
+from ml_dtypes import bfloat16
+
+m = importlib.import_module("fused_decode_qwen")
+
+X = max(m.X_CHUNKS * 2 * m.COL_BLOCK, nl * m.XLAYER)
+WSZ = nl * m.W_LAYER
+KVL = m.N_ATTN_CU * 2 * m.ATTN_ROUNDS * m.KVBLK
+KVN = nl * KVL
+YN = max(m.DEST_TOTAL * m.PAYLOAD, m.K + m.DQ)
+print(
+    f"  geometry: ATTN_MAXL={m.ATTN_MAXL} X={X} W={WSZ} KV={KVN} ({KVN*2/2**20:.0f} MiB) Y={YN}"
+)
+
+dev = xrt.device(0)
+xb = xrt.xclbin(f"{d}/decode_L{ctx}.xclbin")
+dev.register_xclbin(xb)
+hwc = xrt.hw_context(dev, xb.get_uuid())
+kern = xrt.kernel(
+    hwc, [q for q in xb.get_kernels() if "MLIR_AIE" in q.get_name()][0].get_name()
+)
+g, HO = kern.group_id, xrt.bo.host_only
+x_bo = xrt.bo(dev, X * 2, HO, g(3))
+w_bo = xrt.bo(dev, WSZ * 2, HO, g(4))
+kv_bo = xrt.bo(dev, KVN * 2, HO, g(5))
+y_bo = xrt.bo(dev, YN * 2, HO, g(6))
+insts = np.fromfile(f"{d}/decode_L{ctx}.insts.bin", dtype=np.uint32)
+ib = xrt.bo(dev, insts.nbytes, xrt.bo.cacheable, g(1))
+ib.write(insts, 0)
+ib.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+one = np.full(1, 1.0, bfloat16).view(np.uint16)[0]
+for bo, n in ((x_bo, X), (w_bo, WSZ), (kv_bo, KVN)):
+    bo.write(np.full(n, one, np.uint16), 0)
+    bo.sync(TO)
+kvd = np.full(KVN, one, np.uint16)
+
+disp, upl = [], []
+for i in range(warm + iters):
+    t0 = time.perf_counter()
+    kv_bo.write(kvd, 0)
+    kv_bo.sync(TO)
+    x_bo.sync(TO)
+    t1 = time.perf_counter()
+    st = kern(3, ib, insts.size, x_bo, w_bo, kv_bo, y_bo).wait(60000)
+    if "COMPLETED" not in str(st):
+        print(f"DISPATCH DID NOT COMPLETE: state={st}")
+        sys.exit(1)
+    t2 = time.perf_counter()
+    if i >= warm:
+        upl.append((t1 - t0) * 1e3)
+        disp.append((t2 - t1) * 1e3)
+mean = sum(disp) / len(disp)
+sd = (sum((v - mean) ** 2 for v in disp) / len(disp)) ** 0.5
+um = sum(upl) / len(upl)
+print(
+    f"  ctx {ctx:<6} dispatch {mean:8.3f} ms  sd {sd:.3f}  min {min(disp):.3f}  "
+    f"({1000/mean:.2f} tok/s)   + host KV upload {um:.1f} ms -> {1000/(mean+um):.2f} tok/s e2e"
+)
+print(
+    f"CSV,{ctx},{mean:.3f},{sd:.3f},{min(disp):.3f},{1000/mean:.2f},{um:.3f},{1000/(mean+um):.2f}"
+)

--- a/programming_examples/llms/bench/bench_qwen_decode.py
+++ b/programming_examples/llms/bench/bench_qwen_decode.py
@@ -22,7 +22,10 @@ ctx = int(sys.argv[1])
 nl = int(os.environ.get("QWEN_NLAYERS", "36"))
 d = sys.argv[2]
 iters = int(sys.argv[3]) if len(sys.argv) > 3 else 32
-warm = 8
+# Warmup is an argument, not a constant, because sweep_decode.py records it in
+# the emitted run_params: hard-coding it here would make that metadata describe
+# a run that did not happen.
+warm = int(sys.argv[4]) if len(sys.argv) > 4 else 8
 os.environ.update(ATTN_L=str(ctx), QWEN_NLAYERS=str(nl), W_DUAL_CHAN="1")
 import numpy as np, pyxrt as xrt
 from ml_dtypes import bfloat16

--- a/programming_examples/llms/bench/decode_geometry.py
+++ b/programming_examples/llms/bench/decode_geometry.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Emit `bench_decode.exe` BO-geometry flags for a model at a given ATTN_MAXL.
+
+bench_decode.cpp hard-codes llama-3.2-1B at L=2048. Every other (model, context)
+cell needs its BO sizes passed in, and getting one wrong does not fail loudly --
+it benches a differently shaped dispatch and reports a plausible number. So the
+sizes are not restated here: this imports the production builder
+(`fused_decode.py`) with the same environment the driver uses and reads them off
+it, mirroring the driver's own sizing:
+
+    x   K
+    w   W.size                                    (from the requant cache)
+    r   UNI_DEC*RMS_LAYER + 64 + K, LUT at UNI_DEC*RMS_LAYER
+    y   (HOST_ROUNDS+LAYER_RNDS)*PAYLOAD + UNI_LM*VOCAB_SIZE_PADDED
+    kv  UNI_DEC*ATTN_MAXL*KVSZ_TOK
+
+`--check` reproduces bench_decode.cpp's built-in defaults from the same code
+path, which is what licenses using this for the other models. Run it whenever
+the builder's BO sizing changes.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+FUSED_DECODE = Path(__file__).resolve().parents[2] / "fused_decode"
+
+# bench_decode.cpp's built-in defaults, i.e. llama-3.2-1B at ATTN_MAXL=2048.
+# VOCAB_CHUNK_I2=18 and w_elems are that model's, from its lit/Makefile.
+_CHECK_MODEL = dict(model="llama-3.2-1b", i2="18", ctx=2048, w_elems=386662400)
+_CHECK_WANT = dict(
+    k=2048,
+    w_elems=386662400,
+    rms_size=67648,
+    ny=134144,
+    kv_elems=33554432,
+    decode_y=5120,
+    voc_n=129024,
+    rms_lut_off=65536,
+)
+
+
+def geometry(model, vocab_chunk_i2, ctx, w_elems):
+    """Import the builder at this context and read its BO sizes back out."""
+    os.environ.update(
+        DECODE_MODEL=model,
+        VOCAB_CHUNK_I2=str(vocab_chunk_i2),
+        LM_HEAD="0",
+        NLAYERS="1",
+        DECODE_GOLDEN="1",
+        UNIFIED="1",
+        DECODE_GOLDEN_L=str(ctx),
+        W_DUAL_CHAN="1",
+    )
+    # fused_decode.py imports its siblings (proj_qmm_pack, ...) by bare name.
+    if str(FUSED_DECODE) not in sys.path:
+        sys.path.insert(0, str(FUSED_DECODE))
+    spec = importlib.util.spec_from_file_location(
+        "_fused_decode_geom", FUSED_DECODE / "fused_decode.py"
+    )
+    fd = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fd)
+
+    decode_y = (fd.HOST_ROUNDS + fd.LAYER_RNDS) * fd.PAYLOAD
+    return dict(
+        k=fd.K,
+        w_elems=w_elems,
+        rms_size=fd.UNI_DEC * fd.RMS_LAYER + 64 + fd.K,
+        ny=decode_y + fd.UNI_LM * fd.VOCAB_SIZE_PADDED,
+        kv_elems=fd.UNI_DEC * fd.ATTN_MAXL * fd.KVSZ_TOK,
+        decode_y=decode_y,
+        voc_n=fd.UNI_LM * fd.VOCAB_SIZE_PADDED,
+        rms_lut_off=fd.UNI_DEC * fd.RMS_LAYER,
+    )
+
+
+def as_flags(g):
+    """bench_decode.exe CLI form. ATTN_MAXL is deliberately not emitted -- it is
+    an input to the sizing above, not a flag bench_decode.cpp accepts."""
+    return " ".join(f"--{k.replace('_', '-')} {v}" for k, v in g.items())
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", help="DECODE_MODEL, e.g. llama-3.2-1b")
+    p.add_argument("--vocab-chunk-i2", help="VOCAB_CHUNK_I2 for this model")
+    p.add_argument("--ctx", type=int, help="ATTN_MAXL / decode context")
+    p.add_argument("--w-elems", type=int, help="weight element count")
+    p.add_argument("--json", action="store_true", help="emit JSON, not flags")
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="reproduce bench_decode.cpp's built-in defaults and exit",
+    )
+    a = p.parse_args()
+
+    if a.check:
+        g = geometry(
+            _CHECK_MODEL["model"],
+            _CHECK_MODEL["i2"],
+            _CHECK_MODEL["ctx"],
+            _CHECK_MODEL["w_elems"],
+        )
+        bad = {k: (v, g[k]) for k, v in _CHECK_WANT.items() if g[k] != v}
+        print("SELF-CHECK", "PASS" if not bad else f"FAIL {bad}")
+        return 0 if not bad else 1
+
+    missing = [
+        f
+        for f in ("model", "vocab_chunk_i2", "ctx", "w_elems")
+        if getattr(a, f) is None
+    ]
+    if missing:
+        p.error(
+            "--check, or all of: "
+            + ", ".join("--" + m.replace("_", "-") for m in missing)
+        )
+
+    g = geometry(a.model, a.vocab_chunk_i2, a.ctx, a.w_elems)
+    print(json.dumps(g) if a.json else as_flags(g))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/programming_examples/llms/bench/sweep_decode.py
+++ b/programming_examples/llms/bench/sweep_decode.py
@@ -72,7 +72,18 @@ def _run(cmd, cwd=None, timeout=5400, env=None):
     )
 
 
-def build_templates(makefile, ctx, workdir, template_dir, log):
+def _make_vars(args):
+    """Toolchain overrides to hand `make`, in the same form the other lits use.
+
+    lit supplies these as substitutions rather than in the environment, and the
+    runner shells out to make itself, so without forwarding them every build
+    fails at preflight-peano. The profile/verify lits pass PEANO_INSTALL_DIR on
+    each make line for exactly this reason.
+    """
+    return [f"PEANO_INSTALL_DIR={args.peano_dir}"] if args.peano_dir else []
+
+
+def build_templates(makefile, ctx, workdir, template_dir, log, args):
     """Build the decode_L{ctx} / decode_L{ctx-1} pair and stage it in workdir.
 
     Uses _compile_decode_build, not compile-decode: the latter is idempotent on
@@ -87,7 +98,10 @@ def build_templates(makefile, ctx, workdir, template_dir, log):
                 (d / f"decode_L{l}.{ext}").unlink(missing_ok=True)
     shutil.rmtree(FUSED_DECODE / "air_project", ignore_errors=True)
 
-    r = _run(["make", "-f", str(makefile), "_compile_decode_build", f"LBUILD={ctx}"])
+    r = _run(
+        ["make", "-f", str(makefile), "_compile_decode_build", f"LBUILD={ctx}"]
+        + _make_vars(args)
+    )
     log.write_text(r.stdout + r.stderr)
     if r.returncode != 0:
         err = re.search(
@@ -178,6 +192,11 @@ def main():
         "--workdir", type=Path, default=Path("sweep_out"), help="per-context scratch"
     )
     p.add_argument(
+        "--peano-dir",
+        default="",
+        help="Peano install (lit's %PEANO_INSTALL_DIR), forwarded to make.",
+    )
+    p.add_argument(
         "--xrt-dir",
         default="",
         help="XRT install (lit's %XRT_DIR). bench_decode.exe's build rule needs "
@@ -199,7 +218,8 @@ def main():
             if not env.get("XILINX_XRT") and a.xrt_dir:
                 env["XILINX_XRT"] = a.xrt_dir
             r = _run(
-                ["make", "-f", str(FUSED_DECODE / "Makefile"), "bench-decode-exe"],
+                ["make", "-f", str(FUSED_DECODE / "Makefile"), "bench-decode-exe"]
+                + _make_vars(a),
                 env=env,
             )
             if not BENCH_EXE.exists():
@@ -229,7 +249,7 @@ def main():
         }
 
         xclbin, err = build_templates(
-            a.makefile, ctx, wd, a.template_dir, wd / "build.log"
+            a.makefile, ctx, wd, a.template_dir, wd / "build.log", a
         )
         if err:
             rec.update(status=err.split(":")[0], detail=err)

--- a/programming_examples/llms/bench/sweep_decode.py
+++ b/programming_examples/llms/bench/sweep_decode.py
@@ -93,7 +93,16 @@ def build_templates(makefile, ctx, workdir, template_dir, log):
         err = re.search(
             r"error: .{0,90}|Killed|Cannot allocate|out of memory", r.stdout + r.stderr
         )
-        return None, f"build_fail: {err.group(0) if err else 'see build log'}"
+        if err:
+            return None, f"build_fail: {err.group(0)}"
+        # No recognised pattern: carry the tail of the output, because build.log
+        # stays in the lit working directory and never reaches the artifact.
+        tail = " / ".join(
+            l.strip()
+            for l in (r.stdout + r.stderr).strip().splitlines()[-3:]
+            if l.strip()
+        )
+        return None, f"build_fail: {tail[:300] or 'no output'}"
 
     for l in (ctx, ref):
         for ext in ("xclbin", "insts.bin"):
@@ -165,7 +174,15 @@ def main():
     p.add_argument("--n-layers", type=int, default=36, help="bench_qwen only")
     p.add_argument("--iters", type=int, default=20)
     p.add_argument("--warmup", type=int, default=6)
-    p.add_argument("--workdir", type=Path, default=Path("sweep_out"))
+    p.add_argument(
+        "--workdir", type=Path, default=Path("sweep_out"), help="per-context scratch"
+    )
+    p.add_argument(
+        "--xrt-dir",
+        default="",
+        help="XRT install (lit's %XRT_DIR). bench_decode.exe's build rule needs "
+        "XILINX_XRT set, and the lit environment does not export it.",
+    )
     p.add_argument("--out", required=True, type=Path)
     a = p.parse_args()
 
@@ -178,7 +195,13 @@ def main():
             # `make clean` in any model dir removes this; rebuild rather than
             # letting every cell fail with a shell "No such file" that reads
             # like a device fault.
-            r = _run(["make", "-f", str(FUSED_DECODE / "Makefile"), "bench-decode-exe"])
+            env = dict(os.environ)
+            if not env.get("XILINX_XRT") and a.xrt_dir:
+                env["XILINX_XRT"] = a.xrt_dir
+            r = _run(
+                ["make", "-f", str(FUSED_DECODE / "Makefile"), "bench-decode-exe"],
+                env=env,
+            )
             if not BENCH_EXE.exists():
                 print(
                     f"FATAL: cannot build {BENCH_EXE}\n{r.stdout}{r.stderr}",
@@ -189,6 +212,9 @@ def main():
             if getattr(a, f) is None:
                 p.error(f"--driver bench_decode needs --{f.replace('_', '-')}")
 
+    # Absolute: bench_qwen runs with cwd=fused_decode and bench_decode with
+    # cwd=workdir, so a relative path resolves differently for the two drivers.
+    a.workdir = a.workdir.resolve()
     a.workdir.mkdir(parents=True, exist_ok=True)
     points, seen_md5, hard_fail = [], {}, False
 

--- a/programming_examples/llms/bench/sweep_decode.py
+++ b/programming_examples/llms/bench/sweep_decode.py
@@ -1,0 +1,279 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Sweep fused-decode throughput against context length into JSON.
+
+The nightly benchmark's other capture (`extract_perf.py`) profiles one point,
+and that point is the 6-token prompt the profile lit passes -- i.e. an empty KV
+cache. Decode throughput is dominated by KV streaming, so that single number
+sits at the flattering end of a wide range (llama-3.2-1B measures 68.97 tok/s at
+1k context and 5.77 at 128k) and would not move if the KV path regressed. This
+walks the axis instead.
+
+Decode-only on purpose. A context is set by sizing the KV cache and telling the
+device to attend over it, not by prefilling a real prompt of that length, so a
+32k point costs a template build and a few seconds rather than a 32k prefill.
+Contents are synthetic: this is LATENCY ONLY and never a correctness gate --
+`make verify` is the only correctness gate.
+
+TTFT is deliberately not swept here. It is a prefill measurement and its x-axis
+is prompt length, not KV depth, so it needs a real prompt and belongs in its own
+table.
+
+Per context the run is: build the decode template pair at that ATTN_MAXL, guard
+that the build actually produced a *new* xclbin, then dispatch. Contexts listed
+in --expect-fail may fail without failing the run: at 64k/128k the larger models
+legitimately exhaust the XRT host-memory KV BO, and that ceiling is worth
+recording rather than hiding.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+FUSED_DECODE = HERE.parents[1] / "fused_decode"
+BENCH_EXE = FUSED_DECODE / "bench_decode.exe"
+
+# "[bench] n=20  mean 14.488 ms  sd ...  (69.02 tok/s)"
+BENCH_RE = re.compile(r"^\[bench\].*?mean\s+([\d.]+)\s*ms.*?\(([\d.]+)\s*tok/s\)", re.M)
+# bench_qwen.py's summary line: "CSV,<ctx>,<ms>,...,<tok_s>"
+QWEN_CSV_RE = re.compile(r"^CSV,[^,]*,([\d.]+),[^,]*,[^,]*,([\d.]+)", re.M)
+
+# Device-side "the dispatch did not complete" evidence. Deliberately specific:
+# an earlier version matched a bare "timeout", which also matches the shell's
+# own "timeout: failed to run command ..." when the bench binary is missing, and
+# three models were logged as device failures when the real fault was a deleted
+# executable. A missing binary is now caught up front instead.
+XRT_FAIL_RE = re.compile(
+    r"ERT_CMD_STATE|did not complete|not COMPLETED|command timeout|xrt::error", re.I
+)
+
+
+def _md5(path):
+    return hashlib.md5(path.read_bytes()).hexdigest()[:12]
+
+
+def _run(cmd, cwd=None, timeout=5400, env=None):
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        shell=isinstance(cmd, str),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def build_templates(makefile, ctx, workdir, template_dir, log):
+    """Build the decode_L{ctx} / decode_L{ctx-1} pair and stage it in workdir.
+
+    Uses _compile_decode_build, not compile-decode: the latter is idempotent on
+    a build stamp that does not include the context, so it would skip and leave
+    the previous context's templates in place -- a sweep that benches the same
+    binary eight times.
+    """
+    ref = ctx - 1
+    for l in (ctx, ref):
+        for ext in ("xclbin", "insts.bin"):
+            for d in (workdir, template_dir):
+                (d / f"decode_L{l}.{ext}").unlink(missing_ok=True)
+    shutil.rmtree(FUSED_DECODE / "air_project", ignore_errors=True)
+
+    r = _run(["make", "-f", str(makefile), "_compile_decode_build", f"LBUILD={ctx}"])
+    log.write_text(r.stdout + r.stderr)
+    if r.returncode != 0:
+        err = re.search(
+            r"error: .{0,90}|Killed|Cannot allocate|out of memory", r.stdout + r.stderr
+        )
+        return None, f"build_fail: {err.group(0) if err else 'see build log'}"
+
+    for l in (ctx, ref):
+        for ext in ("xclbin", "insts.bin"):
+            src = template_dir / f"decode_L{l}.{ext}"
+            if not src.exists():
+                return None, f"no_template: {src.name} not produced"
+            shutil.copy2(src, workdir / src.name)
+    return workdir / f"decode_L{ctx}.xclbin", None
+
+
+def bench_decode(workdir, ctx, args):
+    from decode_geometry import as_flags, geometry
+
+    geom = geometry(args.bench_model, args.vocab_chunk_i2, ctx, args.w_elems)
+    cmd = (
+        f"{BENCH_EXE} --dir . --base-l {ctx} --ref-l {ctx - 1} --l {ctx} "
+        f"--iters {args.iters} --warmup {args.warmup} {as_flags(geom)}"
+    )
+    r = _run(cmd, cwd=workdir, timeout=1800)
+    return r.stdout + r.stderr, BENCH_RE.search(r.stdout + r.stderr)
+
+
+def bench_qwen(workdir, ctx, args):
+    env = dict(os.environ, QWEN_NLAYERS=str(args.n_layers), W_DUAL_CHAN="1")
+    r = _run(
+        [
+            sys.executable,
+            str(HERE / "bench_qwen_decode.py"),
+            str(ctx),
+            str(workdir),
+            str(args.iters),
+        ],
+        cwd=FUSED_DECODE,
+        timeout=1800,
+        env=env,
+    )
+    return r.stdout + r.stderr, QWEN_CSV_RE.search(r.stdout + r.stderr)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--model-name", required=True, help="example dir name, e.g. llama32_1b_q4nx"
+    )
+    p.add_argument("--makefile", required=True, type=Path)
+    p.add_argument(
+        "--template-dir",
+        required=True,
+        type=Path,
+        help="where _compile_decode_build leaves decode_L<N>.*",
+    )
+    p.add_argument(
+        "--contexts",
+        required=True,
+        help="comma-separated, e.g. 1024,2048,4096,8192,16384,32768,65536,131072",
+    )
+    p.add_argument(
+        "--expect-fail",
+        default="",
+        help="contexts allowed to fail without failing the run",
+    )
+    p.add_argument(
+        "--driver", choices=("bench_decode", "bench_qwen"), default="bench_decode"
+    )
+    p.add_argument("--bench-model", help="DECODE_MODEL for bench_decode geometry")
+    p.add_argument("--vocab-chunk-i2", help="VOCAB_CHUNK_I2 for bench_decode geometry")
+    p.add_argument("--w-elems", type=int, help="weight element count")
+    p.add_argument("--n-layers", type=int, default=36, help="bench_qwen only")
+    p.add_argument("--iters", type=int, default=20)
+    p.add_argument("--warmup", type=int, default=6)
+    p.add_argument("--workdir", type=Path, default=Path("sweep_out"))
+    p.add_argument("--out", required=True, type=Path)
+    a = p.parse_args()
+
+    sys.path.insert(0, str(HERE))
+    contexts = [int(c) for c in a.contexts.split(",") if c.strip()]
+    expect_fail = {int(c) for c in a.expect_fail.split(",") if c.strip()}
+
+    if a.driver == "bench_decode":
+        if not BENCH_EXE.exists():
+            # `make clean` in any model dir removes this; rebuild rather than
+            # letting every cell fail with a shell "No such file" that reads
+            # like a device fault.
+            r = _run(["make", "-f", str(FUSED_DECODE / "Makefile"), "bench-decode-exe"])
+            if not BENCH_EXE.exists():
+                print(
+                    f"FATAL: cannot build {BENCH_EXE}\n{r.stdout}{r.stderr}",
+                    file=sys.stderr,
+                )
+                return 2
+        for f in ("bench_model", "vocab_chunk_i2", "w_elems"):
+            if getattr(a, f) is None:
+                p.error(f"--driver bench_decode needs --{f.replace('_', '-')}")
+
+    a.workdir.mkdir(parents=True, exist_ok=True)
+    points, seen_md5, hard_fail = [], {}, False
+
+    for ctx in contexts:
+        wd = a.workdir / f"L{ctx}"
+        wd.mkdir(parents=True, exist_ok=True)
+        rec = {
+            "context_len": ctx,
+            "decode_tokens_per_sec": None,
+            "ms_per_token": None,
+            "status": "ok",
+        }
+
+        xclbin, err = build_templates(
+            a.makefile, ctx, wd, a.template_dir, wd / "build.log"
+        )
+        if err:
+            rec.update(status=err.split(":")[0], detail=err)
+        else:
+            h = _md5(xclbin)
+            rec["xclbin_md5"] = h
+            if h in seen_md5:
+                # Two contexts producing the same binary means a stale copy got
+                # benched; that silently reports the wrong context's number.
+                rec.update(
+                    status="stale_template",
+                    detail=f"xclbin md5 {h} == context {seen_md5[h]}",
+                )
+            else:
+                seen_md5[h] = ctx
+                runner = bench_decode if a.driver == "bench_decode" else bench_qwen
+                out, m = runner(wd, ctx, a)
+                (wd / "bench.log").write_text(out)
+                if m:
+                    rec["ms_per_token"] = float(m.group(1))
+                    rec["decode_tokens_per_sec"] = float(m.group(2))
+                elif XRT_FAIL_RE.search(out):
+                    rec.update(
+                        status="xrt_incomplete", detail="dispatch did not complete"
+                    )
+                else:
+                    hint = re.search(
+                        r"mmap.{0,60}|err=-\d+|std::bad_alloc|host.mem.{0,40}", out
+                    )
+                    rec.update(
+                        status="run_fail",
+                        detail=hint.group(0) if hint else "no bench line",
+                    )
+
+        if rec["status"] != "ok":
+            if ctx in expect_fail:
+                rec["status"] = "expected_fail"
+            else:
+                hard_fail = True
+        points.append(rec)
+        tps = rec["decode_tokens_per_sec"]
+        print(
+            f"[sweep] {a.model_name} ctx={ctx:<7} "
+            f"{f'{tps:.2f} tok/s' if tps else rec['status']}",
+            flush=True,
+        )
+
+    a.out.write_text(
+        json.dumps(
+            {
+                "model": a.model_name,
+                "axis": "context_len",
+                "metric": "decode_tokens_per_sec",
+                "timestamp_utc": datetime.datetime.now(datetime.timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "runner": os.environ.get("RUNNER_NAME", ""),
+                "run_params": {
+                    "iters": a.iters,
+                    "warmup": a.warmup,
+                    "driver": a.driver,
+                },
+                "points": points,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    print(f"[sweep] wrote {a.out}")
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/programming_examples/llms/bench/sweep_decode.py
+++ b/programming_examples/llms/bench/sweep_decode.py
@@ -125,6 +125,7 @@ def bench_qwen(workdir, ctx, args):
             str(ctx),
             str(workdir),
             str(args.iters),
+            str(args.warmup),
         ],
         cwd=FUSED_DECODE,
         timeout=1800,
@@ -244,9 +245,12 @@ def main():
                 hard_fail = True
         points.append(rec)
         tps = rec["decode_tokens_per_sec"]
+        # `is not None`, not truthiness: a genuine 0.00 tok/s is a measurement,
+        # and printing it as the status would hide a real (if pathological)
+        # result behind what looks like a failure.
         print(
             f"[sweep] {a.model_name} ctx={ctx:<7} "
-            f"{f'{tps:.2f} tok/s' if tps else rec['status']}",
+            f"{f'{tps:.2f} tok/s' if tps is not None else rec['status']}",
             flush=True,
         )
 

--- a/programming_examples/llms/bench/sweep_decode.py
+++ b/programming_examples/llms/bench/sweep_decode.py
@@ -21,9 +21,11 @@ table.
 
 Per context the run is: build the decode template pair at that ATTN_MAXL, guard
 that the build actually produced a *new* xclbin, then dispatch. Contexts listed
-in --expect-fail may fail without failing the run: at 64k/128k the larger models
-legitimately exhaust the XRT host-memory KV BO, and that ceiling is worth
-recording rather than hiding.
+in --expect-fail may fail without failing the run: whether a model reaches
+64k/128k depends on how much host memory XRT will pin for its KV BO, which has
+been observed to differ between two otherwise similar Krackan boxes. That makes
+it a property of the machine, not of the design, so the point is recorded with
+its status rather than either hidden or allowed to red the job.
 """
 
 import argparse

--- a/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
@@ -25,7 +25,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name gemma3_4b_q4nx --makefile %S/Makefile --template-dir %S --bench-model gemma3-4b --vocab-chunk-i2 5 --w-elems 1213644800 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out gemma3_4b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name gemma3_4b_q4nx --makefile %S/Makefile --template-dir %S --bench-model gemma3-4b --vocab-chunk-i2 5 --w-elems 1213644800 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out gemma3_4b_q4nx.sweep.json
 // RUN: FileCheck %s < gemma3_4b_q4nx.sweep.json
 // CHECK: "model": "gemma3_4b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
@@ -25,7 +25,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name gemma3_4b_q4nx --makefile %S/Makefile --template-dir %S --bench-model gemma3-4b --vocab-chunk-i2 5 --w-elems 1213644800 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out gemma3_4b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name gemma3_4b_q4nx --makefile %S/Makefile --template-dir %S --bench-model gemma3-4b --vocab-chunk-i2 5 --w-elems 1213644800 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --peano-dir %PEANO_INSTALL_DIR --xrt-dir %XRT_DIR --out gemma3_4b_q4nx.sweep.json
 // RUN: FileCheck %s < gemma3_4b_q4nx.sweep.json
 // CHECK: "model": "gemma3_4b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
@@ -1,0 +1,36 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// GEMMA-3-4B Q4NX decode throughput vs context length, into
+// gemma3_4b_q4nx.sweep.json (collected by the nightly LLM benchmark).
+//
+// Complements run_npu2_profile.lit rather than repeating it: that test profiles
+// the real prefill+decode path at the profile prompt's ~6 tokens of context.
+// Decode tok/s is dominated by KV streaming and falls from 20.49 to 3.74 tok/s
+// between 1k and 64k on this design, so a single near-zero-context point
+// cannot see a KV-path regression.
+//
+// Decode-only and synthetic (latency, never correctness -- run_npu2_verify.lit
+// is the correctness gate), so unlike the profile test this needs no HF weights
+// and no hf_token: the context is set by sizing the KV cache, not by prefilling
+// a real prompt of that length. llvm_link_pre23 is still required because the
+// build goes through fused_decode's inline-attn merge.
+//
+// 64k and 128k are swept but allowed to fail. This model does not reach 128k:
+// its KV BO wants 17.0 GiB of host memory there and XRT refuses. Where this model does
+// reach them the number is recorded; where it does not, the ceiling is recorded
+// instead of failing CI.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_sweep
+// RUN: cd test_peano_sweep
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name gemma3_4b_q4nx --makefile %S/Makefile --template-dir %S --bench-model gemma3-4b --vocab-chunk-i2 5 --w-elems 1213644800 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out gemma3_4b_q4nx.sweep.json
+// RUN: FileCheck %s < gemma3_4b_q4nx.sweep.json
+// CHECK: "model": "gemma3_4b_q4nx"
+// CHECK: "axis": "context_len"
+// A parsed number at the reference context, not just a well-formed file: if the
+// bench line format drifts out of sweep_decode.py's regex every point goes null
+// and the published curve silently empties while the test stays green.
+// CHECK: "context_len": 2048
+// CHECK-NEXT: "decode_tokens_per_sec": {{[0-9]}}

--- a/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/gemma3_4b_q4nx/run_npu2_sweep.lit
@@ -16,10 +16,11 @@
 // a real prompt of that length. llvm_link_pre23 is still required because the
 // build goes through fused_decode's inline-attn merge.
 //
-// 64k and 128k are swept but allowed to fail. This model does not reach 128k:
-// its KV BO wants 17.0 GiB of host memory there and XRT refuses. Where this model does
-// reach them the number is recorded; where it does not, the ceiling is recorded
-// instead of failing CI.
+// 64k and 128k are swept but allowed to fail. Whether a model reaches them
+// depends on how much host memory XRT will pin for its KV BO, which differs
+// between machines -- both were measured failing on one Krackan box and
+// succeeding on the nightly runner. The point is recorded with its status
+// either way rather than reddening CI on a property of the host.
 //
 // REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
 //

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
@@ -26,7 +26,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_1b_q4nx --makefile %S/../../fused_decode/Makefile --template-dir %S/../../fused_decode --bench-model llama-3.2-1b --vocab-chunk-i2 18 --w-elems 386662400 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out llama32_1b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_1b_q4nx --makefile %S/../../fused_decode/Makefile --template-dir %S/../../fused_decode --bench-model llama-3.2-1b --vocab-chunk-i2 18 --w-elems 386662400 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out llama32_1b_q4nx.sweep.json
 // RUN: FileCheck %s < llama32_1b_q4nx.sweep.json
 // CHECK: "model": "llama32_1b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
@@ -16,11 +16,11 @@
 // a real prompt of that length. llvm_link_pre23 is still required because the
 // build goes through fused_decode's inline-attn merge.
 //
-// 64k and 128k are swept but allowed to fail. This model reaches both, but the
-// allowance is uniform across the four sweeps so one model's ceiling moving
-// does not need a lit edit. Where this model does
-// reach them the number is recorded; where it does not, the ceiling is recorded
-// instead of failing CI.
+// 64k and 128k are swept but allowed to fail. Whether a model reaches them
+// depends on how much host memory XRT will pin for its KV BO, which differs
+// between machines -- both were measured failing on one Krackan box and
+// succeeding on the nightly runner. The point is recorded with its status
+// either way rather than reddening CI on a property of the host.
 //
 // REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
 //

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
@@ -26,7 +26,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_1b_q4nx --makefile %S/../../fused_decode/Makefile --template-dir %S/../../fused_decode --bench-model llama-3.2-1b --vocab-chunk-i2 18 --w-elems 386662400 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out llama32_1b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_1b_q4nx --makefile %S/../../fused_decode/Makefile --template-dir %S/../../fused_decode --bench-model llama-3.2-1b --vocab-chunk-i2 18 --w-elems 386662400 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --peano-dir %PEANO_INSTALL_DIR --xrt-dir %XRT_DIR --out llama32_1b_q4nx.sweep.json
 // RUN: FileCheck %s < llama32_1b_q4nx.sweep.json
 // CHECK: "model": "llama32_1b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_sweep.lit
@@ -1,0 +1,37 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// LLAMA-3.2-1B Q4NX decode throughput vs context length, into
+// llama32_1b_q4nx.sweep.json (collected by the nightly LLM benchmark).
+//
+// Complements run_npu2_profile.lit rather than repeating it: that test profiles
+// the real prefill+decode path at the profile prompt's ~6 tokens of context.
+// Decode tok/s is dominated by KV streaming and falls from 68.97 to 5.77 tok/s
+// between 1k and 128k on this design, so a single near-zero-context point
+// cannot see a KV-path regression.
+//
+// Decode-only and synthetic (latency, never correctness -- run_npu2_verify.lit
+// is the correctness gate), so unlike the profile test this needs no HF weights
+// and no hf_token: the context is set by sizing the KV cache, not by prefilling
+// a real prompt of that length. llvm_link_pre23 is still required because the
+// build goes through fused_decode's inline-attn merge.
+//
+// 64k and 128k are swept but allowed to fail. This model reaches both, but the
+// allowance is uniform across the four sweeps so one model's ceiling moving
+// does not need a lit edit. Where this model does
+// reach them the number is recorded; where it does not, the ceiling is recorded
+// instead of failing CI.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_sweep
+// RUN: cd test_peano_sweep
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_1b_q4nx --makefile %S/../../fused_decode/Makefile --template-dir %S/../../fused_decode --bench-model llama-3.2-1b --vocab-chunk-i2 18 --w-elems 386662400 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out llama32_1b_q4nx.sweep.json
+// RUN: FileCheck %s < llama32_1b_q4nx.sweep.json
+// CHECK: "model": "llama32_1b_q4nx"
+// CHECK: "axis": "context_len"
+// A parsed number at the reference context, not just a well-formed file: if the
+// bench line format drifts out of sweep_decode.py's regex every point goes null
+// and the published curve silently empties while the test stays green.
+// CHECK: "context_len": 2048
+// CHECK-NEXT: "decode_tokens_per_sec": {{[0-9]}}

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
@@ -1,0 +1,36 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// LLAMA-3.2-3B Q4NX decode throughput vs context length, into
+// llama32_3b_q4nx.sweep.json (collected by the nightly LLM benchmark).
+//
+// Complements run_npu2_profile.lit rather than repeating it: that test profiles
+// the real prefill+decode path at the profile prompt's ~6 tokens of context.
+// Decode tok/s is dominated by KV streaming and falls from 28.11 to 4.06 tok/s
+// between 1k and 64k on this design, so a single near-zero-context point
+// cannot see a KV-path regression.
+//
+// Decode-only and synthetic (latency, never correctness -- run_npu2_verify.lit
+// is the correctness gate), so unlike the profile test this needs no HF weights
+// and no hf_token: the context is set by sizing the KV cache, not by prefilling
+// a real prompt of that length. llvm_link_pre23 is still required because the
+// build goes through fused_decode's inline-attn merge.
+//
+// 64k and 128k are swept but allowed to fail. This model does not reach 128k:
+// its KV BO wants 14.0 GiB of host memory there and XRT refuses. Where this model does
+// reach them the number is recorded; where it does not, the ceiling is recorded
+// instead of failing CI.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_sweep
+// RUN: cd test_peano_sweep
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_3b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.2-3b --vocab-chunk-i2 9 --w-elems 1004666880 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out llama32_3b_q4nx.sweep.json
+// RUN: FileCheck %s < llama32_3b_q4nx.sweep.json
+// CHECK: "model": "llama32_3b_q4nx"
+// CHECK: "axis": "context_len"
+// A parsed number at the reference context, not just a well-formed file: if the
+// bench line format drifts out of sweep_decode.py's regex every point goes null
+// and the published curve silently empties while the test stays green.
+// CHECK: "context_len": 2048
+// CHECK-NEXT: "decode_tokens_per_sec": {{[0-9]}}

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
@@ -25,7 +25,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_3b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.2-3b --vocab-chunk-i2 9 --w-elems 1004666880 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out llama32_3b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_3b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.2-3b --vocab-chunk-i2 9 --w-elems 1004666880 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --peano-dir %PEANO_INSTALL_DIR --xrt-dir %XRT_DIR --out llama32_3b_q4nx.sweep.json
 // RUN: FileCheck %s < llama32_3b_q4nx.sweep.json
 // CHECK: "model": "llama32_3b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
@@ -25,7 +25,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_3b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.2-3b --vocab-chunk-i2 9 --w-elems 1004666880 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out llama32_3b_q4nx.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama32_3b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.2-3b --vocab-chunk-i2 9 --w-elems 1004666880 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out llama32_3b_q4nx.sweep.json
 // RUN: FileCheck %s < llama32_3b_q4nx.sweep.json
 // CHECK: "model": "llama32_3b_q4nx"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_sweep.lit
@@ -16,10 +16,11 @@
 // a real prompt of that length. llvm_link_pre23 is still required because the
 // build goes through fused_decode's inline-attn merge.
 //
-// 64k and 128k are swept but allowed to fail. This model does not reach 128k:
-// its KV BO wants 14.0 GiB of host memory there and XRT refuses. Where this model does
-// reach them the number is recorded; where it does not, the ceiling is recorded
-// instead of failing CI.
+// 64k and 128k are swept but allowed to fail. Whether a model reaches them
+// depends on how much host memory XRT will pin for its KV BO, which differs
+// between machines -- both were measured failing on one Krackan box and
+// succeeding on the nightly runner. The point is recorded with its status
+// either way rather than reddening CI on a property of the host.
 //
 // REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
 //

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
@@ -16,11 +16,11 @@
 // a real prompt of that length. llvm_link_pre23 is still required because the
 // build goes through fused_decode's inline-attn merge.
 //
-// 64k and 128k are swept but allowed to fail. This model reaches both, but the
-// allowance is uniform across the four sweeps so one model's ceiling moving
-// does not need a lit edit. Where this model does
-// reach them the number is recorded; where it does not, the ceiling is recorded
-// instead of failing CI.
+// 64k and 128k are swept but allowed to fail. Whether a model reaches them
+// depends on how much host memory XRT will pin for its KV BO, which differs
+// between machines -- both were measured failing on one Krackan box and
+// succeeding on the nightly runner. The point is recorded with its status
+// either way rather than reddening CI on a property of the host.
 //
 // REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
 //

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
@@ -1,0 +1,37 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// QWEN2.5-3B Q4_0 decode throughput vs context length, into
+// qwen25_3b_q4.sweep.json (collected by the nightly LLM benchmark).
+//
+// Complements run_npu2_profile.lit rather than repeating it: that test profiles
+// the real prefill+decode path at the profile prompt's ~6 tokens of context.
+// Decode tok/s is dominated by KV streaming and falls from 27.09 to 1.62 tok/s
+// between 1k and 128k on this design, so a single near-zero-context point
+// cannot see a KV-path regression.
+//
+// Decode-only and synthetic (latency, never correctness -- run_npu2_verify.lit
+// is the correctness gate), so unlike the profile test this needs no HF weights
+// and no hf_token: the context is set by sizing the KV cache, not by prefilling
+// a real prompt of that length. llvm_link_pre23 is still required because the
+// build goes through fused_decode's inline-attn merge.
+//
+// 64k and 128k are swept but allowed to fail. This model reaches both, but the
+// allowance is uniform across the four sweeps so one model's ceiling moving
+// does not need a lit edit. Where this model does
+// reach them the number is recorded; where it does not, the ceiling is recorded
+// instead of failing CI.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_sweep
+// RUN: cd test_peano_sweep
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name qwen25_3b_q4 --makefile %S/Makefile --template-dir %S --driver bench_qwen --n-layers 36 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out qwen25_3b_q4.sweep.json
+// RUN: FileCheck %s < qwen25_3b_q4.sweep.json
+// CHECK: "model": "qwen25_3b_q4"
+// CHECK: "axis": "context_len"
+// A parsed number at the reference context, not just a well-formed file: if the
+// bench line format drifts out of sweep_decode.py's regex every point goes null
+// and the published curve silently empties while the test stays green.
+// CHECK: "context_len": 2048
+// CHECK-NEXT: "decode_tokens_per_sec": {{[0-9]}}

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
@@ -26,7 +26,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name qwen25_3b_q4 --makefile %S/Makefile --template-dir %S --driver bench_qwen --n-layers 36 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out qwen25_3b_q4.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name qwen25_3b_q4 --makefile %S/Makefile --template-dir %S --driver bench_qwen --n-layers 36 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --peano-dir %PEANO_INSTALL_DIR --xrt-dir %XRT_DIR --out qwen25_3b_q4.sweep.json
 // RUN: FileCheck %s < qwen25_3b_q4.sweep.json
 // CHECK: "model": "qwen25_3b_q4"
 // CHECK: "axis": "context_len"

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_sweep.lit
@@ -26,7 +26,7 @@
 //
 // RUN: mkdir -p test_peano_sweep
 // RUN: cd test_peano_sweep
-// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name qwen25_3b_q4 --makefile %S/Makefile --template-dir %S --driver bench_qwen --n-layers 36 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --out qwen25_3b_q4.sweep.json
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name qwen25_3b_q4 --makefile %S/Makefile --template-dir %S --driver bench_qwen --n-layers 36 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --xrt-dir %XRT_DIR --out qwen25_3b_q4.sweep.json
 // RUN: FileCheck %s < qwen25_3b_q4.sweep.json
 // CHECK: "model": "qwen25_3b_q4"
 // CHECK: "axis": "context_len"


### PR DESCRIPTION
The nightly publishes one decode throughput number per model, and it comes from
the profile lit's 6-token prompt — an empty KV cache. Decode is dominated by KV
streaming, so that figure is the flattering end of a wide range and **cannot see
a KV-path regression**. Measured on a Krackan runner today:

| model | 1k | top of range | ratio |
|---|---|---|---|
| llama32_1b_q4nx | 68.97 | 5.77 @ 128k | 12.0x |
| llama32_3b_q4nx | 28.11 | 4.06 @ 64k | 6.9x |
| qwen25_3b_q4 | 27.09 | 1.62 @ 128k | 16.7x |
| gemma3_4b_q4nx | 20.49 | 3.74 @ 64k | 5.5x |

This walks the axis for the four models that can — they are the ones with a
`bench_decode` path. The other eleven keep the existing single-point capture and
are untouched.

## What the page looks like

The four **move out** of the single-point table into a new one, rather than
appearing in both: a near-zero-context scalar next to a curve invites reading
them as comparable numbers, and they are not.

```
### Decode throughput vs context (tok/s)

| Model            |    1k |    2k |    4k |    8k |  16k |  32k |  64k | 128k | Verify |
|:-----------------|------:|------:|------:|------:|-----:|-----:|-----:|-----:|:------:|
| gemma3_4b_q4nx   | 20.49 | 19.13 | 16.86 | 13.67 | 9.91 | 6.39 | 3.74 |    — |   🟢   |
| llama32_1b_q4nx  | 68.97 | 63.54 | 54.75 | 42.93 | 30.03| 18.77| 10.72| 5.77 |   🟢   |
| llama32_3b_q4nx  | 28.11 | 25.69 | 21.90 | 16.94 | 11.66| 7.18 | 4.06 |    — |   🟢   |
| qwen25_3b_q4     | 27.09 | 24.03 | 19.69 | 14.48 | 9.46 | 5.59 | 3.08 | 1.62 |   🟢   |
```

## Design notes

**Decode-only and synthetic.** A context is set by sizing the KV cache, not by
prefilling a real prompt of that length, so a 32k point costs a template build
and a few seconds. It also means the sweep needs no HF weights and no
`hf_token` — its `REQUIRES` is strictly weaker than the profile lit's. Latency
only, never correctness: `make verify` remains the only correctness gate, and
its result rides along as the Verify column.

**64k/128k are swept but allowed to fail.** llama-3.2-3B and gemma3-4B exhaust
what XRT will pin as host memory for the KV BO there. The point is still
recorded with its status and the real error, so the ceiling shows on the
dashboard instead of the curve silently ending. A failure at any *other* context
still reds the job.

**`sweep.json` sits beside `perf.json`, not inside it.** A sweep is a curve and
`history.ndjson`'s one-row-per-model shape cannot hold one. Sweep history goes
to its own `sweep_history.ndjson` for the same reason: every existing row in
`history.ndjson` was taken at ~6 tokens of context, so mixing curve points in
would change what the plotted number means partway through the series and read
as a step that never happened.

**Degrades cleanly.** With no `sweep.json` — any nightly older than this change
— all fifteen models render in the single-point table exactly as before.
Verified.

## Structure

| file | |
|---|---|
| `bench/decode_geometry.py` | BO sizes per (model, context), read off the production builder rather than restated. `--check` reproduces `bench_decode.cpp`'s built-in defaults, which is what licenses using it for the other models. |
| `bench/bench_qwen_decode.py` | qwen's dispatch — `bench_decode.exe` cannot be reused, it binds 4 BOs in a different order. |
| `bench/sweep_decode.py` | the runner; emits `<model>.sweep.json`. |
| `run_npu2_sweep.lit` x4 | one per model. |
| `check-programming-examples-llms-sweep` | new `-j1` suite. |

## Cost

~4–5 min per model, **~17 min for all four**, against the nightly's current
222 min.

## Validation

Full 8-context grid on `llama32_3b_q4nx`, Ryzen AI 7 350: reproduces the
reference sweep at every reachable context (28.07 / 25.61 / 21.85 / 16.96 /
11.65 / 7.18 / 4.06 tok/s) and classifies 128k as `expected_fail` with the mmap
error captured, **exiting 0**. Docs rendering checked against the real
`perf-32216015372` artifact, with and without a sweep file.

## One deliberate difference from the scratch harness this replaces

Its "did the dispatch complete" check was
`grep -qiE "...|TIMEOUT|abort"`, which also matches the shell's own
`timeout: failed to run command ...` when the bench binary is missing — and
`make clean` removes it. Three models were once logged as device failures when
the real fault was a deleted executable. The binary is now checked and rebuilt
up front, and the pattern only matches device-side evidence.

## Follow-ups, deliberately not here

- TTFT vs **prompt length** as its own table (different instrument, different
  x-axis; needs real prompts).
- Charts on the perf-history page from `sweep_history.ndjson` — curves for the
  latest run, plus tok/s at a fixed reference context over time.
- The remaining eleven models, if a decode-only bench path ever exists for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)