### PR TITLE
[docs] Make the Windows guide instructions, and fix what it warned about

### DIFF
--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -6,13 +6,13 @@ Use an **x64 Native Tools Command Prompt for Visual Studio** (`cmd.exe`) for the
 
 MLIR-AIR builds on [MLIR-AIE](https://github.com/Xilinx/mlir-aie), and the two share the same Windows host requirements. Where this guide and [mlir-aie's native Windows guide](https://github.com/Xilinx/mlir-aie/blob/main/docs/buildHostWinNative.md) overlap, they are intended to agree; sections 1–3 below are the common host setup.
 
-> **Python note:** The Windows XRT SDK supplies `pyxrt` bindings for **CPython 3.13**. Use Python 3.13. Another Python version requires an XRT distribution with matching bindings. The whole stack will build and then fail at the final `import pyxrt` if the minor version does not match.
+> **Python note:** `pyxrt` is a compiled extension module, so your Python has to be the exact CPython minor version the XRT SDK built it against — **3.13** at the time of writing. Any other minor version installs and builds the whole stack, then fails at `import pyxrt`. [Section 3](#3-install-the-windows-xrt-sdk) reads the required version straight out of `pyxrt.pyd`; that check is authoritative if a newer SDK has moved on and this note has not.
 
 ## 1. Install the Windows development environment
 
 - A Windows 11 system with a supported Ryzen™ AI / XDNA™ NPU.
 - **Visual Studio 2026** (preferred) or **Visual Studio 2022** — the full IDE or the matching **Build Tools** package. Only needed for the source build in section 6; the wheel path in section 4 does not require a compiler.
-- **Python 3.13** (see the note above).
+- **Python**, at the minor version the note above names.
 - **Git for Windows**.
 - **GNU make**, only if you intend to run the example test suites in
   [section 6.5](#65-testing) — most of those tests shell out to it. Running an
@@ -34,6 +34,7 @@ REM Choose one: the full IDE or the matching Build Tools package
 winget install -e --id Microsoft.VisualStudio.Community
 REM winget install -e --id Microsoft.VisualStudio.BuildTools
 
+REM The package id carries the minor version; match the Python note above
 winget install -e --id Python.Python.3.13
 winget install -e --id Git.Git
 
@@ -47,7 +48,7 @@ from MSYS2 or Chocolatey works equally well.
 
 CMake and Ninja do **not** need a system-wide install; both are pulled into the Python environment in sections 4 and 6.
 
-A dedicated Conda or Miniforge environment works too, when it uses Python 3.13. Activate it before running MLIR-AIE's `iron_setup.py` in [section 6.1](#61-prerequisites), which creates `ironenv` from the active interpreter.
+A dedicated Conda or Miniforge environment works too, as long as it is on that same minor version. Activate it before running MLIR-AIE's `iron_setup.py` in [section 6.1](#61-prerequisites), which creates `ironenv` from the active interpreter.
 
 ## 2. Update and verify the NPU driver
 
@@ -57,24 +58,15 @@ Install the latest Ryzen™ AI / XDNA™ driver, then verify the NPU is visible:
 "C:\Windows\System32\AMD\xrt-smi.exe" examine
 ```
 
-NPU driver **32.0.20101.3760** (XRT **2.21.0**) is the minimum supported on Windows.
-
-Two things worth knowing when checking a driver version:
-
-- AMD publishes two version series that are not comparable — `32.0.203.x` (Ryzen AI direct) and `32.0.201xx.xxxx` (WHQL/OEM). **Compare the XRT version instead**; it is a single monotonic series and is what actually matters here.
-- The driver version reported by `xrt-smi` can be confirmed independently through PnP, which is useful when an installer claims success but changed nothing:
-
-```powershell
-Get-CimInstance Win32_PnPSignedDriver |
-  Where-Object { $_.DeviceName -match 'NPU' } |
-  Select-Object DeviceName, DriverVersion, DriverDate
-```
+MLIR-AIR adds no driver requirement of its own; the supported floor is whatever
+[mlir-aie's native Windows guide](https://github.com/Xilinx/mlir-aie/blob/main/docs/buildHostWinNative.md)
+states, since that is the host setup both repositories share.
 
 ## 3. Install the Windows XRT SDK
 
-The XRT SDK provides the headers, import libraries, tools, and `pyxrt` bindings. Pair the SDK with the **driver's** XRT version, so install the driver first.
+The XRT SDK provides the headers, import libraries, tools, and `pyxrt` bindings. Its version has to match the **driver's** XRT version, which `xrt-smi examine` reports — so install the driver first, then pick the SDK to match.
 
-Download `xrt_windows_sdk.zip` from the [XRT releases page](https://github.com/Xilinx/XRT/releases), choosing the tag matching your driver's XRT version — 2.21.75 or newer. Extract the archive so that its `xrt_sdk\xrt` directory becomes:
+Download that release's `xrt_windows_sdk.zip` from the [XRT releases page](https://github.com/Xilinx/XRT/releases) and extract it so that its `xrt_sdk\xrt` directory becomes:
 
 ```text
 C:\Xilinx\XRT
@@ -82,11 +74,14 @@ C:\Xilinx\XRT
 
 `C:\Xilinx\XRT\python\pyxrt.pyd` should now exist. `C:\Xilinx\XRT` is the canonical location; a different path works as long as the environment variables in the following sections point at it.
 
-To confirm which CPython ABI the bindings were built against, read the binary rather than trusting a label:
+Read the CPython ABI out of the bindings rather than trusting a label, and check it against the Python you installed in section 1:
 
 ```bat
 python -c "import re,pathlib;print(re.search(rb'python(\d)(\d{2})\.dll',pathlib.Path(r'C:\Xilinx\XRT\python\pyxrt.pyd').read_bytes(),re.I).groups())"
+python -c "import sys;print(sys.version_info[:2])"
 ```
+
+Both must print the same major and minor. If they differ, this SDK wants a different Python than the one you have; install that version and use it for the virtual environment in section 4. This check, not the note at the top of the guide, is the authority.
 
 ## 4. Install prebuilt wheels (recommended)
 
@@ -94,7 +89,7 @@ This is the fastest path and needs no compiler, no CMake, and no LLVM clone. Use
 
 MLIR-AIR publishes **Windows AMD64** wheels. Backend dependencies are exposed as pip **extras**; for the AIE backend use the `[aie]` extra, which pins the exact `mlir_aie` version this AIR wheel was tested against and pulls `llvm-aie` (the Peano backend compiler).
 
-1. **Create a virtual environment** with Python 3.13:
+1. **Create a virtual environment** with that Python:
 
    ```bat
    python -m venv airenv

--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -2,22 +2,11 @@
 
 This guide covers the **native Windows** setup for MLIR-AIR. It supports compiling AIR designs and running them on a Ryzen™ AI NPU entirely within Windows, without a POSIX environment. Users who prefer POSIX-style development can instead run WSL2 and follow the [Linux guide](buildingRyzenLin.md).
 
-Use an **x64 Native Tools Command Prompt for Visual Studio** (`cmd.exe`) for the commands in this guide. It provides MSVC, the linker, and the Windows SDK in one configured environment. Visual Studio and Visual Studio Build Tools both install that prompt and add a Start menu shortcut. PowerShell is also supported; the equivalent commands are collected in [Addendum A](#addendum-a-powershell).
+Use an **x64 Native Tools Command Prompt for Visual Studio** (`cmd.exe`) for the commands in this guide. It provides MSVC, the linker, and the Windows SDK in one configured environment. Visual Studio and Visual Studio Build Tools both install that prompt and add a Start menu shortcut. PowerShell is also supported; the equivalent commands are collected in [section 7](#7-powershell).
 
 MLIR-AIR builds on [MLIR-AIE](https://github.com/Xilinx/mlir-aie), and the two share the same Windows host requirements. Where this guide and [mlir-aie's native Windows guide](https://github.com/Xilinx/mlir-aie/blob/main/docs/buildHostWinNative.md) overlap, they are intended to agree; sections 1–3 below are the common host setup.
 
 > **Python note:** The Windows XRT SDK supplies `pyxrt` bindings for **CPython 3.13**. Use Python 3.13. Another Python version requires an XRT distribution with matching bindings. The whole stack will build and then fail at the final `import pyxrt` if the minor version does not match.
-
-## Contents
-
-1. [Install the Windows development environment](#1-install-the-windows-development-environment)
-2. [Update and verify the NPU driver](#2-update-and-verify-the-npu-driver)
-3. [Install the Windows XRT SDK](#3-install-the-windows-xrt-sdk)
-4. [Install prebuilt wheels (recommended)](#4-install-prebuilt-wheels-recommended)
-5. [Running a quick example](#5-running-a-quick-example)
-6. [Build from source](#6-build-from-source)
-7. [Addendum A: PowerShell](#addendum-a-powershell)
-8. [Addendum B: Windows differences and limitations](#addendum-b-windows-differences-and-limitations)
 
 ## 1. Install the Windows development environment
 
@@ -25,6 +14,9 @@ MLIR-AIR builds on [MLIR-AIE](https://github.com/Xilinx/mlir-aie), and the two s
 - **Visual Studio 2026** (preferred) or **Visual Studio 2022** — the full IDE or the matching **Build Tools** package. Only needed for the source build in section 6; the wheel path in section 4 does not require a compiler.
 - **Python 3.13** (see the note above).
 - **Git for Windows**.
+- **GNU make**, only if you intend to run the example test suites in
+  [section 6.5](#65-testing) — most of those tests shell out to it. Running an
+  individual example does not need it.
 
 ### 1.1 Visual Studio components
 
@@ -44,9 +36,18 @@ REM winget install -e --id Microsoft.VisualStudio.BuildTools
 
 winget install -e --id Python.Python.3.13
 winget install -e --id Git.Git
+
+REM Only needed to run the example test suites (section 6.5)
+winget install -e --id ezwinports.make
 ```
 
+`ezwinports.make` is a standalone GNU make with no other dependencies; it picks
+up Git's `sh.exe` as its shell, which is what the Makefile recipes expect. `make`
+from MSYS2 or Chocolatey works equally well.
+
 CMake and Ninja do **not** need a system-wide install; both are pulled into the Python environment in sections 4 and 6.
+
+A dedicated Conda or Miniforge environment works too, when it uses Python 3.13. Activate it before running MLIR-AIE's `iron_setup.py` in [section 6.1](#61-prerequisites), which creates `ironenv` from the active interpreter.
 
 ## 2. Update and verify the NPU driver
 
@@ -73,11 +74,7 @@ Get-CimInstance Win32_PnPSignedDriver |
 
 The XRT SDK provides the headers, import libraries, tools, and `pyxrt` bindings. Pair the SDK with the **driver's** XRT version, so install the driver first.
 
-```text
-https://github.com/Xilinx/XRT/releases/download/2.21.75/xrt_windows_sdk.zip
-```
-
-Extract the archive so that its `xrt_sdk\xrt` directory becomes:
+Download `xrt_windows_sdk.zip` from the [XRT releases page](https://github.com/Xilinx/XRT/releases), choosing the tag matching your driver's XRT version — 2.21.75 or newer. Extract the archive so that its `xrt_sdk\xrt` directory becomes:
 
 ```text
 C:\Xilinx\XRT
@@ -128,7 +125,7 @@ MLIR-AIR publishes **Windows AMD64** wheels. Backend dependencies are exposed as
    set "PYTHONPATH=%MLIR_AIR_INSTALL_DIR%\python;%MLIR_AIE_INSTALL_DIR%\python;%XRT_ROOT%\python"
    ```
 
-   > **`C:\Windows\System32\AMD` on `PATH` is not optional.** MLIR-AIR selects the target device by running `xrt-smi examine` and matching the reported NPU model. If `xrt-smi` cannot be found the lookup fails silently and falls back to **npu1**, so an npu2 part (Strix, Strix Halo, Krackan) is compiled for the wrong target. Alternatively, pass `target_device="npu2"` explicitly to `XRTBackend` / `XRTRunner`.
+   > `C:\Windows\System32\AMD` is on `PATH` so that MLIR-AIR can find `xrt-smi` and select the target device from the NPU model it reports. Passing `target_device="npu2"` to `XRTBackend` / `XRTRunner` selects it explicitly instead.
 
 4. **Verify the install:**
 
@@ -173,7 +170,8 @@ cd build_peano
 python ..\single_core_dma.py --output-format elf
 ```
 
-> **Most examples ship a `Makefile`, and Windows has no `make`.** The Makefiles are thin wrappers — the `run` target is a `mkdir` plus the `python` invocation shown above, so it is easy to run by hand. `make` from MSYS2 or Chocolatey also works if you prefer. See [Addendum B](#addendum-b-windows-differences-and-limitations).
+Most examples also ship a `Makefile` whose `run` target does the same thing, so
+`make run` works too once GNU make is installed ([section 1.2](#12-install-the-tools)).
 
 Explore `programming_examples\` for many more designs: GEMM, element-wise operations, softmax, RMSNorm, RoPE, FlashAttention, and end-to-end LLM examples.
 
@@ -227,17 +225,16 @@ python -c "import zipfile,glob;zipfile.ZipFile(glob.glob('mlir-*.whl')[0]).extra
 
 If you already staged this wheel for a MLIR-AIE source build, check whether the version matches (`utils\clone-llvm.sh --get-wheel-version` in each repo) and reuse that tree rather than downloading 1 GB again.
 
-See [Addendum B](#addendum-b-windows-differences-and-limitations) for two post-extraction fixups that may be needed.
-
 ### 6.3 Configure and build
 
-**Do not use `utils\build-mlir-air-using-wheels.sh` or `utils\build-mlir-air-xrt.sh` on Windows.** Both auto-detect a linker with `if [ -x "$(command -v lld)" ]; then CMAKE_ARGS="$CMAKE_ARGS -DLLVM_USE_LINKER=lld"`. Peano and the Visual Studio Clang components both put `lld` on `PATH`, LLVM then probes the GCC/Clang-style `-fuse-ld=lld` flag, and MSVC rejects it with a configure-time fatal error. Invoke CMake directly instead, as MLIR-AIR's own Windows CI does.
-
-Save this as `configure.cmd` and adjust the paths:
+Invoke CMake directly, as MLIR-AIR's own Windows CI does. Save this as
+`configure.cmd` and adjust the paths; `vswhere` locates Visual Studio regardless
+of which edition and version is installed:
 
 ```bat
 @echo off
-call "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64 >nul 2>&1
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSPATH=%%i"
+call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64 >nul 2>&1
 call "C:\dev\mlir-aie\iron_env.cmd" || exit /b 1
 
 set "AIR_SRC=C:/dev/mlir-air"
@@ -258,10 +255,15 @@ cmake "%AIR_SRC%" ^
   -DXRT_ROOT=C:/Xilinx/XRT ^
   -DLLVM_EXTERNAL_LIT=C:/dev/mlir-aie/ironenv/Scripts/lit.exe ^
   -DPython3_EXECUTABLE=C:/dev/mlir-aie/ironenv/Scripts/python.exe ^
+  -DENABLE_RUN_XRT_TESTS=ON ^
   -DCMAKE_INSTALL_PREFIX=%AIR_SRC%/install
 ```
 
-Every path handed to CMake uses forward slashes. Three configure lines are worth checking before building:
+`-DENABLE_RUN_XRT_TESTS=ON` defaults to OFF and is what lets the test suites in
+[section 6.5](#65-testing) dispatch to the NPU. Every path handed to CMake uses
+forward slashes.
+
+Three configure lines are worth checking before building:
 
 ```text
 -- Found xrt_coreutil
@@ -269,7 +271,11 @@ Every path handed to CMake uses forward slashes. Three configure lines are worth
 -- Skipping e2e tests on Windows (runtime libraries not built)
 ```
 
-The third is expected — see [Addendum B](#addendum-b-windows-differences-and-limitations). Reports that Vitis, `xchesscc`, AIETools, and LibXAIE were not found are also expected and harmless: Windows uses Peano exclusively.
+The third is expected: the `airhost` / `aircpu` host runtimes need POSIX APIs
+(`dlopen`, `mmap`, `ioctl`) and the Linux `amdair` kernel driver, so CMake skips
+them, and with them the `test/` tree. Reports that Vitis, `xchesscc`, AIETools,
+and LibXAIE were not found are also expected and harmless: Windows uses Peano
+exclusively, and Chess-gated tests report *unsupported* rather than failing.
 
 Then build and install:
 
@@ -296,6 +302,8 @@ set "PYTHONPATH=%MLIR_AIR_INSTALL_DIR%\python;%PYTHONPATH%"
 
 ### 6.5 Testing
 
+The compile-only suites need nothing beyond the build environment:
+
 ```bat
 cd C:\dev\mlir-air\build
 ninja check-air-cpp
@@ -303,15 +311,45 @@ ninja check-air-mlir
 ninja check-air-python
 ```
 
-`check-air-cpp` and `check-air-python` pass on Windows. `check-air-mlir` currently has known failures confined to the `Util/Runner` and `Util/Channel` suites; see [Addendum B](#addendum-b-windows-differences-and-limitations).
+#### Running the examples on hardware
 
-The hardware end-to-end suites (`check-air-e2e*`) are **not available on Windows** — they depend on the host runtime libraries, which are not built. Run designs under `programming_examples\` instead.
+`check-programming-examples-peano` dispatches to the NPU, so it needs the
+**runtime** environment of [section 6.4](#64-set-up-the-environment) rather than
+the build environment, plus GNU make on `PATH` — most example tests shell out to
+it. A wrapper that layers both:
 
----
+```bat
+@echo off
+call C:\dev\mlir-aie\iron_env.cmd || exit /b 1
+set "MLIR_AIR_INSTALL_DIR=C:\dev\mlir-air\install"
+set "PATH=%MLIR_AIR_INSTALL_DIR%\bin;%PATH%"
+set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Links;%PATH%"
+set "PATH=%LOCALAPPDATA%\Programs\Git\usr\bin;%PATH%"
+cd /d C:\dev\mlir-air\build
+ninja check-programming-examples-peano
+```
 
-<a id="addendum-a-powershell"></a>
-<details>
-<summary><strong>Addendum A: PowerShell</strong></summary>
+`iron_env.cmd` supplies XRT — which provides `aiebu-asm.exe`, needed to package a
+full ELF — and `C:\Windows\System32\AMD` for `xrt-smi.exe`. The two added `PATH`
+entries are GNU make and Git's `usr\bin`, which make picks up as its shell. The
+full suite takes roughly 20 minutes on a Krackan Point NPU2.
+
+Use `lit` directly, in the same environment, to run one example:
+
+```bat
+lit -sv -j1 --filter "eltwise_add_with_l2.*peano" C:/dev/mlir-air/build/programming_examples
+```
+
+#### The xrt end-to-end suites
+
+`check-air-e2e*` and `check-air-runner` do not exist in a Windows build: the
+`test/` tree is skipped along with the host runtimes it needs
+([section 6.3](#63-configure-and-build)). Even with that guard lifted, much of
+`test/xrt` builds a Linux host binary (`g++-13`, boost, `-luuid -lrt`) or wraps
+execution in `flock`. Use `programming_examples\` as the end-to-end path on
+Windows.
+
+## 7. PowerShell
 
 Visual Studio installs a **Developer PowerShell for VS** shortcut providing the same compiler environment as the Native Tools `cmd.exe` prompt. PowerShell can also be started from an existing Native Tools prompt with `pwsh`, inheriting the compiler environment.
 
@@ -362,69 +400,6 @@ cmake C:/dev/mlir-air `
 ```
 
 The MSVC environment must still be present — start from a Developer PowerShell, or run `VsDevCmd.bat` in a `cmd.exe` prompt and launch `pwsh` from it.
-
-### Conda or Miniforge Python
-
-A dedicated Conda or Miniforge environment works with the SDK when it uses Python 3.13. Activate it before running MLIR-AIE's `iron_setup.py`, which uses the active interpreter when creating `ironenv`.
-
-</details>
-
-<a id="addendum-b-windows-differences-and-limitations"></a>
-<details>
-<summary><strong>Addendum B: Windows differences and limitations</strong></summary>
-
-### Not built on Windows
-
-`runtime_lib` (the `airhost` / `aircpu` host runtimes) depends on POSIX APIs — `dlopen`, `mmap`, `ioctl` — and on the Linux `amdair` kernel driver, so CMake skips it on Windows. Consequently:
-
-- The `check-air-e2e*` targets and the `test/xrt` suite do not exist in a Windows build. `programming_examples\` is the end-to-end path.
-- `Util/Channel` tests in `check-air-mlir` fail because they link a host executable against that runtime.
-
-### Peano only, no Chess
-
-Vitis and `xchesscc` are unavailable on Windows, so Peano is the only core compiler. CMake reporting `Unable to find xchesscc` / `Could NOT find Vitis` / `Could NOT find AIETools` is expected. Chess-gated LIT tests report *unsupported* rather than failing, and examples should be run with `PEANO_INSTALL_DIR` set.
-
-### `check-air-mlir` failures
-
-`Util/Runner` (the `air-runner` performance simulator) currently produces different output on Windows than the tests expect, and a handful of its tests use the `|&` shell operator, which lit's internal shell does not parse on Windows. These are open issues, not setup problems — the rest of the suite passes.
-
-### No `make`
-
-Most `programming_examples` ship Makefiles, and Windows has no `make`. The recipes are thin: `run` is a `mkdir` plus a `python` invocation. Read the Makefile and run the `python` line directly, or install `make` from MSYS2 or Chocolatey. Examples that compile an AIE kernel first (the GEMM examples, for instance) additionally invoke Peano's `clang++` with `--target=aie2p-none-unknown-elf` — that command is also in the Makefile and can be run as-is.
-
-LIT tests driven by Makefiles are skipped automatically on Windows.
-
-### Wrong device auto-detected
-
-`XRTBackend` runs `xrt-smi examine` and matches the reported model name against its device table. If `xrt-smi` is not on `PATH`, detection fails **silently** and falls back to `npu1`. Keep `C:\Windows\System32\AMD` on `PATH`, or pass `target_device="npu2"` explicitly. A design compiled for the wrong target typically shows up as a runtime timeout rather than a clear error.
-
-### Staged LLVM wheel fixups
-
-Two problems can appear after extracting the MLIR distro wheel (section 6.2):
-
-- **Hardcoded DIA SDK path.** `LLVMExports.cmake` inside the wheel can carry an absolute `diaguids.lib` path from the machine that built it. If CMake fails importing LLVM targets over a missing `diaguids.lib`, MLIR-AIE ships a fixup that rewrites it to your Visual Studio installation:
-
-  ```bat
-  python -c "import sys;sys.path.insert(0,r'C:\dev\mlir-aie\utils\mlir_aie_wheels\scripts');from pathlib import Path;import download_mlir;download_mlir._fixup_llvm_diaguids(Path(r'C:\dev\mlir-air\my_install\mlir'))"
-  ```
-
-- **Future-dated timestamps.** Files extracted from these wheels can carry mtimes in the future, which makes Ninja re-run configuration indefinitely. The symptom is a hang, not an error. Stamp them into the past:
-
-  ```bat
-  python -c "import os;[os.utime(os.path.join(r,f),(315600000,315600000)) for r,_,fs in os.walk(r'C:\dev\mlir-air\my_install\mlir') for f in fs]"
-  ```
-
-Both are avoided by reusing a tree that a MLIR-AIE build already staged and patched.
-
-### Endpoint security
-
-Endpoint protection has been observed quarantining individual executables out of the extracted LLVM wheel, which surfaces later as a confusing CMake error. A quick assertion after extraction:
-
-```bat
-if not exist my_install\mlir\bin\llvm-debuginfod.exe echo POSSIBLE AV QUARANTINE
-```
-
-</details>
 
 -----
 

--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -339,16 +339,25 @@ it. A wrapper that layers both:
 call C:\dev\mlir-aie\iron_env.cmd || exit /b 1
 set "MLIR_AIR_INSTALL_DIR=C:\dev\mlir-air\install"
 set "PATH=%MLIR_AIR_INSTALL_DIR%\bin;%PATH%"
-set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Links;%PATH%"
-set "PATH=%LOCALAPPDATA%\Programs\Git\usr\bin;%PATH%"
+
+REM GNU make, plus Git's usr\bin for the sh.exe make uses as its shell. Both
+REM install per-user or machine-wide depending on how they were installed, so
+REM probe rather than assume; add your own directories if either came from
+REM MSYS2 or Chocolatey instead.
+if exist "%LOCALAPPDATA%\Microsoft\WinGet\Links\make.exe" set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Links;%PATH%"
+if exist "%ProgramFiles%\Git\usr\bin\sh.exe" set "PATH=%ProgramFiles%\Git\usr\bin;%PATH%"
+if exist "%LOCALAPPDATA%\Programs\Git\usr\bin\sh.exe" set "PATH=%LOCALAPPDATA%\Programs\Git\usr\bin;%PATH%"
+
+where make >nul 2>&1 || (echo GNU make not found -- see section 1.2. & exit /b 1)
+where sh   >nul 2>&1 || (echo sh.exe not found; is Git for Windows installed? & exit /b 1)
+
 cd /d C:\dev\mlir-air\build
 ninja check-programming-examples-peano
 ```
 
 `iron_env.cmd` supplies XRT — which provides `aiebu-asm.exe`, needed to package a
-full ELF — and `C:\Windows\System32\AMD` for `xrt-smi.exe`. The two added `PATH`
-entries are GNU make and Git's `usr\bin`, which make picks up as its shell. The
-full suite takes roughly 20 minutes on a Krackan Point NPU2.
+full ELF — and `C:\Windows\System32\AMD` for `xrt-smi.exe`. The full suite takes
+roughly 20 minutes on a Krackan Point NPU2.
 
 Use `lit` directly, in the same environment, to run one example:
 

--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -42,6 +42,11 @@ REM Only needed to run the example test suites (section 6.5)
 winget install -e --id ezwinports.make
 ```
 
+`winget` installs Visual Studio without any workload, so open the Visual Studio
+Installer afterwards and add the components in
+[section 1.1](#11-visual-studio-components) — otherwise there is no C++ compiler
+and [section 6.3](#63-configure-and-build) stops with a message saying so.
+
 `ezwinports.make` is a standalone GNU make with no other dependencies; it picks
 up Git's `sh.exe` as its shell, which is what the Makefile recipes expect. `make`
 from MSYS2 or Chocolatey works equally well.
@@ -214,7 +219,15 @@ mkdir my_install
 cd my_install
 pip download mlir==<version printed above> -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
 python -c "import zipfile,glob;zipfile.ZipFile(glob.glob('mlir-*.whl')[0]).extractall('.')"
+cd ..
+python utils\fixup-llvm-diaguids.py my_install\mlir
 ```
+
+That last step repoints one absolute path the wheel carries from the machine
+that built it — `diaguids.lib`, the DIA SDK import library
+`LLVMDebugInfoPDB` links against. Skipping it surfaces much later, as a link
+failure naming a Visual Studio directory you do not have. The script is
+idempotent, so re-running it after a re-extract is harmless.
 
 (If you do have Git Bash handy, `bash utils\clone-llvm.sh --get-wheel-version` prints the same string.)
 
@@ -223,13 +236,21 @@ If you already staged this wheel for a MLIR-AIE source build, check whether the 
 ### 6.3 Configure and build
 
 Invoke CMake directly, as MLIR-AIR's own Windows CI does. Save this as
-`configure.cmd` and adjust the paths; `vswhere` locates Visual Studio regardless
-of which edition and version is installed:
+`configure.cmd` and adjust the paths. `vswhere` finds Visual Studio whatever its
+edition, version or location: `-products *` is needed because the default filter
+covers Community/Professional/Enterprise but silently omits Build Tools, and
+`-requires` rejects an install that has no C++ toolset, which is what a bare
+`winget install` leaves you with.
 
 ```bat
 @echo off
-for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSPATH=%%i"
-call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64 >nul 2>&1
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSPATH=%%i"
+if not defined VSPATH (
+  echo No Visual Studio with the C++ toolset found -- see section 1.1.
+  exit /b 1
+)
+call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64 >nul 2>&1 || exit /b 1
 call "C:\dev\mlir-aie\iron_env.cmd" || exit /b 1
 
 set "AIR_SRC=C:/dev/mlir-air"

--- a/mlir/test/Target/AIRHerdToJSON/json_mm_random_shapes.mlir
+++ b/mlir/test/Target/AIRHerdToJSON/json_mm_random_shapes.mlir
@@ -23,7 +23,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-place-herds="num-rows=6 num-cols=11" | air-translate -air-herds-to-json -num-rows=6 -num-cols=11 |& FileCheck %s
+// RUN: air-opt %s -air-place-herds="num-rows=6 num-cols=11" | air-translate -air-herds-to-json -num-rows=6 -num-cols=11 2>&1 | FileCheck %s
 
 // CHECK: "row": 5, 
 // CHECK: "col": 10

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_overflow.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_overflow.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-place-herds="num-rows=4 num-cols=11" |& FileCheck %s
+// RUN: air-opt %s -air-place-herds="num-rows=4 num-cols=11" 2>&1 | FileCheck %s
 // CHECK: No valid placement found.
 // CHECK: Unplaced herd: matmul_herd_2
 // CHECK: Unplaced herd: gelu_herd_2

--- a/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_random_shapes.mlir
+++ b/mlir/test/Transform/AIRHerdPlacement/matmul_gelu_random_shapes.mlir
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-place-herds="num-rows=6 num-cols=11" |& FileCheck %s
+// RUN: air-opt %s -air-place-herds="num-rows=6 num-cols=11" 2>&1 | FileCheck %s
 
 // CHECK: air.herd {{.*}} attributes {x_loc = 7 {{.*}} y_loc = 4
 // CHECK: air.herd {{.*}} attributes {x_loc = 5 {{.*}} y_loc = 2

--- a/mlir/test/Util/Channel/lit.local.cfg
+++ b/mlir/test/Util/Channel/lit.local.cfg
@@ -1,0 +1,5 @@
+# These tests build and run a host executable linked against the aircpu
+# runtime, so they only apply where that runtime was built. See the `aircpu`
+# feature in ../../lit.cfg.py.
+if "aircpu" not in config.available_features:
+    config.unsupported = True

--- a/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-runner %s -f test -m %S/arch.json |& FileCheck %s
+// RUN: air-runner %s -f test -m %S/arch.json 2>&1 | FileCheck %s
 
 // Check for error emission when not enough resources are allocated to run a herd.
 

--- a/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_herd_per_core.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-runner %s -f test -m %S/arch.json -g core |& FileCheck %s
+// RUN: air-runner %s -f test -m %S/arch.json -g core 2>&1 | FileCheck %s
 
 // Check for error emission when not enough resources are allocated to run a herd.
 // Trace simulation mode set to per-core granularity.

--- a/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-runner %s -f test -m %S/arch.json |& FileCheck %s
+// RUN: air-runner %s -f test -m %S/arch.json 2>&1 | FileCheck %s
 
 // Check for error emission when not enough resources are allocated to run a segment.
 

--- a/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment_per_core.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-runner %s -f test -m %S/arch.json -g core |& FileCheck %s
+// RUN: air-runner %s -f test -m %S/arch.json -g core 2>&1 | FileCheck %s
 
 // Check for error emission when not enough resources are allocated to run a segment.
 // Trace simulation mode set to per-core granularity.

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -59,6 +59,13 @@ config.substitutions.append(
     )
 )
 
+# Tests that link a host executable against the aircpu runtime can only run
+# where that runtime was built. It needs POSIX APIs, so the top-level
+# CMakeLists skips runtime_lib on Windows; gate on the artifact rather than on
+# the platform, which also covers a POSIX build with the runtimes disabled.
+if os.path.isdir(os.path.join(air_runtime_lib, "aircpu")):
+    config.available_features.add("aircpu")
+
 llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
 
 llvm_config.use_default_substitutions()

--- a/programming_examples/attention_decode/Makefile
+++ b/programming_examples/attention_decode/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 # -Os (aggressive size opt) keeps the AIE2P core ELF under the 16 KB
 # program memory limit when rms shares a tile with vecmat + attn +
@@ -42,11 +44,11 @@ ITERS ?= 20
 all: run-attn-decode
 
 print-attn-decode:
-	${powershell} python3 ${srcdir}/attn_decode_npu2.py $(OUTPUT_FORMAT_FLAG) -p --nkv $(NKV) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK)
+	${powershell} $(PYTHON) ${srcdir}/attn_decode_npu2.py $(OUTPUT_FORMAT_FLAG) -p --nkv $(NKV) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK)
 
 run-attn-decode: compile-attn-decode-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py $(OUTPUT_FORMAT_FLAG) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK) --nkv $(NKV) --compile-mode compile-and-run
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_decode_npu2.py $(OUTPUT_FORMAT_FLAG) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK) --nkv $(NKV) --compile-mode compile-and-run
 
 compile-attn-decode-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -70,7 +72,7 @@ compile-attn-decode-kernel-nocompute:
 
 profile-decode-nocompute: compile-attn-decode-kernel-nocompute build-test-exe-decode
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_decode_npu2.py \
 		--nkv $(NKV) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK) \
 		--compile-mode compile-only --output-format xclbin
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_xclbin_decode.exe \
@@ -85,7 +87,7 @@ profile-decode-nocompute: compile-attn-decode-kernel-nocompute build-test-exe-de
 # ============================================================================
 profile-decode: compile-attn-decode-kernel build-test-exe-decode
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_decode_npu2.py \
 		--nkv $(NKV) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK) \
 		--compile-mode compile-only --output-format xclbin
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_xclbin_decode.exe \
@@ -97,7 +99,7 @@ profile-decode: compile-attn-decode-kernel build-test-exe-decode
 # Both xclbin and ELF formats run multi-iteration cleanly for this design.
 profile-decode-elf: compile-attn-decode-kernel build-test-exe-decode-elf
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_decode_npu2.py \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_decode_npu2.py \
 		--nkv $(NKV) --pos $(POS) --k $(N_IN) --n $(DK) --tile-k $(TILE_K) --tile-n $(TILE_N) --seq-len $(LK) \
 		--compile-mode compile-only --output-format elf
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_elf_npu2_decode.exe \

--- a/programming_examples/average_pool/Makefile
+++ b/programming_examples/average_pool/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/average_pool.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/average_pool.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/average_pool.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/average_pool.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/axpy/Makefile
+++ b/programming_examples/axpy/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -34,17 +36,17 @@ PY_FLAGS = --n $(N) --tile-n $(TILE_N) --alpha $(ALPHA) --dtype $(DTYPE) \
 	$(VEC_FLAG) --target $(TARGET) $(OUTPUT_FORMAT_FLAG) $(EXTRA_PY_FLAGS)
 
 print:
-	${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) --print-ir
+	${powershell} $(PYTHON) ${srcdir}/axpy.py $(PY_FLAGS) --print-ir
 
 compile:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) --compile-only
+		${powershell} $(PYTHON) ${srcdir}/axpy.py $(PY_FLAGS) --compile-only
 
 run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/axpy.py $(PY_FLAGS) \
+		${powershell} $(PYTHON) ${srcdir}/axpy.py $(PY_FLAGS) \
 		--perf-iters $(PERF_ITERS)
 
 clean:

--- a/programming_examples/bottleneck/Makefile
+++ b/programming_examples/bottleneck/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -9,7 +11,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -27,7 +29,7 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/bottleneck.py -p
+	${powershell} $(PYTHON) ${srcdir}/bottleneck.py -p
 
 compile-kernels:
 	mkdir -p $(BUILD_DIR)
@@ -49,12 +51,12 @@ compile-kernels:
 
 run: compile-kernels
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} python3 ${srcdir}/bottleneck.py
+	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} $(PYTHON) ${srcdir}/bottleneck.py
 
 # All kernels are inline MLIR in bottleneck_mlir.py — no .o files needed
 run-mlir:
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} python3 ${srcdir}/bottleneck_mlir.py
+	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} $(PYTHON) ${srcdir}/bottleneck_mlir.py
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/cascade_reduction/Makefile
+++ b/programming_examples/cascade_reduction/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/cascade_reduction.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/cascade_reduction.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/cascade_reduction.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/cascade_reduction.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/broadcast/cross_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/cross_herd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/broadcast/multi_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/multi_herd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/broadcast/single_herd/Makefile
+++ b/programming_examples/channel_examples/broadcast/single_herd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/broadcast.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/broadcast_selective_capture/Makefile
+++ b/programming_examples/channel_examples/broadcast_selective_capture/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 BUILD_DIR := build_peano
 
 # Output format: xclbin (default) or elf
@@ -11,11 +13,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/broadcast_selective_capture.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/broadcast_selective_capture.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/broadcast_selective_capture.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/broadcast_selective_capture.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/channel_3d_segment_unroll/Makefile
+++ b/programming_examples/channel_examples/channel_3d_segment_unroll/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/channel_3d_segment_unroll.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/channel_3d_segment_unroll.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/channel_3d_segment_unroll.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/channel_3d_segment_unroll.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/channel_size/Makefile
+++ b/programming_examples/channel_examples/channel_size/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/channel_size.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/channel_size.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/channel_size.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/channel_size.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -21,28 +23,28 @@ ITERATIONS ?= 100
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/dual_herd_packet_switch.py $(OUTPUT_FORMAT_FLAG)
 
 PROFILE_ARGS = $(OUTPUT_FORMAT_FLAG) --tile-size $(TILE_SIZE) --warmup $(WARMUP) --iterations $(ITERATIONS)
 
 profile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
 
 compare:
 	mkdir -p $(BUILD_DIR)
 	@echo "=== Single-herd add ==="
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_herd_add.py $(PROFILE_ARGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_herd_add.py $(PROFILE_ARGS)
 	@echo ""
 	@echo "=== Single-herd mul ==="
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_herd_mul.py $(PROFILE_ARGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_herd_mul.py $(PROFILE_ARGS)
 	@echo ""
 	@echo "=== Dual-herd (fused) ==="
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/dual_herd_packet_switch.py $(PROFILE_ARGS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/multi_segment/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG)
+	cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/herd_to_herd.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/hierarchical/Makefile
+++ b/programming_examples/channel_examples/hierarchical/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/hierarchical.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/hierarchical.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/hierarchical.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/hierarchical.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/mmio/Makefile
+++ b/programming_examples/channel_examples/mmio/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/mmio.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/mmio.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/mmio.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/mmio.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/worker_to_self/Makefile
+++ b/programming_examples/channel_examples/worker_to_self/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/worker_to_self.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/worker_to_self.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/worker_to_self.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/worker_to_self.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/channel_examples/worker_to_worker/Makefile
+++ b/programming_examples/channel_examples/worker_to_worker/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/worker_to_worker.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/worker_to_worker.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/worker_to_worker.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/worker_to_worker.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/conditional_branching/Makefile
+++ b/programming_examples/conditional_branching/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/conv2d/Makefile
+++ b/programming_examples/conv2d/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/conv2d.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/conv2d.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/conv2d.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/conv2d_14x14/Makefile
+++ b/programming_examples/conv2d_14x14/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 DEVICE ?= npu2
 
 ifeq ($(DEVICE),npu2)
@@ -24,7 +26,7 @@ OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 DEVICE_FLAG = --target-device $(DEVICE)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS  = -O2 -std=c++20 --target=aie2-none-unknown-elf  ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -42,14 +44,14 @@ KERNEL_SRC = ${AIEOPT_DIR}/include/aie_kernels/$(AIE_KERNEL_DIR)/conv2dk14.cc
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG) -p
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
 
 profile: compile-kernel build-test-exe
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/conv2d_14x14.py $(OUTPUT_FORMAT_FLAG) $(DEVICE_FLAG)
 	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin --device $(DEVICE)
 
 build-test-exe:

--- a/programming_examples/data_transfer_transpose/channel/Makefile
+++ b/programming_examples/data_transfer_transpose/channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -19,15 +21,15 @@ K ?= 32
 all: run_int run_float
 
 print:
-	${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -p
 
 run_int:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t uint32
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t uint32
 
 run_float:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t float32
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t float32
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/data_transfer_transpose/dma/Makefile
+++ b/programming_examples/data_transfer_transpose/dma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -19,15 +21,15 @@ K ?= 32
 all: run_int run_float
 
 print:
-	${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -p
 
 run_int:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t uint32
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t uint32
 
 run_float:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t float32
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/transpose.py $(OUTPUT_FORMAT_FLAG) -m ${M} -k ${K} -t float32
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/data_transfer_transpose/dma_bf16/Makefile
+++ b/programming_examples/data_transfer_transpose/dma_bf16/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -20,7 +22,7 @@ PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLA
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -p -m $(M) -k $(K)
+	${powershell} $(PYTHON) ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -p -m $(M) -k $(K)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -32,7 +34,7 @@ run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/transpose.o $(BUILD_DIR)/air_project/transpose.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -m $(M) -k $(K)
+		${powershell} $(PYTHON) ${srcdir}/transpose_bf16.py $(OUTPUT_FORMAT_FLAG) -m $(M) -k $(K)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/decode_ffn_swiglu/Makefile
+++ b/programming_examples/decode_ffn_swiglu/Makefile
@@ -4,6 +4,8 @@
 # Single-token GEMV with fused weighted RMSNorm input and SwiGLU output.
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -25,14 +27,14 @@ N_CASCADE ?= 4
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/matvec_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) -p \
+	${powershell} $(PYTHON) ${srcdir}/matvec_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) -p \
 		--m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) \
 		--herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 
 run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) \
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) \
 		--m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) \
 		--herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 
@@ -43,7 +45,7 @@ INT4_M_TILE  ?= 8
 INT4_K_CHUNK ?= 2048
 INT4_GS      ?= 128
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf \
 	-Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body \
 	-DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -61,7 +63,7 @@ compile-kernel-int4:
 run_int4: compile-kernel-int4
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_int4_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) \
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_int4_swiglu_rms.py $(OUTPUT_FORMAT_FLAG) \
 		--m $(M) --k $(K) --gs $(INT4_GS) \
 		--m-tile $(INT4_M_TILE) --k-chunk $(INT4_K_CHUNK)
 

--- a/programming_examples/dequant_awq/Makefile
+++ b/programming_examples/dequant_awq/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -28,7 +30,7 @@ HERD_N ?= 4
 # Per-tile N -- the C kernel processes one tile per call.
 N_TILE := $(shell expr $(N) / $(HERD_N))
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 PEANOWRAP2_FLAGS  = -O2 -std=c++20 --target=aie2-none-unknown-elf  ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
@@ -46,7 +48,7 @@ PY_ARGS = --device $(DEVICE) --n $(N) --group-size $(GROUP_SIZE) --herd-n $(HERD
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS) $(DIRECT_CODEGEN_FLAG)
+	${powershell} $(PYTHON) ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS) $(DIRECT_CODEGEN_FLAG)
 
 # Build dequant.o for the extern path. No-op when --direct-codegen is set
 # (the inline path has no external kernel object).
@@ -74,7 +76,7 @@ ifeq ($(DIRECT_CODEGEN_FLAG),)
 	cp $(BUILD_DIR)/dequant.o $(BUILD_DIR)/air_project/dequant.o
 endif
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
+		${powershell} $(PYTHON) ${srcdir}/dequant_awq.py $(OUTPUT_FORMAT_FLAG) $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
 
 # ELF profile harness (compile module ELF, then run XRT benchmark loop)
 build-test-dequant-exe:
@@ -89,7 +91,7 @@ ifeq ($(DIRECT_CODEGEN_FLAG),)
 	cp $(BUILD_DIR)/dequant.o $(BUILD_DIR)/air_project/dequant.o
 endif
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/dequant_awq.py --compile-mode compile-only --output-format elf $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
+		${powershell} $(PYTHON) ${srcdir}/dequant_awq.py --compile-mode compile-only --output-format elf $(DIRECT_CODEGEN_FLAG) $(PY_ARGS)
 	cd $(BUILD_DIR) && ./test_dequant.exe -e air.elf -k "main:dequant" \
 		-N $(N) -G $(GROUP_SIZE) -H $(HERD_N)
 

--- a/programming_examples/eltwise_add/Makefile
+++ b/programming_examples/eltwise_add/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,8 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
-
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 # Auto-detect XILINX_XRT if not set
 XILINX_XRT ?= $(wildcard /opt/xilinx/xrt)
 
@@ -41,20 +42,20 @@ PY_FLAGS = --shape $(SHAPE) --dtype $(DTYPE) $(TILE_FLAG) $(VEC_FLAG) \
 	--target $(TARGET) $(OUTPUT_FORMAT_FLAG) $(EXTRA_PY_FLAGS)
 
 # Total element count, for the -S argument of test.exe.
-SHAPE_ELEMENTS = $(shell python3 -c "import math,sys;print(math.prod([int(x) for x in '$(SHAPE)'.split()]))")
+SHAPE_ELEMENTS = $(shell $(PYTHON) -c "import math,sys;print(math.prod([int(x) for x in '$(SHAPE)'.split()]))")
 
 print:
-	${powershell} python3 ${srcdir}/eltwise_add.py $(PY_FLAGS) --print-ir
+	${powershell} $(PYTHON) ${srcdir}/eltwise_add.py $(PY_FLAGS) --print-ir
 
 compile:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/eltwise_add.py $(PY_FLAGS) --compile-only
+		${powershell} $(PYTHON) ${srcdir}/eltwise_add.py $(PY_FLAGS) --compile-only
 
 run:
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/eltwise_add.py $(PY_FLAGS) \
+		${powershell} $(PYTHON) ${srcdir}/eltwise_add.py $(PY_FLAGS) \
 		--perf-iters $(PERF_ITERS)
 
 # Bandwidth profiling via the shared test.cpp harness. bf16 only -- test.cpp
@@ -63,7 +64,7 @@ run:
 profile: build-test-exe
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		python3 ${srcdir}/eltwise_add.py $(PY_FLAGS) --compile-only
+		$(PYTHON) ${srcdir}/eltwise_add.py $(PY_FLAGS) --compile-only
 	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
 		-S $(SHAPE_ELEMENTS)
 

--- a/programming_examples/eltwise_add_with_l2/Makefile
+++ b/programming_examples/eltwise_add_with_l2/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/eltwise_add.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/ffn_swiglu/decode/Makefile
+++ b/programming_examples/ffn_swiglu/decode/Makefile
@@ -1,8 +1,9 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 DIM ?= 128
 NUM_COLS ?= 4
 DIM_M_PER_COL = $(shell echo $$(( $(DIM) / $(NUM_COLS) )))
@@ -22,7 +23,7 @@ PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLA
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/ffn_decode.py $(OUTPUT_FORMAT_FLAG) -p --dim $(DIM) --num-cols $(NUM_COLS)
+	${powershell} $(PYTHON) ${srcdir}/ffn_decode.py $(OUTPUT_FORMAT_FLAG) -p --dim $(DIM) --num-cols $(NUM_COLS)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -39,7 +40,7 @@ run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/ffn_kernels.o $(BUILD_DIR)/air_project/ffn_kernels.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/ffn_decode.py --dim $(DIM) --num-cols $(NUM_COLS) $(OUTPUT_FORMAT_FLAG)
+		${powershell} $(PYTHON) ${srcdir}/ffn_decode.py --dim $(DIM) --num-cols $(NUM_COLS) $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/ffn_swiglu/prefill/Makefile
+++ b/programming_examples/ffn_swiglu/prefill/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -16,14 +18,14 @@ DIM ?= 128
 NUM_COLS ?= 4
 DIM_N = $(shell echo $$(( $(DIM) / $(NUM_COLS) )))
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/ffn_prefill.py $(OUTPUT_FORMAT_FLAG) -p \
+	${powershell} $(PYTHON) ${srcdir}/ffn_prefill.py $(OUTPUT_FORMAT_FLAG) -p \
 		--seq-len $(SEQ_LEN) --dim $(DIM) --num-cols $(NUM_COLS)
 
 compile-kernel:
@@ -45,7 +47,7 @@ run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/ffn_kernels.o $(BUILD_DIR)/air_project/ffn_kernels.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/ffn_prefill.py $(OUTPUT_FORMAT_FLAG) \
+		${powershell} $(PYTHON) ${srcdir}/ffn_prefill.py $(OUTPUT_FORMAT_FLAG) \
 		--seq-len $(SEQ_LEN) --dim $(DIM) --num-cols $(NUM_COLS)
 
 clean:

--- a/programming_examples/flash_attention/dataflow_based/Makefile
+++ b/programming_examples/flash_attention/dataflow_based/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Attention parameters
 LK ?= 12288
 LKP ?= 96
@@ -22,7 +24,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 
 # AIE_TARGET can be set to 'aie2' (default) or 'aie2p' to select the target architecture.
@@ -41,13 +43,13 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/attn.py -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/attn.py -p --arch $(AIE_TARGET)
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/attn.o $(BUILD_DIR)/air_project/attn.o
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn.py --lk $(LK) --lkp $(LKP) --lq $(LQ) --dk $(DK) --dv $(DV) --arch $(AIE_TARGET) $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn.py --lk $(LK) --lkp $(LKP) --lq $(LQ) --dk $(DK) --dv $(DV) --arch $(AIE_TARGET) $(OUTPUT_FORMAT_FLAG)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/flash_attention/kernel_fusion_based/Makefile
+++ b/programming_examples/flash_attention/kernel_fusion_based/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Driver script (default = heads-first input layout).
 # Set SCRIPT=attn_npu2_seqfirst.py for the seq-first input variant.
 SCRIPT ?= attn_npu2.py
@@ -38,7 +40,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
@@ -46,16 +48,16 @@ PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/$(SCRIPT) -p --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS)
+	${powershell} $(PYTHON) ${srcdir}/$(SCRIPT) -p --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS)
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/$(SCRIPT) --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) $(EXTRA_PY_FLAGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/$(SCRIPT) --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) $(EXTRA_PY_FLAGS)
 
 # Profile ELF: compile elf and run with C++ test executable for elf format
 # Usage: make profile [LK=...] [LQ=...] etc.
 profile: compile-kernel build-test-exe
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/$(SCRIPT) \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/$(SCRIPT) \
 		--lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) \
 		--compile-mode compile-only
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_elf_npu2.exe -e air.elf -k "main:attention_bf16" \
@@ -64,7 +66,7 @@ profile: compile-kernel build-test-exe
 # Profile xclbin: compile xclbin and run with C++ test executable
 # Usage: make profile-xclbin [LK=...] [LQ=...] etc.
 profile-xclbin: compile-kernel build-test-exe-xclbin
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/$(SCRIPT) \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/$(SCRIPT) \
 		--lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) \
 		--compile-mode compile-only --output-format xclbin
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_xclbin.exe \
@@ -153,16 +155,16 @@ compile-kernel:
 # ============================================================================
 
 print-npu1:
-	${powershell} python3 ${srcdir}/attn_npu1.py -p --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS)
+	${powershell} $(PYTHON) ${srcdir}/attn_npu1.py -p --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS)
 
 run-npu1: compile-kernel-npu1
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_npu1.py --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) $(EXTRA_PY_FLAGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_npu1.py --lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) $(EXTRA_PY_FLAGS)
 
 # Profile xclbin on NPU1: compile xclbin and run with C++ test executable
 # Usage: make profile-npu1 [LK=...] [LQ=...] [NUM_HEADS=...] etc.
 profile-npu1: compile-kernel-npu1 build-test-exe-xclbin
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/attn_npu1.py \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/attn_npu1.py \
 		--lk $(LK) --lkp $(LKP) --lq $(LQ) --lqp $(LQP) --dk $(DK) --dv $(DV) --num-heads $(NUM_HEADS) --num-kv-heads $(NUM_KV_HEADS) \
 		--compile-mode compile-only
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_xclbin.exe \

--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -16,9 +16,10 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-DECODE_DRIVER  := $(srcdir)/fused_decode.py
-AIEOPT_DIR     := $(shell realpath $(dir $(shell which aie-opt))/..)
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
 
+DECODE_DRIVER  := $(srcdir)/fused_decode.py
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 # Per-kernel -O is LOAD-BEARING (do not use one -O for all):
 #   proj_qmm/rms_residual/glu/rope MUST be -O2; attn_qk/attn_kv MUST be -O1.
 #   rope.cc at -O1 MISCOMPILES (Peano loop-metadata) -> the decode HANGS on device
@@ -194,7 +195,7 @@ compile-decode-dynseq: preflight-llvm-link
 	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) $(ATTN_EXTRA) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(srcdir)/kernels/$$k.cc -o $(srcdir)/$$k.ll || exit 1; done
 	@echo ">>> dynseq template decode_dyn_L$(LBUILD)"
-	@cd $(srcdir) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/decode_dyn_L$(LBUILD).log 2>&1; \
+	@cd $(srcdir) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/decode_dyn_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ] && [ -f air_project/npu.air.txn.h ]; then \
 	    mv -f decode.xclbin decode_dyn_L$(LBUILD).xclbin; \
 	    cp -f air_project/npu.air.txn.h decode_dyn_L$(LBUILD).txn.h; \
@@ -234,10 +235,10 @@ _compile_decode_build: preflight-llvm-link
 	@# patch any context length in [1, 2048] into one template at runtime (recompile-free decode).
 	@# The block loop is single-buffered: air-label-scf-for-to-ping-pong declines it, because the
 	@# running max and accumulator are live across blocks. Turbo for ~50 tok/s.
-	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/decode_L$(LBUILD).log 2>&1; \
+	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/decode_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ]; then mv -f decode.xclbin decode_L$(LBUILD).xclbin; mv -f decode.insts.bin decode_L$(LBUILD).insts.bin; \
 	  else echo "decode_L$(LBUILD) FAILED (see /tmp/decode_L$(LBUILD).log)"; exit 1; fi
-	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/decode_L$(LREF).log 2>&1; \
+	@cd $(srcdir) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) $(PYTHON) $(DECODE_DRIVER) >/tmp/decode_L$(LREF).log 2>&1; \
 	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin decode_L$(LREF).insts.bin; mv -f decode.xclbin decode_L$(LREF).xclbin; \
 	  else echo "decode_L$(LREF) FAILED (see /tmp/decode_L$(LREF).log)"; exit 1; fi
 	@echo "Decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."

--- a/programming_examples/gelu/Makefile
+++ b/programming_examples/gelu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -25,15 +27,15 @@ ARGS = $(if $(N),--n $(N)) $(if $(TILE_N),--tile-n $(TILE_N)) \
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS) -p
+	${powershell} $(PYTHON) ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS)
 
 profile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS) --perf-iters $(ITERATIONS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/gelu.py $(OUTPUT_FORMAT_FLAG) $(ARGS) --perf-iters $(ITERATIONS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/gelu_and_mul/Makefile
+++ b/programming_examples/gelu_and_mul/Makefile
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # NPU2 (Strix / AIE2P) only. The kernel links an external C++ vector
 # microkernel (gelu_and_mul.cc -> gelu_and_mul.o) that needs the hardware
 # aie::tanh, so there is no NPU1 / direct-codegen path.
 BUILD_DIR := build_peano
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -33,20 +35,20 @@ compile-kernel:
 
 # Print the MLIR module (no kernel .o / NPU needed)
 print:
-	${powershell} python3 ${srcdir}/gelu_and_mul.py \
+	${powershell} $(PYTHON) ${srcdir}/gelu_and_mul.py \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y) -p
 
 # Compile + run correctness check on NPU2
 run: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/gelu_and_mul.py \
+		${powershell} $(PYTHON) ${srcdir}/gelu_and_mul.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y)
 
 # Compile + run with latency/bandwidth profiling (correctness still checked)
 profile: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/gelu_and_mul.py \
+		${powershell} $(PYTHON) ${srcdir}/gelu_and_mul.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y) \
 		--perf-iters $(ITERATIONS)

--- a/programming_examples/herd_dataflow/Makefile
+++ b/programming_examples/herd_dataflow/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -58,12 +60,12 @@ check_sizes:
 
 print:
 	$(MAKE) -f $(srcdir)/Makefile check_sizes
-	${powershell} python3 ${srcdir}/run.py $(OUTPUT_FORMAT_FLAG) --m-size $(M_SIZE) --n-size $(N_SIZE) -p --mlir-source $(MLIR_SOURCE)
+	${powershell} $(PYTHON) ${srcdir}/run.py $(OUTPUT_FORMAT_FLAG) --m-size $(M_SIZE) --n-size $(N_SIZE) -p --mlir-source $(MLIR_SOURCE)
 
 run: compile-kernel
 	$(MAKE) -f $(srcdir)/Makefile check_sizes
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py $(OUTPUT_FORMAT_FLAG) --m-size $(M_SIZE) --n-size $(N_SIZE) --mlir-source $(MLIR_SOURCE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py $(OUTPUT_FORMAT_FLAG) --m-size $(M_SIZE) --n-size $(N_SIZE) --mlir-source $(MLIR_SOURCE)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/layer_norm/Makefile
+++ b/programming_examples/layer_norm/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Which NPU generation the herd default is sized for: aie2 (NPU1) or aie2p
 # (NPU2, default). This picks the HERD_X default below and nothing else -- the
 # example takes its compilation target from XRT device auto-detection, not from
@@ -34,17 +36,17 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) -p
 
 # Default: multi-tile execution (8 tiles on NPU2, configurable via HERD_X)
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) --M $(M) --N $(N) --herd-x $(HERD_X)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) --M $(M) --N $(N) --herd-x $(HERD_X)
 
 # Original single-tile baseline (herd_x=1)
 run_single_tile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) --M $(M) --N $(N) --herd-x 1
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/layer_norm.py $(OUTPUT_FORMAT_FLAG) --M $(M) --N $(N) --herd-x 1
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/leaky_relu/Makefile
+++ b/programming_examples/leaky_relu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/leaky_relu.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -37,6 +37,18 @@ config.environment["PYTHONPATH"] = os.pathsep.join(
 # os.environ['PYTHONPATH']
 print("Running with PYTHONPATH", config.environment["PYTHONPATH"])
 
+# The example Makefiles resolve the AIE headers through MLIR_AIE_INSTALL_DIR
+# rather than by locating aie-opt on PATH, so point it at the mlir-aie this
+# build was configured against. An explicit setting in the environment wins,
+# matching how llms/shared/infra/external_kernels.py treats the same variable.
+config.environment["MLIR_AIE_INSTALL_DIR"] = os.environ.get(
+    "MLIR_AIE_INSTALL_DIR", config.aie_obj_root
+)
+
+# Makefiles and tests that shell out to Python must use the interpreter this
+# build was configured with, not whichever one PATH happens to resolve first.
+config.environment["PYTHON"] = config.python_executable
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".lit"]
 
@@ -195,7 +207,10 @@ try:
 except ImportError:
     print("lerobot not installed; lerobot feature disabled.")
 
-llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
+# OS is forwarded because lit sanitizes the environment: without it, make's
+# $(OS) is empty under lit and any Windows_NT test in a Makefile silently takes
+# the POSIX branch. Unset on Linux, so forwarding it is a no-op there.
+llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP", "OS"])
 
 llvm_config.use_default_substitutions()
 

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -49,6 +49,12 @@ config.environment["MLIR_AIE_INSTALL_DIR"] = os.environ.get(
 # build was configured with, not whichever one PATH happens to resolve first.
 config.environment["PYTHON"] = config.python_executable
 
+# Examples that build a host program need the XRT this build was configured
+# against. On Linux that arrives via run_on_npu.sh sourcing setup.sh, which
+# exports XILINX_XRT; there is no such script on Windows, so pass the
+# configured path down directly. XILINX_XRT still wins where it is set.
+config.environment["XRT_ROOT"] = os.environ.get("XRT_ROOT", config.xrt_dir)
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".lit"]
 

--- a/programming_examples/llama2_mha/Makefile
+++ b/programming_examples/llama2_mha/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,18 +15,18 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/mha.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/mha.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/mha.py $(OUTPUT_FORMAT_FLAG) --pos 2 --k 288 --n 48 --compile-mode compile-and-run
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/mha.py $(OUTPUT_FORMAT_FLAG) --pos 2 --k 288 --n 48 --compile-mode compile-and-run
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/llms/gemma3_4b_q4nx/Makefile
+++ b/programming_examples/llms/gemma3_4b_q4nx/Makefile
@@ -22,11 +22,12 @@
 #   make compile-decode             Build production templates (ATTN_MAXL=2048, ~15 min)
 
 srcdir     := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
 DEC        := $(srcdir)/../../fused_decode
 DECODE_DRIVER := $(DEC)/fused_decode.py
 PREFILL_DRIVER := $(srcdir)/gemma3_4b_q4nx_prefill.py
-AIEOPT_DIR := $(shell realpath $(dir $(shell which aie-opt))/..)
-
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -167,7 +168,7 @@ compile-decode-dynseq:
 	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> gemma dynseq template decode_dyn_L$(LBUILD)"
-	@cd $(DEC) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/gemma_decode_dyn_L$(LBUILD).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/gemma_decode_dyn_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ] && [ -f air_project/npu.air.txn.h ]; then \
 	    mv -f decode.xclbin $(srcdir)/decode_dyn_L$(LBUILD).xclbin; \
 	    cp -f air_project/npu.air.txn.h $(srcdir)/decode_dyn_L$(LBUILD).txn.h; \
@@ -190,10 +191,10 @@ _compile_decode_build:
 	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> gemma template decode_L$(LBUILD) (+ L$(LREF) slope ref)"
-	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/gemma_decode_L$(LBUILD).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/gemma_decode_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ]; then mv -f decode.xclbin $(srcdir)/decode_L$(LBUILD).xclbin; mv -f decode.insts.bin $(srcdir)/decode_L$(LBUILD).insts.bin; \
 	  else echo "decode_L$(LBUILD) FAILED (see /tmp/gemma_decode_L$(LBUILD).log)"; tail -30 /tmp/gemma_decode_L$(LBUILD).log; exit 1; fi
-	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/gemma_decode_L$(LREF).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) $(PYTHON) $(DECODE_DRIVER) >/tmp/gemma_decode_L$(LREF).log 2>&1; \
 	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin $(srcdir)/decode_L$(LREF).insts.bin; mv -f decode.xclbin $(srcdir)/decode_L$(LREF).xclbin; \
 	  else echo "decode_L$(LREF) FAILED (see /tmp/gemma_decode_L$(LREF).log)"; tail -30 /tmp/gemma_decode_L$(LREF).log; exit 1; fi
 	@echo "Gemma decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."
@@ -203,12 +204,12 @@ _compile_decode_build:
 ## lm_head_gemv). Weight-free build, no NPU dispatch.
 compile-prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(PREFILL_DRIVER) --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(PREFILL_DRIVER) --compile-only
 
 ## Prefill-only Paris gate: PASS iff the first token argmax is 9079 (" Paris").
 prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(PREFILL_DRIVER)
+	cd $(BUILD_DIR) && $(PYTHON) $(PREFILL_DRIVER)
 
 ## Build everything the end-to-end chatbot needs: the prefill ELFs and the
 ## decode templates.
@@ -217,11 +218,11 @@ compile: compile-prefill compile-decode
 ## Run inference (NPU prefill + fused NPU decode). With no PROMPT this is the
 ## canonical Paris gate: PASS iff the first token is 9079 (" Paris").
 run:
-	@cd $(srcdir) && python3 gemma3_4b_q4nx_inference.py --n-tokens 9 $(PROMPT_ARG)
+	@cd $(srcdir) && $(PYTHON) gemma3_4b_q4nx_inference.py --n-tokens 9 $(PROMPT_ARG)
 
 ## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
 ask:
-	@cd $(srcdir) && python3 gemma3_4b_q4nx_inference.py \
+	@cd $(srcdir) && $(PYTHON) gemma3_4b_q4nx_inference.py \
 		--n-tokens $(N_TOKENS) $(PROMPT_ARG)
 
 ## Top-k token-set inclusion gate (NPU q4nx vs HF bf16, 2 prompts x 32 tokens,
@@ -237,12 +238,12 @@ ask:
 ## returns Gemma3ForConditionalGeneration, whose text-only forward is what the
 ## gate compares.)
 verify:
-	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL_CHOICE) --max-prompts $(MAX_PROMPTS)
 
 ## Full-sweep variant of `make verify` (all prompts in the prompt file).
 verify-full:
-	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL_CHOICE)
 
 ## Fast weight-integrity smoke: prefill only, PASS iff the first-token argmax is
@@ -258,7 +259,7 @@ verify-paris: prefill
 ## canonical Paris prompt for `make run`), and an empty --prompt is not a prompt.
 DIAG_PROMPT ?= What is the capital of France?
 diagnosis:
-	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(if $(PROMPT),$(PROMPT),$(DIAG_PROMPT))" \
 		--model $(MODEL_CHOICE)
 
@@ -266,13 +267,13 @@ diagnosis:
 ## prefill dispatch from the one-time weight load the e2e path also pays.
 profile-prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL_DRIVER)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) $(PYTHON) $(PREFILL_DRIVER)
 
 ## End-to-end: TTFT + decode throughput over N_TOKENS tokens (prints the TTFT and
 ## Tokens/second lines the nightly LLM benchmark extracts). Needs production
 ## templates: make compile.
 profile:
-	@cd $(srcdir) && python3 gemma3_4b_q4nx_inference.py --n-tokens $(N_TOKENS)
+	@cd $(srcdir) && $(PYTHON) gemma3_4b_q4nx_inference.py --n-tokens $(N_TOKENS)
 
 ## Back-compat alias for the Paris gate.
 gen: run

--- a/programming_examples/llms/llama32_1b/Makefile
+++ b/programming_examples/llms/llama32_1b/Makefile
@@ -14,6 +14,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -70,21 +72,21 @@ help:
 ## Compile all kernels (prefill + decode, ~4 min)
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat: prepare runtime once, then loop on prompts
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 ## Compile and run in one step
@@ -100,20 +102,20 @@ RUNNER_ADAPTER = llama32_1b.verify_adapter
 ## This is the fast CI gate. For the full 8-prompt sweep, use `make verify-full`.
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`: runs all prompts in the prompt file
 ## (currently 8). Use locally for exhaustive validation; CI uses `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Run the diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 # ============================================================

--- a/programming_examples/llms/llama32_1b_int4/Makefile
+++ b/programming_examples/llms/llama32_1b_int4/Makefile
@@ -20,6 +20,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -96,13 +98,13 @@ help:
 ## rms_gemms_rope_{int4,bf16,bfp16}.elf etc) so they coexist.
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype int4 --compile-only --model $(MODEL) \
 		--cache-dir $(srcdir)/verify_kernel_cache
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype bf16 --compile-only --model $(MODEL) \
 		--cache-dir $(srcdir)/verify_kernel_cache
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype bfp16 --compile-only --model $(MODEL) \
 		--cache-dir $(srcdir)/verify_kernel_cache
 	@echo "Compilation passed."
@@ -110,7 +112,7 @@ compile:
 ## Compile only the bfp16 stitchers (faster iteration during bfp16 dev).
 compile-bfp16:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype bfp16 --compile-only --model $(MODEL) \
 		--cache-dir $(srcdir)/verify_kernel_cache
 	@echo "bfp16 compilation passed."
@@ -120,7 +122,7 @@ compile-bfp16:
 ## `make verify` which goes through the shared verify/ framework).
 run:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype $(PREFILL_DTYPE) --model $(MODEL) \
 		--prompt "$(PROMPT)" --n-layers $(N_LAYERS) --topk $(TOPK) \
 		--cache-dir $(srcdir)/verify_kernel_cache
@@ -130,7 +132,7 @@ run:
 ## gate matching the bf16 baseline's CI gate.
 verify-prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype $(PREFILL_DTYPE) --model $(MODEL) \
 		--prompt "$(PROMPT)" --n-layers $(N_LAYERS) --topk $(TOPK) \
 		--min-overlap $(MIN_OVERLAP) \
@@ -140,7 +142,7 @@ verify-prefill:
 ## prefill+decode equivalent through the shared framework.
 verify-prefill-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_prefill.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_prefill.py \
 		--prefill-dtype $(PREFILL_DTYPE) --model $(MODEL) \
 		--n-layers $(N_LAYERS) --topk $(TOPK) \
 		--min-overlap $(MIN_OVERLAP) \
@@ -153,14 +155,14 @@ verify-prefill-full:
 ## decode; HF reference loads the same AWQ checkpoint in bf16.
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --max-prompts 2
 
 ## Same as `make verify` but runs the full prompt set (slower; local
 ## exhaustive validation). Mirrors the bf16 sibling's `make verify-full`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token
 
 ## Diagnosis lens (per-layer ffn_out cosine). Note: int4 decode adapter
@@ -169,13 +171,13 @@ verify-full:
 ## probe, use the bf16 sibling's `make diagnosis`.
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)"
 
 ## Run with per-kernel + per-layer profiling instrumentation.
 profile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" \
 		--model-path $(MODEL) \
 		--prefill-cache-dir $(PREFILL_INF_CACHE) \
@@ -189,7 +191,7 @@ profile:
 ## kernel caches. Idempotent; re-run after editing stitchers.
 compile-inference:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_inference.py \
 		--compile-only \
 		--model-path $(MODEL) \
 		--prefill-cache-dir $(PREFILL_INF_CACHE) \
@@ -200,14 +202,14 @@ compile-inference:
 ## decode stitchers in isolation.
 compile-decode:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_1b_int4_decode.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_1b_int4_decode.py \
 		--compile-only --cache-dir $(DECODE_INF_CACHE)
 
 ## End-to-end generation: prefill the prompt, then decode N_TOKENS tokens
 ## on the NPU. Override PROMPT, N_TOKENS, MODEL via the command line.
 run-inference:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && flock /tmp/mlir-air-npu.lock python3 \
+	cd $(BUILD_DIR) && flock /tmp/mlir-air-npu.lock $(PYTHON) \
 		$(srcdir)/llama32_1b_int4_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" \
 		--model-path $(MODEL) \
@@ -218,7 +220,7 @@ run-inference:
 ## Ctrl-D / /quit exits.
 chat:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && flock /tmp/mlir-air-npu.lock python3 \
+	cd $(BUILD_DIR) && flock /tmp/mlir-air-npu.lock $(PYTHON) \
 		$(srcdir)/llama32_1b_int4_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) \
 		--model-path $(MODEL) \

--- a/programming_examples/llms/llama32_1b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_1b_q4nx/Makefile
@@ -19,6 +19,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -100,7 +102,7 @@ help:
 ## No weight data or NPU dispatch required.
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --compile-only
 
 ## Build the fused decode (delegates to the standalone programming_examples/fused_decode
 ## example): the Peano kernels + two templates (decode_L2048 + decode_L2047). ~15 min.
@@ -123,7 +125,7 @@ compile-decode-dynseq:
 ## Run unified inference (NPU prefill + fused NPU decode).
 run:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with the decode-throughput / TTFT profiling summary. --no-eos-stop so
@@ -132,14 +134,14 @@ run:
 ## (cold) dispatch and understates steady-state tok/s by ~20%.
 profile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --n-tokens $(N_TOKENS) --profile --no-eos-stop \
 		--prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat REPL (streams the reply token-by-token; /clear resets, /exit quits).
 chat:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 # ---- shared verify subsystem (top-k token-set inclusion, NPU q4nx vs HF bf16) ----
@@ -147,41 +149,41 @@ chat:
 ## Top-k token-set inclusion gate (NPU q4nx vs HF bf16, 2 prompts x 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify` (all prompts in the prompt file).
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational).
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Fast weight-integrity smoke: prefill "The capital of France is"; PASS iff the
 ## first-token argmax == 12366 (" Paris"). Cheap (prefill only, no decode build).
 verify-paris:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(PREFILL) --model $(MODEL_SOURCE)
+	cd $(BUILD_DIR) && $(PYTHON) $(PREFILL) --model $(MODEL_SOURCE)
 
 ## Warm prefill TTFT benchmark at CTX (per-ELF BO-write / NPU-run / BO-read breakdown).
 profile-prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) $(PYTHON) $(PREFILL)
 
 ## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
 ask:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
 
 ## Full prefill+decode Paris gate: first generated token 12366 -> *** PARIS ***.
 gen:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --greedy --n-tokens 12
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --run-only --greedy --n-tokens 12
 
 ## Remove all build artifacts, kernel/weight caches, and verify reports. Also cleans
 ## the fused_decode example, because this one's decode templates live THERE: leaving

