### PR TITLE
[test] Recognize Krackan/Strix Halo in the e2e lit config, and find xrt-smi on Windows

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -82,6 +82,10 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
 
     try:
         xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
+        # Windows ships xrt-smi.exe with the NPU driver (System32\AMD, on PATH)
+        # rather than under the XRT SDK, and it needs the .exe suffix. which()
+        # covers both; on Linux the path above already resolves and is used.
+        xrtsmi = shutil.which(xrtsmi) or shutil.which("xrt-smi") or xrtsmi
         result = subprocess.run(
             [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -97,17 +97,28 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         # parts (Strix Halo, Krackan) that the old strict regex missed.
         npu2_models = ["npu4", "strix", "npu5", "strix halo", "npu6", "krackan"]
         npu1_models = ["npu1", "phoenix"]
-        run_on_npu = f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+        # Serializing through flock and run_on_npu.sh is POSIX-only: flock is
+        # util-linux, and the script is bash that sources
+        # /opt/xilinx/xrt/setup.sh. Now that xrt-smi is found on Windows too,
+        # reusing it there would let the suite configure and then fail to launch
+        # every test carrying this substitution. Run the command directly
+        # instead -- the environment is already set up by whoever invoked lit.
+        if os.name == "nt":
+            run_on_npu = ""
+        else:
+            run_on_npu = (
+                f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+            )
         if any(k in out_lc for k in npu2_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu2")
             run_on_npu2 = run_on_npu
-            print("Running tests on NPU2 with command line: ", run_on_npu2)
+            print("Running tests on NPU2 with command line: ", run_on_npu2 or "(none)")
         elif any(k in out_lc for k in npu1_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu1")
             run_on_npu1 = run_on_npu
-            print("Running tests on NPU1 with command line: ", run_on_npu)
+            print("Running tests on NPU1 with command line: ", run_on_npu or "(none)")
         else:
             # No recognized model: dump xrt-smi output so the cause (format
             # change, or a driver error such as an mmap/memlock failure) is

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -140,17 +140,28 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         # test gated on it reported UNSUPPORTED on hardware that can run it.
         npu2_models = ["npu4", "strix", "npu5", "strix halo", "npu6", "krackan"]
         npu1_models = ["npu1", "phoenix"]
-        run_on_npu = f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+        # Serializing through flock and run_on_npu.sh is POSIX-only: flock is
+        # util-linux, and the script is bash that sources
+        # /opt/xilinx/xrt/setup.sh. Now that xrt-smi is found on Windows too,
+        # reusing it there would let the suite configure and then fail to launch
+        # every test carrying this substitution. Run the command directly
+        # instead -- the environment is already set up by whoever invoked lit.
+        if os.name == "nt":
+            run_on_npu = ""
+        else:
+            run_on_npu = (
+                f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+            )
         if any(k in out_lc for k in npu2_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu2")
             run_on_npu2 = run_on_npu
-            print("Running tests on NPU2 with command line: ", run_on_npu2)
+            print("Running tests on NPU2 with command line: ", run_on_npu2 or "(none)")
         elif any(k in out_lc for k in npu1_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu1")
             run_on_npu1 = run_on_npu
-            print("Running tests on NPU1 with command line: ", run_on_npu1)
+            print("Running tests on NPU1 with command line: ", run_on_npu1 or "(none)")
         else:
             # No recognized model: dump xrt-smi output so the cause (a format
             # change, or a driver error) is visible instead of silently

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -123,39 +123,42 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
 
     try:
         xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
+        # Windows ships xrt-smi.exe with the NPU driver (System32\AMD, on PATH)
+        # rather than under the XRT SDK, and it needs the .exe suffix. which()
+        # covers both; on Linux the path above already resolves and is used.
+        xrtsmi = shutil.which(xrtsmi) or shutil.which("xrt-smi") or xrtsmi
         result = subprocess.run(
             [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        result = result.stdout.decode("utf-8").split("\n")
-        # Older format is "|[0000:41:00.1]  ||RyzenAI-npu1  |"
-        # Newer format is "|[0000:41:00.1]  |NPU Phoenix  |"
-        p = re.compile(r"[\|]?(\[.+:.+:.+\]).+\|(RyzenAI-(npu\d)|NPU (\w+))\W*\|")
-        for l in result:
-            m = p.match(l)
-            if not m:
-                continue
-            print("Found Ryzen AI device:", m.group(1))
-            model = "unknown"
-            if m.group(3):
-                model = str(m.group(3))
-            if m.group(4):
-                model = str(m.group(4))
-            print(f"\tmodel: '{model}'")
+        out = result.stdout.decode("utf-8")
+        out_lc = out.lower()
+        # Case-insensitive substring match against known NPU model strings,
+        # kept in sync with programming_examples/lit.cfg.py and the XRT
+        # backend's NPU_MODELS. The strict regex + exact-match list this
+        # replaces predated Strix Halo and Krackan, so those parts fell to the
+        # "unknown model" branch: `ryzen_ai_npu2` was never added and every
+        # test gated on it reported UNSUPPORTED on hardware that can run it.
+        npu2_models = ["npu4", "strix", "npu5", "strix halo", "npu6", "krackan"]
+        npu1_models = ["npu1", "phoenix"]
+        run_on_npu = f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
+        if any(k in out_lc for k in npu2_models):
             config.available_features.add("ryzen_ai")
-            run_on_npu = (
-                f"flock /tmp/npu.lock {config.air_src_root}/utils/run_on_npu.sh"
-            )
-            if model in ["npu1", "Phoenix"]:
-                run_on_npu1 = run_on_npu
-                config.available_features.add("ryzen_ai_npu1")
-                print("Running tests on NPU1 with command line: ", run_on_npu1)
-            elif model in ["npu4", "Strix"]:
-                run_on_npu2 = run_on_npu
-                config.available_features.add("ryzen_ai_npu2")
-                print("Running tests on NPU4 with command line: ", run_on_npu2)
-            else:
-                print(f"WARNING: xrt-smi reported unknown NPU model '{model}'.")
-            break
+            config.available_features.add("ryzen_ai_npu2")
+            run_on_npu2 = run_on_npu
+            print("Running tests on NPU2 with command line: ", run_on_npu2)
+        elif any(k in out_lc for k in npu1_models):
+            config.available_features.add("ryzen_ai")
+            config.available_features.add("ryzen_ai_npu1")
+            run_on_npu1 = run_on_npu
+            print("Running tests on NPU1 with command line: ", run_on_npu1)
+        else:
+            # No recognized model: dump xrt-smi output so the cause (a format
+            # change, or a driver error) is visible instead of silently
+            # skipping every NPU test.
+            print("WARNING: xrt-smi did not report a recognized NPU model.")
+            print("xrt-smi returncode:", result.returncode)
+            print("xrt-smi examine stdout:\n" + out)
+            print("xrt-smi examine stderr:\n" + result.stderr.decode("utf-8"))
     except Exception as e:
         print(f"Failed to run xrt-smi: {e}")
 else:


### PR DESCRIPTION
Found while running the test suites on a Windows NPU2 (Krackan Point) box. Two independent problems in the lit configs; the first is **not** Windows-specific and costs coverage on Linux CI.

## 1. `test/lit.cfg.py` doesn't recognize Krackan or Strix Halo

It matched the model against an exact list:

```python
elif model in ["npu4", "Strix"]:
    config.available_features.add("ryzen_ai_npu2")
```

`xrt-smi` reports `NPU Krackan`, which falls through to the "unknown model" branch. `ryzen_ai_npu2` is never added, so **every test gated on it reports UNSUPPORTED** — while the suite still goes green, because `ryzen_ai` is added *before* the model check and those tests keep running. The coverage loss is silent.

Measured here: **105 of 109** `check-air-e2e-peano` tests skipped, with only a `WARNING: xrt-smi reported unknown NPU model 'Krackan'` line to show for it.

`programming_examples/lit.cfg.py` already fixed this, with a case-insensitive substring match over the whole `xrt-smi` output aligned with mlir-aie's `hostruntime.py` and the XRT backend's `NPU_MODELS`. This PR ports that same block into `test/lit.cfg.py` rather than extending the exact list, so the two configs stay in sync and a future part is added in one shape. It also inherits that version's diagnostic: on no match, dump `xrt-smi`'s returncode and output instead of skipping silently.

**Please check a recent CI log.** If the benchmark runner is a Krackan part, `check-air-e2e-peano` has been skipping its npu2 tests there as well. Grep for `xrt-smi reported unknown NPU model`.

## 2. `xrt-smi` is not findable on Windows

Both configs assumed `xrt-smi` sits under the XRT install and has no extension:

```python
xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
```

On Windows the NPU driver installs `xrt-smi.exe` into `C:\Windows\System32\AMD` and the XRT SDK ships no copy, so the probe raised `FileNotFoundError` and **no** `ryzen_ai` feature was added at all. Resolved through `shutil.which`, which covers both the missing-directory and the `.exe` case. On Linux the original path resolves and is used unchanged, so this is inert there.

## Verification

Windows / NPU2 (Krackan Point), Peano:

| | before | after |
|---|---|---|
| `test/lit.cfg.py` detection | `WARNING: ... unknown NPU model 'Krackan'` | `Running tests on NPU2` |
| `xrt/0[23]_*peano` | all UNSUPPORTED | **3 passed** |
| `xrt/3[0-9]_*peano` | all UNSUPPORTED | **11 passed**, 3 failed, 10 unsupported |
| `programming_examples` detection | unchanged | unchanged (re-checked) |

The 3 remaining failures are triton tests failing on numerics (`Output 0 does not meet expected output`), not detection — unrelated to this change, and I can't tell from here whether they also fail on Linux.

`black` clean; both files byte-compile.

## Scope note

Getting the xrt e2e suite to configure on Windows at all needs the `if(WIN32)` guard in the top-level `CMakeLists.txt` lifted, since `runtime_lib` isn't built there. I used a local hack for that and am **not** proposing it here — a real version needs to deal with the C++-host tests, which want `g++-13`, boost and `-luuid -lrt`. This PR is only the detection fix, which stands on its own for Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
