### PR TITLE
[programming_examples] Port axpy to air.api and drop the raw-bindings version

### DIFF
--- a/programming_examples/axpy/Makefile
+++ b/programming_examples/axpy/Makefile
@@ -13,14 +13,39 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# Extra Python flags (used by LIT tests to override defaults)
+EXTRA_PY_FLAGS ?=
+
 all: run
 
+N ?= 65536
+TILE_N ?= 1024
+ALPHA ?= 2.0
+DTYPE ?= bf16
+VECTOR_SIZE ?=
+PERF_ITERS ?= 0
+
+VEC_FLAG = $(if $(VECTOR_SIZE),--vector-size $(VECTOR_SIZE),)
+# The device is auto-detected: one invocation has to run on whichever NPU is
+# installed. Set TARGET=npu1|npu2 to compile for a generation that is not
+# plugged in.
+TARGET ?= auto
+PY_FLAGS = --n $(N) --tile-n $(TILE_N) --alpha $(ALPHA) --dtype $(DTYPE) \
+	$(VEC_FLAG) --target $(TARGET) $(OUTPUT_FORMAT_FLAG) $(EXTRA_PY_FLAGS)
+
 print:
-	${powershell} python3 ${srcdir}/axpy.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) --print-ir
+
+compile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) --compile-only
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/axpy.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) \
+		--perf-iters $(PERF_ITERS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/axpy/axpy.py
+++ b/programming_examples/axpy/axpy.py
@@ -1,251 +1,253 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Vectorized AXPY Example
+"""AXPY, written with the air.api DSL.
 
-Implements the AXPY operation on 1D vectors [N]:
-  y = a * x + y
+Computes out = alpha * x + y over a 1-D [N] vector.
 
-where a is a scalar and x, y are vectors.
+The DSL emits the herd, the L1 allocations, the affine tile offsets, the DMAs,
+and the vectorised compute loop; what it hands to the backend is an ordinary AIR
+module. `alpha * x_buf[:] + y_buf[:]` is a lazy expression tree that is lowered
+once, as a single vectorised loop, when it is assigned into out_buf.
 
-Uses a 1x2 AIE herd with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.fma (fused multiply-add)
-with configurable VECTOR_SIZE (default 16).
+Two differences from the raw-bindings implementation this replaces, both
+deliberate:
+
+  - It emits arith.mulf + arith.addf where the predecessor hand-built a
+    vector.fma.
+  - The predecessor pinned a 2-core herd and cycled tiles across it. Here the
+    logical tile grid (N // tile_n) is strip-mined onto whatever the target
+    provides -- 4 cores on npu1, 8 on npu2 -- with each core owning a
+    contiguous block of tiles.
+
+f32 runs scalar, and that is not a tuning choice. A *chained* f32
+multiply-then-add on 512-bit vectors does not legalize in the AIE2 backend:
+
+    LLVM ERROR: unable to legalize instruction: <16 x s32> = G_FMUL
+
+Measured on npu1 and npu2 at 8, 16 and 32 lanes; all three fail. Each op on its
+own is fine -- f32 vector add, sub, mul and div all compile at 16 lanes, and so
+does `2.0 * x[:]` by itself -- so it is specifically the mul feeding an add.
+bf16 has no such problem and vectorises the whole expression. (bf16 *divide*
+does not legalize, but axpy does not divide.) Hence VECTOR_BY_DTYPE below.
 """
 
 import argparse
-from ml_dtypes import bfloat16
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp, fma
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
 
 import numpy as np
+from ml_dtypes import bfloat16
 
-np.random.seed(42)
+from air import api as air
+from air.api import ops  # registers air.ops  # noqa: F401
+from air.api.types import bf16, f32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+DTYPES = {"bf16": (bf16, bfloat16), "f32": (f32, np.float32)}
+
+# Default compute vector width per dtype, overridable with --vector-size. None
+# means "use the dtype's own default" (16 lanes). f32 is pinned to 0 (scalar)
+# because the chained multiply-add does not legalize at any vector width -- see
+# the module docstring. This is the example's choice, not the DSL's: the DSL
+# cannot see that the expression is a mul feeding an add.
+VECTOR_BY_DTYPE = {"bf16": None, "f32": 0}
+
+# This kernel keeps three tiles live in L1, and the pipeline ping-pongs them, so
+# the figure that has to fit a 64 KB compute tile is about twice what is
+# declared.
+L1_BYTES = 65536
+LIVE_BUFFERS = 3
+PINGPONG = 2
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in, alpha=2.0, vector_size=16):
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+def max_tile(dtype):
+    """Largest tile whose three ping-ponged buffers fit L1."""
+    return L1_BYTES // (LIVE_BUFFERS * PINGPONG * dtype.itemsize)
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get([n], xrt_dtype_in)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    vecTy = VectorType.get([VECTOR_SIZE], xrt_dtype_in)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def axpy(arg0, arg1, arg2):
-        # arg0 = x (input), arg1 = y (input), arg2 = output
-
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+def build_axpy(n, tile_n, alpha, dtype=bf16, herd_shape=None, vector=None):
+    """Build an AXPY launch over a 1-D vector of length n."""
+    if n % tile_n:
+        raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
+    if tile_n > max_tile(dtype):
+        raise ValueError(
+            f"tile_n {tile_n} does not fit L1 for {dtype}: three ping-ponged "
+            f"buffers of that size exceed {L1_BYTES // 1024} KB "
+            f"(max tile is {max_tile(dtype)})"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_x,
-            _l3_y,
-            _l3_out,
-        ):
-            l1_x_data = AllocOp(l1MemrefTy, [], [])
-            l1_y_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    x = air.tensor([n], dtype)
+    y = air.tensor([n], dtype)
+    out = air.tensor([n], dtype)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    # Compile-time tile size. v1 resolves this and reports the binding in
+    # launch.search_space; it does not search over it.
+    tile = air.symbol(hint=tile_n, name="tile_n")
 