--- a/programming_examples/llms/llama32_3b/Makefile
+++ b/programming_examples/llms/llama32_3b/Makefile
@@ -14,6 +14,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -70,21 +72,21 @@ help:
 ## Compile all kernels (prefill + decode, ~4 min)
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_3b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_3b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_3b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_3b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat: prepare runtime once, then loop on prompts
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/llama32_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/llama32_3b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 ## Compile and run in one step
@@ -100,20 +102,20 @@ RUNNER_ADAPTER = llama32_3b.verify_adapter
 ## This is the fast CI gate. For the full 8-prompt sweep, use `make verify-full`.
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`: runs all prompts in the prompt file
 ## (currently 8). Use locally for exhaustive validation; CI uses `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Run the diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 # ============================================================

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -24,6 +24,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -55,8 +57,7 @@ DRIVER := $(srcdir)/llama32_3b_q4nx_inference.py
 # 1B build from silently satisfying a 3B run.
 DEC           := $(srcdir)/../../fused_decode
 DECODE_DRIVER := $(DEC)/fused_decode.py
-AIEOPT_DIR    := $(shell realpath $(dir $(shell which aie-opt))/..)
-
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 # Per-kernel -O is LOAD-BEARING (see fused_decode/Makefile): proj_qmm/rms_residual/
 # glu/rope -O2; attn_qk/attn_kv inline .ll -O1. 3B differs only by
 # -DMODEL_TYPE=LLAMA_3_2_3B (the header sets the dims, DH=128, ATTN_IMPL, vocab).
