### PR TITLE
[llms] Release the fused decoders' XRT objects in dependency order

### DIFF
--- a/programming_examples/fused_decode/qwen_prefill_to_decode.py
+++ b/programming_examples/fused_decode/qwen_prefill_to_decode.py
@@ -195,10 +195,14 @@ class QwenFusedDecoder:
                 f"model.layers.{k}.post_attention_layernorm.weight"
             ).astype(bfloat16)
 
-        dev = xrt.device(0)
-        xb = xrt.xclbin(xclbin)
+        # Held on the instance rather than left as locals: the BOs and kernel
+        # below outlive this frame, so the device has to be reachable for as
+        # long as they are, and its release has to be ordered after theirs
+        # (see close()).
+        dev = self._dev = xrt.device(0)
+        xb = self._xb = xrt.xclbin(xclbin)
         dev.register_xclbin(xb)
-        hwc = xrt.hw_context(dev, xb.get_uuid())
+        hwc = self._hwc = xrt.hw_context(dev, xb.get_uuid())
         self.kern = xrt.kernel(
             hwc,
             [q for q in xb.get_kernels() if "MLIR_AIE" in q.get_name()][0].get_name(),
@@ -305,6 +309,34 @@ class QwenFusedDecoder:
             np.float32
         )[m.XO_RMSIN : m.XO_RMSIN + m.K]
         return self._logits(h)
+
+    # Every BO, the insts state and the kernel are created against self._dev,
+    # so the device must be released after all of them. Linux XRT tolerates
+    # the reverse; Windows XRT faults with an access violation as the decoder
+    # is collected.
+    _XRT_RELEASE_ORDER = (
+        "_st",
+        "y_bo",
+        "kv_bo",
+        "w_bo",
+        "x_bo",
+        "kern",
+        "_hwc",
+        "_xb",
+        "_dev",
+    )
+
+    def close(self):
+        """Release the XRT objects in reverse dependency order."""
+        for name in self._XRT_RELEASE_ORDER:
+            if name in self.__dict__:
+                self.__dict__[name] = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 def main():

--- a/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
+++ b/programming_examples/llms/gemma3_4b_q4nx/gemma3_4b_q4nx_inference.py
@@ -351,6 +351,39 @@ class FusedDecoder:
             raise RuntimeError(f"decode dispatch pos{p} state={st}")
         return yv[: self.VOCAB_SIZE]
 