-                dma_memcpy_nd(
-                    l1_x_data,
-                    _l3_x,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_y_data,
-                    _l3_y,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+    with air.launch(name="axpy") as launch:
 
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
+        @launch.body
+        def _():
+            with air.herd(range(0, n, tile), shape=herd_shape) as h:
 
-                # Broadcast scalar alpha to vector
-                a_const = arith.ConstantOp(xrt_dtype_in, alpha)
-                v_a = BroadcastOp(vecTy, a_const)
+                @h.body
+                def _(tx):
+                    tn = h.tile_sizes[0]
+                    window = slice(tx * tn, tx * tn + tn)
 
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_x = subview(
-                        l1_x_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_y = subview(
-                        l1_y_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_out = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    v_x = transfer_read(vecTy, sub_x, [c0], identity_map, cst0, [True])
-                    v_y = transfer_read(vecTy, sub_y, [c0], identity_map, cst0, [True])
-                    # a * x + y via vector.fma
-                    v_result = fma(v_a, v_x, v_y)
-                    transfer_write(None, v_result, sub_out, [c0], identity_map, [True])
-                    yield_([])
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    y_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    out_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
 
-                # Write result from l1_out back to L3 output buffer
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_x_data)
-                DeallocOp(l1_y_data)
-                DeallocOp(l1_out_data)
+                    air.ops.load(x_buf, x[window])
+                    air.ops.load(y_buf, y[window])
 
-                yield_([])
+                    out_buf[:] = alpha * x_buf[:] + y_buf[:]
+
+                    air.ops.store(out_buf, out[window])
+
+    return launch
 
 
 if __name__ == "__main__":
-    N = 65536
-    TILE_N = 1024
-    INPUT_DATATYPE = bfloat16
-    ALPHA = 2.0
-
-    parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the AXPY example",
-    )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--n", type=int, default=N, help="Total number of elements")
-    parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
+    parser = argparse.ArgumentParser(description="air.api AXPY example")
+    parser.add_argument("--n", type=int, default=65536, help="vector length")
+    parser.add_argument("--tile-n", type=int, default=1024, help="tile size")
+    parser.add_argument("--alpha", type=float, default=2.0, help="scalar multiplier")
     parser.add_argument(
-        "--alpha", type=float, default=ALPHA, help="Scalar multiplier a"
+        "--dtype",
+        type=str,
+        default="bf16",
+        choices=sorted(DTYPES),
+        help="element type (default: bf16)",
     )
     parser.add_argument(
         "--vector-size",
         type=int,
-        default=16,
-        help="Vector size for SIMD operations",
+        default=None,
+        dest="vector",
+        help="compute vector width in lanes; 0 forces a scalar loop. Default is "
+        "16 for bf16 and 0 (scalar) for f32: the chained f32 multiply-add does "
+        "not legalize in the AIE2 backend at any vector width.",
     )
     parser.add_argument(
-        "--compile-mode",
+        "--herd-shape",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="EXTENT",
+        help="override the physical herd shape (default: chosen per target)",
+    )
+    parser.add_argument(
+        "--target",
         type=str,
-        choices=["compile-only", "compile-and-run"],
-        dest="compile_mode",
-        default="compile-and-run",
+        default="auto",
+        choices=["auto", "npu1", "npu2"],
+        help="NPU generation to size the herd for and compile against "
+        "(default: auto, i.e. whichever one xrt-smi reports). Naming one "
+        "explicitly is for compiling off-device: a binary built for a "
+        "generation that is not installed still loads, and computes nothing.",
     )
     parser.add_argument(
         "--output-format",
         type=str,
-        choices=["xclbin", "elf"],
         default="xclbin",
+        choices=["xclbin", "elf"],
         dest="output_format",
+        help="binary format aircc produces (default: xclbin). "
+        "elf is npu2-only -- npu1 does not support the full-ELF flow.",
     )
-
+    parser.add_argument(
+        "--perf-iters",
+        type=int,
+        default=0,
+        dest="perf_iters",
+        help="if >0, time the kernel over this many iterations (after warmup) "
+        "and print Latency alongside the correctness check",
+    )
+    parser.add_argument("--print-ir", action="store_true")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.n, args.tile_n, INPUT_DATATYPE, args.alpha, args.vector_size
+    if args.perf_iters < 0:
+        parser.error("--perf-iters must be >= 0")
+
+    dtype, np_dtype = DTYPES[args.dtype]
+    vector = VECTOR_BY_DTYPE[args.dtype] if args.vector is None else args.vector
+    launch = build_axpy(
+        n=args.n,
+        tile_n=args.tile_n,
+        alpha=args.alpha,
+        dtype=dtype,
+        herd_shape=args.herd_shape,
+        vector=vector,
     )
-    if args.print_module_only:
-        print(mlir_module)
-        exit(0)
 
-    input_x = np.random.randn(args.n).astype(INPUT_DATATYPE)
-    input_y = np.random.randn(args.n).astype(INPUT_DATATYPE)
+    if args.print_ir:
+        print(launch.mlir())
+        raise SystemExit(0)
 
-    if args.compile_mode == "compile-and-run":
-        num_samples = 100
-        sampled_indices = np.vstack([np.random.randint(0, args.n, num_samples)])
-        sampled_values = np.array(
-            [(args.alpha * input_x[i] + input_y[i]) for i in zip(*sampled_indices)],
-            dtype=INPUT_DATATYPE,
-        )
-        sampled_data = {
-            "shape": (args.n,),
-            "indices": sampled_indices,
-            "values": sampled_values,
-        }
-
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="axpy",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_x, input_y],
-                stochastic_expected_outputs=[sampled_data],
-                rtol=1e-2,
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_only:
+        # Build first: it resolves --target auto, and the backend has to compile
+        # for the same generation the herd was sized for.
+        module = launch.build(target=args.target)
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            instance_name="axpy",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(module)
         backend.unload()
