### PR TITLE
[python] air.api: export ops rather than relying on an import side effect

### DIFF
--- a/programming_examples/axpy/axpy.py
+++ b/programming_examples/axpy/axpy.py
@@ -38,7 +38,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops  # registers air.ops  # noqa: F401
 from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner

--- a/programming_examples/eltwise_add/eltwise_add.py
+++ b/programming_examples/eltwise_add/eltwise_add.py
@@ -27,7 +27,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops  # registers air.ops  # noqa: F401
 from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner

--- a/programming_examples/gelu/gelu.py
+++ b/programming_examples/gelu/gelu.py
@@ -7,9 +7,9 @@ Computes out = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))) over a 1-
 
 The whole compute body is one line:
 
-    out_buf[:] = ops.gelu(x_buf[:])
+    out_buf[:] = air.ops.gelu(x_buf[:])
 
-`ops.gelu` is a composition over `ops.tanh`, written the same way the
+`air.ops.gelu` is a composition over `air.ops.tanh`, written the same way the
 raw-bindings kernel it replaces wrote it. Operand order differs in
 places, but only where multiplication is commutative, which is exact in IEEE --
 so the emitted arithmetic is the predecessor's, op for op.
@@ -36,7 +36,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
@@ -59,7 +58,12 @@ def gelu_reference(x):
     return (
         0.5
         * xf
-        * (1.0 + np.tanh(ops.GELU_SQRT_2_OVER_PI * (xf + ops.GELU_BETA * xf * xf * xf)))
+        * (
+            1.0
+            + np.tanh(
+                air.ops.GELU_SQRT_2_OVER_PI * (xf + air.ops.GELU_BETA * xf * xf * xf)
+            )
+        )
     ).astype(x.dtype)
 
 
@@ -110,7 +114,7 @@ def build_gelu(n, tile_n, herd_shape=None, vector=None):
 
                     air.ops.load(x_buf, x[window])
 
-                    out_buf[:] = ops.gelu(x_buf[:])
+                    out_buf[:] = air.ops.gelu(x_buf[:])
 
                     air.ops.store(out_buf, out[window])
 

--- a/programming_examples/leaky_relu/leaky_relu.py
+++ b/programming_examples/leaky_relu/leaky_relu.py
@@ -38,7 +38,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
@@ -92,9 +91,9 @@ def build_leaky_relu(n, tile_n, alpha, dtype=bf16, herd_shape=None, vector=None)
                     air.ops.load(x_buf, x[window])
 
                     # max(x, 0) + alpha * min(x, 0) -- see the module docstring.
-                    out_buf[:] = ops.maximum(x_buf[:], 0.0) + alpha * ops.minimum(
+                    out_buf[:] = air.ops.maximum(
                         x_buf[:], 0.0
-                    )
+                    ) + alpha * air.ops.minimum(x_buf[:], 0.0)
 
                     air.ops.store(out_buf, out[window])
 

--- a/programming_examples/relu/relu.py
+++ b/programming_examples/relu/relu.py
@@ -8,9 +8,9 @@ Computes out = max(x, 0) over a 1-D [N] vector.
 The DSL emits the herd, the L1 allocations, the affine tile offsets, the DMAs,
 and the vectorised compute loop; the compute itself is one line:
 
-    out_buf[:] = ops.relu(x_buf[:])
+    out_buf[:] = air.ops.relu(x_buf[:])
 
-`ops.relu` is `ops.maximum(x, 0.0)`, which lowers to the same `arith.maximumf`
+`air.ops.relu` is `air.ops.maximum(x, 0.0)`, which lowers to the same `arith.maximumf`
 against a broadcast zero that the raw-bindings implementation built by hand.
 
 f32 runs scalar, and that is not a tuning choice: mlir-aie's
@@ -34,7 +34,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
@@ -90,7 +89,7 @@ def build_relu(n, tile_n, dtype=bf16, herd_shape=None, vector=None):
 
                     air.ops.load(x_buf, x[window])
 
-                    out_buf[:] = ops.relu(x_buf[:])
+                    out_buf[:] = air.ops.relu(x_buf[:])
 
                     air.ops.store(out_buf, out[window])
 