@@ -121,7 +122,7 @@ help:
 ## templates are a separate ~15 min build -- see `make compile-decode`.
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --compile-only
 
 ## Build the fused decode at the 3B geometry: Peano kernels (LLAMA_3_2_3B) + two
 ## same-ATTN_MAXL templates (decode_L$(LBUILD) + decode_L$(LREF)) into THIS dir.
@@ -177,7 +178,7 @@ compile-decode-dynseq:
 	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> 3B dynseq template decode_dyn_L$(LBUILD)"
-	@cd $(DEC) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/llama3b_decode_dyn_L$(LBUILD).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/llama3b_decode_dyn_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ] && [ -f air_project/npu.air.txn.h ]; then \
 	    mv -f decode.xclbin $(srcdir)/decode_dyn_L$(LBUILD).xclbin; \
 	    cp -f air_project/npu.air.txn.h $(srcdir)/decode_dyn_L$(LBUILD).txn.h; \
@@ -198,10 +199,10 @@ _compile_decode_build:
 	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> 3B template decode_L$(LBUILD) (+ L$(LREF) slope ref)"
-	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LBUILD).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) $(PYTHON) $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LBUILD).log 2>&1; \
 	  if [ -f decode.xclbin ]; then mv -f decode.xclbin $(srcdir)/decode_L$(LBUILD).xclbin; mv -f decode.insts.bin $(srcdir)/decode_L$(LBUILD).insts.bin; \
 	  else echo "decode_L$(LBUILD) FAILED (see /tmp/llama3b_decode_L$(LBUILD).log)"; tail -30 /tmp/llama3b_decode_L$(LBUILD).log; exit 1; fi