+        print("Compiled successfully.")
+        print("Search space:", launch.search_space)
+        raise SystemExit(0)
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal(args.n, dtype=np.float32).astype(np_dtype)
+    y_np = rng.standard_normal(args.n, dtype=np.float32).astype(np_dtype)
+
+    # Reference in fp32, rounded back to the kernel's dtype.
+    #
+    # bf16 carries the predecessor's exact gate -- rtol=1e-2 with the runner's
+    # default atol -- so this is strictly stronger than what it replaces: the
+    # same per-element tolerance, applied to all N elements instead of the 100
+    # random indices the predecessor sampled. Measured worst case across the
+    # full array is rel_err max 7.8e-03, so there is real headroom and no need
+    # to loosen. f32 takes the runner's default rtol (measured 3.6e-05).
+    ref = (args.alpha * x_np.astype(np.float32) + y_np.astype(np.float32)).astype(
+        np_dtype
+    )
+    rtol, atol = (1e-2, 1e-8) if args.dtype == "bf16" else (1e-3, 1e-8)
+
+    # Checked through XRTRunner rather than a bare np.allclose: it is the same
+    # harness every other example in this tree uses, so an air.api kernel gets
+    # the same error statistics (report_precision) and the same PASS!/failed.
+    # reporting that the lit harnesses grep for.
+    module = launch.build(target=args.target)
+    print(
+        f"AXPY n={args.n} tile_n={args.tile_n} alpha={args.alpha} "
+        f"dtype={args.dtype} on {launch.target}"
+    )
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="axpy",
+        target_device=launch.target,
+        runtime_loop_tiling_sizes=[4, 4],
+        report_precision=True,
+        n_perf_iters=args.perf_iters,
+    )
+    raise SystemExit(
+        runner.run_test(
+            module,
+            inputs=[x_np, y_np],
+            expected_outputs=[ref],
+            rtol=rtol,
+            atol=atol,
+        )
+    )