--- a/programming_examples/sigmoid/sigmoid.py
+++ b/programming_examples/sigmoid/sigmoid.py
@@ -7,9 +7,9 @@ Computes out = 0.5 * (tanh(x/2) + 1), the logistic function over a 1-D [N] bf16 
 
 The whole compute body is one line:
 
-    out_buf[:] = ops.sigmoid(x_buf[:])
+    out_buf[:] = air.ops.sigmoid(x_buf[:])
 
-`ops.sigmoid` is a composition over `ops.tanh`, written the same way the
+`air.ops.sigmoid` is a composition over `air.ops.tanh`, written the same way the
 raw-bindings kernel it replaces wrote it -- via tanh rather than exp, which keeps it clear of two AIE2
 limitations at once: exp would need a division, and bf16 has no vector division. Operand order differs in
 places, but only where multiplication is commutative, which is exact in IEEE --
@@ -37,7 +37,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
@@ -107,7 +106,7 @@ def build_sigmoid(n, tile_n, herd_shape=None, vector=None):
 
                     air.ops.load(x_buf, x[window])
 
-                    out_buf[:] = ops.sigmoid(x_buf[:])
+                    out_buf[:] = air.ops.sigmoid(x_buf[:])
 
                     air.ops.store(out_buf, out[window])
 

--- a/programming_examples/silu/silu.py
+++ b/programming_examples/silu/silu.py
@@ -7,9 +7,9 @@ Computes out = x * sigmoid(x), also known as swish over a 1-D [N] bf16 vector.
 
 The whole compute body is one line:
 
-    out_buf[:] = ops.silu(x_buf[:])
+    out_buf[:] = air.ops.silu(x_buf[:])
 
-`ops.silu` is a composition over `ops.tanh`, written the same way the
+`air.ops.silu` is a composition over `air.ops.tanh`, written the same way the
 raw-bindings kernel it replaces wrote it -- via tanh rather than exp, which avoids a
 division that bf16 cannot vectorise. Operand order differs in
 places, but only where multiplication is commutative, which is exact in IEEE --
@@ -37,7 +37,6 @@ import numpy as np
 from ml_dtypes import bfloat16
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
@@ -107,7 +106,7 @@ def build_silu(n, tile_n, herd_shape=None, vector=None):
 
                     air.ops.load(x_buf, x[window])
 
-                    out_buf[:] = ops.silu(x_buf[:])
+                    out_buf[:] = air.ops.silu(x_buf[:])
 
                     air.ops.store(out_buf, out[window])
 

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -8,10 +8,10 @@
 ``air.api`` sits above ``air.dialects`` and emits ordinary AIR IR: the module a
 traced program produces is the same kind of module ``@module_builder`` builds by
 hand, and it takes the same ``XRTBackend`` pipeline. Structural declarations live
-here; imperative memory operations live in ``air.api.ops``::
+here; memory transfers and elementwise compute live in ``ops``, which this
+package re-exports, so one import reaches the whole DSL::
 
     from air import api as air
-    import air.api.ops
     from air.api.types import bf16
 
     A = air.tensor([M, N], bf16)
@@ -25,6 +25,7 @@ here; imperative memory operations live in ``air.api.ops``::
                 @h.body
                 def _(tx, ty):
                     a = air.alloc([tm, tn], bf16, scope=h.private())
+                    air.ops.load(a, A[...])
                     ...
 
 Scope of this version: elementwise kernels over a 1-D or 2-D herd -- tensors,
@@ -33,12 +34,15 @@ Everything outside that raises ``NotImplementedError`` at the point of use.
 Nothing degrades quietly into a kernel that runs and returns wrong numbers.
 """
 
+from . import ops
 from ._compile import CompiledKernel, LaunchContext, compile, launch
 from ._trace import HerdContext, Scope, Symbol, alloc, herd, symbol, tensor, wait
 from ._value import Buffer, Tensor, TensorSlice, Token
 from .types import DType, bf16, f16, f32, i8, i16, i32
 
 __all__ = [
+    # operations
+    "ops",
     # launch hierarchy
     "launch",
     "herd",

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Imperative memory operations.
+"""Memory transfers and elementwise compute.
 
 Re-exported by :mod:`air.api`, so importing the package is enough::
 