-	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LREF).log 2>&1; \
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) $(PYTHON) $(DECODE_DRIVER) >/tmp/llama3b_decode_L$(LREF).log 2>&1; \
 	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin $(srcdir)/decode_L$(LREF).insts.bin; mv -f decode.xclbin $(srcdir)/decode_L$(LREF).xclbin; \
 	  else echo "decode_L$(LREF) FAILED (see /tmp/llama3b_decode_L$(LREF).log)"; tail -30 /tmp/llama3b_decode_L$(LREF).log; exit 1; fi
 	@echo "3B decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."
@@ -209,7 +210,7 @@ _compile_decode_build:
 ## Run unified inference
 run:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown. --no-eos-stop so throughput is averaged
@@ -218,13 +219,13 @@ run:
 ## llama32_1b_q4nx, whose profile target has carried this since it was written.
 profile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --n-tokens $(N_TOKENS) --profile --no-eos-stop \
 		--prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat REPL
 chat:
-	cd $(BUILD_DIR) && python3 $(DRIVER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 # The shared verify framework lives under programming_examples/llms/verify/.
@@ -234,13 +235,13 @@ RUNNER_ADAPTER = llama32_3b_q4nx.verify_adapter
 ## Top-k token-set inclusion gate (NPU q4nx vs HF bf16, 2 prompts x 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify` (all prompts in the prompt file).
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (single prompt through the shared runner, informational).
@@ -249,29 +250,29 @@ verify-full:
 ## reports the token-level view instead. `make verify` is the PASS/FAIL gate.
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Fast weight-integrity smoke: prefill "The capital of France is"; PASS iff the
 ## first-token argmax == 12366 (" Paris"). Cheap (prefill only, no decode build).
 verify-paris:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(PREFILL) --model $(MODEL_SOURCE)
+	cd $(BUILD_DIR) && $(PYTHON) $(PREFILL) --model $(MODEL_SOURCE)
 
 ## Warm prefill TTFT benchmark at CTX (per-ELF BO-write / NPU-run / BO-read breakdown).
 profile-prefill:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) $(PYTHON) $(PREFILL)
 
 ## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
 ask:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --run-only --prompt "$(PROMPT)" --model $(MODEL) --n-tokens $(N_TOKENS)
 
 ## Paris gate: greedy-decode "The capital of France is"; first token must be 12366.
 gen:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(DRIVER) --run-only --model base --n-tokens 12 \