+    # Kernels, insts states and BOs are all created against self.dev, but
+    # self.dev is assigned first and CPython clears an instance __dict__ in
+    # insertion order, so the device is released before the objects that
+    # depend on it. Linux XRT tolerates that; Windows XRT faults with an
+    # access violation while the decoder is collected. `ib` and `_st` alias
+    # into `_ist`, so they have to be dropped ahead of it or they keep that
+    # state (and its cacheable BO) alive past the device.
+    _XRT_RELEASE_ORDER = (
+        "ib",
+        "_st",
+        "_ist",
+        "kvc",
+        "y_bo",
+        "r_bo",
+        "w_bo",
+        "x_bo",
+        "kern",
+        "_kern",
+        "dev",
+    )
+
+    def close(self):
+        """Release the XRT objects in reverse dependency order."""
+        for name in self._XRT_RELEASE_ORDER:
+            if name in self.__dict__:
+                self.__dict__[name] = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
 
 def _prefill_npu(prompt, model, seq_len=None):
     """Batched AIR prefill on the NPU -> (Kc, Vc, first_token, ttft_s).

--- a/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
+++ b/programming_examples/llms/llama32_1b_q4nx/llama32_1b_q4nx_inference.py
@@ -540,6 +540,32 @@ class FusedDecoder:
             )
         return logits[: self.VOCAB_SIZE]
 
+    _XRT_RELEASE_ORDER = (
+        "ib",
+        "_st",
+        "_ist",
+        "kvc",
+        "y_bo",
+        "r_bo",
+        "w_bo",
+        "x_bo",
+        "kern",
+        "_kern",
+        "dev",
+    )
+
+    def close(self):
+        """Release the XRT objects in reverse dependency order."""
+        for name in self._XRT_RELEASE_ORDER:
+            if name in self.__dict__:
+                self.__dict__[name] = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
 
 # ------------------------------------------------------------------ orchestration
 EOS_IDS = (128001, 128009)  # <|end_of_text|>, <|eot_id|>

--- a/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
+++ b/programming_examples/llms/llama32_3b_q4nx/q4nx_decode_3b.py
@@ -367,3 +367,36 @@ class FusedDecode3B:
             self.y_bo.map(), dtype=bfloat16, count=voc_n, offset=self.decode_y * 2
         ).astype(np.float32)
         return yv[: self.VOCAB_SIZE]
+
+    # Kernels, insts states and BOs are all created against self.dev, but
+    # self.dev is assigned first and CPython clears an instance __dict__ in
+    # insertion order, so the device is released before the objects that
+    # depend on it. Linux XRT tolerates that; Windows XRT faults with an
+    # access violation while the decoder is collected. `ib` and `_st` alias
+    # into `_ist`, so they have to be dropped ahead of it or they keep that
+    # state (and its cacheable BO) alive past the device.
+    _XRT_RELEASE_ORDER = (
+        "ib",
+        "_st",
+        "_ist",
+        "kvc",
+        "y_bo",
+        "r_bo",
+        "w_bo",
+        "x_bo",
+        "kern",
+        "_kern",
+        "dev",
+    )
+
+    def close(self):
+        """Release the XRT objects in reverse dependency order."""
+        for name in self._XRT_RELEASE_ORDER:
+            if name in self.__dict__:
+                self.__dict__[name] = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass


### PR DESCRIPTION
Follow-up to #1825 (independent of it; branched from `main`).

All four q4/q4nx fused decoders build every kernel, insts state and BO against a device they assign **first**. CPython clears an instance `__dict__` in insertion order, so collection releases the device before the objects that depend on it. Linux XRT tolerates that; Windows XRT raises an access violation.

| Example | Class | File |
|---|---|---|
| llama32_1b_q4nx | `FusedDecoder` | `llama32_1b_q4nx_inference.py` |
| llama32_3b_q4nx | `FusedDecode3B` | `q4nx_decode_3b.py` |
| gemma3_4b_q4nx | `FusedDecoder` | `gemma3_4b_q4nx_inference.py` |
| qwen25_3b_q4 | `QwenFusedDecoder` | `fused_decode/qwen_prefill_to_decode.py` |

## Why it reads as a decode bug

On llama32_1b_q4nx the Paris gate generates all 12 tokens, prints its throughput line, and *then* dies at `0xC0000005` while returning from `generate()` — before the caller prints the token ids or the verdict. The work completed; only the teardown faulted. `make gen` reported no result and a crash exit code, which looks like decode produced nothing.

## The fix

Each decoder gets an explicit `close()`, called from `__del__`, dropping the XRT attributes in reverse dependency order.

`ib` and `_st` alias into `_ist`, so they must go first. Dropping `_ist` alone leaves that state — and its cacheable BO — alive through those aliases and past the device. An order that omitted them did **not** fix the crash; that failed attempt is what identified the aliases.

`QwenFusedDecoder` differed: it left `dev`, `xclbin` and `hw_context` as locals of `__init__` while the BOs and kernel lived on the instance, so the device's Python reference was dropped as soon as construction finished. They are now held on the instance, making the lifetime explicit and the release ordered. Nothing else changes — the BOs kept the underlying device alive regardless, which is why qwen works on Linux today.

## Verification

llama32_1b_q4nx, prefill + fused decode on NPU2 (Krackan, Windows):

```
[inference] gen ids: [12366, 13, 578, 6864, 315, 279, 3723, 4273, 374, 6652, 423, 732, 13]
*** PARIS ***
=== ERRORLEVEL = 0 ===
```

" Paris. The capital of the United States is Washington D C." at ~48 tok/s. The identical run before the fix exited `0xC0000005` with no verdict.

The other three are fixed **by inspection** — I had no Windows-built weights for them (each needs its own multi-ELF build plus a 3–4B download). To make that less of a leap, an AST check confirms every XRT-valued attribute of all four classes appears in its release order, with none listed that is never assigned:

```
FusedDecoder     (1b)    MISSING from order: none
FusedDecode3B    (3b)    MISSING from order: FROM, TO   <- sync-direction enums, not device-derived
FusedDecoder     (gemma) MISSING from order: none
QwenFusedDecoder (qwen)  MISSING from order: none
```

`black` clean; all four byte-compile.

## Linux impact

Inert. The change only makes explicit an ordering the platform already tolerated; no attribute is added or removed from the final state, and `close()` is idempotent. Worth a reviewer's eye on the `__del__` additions in case any of these decoders is expected to participate in a reference cycle — PEP 442 makes that collectable, but the maintainers know these lifetimes better than I do.

Note: reproducing the Windows e2e also needs #1825, whose `XRTBackend.unload()` fix keeps the prefill worker subprocess from faulting at exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