@@ -11,10 +11,10 @@ Re-exported by :mod:`air.api`, so importing the package is enough::
 
     air.ops.load(buf, A[window])
 
-Every implemented op returns a :class:`~air.api._value.Token`. AIR builds its
-real asynchronous dependency graph from program order in the ``air-dependency``
-pass, so a v1 token carries no SSA value -- it exists so that ``dependency=``
-can be type-checked instead of silently ignored.
+The transfer ops (``load``, ``store``) return a :class:`~air.api._value.Token`.
+AIR builds its real asynchronous dependency graph from program order in the
+``air-dependency`` pass, so a v1 token carries no SSA value -- it exists so that
+``dependency=`` can be type-checked instead of silently ignored.
 
 Elementwise compute ops (``maximum``, ``minimum``, ``relu``, ``tanh``, and the
 ``sigmoid``/``silu``/``gelu`` compositions built on them) build lazy expression

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -5,9 +5,11 @@
 
 """Imperative memory operations.
 
-Import as::
+Re-exported by :mod:`air.api`, so importing the package is enough::
 
-    import air.api.ops
+    from air import api as air
+
+    air.ops.load(buf, A[window])
 
 Every implemented op returns a :class:`~air.api._value.Token`. AIR builds its
 real asynchronous dependency graph from program order in the ``air-dependency``

--- a/python/test/api/activations.py
+++ b/python/test/api/activations.py
@@ -17,7 +17,6 @@ avoids a division that bf16 cannot vectorise.
 """
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16
 
 
@@ -57,7 +56,7 @@ def run(f):
 # CHECK: vector.transfer_write {{.*}} vector<16xbf16>
 @run
 def tanh_unary():
-    print(build(65536, 1024, lambda b: ops.tanh(b[:]), herd_shape=(4,)).mlir())
+    print(build(65536, 1024, lambda b: air.ops.tanh(b[:]), herd_shape=(4,)).mlir())
 
 
 # CHECK-LABEL: TEST: sigmoid_is_tanh_based
@@ -70,7 +69,7 @@ def tanh_unary():
 # CHECK: arith.mulf {{.*}} : vector<16xbf16>
 @run
 def sigmoid_is_tanh_based():
-    print(build(65536, 1024, lambda b: ops.sigmoid(b[:]), herd_shape=(4,)).mlir())
+    print(build(65536, 1024, lambda b: air.ops.sigmoid(b[:]), herd_shape=(4,)).mlir())
 
 
 # CHECK-LABEL: TEST: silu_multiplies_by_x
@@ -82,7 +81,7 @@ def sigmoid_is_tanh_based():
 # CHECK: arith.mulf {{.*}} : vector<16xbf16>
 @run
 def silu_multiplies_by_x():
-    print(build(65536, 1024, lambda b: ops.silu(b[:]), herd_shape=(4,)).mlir())
+    print(build(65536, 1024, lambda b: air.ops.silu(b[:]), herd_shape=(4,)).mlir())
 
 
 # CHECK-LABEL: TEST: gelu_cubic_then_tanh
@@ -94,7 +93,7 @@ def silu_multiplies_by_x():
 # CHECK: arith.addf {{.*}} : vector<16xbf16>
 @run
 def gelu_cubic_then_tanh():
-    print(build(65536, 1024, lambda b: ops.gelu(b[:]), herd_shape=(4,)).mlir())
+    print(build(65536, 1024, lambda b: air.ops.gelu(b[:]), herd_shape=(4,)).mlir())
 
 
 # CHECK-LABEL: TEST: scalar_fallback_is_emitted_but_will_not_compile
@@ -114,4 +113,4 @@ def gelu_cubic_then_tanh():
 # CHECK: memref.store
 @run
 def scalar_fallback_is_emitted_but_will_not_compile():
-    print(build(48, 12, lambda b: ops.tanh(b[:]), herd_shape=(4,)).mlir())
+    print(build(48, 12, lambda b: air.ops.tanh(b[:]), herd_shape=(4,)).mlir())