+	cd $(BUILD_DIR) && $(PYTHON) $(DRIVER) --run-only --model base --n-tokens 12 \
 		--prompt "The capital of France is"
 
 ## Remove build artifacts. Deliberately KEEPS $(srcdir)/.decode_wcache: that is the

--- a/programming_examples/llms/qwen25_0_5b/Makefile
+++ b/programming_examples/llms/qwen25_0_5b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_0_5b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_0_5b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_0_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_0_5b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_0_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_0_5b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_0_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_0_5b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen25_0_5b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/qwen25_1_5b/Makefile
+++ b/programming_examples/llms/qwen25_1_5b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_1_5b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_1_5b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_1_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_1_5b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_1_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_1_5b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_1_5b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_1_5b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen25_1_5b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/qwen25_3b/Makefile
+++ b/programming_examples/llms/qwen25_3b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_3b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_3b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_3b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen25_3b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen25_3b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen25_3b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -19,6 +19,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 SEQ_LEN  ?= 2048
 N_LAYERS ?= 36
 BENCH_L  ?= 2048
@@ -34,8 +36,7 @@ PREFILL := $(srcdir)/qwen25_3b_q4_prefill.py
 DEC            := $(srcdir)/../../fused_decode
 DECODE_DRIVER  := $(DEC)/fused_decode_qwen.py
 HANDOFF        := $(DEC)/qwen_prefill_to_decode.py
-AIEOPT_DIR     := $(shell realpath $(dir $(shell which aie-opt))/..)
-
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 # Decode context CAP. The attention herd takes L as a runtime operand (an RTP the
 # instruction stream writes), so the device attends over the real context and
 # appends at the real position; LBUILD only sizes the KV cache. Two templates one
@@ -136,7 +137,7 @@ help:
 
 ## Build/cache the prefill ELFs and exit. No weights, no NPU dispatch.
 compile:
-	cd $(srcdir) && python3 $(PREFILL) --compile-only \
+	cd $(srcdir) && $(PYTHON) $(PREFILL) --compile-only \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS)
 
 ## Build the fused Qwen decode: the Peano kernels (QWEN2_5_3B) + two templates
@@ -169,7 +170,7 @@ compile-decode-dynseq:
 	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
 	@echo ">>> qwen dynseq template decode_dyn_L$(LBUILD)"
 	@cd $(DEC) && QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$(LBUILD) W_DUAL_CHAN=$(W_DUAL_CHAN) \
-	  DECODE_DYNSEQ=1 python3 $(DECODE_DRIVER) >/tmp/qwen_decode_dyn_L$(LBUILD).log 2>&1; \
+	  DECODE_DYNSEQ=1 $(PYTHON) $(DECODE_DRIVER) >/tmp/qwen_decode_dyn_L$(LBUILD).log 2>&1; \
 	  if [ -f $(DEC)/decode_qwen.xclbin ] && [ -f $(DEC)/air_project/npu.air.txn.h ]; then \
 	    mv -f $(DEC)/decode_qwen.xclbin $(srcdir)/decode_dyn_L$(LBUILD).xclbin; \
 	    cp -f $(DEC)/air_project/npu.air.txn.h $(srcdir)/decode_dyn_L$(LBUILD).txn.h; \
@@ -202,7 +203,7 @@ _compile_decode_build:
 	@for W in $(LBUILD) $(LREF); do \
 	  echo ">>> qwen decode template decode_L$$W (NLAYERS=$(N_LAYERS) W_DUAL_CHAN=$(W_DUAL_CHAN))"; \
 	  cd $(DEC) && QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$$W W_DUAL_CHAN=$(W_DUAL_CHAN) \
-	    python3 $(DECODE_DRIVER) >/tmp/qwen_decode_L$$W.log 2>&1; \
+	    $(PYTHON) $(DECODE_DRIVER) >/tmp/qwen_decode_L$$W.log 2>&1; \
 	  if [ -f $(DEC)/decode_qwen.xclbin ] && [ -f $(DEC)/decode_qwen.insts.bin ]; then \
 	    mv -f $(DEC)/decode_qwen.xclbin $(srcdir)/decode_L$$W.xclbin; \
 	    mv -f $(DEC)/decode_qwen.insts.bin $(srcdir)/decode_L$$W.insts.bin; \
@@ -214,12 +215,12 @@ _compile_decode_build:
 
 ## First-token gate: prefill "The capital of France is"; PASS iff argmax == 12095.
 run:
-	cd $(srcdir) && python3 $(PREFILL) \
+	cd $(srcdir) && $(PYTHON) $(PREFILL) \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL)
 
 ## Prefill GEN_PROMPT and dump the per-layer roped-K / biased-V hand-off cache.
 dump-kv:
-	cd $(srcdir) && python3 $(PREFILL) \
+	cd $(srcdir) && $(PYTHON) $(PREFILL) \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL) \
 		--prompt "$(GEN_PROMPT)" --dump-kv $(KV_NPZ)
 
@@ -229,12 +230,12 @@ dump-kv:
 ## holds for ANY prompt that fits the cache, since both sides see the same
 ## context (they used to diverge once the prompt outgrew the decode's window).
 gen: dump-kv
-	cd $(DEC) && $(DECODE_ENV) python3 $(HANDOFF) --kv $(KV_NPZ) --n-gen $(N_GEN) \
+	cd $(DEC) && $(DECODE_ENV) $(PYTHON) $(HANDOFF) --kv $(KV_NPZ) --n-gen $(N_GEN) \
 		--templates $(srcdir)
 
 ## Warm TTFT benchmark (+ per-ELF profile).
 bench:
-	cd $(srcdir) && python3 $(PREFILL) \
+	cd $(srcdir) && $(PYTHON) $(PREFILL) \
 		--seq-len $(SEQ_LEN) --n-layers $(N_LAYERS) --model $(MODEL) \
 		--bench-l $(BENCH_L)
 
@@ -244,7 +245,7 @@ profile-prefill: bench
 
 ## Q4_0 quant-error report for layer 0 (no NPU).
 weights:
-	cd $(srcdir) && python3 $(srcdir)/qwen25_3b_q4_weights.py --model $(MODEL)
+	cd $(srcdir) && $(PYTHON) $(srcdir)/qwen25_3b_q4_weights.py --model $(MODEL)
 
 # ---- correctness gate (identical to the other three Q4NX examples) ----
 #
@@ -255,12 +256,12 @@ weights:
 
 ## Top-k token-set inclusion gate (NPU q4 vs HF bf16, 2 prompts x 32 tokens, k=5).
 verify:
-	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(DECODE_ENV) $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL_CHOICE) --max-prompts $(MAX_PROMPTS)
 
 ## Full-sweep variant of `make verify` (all prompts in the prompt file).
 verify-full:
-	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(DECODE_ENV) $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL_CHOICE)
 
 ## Fast weight-integrity smoke: prefill "The capital of France is"; PASS iff the
@@ -272,7 +273,7 @@ verify-paris: run
 ## The Q4_0 prefill does not expose per-layer ffn_out, so this reports the
 ## token-level view rather than per-layer cosines.
 diagnosis:
-	cd $(srcdir)/.. && $(DECODE_ENV) python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(srcdir)/.. && $(DECODE_ENV) $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(GEN_PROMPT)" --model $(MODEL_CHOICE)
 
 ## Perf capture for llms/bench/extract_perf.py: prefill TTFT + fused decode

--- a/programming_examples/llms/qwen3_0_6b/Makefile
+++ b/programming_examples/llms/qwen3_0_6b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_0_6b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_0_6b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_0_6b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_0_6b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_0_6b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_0_6b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_0_6b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_0_6b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen3_0_6b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/qwen3_1_7b/Makefile
+++ b/programming_examples/llms/qwen3_1_7b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_1_7b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_1_7b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_1_7b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_1_7b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_1_7b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen3_1_7b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/qwen3_4b/Makefile
+++ b/programming_examples/llms/qwen3_4b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -46,21 +48,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_4b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_4b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_4b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/qwen3_4b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/qwen3_4b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 all: compile profile
@@ -71,19 +73,19 @@ RUNNER_ADAPTER = qwen3_4b.verify_adapter
 ## Top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Remove all build artifacts and verify reports

--- a/programming_examples/llms/shared/infra/ffn_swiglu/Makefile
+++ b/programming_examples/llms/shared/infra/ffn_swiglu/Makefile
@@ -1,6 +1,8 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
 progdir := $(realpath $(srcdir)/../..)
 
 ifdef PEANO_INSTALL_DIR
@@ -10,7 +12,7 @@ else
 endif
 
 # Peano compiler flags
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -25,21 +27,21 @@ compile-kernel:
 
 # Print combined MLIR module
 print:
-	${powershell} python3 ${srcdir}/run.py -p
+	${powershell} $(PYTHON) ${srcdir}/run.py -p
 
 # Print each sub-kernel's MLIR separately
 print-kernels:
-	${powershell} python3 ${srcdir}/run.py --print-kernels -p
+	${powershell} $(PYTHON) ${srcdir}/run.py --print-kernels -p
 
 # Compile + run correctness test
 run: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/run.py
+		${powershell} $(PYTHON) ${srcdir}/run.py
 
 # Compile + run with profiling
 profile: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/run.py --profile
+		${powershell} $(PYTHON) ${srcdir}/run.py --profile
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/llms/smollm2_1_7b/Makefile
+++ b/programming_examples/llms/smollm2_1_7b/Makefile
@@ -10,6 +10,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Build directory
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -59,21 +61,21 @@ help:
 ## Compile all kernels
 compile:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(srcdir)/smollm2_1_7b_inference.py --compile-only
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/smollm2_1_7b_inference.py --compile-only
 
 ## Run unified inference
 run:
-	cd $(BUILD_DIR) && python3 $(srcdir)/smollm2_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/smollm2_1_7b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Run with detailed profiling breakdown
 profile:
-	cd $(BUILD_DIR) && python3 $(srcdir)/smollm2_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/smollm2_1_7b_inference.py \
 		--run-only --n-tokens $(N_TOKENS) --profile --prompt "$(PROMPT)" --model $(MODEL)
 
 ## Interactive chat: prepare runtime once, then loop on prompts
 chat:
-	cd $(BUILD_DIR) && python3 $(srcdir)/smollm2_1_7b_inference.py \
+	cd $(BUILD_DIR) && $(PYTHON) $(srcdir)/smollm2_1_7b_inference.py \
 		--run-only --interactive --n-tokens $(N_TOKENS) --model $(MODEL)
 
 ## Compile and run in one step
@@ -88,19 +90,19 @@ RUNNER_ADAPTER = smollm2_1_7b.verify_adapter
 ## Run the top-k token-level inclusion gate (NPU vs HF bf16, 2 prompts × 32 tokens, k=5).
 verify:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL) --max-prompts 2
 
 ## Full-sweep variant of `make verify`.
 verify-full:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts topk_token --model $(MODEL)
 
 ## Run the diagnosis lens (per-layer ffn_out cosine vs HF bf16, single prompt, informational)
 diagnosis:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+	cd $(BUILD_DIR) && $(PYTHON) $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
 		--prompts single --prompt "$(PROMPT)" --model $(MODEL)
 
 # ============================================================

--- a/programming_examples/llms/smolvla/Makefile
+++ b/programming_examples/llms/smolvla/Makefile
@@ -31,10 +31,10 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # The interpreter that runs the model. It needs torch + lerobot (installed by
 # requirements.txt) AND air + pyxrt (from the sourced mlir-air environment) in
 # ONE process, which is what makes the in-process NPU path work. Defaults to
-# the environment's python3; override if your lerobot install lives elsewhere:
+# the environment's $(PYTHON); override if your lerobot install lives elsewhere:
 #     make verify LEROBOT_PYTHON=/path/to/venv/bin/python
-LEROBOT_PYTHON ?= python3
-NPU_PYTHON     ?= python3
+LEROBOT_PYTHON ?= $(PYTHON)
+NPU_PYTHON     ?= $(PYTHON)
 BUILD_DIR      ?= build
 REPS           ?= 5
 

--- a/programming_examples/matrix_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Tile sizes
 TILE_M ?= 128
 TILE_K_L2 ?= 64
@@ -30,7 +32,7 @@ else
   DIRECT_CODEGEN_FLAG ?=
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -68,27 +70,27 @@ endif
 all: run4x4
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p --herd-m 8 --herd-n 4 --m 2048 --n 1024 --k 512 \
+	${powershell} $(PYTHON) ${srcdir}/run.py -p --herd-m 8 --herd-n 4 --m 2048 --n 1024 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run8x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 -v \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 -v \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run4x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run2x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run2x2: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run1x1: compile-kernel-1x1
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 compile-kernel-1x1:
 	mkdir -p $(BUILD_DIR)
@@ -115,7 +117,7 @@ compile-kernel-1x1:
 	fi
 
 run3x3: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 	
 # LLAMA-3.2-1B GEMM shapes (M=128, herd 8x4, tile_m=16)
@@ -130,19 +132,19 @@ compile-kernel-llama:
 run_llama_8x4: run_llama_8x4_qo run_llama_8x4_kv run_llama_8x4_gate_up run_llama_8x4_down
 
 run_llama_8x4_qo: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 2048 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 2048 \
 		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run_llama_8x4_kv: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 512 \
 		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run_llama_8x4_gate_up: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 8192 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 2048 --n 8192 \
 		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 run_llama_8x4_down: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 8192 --n 2048 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 128 --k 8192 --n 2048 \
 		--tile-m 16 --tile-k-l2 64 --tile-k-l1 32 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG) $(OUTPUT_DTYPE_FLAG)
 
 profile: compile-kernel build-test-exe
@@ -161,7 +163,7 @@ sweep4x4: compile-kernel build-test-exe
 		for N in 256 512 1024 2048; do \
 			for K in 256 512 1024 2048; do \
 				echo "Running with M=$$M, N=$$N, K=$$K"; \
-				cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m $$M --n $$N --k $$K --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
+				cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --m $$M --n $$N --k $$K --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
 				./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $$M -N $$N -K $$K; \
 			done; \
 		done; \

--- a/programming_examples/matrix_multiplication/bf16_in_bf16_out/Makefile
+++ b/programming_examples/matrix_multiplication/bf16_in_bf16_out/Makefile
@@ -10,6 +10,8 @@
 #   false = direct-codegen bf16 (per-L2-tile bf16 truncation; faster, lower precision).
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 TILE_M ?= 64
 TILE_K_L2 ?= 256
 TILE_K_L1 ?= 32
@@ -37,7 +39,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -56,7 +58,7 @@ compile-kernel:
 	fi
 
 run: compile-kernel
-	cd $(BUILD_DIR) && python3 ${srcdir}/run.py --arch $(AIE_TARGET) \
+	cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --arch $(AIE_TARGET) \
 		--high-precision $(HIGH_PRECISION) --method $(METHOD) \
 		--m $(M) --k $(K) --n $(N) \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) \

--- a/programming_examples/matrix_multiplication/bf16_in_fp32_out/Makefile
+++ b/programming_examples/matrix_multiplication/bf16_in_fp32_out/Makefile
@@ -7,6 +7,8 @@
 # direct (compiler, self-contained).
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Tile config (registry-best for large GEMMs on NPU2, full-chip 8x4 herd).
 TILE_M ?= 64
 TILE_K_L2 ?= 256
@@ -35,7 +37,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -53,7 +55,7 @@ compile-kernel:
 	fi
 
 run: compile-kernel
