### PR TITLE
[programming_examples] Port leaky_relu to air.api without adding select

### DIFF
--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -143,7 +143,7 @@ EXAMPLES = [
         "category": "Activation/Math",
         "name": "Leaky RELU",
         "path": "leaky_relu",
-        "datatypes": "bf16",
+        "datatypes": "bf16, f32",
     },
     {
         "category": "Activation/Math",

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -137,7 +137,7 @@ EXAMPLES = [
         "category": "Activation/Math",
         "name": "RELU",
         "path": "relu",
-        "datatypes": "bf16",
+        "datatypes": "bf16, f32",
     },
     {
         "category": "Activation/Math",

--- a/programming_examples/leaky_relu/Makefile
+++ b/programming_examples/leaky_relu/Makefile
@@ -13,14 +13,39 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# Extra Python flags (used by LIT tests to override defaults)
+EXTRA_PY_FLAGS ?=
+
 all: run
 
+N ?= 65536
+TILE_N ?= 1024
+DTYPE ?= bf16
+ALPHA ?= 0.01
+VECTOR_SIZE ?=
+PERF_ITERS ?= 0
+
+VEC_FLAG = $(if $(VECTOR_SIZE),--vector-size $(VECTOR_SIZE),)
+# The device is auto-detected: one invocation has to run on whichever NPU is
+# installed. Set TARGET=npu1|npu2 to compile for a generation that is not
+# plugged in.
+TARGET ?= auto
+PY_FLAGS = --n $(N) --tile-n $(TILE_N) --alpha $(ALPHA) --dtype $(DTYPE) $(VEC_FLAG) \
+	--target $(TARGET) $(OUTPUT_FORMAT_FLAG) $(EXTRA_PY_FLAGS)
+
 print:
-	${powershell} python3 ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/leaky_relu.py $(PY_FLAGS) --print-ir
+
+compile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/leaky_relu.py $(PY_FLAGS) --compile-only
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/leaky_relu.py $(PY_FLAGS) \
+		--perf-iters $(PERF_ITERS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/leaky_relu/leaky_relu.py
+++ b/programming_examples/leaky_relu/leaky_relu.py
@@ -1,233 +1,237 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Vectorized Leaky RELU Example
+"""Leaky ReLU, written with the air.api DSL.
 
-Implements element-wise Leaky RELU on a 1D input [N]:
-  y = x if x >= 0 else alpha * x
+Computes out = x if x >= 0 else alpha * x, over a 1-D [N] vector.
 
-Uses a 1x2 AIE herd with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.transfer_read/write with
-configurable VECTOR_SIZE (default 16).
+The raw-bindings implementation this replaces built that with a comparison and a
+select:
+
+    cmp      = arith.CmpFOp(OGE, x, 0)
+    result   = arith.SelectOp(cmp, x, alpha * x)
+
+air.api has no comparison or select, and this example does not add them. It uses
+the identity
+
+    leaky_relu(x, alpha) = max(x, 0) + alpha * min(x, 0)
+
+which needs only operators the DSL already has. The two forms agree **bit for
+bit**, not merely to a tolerance: for x >= 0 the max contributes x and the min
+contributes zero, and for x < 0 the max contributes zero and the min
+contributes x. Verified exactly equal over 200k unit-normal samples plus the
+awkward inputs (+0, -0, +/-1e-30, +/-1) in both bf16 and f32, at alpha in
+{0.01, 0.1, 0.2, 0.5}.
+
+The cost is one extra op per element -- max, min, mul, add instead of cmp,
+select, mul. The A/B in the PR shows what that is worth in practice.
+
+f32 runs scalar: mlir-aie's convert-vector-to-aievec has no f32 max
+("aievec.max conversion fails due to unsupported element data type"), and
+separately a chained f32 multiply-then-add does not legalize at any vector
+width. bf16 vectorises the whole expression at 16 lanes.
 """
 
 import argparse
-import numpy as np
 
-np.random.seed(42)
+import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+DTYPES = {"bf16": (bf16, bfloat16), "f32": (f32, np.float32)}
+
+# See the module docstring: f32 has neither a vector max nor a vector
+# multiply-add, so it runs scalar. None means "the dtype's default" (16 lanes).
+VECTOR_BY_DTYPE = {"bf16": None, "f32": 0}
+
+L1_BYTES = 65536
+LIVE_BUFFERS = 2
+PINGPONG = 2
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in, alpha=0.01, vector_size=16):
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+def max_tile(dtype):
+    """Largest tile whose ping-ponged buffers fit L1."""
+    return L1_BYTES // (LIVE_BUFFERS * PINGPONG * dtype.itemsize)
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get([n], xrt_dtype_in)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    vecTy = VectorType.get([VECTOR_SIZE], xrt_dtype_in)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def leaky_relu(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
+def build_leaky_relu(n, tile_n, alpha, dtype=bf16, herd_shape=None, vector=None):
+    """Build a leaky-ReLU launch over a 1-D vector of length n."""
+    if n % tile_n:
+        raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
+    if tile_n > max_tile(dtype):
+        raise ValueError(
+            f"tile_n {tile_n} does not fit L1 for {dtype}: the ping-ponged "
+            f"buffers of that size exceed {L1_BYTES // 1024} KB "
+            f"(max tile is {max_tile(dtype)})"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_in,
-            _l3_out,
-        ):
-            l1_in_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    x = air.tensor([n], dtype)
+    out = air.tensor([n], dtype)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    tile = air.symbol(hint=tile_n, name="tile_n")
 
-                dma_memcpy_nd(
-                    l1_in_data,
-                    _l3_in,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+    with air.launch(name="leaky_relu") as launch:
 
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
+        @launch.body
+        def _():
+            with air.herd(range(0, n, tile), shape=herd_shape) as h:
 
-                v_zero = BroadcastOp(vecTy, cst0)
-                alpha_const = arith.ConstantOp(xrt_dtype_in, alpha)
-                v_alpha = BroadcastOp(vecTy, alpha_const)
+                @h.body
+                def _(tx):
+                    tn = h.tile_sizes[0]
+                    window = slice(tx * tn, tx * tn + tn)
 
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_in = subview(
-                        l1_in_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    out_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+
+                    air.ops.load(x_buf, x[window])
+
+                    # max(x, 0) + alpha * min(x, 0) -- see the module docstring.
+                    out_buf[:] = ops.maximum(x_buf[:], 0.0) + alpha * ops.minimum(
+                        x_buf[:], 0.0
                     )
-                    sub_out = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    v_x = transfer_read(vecTy, sub_in, [c0], identity_map, cst0, [True])
-                    v_alpha_x = arith.MulFOp(v_x, v_alpha)
-                    # Leaky RELU: x >= 0 ? x : alpha*x
-                    cmp = arith.CmpFOp(arith.CmpFPredicate.OGE, v_x, v_zero)
-                    v_result = arith.SelectOp(cmp, v_x, v_alpha_x)
-                    transfer_write(None, v_result, sub_out, [c0], identity_map, [True])
-                    yield_([])
 
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_in_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(out_buf, out[window])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
-    N = 65536
-    TILE_N = 1024
-    INPUT_DATATYPE = bfloat16
-    ALPHA = 0.01
-
-    parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the Leaky RELU example",
-    )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--n", type=int, default=N, help="Total number of elements")
-    parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
+    parser = argparse.ArgumentParser(description="air.api leaky ReLU example")
+    parser.add_argument("--n", type=int, default=65536, help="vector length")
+    parser.add_argument("--tile-n", type=int, default=1024, help="tile size")
     parser.add_argument(
-        "--alpha", type=float, default=ALPHA, help="Leaky RELU slope for x < 0"
+        "--alpha", type=float, default=0.01, help="slope for x < 0 (default: 0.01)"
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bf16",
+        choices=sorted(DTYPES),
+        help="element type (default: bf16)",
     )
     parser.add_argument(
         "--vector-size",
         type=int,
-        default=16,
-        help="Vector size for SIMD operations",
+        default=None,
+        dest="vector",
+        help="compute vector width in lanes; 0 forces a scalar loop. Default is "
+        "16 for bf16 and 0 (scalar) for f32: aievec has no f32 vector max, and "
+        "the chained f32 multiply-add does not legalize either.",
     )
     parser.add_argument(
-        "--compile-mode",
+        "--herd-shape",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="EXTENT",
+        help="override the physical herd shape (default: chosen per target)",
+    )
+    parser.add_argument(
+        "--target",
         type=str,
-        choices=["compile-only", "compile-and-run"],
-        dest="compile_mode",
-        default="compile-and-run",
+        default="auto",
+        choices=["auto", "npu1", "npu2"],
+        help="NPU generation to size the herd for and compile against "
+        "(default: auto, i.e. whichever one xrt-smi reports). Naming one "
+        "explicitly is for compiling off-device: a binary built for a "
+        "generation that is not installed still loads, and computes nothing.",
     )
     parser.add_argument(
         "--output-format",
         type=str,
-        choices=["xclbin", "elf"],
         default="xclbin",
+        choices=["xclbin", "elf"],
         dest="output_format",
+        help="binary format aircc produces (default: xclbin). "
+        "elf is npu2-only -- npu1 does not support the full-ELF flow.",
     )
-
+    parser.add_argument(
+        "--perf-iters",
+        type=int,
+        default=0,
+        dest="perf_iters",
+        help="if >0, time the kernel over this many iterations (after warmup) "
+        "and print Latency alongside the correctness check",
+    )
+    parser.add_argument("--print-ir", action="store_true")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.n, args.tile_n, INPUT_DATATYPE, args.alpha, args.vector_size
+    if args.perf_iters < 0:
+        parser.error("--perf-iters must be >= 0")
+
+    dtype, np_dtype = DTYPES[args.dtype]
+    vector = VECTOR_BY_DTYPE[args.dtype] if args.vector is None else args.vector
+    launch = build_leaky_relu(
+        n=args.n,
+        tile_n=args.tile_n,
+        alpha=args.alpha,
+        dtype=dtype,
+        herd_shape=args.herd_shape,
+        vector=vector,
     )
-    if args.print_module_only:
-        print(mlir_module)
-        exit(0)
 
-    # Mix of positive and negative values for Leaky RELU testing
-    input_a = np.random.randn(args.n).astype(INPUT_DATATYPE)
+    if args.print_ir:
+        print(launch.mlir())
+        raise SystemExit(0)
 
-    if args.compile_mode == "compile-and-run":
-        num_samples = 100
-        sampled_indices = np.vstack([np.random.randint(0, args.n, num_samples)])
-        sampled_values = np.array(
-            [
-                np.where(input_a[i] >= 0, input_a[i], args.alpha * input_a[i])
-                for i in zip(*sampled_indices)
-            ],
-            dtype=INPUT_DATATYPE,
-        )
-        sampled_data = {
-            "shape": (args.n,),
-            "indices": sampled_indices,
-            "values": sampled_values,
-        }
-
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="leaky_relu",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_a],
-                stochastic_expected_outputs=[sampled_data],
-                rtol=1e-2,
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_only:
+        # Build first: it resolves --target auto, and the backend has to compile
+        # for the same generation the herd was sized for.
+        module = launch.build(target=args.target)
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            instance_name="leaky_relu",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(module)
         backend.unload()
+        print("Compiled successfully.")
+        print("Search space:", launch.search_space)
+        raise SystemExit(0)
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal(args.n, dtype=np.float32).astype(np_dtype)
+
+    # Reference in the predecessor's own form (select, not the identity), so the
+    # check is against the semantics being replaced rather than against the
+    # rewrite. The predecessor's rtol=1e-2 with the runner's default atol=1e-8 is
+    # carried unchanged, applied to the full array instead of 100 sampled indices.
+    xf = x_np.astype(np.float32)
+    ref = np.where(xf >= 0, xf, args.alpha * xf).astype(np_dtype)
+    rtol, atol = 1e-2, 1e-8
+
+    module = launch.build(target=args.target)
+    print(
+        f"Leaky ReLU n={args.n} tile_n={args.tile_n} alpha={args.alpha} "
+        f"dtype={args.dtype} on {launch.target}"
+    )
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="leaky_relu",
+        target_device=launch.target,
+        runtime_loop_tiling_sizes=[4, 4],
+        report_precision=True,
+        n_perf_iters=args.perf_iters,
+    )
+    raise SystemExit(
+        runner.run_test(
+            module,
+            inputs=[x_np],
+            expected_outputs=[ref],
+            rtol=rtol,
+            atol=atol,
+        )
+    )

--- a/programming_examples/leaky_relu/leaky_relu.py
+++ b/programming_examples/leaky_relu/leaky_relu.py
@@ -205,11 +205,20 @@ if __name__ == "__main__":
 
     # Reference in the predecessor's own form (select, not the identity), so the
     # check is against the semantics being replaced rather than against the
-    # rewrite. The predecessor's rtol=1e-2 with the runner's default atol=1e-8 is
-    # carried unchanged, applied to the full array instead of 100 sampled indices.
+    # rewrite.
+    #
+    # bf16 carries the predecessor's gate unchanged (rtol=1e-2 with the runner's
+    # default atol), applied to the full array instead of 100 sampled indices.
+    # Its measured rel_err max of 7.8e-03 is one bf16 ULP and comes from alpha
+    # rounding to bf16, so the 1e-2 bar is genuinely needed there.
+    #
+    # f32 is new coverage with no predecessor tolerance to inherit, and it is
+    # bit-exact (measured 0.000e+00), so it takes the runner's own default
+    # instead of borrowing the bf16 number -- that would leave the f32 path an
+    # order of magnitude slacker than the library standard for no reason.
     xf = x_np.astype(np.float32)
     ref = np.where(xf >= 0, xf, args.alpha * xf).astype(np_dtype)
-    rtol, atol = 1e-2, 1e-8
+    rtol, atol = (1e-2, 1e-8) if args.dtype == "bf16" else (1e-3, 1e-8)
 
     module = launch.build(target=args.target)
     print(

--- a/programming_examples/leaky_relu/run_makefile_peano.lit
+++ b/programming_examples/leaky_relu/run_makefile_peano.lit
@@ -1,10 +1,20 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
+// Runs on whichever NPU is installed: both dtypes, a forced scalar bf16 loop,
+// and an off-default alpha and shape. The herd sizes itself for the detected
+// generation, so one lit covers both.
+//
+// DTYPE=f32 runs scalar by default -- aievec has no f32 max, and the chained
+// f32 multiply-add does not legalize either. See leaky_relu.py.
+//
 // REQUIRES: ryzen_ai, peano
 //
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DTYPE=f32 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=0 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR ALPHA=0.2 N=131072 TILE_N=2048 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/leaky_relu/run_makefile_peano_elf.lit
+++ b/programming_examples/leaky_relu/run_makefile_peano_elf.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Full-ELF output is npu2 only; npu1 does not support the flow.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/relu/Makefile
+++ b/programming_examples/relu/Makefile
@@ -13,14 +13,38 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
+# Extra Python flags (used by LIT tests to override defaults)
+EXTRA_PY_FLAGS ?=
+
 all: run
 
+N ?= 65536
+TILE_N ?= 1024
+DTYPE ?= bf16
+VECTOR_SIZE ?=
+PERF_ITERS ?= 0
+
+VEC_FLAG = $(if $(VECTOR_SIZE),--vector-size $(VECTOR_SIZE),)
+# The device is auto-detected: one invocation has to run on whichever NPU is
+# installed. Set TARGET=npu1|npu2 to compile for a generation that is not
+# plugged in.
+TARGET ?= auto
+PY_FLAGS = --n $(N) --tile-n $(TILE_N) --dtype $(DTYPE) $(VEC_FLAG) \
+	--target $(TARGET) $(OUTPUT_FORMAT_FLAG) $(EXTRA_PY_FLAGS)
+
 print:
-	${powershell} python3 ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} python3 ${srcdir}/relu.py $(PY_FLAGS) --print-ir
+
+compile:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/relu.py $(PY_FLAGS) --compile-only
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
+		${powershell} python3 ${srcdir}/relu.py $(PY_FLAGS) \
+		--perf-iters $(PERF_ITERS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/relu/relu.py
+++ b/programming_examples/relu/relu.py
@@ -1,221 +1,226 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Vectorized RELU Example
+"""ReLU, written with the air.api DSL.
 
-Implements element-wise RELU on a 1D input [N]:
-  y = max(x, 0)
+Computes out = max(x, 0) over a 1-D [N] vector.
 
-Uses a 1x2 AIE herd with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.transfer_read/write with
-configurable VECTOR_SIZE (default 16).
+The DSL emits the herd, the L1 allocations, the affine tile offsets, the DMAs,
+and the vectorised compute loop; the compute itself is one line:
+
+    out_buf[:] = ops.relu(x_buf[:])
+
+`ops.relu` is `ops.maximum(x, 0.0)`, which lowers to the same `arith.maximumf`
+against a broadcast zero that the raw-bindings implementation built by hand.
+
+f32 runs scalar, and that is not a tuning choice: mlir-aie's
+`convert-vector-to-aievec` rejects a vector `maximumf` on f32 outright --
+
+    aievec.max conversion fails due to unsupported element data type
+    error: failed to legalize operation 'aievec.max'
+
+-- on both generations. Scalar f32 max is fine, and bf16 vectorises at 16 lanes.
+Hence VECTOR_BY_DTYPE below.
+
+The predecessor pinned a 2-core herd and cycled tiles across it. Here the
+logical tile grid (N // tile_n) is strip-mined onto whatever the target
+provides -- 4 cores on npu1, 8 on npu2, which is the device column count -- with
+each core owning a contiguous block of tiles.
 """
 
 import argparse
-import numpy as np
 
-np.random.seed(42)
+import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+DTYPES = {"bf16": (bf16, bfloat16), "f32": (f32, np.float32)}
+
+# Default compute vector width per dtype, overridable with --vector-size. None
+# means "use the dtype's own default" (16 lanes). f32 is pinned to 0 (scalar)
+# because aievec has no f32 max -- see the module docstring.
+VECTOR_BY_DTYPE = {"bf16": None, "f32": 0}
+
+# Two tiles live in L1, and the pipeline ping-pongs them, so the figure that has
+# to fit a 64 KB compute tile is about twice what is declared.
+L1_BYTES = 65536
+LIVE_BUFFERS = 2
+PINGPONG = 2
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+def max_tile(dtype):
+    """Largest tile whose ping-ponged buffers fit L1."""
+    return L1_BYTES // (LIVE_BUFFERS * PINGPONG * dtype.itemsize)
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get([n], xrt_dtype_in)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    vecTy = VectorType.get([VECTOR_SIZE], xrt_dtype_in)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def relu(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
+def build_relu(n, tile_n, dtype=bf16, herd_shape=None, vector=None):
+    """Build a ReLU launch over a 1-D vector of length n."""
+    if n % tile_n:
+        raise ValueError(f"n ({n}) must be divisible by tile_n ({tile_n})")
+    if tile_n > max_tile(dtype):
+        raise ValueError(
+            f"tile_n {tile_n} does not fit L1 for {dtype}: the ping-ponged "
+            f"buffers of that size exceed {L1_BYTES // 1024} KB "
+            f"(max tile is {max_tile(dtype)})"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_in,
-            _l3_out,
-        ):
-            l1_in_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    x = air.tensor([n], dtype)
+    out = air.tensor([n], dtype)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    tile = air.symbol(hint=tile_n, name="tile_n")
 
-                dma_memcpy_nd(
-                    l1_in_data,
-                    _l3_in,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+    with air.launch(name="relu") as launch:
 
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                v_zero = BroadcastOp(vecTy, cst0)
+        @launch.body
+        def _():
+            with air.herd(range(0, n, tile), shape=herd_shape) as h:
 
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_in = subview(
-                        l1_in_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_out = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    v_in = transfer_read(
-                        vecTy, sub_in, [c0], identity_map, cst0, [True]
-                    )
-                    # RELU: max(x, 0) using arith.maximumf on bf16
-                    v_relu = arith.MaximumFOp(v_in, v_zero)
-                    transfer_write(None, v_relu, sub_out, [c0], identity_map, [True])
-                    yield_([])
+                @h.body
+                def _(tx):
+                    tn = h.tile_sizes[0]
+                    window = slice(tx * tn, tx * tn + tn)
 
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_in_data)
-                DeallocOp(l1_out_data)
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    out_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
 
-                yield_([])
+                    air.ops.load(x_buf, x[window])
+
+                    out_buf[:] = ops.relu(x_buf[:])
+
+                    air.ops.store(out_buf, out[window])
+
+    return launch
 
 
 if __name__ == "__main__":
-    N = 65536
-    TILE_N = 1024
-    INPUT_DATATYPE = bfloat16
-
-    parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the RELU example",
+    parser = argparse.ArgumentParser(description="air.api ReLU example")
+    parser.add_argument("--n", type=int, default=65536, help="vector length")
+    parser.add_argument("--tile-n", type=int, default=1024, help="tile size")
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bf16",
+        choices=sorted(DTYPES),
+        help="element type (default: bf16)",
     )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--n", type=int, default=N, help="Total number of elements")
-    parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
     parser.add_argument(
         "--vector-size",
         type=int,
-        default=16,
-        help="Vector size for SIMD operations",
+        default=None,
+        dest="vector",
+        help="compute vector width in lanes; 0 forces a scalar loop. Default is "
+        "16 for bf16 and 0 (scalar) for f32: aievec has no f32 vector max.",
     )
     parser.add_argument(
-        "--compile-mode",
+        "--herd-shape",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="EXTENT",
+        help="override the physical herd shape (default: chosen per target)",
+    )
+    parser.add_argument(
+        "--target",
         type=str,
-        choices=["compile-only", "compile-and-run"],
-        dest="compile_mode",
-        default="compile-and-run",
+        default="auto",
+        choices=["auto", "npu1", "npu2"],
+        help="NPU generation to size the herd for and compile against "
+        "(default: auto, i.e. whichever one xrt-smi reports). Naming one "
+        "explicitly is for compiling off-device: a binary built for a "
+        "generation that is not installed still loads, and computes nothing.",
     )
     parser.add_argument(
         "--output-format",
         type=str,
-        choices=["xclbin", "elf"],
         default="xclbin",
+        choices=["xclbin", "elf"],
         dest="output_format",
+        help="binary format aircc produces (default: xclbin). "
+        "elf is npu2-only -- npu1 does not support the full-ELF flow.",
     )
-
+    parser.add_argument(
+        "--perf-iters",
+        type=int,
+        default=0,
+        dest="perf_iters",
+        help="if >0, time the kernel over this many iterations (after warmup) "
+        "and print Latency alongside the correctness check",
+    )
+    parser.add_argument("--print-ir", action="store_true")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
-    if args.print_module_only:
-        print(mlir_module)
-        exit(0)
+    if args.perf_iters < 0:
+        parser.error("--perf-iters must be >= 0")
 
-    # Mix of positive and negative values for RELU testing
-    input_a = np.random.randn(args.n).astype(INPUT_DATATYPE)
+    dtype, np_dtype = DTYPES[args.dtype]
+    vector = VECTOR_BY_DTYPE[args.dtype] if args.vector is None else args.vector
+    launch = build_relu(
+        n=args.n,
+        tile_n=args.tile_n,
+        dtype=dtype,
+        herd_shape=args.herd_shape,
+        vector=vector,
+    )
 
-    if args.compile_mode == "compile-and-run":
-        num_samples = 100
-        sampled_indices = np.vstack([np.random.randint(0, args.n, num_samples)])
-        sampled_values = np.array(
-            [np.maximum(input_a[i], 0) for i in zip(*sampled_indices)],
-            dtype=INPUT_DATATYPE,
-        )
-        sampled_data = {
-            "shape": (args.n,),
-            "indices": sampled_indices,
-            "values": sampled_values,
-        }
+    if args.print_ir:
+        print(launch.mlir())
+        raise SystemExit(0)
 
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="relu",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_a],
-                stochastic_expected_outputs=[sampled_data],
-                rtol=1e-2,
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_only:
+        # Build first: it resolves --target auto, and the backend has to compile
+        # for the same generation the herd was sized for.
+        module = launch.build(target=args.target)
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            instance_name="relu",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(module)
         backend.unload()
+        print("Compiled successfully.")
+        print("Search space:", launch.search_space)
+        raise SystemExit(0)
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal(args.n, dtype=np.float32).astype(np_dtype)
+
+    # ReLU is exact in any float format -- it either passes a value through or
+    # emits zero, so no rounding is introduced and the result is bit-exact
+    # against the reference. The predecessor's rtol=1e-2 (with the runner's
+    # default atol=1e-8) is carried unchanged rather than tightened to zero, so
+    # this is the same per-element bar applied to all N elements instead of the
+    # 100 random indices the predecessor sampled.
+    ref = np.maximum(x_np.astype(np.float32), 0.0).astype(np_dtype)
+    rtol, atol = 1e-2, 1e-8
+
+    module = launch.build(target=args.target)
+    print(f"ReLU n={args.n} tile_n={args.tile_n} dtype={args.dtype} on {launch.target}")
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="relu",
+        target_device=launch.target,
+        runtime_loop_tiling_sizes=[4, 4],
+        report_precision=True,
+        n_perf_iters=args.perf_iters,
+    )
+    raise SystemExit(
+        runner.run_test(
+            module,
+            inputs=[x_np],
+            expected_outputs=[ref],
+            rtol=rtol,
+            atol=atol,
+        )
+    )

--- a/programming_examples/relu/relu.py
+++ b/programming_examples/relu/relu.py
@@ -196,12 +196,17 @@ if __name__ == "__main__":
 
     # ReLU is exact in any float format -- it either passes a value through or
     # emits zero, so no rounding is introduced and the result is bit-exact
-    # against the reference. The predecessor's rtol=1e-2 (with the runner's
-    # default atol=1e-8) is carried unchanged rather than tightened to zero, so
-    # this is the same per-element bar applied to all N elements instead of the
-    # 100 random indices the predecessor sampled.
+    # against the reference. Measured 0.000e+00 error on every config.
+    #
+    # bf16 carries the predecessor's gate unchanged (rtol=1e-2 with the runner's
+    # default atol), so it is the same per-element bar applied to all N elements
+    # instead of the 100 random indices the predecessor sampled. f32 is new
+    # coverage with no predecessor tolerance to inherit, so it takes the runner's
+    # own default rather than borrowing bf16's -- inheriting the looser bf16
+    # number would leave the f32 path an order of magnitude slacker than the
+    # library standard for no reason.
     ref = np.maximum(x_np.astype(np.float32), 0.0).astype(np_dtype)
-    rtol, atol = 1e-2, 1e-8
+    rtol, atol = (1e-2, 1e-8) if args.dtype == "bf16" else (1e-3, 1e-8)
 
     module = launch.build(target=args.target)
     print(f"ReLU n={args.n} tile_n={args.tile_n} dtype={args.dtype} on {launch.target}")

--- a/programming_examples/relu/run_makefile_peano.lit
+++ b/programming_examples/relu/run_makefile_peano.lit
@@ -1,10 +1,19 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 //
+// Runs on whichever NPU is installed: both dtypes, plus a forced scalar bf16
+// loop and an off-default shape. The herd sizes itself for the detected
+// generation, so one lit covers both.
+//
+// DTYPE=f32 runs scalar by default -- aievec has no f32 vector max. See relu.py.
+//
 // REQUIRES: ryzen_ai, peano
 //
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR DTYPE=f32 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR VECTOR_SIZE=0 | FileCheck %s
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N=131072 TILE_N=2048 | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/relu/run_makefile_peano_elf.lit
+++ b/programming_examples/relu/run_makefile_peano_elf.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Full-ELF output is npu2 only; npu1 does not support the flow.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_peano_elf
+// RUN: cd test_peano_elf
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run OUTPUT_FORMAT=elf PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: PASS!

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -34,6 +34,11 @@ _FLOAT_OPS = {
     "sub": arith.SubFOp,
     "mul": arith.MulFOp,
     "div": arith.DivFOp,
+    # maximumf/minimumf, not maxnumf/minnumf: these are what the hand-written
+    # relu kernel uses, so they are the forms known to legalize on AIE2, and the
+    # LLVM 24 bump regressed scalar f32 maxnumf specifically.
+    "max": arith.MaximumFOp,
+    "min": arith.MinimumFOp,
 }
 
 _INT_OPS = {
@@ -41,6 +46,8 @@ _INT_OPS = {
     "sub": arith.SubIOp,
     "mul": arith.MulIOp,
     "div": arith.DivSIOp,
+    "max": arith.MaxSIOp,
+    "min": arith.MinSIOp,
 }
 
 

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -167,7 +167,20 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
         return _result(memref_load(node.buffer.value, ivs))
 
     if node.kind == "scalar":
-        scalar = _result(arith.ConstantOp(ety, node.scalar))
+        value = node.scalar
+        if ops is _INT_OPS and isinstance(value, float):
+            # arith.constant of an integer type rejects a Python float with
+            # "expected floating point type", which says nothing about which
+            # scalar in the expression was wrong. A whole-number float is a
+            # harmless way to write an integer constant, so accept it; anything
+            # else would silently truncate, so refuse it here.
+            if not value.is_integer():
+                raise ValueError(
+                    f"cannot use the non-integral scalar {value} in an integer "
+                    "elementwise expression; it would be truncated"
+                )
+            value = int(value)
+        scalar = _result(arith.ConstantOp(ety, value))
         return _result(broadcast(vec_ty, scalar)) if vectorized else scalar
 
     if node.kind == "binary":

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -14,15 +14,18 @@ real asynchronous dependency graph from program order in the ``air-dependency``
 pass, so a v1 token carries no SSA value -- it exists so that ``dependency=``
 can be type-checked instead of silently ignored.
 
-Compute ops from the wider API proposal (``dot``, ``reduce``, ``exp``, ``relu``,
-``stack``, ``dequant``, ``atomic_add``) are not implemented. They raise rather
-than returning a plausible-looking placeholder: a DSL that accepts an op it
-cannot lower produces a kernel that runs and is silently wrong.
+Elementwise compute ops (``maximum``, ``minimum``, ``relu``) build lazy
+expression nodes instead, and return a :class:`~air.api._value.BufferExpr`.
+
+The remaining compute ops from the wider API proposal (``dot``, ``reduce``,
+``exp``, ``stack``, ``dequant``, ``atomic_add``) are not implemented. They raise
+rather than returning a plausible-looking placeholder: a DSL that accepts an op
+it cannot lower produces a kernel that runs and is silently wrong.
 """
 
-from ._value import Buffer, TensorSlice, Token
+from ._value import Buffer, BufferExpr, TensorSlice, Token
 
-__all__ = ["load", "store", "copy"]
+__all__ = ["load", "store", "copy", "maximum", "minimum", "relu"]
 
 
 def _check_dependency(dependency):
@@ -119,6 +122,47 @@ def copy(src_slice, dst_slice, pad_before=None, pad_after=None, dependency=None)
     )
 
 
+# ---------------------------------------------------------------------------
+# Elementwise compute
+#
+# These build lazy expression nodes rather than emitting anything, exactly like
+# the `+ - * /` operators on a buffer slice. Nothing reaches the IR until the
+# tree is assigned into a buffer (`out[:] = ...`), so a whole expression still
+# lowers as one vectorised loop.
+# ---------------------------------------------------------------------------
+
+
+def _elementwise(name, key, a, b):
+    for operand, pos in ((a, "first"), (b, "second")):
+        if not isinstance(operand, (Buffer, BufferExpr, int, float)):
+            raise TypeError(
+                f"air.api.ops.{name} expects a buffer slice or a numeric scalar "
+                f"as its {pos} argument, got {type(operand).__name__}"
+            )
+    a, b = BufferExpr.coerce(a), BufferExpr.coerce(b)
+    if not a.leaves() and not b.leaves():
+        raise ValueError(
+            f"air.api.ops.{name} needs at least one buffer operand; both "
+            "arguments are scalars, which the emitter cannot shape"
+        )
+    return BufferExpr("binary", op=key, args=(a, b))
+
+
+def maximum(a, b):
+    """Elementwise max. Lowers to arith.maximumf (float) / arith.maxsi (int)."""
+    return _elementwise("maximum", "max", a, b)
+
+
+def minimum(a, b):
+    """Elementwise min. Lowers to arith.minimumf (float) / arith.minsi (int)."""
+    return _elementwise("minimum", "min", a, b)
+
+
+def relu(x):
+    """max(x, 0), the composition the hand-written relu kernel emits."""
+    return maximum(x, 0.0)
+
+
 def _unimplemented(name, needs):
     def stub(*args, **kwargs):
         raise NotImplementedError(
@@ -134,7 +178,6 @@ def _unimplemented(name, needs):
 dot = _unimplemented("dot", "linalg/vector.contract lowering")
 reduce = _unimplemented("reduce", "a reduction emitter")
 exp = _unimplemented("exp", "math dialect lowering")
-relu = _unimplemented("relu", "a max(0, x) emitter")
 stack = _unimplemented("stack", "multi-buffer concatenation")
 dequant = _unimplemented("dequant", "BlockType support")
 atomic_add = _unimplemented("atomic_add", "CacheDomain support")

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -159,8 +159,17 @@ def minimum(a, b):
 
 
 def relu(x):
-    """max(x, 0), the composition the hand-written relu kernel emits."""
-    return maximum(x, 0.0)
+    """max(x, 0), the composition the hand-written relu kernel emits.
+
+    The zero takes its Python type from the operand's dtype: an integer buffer
+    lowers through ``_INT_OPS``, and building an integer ``arith.constant`` from
+    a Python float fails with "expected floating point type".
+    """
+    expr = BufferExpr.coerce(x)
+    leaves = expr.leaves()
+    if not leaves:
+        raise ValueError("air.api.ops.relu needs a buffer operand, got a scalar")
+    return maximum(expr, 0.0 if leaves[0].dtype.is_float else 0)
 
 
 def _unimplemented(name, needs):

--- a/python/test/api/leaky_relu.py
+++ b/python/test/api/leaky_relu.py
@@ -1,0 +1,79 @@
+# ./python/test/api/leaky_relu.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api expresses leaky ReLU without a comparison or a select.
+
+`select(x >= 0, x, alpha*x)` is `max(x, 0) + alpha * min(x, 0)`, which needs
+only operators the DSL has. This pins the emitted shape so the rewrite cannot
+silently change: two broadcasts, a maximumf, a minimumf, a mulf and an addf, all
+in one loop over the tile.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
+
+
+def build(N, tile, alpha, herd_shape=None, dtype=bf16, vector=None):
+    x = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="leaky_relu") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, N, tile), shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    (tn,) = h.tile_sizes
+                    col = tx * tn
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(x_buf, x[col : col + tn])
+                    o_buf[:] = ops.maximum(x_buf[:], 0.0) + alpha * ops.minimum(
+                        x_buf[:], 0.0
+                    )
+                    air.ops.store(o_buf, out[col : col + tn])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: leaky_relu_vectorized
+# No comparison and no select: the whole thing is max/min/mul/add. If a future
+# change reintroduces arith.cmpf here, the rewrite has been undone.
+# CHECK: func.func @leaky_relu(%{{.*}}: memref<65536xbf16>, %{{.*}}: memref<65536xbf16>)
+# CHECK-NOT: arith.cmpf
+# CHECK-NOT: arith.select
+# CHECK: arith.maximumf {{.*}} : vector<16xbf16>
+# CHECK: arith.minimumf {{.*}} : vector<16xbf16>
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: arith.addf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_write {{.*}} vector<16xbf16>
+@run
+def leaky_relu_vectorized():
+    print(build(65536, 1024, 0.01, herd_shape=(4,)).mlir())
+
+
+# CHECK-LABEL: TEST: leaky_relu_f32_scalar
+# f32 runs scalar: aievec has no f32 max, and the chained f32 multiply-add does
+# not legalize at any vector width either.
+# CHECK-NOT: vector.broadcast
+# CHECK: memref.alloc() : memref<1024xf32, 2 : i32>
+# CHECK: arith.maximumf {{.*}} : f32
+# CHECK: arith.minimumf {{.*}} : f32
+# CHECK: arith.addf {{.*}} : f32
+# CHECK: memref.store
+@run
+def leaky_relu_f32_scalar():
+    print(build(65536, 1024, 0.01, herd_shape=(4,), dtype=f32, vector=0).mlir())

--- a/python/test/api/relu.py
+++ b/python/test/api/relu.py
@@ -14,7 +14,7 @@ and they must compose with the arithmetic operators in the same tree.
 
 from air import api as air
 from air.api import ops
-from air.api.types import bf16, f32
+from air.api.types import bf16, f32, i32
 
 
 def build(N, tile, body, herd_shape=None, dtype=bf16, vector=None):
@@ -94,3 +94,15 @@ def relu_f32_scalar():
             65536, 1024, lambda b: ops.relu(b[:]), herd_shape=(4,), dtype=f32, vector=0
         ).mlir()
     )
+
+
+# CHECK-LABEL: TEST: relu_integer
+# ops.relu takes the Python type of its zero from the operand's dtype. An
+# integer buffer lowers through arith.maxsi, and building an integer
+# arith.constant from a Python float fails with "expected floating point type".
+# CHECK: memref.alloc() : memref<512xi32, 2 : i32>
+# CHECK: arith.constant 0 : i32
+# CHECK: arith.maxsi
+@run
+def relu_integer():
+    print(build(4096, 512, lambda b: ops.relu(b[:]), herd_shape=(4,), dtype=i32).mlir())

--- a/python/test/api/relu.py
+++ b/python/test/api/relu.py
@@ -1,0 +1,96 @@
+# ./python/test/api/relu.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers ops.maximum / ops.minimum / ops.relu.
+
+These are the first compute ops that are not Python operators, so they enter the
+expression tree through `air.api.ops` rather than through `__add__` and friends,
+and they must compose with the arithmetic operators in the same tree.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
+
+
+def build(N, tile, body, herd_shape=None, dtype=bf16, vector=None):
+    x = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="relu") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, N, tile), shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    (tn,) = h.tile_sizes
+                    col = tx * tn
+                    x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(x_buf, x[col : col + tn])
+                    o_buf[:] = body(x_buf)
+                    air.ops.store(o_buf, out[col : col + tn])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: relu_vectorized
+# ops.relu is max(x, 0): a broadcast zero and a single arith.maximumf, which is
+# exactly what the hand-written kernel emitted.
+# CHECK: func.func @relu(%{{.*}}: memref<65536xbf16>, %{{.*}}: memref<65536xbf16>)
+# CHECK: air.herd @herd_0 tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c4{{.*}}, %{{.*}}=%c1
+# CHECK: vector.transfer_read {{.*}} vector<16xbf16>
+# CHECK: vector.broadcast {{.*}} : bf16 to vector<16xbf16>
+# CHECK: arith.maximumf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_write {{.*}} vector<16xbf16>
+@run
+def relu_vectorized():
+    print(build(65536, 1024, lambda b: ops.relu(b[:]), herd_shape=(4,)).mlir())
+
+
+# CHECK-LABEL: TEST: clamp_composes
+# maximum and minimum nest, and compose with the arithmetic operators, all in
+# one tree lowered as a single loop.
+# CHECK: arith.maximumf {{.*}} : vector<16xbf16>
+# CHECK: arith.minimumf {{.*}} : vector<16xbf16>
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+@run
+def clamp_composes():
+    print(
+        build(
+            65536,
+            1024,
+            lambda b: ops.minimum(ops.maximum(b[:], 0.0), 6.0) * 2.0,
+            herd_shape=(4,),
+        ).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: relu_f32_scalar
+# f32 relu runs scalar and the example pins it that way: mlir-aie's
+# convert-vector-to-aievec rejects a vector maximumf on f32 outright with
+# "aievec.max conversion fails due to unsupported element data type", on both
+# generations. Scalar f32 max is fine.
+# CHECK-NOT: vector.broadcast
+# CHECK: memref.alloc() : memref<1024xf32, 2 : i32>
+# CHECK: arith.maximumf {{.*}} : f32
+# CHECK: memref.store
+@run
+def relu_f32_scalar():
+    print(
+        build(
+            65536, 1024, lambda b: ops.relu(b[:]), herd_shape=(4,), dtype=f32, vector=0
+        ).mlir()
+    )


### PR DESCRIPTION
> **Stacked on #1830** (#1828 has since merged, so this is now a two-deep stack, rebased onto `main` and conflict-free). This uses `ops.maximum`/`ops.minimum`, added in #1830. Merge that first; this PR's diff then collapses to the leaky_relu-only changes — 6 files.

Ports `programming_examples/leaky_relu` to the `air.api` DSL and deletes the raw-bindings implementation, continuing the series from #1823 (eltwise_add), #1828 (axpy) and #1830 (relu).

## No `select` was added to the DSL

The predecessor expressed the kernel with a comparison and a select:

```python
cmp    = arith.CmpFOp(OGE, x, 0)
result = arith.SelectOp(cmp, x, alpha * x)
```

`air.api` has neither, and this PR does not add them. It uses the identity

```
leaky_relu(x, alpha) = max(x, 0) + alpha * min(x, 0)
```

which needs only operators the DSL already has after #1830. For `x >= 0` the max contributes `x` and the min contributes zero; for `x < 0` the max contributes zero and the min contributes `x`.

This is **bit-exact, not approximate**, and was checked rather than assumed:

- the two forms are bit-identical over 200k unit-normal samples plus the awkward inputs (`+0`, `-0`, `±1e-30`, `±1`), in both bf16 and f32, at `alpha ∈ {0.01, 0.1, 0.2, 0.5}`;
- simulating **both** forms under bf16 intermediate rounding gives bit-identical device semantics, so the rewrite adds no rounding step.

`python/test/api/leaky_relu.py` pins the emitted shape with `CHECK-NOT: arith.cmpf` / `CHECK-NOT: arith.select`, so the rewrite cannot be silently undone.

### Reading the precision line

bf16 reports `rel_err max = 7.8e-03` against an fp32 reference, which is one bf16 ULP. That comes entirely from `alpha` rounding to bf16 (`0.01` → `0.010009765625`) — it is inherent to bf16 leaky ReLU and present in the predecessor **identically**. I verified that rather than inferring it. f32 is bit-exact.

## Coverage audit: old vs new

| Axis | Before | After | |
|---|---|---|---|
| Shape / tile / alpha | 1-D N=65536, 1024, 0.01 | same flags, same defaults | = |
| dtype | bf16 only (hardcoded) | bf16 + f32 | gain |
| Vector width | 16 | 16 bf16 / 0 f32 (see below) | = |
| Herd | fixed 2 cores | 4 on npu1, 8 on npu2; `--herd-shape` | gain |
| Device target | implicit | `--target auto\|npu1\|npu2`, auto-detected | gain |
| Output format | xclbin / elf | same | = |
| Perf harness | none | `--perf-iters` | gain |
| Correctness scope | 100 sampled indices | all N elements | gain |
| Tolerance | rtol=1e-2, atol=1e-8 (runner default) | **identical** | = |
| **Hardware lit invocations** | **1** | **5** (4 peano + 1 elf) | gain |
| lit `REQUIRES` | `ryzen_ai, peano` | same, plus `ryzen_ai_npu2` for elf | gain |
| Makefile | 4 targets, no knobs | 5 targets, 7 knobs | gain |

The reference is computed in the predecessor's own `np.where` form, so the check is against the semantics being replaced rather than against the rewrite.

## Verification

Hardware, npu1 (Phoenix) — all `PASS!`:

| Config | mean_rel_L1 | rel_err max |
|---|---|---|
| bf16 vectorised | 3.666e-05 | 7.812e-03 |
| bf16 scalar | 3.666e-05 | 7.812e-03 |
| f32 scalar | 0.000e+00 | 0.000e+00 |
| bf16 α=0.2, N=131072 | 6.002e-04 | 7.812e-03 |

Compile-only sweep green across dtype × target × vector width on both generations. npu2 left to CI.

**Performance A/B**, same session, alternating, 12 paired reps:

| Arm | Config | Median |
|---|---|---|
| A | predecessor, cmp+select, 2 cores | 232.1 µs |
| B | air.api, max+min, 4 cores | 218.6 µs |

B ahead in **9/12** paired reps, **+5.8%** median, +5.3% on min. The first six reps were genuinely ambiguous (3/6) with a 434 µs outlier in arm A, so I ran six more at 400 iterations where dispatch noise averages out better — those are **6/6**. Worth stating plainly: the extra op per element (max, min, mul, add vs cmp, select, mul) costs nothing measurable here, because at 256 KB of traffic and ~220 µs the kernel is dispatch-bound.

Method: host-observed wall time (`time.perf_counter()` around `run.start()/wait2()`), not device-side bandwidth — leaky_relu has no `test.cpp`. Adequate for a relative A/B, which is why no absolute bandwidth is quoted.

## f32 runs scalar

Pinned by the example, not the emitter: aievec has no f32 max (`aievec.max conversion fails due to unsupported element data type`), and separately a chained f32 multiply-then-add does not legalize at any vector width. bf16 vectorises the whole expression at 16 lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