--- a/python/test/api/axpy.py
+++ b/python/test/api/axpy.py
@@ -15,7 +15,6 @@ does not have one.
 """
 
 from air import api as air
-from air.api import ops  # noqa: F401
 from air.api.types import bf16, f32
 
 

--- a/python/test/api/eltwise_add.py
+++ b/python/test/api/eltwise_add.py
@@ -10,7 +10,6 @@
 from itertools import product
 
 from air import api as air
-from air.api import ops  # noqa: F401
 from air.api.types import bf16, f32
 
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -15,7 +15,6 @@ replaces: there, an unsupported construct was absorbed and the program still
 from itertools import product
 
 from air import api as air
-from air.api import ops  # noqa: F401
 from air.api.types import bf16, f32
 
 

--- a/python/test/api/leaky_relu.py
+++ b/python/test/api/leaky_relu.py
@@ -14,7 +14,6 @@ in one loop over the tile.
 """
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16, f32
 
 
@@ -35,7 +34,7 @@ def build(N, tile, alpha, herd_shape=None, dtype=bf16, vector=None):
                     x_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
                     o_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
                     air.ops.load(x_buf, x[col : col + tn])
-                    o_buf[:] = ops.maximum(x_buf[:], 0.0) + alpha * ops.minimum(
+                    o_buf[:] = air.ops.maximum(x_buf[:], 0.0) + alpha * air.ops.minimum(
                         x_buf[:], 0.0
                     )
                     air.ops.store(o_buf, out[col : col + tn])

--- a/python/test/api/relu.py
+++ b/python/test/api/relu.py
@@ -5,7 +5,7 @@
 
 # RUN: %PYTHON %s | FileCheck %s
 
-"""air.api lowers ops.maximum / ops.minimum / ops.relu.
+"""air.api lowers air.ops.maximum / air.ops.minimum / air.ops.relu.
 
 These are the first compute ops that are not Python operators, so they enter the
 expression tree through `air.api.ops` rather than through `__add__` and friends,
@@ -13,7 +13,6 @@ and they must compose with the arithmetic operators in the same tree.
 """
 
 from air import api as air
-from air.api import ops
 from air.api.types import bf16, f32, i32
 
 
@@ -47,7 +46,7 @@ def run(f):
 
 
 # CHECK-LABEL: TEST: relu_vectorized
-# ops.relu is max(x, 0): a broadcast zero and a single arith.maximumf, which is
+# air.ops.relu is max(x, 0): a broadcast zero and a single arith.maximumf, which is
 # exactly what the hand-written kernel emitted.
 # CHECK: func.func @relu(%{{.*}}: memref<65536xbf16>, %{{.*}}: memref<65536xbf16>)
 # CHECK: air.herd @herd_0 tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c4{{.*}}, %{{.*}}=%c1
@@ -57,7 +56,7 @@ def run(f):
 # CHECK: vector.transfer_write {{.*}} vector<16xbf16>
 @run
 def relu_vectorized():
-    print(build(65536, 1024, lambda b: ops.relu(b[:]), herd_shape=(4,)).mlir())
+    print(build(65536, 1024, lambda b: air.ops.relu(b[:]), herd_shape=(4,)).mlir())
 
 
 # CHECK-LABEL: TEST: clamp_composes
@@ -72,7 +71,7 @@ def clamp_composes():
         build(
             65536,
             1024,
-            lambda b: ops.minimum(ops.maximum(b[:], 0.0), 6.0) * 2.0,
+            lambda b: air.ops.minimum(air.ops.maximum(b[:], 0.0), 6.0) * 2.0,
             herd_shape=(4,),
         ).mlir()
     )
@@ -91,13 +90,18 @@ def clamp_composes():
 def relu_f32_scalar():
     print(
         build(
-            65536, 1024, lambda b: ops.relu(b[:]), herd_shape=(4,), dtype=f32, vector=0
+            65536,
+            1024,
+            lambda b: air.ops.relu(b[:]),
+            herd_shape=(4,),
+            dtype=f32,
+            vector=0,
         ).mlir()
     )
 
 
 # CHECK-LABEL: TEST: relu_integer
-# ops.relu takes the Python type of its zero from the operand's dtype. An
+# air.ops.relu takes the Python type of its zero from the operand's dtype. An
 # integer buffer lowers through arith.maxsi, and building an integer
 # arith.constant from a Python float fails with "expected floating point type".
 # CHECK: memref.alloc() : memref<512xi32, 2 : i32>
@@ -105,4 +109,8 @@ def relu_f32_scalar():
 # CHECK: arith.maxsi
 @run
 def relu_integer():
-    print(build(4096, 512, lambda b: ops.relu(b[:]), herd_shape=(4,), dtype=i32).mlir())
+    print(
+        build(
+            4096, 512, lambda b: air.ops.relu(b[:]), herd_shape=(4,), dtype=i32
+        ).mlir()
+    )

--- a/python/test/api/relu.py
+++ b/python/test/api/relu.py
@@ -8,7 +8,7 @@
 """air.api lowers air.ops.maximum / air.ops.minimum / air.ops.relu.
 
 These are the first compute ops that are not Python operators, so they enter the
-expression tree through `air.api.ops` rather than through `__add__` and friends,
+expression tree through `air.ops` rather than through `__add__` and friends,
 and they must compose with the arithmetic operators in the same tree.
 """
 


### PR DESCRIPTION
`air.ops.load(...)` is used throughout the `air.api` examples, but nothing in `air/api/__init__.py` ever exported `ops`. It worked only as an **import side effect**: importing a submodule binds it as an attribute on the parent package, so `air.ops` existed if and only if something had already run `from air.api import ops`.

```python
from air import api as air
air.ops.load(...)          # AttributeError: module 'air.api' has no attribute 'ops'

from air.api import ops    # <- this is what made the line above work
air.ops.load(...)          # fine
```

Five files were carrying that import purely for the side effect, two of them saying so outright:

```python
from air.api import ops  # registers air.ops  # noqa: F401
```

The `# noqa: F401` is the tell. The linter was right — the name really was unused — and the import was load-bearing for a reason nothing declared. All 13 files that use `air.ops` happen to have it today, so nothing is broken; but the invariant is a convention, not a mechanism, and the first file to reach for `air.ops` without copying the incantation fails at trace time.

Python binds the submodule regardless, so the alias **cannot be removed — only made deterministic**. This PR makes it deliberate.

## Two commits

**1. Export `ops`.** `air.api` now does `from . import ops` and lists it in `__all__`; the five side-effect imports are gone. The package docstring and `ops`'s own docstring drop `import air.api.ops` in favour of the one import that now reaches everything.

**2. One spelling.** The landed examples used both, routinely in the same file — `air.ops.load` for transfers, a bare `ops.gelu` two lines later. Both resolve to the same module object, so this is style, not behaviour. But these files are the API's teaching material, and mixing the two makes `ops` look like a second namespace. Settled on the qualified form, which matches how the rest of the DSL reads: `air.tensor`, `air.herd`, `air.alloc`, `air.ops.load`.

Each commit stands alone — the suites pass at commit 1 as well as at the tip, so the second is droppable if you disagree on the spelling.

## Verification

No functional change: same module object either way. Verified on npu2 (Strix HX 370, pinned peano `f4a72c27`) across **every configuration the lit files cover** — 26 device runs over all seven `air.api` examples:

| example | configurations |
|---|---|
| axpy | default, `DTYPE=f32`, `VECTOR_SIZE=0`, `ALPHA=-0.5 TILE_N=2048`, `OUTPUT_FORMAT=elf` |
| eltwise_add | default, `SHAPE=65536`, `DTYPE=f32`, `SHAPE=65536 DTYPE=f32 VECTOR_SIZE=0`, `OUTPUT_FORMAT=elf`, `SHAPE=4194304 TILE=2048` |
| relu | default, `DTYPE=f32`, `VECTOR_SIZE=0`, `N=131072 TILE_N=2048`, `OUTPUT_FORMAT=elf` |
| leaky_relu | default, `DTYPE=f32`, `VECTOR_SIZE=0`, `ALPHA=0.2 N=131072 TILE_N=2048`, `OUTPUT_FORMAT=elf` |
| gelu / sigmoid / silu | default, `N=131072 TILE_N=2048` |

All 26 PASS. All six `python/test/api` suites pass under FileCheck, at both commits. `black` clean.

One note on method: `lit` reports these tests `UNSUPPORTED` on my setup — its Peano/XRT feature detection fails against this build config — so the runs above drive the same `make` targets the lit files invoke, rather than lit itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