-	cd $(BUILD_DIR) && python3 ${srcdir}/run.py --arch $(AIE_TARGET) --codegen $(CODEGEN) \
+	cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --arch $(AIE_TARGET) --codegen $(CODEGEN) \
 		--m $(M) --k $(K) --n $(N) \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) \
 		--herd-m $(HERD_M) --herd-n $(HERD_N) --compile-mode $(COMPILE_MODE) --perf-iters $(PERF_ITERS)

--- a/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
+++ b/programming_examples/matrix_multiplication/bf16_x_bfp16/Makefile
@@ -3,6 +3,8 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 M       ?= 64
 K       ?= 128
 N       ?= 128
@@ -21,7 +23,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -33,7 +35,7 @@ PY_ARGS = --m $(M) --k $(K) --n $(N) \
 all: run
 
 print:
-	${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) -p
+	${powershell} $(PYTHON) $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) -p
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -48,11 +50,11 @@ compile-kernel:
 
 run: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS)
+	  ${powershell} $(PYTHON) $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS)
 
 compile-only: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) --compile-mode compile-only
+	  ${powershell} $(PYTHON) $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) --compile-mode compile-only
 
 # Build the C++ XRT timing harness. Mirrors bf16/Makefile:build-test-exe.
 build-test-exe:
@@ -86,7 +88,7 @@ build-test-exe:
 # End-to-end latency profile: build xclbin then run the C++ harness.
 profile: compile-kernel build-test-exe
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) \
+	  ${powershell} $(PYTHON) $(srcdir)/matmul_bf16_x_bfp16.py $(PY_ARGS) \
 	    --compile-mode compile-and-xclbin
 	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE \
 	  -i air.insts.bin -M $(M) -K $(K) -N $(N)

--- a/programming_examples/matrix_multiplication/bfp16/Makefile
+++ b/programming_examples/matrix_multiplication/bfp16/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Tile sizes.
 # bfp16ebs8 constrains these more than bf16 does: the host shuffle requires
 # TILE_K_L1 % 64 == 0 and TILE_N % 64 == 0 (tile width in elements), and
@@ -20,7 +22,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -55,34 +57,34 @@ COMMON_ARGS = --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L
 all: run4x4
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p --herd-m 8 --herd-n 4 --m 2048 --n 1024 --k 512 \
+	${powershell} $(PYTHON) ${srcdir}/run.py -p --herd-m 8 --herd-n 4 --m 2048 --n 1024 --k 512 \
 		--tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --arch $(AIE_TARGET)
 
 run8x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 -v \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 -v \
 		$(COMMON_ARGS)
 
 run4x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 \
 		$(COMMON_ARGS)
 
 run2x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 \
 		$(COMMON_ARGS)
 
 run2x2: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 \
 		$(COMMON_ARGS)
 
 # 576 = 9 * 64, so the 64-element tile floor still divides it 3 ways.
 run3x3: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 \
 		--tile-m 64 --tile-k-l2 192 --tile-k-l1 64 --tile-n 64 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
 
 # Smallest single-PE config. TILE_K_L1/TILE_N cannot go below 64 for bfp16ebs8
 # (host shuffle granularity), so this is 64x64x64 rather than bf16's 32x32x16.
 run1x1: compile-kernel-1x1
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 \
 		--tile-m 64 --tile-k-l2 64 --tile-k-l1 64 --tile-n 64 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(OUTPUT_DTYPE_FLAG)
 
 compile-kernel-1x1:
@@ -112,25 +114,25 @@ LLAMA_ARGS = --tile-m $(LLAMA_TILE_M) --tile-k-l2 128 --tile-k-l1 $(LLAMA_TILE_K
 run_llama_4x4: run_llama_4x4_qo run_llama_4x4_kv run_llama_4x4_gate_up
 
 run_llama_4x4_qo: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 2048 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 2048 \
 		$(LLAMA_ARGS)
 
 run_llama_4x4_kv: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 512 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 512 \
 		$(LLAMA_ARGS)
 
 run_llama_4x4_gate_up: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 8192 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 2048 --n 8192 \
 		$(LLAMA_ARGS)
 
 run_llama_4x4_down: compile-kernel-llama
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 8192 --n 2048 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/run.py --herd-m $(LLAMA_HERD_M) --herd-n $(LLAMA_HERD_N) --m 128 --k 8192 --n 2048 \
 		$(LLAMA_ARGS)
 
 # Report latency + GFLOPs alongside the correctness check. Uses XRTRunner's
 # built-in timing (--perf-iters), so no separate C++ harness is needed.
 profile: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m 1024 --k 1024 --n 1024 \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --m 1024 --k 1024 --n 1024 \
 		--herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --perf-iters 50 $(COMMON_ARGS)
 
 # Measure the e2e latencies across a range of problem shapes.
@@ -139,7 +141,7 @@ sweep4x4: compile-kernel
 		for N in 256 512 1024 2048; do \
 			for K in 256 512 1024 2048; do \
 				echo "Running with M=$$M, N=$$N, K=$$K"; \
-				cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m $$M --n $$N --k $$K \
+				cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --m $$M --n $$N --k $$K \
 					--herd-m 4 --herd-n 4 --perf-iters 20 $(COMMON_ARGS); \
 			done; \
 		done; \

--- a/programming_examples/matrix_multiplication/bfp16/run_npu1_unsupported_arch.lit
+++ b/programming_examples/matrix_multiplication/bfp16/run_npu1_unsupported_arch.lit
@@ -7,6 +7,6 @@
 //
 // RUN: mkdir -p test_npu1_unsupported_arch
 // RUN: cd test_npu1_unsupported_arch
-// RUN: not python3 %S/run.py --arch aie2 --compile-mode compile-only 2>&1 | FileCheck %s
+// RUN: not %PYTHON %S/run.py --arch aie2 --compile-mode compile-only 2>&1 | FileCheck %s
 // CHECK: Error: --arch aie2 is not supported
 // CHECK: AIE2P-only

--- a/programming_examples/matrix_multiplication/i16/Makefile
+++ b/programming_examples/matrix_multiplication/i16/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Tile sizes
 TILE_M ?= 64
 TILE_K_L2 ?= 128
@@ -30,7 +32,7 @@ else
   DIRECT_CODEGEN_FLAG ?=
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -61,27 +63,27 @@ endif
 all: run4x4
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	${powershell} $(PYTHON) ${srcdir}/run.py -p --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run8x4: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run4x4: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run2x4: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run2x2: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run1x1: compile-kernel-1x1
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 compile-kernel-1x1:
 	mkdir -p $(BUILD_DIR)
@@ -109,7 +111,7 @@ compile-kernel-1x1:
 
 run3x3: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 --tile-k-l2 288 --tile-k-l1 48 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 576 --n 576 --k 576 --tile-k-l2 288 --tile-k-l1 48 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 profile: compile-kernel build-test-exe
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python ../run.py --m 1024 --k 1024 --n 1024 \
@@ -122,7 +124,7 @@ sweep4x4: compile-kernel build-test-exe
 		for N in 256 512 1024 2048; do \
 			for K in 256 512 1024 2048; do \
 			echo "Running with M=$$M, N=$$N, K=$$K"; \
-			cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m $$M --n $$N --k $$K --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
+			cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --m $$M --n $$N --k $$K --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
 			./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $$M -N $$N -K $$K; \
 			done; \
 		done; \

--- a/programming_examples/matrix_multiplication/i8/Makefile
+++ b/programming_examples/matrix_multiplication/i8/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Tile sizes
 TILE_M ?= 128
 TILE_K_L2 ?= 64
@@ -30,7 +32,7 @@ else
   DIRECT_CODEGEN_FLAG ?=
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -60,22 +62,22 @@ endif
 all: run4x4
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	${powershell} $(PYTHON) ${srcdir}/run.py -p --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run8x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 1024 --k 1024 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 8 --herd-n 4 --m 1024 --n 1024 --k 1024 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run4x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 4 --herd-n 4 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run2x4: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 4 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run2x2: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 2 --herd-n 2 --m 512 --n 512 --k 512 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 run1x1: compile-kernel-1x1
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 
 compile-kernel-1x1:
 	mkdir -p $(BUILD_DIR)
@@ -102,7 +104,7 @@ compile-kernel-1x1:
 	fi
 
 run3x3: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 1152 --n 1152 --k 1152 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --herd-m 3 --herd-n 3 --m 1152 --n 1152 --k 1152 --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --compile-mode $(COMPILE_MODE) --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG)
 	
 profile: compile-kernel build-test-exe
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python ../run.py --m 1024 --k 1024 --n 1024 \
@@ -115,7 +117,7 @@ sweep4x4: compile-kernel build-test-exe
 		for N in 512 1024 2048; do \
 			for K in 256 512 1024 2048; do \
 				echo "Running with M=$$M, N=$$N, K=$$K"; \
-				cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --m $$M --n $$N --k $$K --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
+				cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --m $$M --n $$N --k $$K --tile-m $(TILE_M) --tile-k-l2 $(TILE_K_L2) --tile-k-l1 $(TILE_K_L1) --tile-n $(TILE_N) --herd-m $(MAX_HERD_M) --herd-n $(MAX_HERD_N) --compile-mode compile-and-xclbin --arch $(AIE_TARGET) $(DIRECT_CODEGEN_FLAG); \
 				./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $$M -N $$N -K $$K; \
 			done; \
 		done; \

--- a/programming_examples/matrix_multiplication/int4_awq/Makefile
+++ b/programming_examples/matrix_multiplication/int4_awq/Makefile
@@ -5,6 +5,8 @@
 # directory and is shared (matmul_int4_bf16_packed + zero_vectorized_bf16_mn).
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
 INT4_SRCDIR := $(srcdir)/../../matrix_vector_multiplication/int4_awq
 
 # TILE_K_L2 must equal K: the segment-level K loop has 1 iter so the per-PE
@@ -26,7 +28,7 @@ else
   BUILD_DIR := build_chess
 endif
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -38,7 +40,7 @@ PY_ARGS = --m $(M) --k $(K) --n $(N) --gs $(GS) \
 all: run_packed
 
 print:
-	${powershell} python3 ${srcdir}/matmul_int4_packed.py $(PY_ARGS) -p
+	${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py $(PY_ARGS) -p
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -53,18 +55,18 @@ compile-kernel:
 
 run_packed: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matmul_int4_packed.py $(PY_ARGS)
+	  ${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py $(PY_ARGS)
 
 run1x1: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matmul_int4_packed.py \
+	  ${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py \
 	    --m 16 --k 128 --n 16 --gs $(GS) \
 	    --tile-m 16 --tile-n 16 --tile-k-l1 128 --tile-k-l2 128 \
 	    --herd-m 1 --herd-n 1
 
 run2x4: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matmul_int4_packed.py \
+	  ${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py \
 	    --m 64 --k 128 --n 128 --gs $(GS) \
 	    --tile-m $(TILE_M) --tile-n $(TILE_N) \
 	    --tile-k-l1 $(TILE_K_L1) --tile-k-l2 128 \
@@ -72,7 +74,7 @@ run2x4: compile-kernel
 
 run8x4: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matmul_int4_packed.py \
+	  ${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py \
 	    --m 256 --k 128 --n 128 --gs $(GS) \
 	    --tile-m $(TILE_M) --tile-n $(TILE_N) \
 	    --tile-k-l1 $(TILE_K_L1) --tile-k-l2 128 \
@@ -81,7 +83,7 @@ run8x4: compile-kernel
 # Llama Q-proj scale: M=N=K=2048, herd 8x4, TILE_K_L2=K (no re-zero).
 run_llama_qproj: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matmul_int4_packed.py \
+	  ${powershell} $(PYTHON) ${srcdir}/matmul_int4_packed.py \
 	    --m 2048 --k 2048 --n 2048 --gs $(GS) \
 	    --tile-m 16 --tile-n 16 --tile-k-l1 128 --tile-k-l2 2048 \
 	    --herd-m 8 --herd-n 4

--- a/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/multi_core_channel.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/multi_core_channel.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/multi_core_channel.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/multi_core_channel.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/multi_core_dma.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/multi_core_dma.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/multi_core_dma.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/multi_core_dma.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/multi_launch_channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/multi_launch_channel.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/multi_launch_channel.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/multi_launch_channel.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/multi_launch_channel.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_scalar_add/single_core_channel/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core_channel.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core_channel.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core_channel.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core_channel.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_scalar_add/single_core_dma/Makefile
+++ b/programming_examples/matrix_scalar_add/single_core_dma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core_dma.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core_dma.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core_dma.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core_dma.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/matrix_vector_multiplication/bf16/Makefile
+++ b/programming_examples/matrix_vector_multiplication/bf16/Makefile
@@ -4,6 +4,8 @@
 # GEMV BF16: C[M] = A[M,K] @ B[K]
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -15,7 +17,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -41,13 +43,13 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
+	${powershell} $(PYTHON) ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
 
 run: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
 
 profile: compile-kernel build-test-exe
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/matvec.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-m $(HERD_M)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $(M) -K $(K)
 
 # Convenience targets matching IRON GEMV test shapes (4 columns default)

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/Makefile
@@ -5,6 +5,8 @@
 # K-reduction split across n_cascade tiles per column via cascade channels.
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,7 +18,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -32,10 +34,10 @@ N_CASCADE ?= 4
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	${powershell} $(PYTHON) ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir) || \
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir) || \
 	  (echo "=== npu.air.mlir (packet_flow and aie.flow lines) ===" >&2 && \
 	   grep -n "packet_flow\|aie.flow" air_project/npu.air.mlir >&2 2>/dev/null; \
 	   echo "=== input_with_addresses.mlir (packet_flow lines) ===" >&2 && \
@@ -46,7 +48,7 @@ run:
 
 profile: build-test-exe
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/matvec_cascade.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $(M) -K $(K)
 
 # 8 columns x 4 cascade tiles (full device, tile_m=2 fits L2)
@@ -73,18 +75,18 @@ build-test-exe:
 # M_INPUT (= rows per inner kernel iter) can be any divisor of tile_m.
 
 print_add:
-	${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	${powershell} $(PYTHON) ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) -p --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 
 run_add:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE) $(if $(DEBUG_IR),--debug-ir)
 
 build-test-add-exe:
 	@$(MAKE) build-test-exe-impl SRC=test_add.cpp OUT=test_add.exe
 
 profile_add: build-test-add-exe
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) ${srcdir}/matvec_cascade_add.py $(OUTPUT_FORMAT_FLAG) --compile-mode compile-and-xclbin --m $(M) --k $(K) --tile-m $(TILE_M) --m-input $(M_INPUT) --herd-cols $(HERD_COLS) --n-cascade $(N_CASCADE)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ./test_add.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin -M $(M) -K $(K)
 
 # 8 columns x 4 cascade tiles, fused GEMV+add
@@ -110,13 +112,13 @@ compile-mv-bf16:
 		-c ${srcdir}/mv_bf16.cc -o $(BUILD_DIR)/mv_bf16.o
 
 print_2tile_add:
-	${powershell} python3 ${srcdir}/matvec_2tile_add.py $(OUTPUT_FORMAT_FLAG) -p \
+	${powershell} $(PYTHON) ${srcdir}/matvec_2tile_add.py $(OUTPUT_FORMAT_FLAG) -p \
 		--m $(M) --k $(K) --tile-m $(TILE_M_2T) --k-chunk $(K_CHUNK_2T) --herd-cols $(HERD_COLS)
 
 run_2tile_add: compile-mv-bf16
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_2tile_add.py $(OUTPUT_FORMAT_FLAG) \
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_2tile_add.py $(OUTPUT_FORMAT_FLAG) \
 		--m $(M) --k $(K) --tile-m $(TILE_M_2T) --k-chunk $(K_CHUNK_2T) --herd-cols $(HERD_COLS)
 
 build-test-exe-impl:

--- a/programming_examples/matrix_vector_multiplication/int4_awq/Makefile
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/Makefile
@@ -4,6 +4,8 @@
 # int4 AWQ GEMV / GEMV+R examples (packed Q+S+Z BO).
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -20,7 +22,7 @@ GS      ?= 128
 M_TILE  ?= 8
 K_CHUNK ?= 2048
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -29,10 +31,10 @@ PY_ARGS = --m $(M) --k $(K) --gs $(GS) --m-tile $(M_TILE) --k-chunk $(K_CHUNK)
 all: run_packed
 
 print_packed:
-	${powershell} python3 ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
+	${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
 
 print_packed_add:
-	${powershell} python3 ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
+	${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) -p $(PY_ARGS)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -48,13 +50,13 @@ compile-kernel:
 run_packed: compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
 
 # GEMV + fused residual add (LA-style 2-tile cascade)
 run_packed_add: compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed_add.py $(OUTPUT_FORMAT_FLAG) $(PY_ARGS)
 
 # ELF profile harnesses (compile module, then run XRT benchmark loop)
 build-test-packed-exe:
@@ -66,14 +68,14 @@ build-test-packed-add-exe:
 profile_packed: build-test-packed-exe compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_int4_packed.py --compile-mode compile-only --output-format elf $(PY_ARGS)
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed.py --compile-mode compile-only --output-format elf $(PY_ARGS)
 	cd $(BUILD_DIR) && ./test_packed.exe -e air.elf -k "main:matvec_int4_packed" \
 	  -M $(M) -K $(K) -G $(GS) -T $(M_TILE) -C $(K_CHUNK)
 
 profile_packed_add: build-test-packed-add-exe compile-kernel
 	mkdir -p $(BUILD_DIR)
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-	  ${powershell} python3 ${srcdir}/matvec_int4_packed_add.py --compile-mode compile-only --output-format elf $(PY_ARGS)
+	  ${powershell} $(PYTHON) ${srcdir}/matvec_int4_packed_add.py --compile-mode compile-only --output-format elf $(PY_ARGS)
 	cd $(BUILD_DIR) && ./test_packed_add.exe -e air.elf -k "main:matvec_int4_packed_add" \
 	  -M $(M) -K $(K) -G $(GS) -T $(M_TILE) -C $(K_CHUNK)
 

--- a/programming_examples/mnist_fc/argmax/Makefile
+++ b/programming_examples/mnist_fc/argmax/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ NE1 ?= 500
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py --ne0 $(NE0) --ne1 $(NE1) -p
+	${powershell} $(PYTHON) ${srcdir}/run.py --ne0 $(NE0) --ne1 $(NE1) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --ne0 $(NE0) --ne1 $(NE1) -v
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --ne0 $(NE0) --ne1 $(NE1) -v
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/mnist_fc/broadcast_bias_add/Makefile
+++ b/programming_examples/mnist_fc/broadcast_bias_add/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ N ?= 500
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py --M $(M) --N $(N) -p
+	${powershell} $(PYTHON) ${srcdir}/run.py --M $(M) --N $(N) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --M $(M) --N $(N) -v
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --M $(M) --N $(N) -v
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/mnist_fc/integration/Makefile
+++ b/programming_examples/mnist_fc/integration/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -11,11 +13,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p
+	${powershell} $(PYTHON) ${srcdir}/run.py -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py -v
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py -v
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/mnist_fc/relu/Makefile
+++ b/programming_examples/mnist_fc/relu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ N ?= 500
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py --M $(M) --N $(N) -p
+	${powershell} $(PYTHON) ${srcdir}/run.py --M $(M) --N $(N) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/run.py --M $(M) --N $(N) -v
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/run.py --M $(M) --N $(N) -v
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/multi_segment/multi_segment_channel/Makefile
+++ b/programming_examples/multi_segment/multi_segment_channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/multi_segment/multi_segment_dma/Makefile
+++ b/programming_examples/multi_segment/multi_segment_dma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/multi_segment.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/passthrough/passthrough_channel/Makefile
+++ b/programming_examples/passthrough/passthrough_channel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/passthrough_channel.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/passthrough_channel.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/passthrough_channel.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/passthrough_channel.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/passthrough/passthrough_dma/Makefile
+++ b/programming_examples/passthrough/passthrough_dma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -20,11 +22,11 @@ DTYPE_FLAG = --dtype $(DTYPE)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/passthrough_dma.py $(OUTPUT_FORMAT_FLAG) $(DTYPE_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/passthrough/passthrough_kernel/Makefile
+++ b/programming_examples/passthrough/passthrough_kernel/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -36,10 +38,10 @@ targetname = passThroughKernel
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/passthrough_kernel.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/passthrough_kernel.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/passthrough_kernel.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/passthrough_kernel.py $(OUTPUT_FORMAT_FLAG)
 	
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/primitives/scalar_examples/scalar_invsqrt/Makefile
+++ b/programming_examples/primitives/scalar_examples/scalar_invsqrt/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -12,11 +14,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/scalar_invsqrt.py -p
+	${powershell} $(PYTHON) ${srcdir}/scalar_invsqrt.py -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/scalar_invsqrt.py
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/scalar_invsqrt.py
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/scalar_examples/scalar_reciprocal/Makefile
+++ b/programming_examples/primitives/scalar_examples/scalar_reciprocal/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -12,11 +14,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/scalar_reciprocal.py -p
+	${powershell} $(PYTHON) ${srcdir}/scalar_reciprocal.py -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/scalar_reciprocal.py
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/scalar_reciprocal.py
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/scalar_examples/scalar_shift_saturate/Makefile
+++ b/programming_examples/primitives/scalar_examples/scalar_shift_saturate/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -19,11 +21,11 @@ SHIFT_AMOUNT ?= 4
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/scalar_shift_saturate.py -p --shift-amount $(SHIFT_AMOUNT)
+	${powershell} $(PYTHON) ${srcdir}/scalar_shift_saturate.py -p --shift-amount $(SHIFT_AMOUNT)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/scalar_shift_saturate.py $(OUTPUT_FORMAT_FLAG) --shift-amount $(SHIFT_AMOUNT)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/scalar_shift_saturate.py $(OUTPUT_FORMAT_FLAG) --shift-amount $(SHIFT_AMOUNT)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_add/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_add/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,10 +30,10 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_add.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_add.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_add.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_add.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_andi/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_andi/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -18,11 +20,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_andi.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_andi.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_andi.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_andi.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_broadcast_scalar/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_broadcast_scalar/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,10 +18,10 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_broadcast_scalar.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/vector_broadcast_scalar.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_broadcast_scalar.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_broadcast_scalar.py $(OUTPUT_FORMAT_FLAG)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_div/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_div/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -22,11 +24,11 @@ AIE_TARGET ?= aie2
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_div.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_div.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_div.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_div.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_exp/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_exp/Makefile
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 BUILD_DIR := build_peano
 
 # Output format: xclbin (default) or elf
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 
@@ -27,11 +29,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_exp.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET) --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_exp.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET) --vector-size $(VECTOR_SIZE)
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_exp.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_exp.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET) --vector-size $(VECTOR_SIZE)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/primitives/vector_examples/vector_fma/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_fma/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,10 +30,10 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_fma.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_fma.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_fma.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_fma.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_fptosi/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_fptosi/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -18,11 +20,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_fptosi.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_fptosi.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_fptosi.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_fptosi.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_max/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_max/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,10 +30,10 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_max.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_max.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_max.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_max.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_mul/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_mul/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,11 +30,11 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_mul.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_mul.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_mul.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_mul.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_muladd/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_muladd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -22,10 +24,10 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_muladd.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_muladd.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_muladd.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_muladd.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_ori/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_ori/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -18,11 +20,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_ori.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_ori.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_ori.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_ori.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_reciprocal/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_reciprocal/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -18,11 +20,11 @@ AIE_TARGET ?= aie2
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_reciprocal.py -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_reciprocal.py -p --arch $(AIE_TARGET)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_reciprocal.py --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_reciprocal.py --arch $(AIE_TARGET)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_reduce_add/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_reduce_add/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -19,10 +21,10 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_reduce_add.py $(OUTPUT_FORMAT_FLAG) -p --n $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_reduce_add.py $(OUTPUT_FORMAT_FLAG) -p --n $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_reduce_add.py $(OUTPUT_FORMAT_FLAG) --n $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_reduce_add.py $(OUTPUT_FORMAT_FLAG) --n $(VECTOR_SIZE)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_reduce_max/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_reduce_max/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,10 +18,10 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_reduce_max.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/vector_reduce_max.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_reduce_max.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_reduce_max.py $(OUTPUT_FORMAT_FLAG)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_rsqrt/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_rsqrt/Makefile
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 BUILD_DIR := build_peano
 
 # Output format: xclbin (default) or elf
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 
@@ -22,33 +24,33 @@ all: run
 
 # Default target (Version 1)
 print:
-	${powershell} python3 ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run: run-v1
 
 # Version 1: f32 vector rsqrt
 print-v1:
-	${powershell} python3 ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run-v1: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v1.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
 
 # Version 2: f32 scalar rsqrt in loop
 print-v2:
-	${powershell} python3 ${srcdir}/vector_rsqrt_v2.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v2.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run-v2: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_rsqrt_v2.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v2.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
 
 # Version 3: bf16 vector rsqrt with f32 conversion
 print-v3:
-	${powershell} python3 ${srcdir}/vector_rsqrt_v3.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v3.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run-v3: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_rsqrt_v3.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_rsqrt_v3.py $(OUTPUT_FORMAT_FLAG) --arch $(AIE_TARGET)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/primitives/vector_examples/vector_select/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_select/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,10 +30,10 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_select.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_select.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_select.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_select.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_sitofp/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_sitofp/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -18,11 +20,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_sitofp.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_sitofp.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_sitofp.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_sitofp.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_sub/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_sub/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -28,10 +30,10 @@ BF16_EMULATION ?=
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_sub.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	${powershell} $(PYTHON) ${srcdir}/vector_sub.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_sub.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_sub.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) $(if $(BF16_EMULATION),--bf16-emulation,)
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_tanh/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_tanh/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 BUILD_DIR := build_peano
 
 # Output format: xclbin (default) or elf