--- a/programming_examples/axpy/run_makefile_peano.lit
+++ b/programming_examples/axpy/run_makefile_peano.lit
@@ -1,10 +1,20 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
+// Runs on whichever NPU is installed: both dtypes, plus a forced scalar bf16
+// loop and an off-default alpha and tile. The herd sizes itself for the
+// detected generation, so one lit covers both.
+//
+// DTYPE=f32 runs scalar by default -- the chained f32 multiply-add does not
+// legalize at any vector width. See axpy.py.
+//
 // REQUIRES: ryzen_ai, peano
 //
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DTYPE=f32 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=0 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR ALPHA=-0.5 TILE_N=2048 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/axpy/run_makefile_peano_elf.lit
+++ b/programming_examples/axpy/run_makefile_peano_elf.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Full-ELF output is npu2 only; npu1 does not support the flow.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -83,7 +83,7 @@ EXAMPLES = [
         "category": "Linear Algebra",
         "name": "AXPY",
         "path": "axpy",
-        "datatypes": "bf16",
+        "datatypes": "bf16, f32",
     },
     {
         "category": "Element-wise",

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -138,15 +138,30 @@ def _emit_scalar(dst, expr, ops):
 # ---------------------------------------------------------------------------
 
 
+def _result(v):
+    """Reduce a single-result OpView to its Value.
+
+    Every consumer here has to receive a Value, not an OpView: the generated
+    arith builders infer their own result type from ``operands[0].type``, and
+    only a Value carries ``.type``. A one-operator expression never exposes this
+    -- its operands come straight from ``transfer_read``, which already yields a
+    Value -- but any nested expression (``alpha * x[:] + y[:]``) feeds one
+    builder's output into the next.
+    """
+    return v.result if hasattr(v, "result") else v
+
+
 def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
     if node.kind == "buffer":
         if vectorized:
-            return transfer_read(vec_ty, node.buffer.value, ivs, minor, pad, [True])
-        return memref_load(node.buffer.value, ivs)
+            return _result(
+                transfer_read(vec_ty, node.buffer.value, ivs, minor, pad, [True])
+            )
+        return _result(memref_load(node.buffer.value, ivs))
 
     if node.kind == "scalar":
-        scalar = arith.ConstantOp(ety, node.scalar)
-        return broadcast(vec_ty, scalar) if vectorized else scalar
+        scalar = _result(arith.ConstantOp(ety, node.scalar))
+        return _result(broadcast(vec_ty, scalar)) if vectorized else scalar
 
     if node.kind == "binary":
         op = ops.get(node.op)
@@ -157,6 +172,6 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
             )
         lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad)
         rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad)
-        return op(lhs, rhs)
+        return _result(op(lhs, rhs))
 
     raise AssertionError(f"unknown expression node kind {node.kind!r}")