@@ -17,11 +19,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_tanh.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/vector_tanh.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE) --arch $(AIE_TARGET)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_tanh.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) --arch $(AIE_TARGET)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_tanh.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE) --arch $(AIE_TARGET)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/primitives/vector_examples/vector_xori/Makefile
+++ b/programming_examples/primitives/vector_examples/vector_xori/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -18,11 +20,11 @@ VECTOR_SIZE ?= 16
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/vector_xori.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
+	${powershell} $(PYTHON) ${srcdir}/vector_xori.py $(OUTPUT_FORMAT_FLAG) -p --vector-size $(VECTOR_SIZE)
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/vector_xori.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/vector_xori.py $(OUTPUT_FORMAT_FLAG) --vector-size $(VECTOR_SIZE)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/relu/Makefile
+++ b/programming_examples/relu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/relu.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/rms_norm/Makefile
+++ b/programming_examples/rms_norm/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/rms_norm.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/rms_norm.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/rms_norm.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/rms_norm.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/rope_halfsplit/Makefile
+++ b/programming_examples/rope_halfsplit/Makefile
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # NPU2 (Strix / AIE2P) only. The kernel links an external C++ vector
 # microkernel (rope_halfsplit.cc -> rope.o, the half-split RoPE that
 # llama-3.2-1B links via external_kernels.py:compile_rope). No NPU1 path.
 BUILD_DIR := build_peano
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -32,14 +34,14 @@ compile-kernel:
 
 # Print the MLIR module (no kernel .o / NPU needed)
 print:
-	${powershell} python3 ${srcdir}/rope_halfsplit.py \
+	${powershell} $(PYTHON) ${srcdir}/rope_halfsplit.py \
 		--rows $(ROWS) --head-dim $(HEAD_DIM) --herd-x $(HERD_X) \
 		--herd-y $(HERD_Y) -p
 
 # Compile + run correctness check on NPU2
 run: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_halfsplit.py \
+		${powershell} $(PYTHON) ${srcdir}/rope_halfsplit.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--rows $(ROWS) --head-dim $(HEAD_DIM) --herd-x $(HERD_X) \
 		--herd-y $(HERD_Y)
@@ -47,7 +49,7 @@ run: compile-kernel
 # Compile + run with latency profiling (correctness still checked)
 profile: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_halfsplit.py \
+		${powershell} $(PYTHON) ${srcdir}/rope_halfsplit.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--rows $(ROWS) --head-dim $(HEAD_DIM) --herd-x $(HERD_X) \
 		--herd-y $(HERD_Y) \

--- a/programming_examples/rope_lut/Makefile
+++ b/programming_examples/rope_lut/Makefile
@@ -1,8 +1,9 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -22,7 +23,7 @@ PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLA
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
+	${powershell} $(PYTHON) ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
 		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X) -p
 
 compile-kernel:
@@ -40,14 +41,14 @@ compile-xclbin: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_lut.py --output-format xclbin --compile-mode compile-only \
+		${powershell} $(PYTHON) ${srcdir}/rope_lut.py --output-format xclbin --compile-mode compile-only \
 		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X)
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
+		${powershell} $(PYTHON) ${srcdir}/rope_lut.py $(OUTPUT_FORMAT_FLAG) \
 		--seq-len $(SEQ_LEN) --embed-dim $(EMBED_DIM) --herd-x $(HERD_X)
 
 # C++ profiling harness (10 warmup + 20 measured iterations, microsecond precision)
@@ -63,7 +64,7 @@ run_llama: compile-kernel build-test-exe
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		python3 ${srcdir}/rope_lut.py --output-format xclbin \
+		$(PYTHON) ${srcdir}/rope_lut.py --output-format xclbin \
 		--seq-len 65536 --embed-dim 64 --herd-x 8
 	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
 		-R 65536 -D 64
@@ -72,7 +73,7 @@ run_llama: compile-kernel build-test-exe
 	@echo "  Prefill RoPE K: 16384 rows x 64, herd=[8,1]"
 	@echo "============================================"
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		python3 ${srcdir}/rope_lut.py --output-format xclbin \
+		$(PYTHON) ${srcdir}/rope_lut.py --output-format xclbin \
 		--seq-len 16384 --embed-dim 64 --herd-x 8
 	cd $(BUILD_DIR) && ./test.exe -x air.xclbin -k MLIR_AIE -i air.insts.bin \
 		-R 16384 -D 64

--- a/programming_examples/rope_sincos/Makefile
+++ b/programming_examples/rope_sincos/Makefile
@@ -1,8 +1,9 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -32,7 +33,7 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/rope_sincos.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/rope_sincos.py $(OUTPUT_FORMAT_FLAG) -p
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)
@@ -51,13 +52,13 @@ compile-xclbin: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_sincos.py --output-format xclbin --compile-mode compile-only
+		${powershell} $(PYTHON) ${srcdir}/rope_sincos.py --output-format xclbin --compile-mode compile-only
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)/air_project
 	cp $(BUILD_DIR)/rope.o $(BUILD_DIR)/air_project/rope.o
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/rope_sincos.py $(OUTPUT_FORMAT_FLAG)
+		${powershell} $(PYTHON) ${srcdir}/rope_sincos.py $(OUTPUT_FORMAT_FLAG)
 
 # C++ profiling harness (10 warmup + 20 measured iterations, microsecond precision)
 profile: compile-xclbin build-test-exe

--- a/programming_examples/segment_alloc/Makefile
+++ b/programming_examples/segment_alloc/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/segment_alloc.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/segment_alloc.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/segment_alloc.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/segment_alloc.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/segment_unroll/Makefile
+++ b/programming_examples/segment_unroll/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -16,11 +18,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/segment_unroll.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/segment_unroll.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/segment_unroll.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/segment_unroll.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/shared_l1_multi_herd/Makefile
+++ b/programming_examples/shared_l1_multi_herd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -11,11 +13,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p
+	${powershell} $(PYTHON) ${srcdir}/run.py -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} python3 ${srcdir}/run.py
+	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} $(PYTHON) ${srcdir}/run.py
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/shared_l1_single_herd/Makefile
+++ b/programming_examples/shared_l1_single_herd/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -11,11 +13,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/run.py -p
+	${powershell} $(PYTHON) ${srcdir}/run.py -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} python3 ${srcdir}/run.py
+	cd $(BUILD_DIR) && PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) ${powershell} $(PYTHON) ${srcdir}/run.py
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/shim_dma_2d/Makefile
+++ b/programming_examples/shim_dma_2d/Makefile
@@ -16,7 +16,24 @@ else
   DEVICE := npu1_1col
 endif
 
-MLIR_AIE_INSTALL_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+# Windows sets OS itself, but lit sanitizes the environment, so fall back to
+# uname -- Git Bash, which make uses as its shell here, reports MINGW*.
+ifeq ($(OS),Windows_NT)
+  WINDOWS := 1
+else ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(shell uname -s 2>/dev/null)))
+  WINDOWS := 1
+endif
+
+# Prefer the environment (utils/env_setup.sh on Linux, mlir-aie's iron_env.cmd
+# on Windows) over probing PATH, and normalize separators: make's shell strips
+# backslashes, and realpath under Git Bash emits an MSYS path that native
+# Windows tools cannot open.
+MLIR_AIE_INSTALL_DIR := $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
+
+# XRT's own setup.sh exports XILINX_XRT; the Windows SDK is pointed at by
+# XRT_ROOT instead (iron_env.cmd deliberately clears XILINX_XRT).
+XRT_DIR := $(subst \,/,$(if $(XILINX_XRT),$(XILINX_XRT),$(XRT_ROOT)))
+TEST_LIB_DIR := $(MLIR_AIE_INSTALL_DIR)/runtime_lib/x86_64/test_lib
 
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
@@ -45,6 +62,39 @@ $(BUILD_DIR)/final.py.xclbin: $(BUILD_DIR)/air.mlir
 	mkdir -p ${@D}
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) build.py $(OUTPUT_FORMAT_FLAG) air.mlir
 
+ifdef WINDOWS
+
+# MSVC build of the same host program. Flags are spelled with a leading dash,
+# which cl accepts as a synonym for a slash: make's shell here is Git Bash,
+# and MSYS rewrites anything that looks like a POSIX path, turning /nologo
+# into C:/.../Git/nologo. Two of them are load-bearing:
+#   -Zc:__cplusplus  - without it cl reports __cplusplus as 199711L, so XRT's
+#                      detail/any.h takes its pre-C++17 branch and demands
+#                      boost/any.hpp, which the Windows SDK does not ship.
+#   -MD              - test_utils.lib in the mlir_aie wheel is built against
+#                      the dynamic CRT, while cl defaults to /MT (LNK2038).
+# uuid/rt/stdc++ have no Windows equivalent and are not needed.
+${targetname}.exe: ${srcdir}/test.cpp
+	@if ! command -v cl >/dev/null 2>&1; then \
+		echo "Error: cl.exe not found. Run from an x64 Native Tools Command Prompt for Visual Studio."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(XRT_DIR)" ]; then \
+		echo "Error: neither XRT_ROOT nor XILINX_XRT is set. Point one at your XRT install."; \
+		exit 1; \
+	fi; \
+	if [ -z "$(MLIR_AIE_INSTALL_DIR)" ]; then \
+		echo "Error: MLIR_AIE_INSTALL_DIR could not be determined. Please make sure aie-opt is in your PATH."; \
+		exit 1; \
+	fi; \
+	mkdir -p $(BUILD_DIR); \
+	cd $(BUILD_DIR) && cl -nologo -EHsc -MD -std:c++20 -Zc:__cplusplus \
+		${srcdir}/test.cpp -Fe:${targetname}.exe \
+		-I"$(XRT_DIR)/include" -I"$(TEST_LIB_DIR)/include" \
+		-link "$(XRT_DIR)/lib/xrt_coreutil.lib" "$(TEST_LIB_DIR)/lib/test_utils.lib"
+
+else
+
 ${targetname}.exe: ${srcdir}/test.cpp
 	@GPP=$$( \
 		for bin in /usr/bin/g++-*; do \
@@ -58,7 +108,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 		echo "Error: No g++ version >= 13 found in /usr/bin."; \
 		exit 1; \
 	fi; \
-	if [ -z "$$XILINX_XRT" ]; then \
+	if [ -z "$(XRT_DIR)" ]; then \
 		echo "Error: XILINX_XRT environment variable not set. Please make sure to have sourced xrt/setup.sh."; \
 		exit 1; \
 	fi; \
@@ -69,10 +119,12 @@ ${targetname}.exe: ${srcdir}/test.cpp
 	echo "Using compiler: $$GPP"; \
 	mkdir -p $(BUILD_DIR); \
 	cd $(BUILD_DIR) && $$GPP ${srcdir}/test.cpp -o ${targetname}.exe -std=c++23 -Wall \
-		-I$$XILINX_XRT/include -L$$XILINX_XRT/lib \
-		-I$(MLIR_AIE_INSTALL_DIR)/runtime_lib/x86_64/test_lib/include \
-		-L$(MLIR_AIE_INSTALL_DIR)/runtime_lib/x86_64/test_lib/lib \
+		-I$(XRT_DIR)/include -L$(XRT_DIR)/lib \
+		-I$(TEST_LIB_DIR)/include \
+		-L$(TEST_LIB_DIR)/lib \
 		-luuid -lxrt_coreutil -lrt -lstdc++ -ltest_utils
+
+endif
 
 run: ${targetname}.exe $(BUILD_DIR)/final.xclbin $(BUILD_DIR)/final.insts.bin 
 	${powershell} $(BUILD_DIR)/${targetname}.exe -x $(BUILD_DIR)/final.xclbin -i $(BUILD_DIR)/final.insts.bin -k MLIR_AIE

--- a/programming_examples/shim_dma_2d/Makefile
+++ b/programming_examples/shim_dma_2d/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
 targetname := shim_dma_2d
 
 # AIE_TARGET can be set to 'aie2' (default) or 'aie2p' to select the target architecture.
@@ -33,7 +35,7 @@ all: $(BUILD_DIR)/final.xclbin
 
 $(BUILD_DIR)/air.mlir: ${srcdir}/${targetname}.py
 	mkdir -p ${@D}
-	python3 $< > $@
+	$(PYTHON) $< > $@
 
 $(BUILD_DIR)/final.xclbin: $(BUILD_DIR)/air.mlir
 	mkdir -p ${@D}
@@ -41,7 +43,7 @@ $(BUILD_DIR)/final.xclbin: $(BUILD_DIR)/air.mlir
 
 $(BUILD_DIR)/final.py.xclbin: $(BUILD_DIR)/air.mlir
 	mkdir -p ${@D}
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && python3 build.py $(OUTPUT_FORMAT_FLAG) air.mlir
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && $(PYTHON) build.py $(OUTPUT_FORMAT_FLAG) air.mlir
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	@GPP=$$( \
@@ -76,11 +78,11 @@ run: ${targetname}.exe $(BUILD_DIR)/final.xclbin $(BUILD_DIR)/final.insts.bin
 	${powershell} $(BUILD_DIR)/${targetname}.exe -x $(BUILD_DIR)/final.xclbin -i $(BUILD_DIR)/final.insts.bin -k MLIR_AIE
 
 run_py: $(BUILD_DIR)/final.xclbin $(BUILD_DIR)/final.insts.bin
-	${powershell} python3 ${srcdir}/test.py $(BUILD_DIR)/final.xclbin $(BUILD_DIR)/final.insts.bin
+	${powershell} $(PYTHON) ${srcdir}/test.py $(BUILD_DIR)/final.xclbin $(BUILD_DIR)/final.insts.bin
 
 pyworkflow:
 	mkdir -p pybuild
-	cd pybuild && ${powershell} python3 ${srcdir}/run.py
+	cd pybuild && ${powershell} $(PYTHON) ${srcdir}/run.py
 
 clean:
 	rm -rf build_peano build_chess pybuild tmp __pycache__

--- a/programming_examples/sigmoid/Makefile
+++ b/programming_examples/sigmoid/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/sigmoid.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/sigmoid.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/sigmoid.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/sigmoid.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/silu/Makefile
+++ b/programming_examples/silu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/silu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/silu.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/silu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/silu.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/silu_and_mul/Makefile
+++ b/programming_examples/silu_and_mul/Makefile
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # NPU2 (Strix / AIE2P) only. The kernel links an external C++ vector
 # microkernel (silu_and_mul.cc -> silu_and_mul.o) that needs the hardware
 # aie::tanh, so there is no NPU1 / direct-codegen path.
 BUILD_DIR := build_peano
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
 
@@ -33,20 +35,20 @@ compile-kernel:
 
 # Print the MLIR module (no kernel .o / NPU needed)
 print:
-	${powershell} python3 ${srcdir}/silu_and_mul.py \
+	${powershell} $(PYTHON) ${srcdir}/silu_and_mul.py \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y) -p
 
 # Compile + run correctness check on NPU2
 run: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/silu_and_mul.py \
+		${powershell} $(PYTHON) ${srcdir}/silu_and_mul.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y)
 
 # Compile + run with latency/bandwidth profiling (correctness still checked)
 profile: compile-kernel
 	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && \
-		${powershell} python3 ${srcdir}/silu_and_mul.py \
+		${powershell} $(PYTHON) ${srcdir}/silu_and_mul.py \
 		--output-format $(OUTPUT_FORMAT) \
 		--n $(N) --tile-n $(TILE_N) --herd-x $(HERD_X) --herd-y $(HERD_Y) \
 		--perf-iters $(ITERATIONS)

--- a/programming_examples/sine_cosine/Makefile
+++ b/programming_examples/sine_cosine/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,18 +15,18 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/sine_cosine.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/sine_cosine.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/sine_cosine.py $(OUTPUT_FORMAT_FLAG) --mode cos --n 192 --herd-n 4
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/sine_cosine.py $(OUTPUT_FORMAT_FLAG) --mode cos --n 192 --herd-n 4
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/softmax/Makefile
+++ b/programming_examples/softmax/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -34,11 +36,11 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/softmax.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
+	${powershell} $(PYTHON) ${srcdir}/softmax.py $(OUTPUT_FORMAT_FLAG) -p --arch $(AIE_TARGET)
 
 run: compile-kernel
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/softmax.py $(OUTPUT_FORMAT_FLAG) --n 2048 --herd-n 4
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/softmax.py $(OUTPUT_FORMAT_FLAG) --n 2048 --herd-n 4
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/swiglu/Makefile
+++ b/programming_examples/swiglu/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
 else
@@ -14,11 +16,11 @@ OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/swiglu.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/swiglu.py $(OUTPUT_FORMAT_FLAG) -p
 
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/swiglu.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/swiglu.py $(OUTPUT_FORMAT_FLAG)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/Makefile
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__
@@ -34,10 +36,10 @@ endif
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/Makefile
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,7 +15,7 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 # Peano's aie2 backend implements the plain mul_elem_16/mac_elem_16 float
 # intrinsics but not the _conf variants that stock Xilinx/aie_api calls; the
@@ -23,10 +25,10 @@ PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/Makefile
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # Determine build dir based on whether PEANO_INSTALL_DIR is set
 ifdef PEANO_INSTALL_DIR
   BUILD_DIR := build_peano
@@ -13,17 +15,17 @@ endif
 OUTPUT_FORMAT ?= xclbin
 OUTPUT_FORMAT_FLAG = --output-format $(OUTPUT_FORMAT)
 
-AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)
+AIEOPT_DIR ?= $(if $(MLIR_AIE_INSTALL_DIR),$(subst \,/,$(MLIR_AIE_INSTALL_DIR)),$(shell realpath $(dir $(shell which aie-opt))/..))
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
 PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include -D__AIE_API_AIE_ADF_HPP__ -mllvm -aie-disable-fold-imm
 
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG) -p
 
 run: compile-kernel
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/single_core.py $(OUTPUT_FORMAT_FLAG)
 
 compile-kernel:
 	mkdir -p $(BUILD_DIR)

--- a/programming_examples/weighted_rms_norm/Makefile
+++ b/programming_examples/weighted_rms_norm/Makefile
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # AIE target: aie2 (NPU1) or aie2p (NPU2, default)
 AIE_TARGET ?= aie2p
 
@@ -27,22 +29,22 @@ ITERATIONS ?= 5
 all: run
 
 print:
-	${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) -p
+	${powershell} $(PYTHON) ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) -p
 
 # Default: multi-tile execution (8 tiles on NPU2, configurable via HERD_X)
 run:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X)
 
 # Original single-tile baseline (herd_x=1)
 run_single_tile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x 1
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x 1
 
 # Profile multi-tile execution (timing + bandwidth; correctness via `make run`)
 profile:
 	mkdir -p $(BUILD_DIR)
-	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X) --profile --iterations $(ITERATIONS)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} $(PYTHON) ${srcdir}/weighted_rms_norm.py $(OUTPUT_FORMAT_FLAG) --herd-x $(HERD_X) --profile --iterations $(ITERATIONS)
 
 clean:
 	rm -rf $(BUILD_DIR) __pycache__

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -33,6 +33,34 @@ NPU_MODELS = {
 }
 
 
+def _xrt_smi_fallback():
+    """Where xrt-smi lives when it is not on PATH.
+
+    The NPU driver installs it under %SystemRoot%\\System32\\AMD on Windows and
+    the XRT package puts it in /opt/xilinx/xrt/bin on Linux.
+    """
+    if os.name == "nt":
+        return os.path.join(
+            os.environ.get("SystemRoot", r"C:\Windows"), "System32", "AMD", "xrt-smi"
+        )
+    return "/opt/xilinx/xrt/bin/xrt-smi"
+
+
+def _warn_undetected(reason, default):
+    """Announce that the target device is a guess, and how to stop guessing.
+
+    Always printed rather than gated behind `verbose`: a design built for the
+    wrong generation loads and computes nothing, with no later diagnostic, so a
+    silent fallback turns a missing tool into a wrong numerical result.
+    """
+    print(
+        f"WARNING: could not detect the NPU generation ({reason}); "
+        f"falling back to '{default}'. If that is not this machine's NPU, the "
+        f"design will build and run but produce wrong results. Pass "
+        f"target_device= explicitly, or put xrt-smi on PATH."
+    )
+
+
 def detect_target_device(verbose=False, default="npu1"):
     """Return the NPU generation xrt-smi reports, or `default` if it can't tell.
 
@@ -44,7 +72,7 @@ def detect_target_device(verbose=False, default="npu1"):
     than asking.
     """
     try:
-        xrtsmi = shutil.which("xrt-smi") or "/opt/xilinx/xrt/bin/xrt-smi"
+        xrtsmi = shutil.which("xrt-smi") or _xrt_smi_fallback()
         result = subprocess.run(
             [xrtsmi, "examine"],
             stdout=subprocess.PIPE,
@@ -52,20 +80,16 @@ def detect_target_device(verbose=False, default="npu1"):
             timeout=10,
         )
     except Exception as e:
-        if verbose:
-            print("Failed to run xrt-smi, using default target device")
-            print(e)
+        _warn_undetected(f"could not run xrt-smi ({e})", default)
         return default
 
     if result.returncode != 0:
-        if verbose:
-            print(
-                f"xrt-smi exited with code {result.returncode}, "
-                f"using default target device"
-            )
-            stderr = result.stderr.decode("utf-8").strip()
-            if stderr:
-                print(f"xrt-smi stderr: {stderr}")
+        stderr = result.stderr.decode("utf-8").strip()
+        _warn_undetected(
+            f"xrt-smi exited with code {result.returncode}"
+            + (f": {stderr}" if stderr else ""),
+            default,
+        )
         return default
 
     # Case-insensitive substring matching against NPU_MODELS, aligned with
@@ -77,10 +101,10 @@ def detect_target_device(verbose=False, default="npu1"):
                 print(f"Detected NPU device: {version}")
             return version
 
-    print(
-        f"WARNING: xrt-smi did not report a recognized NPU model. "
-        f"Supported: {dict(NPU_MODELS)}. "
-        f"Falling back to '{default}'."
+    _warn_undetected(
+        f"xrt-smi did not report a recognized NPU model "
+        f"(supported: {dict(NPU_MODELS)})",
+        default,
     )
     return default
 

--- a/utils/build-mlir-air-using-wheels.sh
+++ b/utils/build-mlir-air-using-wheels.sh
@@ -131,9 +131,17 @@ CMAKE_ARGS="$CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF"
 CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=on"
 CMAKE_ARGS="$CMAKE_ARGS -DPEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}"
 
-if [ -x "$(command -v lld)" ]; then
-  CMAKE_ARGS="$CMAKE_ARGS -DLLVM_USE_LINKER=lld"
-fi
+# LLVM_USE_LINKER is a GNU/Clang driver option that MSVC's link.exe rejects.
+# Under Git Bash the probe below still succeeds, because Peano ships an lld, so
+# without this guard a native Windows configure fails on a linker it never uses.
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN*) ;;
+  *)
+    if [ -x "$(command -v lld)" ]; then
+      CMAKE_ARGS="$CMAKE_ARGS -DLLVM_USE_LINKER=lld"
+    fi
+    ;;
+esac
 
 if [ -x "$(command -v ccache)" ]; then
   CMAKE_ARGS="$CMAKE_ARGS -DLLVM_CCACHE_BUILD=ON"

--- a/utils/build-mlir-air-xrt.sh
+++ b/utils/build-mlir-air-xrt.sh
@@ -77,9 +77,17 @@ CMAKE_ARGS="$CMAKE_ARGS -DENABLE_RUN_XRT_TESTS=ON"
 CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=on"
 CMAKE_ARGS="$CMAKE_ARGS -DPEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}"
 
-if [ -x "$(command -v lld)" ]; then
-  CMAKE_ARGS="$CMAKE_ARGS -DLLVM_USE_LINKER=lld"
-fi
+# LLVM_USE_LINKER is a GNU/Clang driver option that MSVC's link.exe rejects.
+# Under Git Bash the probe below still succeeds, because Peano ships an lld, so
+# without this guard a native Windows configure fails on a linker it never uses.
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN*) ;;
+  *)
+    if [ -x "$(command -v lld)" ]; then
+      CMAKE_ARGS="$CMAKE_ARGS -DLLVM_USE_LINKER=lld"
+    fi
+    ;;
+esac
 
 if [ -x "$(command -v ccache)" ]; then
   CMAKE_ARGS="$CMAKE_ARGS -DLLVM_CCACHE_BUILD=ON"

--- a/utils/fixup-llvm-diaguids.py
+++ b/utils/fixup-llvm-diaguids.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Repoint a staged LLVM distro wheel's diaguids.lib at the local DIA SDK.
+
+The wheel is built on a machine with its own Visual Studio, and
+LLVMExports.cmake bakes in that machine's absolute path to diaguids.lib -- the
+DIA SDK import library LLVMDebugInfoPDB links against. Every host whose Visual
+Studio edition, version or install location differs then fails at link time
+with a bare "missing and no known rule to make it", naming a path that has
+nothing to do with the local install.
+
+Rewrites the recorded path to this machine's. Idempotent, and a no-op off
+Windows.
+
+    python utils/fixup-llvm-diaguids.py my_install/mlir
+"""
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+# Matches the absolute path only, leaving the rest of the ;-separated
+# INTERFACE_LINK_LIBRARIES list alone.
+DIAGUIDS_RE = re.compile(r"[A-Za-z]:[^\";]*diaguids\.lib", re.IGNORECASE)
+
+
+def visual_studio_dirs():
+    """Every installed Visual Studio, newest first.
+
+    -products * is required: vswhere's default product filter covers
+    Community/Professional/Enterprise and silently excludes Build Tools, which
+    is one of the two installs this repository's Windows guide recommends.
+    """
+    vswhere = pathlib.Path(
+        os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+        "Microsoft Visual Studio",
+        "Installer",
+        "vswhere.exe",
+    )
+    if not vswhere.is_file():
+        return []
+    out = subprocess.run(
+        [str(vswhere), "-all", "-products", "*", "-property", "installationPath"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [pathlib.Path(line.strip()) for line in out.splitlines() if line.strip()]
+
+
+def find_diaguids():
+    """The first installed diaguids.lib, or None."""
+    for vs in visual_studio_dirs():
+        lib = vs / "DIA SDK" / "lib" / "amd64" / "diaguids.lib"
+        if lib.is_file():
+            return lib
+    return None
+
+
+def main(argv):
+    if len(argv) != 2:
+        print(__doc__)
+        return 2
+    if os.name != "nt":
+        return 0
+
+    exports = pathlib.Path(argv[1]) / "lib" / "cmake" / "llvm" / "LLVMExports.cmake"
+    if not exports.is_file():
+        print(f"error: {exports} not found; is that the staged mlir directory?")
+        return 1
+
+    text = exports.read_text(encoding="utf-8")
+    recorded = DIAGUIDS_RE.findall(text)
+    if not recorded:
+        print("No diaguids.lib path recorded; nothing to do.")
+        return 0
+    if all(pathlib.Path(p).is_file() for p in recorded):
+        print(f"diaguids.lib already resolves: {recorded[0]}")
+        return 0
+
+    local = find_diaguids()
+    if local is None:
+        print(
+            "error: no diaguids.lib found in any Visual Studio install.\n"
+            "The DIA SDK ships with Visual Studio; install it, or the C++\n"
+            "workload if Visual Studio is present without it."
+        )
+        return 1
+
+    exports.write_text(DIAGUIDS_RE.sub(local.as_posix(), text), encoding="utf-8")
+    print(f"diaguids.lib: {recorded[0]}\n          ->  {local.as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
[docs] Make the Windows guide instructions, and fix what it warned about

The native Windows guide landed as an inventory of things that go wrong
rather than as instructions. Most of those entries described real bugs, so
fix the bugs and delete the warnings instead of rewording them.

Portability fixes, each one deleting a workaround from the guide:

- programming_examples Makefiles called `python3`, which a Windows virtual
  environment does not create -- the name falls through to the Microsoft
  Store app-execution alias. They now call `$(PYTHON)`, defaulting to
  `python` on Windows and `python3` elsewhere.

- `AIEOPT_DIR = $(shell realpath $(dir $(shell which aie-opt))/..)` returns
  an MSYS path under Git Bash, which Peano's native `clang++.exe` cannot
  read. It now prefers `MLIR_AIE_INSTALL_DIR`, which utils/env_setup.sh
  already exports on Linux and mlir-aie's iron_env.cmd exports on Windows,
  and normalizes backslashes because make's shell strips them. The
  `realpath` probe is unchanged when that variable is unset, so Linux
  behaviour is the same as before.

- lit sanitizes the environment down to config.environment, so Makefiles
  run under lit saw neither of those variables and `$(OS)` was empty.
  programming_examples/lit.cfg.py now exports MLIR_AIE_INSTALL_DIR and
  PYTHON, and forwards OS so a Windows_NT test in a Makefile takes the
  branch it does in a plain shell.

- The XRT backend fell back to npu1 whenever the xrt-smi probe failed, and
  said so only under `verbose`. A design built for the wrong generation
  loads and computes nothing with no later diagnostic, so the fallback now
  always explains itself and points at `target_device=`. It also knows
  where the NPU driver puts xrt-smi on Windows.

- utils/build-mlir-air-{using-wheels,xrt}.sh passed `-DLLVM_USE_LINKER=lld`
  whenever `lld` was on PATH. Peano ships one, so a native MSVC configure
  failed on a linker it never uses. Skipped under MSYS/MinGW/Cygwin.

- Seven lit RUN lines used `|&`, which lit's internal shell does not parse.
  Replaced with `2>&1 |`, already the convention in the other 25.

- mlir/test/Util/Channel links a host executable against the aircpu
  runtime, which is not built where the POSIX host runtimes are skipped.
  Gated on a new `aircpu` feature so those tests report unsupported rather
  than failing.

Guide changes: drop both addenda and fold the surviving platform facts into
the sections they belong to; drop the contents list and the pass/fail counts,
which go stale the first time anyone adds a test; find Visual Studio with
vswhere rather than hardcoding one edition and version; link the XRT releases
page and state a minimum rather than pinning a URL.

On a Krackan Point NPU2, check-programming-examples-peano goes from 181
passed / 33 failed to 215 passed / 6 failed. The remainder need a Linux host
toolchain (g++ >= 13, flock), an unrelated torch install, or hit a
vector.contract legalization failure that is not platform specific.