--- a/python/test/api/axpy.py
+++ b/python/test/api/axpy.py
@@ -1,0 +1,106 @@
+# ./python/test/api/axpy.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers a nested elementwise expression: out = alpha * x + y.
+
+Distinct from the eltwise_add tests in one way that matters: the right-hand side
+is a *tree*, not a single operator. One arith builder's output feeds the next,
+which is the case that requires each intermediate to be reduced to a Value --
+the builders infer their result type from ``operands[0].type``, and an OpView
+does not have one.
+"""
+
+from air import api as air
+from air.api import ops  # noqa: F401
+from air.api.types import bf16, f32
+
+
+def build(N, tile, alpha, herd_shape=None, dtype=bf16, vector=None):
+    x = air.tensor([N], dtype)
+    y = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="axpy") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, N, tile), shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    (tn,) = h.tile_sizes
+                    col = tx * tn
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    y_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    out_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(x_buf, x[col : col + tn])
+                    air.ops.load(y_buf, y[col : col + tn])
+                    out_buf[:] = alpha * x_buf[:] + y_buf[:]
+                    air.ops.store(out_buf, out[col : col + tn])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: axpy_vectorized
+# The scalar is broadcast to the compute width once and multiplied in, then
+# added: two chained arith ops on vector<16xbf16>. 64 tiles strip-mined onto 4
+# cores gives 16 repeats, folded into one affine map: (tx*16 + i)*1024.
+# CHECK: affine_map<()[s0, s1] -> (s0 * 16384 + s1 * 1024)>
+# CHECK: func.func @axpy(%{{.*}}: memref<65536xbf16>, %{{.*}}: memref<65536xbf16>, %{{.*}}: memref<65536xbf16>)
+# CHECK: air.herd @herd_0 tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c4{{.*}}, %{{.*}}=%c1
+# CHECK: scf.for
+# CHECK: memref.alloc() : memref<1024xbf16, 2 : i32>
+# CHECK: air.dma_memcpy_nd
+# CHECK: arith.constant 2.000000e+00 : bf16
+# CHECK: vector.broadcast {{.*}} : bf16 to vector<16xbf16>
+# CHECK: vector.transfer_read {{.*}} vector<16xbf16>
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_read {{.*}} vector<16xbf16>
+# CHECK: arith.addf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_write {{.*}} vector<16xbf16>
+# CHECK: air.dma_memcpy_nd
+# CHECK: memref.dealloc
+@run
+def axpy_vectorized():
+    print(build(65536, 1024, 2.0, herd_shape=(4,)).mlir())
+
+
+# CHECK-LABEL: TEST: axpy_scalar_fallback
+# A 12-wide tile is not a multiple of the bf16 vector width, so the whole tree
+# lowers scalar -- including the broadcast, which becomes a plain constant.
+# CHECK-NOT: vector.broadcast
+# CHECK: memref.load
+# CHECK: arith.mulf {{.*}} : bf16
+# CHECK: memref.load
+# CHECK: arith.addf {{.*}} : bf16
+# CHECK: memref.store
+@run
+def axpy_scalar_fallback():
+    print(build(48, 12, 2.0, herd_shape=(4,)).mlir())
+
+
+# CHECK-LABEL: TEST: axpy_f32_scalar
+# f32 axpy runs scalar, and the example pins it that way. A chained f32
+# multiply-add on 512-bit vectors does not legalize in the AIE2 backend
+# ("unable to legalize instruction: <16 x s32> = G_FMUL"), at 8, 16 or 32 lanes,
+# on either generation -- although each op on its own vectorises fine. The DSL
+# cannot detect that, since it is a property of the pair, so the emitter still
+# vectorises f32 on request and it is the caller that asks for scalar.
+# CHECK-NOT: vector.broadcast
+# CHECK: memref.alloc() : memref<1024xf32, 2 : i32>
+# CHECK: arith.mulf {{.*}} : f32
+# CHECK: arith.addf {{.*}} : f32
+# CHECK: memref.store
+@run
+def axpy_f32_scalar():
+    print(build(65536, 1024, 2.0, herd_shape=(4,), dtype=f32, vector=0).mlir())


### PR DESCRIPTION
Ports `programming_examples/axpy` to the `air.api` DSL and deletes the raw-bindings implementation it replaces, following the path `eltwise_add` took in #1823.

The example goes from ~250 lines of hand-built `AffineMap`/`dma_memcpy_nd`/`transfer_read` to a herd body whose compute is one line:

```python
out_buf[:] = alpha * x_buf[:] + y_buf[:]
```

## Coverage audit: old vs new

Since this deletes the predecessor, here is the side-by-side. Every axis is a gain or unchanged.

| Axis | Before | After | |
|---|---|---|---|
| Shape / tile / alpha | 1-D N=65536, 1024, 2.0 | same flags, same defaults | = |
| dtype | bf16 only (hardcoded) | bf16 + f32 | gain |
| Vector width | 16 | 16 bf16 / 0 f32 (see below) | = |
| Herd | fixed 2 cores | 4 on npu1, 8 on npu2; `--herd-shape` | gain |
| Device target | implicit | `--target auto\|npu1\|npu2`, auto-detected | gain |
| Output format | xclbin / elf | same | = |
| Perf harness | none | `--perf-iters` | gain |
| Correctness scope | 100 sampled indices | all 65536 elements | gain |
| Tolerance | rtol=1e-2, atol=1e-8 (runner default) | **identical** | = |
| Harness / PASS string | `XRTRunner` / `PASS!` | same, plus `report_precision` | gain |
| **Hardware lit invocations** | **1** | **5** (4 peano + 1 elf) | gain |
| lit `REQUIRES` | `ryzen_ai, peano` | same, plus `ryzen_ai_npu2` for elf | gain |
| Makefile | 4 targets, no knobs | 5 targets, 8 knobs | gain |

`--output-format elf` was reachable from the CLI before but exercised by no test; it now has a gate.

The tolerance row is the one worth stressing: the full-array check runs at the *predecessor's exact tolerance*, not a relaxed one. Measured worst case is `rel_err max 7.8e-03` against `rtol=1e-2`, so no loosening was needed to widen the check.

Three deliberate behaviour changes, none silent: `-p/--print-module-only` → `--print-ir` and `--compile-mode compile-only` → `--compile-only` (loud argparse failures; nothing outside the example's own Makefile referenced the old spellings); the predecessor's `assert tile_n % vector_size == 0` becomes the DSL's documented scalar fallback; and a logical grid with few divisors narrows the herd rather than erroring.

## Verification

Hardware, npu1 (Phoenix) — all `PASS!`:

| Config | mean_rel_L1 | rel_err max |
|---|---|---|
| bf16 vectorised | 1.999e-03 | 7.812e-03 |
| bf16 scalar | 1.999e-03 | 7.812e-03 |
| f32 | 1.150e-08 | 3.616e-05 |
| bf16 α=-0.5, tile 2048 | 2.024e-03 | 7.812e-03 |

Compile-only sweep green across dtype × target × vector width on both generations. npu2 is left to CI — no npu2 hardware on the box this was developed on.

**Performance A/B**, same session, alternating reps, `--perf-iters 100`, Default power mode:

| Arm | Config | Latencies (µs, sorted) | Median |
|---|---|---|---|
| A | predecessor, 2 cores, `vector.fma` | 234.5 263.1 281.6 307.3 | ~272 |
| B | air.api, 4 cores, `mulf`+`addf` | 203.8 213.7 213.9 223.6 | ~214 |
| C | air.api, 2 cores, `mulf`+`addf` | 209.2 228.4 253.6 276.5 | ~241 |

B beats A in 4/4 paired reps and C beats A in 4/4, so the ~21% median win survives the ~30% run-to-run variance. Arm C matches the predecessor's herd width and still wins, which isolates the two effects: `arith.mulf`+`arith.addf` is not a regression against the hand-built `vector.fma`, and the wider herd adds on top.

Note the method is host-observed wall time (`time.perf_counter()` around `run.start()/wait2()`), not device-side bandwidth — axpy has no `test.cpp` harness. That is adequate for a relative A/B and is why no absolute bandwidth figure is quoted.

## Supporting changes

**`python/air/api/_emit.py` — a real DSL bug.** Elementwise lowering returned `OpView`s, but the generated `arith` builders infer their result type from `operands[0].type`, which only a `Value` carries. A single operator never exposed this, because `eltwise_add`'s operands come straight from `transfer_read`; any *nested* expression crashed, and `alpha * x[:] + y[:]` is the first one in the tree. Pinned by `python/test/api/axpy.py`.

**f32 runs scalar, pinned by the example rather than the emitter.** A chained f32 multiply-then-add on 512-bit vectors does not legalize in the AIE2 backend:

```
LLVM ERROR: unable to legalize instruction: <16 x s32> = G_FMUL
```

at 8, 16 and 32 lanes, on both generations. The narrow shape matters: f32 vector add, sub, mul **and** div each compile fine at 16 lanes, and `2.0 * x[:]` alone compiles — it is specifically the mul feeding an add. bf16 vectorises the whole chain. (Separately noted while probing: bf16 *divide* does not legalize.) The DSL sees one expression tree and cannot know which operator pairs the backend will fuse, so a heuristic in `_emit.py` would silently de-vectorise valid code; a loud backend error plus a documented per-dtype default in the example is the better failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
