### PR TITLE
[python] air.api: express the staged, micro-tiled matmul

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,7 +48,10 @@ if(AIE_ENABLE_BINDINGS_PYTHON)
       api/__init__.py
       api/_compile.py
       api/_emit.py
+      api/_extern.py
       api/_index.py
+      api/_loop.py
+      api/_pack.py
       api/_trace.py
       api/_value.py
       api/ops.py

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -28,16 +28,70 @@ package re-exports, so one import reaches the whole DSL::
                     air.ops.load(a, A[...])
                     ...
 
-Scope of this version: elementwise kernels over a 1-D or 2-D herd -- tensors,
-L1 allocation, DMA in and out, and elementwise arithmetic on whole tiles.
-Everything outside that raises ``NotImplementedError`` at the point of use.
-Nothing degrades quietly into a kernel that runs and returns wrong numbers.
+Scope of this version: kernels over a 1-D or 2-D herd -- tensors, allocation in
+L1 (a core) and L2 (a memtile, via ``air.segment``), DMA between any two levels,
+elementwise arithmetic on whole L1 tiles, an ``air.sequential`` loop, and
+``ops.dot``, a contraction that dispatches on operand rank onto ``linalg.dot`` /
+``vecmat`` / ``matvec`` / ``matmul``. Everything outside that raises
+``NotImplementedError`` at the point of use. Nothing degrades quietly into a
+kernel that runs and returns wrong numbers.
+
+``launch``, ``segment`` and ``herd`` are independent levels: a kernel that needs
+no staging writes a herd on its own, and one that does wraps it in a segment.
+Giving ``air.segment`` an iteration space makes it the *launch* grid, one segment
+instance per point -- which is where outer tiling has to go, because the L2
+staging buffers are refilled per point. Indexing a buffer with a partial
+subscript (``staged[tx, 0:n, :]``) names a DMA region for
+``ops.load``/``ops.store``; ``buf[:]`` in an expression is an elementwise read,
+and is rejected on L2, which has no compute core.
+
+For the AIE2 matmul intrinsic a tile has to be laid out in micro-tile order.
+``air.micro_tile(m, k, n)`` builds those shapes, and the packing is *not* a
+memref layout -- the buffer stays contiguous and the reordering lives in the DMA
+access pattern, which is derived rather than spelled out::
+
+    mm = air.micro_tile(m=4, k=8, n=4)
+    a  = air.alloc(mm.a(tile_m, tile_k), bf16, scope=h.private())
+    acc = air.alloc(mm.c(tile_m, tile_n, lead=herd_shape), bf16,
+                    scope=seg.shared())
+    ops.load(a, l2_a[tx, 0, :, k : k + tile_k])   # the DMA performs the pack
+    ops.dot(a, b, acc=acc)                        # rank 6: block_matmul
+
+A packed buffer is subscripted in *logical* coordinates, so the program keeps
+thinking in ``[M, N]``. ``<segment>.shared()`` allocates L1 with the segment's
+lifetime, for an accumulator carried across a reduction loop at segment scope.
+
+``air.sequential`` is named for what ``scf.for`` guarantees -- its trips are
+ordered in time on one core -- as against the herd's grid, which is spatial.
+``air.parallel`` is its unordered counterpart (``scf.parallel``); it is declared
+below and raises, because nothing emits it yet.
+
+One hardware caveat that the DSL cannot see and so cannot raise on: an
+*unstaged* K reduction on a 2-D herd is wrong past a single trip. Both operands
+are then broadcast, and the resulting packet flows share one shim channel whose
+coalesced buffer descriptors do not line up with the per-trip ring on the
+receiving tile. Staging through ``air.segment`` avoids it entirely, which is what
+every hand-written matmul in the tree does; a 1-D herd is also unaffected.
 """
 
 from . import ops
 from ._compile import CompiledKernel, LaunchContext, compile, launch
-from ._trace import HerdContext, Scope, Symbol, alloc, herd, symbol, tensor, wait
-from ._value import Buffer, Tensor, TensorSlice, Token
+from ._extern import ExternKernel, extern
+from ._loop import sequential
+from ._pack import MicroTile, PackedShape, micro_tile
+from ._trace import (
+    HerdContext,
+    Scope,
+    SegmentContext,
+    Symbol,
+    alloc,
+    herd,
+    segment,
+    symbol,
+    tensor,
+    wait,
+)
+from ._value import Buffer, BufferSlice, Tensor, TensorSlice, Token
 from .types import DType, bf16, f16, f32, i8, i16, i32
 
 __all__ = [
@@ -45,13 +99,20 @@ __all__ = [
     "ops",
     # launch hierarchy
     "launch",
+    "segment",
     "herd",
     # declarations
     "tensor",
     "alloc",
     "symbol",
+    "extern",
     # control flow
+    "sequential",
     "wait",
+    # micro-tiled (packed) layouts
+    "micro_tile",
+    "MicroTile",
+    "PackedShape",
     # compilation
     "compile",
     # types
@@ -64,9 +125,12 @@ __all__ = [
     "i32",
     # objects surfaced for isinstance checks and typing
     "LaunchContext",
+    "SegmentContext",
     "HerdContext",
+    "ExternKernel",
     "CompiledKernel",
     "Buffer",
+    "BufferSlice",
     "Tensor",
     "TensorSlice",
     "Token",
@@ -88,7 +152,15 @@ def _unimplemented(name, needs):
 # Names from the wider API proposal that this version does not lower. They are
 # present, and they raise -- an accepted-but-ignored capability gate is worse
 # than an absent one, because the kernel still compiles and still runs.
-segment = _unimplemented("segment", "air.segment emission and L2 allocation")
+# The unordered counterpart of air.sequential: an scf.parallel inside a herd
+# body, whose trips carry no ordering guarantee. Named here so that reaching for
+# it fails at the call site with this explanation rather than as an
+# AttributeError, and so the name cannot later be attached to the herd grid --
+# air.herd emits air.herd directly, and an scf.parallel reaches the spatial
+# hierarchy only when a conversion pass selects it, which in general it does not.
+parallel = _unimplemented(
+    "parallel", "scf.parallel emission; use air.sequential for an ordered loop"
+)
 BlockType = _unimplemented("BlockType", "block floating-point types")
 Field = _unimplemented("Field", "block floating-point types")
 Scratchpad = _unimplemented("Scratchpad", "fabric property gating")

--- a/python/air/api/_compile.py
+++ b/python/air/api/_compile.py
@@ -113,7 +113,7 @@ class LaunchContext:
                 def _kernel(*args):
                     for t, v in zip(self.tensors, args):
                         t.value = v
-                    trace = Trace(self.tensors)
+                    trace = Trace(self.tensors, module=module)
                     previous = set_active_trace(trace)
                     previous_target = set_target(self.target)
                     try:

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -61,11 +61,9 @@ _INT_OPS = {
 def emit_elementwise(dst, expr):
     """Emit ``dst[:] = expr`` as a loop nest over ``dst``'s shape."""
     leaves = expr.leaves()
-    if not leaves:
-        raise ValueError(
-            "elementwise assignment needs at least one buffer on the "
-            "right-hand side; assigning a bare scalar is not supported yet"
-        )
+    # A bare scalar on the right-hand side is a fill (`acc[:] = 0.0`), which is
+    # how an accumulator is zeroed before a K loop. It needs no leaves: the
+    # destination supplies the shape.
     for leaf in leaves:
         if leaf.shape != dst.shape:
             raise ValueError(
@@ -84,9 +82,11 @@ def emit_elementwise(dst, expr):
             )
 
     shape = dst.shape
-    inner = shape[-1]
+    # A rank-0 buffer is a single scalar -- the accumulator linalg.dot writes
+    # into. There is no innermost dimension to vectorise, and the loop nest is
+    # empty, so the scalar path handles it with no induction variables at all.
     width = dst.vector_width
-    vectorized = width > 0 and inner % width == 0
+    vectorized = bool(shape) and width > 0 and shape[-1] % width == 0
 
     ops = _FLOAT_OPS if dst.dtype.is_float else _INT_OPS
     if vectorized:
@@ -175,6 +175,12 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
 
     if node.kind == "scalar":
         value = node.scalar
+        if ops is _FLOAT_OPS and isinstance(value, int) and not isinstance(value, bool):
+            # arith.constant of a float type with a Python int does not raise --
+            # it fails an assertion inside cast<IntegerType> and aborts the
+            # process, taking the traceback with it. `x[:] + 1` on an f32 buffer
+            # is ordinary Python, so widen rather than reject.
+            value = float(value)
         if ops is _INT_OPS and isinstance(value, float):
             # arith.constant of an integer type rejects a Python float with
             # "expected floating point type", which says nothing about which

--- a/python/air/api/_extern.py
+++ b/python/air/api/_extern.py
@@ -1,0 +1,174 @@
+# ./python/air/api/_extern.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Calling a hand-written AIE kernel from a traced program.
+
+    mv = air.extern("matvec_vectorized_bf16_bf16", object="mv.o",
+                    scalars=[i32, i32, i32])
+    mv(1, K, row, a_buf, b_buf, c_buf)
+
+Every vectorised matmul-family example in this tree computes through a ``.cc``
+kernel written against the AIE intrinsics (``aie::load_v``, ``aie::mac``,
+``aie::accum``), because ``ops.dot`` on its own lowers through
+``convert-linalg-to-loops`` and comes out scalar. This is the escape hatch to
+that kernel, and it is deliberately general: what it emits is a ``func.call``,
+not a contraction, so it serves the fill and dequantisation kernels those
+examples also call.
+
+The shape is taken from what the hand-written examples actually emit::
+
+    func.func private @matvec_vectorized_bf16_bf16(i32, i32, i32,
+        memref<1x8192xbf16, 2 : i32>, memref<8192xbf16, 2 : i32>,
+        memref<4xbf16, 2 : i32>)
+        attributes {link_with = "mv.o", llvm.emit_c_interface}
+    ...
+    air.herd @herd_0 ... attributes {link_with = "mv.o"} {
+      func.call @matvec_vectorized_bf16_bf16(%c1_i32, %c8192_i32, %2, ...)
+
+Reading that IR settles the split between what is declared and what is
+inferred: the declaration is *exactly* the types of the call's arguments, and
+carries nothing the call site does not already have. Buffer types are therefore
+derived from the :class:`Buffer` objects -- which is where all the verbosity
+lives -- while scalar element types must be declared, because a Python ``0.0``
+cannot distinguish the ``bf16`` a fill kernel wants from the ``f32`` it does
+not, and ``1`` cannot pick between ``i32`` and ``index``. Guessing either would
+be the silent-wrongness failure this package exists to avoid.
+"""
+
+from ._index import IndexExpr
+from ._value import Buffer
+
+__all__ = ["ExternKernel", "extern"]
+
+
+class ExternKernel:
+    """A private ``func.func`` in an object file, callable from a herd body."""
+
+    def __init__(self, name, object=None, scalars=()):
+        if not isinstance(name, str) or not name:
+            raise TypeError("air.extern(name) takes the kernel's C symbol name")
+        if not object:
+            raise ValueError(
+                "air.extern requires object=<file>, the compiled kernel aircc "
+                'should link against, e.g. object="mv.o". It becomes the '
+                "link_with attribute on both the declaration and the herd."
+            )
+        from .types import DType
+
+        for s in scalars:
+            if not isinstance(s, DType):
+                raise TypeError(
+                    f"air.extern(scalars=...) takes element types such as i32 or "
+                    f"bf16, got {type(s).__name__}. Scalar types have to be "
+                    "stated: a Python 0.0 does not say whether the kernel wants "
+                    "bf16 or f32, and buffer types are inferred from the buffers "
+                    "themselves."
+                )
+        self.name = name
+        self.object = object
+        self.scalars = list(scalars)
+        # The declaration, materialised at the first call from the call's own
+        # argument types, and reused after that.
+        self._decl = None
+        self._arg_types = None
+
+    def __repr__(self):
+        return f"air.api.extern({self.name!r}, object={self.object!r})"
+
+    def __call__(self, *args):
+        from air.ir import InsertionPoint, StringAttr, UnitAttr
+        from air.dialects import arith
+        from air.dialects.func import CallOp, FuncOp
+
+        from ._trace import active_trace, current_herd
+
+        herd = current_herd()
+        trace = active_trace()
+
+        n_scalars = sum(1 for a in args if not isinstance(a, Buffer))
+        if n_scalars != len(self.scalars):
+            raise TypeError(
+                f"{self.name} was declared with {len(self.scalars)} scalar "
+                f"argument type(s) but called with {n_scalars}; air.extern needs "
+                "one element type per non-buffer argument, in order"
+            )
+
+        values, types, scalars = [], [], iter(self.scalars)
+        for pos, arg in enumerate(args):
+            if isinstance(arg, Buffer):
+                if arg.value is None:
+                    raise RuntimeError(
+                        f"{self.name}: buffer argument {pos} used before allocation"
+                    )
+                values.append(arg.value)
+                types.append(arg.value.type)
+            else:
+                dtype = next(scalars)
+                values.append(_scalar_value(arg, dtype, self.name, pos, arith))
+                types.append(dtype.mlir())
+
+        if self._decl is None:
+            # Declarations go at the top of the module, as the hand-written
+            # examples emit them, so the IR reads the same way.
+            with InsertionPoint.at_block_begin(trace.module.body):
+                decl = FuncOp(self.name, (types, []), visibility="private")
+                decl.attributes["link_with"] = StringAttr.get(self.object)
+                decl.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+            self._decl, self._arg_types = decl, types
+        elif [str(t) for t in types] != [str(t) for t in self._arg_types]:
+            raise TypeError(
+                f"{self.name} is already declared as "
+                f"({', '.join(str(t) for t in self._arg_types)}) but is now "
+                f"called with ({', '.join(str(t) for t in types)}). A C symbol "
+                "has one signature; use a second air.extern for a second "
+                "kernel, or make the buffer shapes agree."
+            )
+
+        # aircc links one object per herd, so the attribute is a single string.
+        herd.require_object(self.object, self.name)
+        return CallOp(self._decl, values)
+
+
+def _scalar_value(arg, dtype, name, pos, arith):
+    """Materialise a non-buffer argument as ``dtype``."""
+    if isinstance(arg, IndexExpr):
+        # A loop induction variable or tile coordinate. It folds to a Python int
+        # when the expression is constant, and otherwise materialises as an
+        # index Value that the kernel's i32 parameter needs a cast from -- which
+        # is exactly what the hand-written matvec emits for its row offset.
+        value = arg.materialize()
+        if not isinstance(value, int):
+            if dtype.is_float:
+                raise TypeError(
+                    f"{name}: argument {pos} is a tile coordinate or loop "
+                    f"variable, which is an integer, but was declared {dtype}"
+                )
+            return arith.index_cast(dtype.mlir(), value)
+        arg = value
+
+    if dtype.is_float:
+        if not isinstance(arg, (int, float)):
+            raise TypeError(
+                f"{name}: argument {pos} was declared {dtype} but got "
+                f"{type(arg).__name__}"
+            )
+        return arith.ConstantOp(dtype.mlir(), float(arg)).result
+
+    if isinstance(arg, float) and not float(arg).is_integer():
+        raise ValueError(
+            f"{name}: argument {pos} is {arg}, which is not an integer, but was "
+            f"declared {dtype}"
+        )
+    if not hasattr(arg, "__index__") and not isinstance(arg, float):
+        raise TypeError(
+            f"{name}: argument {pos} was declared {dtype} but got "
+            f"{type(arg).__name__}"
+        )
+    return arith.ConstantOp(dtype.mlir(), int(arg)).result
+
+
+def extern(name, object=None, scalars=()):
+    """Declare a hand-written kernel from ``object``; call it inside a herd."""
+    return ExternKernel(name, object=object, scalars=scalars)

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -1,0 +1,125 @@
+# ./python/air/api/_loop.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""A sequential loop inside a herd body.
+
+    for k in air.sequential(0, K, tile_k):
+        air.ops.load(a_buf, A[row : row + tm, k : k + tile_k])
+        air.ops.dot(a_buf, b_buf, acc=acc)
+
+This emits one ``scf.for`` and hands the body an induction *variable*. The
+distinction from a plain Python ``for k in range(...)`` is the whole point:
+Python's loop runs at trace time and unrolls, emitting one straight-line copy of
+the body per trip against the same L1 buffers. The AIE core that comes out has no
+loop in it, so the objectFifo acquire/release pairs that the pipeline would place
+inside the loop end up stranded between the unrolled copies, and the kernel
+computes with stale operands. A reduction that reuses a buffer across trips --
+which is to say, every reduction -- has to reach the compiler as a loop.
+
+Bounds must be Python integers. A dynamic trip count would need the bound to be
+an SSA value, and nothing in the DSL produces one; accepting an ``IndexExpr``
+here would only defer the failure into the IR.
+"""
+
+from ._index import IndexExpr
+
+__all__ = ["sequential", "loop_depth", "aborted_loops"]
+
+# Loops whose body exited early (break / return / an exception the caller
+# swallowed). Emission still closes the region so the IR stays well formed, but
+# the body is short of trips and the herd would compute a partial reduction, so
+# the count is checked once the herd body is finished. See `aborted_loops`.
+_ABORTED = 0
+
+# How many air.sequential bodies are currently open. air.alloc consults this: an
+# allocation inside a loop is freed by the herd after the loop closes, and the
+# dealloc would not be dominated by its alloc.
+_DEPTH = 0
+
+
+def loop_depth():
+    return _DEPTH
+
+
+def enter_body():
+    """Start a fresh loop-depth frame, returning the one to restore.
+
+    Depth exists to catch an ``air.alloc`` nested inside a loop *in the same
+    body*, where the dealloc would be emitted after the loop and so would not be
+    dominated by its alloc. A loop further out is a different matter entirely: a
+    herd inside a segment-scope reduction is re-entered once per trip, and its
+    body's allocs and deallocs are both inside that trip. Counting the outer loop
+    would reject the shape every staged matmul in the tree uses.
+    """
+    global _DEPTH
+    previous, _DEPTH = _DEPTH, 0
+    return previous
+
+
+def exit_body(previous):
+    global _DEPTH
+    _DEPTH = previous
+
+
+def aborted_loops():
+    return _ABORTED
+
+
+def sequential(start, stop=None, step=None, name=None):
+    """A sequential ``scf.for`` over ``[start, stop)`` in strides of ``step``.
+
+    Yields the induction variable as an :class:`IndexExpr`, so it composes with
+    tile coordinates and tensor slices exactly like a herd coordinate does.
+    """
+    global _ABORTED, _DEPTH
+
+    if stop is None:
+        start, stop = 0, start
+    if step is None:
+        step = 1
+
+    lo, hi, st = (
+        _as_bound(v, n) for v, n in ((start, "start"), (stop, "stop"), (step, "step"))
+    )
+    if st <= 0:
+        raise ValueError(f"air.sequential needs a positive step, got {st}")
+    if hi < lo:
+        raise ValueError(
+            f"air.sequential({lo}, {hi}) counts backwards; stop must be >= start"
+        )
+    if (hi - lo) % st:
+        raise ValueError(
+            f"air.sequential({lo}, {hi}, {st}) does not tile its extent exactly: "
+            f"{(hi - lo) // st} steps of {st} span {((hi - lo) // st) * st}, past "
+            f"the extent of {hi - lo}. air.api has no partial trips, so the last "
+            "one would run off the end of whatever it indexes."
+        )
+
+    from air.dialects.scf import for_ as scf_for, yield_
+
+    for iv in scf_for(lo, hi, st):
+        _DEPTH += 1
+        completed = False
+        try:
+            yield IndexExpr.leaf(iv, name or "k")
+            completed = True
+        finally:
+            _DEPTH -= 1
+            if not completed:
+                _ABORTED += 1
+            # Terminate the region either way: leaving a block without a
+            # terminator turns a diagnosable "you broke out of a loop" into an
+            # MLIR verifier crash somewhere else entirely.
+            yield_([])
+
+
+def _as_bound(value, which):
+    if isinstance(value, bool) or not hasattr(value, "__index__"):
+        raise TypeError(
+            f"air.sequential({which}=...) takes a Python integer (or an air.symbol), "
+            f"got {type(value).__name__} {value!r}. Loop bounds are resolved at "
+            "trace time; a bound computed from a tile coordinate is not supported."
+        )
+    return int(value)

--- a/python/air/api/_pack.py
+++ b/python/air/api/_pack.py
@@ -1,0 +1,269 @@
+# ./python/air/api/_pack.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Micro-blocked (``packed``) tile layouts for the AIE2 matmul intrinsic.
+
+The AIE2 vector unit multiplies a fixed micro-tile -- ``4x8x4`` for bf16 -- so a
+32x32 L1 tile has to be laid out as a grid of those micro-tiles rather than
+row-major, and the contraction becomes a 6-D ``linalg.generic`` over
+``[.., group, group, micro, micro]``. This module builds those shapes and the
+DMA access patterns that produce them.
+
+Where the packing actually lives
+--------------------------------
+
+Read the IR of the example this models
+(``programming_examples/matrix_multiplication/bf16/run.py --print-module-only``)
+and three things are true of every alloc in it:
+
+* there is **no layout attribute anywhere** -- every ``memref.alloc`` is an
+  ordinary contiguous memref;
+* the packing is carried by the **shape**, ``memref<1x1x2x8x4x8xbf16, 2 : i32>``;
+* the only strided memref type in the module is the *result* of
+  ``memref.subview``, which MLIR derives rather than anyone declaring.
+
+The transform itself is in the DMA, and specifically in the fact that its access
+pattern has a **higher rank than the memref it reads**::
+
+    air.dma_memcpy_nd (%l1_a[] [] [],
+        %l2_a[%tx, 0, 0, 0, 0, %k] [1, 1, 2, 8, 4, 8] [1024, 1024, 8, 128, 32, 1])
+      : (memref<1x1x2x8x4x8xbf16, 2 : i32>, memref<1x1x32x32xbf16, 1 : i32>)
+
+Six offsets/sizes/strides against a rank-4 L2 memref. That tuple *is* the pack:
+the DMA walks the flat L2 tile in micro-tile order and lands it contiguously in
+L1. So packing is neither a buffer layout nor a reshape -- it is an access
+pattern, and the buffer on the packed side is plain.
+
+Why this is a derivation and not a stride tuple
+-----------------------------------------------
+
+Handing the user six raw strides would be the raw bindings with extra steps, and
+a wrong stride is silently wrong output rather than an error. But the strides are
+fully determined by the micro-tile and the *source buffer's own* row-major
+strides, so the DSL can compute them and check the result against the
+destination's shape. Writing ``s_M``/``s_K``/``s_N`` for the source strides along
+its logical axes:
+
+======  =========================  ======================  =====================================
+role    pattern dims               sizes                   strides
+======  =========================  ======================  =====================================
+``A``   ``k_grp, m_grp, m, k``     ``K/k, M/m, m, k``      ``k*s_K, m*s_M, s_M, s_K``
+``B``   ``n_grp, k_grp, k, n``     ``N/n, K/k, k, n``      ``n*s_N, k*s_K, s_K, s_N``
+``C``   ``m_grp, m, n_grp, n``     ``M/m, m, N/n, n``      ``s_mgrp, s_m, s_ngrp, s_n``
+======  =========================  ======================  =====================================
+
+``A`` and ``B`` pack (flat source, packed destination); ``C`` unpacks, reading
+the packed L1 buffer back in logical row-major order, so its strides come from
+the packed buffer's own shape. Each row above reproduces the reference example's
+literal stride tuple exactly -- ``[1024,1024,8,128,32,1]``,
+``[1024,1024,4,256,32,1]`` and ``[1024,1024,16,4,128,1]`` respectively -- which is
+the test that this table is right rather than merely plausible.
+
+Offsets follow one rule: a logical offset lands on the *innermost* pattern
+dimension for its axis, the one carrying that axis's base stride. That is why the
+reference puts the K offset last, at stride 1, for ``A``.
+"""
+
+from ._index import coerce_index
+
+__all__ = ["MicroTile", "PackedShape", "micro_tile"]
+
+
+class PackedShape(tuple):
+    """A packed tile shape, plus the descriptor that produced it.
+
+    It *is* a tuple, so ``air.alloc`` takes it wherever a shape goes and nothing
+    else has to know about packing. Carrying the descriptor along is what lets
+    ``ops.load``/``ops.store`` derive the access pattern later without the call
+    site repeating the micro-tile.
+    """
+
+    # No __slots__: a subtype of tuple cannot have a non-empty one.
+
+    def __new__(cls, extents, role, micro, logical, lead):
+        self = super().__new__(cls, tuple(int(e) for e in extents))
+        self.role = role
+        self.micro = micro
+        self.logical = tuple(int(x) for x in logical)
+        self.lead = tuple(int(x) for x in lead)
+        return self
+
+    def __repr__(self):
+        return (
+            f"PackedShape({tuple(self)}, role={self.role!r}, "
+            f"micro={self.micro!r}, logical={self.logical})"
+        )
+
+
+def _check_divides(name, extent, unit, role, axis):
+    if unit <= 0:
+        raise ValueError(f"micro-tile {name} must be positive, got {unit}")
+    if extent % unit:
+        raise ValueError(
+            f"operand {role}'s {axis} extent {extent} is not a multiple of the "
+            f"micro-tile {name}={unit}, so it cannot be laid out as whole "
+            f"micro-tiles. Pick a tile size divisible by {unit}, or a micro-tile "
+            f"that divides {extent}."
+        )
+    return extent // unit
+
+
+class MicroTile:
+    """The AIE2 matmul intrinsic's operand shape: ``m x k`` by ``k x n``.
+
+    ``(4, 8, 4)`` is the bf16 shape and ``(4, 8, 8)`` the int8 one; the value that
+    matters is whatever the external kernel was compiled for. The reference
+    example passes exactly these through ``-DDIM_M``/``-DDIM_K``/``-DDIM_N`` to
+    ``mm.cc``, so a mismatch here is a mismatch with the object file.
+    """
+
+    __slots__ = ("m", "k", "n")
+
+    def __init__(self, m, k, n):
+        for name, v in (("m", m), ("k", k), ("n", n)):
+            if int(v) <= 0:
+                raise ValueError(f"micro-tile {name} must be positive, got {v}")
+        self.m, self.k, self.n = int(m), int(k), int(n)
+
+    def __repr__(self):
+        return f"MicroTile(m={self.m}, k={self.k}, n={self.n})"
+
+    def __eq__(self, other):
+        return isinstance(other, MicroTile) and (self.m, self.k, self.n) == (
+            other.m,
+            other.k,
+            other.n,
+        )
+
+    def __hash__(self):
+        return hash((self.m, self.k, self.n))
+
+    # -- packed shapes -----------------------------------------------------
+    #
+    # `lead` is the pair of outer dimensions every buffer in this layout carries.
+    # For the per-core A and B tiles it is (1, 1); for a C accumulator shared
+    # across the herd it is the herd shape, and the core selects its own slab
+    # with a subview -- which is exactly what the reference does.
+
+    def a(self, M, K, lead=(1, 1)):
+        """``[*lead, K/k, M/m, m, k]`` -- the packed left operand."""
+        M, K = int(M), int(K)
+        kg = _check_divides("k", K, self.k, "A", "K")
+        mg = _check_divides("m", M, self.m, "A", "M")
+        return PackedShape(
+            tuple(lead) + (kg, mg, self.m, self.k), "A", self, (M, K), lead
+        )
+
+    def b(self, K, N, lead=(1, 1)):
+        """``[*lead, N/n, K/k, k, n]`` -- the packed right operand."""
+        K, N = int(K), int(N)
+        ng = _check_divides("n", N, self.n, "B", "N")
+        kg = _check_divides("k", K, self.k, "B", "K")
+        return PackedShape(
+            tuple(lead) + (ng, kg, self.k, self.n), "B", self, (K, N), lead
+        )
+
+    def c(self, M, N, lead=(1, 1)):
+        """``[*lead, N/n, M/m, m, n]`` -- the packed accumulator."""
+        M, N = int(M), int(N)
+        ng = _check_divides("n", N, self.n, "C", "N")
+        mg = _check_divides("m", M, self.m, "C", "M")
+        return PackedShape(
+            tuple(lead) + (ng, mg, self.m, self.n), "C", self, (M, N), lead
+        )
+
+
+def micro_tile(m, k, n):
+    """The AIE2 matmul intrinsic shape; ``(4, 8, 4)`` for bf16."""
+    return MicroTile(m, k, n)
+
+
+# ---------------------------------------------------------------------------
+# Access-pattern derivation
+# ---------------------------------------------------------------------------
+
+
+def pack_pattern(packed, sizes, strides, offsets):
+    """Derive the rank-``lead+4`` DMA pattern for one packed operand.
+
+    The three inputs describe the region in **logical** terms -- ``lead``
+    dimensions followed by the operand's two logical axes -- and the result is
+    the micro-tiled pattern over the same elements.
+
+    Which buffer they describe depends on the direction, because a pack and an
+    unpack put the pattern on opposite sides:
+
+    * ``A``/``B`` **pack**: the pattern goes on the flat source, so ``strides``
+      are the *source* buffer's row-major strides and the derivation reorders
+      them into micro-tile order.
+    * ``C`` **unpacks**: the pattern goes on the packed buffer itself and walks
+      it back in logical row-major order, so only the ``lead`` strides are taken
+      from the caller -- the four inner strides come from the packed shape.
+    """
+    nlead = len(packed.lead)
+    if len(sizes) != nlead + 2:
+        raise ValueError(
+            f"a packed {packed.role} operand needs a region of rank "
+            f"{nlead + 2} -- {nlead} leading dimension(s) then the two logical "
+            f"axes -- but got rank {len(sizes)}, {tuple(sizes)}"
+        )
+
+    lead_sizes = list(sizes[:nlead])
+    lead_strides = list(strides[:nlead])
+    lead_offsets = list(offsets[:nlead])
+    # The two logical axes, in the order the flat side stores them: A is (M, K),
+    # B is (K, N), C is (M, N).
+    e0, e1 = sizes[nlead], sizes[nlead + 1]
+    s0, s1 = strides[nlead], strides[nlead + 1]
+    o0, o1 = offsets[nlead], offsets[nlead + 1]
+    zero = coerce_index(0)
+    micro = packed.micro
+
+    if packed.role == "A":
+        # (M, K) -> [k_grp, m_grp, m, k]
+        m, k = micro.m, micro.k
+        _expect(packed, "M", e0, m)
+        _expect(packed, "K", e1, k)
+        inner = (
+            [e1 // k, e0 // m, m, k],
+            [k * s1, m * s0, s0, s1],
+            [zero, zero, o0, o1],
+        )
+    elif packed.role == "B":
+        # (K, N) -> [n_grp, k_grp, k, n]
+        k, n = micro.k, micro.n
+        _expect(packed, "K", e0, k)
+        _expect(packed, "N", e1, n)
+        inner = (
+            [e1 // n, e0 // k, k, n],
+            [n * s1, k * s0, s0, s1],
+            [zero, zero, o0, o1],
+        )
+    elif packed.role == "C":
+        # (M, N) -> [m_grp, m, n_grp, n], read out of the packed buffer.
+        m, n = micro.m, micro.n
+        _expect(packed, "M", e0, m)
+        _expect(packed, "N", e1, n)
+        mg = packed[nlead + 1]
+        s_n, s_m, s_mgrp, s_ngrp = 1, n, m * n, mg * m * n
+        inner = (
+            [e0 // m, m, e1 // n, n],
+            [s_mgrp, s_m, s_ngrp, s_n],
+            [zero, o0, zero, o1],
+        )
+    else:  # pragma: no cover -- role is set only by MicroTile
+        raise AssertionError(f"unknown packed operand role {packed.role!r}")
+
+    isizes, istrides, ioffsets = inner
+    return lead_offsets + ioffsets, lead_sizes + isizes, lead_strides + istrides
+
+
+def _expect(packed, axis, extent, unit):
+    if extent % unit:
+        raise ValueError(
+            f"the {axis} extent of this region is {extent}, which is not a "
+            f"multiple of the micro-tile {packed.micro!r} the packed buffer was "
+            f"allocated with, so it cannot be split into whole micro-tiles"
+        )

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -860,6 +860,21 @@ def alloc(shape, dtype, scope=None, vector=None):
         # private() is the memtile; shared() is core L1 with segment lifetime.
         if scope.kind == "shared":
             space, memory_space, capacity = "L1", MemorySpace.L1, L1_BYTES
+            if not isinstance(shape, PackedShape):
+                # The L1 budget for a shared buffer is per *core*, so the
+                # accounting has to know which leading dimensions are the herd.
+                # A PackedShape records them; a plain list does not, and
+                # guessing would either overcharge (rejecting a design that
+                # fits) or undercharge (passing one that does not).
+                raise NotImplementedError(
+                    "<segment>.shared() currently requires a micro-tiled shape "
+                    "from air.micro_tile(...), because the per-core L1 charge "
+                    "depends on knowing which leading dimensions are the herd. "
+                    f"Got a plain shape {list(shape)}. Either allocate it with "
+                    "mm.c(...)/mm.a(...)/mm.b(...), or, if the buffer does not "
+                    "have to outlive one entry into the herd, allocate it "
+                    "per-core in the herd body with <herd>.private()."
+                )
         else:
             space, memory_space, capacity = "L2", MemorySpace.L2, L2_BYTES
         where = "a segment"
@@ -912,7 +927,7 @@ def alloc(shape, dtype, scope=None, vector=None):
         # per core. The leading dimensions are the herd shape by construction:
         # that is what makes the per-core subview well defined.
         per_core = nbytes
-        for extent in getattr(shape, "lead", ()):
+        for extent in shape.lead:
             per_core //= int(extent)
         nbytes = per_core
     # A segment holds L2 memtile buffers and herd-shared L1 buffers at once, so

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -33,18 +33,22 @@ import itertools
 import re
 
 from ._index import IndexExpr
+from ._pack import PackedShape
 from ._value import Buffer, Tensor, Token
 
 __all__ = [
     "Symbol",
     "HerdContext",
+    "SegmentContext",
     "Scope",
     "herd",
+    "segment",
     "alloc",
     "tensor",
     "symbol",
     "wait",
     "current_herd",
+    "current_segment",
 ]
 
 
@@ -59,6 +63,7 @@ PENDING_SYMBOLS = []
 
 # The herd currently being traced, and the launch currently being traced.
 _CURRENT_HERD = None
+_CURRENT_SEGMENT = None
 _ACTIVE_TRACE = None
 
 # The device being traced for. A herd resolves its physical shape when it is
@@ -89,12 +94,19 @@ NO_DEVICE_TARGET = "npu2"
 # L1 (tile-local) memory per compute tile. Same on AIE2 and AIE2p.
 L1_BYTES = 65536
 
+# L2 (memtile) memory per segment. The figure the hand-written staging examples
+# assert against, e.g. matrix_vector_multiplication/bf16/matvec.py.
+L2_BYTES = 512 * 1024
+
 
 class Trace:
     """Per-build state: the tensors bound to the function being traced."""
 
-    def __init__(self, tensors):
+    def __init__(self, tensors, module=None):
         self.tensors = tensors
+        # The enclosing builtin.module, so that air.extern can place its private
+        # func.func declarations at module scope from deep inside a herd body.
+        self.module = module
         # Peak declared L1 bytes across the trace, used to explain an
         # out-of-memory failure from the AIE placer in DSL terms.
         self.l1_peak = 0
@@ -153,6 +165,14 @@ def current_herd():
             "this operation must be used inside a herd body (@herd.body)"
         )
     return _CURRENT_HERD
+
+
+def current_segment(required=True):
+    if _CURRENT_SEGMENT is None and required:
+        raise RuntimeError(
+            "this operation must be used inside a segment body (@segment.body)"
+        )
+    return _CURRENT_SEGMENT
 
 
 def infer_name(fallback, depth=2):
@@ -344,7 +364,18 @@ def _dim_from_values(values):
         raise ValueError("empty iteration range")
     _reject_nonzero_start(values[0], f"{list(values[:4])}...")
     if len(values) == 1:
-        return _Dim(1, 1)
+        # itertools.product materialises its inputs, so a one-element axis
+        # arrives as `(0,)` and its step is simply gone -- range(0, 32, 32) and
+        # range(0, 32, 1)[:1] are indistinguishable here. Guessing 1 is what the
+        # tile size then becomes, and the kernel quietly computes on 1x1 tiles.
+        raise ValueError(
+            "air.herd cannot recover the tile size of a single-tile axis from "
+            "an itertools.product: product materialises its inputs, so "
+            "range(0, N, N) reaches the DSL as just (0,) with no step. Pass the "
+            "grid as a list of ranges instead -- air.herd([range(0, M, tm), "
+            "range(0, N, tn)]) -- which keeps the steps, or use a 1-D "
+            "air.herd(range(...)) if the other axis is trivial."
+        )
     step = values[1] - values[0]
     for a, b in zip(values, values[1:]):
         if b - a != step:
@@ -400,6 +431,156 @@ def _positional_arity(fn):
 
 
 # ---------------------------------------------------------------------------
+# Segment
+# ---------------------------------------------------------------------------
+
+
+class SegmentContext:
+    """A device segment: memtile (L2) scope, with herds nested inside it.
+
+    A segment stages data between L3 and L1 so that a herd's cores read their
+    operands from a memtile rather than each streaming from L3 over its own shim
+    channel. That is what the hand-written matmul examples all do, and it is the
+    reason a wide herd is worth having.
+
+    ``air.launch``, ``air.segment`` and ``air.herd`` are independent ops, and a
+    kernel that does not need staging keeps the plain ``func`` + ``air.herd``
+    shape. A segment, though, is emitted **inside an ``air.launch``**, because
+    the pipeline will not supply one: ``air-insert-launch-around-herd`` wraps a
+    *bare* herd in a launch and a segment, and skips a herd that is already
+    inside a segment. A segment with no launch above it compiles, and silently
+    computes zeros for anything beyond a plain copy -- verified on npu1, and the
+    reason every hand-written staging example in the tree nests the two.
+    """
+
+    def __init__(self, grid=None, name=None):
+        # A grid here is the *launch* iteration space: one segment instance per
+        # point, which is how the reference matmul tiles M and N. It cannot be
+        # the herd's job, because the L2 staging buffers are re-filled per point
+        # -- the outer tiling has to sit where the L3->L2 transfers are.
+        self.dims = parse_grid(grid) if grid is not None else ()
+        if len(self.dims) > 2:
+            raise NotImplementedError(
+                f"air.launch is 2-D, so a segment grid is 1-D or 2-D; got "
+                f"{len(self.dims)}-D"
+            )
+        self.grid = tuple(d.count for d in self.dims)
+        self.tile_sizes = tuple(d.step for d in self.dims)
+        self.name = name or "segment_0"
+        self._buffers = []
+        self._registered = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def private(self):
+        """L2 (memtile) scope, shared by every core in the segment."""
+        return Scope("private", self)
+
+    def shared(self):
+        """L1 scope, but allocated *here* rather than in the herd body.
+
+        A buffer in a herd body lives and dies with one entry into the herd. An
+        accumulator cannot: it is zeroed once, added into across every trip of a
+        reduction loop that sits at segment scope -- so the herd is entered once
+        per trip -- and drained at the end. Allocating it here gives it the
+        lifetime of the segment, and the nested herd receives it as an operand
+        like any other segment buffer.
+
+        It is still L1, so it is still charged against the 64 KB core budget, and
+        each core addresses its own slab of it -- which is why such a buffer is
+        allocated with leading herd dimensions and subscripted by tile
+        coordinate.
+        """
+        return Scope("shared", self)
+
+    def register_buffer(self, buf):
+        self._buffers.append(buf)
+
+    @property
+    def body(self):
+        def decorator(fn):
+            if self._registered:
+                raise RuntimeError("segment body registered twice")
+            self._registered = True
+            self._emit(fn)
+            return fn
+
+        return decorator
+
+    def _emit(self, fn):
+        global _CURRENT_SEGMENT
+
+        trace = active_trace()
+        n_expected = len(self.dims)
+        if _positional_arity(fn) != n_expected:
+            raise TypeError(
+                f"segment body takes {_positional_arity(fn)} coordinate "
+                f"argument(s) but the launch iteration space is "
+                f"{n_expected}-D"
+                + (
+                    "; a segment with no grid is a single instance and its body "
+                    "takes no arguments"
+                    if n_expected == 0
+                    else ""
+                )
+            )
+
+        from air.dialects.air import launch as launch_region
+        from air.dialects.air import segment as segment_region
+        from air.dialects.memref import DeallocOp
+
+        tensors = trace.tensors
+        segment_self = self
+
+        # air.launch is always 2-D; an absent or 1-D grid pads with 1. Its block
+        # arguments are sizes*2 + operands, so the operands start at index 4.
+        counts = list(self.grid) + [1] * (2 - len(self.grid))
+
+        @launch_region(sizes=counts, operands=[t.value for t in tensors])
+        def launch_body(*largs):
+            # The launch induction variables become segment operands, ahead of
+            # the tensors -- air.segment is IsolatedFromAbove, so a coordinate
+            # cannot simply be referenced from inside it.
+            ivs = list(largs[: len(segment_self.dims)])
+            outer = ivs + list(largs[4:])
+
+            # sizes=[] on the segment means its block arguments are exactly the
+            # operands.
+            @segment_region(name=segment_self.name, operands=outer)
+            def segment_body(*args):
+                global _CURRENT_SEGMENT
+
+                coords = [
+                    IndexExpr.leaf(v, f"s{axis}")
+                    for axis, v in enumerate(args[: len(ivs)])
+                ]
+                bound = args[len(ivs) :]
+                saved = [t.value for t in tensors]
+                for t, v in zip(tensors, bound):
+                    t.value = v
+                previous, _CURRENT_SEGMENT = _CURRENT_SEGMENT, segment_self
+                try:
+                    fn(*coords)
+                    # Freed here, inside the region the allocs were emitted into.
+                    for buf in segment_self._buffers:
+                        DeallocOp(buf.value)
+                finally:
+                    segment_self._buffers.clear()
+                    for t, v in zip(tensors, saved):
+                        t.value = v
+                    _CURRENT_SEGMENT = previous
+
+
+def segment(grid=None, name=None):
+    """A device segment with L2 scope; nest herds inside its body."""
+    return SegmentContext(grid=grid, name=name)
+
+
+# ---------------------------------------------------------------------------
 # Herd
 # ---------------------------------------------------------------------------
 
@@ -421,6 +602,26 @@ class HerdContext:
         self.repeats = tuple(g // p for g, p in zip(self.grid, self.physical))
         self._buffers = []
         self._registered = False
+        # Object files required by air.extern calls in this herd's body.
+        self._objects = {}
+        # The core's position in the herd, bound while the body is traced.
+        self._coords = []
+
+    def require_object(self, obj, kernel):
+        """Record that this herd calls ``kernel`` from ``obj``.
+
+        aircc links one object per herd -- link_with is a single string -- so a
+        body that reaches into two of them cannot be built.
+        """
+        if self._objects and obj not in self._objects:
+            other, other_kernel = next(iter(self._objects.items()))
+            raise ValueError(
+                f"herd '{self.name}' calls {kernel} from {obj!r} and "
+                f"{other_kernel} from {other!r}, but a herd links against a "
+                "single object file. Compile both kernels into one object, or "
+                "put them in separate herds."
+            )
+        self._objects[obj] = kernel
 
     def _resolve_physical(self, shape):
         by_rank = PHYSICAL_HERD[self.target]
@@ -461,7 +662,12 @@ class HerdContext:
 
     def shared(self):
         raise NotImplementedError(
-            "shared L1 scope is not exposed by air.api yet; use herd.private()"
+            "air.api has no <herd>.shared(): a buffer allocated in a herd body "
+            "is core-local, and it dies when the body ends. For a buffer the "
+            "herd's cores share -- an accumulator carried across a reduction "
+            "loop at segment scope, say -- use <segment>.shared(), which "
+            "allocates L1 with the segment's lifetime and passes it into the "
+            "herd as an operand."
         )
 
     @property
@@ -494,8 +700,19 @@ class HerdContext:
         from air.dialects.memref import DeallocOp
         from air.dialects.scf import for_ as range_, yield_
 
+        from ._loop import aborted_loops, enter_body, exit_body
+
+        aborted_before = aborted_loops()
+
         tensors = trace.tensors
-        operands = [t.value for t in tensors]
+        # air.herd is IsolatedFromAbove, so an L2 buffer allocated in the
+        # enclosing segment has to be passed in explicitly. Every live one is
+        # passed, referenced or not -- the same policy already applied to
+        # tensors, and the tracer cannot know what the body will touch until it
+        # has run it.
+        enclosing = current_segment(required=False)
+        staged = list(enclosing._buffers) if enclosing is not None else []
+        operands = [t.value for t in tensors] + [b.value for b in staged]
         # air.herd is always 2-D. A 1-D grid is laid out along x -- [P, 1], the
         # orientation the hand-written eltwise_add kernel uses for its 8-core
         # npu2 config. [1, P] does not place.
@@ -509,15 +726,26 @@ class HerdContext:
             global _CURRENT_HERD
 
             coords = list(args[:2])
-            inner_tensors = args[4:]
+            inner = args[4:]
 
-            # Inside the herd, tensors resolve to the herd's block arguments.
+            # Inside the herd, tensors and staged L2 buffers resolve to the
+            # herd's block arguments, in the order they were passed as operands.
             saved = [t.value for t in tensors]
-            for t, v in zip(tensors, inner_tensors):
+            saved_staged = [b.value for b in staged]
+            for t, v in zip(tensors, inner[: len(tensors)]):
                 t.value = v
+            for b, v in zip(staged, inner[len(tensors) :]):
+                b.value = v
             previous, _CURRENT_HERD = _CURRENT_HERD, herd_self
 
             phys_coords = coords if two_d else coords[:1]
+            # The core's own position in the herd, as opposed to the logical
+            # tile id the body is handed (which folds in strip-mining). A
+            # herd-shared buffer is indexed by this: it has one slab per core,
+            # not one per logical tile.
+            herd_self._coords = [
+                IndexExpr.leaf(c, f"c{axis}") for axis, c in enumerate(phys_coords)
+            ]
 
             def run(strip_ivs):
                 tile_ids = []
@@ -534,13 +762,34 @@ class HerdContext:
                     DeallocOp(buf.value)
                 herd_self._buffers.clear()
 
+            outer_depth = enter_body()
             try:
                 run_strip_mined(run, herd_self.repeats, range_, yield_)
             finally:
+                exit_body(outer_depth)
                 herd_self._buffers.clear()
                 for t, v in zip(tensors, saved):
                     t.value = v
+                for b, v in zip(staged, saved_staged):
+                    b.value = v
                 _CURRENT_HERD = previous
+
+        # aircc compiles the object named here alongside the herd's cores.
+        if herd_self._objects:
+            from air.ir import StringAttr
+
+            herd_body.attributes["link_with"] = StringAttr.get(
+                next(iter(herd_self._objects))
+            )
+
+        if aborted_loops() != aborted_before:
+            raise RuntimeError(
+                "a body left an air.sequential loop early (break, return, or a "
+                "swallowed exception). An air.sequential body is traced once and "
+                "stands for every trip, so an early exit does not shorten the "
+                "loop -- it truncates the body of all of them, and the kernel "
+                "computes a partial result. Restructure the loop bounds instead."
+            )
 
 
 def run_strip_mined(run, repeats, range_, yield_):
@@ -579,18 +828,60 @@ def tensor(shape, dtype, name=None):
 
 
 def alloc(shape, dtype, scope=None, vector=None):
-    """Allocate an L1 tile inside a herd body."""
+    """Allocate a tile: L1 in a herd body, or L2 in a segment body."""
     from air.ir import IntegerAttr, MemRefType
     from air.dialects.air import MemorySpace
     from air.dialects.memref import AllocOp
     from air.extras import types as T
 
-    h = current_herd()
+    from ._loop import loop_depth
+
     if scope is None:
-        raise ValueError("air.alloc requires scope=<herd>.private()")
-    if not isinstance(scope, Scope) or scope.kind != "private":
+        raise ValueError(
+            "air.alloc requires scope=<herd>.private() (L1) or "
+            "scope=<segment>.private() (L2)"
+        )
+    if not isinstance(scope, Scope) or scope.kind not in ("private", "shared"):
         raise NotImplementedError(
-            f"air.api can only allocate in a herd's private (L1) scope, got {scope!r}"
+            f"air.api can only allocate in a private or shared scope, got {scope!r}"
+        )
+
+    owner = scope.owner
+    if isinstance(owner, HerdContext):
+        if scope.kind != "private":
+            raise NotImplementedError(
+                "air.api has no <herd>.shared(); a buffer allocated in a herd "
+                "body is core-local. For a buffer the herd's cores share, use "
+                "<segment>.shared(), which allocates it at segment scope."
+            )
+        space, memory_space, capacity, where = "L1", MemorySpace.L1, L1_BYTES, "a herd"
+        holder = current_herd()
+    elif isinstance(owner, SegmentContext):
+        # private() is the memtile; shared() is core L1 with segment lifetime.
+        if scope.kind == "shared":
+            space, memory_space, capacity = "L1", MemorySpace.L1, L1_BYTES
+        else:
+            space, memory_space, capacity = "L2", MemorySpace.L2, L2_BYTES
+        where = "a segment"
+        holder = current_segment()
+    else:
+        raise NotImplementedError(
+            f"air.api cannot allocate in {scope!r}; use <herd>.private() for L1 "
+            "or <segment>.private() for L2"
+        )
+    if holder is not owner:
+        raise RuntimeError(
+            f"air.alloc(scope=...) names {where} that is not the one currently "
+            "being traced; allocate inside the body of the scope you are asking "
+            "for"
+        )
+    if space == "L1" and loop_depth():
+        raise NotImplementedError(
+            "air.alloc inside an air.sequential body is not supported: the herd "
+            "frees its buffers once the body is finished, which is outside the "
+            "loop, so the dealloc would not be dominated by its alloc. Hoist the "
+            "allocation above the loop -- the buffer is reused across trips, "
+            "which is what a loop is for."
         )
     # 0 is meaningful -- it selects the scalar path. Negative is not, and it
     # would otherwise pass a caller's own `tile % width` guard unnoticed, since
@@ -604,34 +895,60 @@ def alloc(shape, dtype, scope=None, vector=None):
     memref_ty = MemRefType.get(
         [int(s) for s in shape],
         dtype.mlir(),
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
+        memory_space=IntegerAttr.get(T.i32(), memory_space),
     )
-    # Reject what is certainly impossible before the AIE placer has to. A
-    # single tile's declared buffers cannot exceed L1; note that the pipeline
-    # may additionally ping-pong these, so fitting here is necessary but not
-    # sufficient (see the hint attached to placement failures).
+    # Reject what is certainly impossible before the AIE placer has to. Note
+    # that for L1 the pipeline may additionally ping-pong these, so fitting here
+    # is necessary but not sufficient (see the hint on placement failures).
     nbytes = 1
     for extent in shape:
         nbytes *= int(extent)
     nbytes *= dtype.itemsize
-    live = sum(_buffer_bytes(b) for b in h._buffers) + nbytes
-    if nbytes > L1_BYTES:
+    if scope.kind == "shared":
+        # A herd-shared buffer is declared once with leading herd dimensions,
+        # and each core addresses exactly one slab of it. Charging the whole
+        # thing against one core's 64 KB would reject configurations that fit
+        # comfortably -- a 4x4 herd of 16 KB slabs is 256 KB in total and 16 KB
+        # per core. The leading dimensions are the herd shape by construction:
+        # that is what makes the per-core subview well defined.
+        per_core = nbytes
+        for extent in getattr(shape, "lead", ()):
+            per_core //= int(extent)
+        nbytes = per_core
+    # A segment holds L2 memtile buffers and herd-shared L1 buffers at once, so
+    # each budget only counts its own space.
+    live = sum(_buffer_bytes(b) for b in holder._buffers if b.space == space) + nbytes
+    unit = "a compute tile" if space == "L1" else "a memtile"
+    if nbytes > capacity:
         raise ValueError(
-            f"air.alloc({list(shape)}, {dtype}) needs {nbytes / 1024:.1f} KB but a "
-            f"compute tile has {L1_BYTES / 1024:.0f} KB of L1; use a smaller tile"
+            f"air.alloc({list(shape)}, {dtype}) needs {nbytes / 1024:.1f} KB but "
+            f"{unit} has {capacity / 1024:.0f} KB of {space}; use a smaller tile"
         )
-    if live > L1_BYTES:
+    if live > capacity:
         raise ValueError(
-            f"L1 budget exceeded: this herd body has {live / 1024:.1f} KB of live "
-            f"buffers but a compute tile has {L1_BYTES / 1024:.0f} KB; use a "
-            "smaller tile"
+            f"{space} budget exceeded: this {where.split()[-1]} body has "
+            f"{live / 1024:.1f} KB of live buffers but {unit} has "
+            f"{capacity / 1024:.0f} KB; use a smaller tile"
         )
 
     op = AllocOp(memref_ty, [], [])
-    buf = Buffer(shape, dtype, scope=scope, vector_width=vector, value=op.result)
-    h.register_buffer(buf)
-    trace = active_trace()
-    trace.l1_peak = max(trace.l1_peak, live)
+    buf = Buffer(
+        shape,
+        dtype,
+        scope=scope,
+        vector_width=vector,
+        value=op.result,
+        space=space,
+        # A PackedShape is an ordinary tuple as far as the memref is concerned --
+        # the packing is not a layout, it is just this shape. Carrying the
+        # descriptor onto the buffer is what lets ops.load/store derive the
+        # micro-tiled access pattern without the call site restating it.
+        pack=shape if isinstance(shape, PackedShape) else None,
+    )
+    holder.register_buffer(buf)
+    if space == "L1":
+        trace = active_trace()
+        trace.l1_peak = max(trace.l1_peak, live)
     return buf
 
 
@@ -639,6 +956,12 @@ def _buffer_bytes(buf):
     n = buf.dtype.itemsize
     for extent in buf.shape:
         n *= extent
+    # Mirror the per-core charge applied when a herd-shared buffer was
+    # allocated, so the running total and the new allocation are on the same
+    # footing.
+    if getattr(buf.scope, "kind", None) == "shared" and buf.pack is not None:
+        for extent in buf.pack.lead:
+            n //= int(extent)
     return n
 
 

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -20,7 +20,7 @@ Three rules shape this module:
 
 from ._index import coerce_index
 
-__all__ = ["Token", "Tensor", "TensorSlice", "Buffer", "BufferExpr"]
+__all__ = ["Token", "Tensor", "TensorSlice", "Buffer", "BufferSlice", "BufferExpr"]
 
 
 class Token:
@@ -139,50 +139,180 @@ class TensorSlice:
 
 
 class Buffer:
-    """A tile allocated in a hardware scope (L1 today)."""
+    """A tile allocated in a hardware scope: L1 (a core) or L2 (a memtile).
 
-    def __init__(self, shape, dtype, scope=None, vector_width=None, value=None):
+    A subscript designates a *region* of the buffer, and what that means depends
+    on where it is used -- the same rule the API proposal's examples assume. A
+    whole-tile subscript (``buf[:]``) in an expression is an elementwise read; a
+    partial subscript (``buf[tx, 0:tm, :]``) is an access pattern for a DMA, and
+    only ``ops.load``/``ops.store`` accept one.
+    """
+
+    def __init__(
+        self,
+        shape,
+        dtype,
+        scope=None,
+        vector_width=None,
+        value=None,
+        space="L1",
+        pack=None,
+    ):
         self.shape = tuple(int(s) for s in shape)
         self.dtype = dtype
         self.scope = scope
+        # A PackedShape when this tile is laid out in micro-tile order for the
+        # AIE2 matmul intrinsic, else None. It does not change the memref -- the
+        # buffer is contiguous either way -- but it tells ops.load/store how to
+        # walk the flat side. See _pack.py.
+        self.pack = pack
+        # "L1" (core-local) or "L2" (memtile). Recorded rather than derived from
+        # `scope` so that _value.py stays independent of the tracer.
+        self.space = space
         self.vector_width = (
             dtype.default_vector_width if vector_width is None else int(vector_width)
         )
         # The memref SSA value produced by memref.alloc.
         self.value = value
+        self.strides = _row_major_strides(self.shape)
 
-    # -- reading: builds a lazy expression, emits nothing -------------------
+    # -- reading: whole tile is a lazy expression, a region is a DMA slice ---
 
     def __getitem__(self, key):
-        self._require_whole(key, "read")
-        return BufferExpr.leaf(self)
+        if self._is_whole(key):
+            self._require_compute("read")
+            return BufferExpr.leaf(self)
+        if self.pack is not None:
+            return self._packed_slice(key)
+        key = _normalize_key(key, len(self.shape), "buffer")
+        offsets, sizes = [], []
+        for dim, (sub, extent) in enumerate(zip(key, self.shape)):
+            offset, size = _resolve_subscript(sub, extent, dim)
+            offsets.append(offset)
+            sizes.append(size)
+        return BufferSlice(self, offsets, sizes, list(self.strides))
+
+    def _packed_slice(self, key):
+        """Subscript a micro-tiled buffer in *logical* coordinates.
+
+        The whole point of a packed layout is that the program keeps thinking in
+        ``[M, N]`` while the memref is ``[N/n, M/m, m, n]``, so the subscript is
+        the logical one: ``l1_c[tx, ty, :, :]`` on a herd-shared accumulator
+        names one core's ``tile_m x tile_n`` slab. The rank-6 access pattern is
+        derived from it -- see ``_pack.pack_pattern``.
+        """
+        from ._pack import pack_pattern
+
+        logical = self.pack.lead + self.pack.logical
+        key = _normalize_key(key, len(logical), "packed buffer")
+        offsets, sizes = [], []
+        for dim, (sub, extent) in enumerate(zip(key, logical)):
+            offset, size = _resolve_subscript(sub, extent, dim)
+            offsets.append(offset)
+            sizes.append(size)
+        pat_offsets, pat_sizes, pat_strides = pack_pattern(
+            self.pack, sizes, self.strides, offsets
+        )
+        return BufferSlice(
+            self, pat_offsets, pat_sizes, pat_strides, logical_sizes=sizes
+        )
 
     # -- writing: this is what triggers emission ----------------------------
 
     def __setitem__(self, key, value):
-        self._require_whole(key, "write")
+        if not self._is_whole(key):
+            raise NotImplementedError(
+                "partial assignment into a buffer is not supported yet; a "
+                "partial subscript names a DMA region, so use "
+                "air.api.ops.load(dst, src[...]) to fill one. air.api handles "
+                "whole-tile elementwise assignment (buf[:] = ...) only"
+            )
+        self._require_compute("write")
+        if self.pack is not None:
+            return self._packed_fill(value)
         from ._emit import emit_elementwise
 
         emit_elementwise(self, BufferExpr.coerce(value))
 
-    def _require_whole(self, key, what):
-        """v1 only supports whole-tile elementwise access (``buf[:]``)."""
+    def _packed_fill(self, value):
+        """``acc[:] = 0.0`` on a micro-tiled buffer, as one ``linalg.fill``.
+
+        The generic emitter would build a loop nest over the *packed* shape --
+        six nested loops and a scalar store per element, tens of thousands of
+        them for a real tile, which is the documented cause of NPU timeouts.
+        Zeroing an accumulator has no elementwise structure worth preserving, so
+        it goes out as the single op the reference uses.
+        """
+        from air.dialects.arith import ConstantOp
+        from air.dialects.linalg import fill
+
+        from . import ops as _ops
+
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise NotImplementedError(
+                "only a scalar fill is supported on a micro-tiled buffer "
+                f"(got {value!r}): its elements are not in row-major order, so "
+                "an elementwise expression over it would not mean what it reads "
+                "like. Compute into it with air.api.ops.dot instead."
+            )
+        scalar = float(value) if self.dtype.is_float else int(value)
+        cst = ConstantOp(self.dtype.mlir(), scalar)
+        return fill(cst, outs=[_ops.accumulator_subview(self)])
+
+    @staticmethod
+    def _is_whole(key):
         key = key if isinstance(key, tuple) else (key,)
-        whole = all(
+        return all(
             isinstance(k, slice)
             and k.start is None
             and k.stop is None
             and k.step is None
             for k in key
         )
-        if not whole:
-            raise NotImplementedError(
-                f"partial {what} of an L1 buffer is not supported yet; "
-                "air.api v1 handles whole-tile elementwise access (buf[:]) only"
+
+    def _require_compute(self, what):
+        """Elementwise access needs a core, and a memtile does not have one."""
+        if self.space != "L1":
+            raise TypeError(
+                f"cannot {what} an {self.space} buffer elementwise: {self.space} "
+                "is a memtile, which has DMA engines but no compute core. Stage "
+                "the tile into an L1 buffer with air.api.ops.load first, and "
+                "compute on that."
             )
 
     def __repr__(self):
-        return f"Buffer(shape={self.shape}, dtype={self.dtype})"
+        return f"Buffer(shape={self.shape}, dtype={self.dtype}, space={self.space})"
+
+
+class BufferSlice:
+    """An access pattern into a :class:`Buffer`, for use as a DMA endpoint."""
+
+    __slots__ = ("buffer", "offsets", "sizes", "strides", "logical_sizes")
+
+    def __init__(self, buffer, offsets, sizes, strides, logical_sizes=None):
+        self.buffer = buffer
+        self.offsets = offsets
+        self.sizes = sizes
+        self.strides = strides
+        # For a micro-tiled buffer the access pattern's rank and the region's
+        # rank differ -- a [1, 1, 32, 32] logical region is walked as a
+        # [1, 1, 8, 4, 8, 4] pattern. Transfers are shape-checked against the
+        # logical view, which is the one the two endpoints have in common.
+        self.logical_sizes = list(sizes if logical_sizes is None else logical_sizes)
+
+    @property
+    def dtype(self):
+        return self.buffer.dtype
+
+    @property
+    def value(self):
+        return self.buffer.value
+
+    def materialize_offsets(self):
+        return [o.materialize() for o in self.offsets]
+
+    def __repr__(self):
+        return f"BufferSlice({self.buffer!r}, sizes={self.sizes})"
 
 
 class BufferExpr:
@@ -213,6 +343,13 @@ class BufferExpr:
             return BufferExpr.leaf(value)
         if isinstance(value, (int, float)):
             return BufferExpr("scalar", scalar=value)
+        if isinstance(value, BufferSlice):
+            raise TypeError(
+                f"cannot use {value!r} in an elementwise expression: a partial "
+                "subscript names a DMA region, not a value. Move the region into "
+                "an L1 buffer with air.api.ops.load(dst, src[...]) and compute on "
+                "that buffer"
+            )
         raise TypeError(
             f"cannot use {value!r} ({type(value).__name__}) in an elementwise "
             "expression; expected a buffer slice or a numeric scalar"

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -20,16 +20,21 @@ Elementwise compute ops (``maximum``, ``minimum``, ``relu``, ``tanh``, and the
 ``sigmoid``/``silu``/``gelu`` compositions built on them) build lazy expression
 nodes instead, and return a :class:`~air.api._value.BufferExpr`.
 
-The remaining compute ops from the wider API proposal (``dot``, ``exp``,
-``reduce``, ``stack``, ``dequant``, ``atomic_add``) are not implemented. They
-raise rather than returning a plausible-looking placeholder: a DSL that accepts
-an op it cannot lower produces a kernel that runs and is silently wrong.
-``exp`` is on that list by choice rather than by oversight -- the activations
-here are composed from ``tanh``, which has a checked lowering, so nothing has
-needed a vector ``exp`` yet.
+``dot`` is a statement rather than an expression: it accumulates into a buffer
+and returns a Token, matching the signature the API proposal specified. On rank-6
+(micro-tiled) operands it becomes the blocked contraction the AIE2 matmul
+intrinsic wants; see ``air.api._pack``.
+
+The remaining compute ops from the wider API proposal (``reduce``, ``exp``,
+``stack``, ``dequant``, ``atomic_add``) are not implemented. They raise rather
+than returning a plausible-looking placeholder: a DSL that accepts an op it
+cannot lower produces a kernel that runs and is silently wrong. ``exp`` is on
+that list by choice rather than by oversight -- the activations here are composed
+from ``tanh``, which has a checked lowering, so nothing has needed a vector
+``exp`` yet.
 """
 
-from ._value import Buffer, BufferExpr, TensorSlice, Token
+from ._value import Buffer, BufferExpr, BufferSlice, TensorSlice, Token
 
 __all__ = [
     "load",
@@ -42,6 +47,7 @@ __all__ = [
     "sigmoid",
     "silu",
     "gelu",
+    "dot",
 ]
 
 
@@ -66,69 +72,223 @@ def _check_padding(pad_before, pad_after):
     )
 
 
-def _check_transfer(buf, sl, direction):
-    if not isinstance(buf, Buffer):
-        raise TypeError(
-            f"air.api.ops.{direction} expects an L1 buffer from air.alloc(), got "
-            f"{type(buf).__name__}"
-        )
-    if not isinstance(sl, TensorSlice):
-        raise TypeError(
-            f"air.api.ops.{direction} expects a tensor slice such as A[i:i+n], "
-            f"got {type(sl).__name__}"
-        )
-    if buf.value is None:
-        raise RuntimeError("buffer used before allocation")
-    if tuple(sl.sizes) != buf.shape:
-        raise ValueError(
-            f"transfer shape mismatch: buffer is {buf.shape} but the tensor "
-            f"slice is {tuple(sl.sizes)}"
-        )
-    if sl.dtype is not buf.dtype:
-        raise ValueError(
-            f"transfer dtype mismatch: buffer is {buf.dtype} but the tensor is "
-            f"{sl.dtype}"
-        )
+# A transfer endpoint is a whole buffer, a region of one, or a region of a
+# global tensor. `Endpoint` normalises the three into (value, dtype, sizes,
+# access pattern) so load and store can be written once for every level of the
+# memory hierarchy -- L3 to L2, L2 to L1, L1 to L2, L2 to L3.
+class _Endpoint:
+    __slots__ = ("value", "dtype", "sizes", "pattern", "tensor", "what", "raw")
+
+    def __init__(
+        self, value, dtype, sizes, pattern, tensor=None, what="buffer", raw=None
+    ):
+        self.value = value
+        self.dtype = dtype
+        self.sizes = sizes
+        # None means "the whole memref": dma_memcpy_nd prints that as [] [] [].
+        self.pattern = pattern
+        self.tensor = tensor
+        self.what = what
+        # The pattern before its offsets were materialised into SSA values, kept
+        # so a packed destination can re-derive the pattern from it (see
+        # _repack_source). Materialising is one-way.
+        self.raw = raw
 
 
-def load(dst, src_slice, pad_before=None, pad_after=None, dependency=None):
-    """Copy a tile from a global tensor into an L1 buffer (L3 -> L1)."""
-    from air.dialects.air import dma_memcpy_nd
-
-    _check_dependency(dependency)
-    _check_padding(pad_before, pad_after)
-    _check_transfer(dst, src_slice, "load")
-
-    op = dma_memcpy_nd(
-        dst.value,
-        src_slice.tensor.value,
-        src_offsets=src_slice.materialize_offsets(),
-        src_sizes=list(src_slice.sizes),
-        src_strides=list(src_slice.strides),
+def _endpoint(obj, direction, role):
+    if isinstance(obj, Buffer):
+        if obj.value is None:
+            raise RuntimeError("buffer used before allocation")
+        # A micro-tiled buffer is contiguous, so it still transfers as a whole
+        # memref; but it is *shaped* [.., N/n, M/m, m, n] while the other end
+        # thinks in [.., M, N], so it reports the logical extents.
+        sizes = obj.pack.lead + obj.pack.logical if obj.pack else obj.shape
+        return _Endpoint(obj.value, obj.dtype, sizes, None, what="buffer")
+    if isinstance(obj, BufferSlice):
+        if obj.value is None:
+            raise RuntimeError("buffer used before allocation")
+        return _Endpoint(
+            obj.value,
+            obj.dtype,
+            tuple(obj.logical_sizes),
+            (obj.materialize_offsets(), list(obj.sizes), list(obj.strides)),
+            what="buffer slice",
+            raw=(list(obj.offsets), list(obj.sizes), list(obj.strides)),
+        )
+    if isinstance(obj, TensorSlice):
+        return _Endpoint(
+            obj.tensor.value,
+            obj.dtype,
+            tuple(obj.sizes),
+            (obj.materialize_offsets(), list(obj.sizes), list(obj.strides)),
+            tensor=obj.tensor,
+            what="tensor slice",
+            raw=(list(obj.offsets), list(obj.sizes), list(obj.strides)),
+        )
+    raise TypeError(
+        f"air.api.ops.{direction} expects its {role} to be a buffer from "
+        f"air.alloc(), a region of one such as staged[tx, 0:n, :], or a tensor "
+        f"slice such as A[i:i+n]; got {type(obj).__name__}"
     )
-    return Token(op)
 
 
-def store(src, dst_slice, pad_before=None, pad_after=None, dependency=None):
-    """Copy an L1 buffer back into a global tensor (L1 -> L3)."""
+def _squeeze_leading_units(sizes, rank):
+    """Drop leading unit dimensions until ``sizes`` has rank ``rank``.
+
+    A staged L2 tile is indexed per core, so the natural access pattern carries
+    a leading 1 -- ``staged[tx, j:j+m, :]`` is ``[1, m, k]`` into an ``[m, k]``
+    L1 buffer, exactly as the hand-written matvec kernel writes it. Only leading
+    ones are dropped, so a genuine shape mismatch still fails.
+    """
+    sizes = list(sizes)
+    while len(sizes) > rank and sizes[0] == 1:
+        sizes.pop(0)
+    return tuple(sizes)
+
+
+def _check_pair(dst, src, direction):
+    """Shapes and dtypes must agree, up to leading unit dimensions."""
+    d, s = tuple(dst.sizes), tuple(src.sizes)
+    if d != s:
+        rank = min(len(d), len(s))
+        if _squeeze_leading_units(d, rank) != _squeeze_leading_units(s, rank):
+            raise ValueError(
+                f"transfer shape mismatch in air.api.ops.{direction}: the "
+                f"destination {dst.what} is {d} but the source {src.what} is {s}"
+            )
+    if dst.dtype is not src.dtype:
+        raise ValueError(
+            f"transfer dtype mismatch in air.api.ops.{direction}: the "
+            f"destination {dst.what} is {dst.dtype} but the source {src.what} "
+            f"is {src.dtype}"
+        )
+
+
+def _emit_dma(dst, src):
     from air.dialects.air import dma_memcpy_nd
 
+    kwargs = {}
+    if dst.pattern is not None:
+        offsets, sizes, strides = dst.pattern
+        kwargs.update(dst_offsets=offsets, dst_sizes=sizes, dst_strides=strides)
+    if src.pattern is not None:
+        offsets, sizes, strides = src.pattern
+        kwargs.update(src_offsets=offsets, src_sizes=sizes, src_strides=strides)
+    return dma_memcpy_nd(dst.value, src.value, **kwargs)
+
+
+def load(dst, src, pad_before=None, pad_after=None, dependency=None):
+    """Fill a buffer from a tensor or from a coarser buffer.
+
+    ``load(l1, A[i:i+n])`` is L3 to L1; ``load(l1, staged[tx, 0:n, :])`` is L2 to
+    L1; ``load(l2, A[i:i+n])`` is L3 to L2. The destination is always the buffer
+    being filled.
+    """
     _check_dependency(dependency)
     _check_padding(pad_before, pad_after)
-    _check_transfer(src, dst_slice, "store")
+
+    if not isinstance(dst, Buffer):
+        raise TypeError(
+            f"air.api.ops.load fills a buffer, so its first argument must be one "
+            f"from air.alloc(); got {type(dst).__name__}"
+        )
+    dst_ep = _endpoint(dst, "load", "destination")
+    src_ep = _endpoint(src, "load", "source")
+    if dst.pack is not None:
+        src_ep = _repack_source(dst, src, src_ep)
+    _check_pair(dst_ep, src_ep, "load")
+    return Token(_emit_dma(dst_ep, src_ep))
+
+
+def _repack_source(dst, src, src_ep):
+    """Re-walk a flat source in micro-tile order, for a packed destination.
+
+    Filling a micro-tiled A or B tile is the one transfer where the access
+    pattern goes on the *other* side: the destination is contiguous (``[] [] []``
+    in the emitted IR) and the flat source is read out of order, so that the DMA
+    itself performs the pack. The pattern is derived from the destination's
+    micro-tile, so the call site writes an ordinary logical slice::
+
+        ops.load(l1_a, l2_a[tx, 0, :, kk : kk + tile_k])
+
+    A packed source, by contrast, already carries its own pattern -- it is an
+    unpack, and ``Buffer.__getitem__`` built it.
+    """
+    from ._pack import pack_pattern
+
+    # A packed source is already an unpack and carries its own pattern.
+    if _pack_of(src) is not None:
+        return src_ep
+    if dst.pack.role == "C":
+        raise NotImplementedError(
+            "air.api.ops.load into a micro-tiled C accumulator is not supported: "
+            "C is written by ops.dot and drained with ops.store. Zero it with "
+            "acc[:] = 0.0 rather than loading into it."
+        )
+    if src_ep.raw is None:
+        raise TypeError(
+            "air.api.ops.load into a micro-tiled buffer needs a source *region*, "
+            f"not a whole buffer, so that the {dst.pack.role} pack can be "
+            "derived; index the source, e.g. l2_a[tx, 0, :, k : k + tile_k]"
+        )
+    offsets, sizes, strides = src_ep.raw
+    if len(sizes) != len(dst.pack.lead) + 2:
+        raise ValueError(
+            f"air.api.ops.load into a micro-tiled {dst.pack.role} buffer needs a "
+            f"source region of rank {len(dst.pack.lead) + 2}, with the two "
+            f"logical axes last; got rank {len(sizes)}, {tuple(sizes)}"
+        )
+    p_off, p_sizes, p_strides = pack_pattern(dst.pack, sizes, strides, offsets)
+    src_ep.pattern = ([o.materialize() for o in p_off], p_sizes, p_strides)
+    return src_ep
+
+
+def _pack_of(obj):
+    if isinstance(obj, Buffer):
+        return obj.pack
+    if isinstance(obj, BufferSlice):
+        return obj.buffer.pack
+    return None
+
+
+def store(src, dst, pad_before=None, pad_after=None, dependency=None):
+    """Drain a buffer into a tensor or into a coarser buffer.
+
+    ``store(l1, C[i:i+n])`` is L1 to L3; ``store(l1, staged[tx, :])`` is L1 to
+    L2; ``store(l2, C[i:i+n])`` is L2 to L3. The source is always the buffer
+    being drained.
+    """
+    _check_dependency(dependency)
+    _check_padding(pad_before, pad_after)
+
+    if isinstance(src, Buffer) and src.pack is not None:
+        # Draining a micro-tiled buffer whole would emit `[] [] []` -- a
+        # contiguous read, which copies the tile still in micro-tile order and is
+        # silently wrong. The unpack lives in the access pattern, so the source
+        # has to be subscripted for one to exist.
+        raise TypeError(
+            "air.api.ops.store cannot drain a micro-tiled buffer whole: the "
+            "unpack back to row-major order is the access pattern, and a whole "
+            "buffer has none. Subscript it in logical coordinates, e.g. "
+            f"ops.store(acc[{', '.join(['0'] * len(src.pack.lead))}, :, :], "
+            "l2_c[...])."
+        )
+    if not isinstance(src, (Buffer, BufferSlice)):
+        raise TypeError(
+            f"air.api.ops.store drains a buffer, so its first argument must be "
+            f"one from air.alloc() or a region of one; got {type(src).__name__}"
+        )
+    src_ep = _endpoint(src, "store", "source")
+    dst_ep = _endpoint(dst, "store", "destination")
+    _check_pair(dst_ep, src_ep, "store")
 
     # Being the destination of a store is what makes a tensor an output, which
-    # in turn fixes the kernel's calling convention (inputs first, then outputs).
-    dst_slice.tensor.is_output = True
+    # in turn fixes the kernel's calling convention (inputs first, then
+    # outputs). A store into L2 is staging, not an output, so it must not count.
+    if dst_ep.tensor is not None:
+        dst_ep.tensor.is_output = True
 
-    op = dma_memcpy_nd(
-        dst_slice.tensor.value,
-        src.value,
-        dst_offsets=dst_slice.materialize_offsets(),
-        dst_sizes=list(dst_slice.sizes),
-        dst_strides=list(dst_slice.strides),
-    )
-    return Token(op)
+    return Token(_emit_dma(dst_ep, src_ep))
 
 
 def copy(src_slice, dst_slice, pad_before=None, pad_after=None, dependency=None):
@@ -235,6 +395,242 @@ def gelu(x):
     return 0.5 * expr * (tanh(inner) + 1.0)
 
 
+# ---------------------------------------------------------------------------
+# Matrix multiply-accumulate
+# ---------------------------------------------------------------------------
+
+
+# Rank dispatch, following numpy.dot / tl.dot rather than linalg's naming: `dot`
+# is the contraction, and which linalg op carries it depends on the operand
+# ranks. The rule is uniform -- contract a's last axis against b's first, and the
+# accumulator keeps what is left of each -- so all four cases fall out of one
+# shape computation.
+_CONTRACTIONS = {
+    (1, 1): ("dot", "(k,) . (k,) -> ()"),
+    (1, 2): ("vecmat", "(k,) @ (k, n) -> (n,)"),
+    (2, 1): ("matvec", "(m, k) @ (k,) -> (m,)"),
+    (2, 2): ("matmul", "(m, k) @ (k, n) -> (m, n)"),
+}
+
+
+# The micro-tiled contraction. `linalg` has no named op for it -- the reference
+# example defines it with the OpDSL, and so does this, from the same index
+# expression. It is built lazily because the OpDSL decorator runs once and
+# importing linalg.opdsl at module scope would pull it in for every program
+# regardless of whether anything contracts.
+_BLOCK_MATMUL = None
+
+
+def _block_matmul_op():
+    global _BLOCK_MATMUL
+    if _BLOCK_MATMUL is not None:
+        return _BLOCK_MATMUL
+
+    import air.dialects.linalg.opdsl.lang as lang
+    from air.dialects.linalg.opdsl.lang import (
+        D,
+        S,
+        TensorDef,
+        TypeFn,
+        domain,
+        linalg_structured_op,
+    )
+
+    @linalg_structured_op()
+    def block_matmul(
+        A=TensorDef(lang.TV.T1, S.a, S.c, S.f, S.d, S.g, S.i),
+        B=TensorDef(lang.TV.T2, S.b, S.c, S.e, S.f, S.i, S.h),
+        C=TensorDef(lang.TV.U, S.b, S.a, S.e, S.d, S.g, S.h, output=True),
+    ):
+        domain(D.a, D.b, D.c, D.d, D.e, D.f, D.g, D.h, D.i)
+        C[D.b, D.a, D.e, D.d, D.g, D.h] += TypeFn.cast_signed(
+            lang.TV.U, A[D.a, D.c, D.f, D.d, D.g, D.i]
+        ) * TypeFn.cast_signed(lang.TV.U, B[D.b, D.c, D.e, D.f, D.i, D.h])
+
+    _BLOCK_MATMUL = block_matmul
+    return _BLOCK_MATMUL
+
+
+def accumulator_subview(acc):
+    """The calling core's slab of a micro-tiled accumulator.
+
+    A herd-shared accumulator is one memref with a leading dimension per herd
+    axis, and a core may only touch its own slab -- there is no choice to make,
+    so the DSL emits the ``memref.subview`` itself rather than asking for
+    coordinates it could only re-check. A per-core accumulator has leading
+    dimensions of 1 and needs no subview in principle; one is emitted anyway,
+    because that is the op the transform script's tile sizes are stated against.
+    """
+    from air.dialects.memref import subview
+
+    from ._trace import current_herd
+
+    nlead = len(acc.pack.lead)
+    coords = current_herd()._coords
+    if len(coords) > nlead:
+        raise ValueError(
+            f"the accumulator has {nlead} leading dimension(s) but the herd is "
+            f"{len(coords)}-D; a herd-shared accumulator needs one leading "
+            "dimension per herd axis so that every core has its own slab"
+        )
+    offsets = [c.materialize() for c in coords]
+    offsets += [0] * (len(acc.shape) - len(offsets))
+    sizes = [1] * nlead + list(acc.shape[nlead:])
+    return subview(
+        acc.value, offsets=offsets, sizes=sizes, strides=[1] * len(acc.shape)
+    )
+
+
+def _check_packed_operands(a, b, acc):
+    """The three micro-tiles have to agree on m, k, n and on their extents."""
+    packs = {"a": a.pack, "b": b.pack, "acc": acc.pack}
+    missing = [n for n, p in packs.items() if p is None]
+    if missing:
+        raise TypeError(
+            f"air.api.ops.dot got rank-6 operands, which means the micro-tiled "
+            f"contraction, but {', '.join(missing)} "
+            f"{'was' if len(missing) == 1 else 'were'} not allocated with a "
+            "micro-tiled shape. Allocate all three from the same air.micro_tile, "
+            "e.g. air.alloc(mm.a(tile_m, tile_k), bf16, scope=h.private())."
+        )
+    roles = {"a": "A", "b": "B", "acc": "C"}
+    for name, want in roles.items():
+        if packs[name].role != want:
+            raise ValueError(
+                f"air.api.ops.dot expects {name} to be a micro-tiled {want} "
+                f"operand (mm.{want.lower()}(...)), but it was built as "
+                f"{packs[name].role}"
+            )
+    micros = {n: p.micro for n, p in packs.items()}
+    if len(set(micros.values())) != 1:
+        raise ValueError(
+            "air.api.ops.dot needs one micro-tile across all three operands, "
+            f"got a={micros['a']!r}, b={micros['b']!r}, acc={micros['acc']!r}. "
+            "The micro-tile is the shape of the hardware intrinsic; mixing them "
+            "would silently contract the wrong elements."
+        )
+    (m_a, k_a), (k_b, n_b), (m_c, n_c) = (
+        packs["a"].logical,
+        packs["b"].logical,
+        packs["acc"].logical,
+    )
+    if k_a != k_b:
+        raise ValueError(
+            f"air.api.ops.dot shape mismatch: a is {m_a}x{k_a} and b is "
+            f"{k_b}x{n_b}; the contracting extents must agree"
+        )
+    if (m_c, n_c) != (m_a, n_b):
+        raise ValueError(
+            f"air.api.ops.dot shape mismatch: a @ b is {m_a}x{n_b} but acc is "
+            f"{m_c}x{n_c}"
+        )
+
+
+def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
+    """``acc += a @ b`` over L1 tiles. Returns a :class:`Token`.
+
+    This is a *statement*, not an expression, and the accumulator is a buffer
+    rather than a value -- the signature the API proposal specified, and the
+    right one for the hardware. Accumulating into memory is what
+    ``linalg.matmul``'s ``outs=`` means, and it avoids a loop-carried SSA vector
+    accumulator, which LLVM splits into sub-512-bit pieces the AIE2 backend
+    cannot legalize.
+
+    What is emitted is a plain ``linalg.matmul``. That is deliberate and is what
+    every matmul example in this tree does: none of them hand-writes
+    ``vector.contract``. Emitting linalg is the fork point that keeps both
+    lowering strategies available -- ``transform.air.herd_vectorize`` for direct
+    codegen, or ``lower_linalg_to_func`` to call an external kernel -- and
+    hand-writing the vectorised form would forfeit the second.
+
+    Mixed precision is expected: ``a``/``b`` are typically bf16 and ``acc`` f32.
+
+    The operand ranks pick the contraction, as ``numpy.dot`` does -- ``dot`` here
+    means the contraction, not specifically a vector inner product:
+
+    ==============  ==========================  =================
+    ranks           shapes                      linalg op
+    ==============  ==========================  =================
+    1-D x 1-D       ``(k,) . (k,) -> ()``       ``linalg.dot``
+    1-D x 2-D       ``(k,) @ (k,n) -> (n,)``    ``linalg.vecmat``
+    2-D x 1-D       ``(m,k) @ (k,) -> (m,)``    ``linalg.matvec``
+    2-D x 2-D       ``(m,k) @ (k,n) -> (m,n)``  ``linalg.matmul``
+    ==============  ==========================  =================
+
+    One rule covers all four: ``a``'s last axis contracts against ``b``'s first,
+    and ``acc`` keeps what is left of each.
+    """
+    from air.dialects import linalg
+
+    _check_dependency(dependency)
+    for name, buf in (("a", a), ("b", b), ("acc", acc)):
+        if buf is None:
+            raise TypeError(f"air.api.ops.dot requires {name}=")
+        if not isinstance(buf, Buffer):
+            raise TypeError(
+                f"air.api.ops.dot expects {name} to be an L1 buffer from "
+                f"air.alloc(), got {type(buf).__name__}"
+            )
+        if buf.value is None:
+            raise RuntimeError(f"air.api.ops.dot: {name} used before allocation")
+
+    if alpha != 1.0:
+        raise NotImplementedError(
+            "air.api.ops.dot(alpha=...) is not implemented yet; it needs a "
+            "scaled linalg.generic rather than a named contraction"
+        )
+
+    ranks = (len(a.shape), len(b.shape))
+    if ranks == (6, 6):
+        if transpose_b:
+            raise NotImplementedError(
+                "air.api.ops.dot(transpose_b=True) is not implemented for "
+                "micro-tiled operands; pack B transposed instead"
+            )
+        _check_packed_operands(a, b, acc)
+        op = _block_matmul_op()(a.value, b.value, outs=[accumulator_subview(acc)])
+        return Token(op)
+
+    if ranks not in _CONTRACTIONS:
+        raise NotImplementedError(
+            f"air.api.ops.dot contracts 1-D and 2-D tiles; got ranks {ranks} "
+            f"(a is {a.shape}, b is {b.shape}). There is no named linalg op past "
+            "one batch dimension, and a batch axis belongs in the herd grid if "
+            "it is spatial or in air.sequential if it is temporal -- putting it "
+            "inside the contraction hides the schedule."
+        )
+    op_name, signature = _CONTRACTIONS[ranks]
+
+    if transpose_b and ranks != (2, 2):
+        raise ValueError(
+            f"air.api.ops.dot(transpose_b=True) is meaningless for {signature}; "
+            "it transposes a matrix operand"
+        )
+    if transpose_b:
+        raise NotImplementedError(
+            "air.api.ops.dot(transpose_b=True) is not implemented yet; it needs "
+            "linalg.matmul_transpose_b"
+        )
+
+    # a's last axis contracts against b's first; acc keeps the rest of each.
+    k_a, k_b = a.shape[-1], b.shape[0]
+    if k_a != k_b:
+        raise ValueError(
+            f"air.api.ops.dot shape mismatch for {signature}: a is {a.shape} and "
+            f"b is {b.shape}; a's contracting dimension ({k_a}) must equal b's "
+            f"({k_b})"
+        )
+    expected = tuple(a.shape[:-1]) + tuple(b.shape[1:])
+    if tuple(acc.shape) != expected:
+        raise ValueError(
+            f"air.api.ops.dot shape mismatch for {signature}: a . b is "
+            f"{expected} but acc is {tuple(acc.shape)}"
+        )
+
+    op = getattr(linalg, op_name)(a.value, b.value, outs=[acc.value])
+    return Token(op)
+
+
 def _unimplemented(name, needs):
     def stub(*args, **kwargs):
         raise NotImplementedError(
@@ -247,7 +643,6 @@ def _unimplemented(name, needs):
 
 # Named so that a program using them fails loudly at the call site rather than
 # at compile time with a confusing IR error.
-dot = _unimplemented("dot", "linalg/vector.contract lowering")
 # math.exp exists in the bindings, but nothing needs it yet and it has not
 # been checked for an aievec lowering -- untested surface is worse than none.
 exp = _unimplemented("exp", "a checked aievec lowering; use ops.tanh, which has one")

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -571,6 +571,17 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
                 f"air.api.ops.dot expects {name} to be an L1 buffer from "
                 f"air.alloc(), got {type(buf).__name__}"
             )
+        if buf.space != "L1":
+            # A contraction runs on a core, and only L1 is core-local. An L2
+            # buffer reaching here would emit a contraction over memtile memory,
+            # which has DMA engines and no compute -- the same rule that makes
+            # an elementwise read of an L2 buffer an error.
+            raise TypeError(
+                f"air.api.ops.dot expects {name} to be an L1 buffer, but it is "
+                f"in {buf.space}: a memtile has DMA engines and no compute "
+                "core, so it cannot be contracted over. Stage the tile into L1 "
+                "with air.api.ops.load first."
+            )
         if buf.value is None:
             raise RuntimeError(f"air.api.ops.dot: {name} used before allocation")
 

--- a/python/test/api/dot.py
+++ b/python/test/api/dot.py
@@ -1,0 +1,168 @@
+# ./python/test/api/dot.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers a tiled contraction: a K reduction accumulating into a buffer.
+
+Two pieces of surface are exercised here that the elementwise examples do not
+reach. Both are load-bearing for correctness on hardware, not conveniences:
+
+``air.sequential`` emits an ``scf.for``. A plain Python ``for k in range(...)`` runs
+at trace time and unrolls, so the AIE core comes out with no loop in it -- just
+one straight-line copy of the body per trip over the same L1 buffers, with the
+objectFifo acquire/release pairs stranded between the copies. That kernel builds
+and runs and computes with stale operands. The loop has to reach the compiler as
+a loop; see the ``dot_k_loop`` check that the DMAs and the matmul are *inside*
+the ``scf.for``.
+
+Scalar fill: ``acc[:] = 0.0`` has no buffer on the right-hand side, and the
+destination alone supplies the shape. That is how an accumulator is zeroed
+before a reduction, and for ``linalg.dot`` the destination is rank 0.
+
+Rank dispatch: ``ops.dot`` is the *contraction*, in the ``numpy.dot`` /
+``tl.dot`` sense rather than linalg's narrower one, so the operand ranks pick
+which named op carries it. One rule covers all four -- ``a``'s last axis
+contracts against ``b``'s first, and ``acc`` keeps what is left of each.
+"""
+
+from air import api as air
+from air.api import ops  # noqa: F401
+from air.api.types import bf16, f32
+
+
+def build(M, N, K, tm, tn, tk, herd_shape=None):
+    A = air.tensor([M, K], bf16)
+    B = air.tensor([K, N], bf16)
+    C = air.tensor([M, N], f32)
+
+    with air.launch(name="gemm") as launch:
+
+        @launch.body
+        def _():
+            # A list of ranges, not itertools.product: product materialises its
+            # inputs, so a single-tile axis loses its step. See errors.py.
+            with air.herd([range(0, M, tm), range(0, N, tn)], shape=herd_shape) as h:
+
+                @h.body
+                def _(tx, ty):
+                    bm, bn = h.tile_sizes
+                    row, col = tx * bm, ty * bn
+
+                    acc = air.alloc([bm, bn], f32, scope=h.private())
+                    a_buf = air.alloc([bm, tk], bf16, scope=h.private())
+                    b_buf = air.alloc([tk, bn], bf16, scope=h.private())
+
+                    acc[:] = 0.0
+                    for k in air.sequential(0, K, tk):
+                        air.ops.load(a_buf, A[row : row + bm, k : k + tk])
+                        air.ops.load(b_buf, B[k : k + tk, col : col + bn])
+                        air.ops.dot(a_buf, b_buf, acc=acc)
+
+                    air.ops.store(acc, C[row : row + bm, col : col + bn])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: dot_k_loop
+# The accumulator is filled first, outside the K loop -- a vector broadcast of
+# zero written across the tile, with no transfer_read, because there is no
+# buffer on the right-hand side.
+# CHECK: func.func @gemm(%{{.*}}: memref<64x64xbf16>, %{{.*}}: memref<64x64xbf16>, %{{.*}}: memref<64x64xf32>)
+# CHECK: air.herd @herd_0
+# CHECK: memref.alloc() : memref<32x32xf32, 2 : i32>
+# CHECK: vector.broadcast %{{.*}} : f32 to vector<16xf32>
+# CHECK: vector.transfer_write
+#
+# Then the K reduction: one scf.for whose *body* holds both loads and the
+# matmul. The step is the K tile, so this is a real loop over 2 trips rather
+# than two unrolled copies -- exactly one linalg.matmul appears in the module.
+# CHECK: scf.for %{{.*}} = %c0{{.*}} to %c64{{.*}} step %c32
+# CHECK: air.dma_memcpy_nd
+# CHECK: air.dma_memcpy_nd
+# CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<32x32xbf16, 2 : i32>, memref<32x32xbf16, 2 : i32>) outs(%{{.*}} : memref<32x32xf32, 2 : i32>)
+# CHECK-NOT: linalg.matmul
+# CHECK: air.dma_memcpy_nd
+# CHECK: memref.dealloc
+@run
+def dot_k_loop():
+    print(build(64, 64, 64, 32, 32, 32, herd_shape=(2, 2)).mlir())
+
+
+# CHECK-LABEL: TEST: dot_single_core
+# A 1-D physical shape still gets its K loop; nothing about the reduction is
+# tied to the herd being 2-D.
+# CHECK: air.herd @herd_0 tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c1{{.*}}, %{{.*}}=%c1
+# CHECK: scf.for %{{.*}} = %c0{{.*}} to %c256{{.*}} step %c32
+# CHECK: linalg.matmul
+@run
+def dot_single_core():
+    print(build(32, 32, 256, 32, 32, 32, herd_shape=(1, 1)).mlir())
+
+
+# CHECK-LABEL: TEST: dot_mixed_precision
+# bf16 operands accumulating into f32 is the intended shape: linalg.matmul
+# carries the mixed types straight through.
+# CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<32x64xbf16, 2 : i32>, memref<64x32xbf16, 2 : i32>) outs(%{{.*}} : memref<32x32xf32, 2 : i32>)
+@run
+def dot_mixed_precision():
+    print(build(64, 64, 128, 32, 32, 64, herd_shape=(2, 2)).mlir())
+
+
+# CHECK-LABEL: TEST: dot_rank_dispatch
+# Four contractions from one spelling. Ranks pick the op; nothing else changes.
+# CHECK: memref.alloc() : memref<f32, 2 : i32>
+# CHECK: linalg.dot ins(%{{.*}}, %{{.*}} : memref<64xbf16, 2 : i32>, memref<64xbf16, 2 : i32>) outs(%{{.*}} : memref<f32, 2 : i32>)
+# CHECK: linalg.vecmat ins(%{{.*}}, %{{.*}} : memref<64xbf16, 2 : i32>, memref<64x32xbf16, 2 : i32>) outs(%{{.*}} : memref<32xf32, 2 : i32>)
+# CHECK: linalg.matvec ins(%{{.*}}, %{{.*}} : memref<32x64xbf16, 2 : i32>, memref<64xbf16, 2 : i32>) outs(%{{.*}} : memref<32xf32, 2 : i32>)
+# CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<32x64xbf16, 2 : i32>, memref<64x32xbf16, 2 : i32>) outs(%{{.*}} : memref<32x32xf32, 2 : i32>)
+@run
+def dot_rank_dispatch():
+    K, T = 64, 32
+    v = air.tensor([K], bf16)
+    m = air.tensor([T, K], bf16)
+    n = air.tensor([K, T], bf16)
+    out = air.tensor([T, T], f32)
+
+    with air.launch(name="ranks") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, 1, 1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    vb = air.alloc([K], bf16, scope=h.private())
+                    mb = air.alloc([T, K], bf16, scope=h.private())
+                    nb = air.alloc([K, T], bf16, scope=h.private())
+                    air.ops.load(vb, v[0:K])
+                    air.ops.load(mb, m[0:T, 0:K])
+                    air.ops.load(nb, n[0:K, 0:T])
+
+                    # (k,) . (k,) -> ()
+                    s = air.alloc([], f32, scope=h.private(), vector=0)
+                    s[:] = 0.0
+                    air.ops.dot(vb, vb, acc=s)
+                    # (k,) @ (k,n) -> (n,)
+                    y = air.alloc([T], f32, scope=h.private(), vector=0)
+                    y[:] = 0.0
+                    air.ops.dot(vb, nb, acc=y)
+                    # (m,k) @ (k,) -> (m,)
+                    z = air.alloc([T], f32, scope=h.private(), vector=0)
+                    z[:] = 0.0
+                    air.ops.dot(mb, vb, acc=z)
+                    # (m,k) @ (k,n) -> (m,n)
+                    c = air.alloc([T, T], f32, scope=h.private(), vector=0)
+                    c[:] = 0.0
+                    air.ops.dot(mb, nb, acc=c)
+                    air.ops.store(c, out[0:T, 0:T])
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -384,8 +384,6 @@ def _():
 
     _trace(body, grid=(512, 512, 256), shape=(2, 2))
 
-    _trace(body, grid=(512, 512, 256), shape=(2, 2))
-
 
 # A caller's own "tile must be a multiple of the vector width" guard does not
 # catch this: Python's modulo is 0 for any divisor of the tile, sign included,
@@ -787,3 +785,29 @@ def _():
         air.alloc([32, 32], bf16, scope=h.shared())
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_on_an_l2_buffer
+# A contraction runs on a core; a memtile has DMA engines and none. The
+# operand check said "L1 buffer" long before it checked for one.
+# CHECK: TypeError: air.api.ops.dot expects a to be an L1 buffer, but it is in L2
+@expect(TypeError, "dot_on_an_l2_buffer")
+def _():
+    def body(seg, A, C):
+        staged = air.alloc([32, 32], bf16, scope=seg.private())
+        ops.dot(staged, staged, acc=staged)
+
+    _staged(body)
+
+
+# CHECK-LABEL: TEST: shared_alloc_needs_a_packed_shape
+# The per-core L1 charge depends on knowing which leading dimensions are the
+# herd; a plain shape does not say, and guessing either way misreports the
+# budget.
+# CHECK: NotImplementedError: <segment>.shared() currently requires a micro-tiled shape
+@expect(NotImplementedError, "shared_alloc_needs_a_packed_shape")
+def _():
+    def body(seg, A, C):
+        air.alloc([1, 1, 32, 32], bf16, scope=seg.shared())
+
+    _staged(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -15,6 +15,7 @@ replaces: there, an unsupported construct was absorbed and the program still
 from itertools import product
 
 from air import api as air
+from air.api import ops  # noqa: F401
 from air.api.types import bf16, f32
 
 
@@ -90,7 +91,7 @@ def _():
 
 
 # CHECK-LABEL: TEST: partial_buffer_write
-# CHECK: NotImplementedError: partial write of an L1 buffer
+# CHECK: NotImplementedError: partial assignment into a buffer is not supported
 @expect(NotImplementedError, "partial_buffer_write")
 def _():
     def body(h, tx, ty, A, B, C):
@@ -167,9 +168,10 @@ def _():
     launch.mlir()
 
 
-# CHECK-LABEL: TEST: alloc_outside_herd
-# CHECK: RuntimeError: this operation must be used inside a herd body
-@expect(RuntimeError, "alloc_outside_herd")
+# CHECK-LABEL: TEST: alloc_without_scope
+# air.alloc has two scopes to choose between now, so the message names both.
+# CHECK: ValueError: air.alloc requires scope=<herd>.private() (L1) or scope=<segment>.private() (L2)
+@expect(ValueError, "alloc_without_scope")
 def _():
     air.alloc([8, 8], bf16, scope=None)
 
@@ -195,18 +197,90 @@ def _():
     _trace(body, shape=(3, 2))
 
 
+def _dot_shapes(a_shape, b_shape, acc_shape):
+    """Allocate three L1 tiles with the given shapes and call ops.dot on them."""
+    from air.api.types import bf16, f32
+
+    t = air.tensor([64], bf16)
+    with air.launch(name="dotchk") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, 64, 16), shape=(4,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc(a_shape, bf16, scope=h.private())
+                    b = air.alloc(b_shape, bf16, scope=h.private())
+                    acc = air.alloc(acc_shape, f32, scope=h.private())
+                    air.ops.dot(a, b, acc=acc)
+
+    launch.mlir()
+
+
 # CHECK-LABEL: TEST: unimplemented_op
-# CHECK: NotImplementedError: air.api.ops.dot is not implemented yet
+# CHECK: NotImplementedError: air.api.ops.reduce is not implemented yet
 @expect(NotImplementedError, "unimplemented_op")
+def _():
+    air.ops.reduce(None, 0, "add")
+
+
+# ops.dot is implemented, but it is a statement over three L1 buffers, so a
+# missing or non-buffer operand is a user error rather than something to default.
+# CHECK-LABEL: TEST: dot_requires_buffers
+# CHECK: TypeError: air.api.ops.dot requires a=
+@expect(TypeError, "dot_requires_buffers")
 def _():
     air.ops.dot(None, None)
 
 
-# CHECK-LABEL: TEST: unimplemented_segment
-# CHECK: NotImplementedError: air.api.segment is not implemented yet
-@expect(NotImplementedError, "unimplemented_segment")
+# CHECK-LABEL: TEST: dot_rank_too_high
+# There is no named linalg op past one batch dimension, and a batch axis belongs
+# in the herd grid or in air.sequential, not hidden inside the contraction.
+# CHECK: NotImplementedError: air.api.ops.dot contracts 1-D and 2-D tiles; got ranks (3, 3)
+@expect(NotImplementedError, "dot_rank_too_high")
 def _():
-    air.segment(range(2))
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([2, 8, 8], bf16, scope=h.private())
+        acc = air.alloc([2, 8, 8], f32, scope=h.private())
+        ops.dot(a, a, acc=acc)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_vecmat_acc_shape
+# The rank rule is uniform: a's last axis contracts against b's first, and acc
+# keeps what is left of each -- here (k,) @ (k,n) leaves (n,).
+# CHECK: ValueError: air.api.ops.dot shape mismatch for (k,) @ (k, n) -> (n,)
+@expect(ValueError, "dot_vecmat_acc_shape")
+def _():
+    def body(h, tx, ty, A, B, C):
+        v = air.alloc([64], bf16, scope=h.private())
+        m = air.alloc([64, 32], bf16, scope=h.private())
+        acc = air.alloc([64], f32, scope=h.private())  # should be [32]
+        ops.dot(v, m, acc=acc)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_transpose_b_on_a_vector
+# CHECK: ValueError: air.api.ops.dot(transpose_b=True) is meaningless for (m, k) @ (k,) -> (m,)
+@expect(ValueError, "dot_transpose_b_on_a_vector")
+def _():
+    def body(h, tx, ty, A, B, C):
+        m = air.alloc([32, 64], bf16, scope=h.private())
+        v = air.alloc([64], bf16, scope=h.private())
+        acc = air.alloc([32], f32, scope=h.private())
+        ops.dot(m, v, acc=acc, transpose_b=True)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_shape_mismatch
+# CHECK: ValueError: air.api.ops.dot shape mismatch
+@expect(ValueError, "dot_shape_mismatch")
+def _():
+    _dot_shapes((16, 32), (64, 16), (16, 16))
 
 
 # CHECK-LABEL: TEST: nonaffine_index
@@ -310,6 +384,8 @@ def _():
 
     _trace(body, grid=(512, 512, 256), shape=(2, 2))
 
+    _trace(body, grid=(512, 512, 256), shape=(2, 2))
+
 
 # A caller's own "tile must be a multiple of the vector width" guard does not
 # catch this: Python's modulo is 0 for any divisor of the tile, sign included,
@@ -320,5 +396,394 @@ def _():
 def _():
     def body(h, tx, ty, A, B, C):
         air.alloc([64, 64], bf16, scope=h.private(), vector=-4)
+
+    _trace(body)
+
+
+# ---------------------------------------------------------------------------
+# air.sequential and the K reduction
+# ---------------------------------------------------------------------------
+
+
+# CHECK-LABEL: TEST: product_single_tile_axis
+# itertools.product materialises its inputs, so a one-tile axis arrives as (0,)
+# with its step gone. Guessing 1 would silently compute on 1x1 tiles.
+# CHECK: ValueError: air.herd cannot recover the tile size of a single-tile axis
+@expect(ValueError, "product_single_tile_axis")
+def _():
+    air.herd(product(range(0, 64, 64), range(0, 128, 32)))
+
+
+# CHECK-LABEL: TEST: sequential_partial_trip
+# CHECK: ValueError: air.sequential(0, 100, 32) does not tile its extent exactly
+@expect(ValueError, "sequential_partial_trip")
+def _():
+    def body(h, tx, ty, A, B, C):
+        for _ in air.sequential(0, 100, 32):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: sequential_negative_step
+# CHECK: ValueError: air.sequential needs a positive step, got -1
+@expect(ValueError, "sequential_negative_step")
+def _():
+    def body(h, tx, ty, A, B, C):
+        for _ in air.sequential(0, 64, -1):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: sequential_non_integer_bound
+# CHECK: TypeError: air.sequential(stop=...) takes a Python integer
+@expect(TypeError, "sequential_non_integer_bound")
+def _():
+    def body(h, tx, ty, A, B, C):
+        for _ in air.sequential(0, 64.0, 32):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: sequential_bound_from_tile_coordinate
+# A loop bound is resolved at trace time; a tile coordinate is an SSA value and
+# cannot be one.
+# CHECK: TypeError: air.sequential(stop=...) takes a Python integer
+@expect(TypeError, "sequential_bound_from_tile_coordinate")
+def _():
+    def body(h, tx, ty, A, B, C):
+        for _ in air.sequential(0, tx, 1):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: alloc_inside_sequential
+# The herd frees its buffers after the body, which is outside the loop, so the
+# dealloc would not be dominated by its alloc.
+# CHECK: NotImplementedError: air.alloc inside an air.sequential body is not supported
+@expect(NotImplementedError, "alloc_inside_sequential")
+def _():
+    def body(h, tx, ty, A, B, C):
+        for _ in air.sequential(0, 64, 32):
+            air.alloc([32, 32], bf16, scope=h.private())
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: break_out_of_sequential
+# An air.sequential body is traced once and stands for every trip, so breaking out
+# truncates all of them rather than shortening the loop.
+# CHECK: RuntimeError: a body left an air.sequential loop early
+@expect(RuntimeError, "break_out_of_sequential")
+def _():
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([32, 32], bf16, scope=h.private())
+        for _ in air.sequential(0, 64, 32):
+            buf[:] = buf[:] + 1.0
+            break
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_alpha_unimplemented
+# CHECK: NotImplementedError: air.api.ops.dot(alpha=...) is not implemented
+@expect(NotImplementedError, "dot_alpha_unimplemented")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 32], bf16, scope=h.private())
+        b = air.alloc([32, 32], bf16, scope=h.private())
+        acc = air.alloc([32, 32], f32, scope=h.private())
+        ops.dot(a, b, acc=acc, alpha=2.0)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: parallel_unimplemented
+# The unordered counterpart of air.sequential. Declared so that reaching for it
+# says what it would be, rather than raising AttributeError.
+# CHECK: NotImplementedError: air.api.parallel is not implemented yet
+@expect(NotImplementedError, "parallel_unimplemented")
+def _():
+    air.parallel(0, 64, 16)
+
+
+# ---------------------------------------------------------------------------
+# air.segment and L2 staging
+# ---------------------------------------------------------------------------
+
+
+def _staged(body, l2_shape=(64, 64), dtype=bf16):
+    """Build a launch whose *segment* body is ``body(seg, A, C)``."""
+    A = air.tensor(list(l2_shape), dtype)
+    C = air.tensor(list(l2_shape), dtype)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    body(seg, A, C)
+
+    return launch.mlir()
+
+
+# CHECK-LABEL: TEST: elementwise_on_l2
+# A memtile has DMA engines but no compute core, so an L2 buffer can only be a
+# transfer endpoint.
+# CHECK: TypeError: cannot read an L2 buffer elementwise
+@expect(TypeError, "elementwise_on_l2")
+def _():
+    def body(seg, A, C):
+        staged = air.alloc([64, 64], bf16, scope=seg.private())
+        staged[:] = staged[:] + 1.0
+
+    _staged(body)
+
+
+# CHECK-LABEL: TEST: l2_alloc_outside_segment
+# CHECK: RuntimeError: this operation must be used inside a segment body
+@expect(RuntimeError, "l2_alloc_outside_segment")
+def _():
+    seg = air.segment(name="detached")
+
+    def body(h, tx, ty, A, B, C):
+        air.alloc([32, 32], bf16, scope=seg.private())
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: l1_alloc_outside_herd
+# CHECK: RuntimeError: this operation must be used inside a herd body
+@expect(RuntimeError, "l1_alloc_outside_herd")
+def _():
+    def body(seg, A, C):
+        h = air.herd(range(0, 64, 32), shape=(2,))
+        air.alloc([32, 32], bf16, scope=h.private())
+
+    _staged(body)
+
+
+# CHECK-LABEL: TEST: l2_budget_exceeded
+# 512 KB per memtile, the figure the hand-written staging examples assert.
+# CHECK: ValueError: air.alloc([1024, 1024], air.api.bf16) needs 2048.0 KB
+@expect(ValueError, "l2_budget_exceeded")
+def _():
+    def body(seg, A, C):
+        air.alloc([1024, 1024], bf16, scope=seg.private())
+
+    _staged(body)
+
+
+# A segment grid is the launch iteration space, and air.launch is 2-D.
+# CHECK-LABEL: TEST: segment_grid_too_deep
+# CHECK: NotImplementedError: air.launch is 2-D, so a segment grid is 1-D or 2-D
+@expect(NotImplementedError, "segment_grid_too_deep")
+def _():
+    air.segment(product(range(0, 128, 64), range(0, 128, 64), range(0, 128, 64)))
+
+
+# CHECK-LABEL: TEST: segment_body_takes_no_args
+# CHECK: TypeError: segment body takes 1 coordinate argument(s) but the launch iteration space is 0-D
+@expect(TypeError, "segment_body_takes_no_args")
+def _():
+    air.tensor([64, 64], bf16)
+    air.tensor([64, 64], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _(sx):
+                    pass
+
+    launch.mlir()
+
+
+# CHECK-LABEL: TEST: buffer_slice_in_expression
+# A partial subscript names a DMA region, not a value.
+# CHECK: TypeError: cannot use BufferSlice
+@expect(TypeError, "buffer_slice_in_expression")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 32], bf16, scope=h.private())
+        b = air.alloc([32, 32], bf16, scope=h.private())
+        b[:] = a[0:16, :]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: partial_assignment_into_buffer
+# CHECK: NotImplementedError: partial assignment into a buffer is not supported
+@expect(NotImplementedError, "partial_assignment_into_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 32], bf16, scope=h.private())
+        a[0:16, :] = 1.0
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: staged_transfer_shape_mismatch
+# Only *leading* unit dimensions are squeezed, so a genuine mismatch still
+# fails rather than being reshaped into something plausible.
+# CHECK: ValueError: transfer shape mismatch in air.api.ops.load
+@expect(ValueError, "staged_transfer_shape_mismatch")
+def _():
+    def body(seg, A, C):
+        staged = air.alloc([64, 64], bf16, scope=seg.private())
+
+        with air.herd(range(0, 2, 1), shape=(2,)) as h:
+
+            @h.body
+            def _(tx):
+                l1 = air.alloc([16], bf16, scope=h.private())
+                ops.load(l1, staged[tx, 0:32])
+
+    _staged(body)
+
+
+# CHECK-LABEL: TEST: load_first_argument_must_be_a_buffer
+# CHECK: TypeError: air.api.ops.load fills a buffer
+@expect(TypeError, "load_first_argument_must_be_a_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 32], bf16, scope=h.private())
+        ops.load(A[0:32, 0:32], a)
+
+    _trace(body)
+
+
+# ---------------------------------------------------------------------------
+# Micro-tiled (packed) layouts
+#
+# Every one of these is a case where guessing would produce a kernel that runs
+# and is silently wrong -- a mismatched micro-tile contracts the wrong elements,
+# and a whole-buffer drain copies a tile still in micro-tile order.
+# ---------------------------------------------------------------------------
+
+
+def _mm():
+    return air.micro_tile(m=4, k=8, n=4)
+
+
+# CHECK-LABEL: TEST: micro_tile_does_not_divide
+# CHECK: ValueError: operand A's M extent 30 is not a multiple of the micro-tile m=4
+@expect(ValueError, "micro_tile_does_not_divide")
+def _():
+    _mm().a(30, 32)
+
+
+# CHECK-LABEL: TEST: packed_buffer_no_whole_drain
+# A whole-buffer store emits `[] [] []`, a contiguous read, which would copy the
+# tile still micro-tiled. The unpack *is* the access pattern.
+# CHECK: TypeError: air.api.ops.store cannot drain a micro-tiled buffer whole
+@expect(TypeError, "packed_buffer_no_whole_drain")
+def _():
+    def body(seg, A, C):
+        mm = _mm()
+        l2 = air.alloc([1, 1, 32, 32], bf16, scope=seg.private())
+        acc = air.alloc(mm.c(32, 32), bf16, scope=seg.shared())
+        ops.store(acc, l2[0, 0, :, :])
+
+    _staged(body)
+
+
+# CHECK-LABEL: TEST: packed_load_needs_a_region
+# CHECK: TypeError: air.api.ops.load into a micro-tiled buffer needs a source *region*
+@expect(TypeError, "packed_load_needs_a_region")
+def _():
+    def body(h, tx, ty, A, B, C):
+        l1 = air.alloc(_mm().a(32, 16), bf16, scope=h.private())
+        other = air.alloc([1, 1, 32, 32], bf16, scope=h.private())
+        ops.load(l1, other)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: packed_operands_must_share_a_micro_tile
+# CHECK: ValueError: air.api.ops.dot needs one micro-tile across all three operands
+@expect(ValueError, "packed_operands_must_share_a_micro_tile")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc(air.micro_tile(4, 8, 4).a(32, 16), bf16, scope=h.private())
+        b = air.alloc(air.micro_tile(4, 8, 8).b(16, 32), bf16, scope=h.private())
+        c = air.alloc(air.micro_tile(4, 8, 4).c(32, 32), bf16, scope=h.private())
+        ops.dot(a, b, acc=c)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: packed_operand_roles_must_match
+# CHECK: ValueError: air.api.ops.dot expects b to be a micro-tiled B operand
+@expect(ValueError, "packed_operand_roles_must_match")
+def _():
+    def body(h, tx, ty, A, B, C):
+        mm = _mm()
+        a = air.alloc(mm.a(32, 16), bf16, scope=h.private())
+        b = air.alloc(mm.a(32, 16), bf16, scope=h.private())
+        c = air.alloc(mm.c(32, 32), bf16, scope=h.private())
+        ops.dot(a, b, acc=c)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: packed_contraction_extents_must_agree
+# CHECK: ValueError: air.api.ops.dot shape mismatch: a is 32x16 and b is 32x32
+@expect(ValueError, "packed_contraction_extents_must_agree")
+def _():
+    def body(h, tx, ty, A, B, C):
+        mm = _mm()
+        a = air.alloc(mm.a(32, 16), bf16, scope=h.private())
+        b = air.alloc(mm.b(32, 32), bf16, scope=h.private())
+        c = air.alloc(mm.c(32, 32), bf16, scope=h.private())
+        ops.dot(a, b, acc=c)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: unpacked_operand_in_packed_dot
+# CHECK: TypeError: air.api.ops.dot got rank-6 operands
+@expect(TypeError, "unpacked_operand_in_packed_dot")
+def _():
+    def body(h, tx, ty, A, B, C):
+        mm = _mm()
+        a = air.alloc(mm.a(32, 16), bf16, scope=h.private())
+        b = air.alloc([1, 1, 8, 2, 8, 4], bf16, scope=h.private())
+        c = air.alloc(mm.c(32, 32), bf16, scope=h.private())
+        ops.dot(a, b, acc=c)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: no_elementwise_expression_on_packed
+# The elements are not in row-major order, so an elementwise expression over a
+# packed buffer would not mean what it reads like.
+# CHECK: NotImplementedError: only a scalar fill is supported on a micro-tiled buffer
+@expect(NotImplementedError, "no_elementwise_expression_on_packed")
+def _():
+    def body(h, tx, ty, A, B, C):
+        mm = _mm()
+        c = air.alloc(mm.c(32, 32), bf16, scope=h.private())
+        d = air.alloc(mm.c(32, 32), bf16, scope=h.private())
+        c[:] = d[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: no_herd_shared_scope
+# CHECK: NotImplementedError: air.api has no <herd>.shared()
+@expect(NotImplementedError, "no_herd_shared_scope")
+def _():
+    def body(h, tx, ty, A, B, C):
+        air.alloc([32, 32], bf16, scope=h.shared())
 
     _trace(body)

--- a/python/test/api/pack.py
+++ b/python/test/api/pack.py
@@ -1,0 +1,149 @@
+# ./python/test/api/pack.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Micro-tiled (packed) layouts: shapes, DMA patterns, and the contraction.
+
+Every CHECK here is transcribed from the IR of the example this models:
+
+    programming_examples/matrix_multiplication/bf16/run.py \
+        --herd-m 1 --herd-n 1 --m 64 --n 64 --k 64 --tile-m 32 \
+        --tile-k-l2 32 --tile-k-l1 16 --tile-n 32 --arch aie2 --print-module-only
+
+so a failure here means the DSL has drifted from a form known to run on
+hardware, not merely from a form that looked reasonable when this was written.
+"""
+
+import air.api as air
+import air.api.ops as ops
+from air.api import bf16
+
+M = N = K = 64
+TILE_M = TILE_N = TILE_K_L2 = 32
+TILE_K_L1 = 16
+HERD_M = HERD_N = 1
+
+
+def build():
+    mm = air.micro_tile(m=4, k=8, n=4)
+
+    A = air.tensor([M, K], bf16)
+    B = air.tensor([K, N], bf16)
+    C = air.tensor([M, N], bf16)
+
+    with air.launch(name="matmul", target="npu1") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(
+                [range(0, M, TILE_M * HERD_M), range(0, N, TILE_N * HERD_N)],
+                name="matmul_seg",
+            ) as seg:
+
+                @seg.body
+                def _(ss, st):
+                    row, col = ss * TILE_M * HERD_M, st * TILE_N * HERD_N
+
+                    l2_a = air.alloc(
+                        [1, 1, TILE_M, TILE_K_L2], bf16, scope=seg.private()
+                    )
+                    l2_b = air.alloc(
+                        [1, HERD_N, TILE_K_L2, TILE_N], bf16, scope=seg.private()
+                    )
+                    l2_c = air.alloc([1, 1, TILE_M, TILE_N], bf16, scope=seg.private())
+                    acc = air.alloc(
+                        mm.c(TILE_M, TILE_N, lead=(HERD_M, HERD_N)),
+                        bf16,
+                        scope=seg.shared(),
+                    )
+
+                    with air.herd([range(HERD_M), range(HERD_N)], name="fill") as h0:
+
+                        @h0.body
+                        def _(tx, ty):
+                            acc[:] = 0.0
+
+                    for k2 in air.sequential(0, K, TILE_K_L2):
+                        ops.load(l2_a, A[row : row + TILE_M, k2 : k2 + TILE_K_L2])
+                        ops.load(l2_b, B[k2 : k2 + TILE_K_L2, col : col + TILE_N])
+
+                        with air.herd([range(HERD_M), range(HERD_N)], name="mm") as h:
+
+                            @h.body
+                            def _(tx, ty):
+                                l1_a = air.alloc(
+                                    mm.a(TILE_M, TILE_K_L1), bf16, scope=h.private()
+                                )
+                                l1_b = air.alloc(
+                                    mm.b(TILE_K_L1, TILE_N), bf16, scope=h.private()
+                                )
+                                for k1 in air.sequential(0, TILE_K_L2, TILE_K_L1):
+                                    ops.load(l1_a, l2_a[tx, 0, :, k1 : k1 + TILE_K_L1])
+                                    ops.load(l1_b, l2_b[0, ty, k1 : k1 + TILE_K_L1, :])
+                                    ops.dot(l1_a, l1_b, acc=acc)
+
+                    with air.herd([range(HERD_M), range(HERD_N)], name="drain") as h2:
+
+                        @h2.body
+                        def _(tx, ty):
+                            ops.store(acc[tx, ty, :, :], l2_c[tx, ty, :, :])
+
+                    ops.store(l2_c, C[row : row + TILE_M, col : col + TILE_N])
+
+    return launch
+
+
+# The three indexing maps of the contraction, byte-identical to the reference's.
+# CHECK-DAG: affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>
+# CHECK-DAG: affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d2, d4, d5, d8, d7)>
+# CHECK-DAG: affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d0, d4, d3, d6, d7)>
+
+# The launch carries the M/N tiling: 64/32 = 2 in each direction. The L2
+# staging buffers are refilled per point, so this cannot be the herd's job.
+# CHECK-LABEL: func.func @matmul
+# CHECK: air.launch (%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) in (%{{[a-z0-9_]+}}=%c2{{[a-z0-9_]*}}, %{{[a-z0-9_]+}}=%c2{{[a-z0-9_]*}})
+
+# The launch induction variables are passed into the segment as operands --
+# air.segment is IsolatedFromAbove, so they cannot be referenced through it.
+# CHECK: air.segment @matmul_seg args({{.*}}) : index, index, memref<64x64xbf16>
+
+# Packed shapes. A is [1,1,K/k,M/m,m,k], B is [1,1,N/n,K/k,k,n], C is
+# [herd_m,herd_n,N/n,M/m,m,n]. All contiguous: packing is not a layout.
+# CHECK: memref.alloc() : memref<1x1x32x32xbf16, 1 : i32>
+# CHECK: memref.alloc() : memref<1x1x8x8x4x4xbf16, 2 : i32>
+
+# Zeroing a packed accumulator is one linalg.fill on the core's own slab, not a
+# six-deep scalar loop nest.
+# CHECK: %[[SV0:[a-z0-9_]+]] = memref.subview %{{[a-z0-9_]+}}[%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1]
+# CHECK-SAME: to memref<1x1x8x8x4x4xbf16, strided<[1024, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
+# CHECK: linalg.fill ins(%{{[a-z0-9_]+}} : bf16) outs(%[[SV0]]
+
+# L1 A tile: the pack. Six offsets/sizes/strides against a rank-4 L2 memref --
+# the DMA walks it in micro-tile order and lands it contiguously in L1.
+# CHECK: air.dma_memcpy_nd (%{{[a-z0-9_]+}}[] [] [], %{{[a-z0-9_]+}}[%{{[a-z0-9_]+}}, 0, 0, 0, 0, %{{[a-z0-9_]+}}]
+# CHECK-SAME: [1, 1, 2, 8, 4, 8] [1024, 1024, 8, 128, 32, 1])
+# CHECK-SAME: (memref<1x1x2x8x4x8xbf16, 2 : i32>, memref<1x1x32x32xbf16, 1 : i32>)
+
+# L1 B tile: same, with the K offset on the k_in dimension.
+# CHECK: air.dma_memcpy_nd (%{{[a-z0-9_]+}}[] [] [], %{{[a-z0-9_]+}}[0, %{{[a-z0-9_]+}}, 0, 0, %{{[a-z0-9_]+}}, 0]
+# CHECK-SAME: [1, 1, 8, 2, 8, 4] [1024, 1024, 4, 256, 32, 1])
+# CHECK-SAME: (memref<1x1x8x2x8x4xbf16, 2 : i32>, memref<1x1x32x32xbf16, 1 : i32>)
+
+# The contraction: a 9-dimensional linalg.generic over the micro-tile grid,
+# accumulating into the core's subview of the shared accumulator.
+# CHECK: %[[SV1:[a-z0-9_]+]] = memref.subview %{{[a-z0-9_]+}}[%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4]
+# CHECK: linalg.generic
+# CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+# CHECK-SAME: ins(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}} : memref<1x1x2x8x4x8xbf16, 2 : i32>, memref<1x1x8x2x8x4xbf16, 2 : i32>)
+# CHECK-SAME: outs(%[[SV1]]
+
+# The drain: the pattern moves to the packed side and walks it back in logical
+# row-major order, which is the unpack.
+# CHECK: air.dma_memcpy_nd (%{{[a-z0-9_]+}}[%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}, 0, 0] [1, 1, 32, 32] [1024, 1024, 32, 1],
+# CHECK-SAME: %{{[a-z0-9_]+}}[%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}, 0, 0, 0, 0] [1, 1, 8, 4, 8, 4] [1024, 1024, 16, 4, 128, 1])
+
+
+print(build().build(target="npu1"))

--- a/python/test/api/segment.py
+++ b/python/test/api/segment.py
@@ -1,0 +1,126 @@
+# ./python/test/api/segment.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api stages data through L2: L3 -> L2 -> L1 -> L2 -> L3.
+
+A herd whose cores each stream operands straight from L3 needs a shim DMA
+channel per core per tensor, which is what bounds the herd width. Staging
+through a memtile lifts that: the segment moves one large tile L3 -> L2, and
+each core takes its own window L2 -> L1. This is the shape every hand-written
+matmul in the tree uses, e.g.
+``programming_examples/matrix_vector_multiplication/bf16/matvec.py``.
+
+Two pieces of surface appear here that the herd-only examples do not reach:
+
+``air.segment`` is an independent level, not a wrapper the DSL forces on you.
+``launch``, ``segment`` and ``herd`` each emit only when written, so a kernel
+that needs no staging keeps the plain ``func`` + ``air.herd`` shape -- see
+``eltwise_add.py``, whose IR this change leaves untouched.
+
+A *partial* subscript on a buffer (``staged[tx, 0:n]``) names a DMA region
+rather than a value, so it is accepted by ``ops.load``/``ops.store`` and refused
+by an elementwise expression. ``buf[:]`` still means an elementwise read, and is
+refused on L2, which is a memtile and has no compute core.
+"""
+
+from air import api as air
+from air.api import ops  # noqa: F401
+from air.api.types import f32, i32
+
+CORES, TILE = 4, 64
+
+
+def build(dtype=i32, cores=CORES, tile=TILE):
+    A = air.tensor([cores, tile], dtype)
+    C = air.tensor([cores, tile], dtype)
+
+    with air.launch(name="stage") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    a_l2 = air.alloc([cores, tile], dtype, scope=seg.private())
+                    c_l2 = air.alloc([cores, tile], dtype, scope=seg.private())
+                    ops.load(a_l2, A[0:cores, 0:tile])
+
+                    with air.herd(range(0, cores, 1), shape=(cores,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            l1 = air.alloc([tile], dtype, scope=h.private(), vector=0)
+                            # The slice is [1, tile] into a rank-1 buffer: a
+                            # staged tile is indexed per core, so the natural
+                            # pattern carries a leading 1, which is squeezed.
+                            ops.load(l1, a_l2[tx, 0:tile])
+                            l1[:] = l1[:] + 1
+                            ops.store(l1, c_l2[tx, 0:tile])
+
+                    ops.store(c_l2, C[0:cores, 0:tile])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: staged_passthrough
+# A segment is emitted inside an air.launch, and that is load-bearing rather
+# than decorative: air-insert-launch-around-herd wraps a *bare* herd in a launch
+# and a segment, and skips a herd that already sits in a segment. A segment with
+# no launch above it compiles and then computes zeros for anything beyond a
+# plain copy -- measured on npu1, with a raw-bindings reproduction.
+# CHECK: func.func @stage(%{{.*}}: memref<4x64xi32>, %{{.*}}: memref<4x64xi32>)
+# CHECK: air.launch (%{{.*}}, %{{.*}}) in ({{.*}}) args({{.*}}) : memref<4x64xi32>, memref<4x64xi32>
+#
+# The segment takes the L3 tensors as operands -- it is IsolatedFromAbove, so
+# nothing is captured implicitly -- and the L2 buffers land in memory space 1.
+# CHECK: air.segment @seg args(%[[SA:.*]]=%{{.*}}, %{{.*}}=%{{.*}}) : memref<4x64xi32>, memref<4x64xi32>
+# CHECK: memref.alloc() : memref<4x64xi32, 1 : i32>
+# CHECK: memref.alloc() : memref<4x64xi32, 1 : i32>
+#
+# L3 -> L2, in the segment body and outside the herd: staged once for every
+# core, not once per core.
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %[[SA]][0, 0] [4, 64] [64, 1]) : (memref<4x64xi32, 1 : i32>, memref<4x64xi32>)
+#
+# The herd is nested inside, and carries the L2 buffers as operands after the
+# tensors -- it is IsolatedFromAbove too, so a memtile buffer cannot simply be
+# referenced from within it.
+# CHECK: air.herd @herd_0 tile (%[[TX:.*]], %{{.*}}) in ({{.*}}) args({{.*}}) : memref<4x64xi32>, memref<4x64xi32>, memref<4x64xi32, 1 : i32>, memref<4x64xi32, 1 : i32>
+# CHECK: memref.alloc() : memref<64xi32, 2 : i32>
+#
+# L2 -> L1, one window per core: the tile coordinate becomes the offset, and
+# the access pattern is [1, 64] into a rank-1 L1 buffer.
+# CHECK: %[[OFF:.*]] = affine.apply {{.*}}[%[[TX]]]
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[%[[OFF]], 0] [1, 64] [64, 1]) : (memref<64xi32, 2 : i32>, memref<4x64xi32, 1 : i32>)
+# CHECK: memref.load
+# CHECK: arith.addi
+#
+# L1 -> L2 writeback into the same window, then L2 -> L3 once, after the herd.
+# CHECK: air.dma_memcpy_nd (%{{.*}}[%{{.*}}, 0] [1, 64] [64, 1], %{{.*}}[] [] []) : (memref<4x64xi32, 1 : i32>, memref<64xi32, 2 : i32>)
+# CHECK: memref.dealloc {{.*}} : memref<64xi32, 2 : i32>
+# CHECK: air.dma_memcpy_nd (%{{.*}}[0, 0] [4, 64] [64, 1], %{{.*}}[] [] []) : (memref<4x64xi32>, memref<4x64xi32, 1 : i32>)
+# CHECK: memref.dealloc {{.*}} : memref<4x64xi32, 1 : i32>
+# CHECK: memref.dealloc {{.*}} : memref<4x64xi32, 1 : i32>
+@run
+def staged_passthrough():
+    print(build().mlir())
+
+
+# CHECK-LABEL: TEST: staged_f32
+# Nothing about staging is dtype-specific; f32 differs only in the element type
+# and in the compute op the expression lowers to.
+# CHECK: memref.alloc() : memref<4x64xf32, 1 : i32>
+# CHECK: arith.addf
+@run
+def staged_f32():
+    print(build(dtype=f32).mlir())


### PR DESCRIPTION
Extends `air.api` from elementwise kernels over a herd to the shape every matmul in this tree uses: an L3→L2→L1 staged reduction whose L1 tiles are laid out for the AIE2 matmul intrinsic.

**No programming example changes.** The seven examples already on `air.api` emit byte-identical IR, checked against a clean `origin/main` worktree.

## Verification

End to end on npu1 against `matrix_multiplication/bf16` `run1x1` (64×64×64 bf16, herd 1×1, tile 32×32, `tile_k_l2` 32, `tile_k_l1` 16, micro-tile 4×8×4), in **both** lowering modes that example supports:

| route | mechanism | result |
|---|---|---|
| A1 | `lower_linalg_to_func="mm.o"` | PASS, `mean_rel_L1=8.650e-03` |
| B | transform script, direct codegen | PASS, `mean_rel_L1=1.771e-03` |

Route B's figure is the reference's own for that configuration, so this is the same computation rather than another one that also passes. The reference's ~117-line transform script was applied **verbatim** and works unchanged — it requires exactly three herds in fill/matmul/drain order and matches on specific `linalg` ops and `scf.for` nesting depths, so it is a fairly strong structural check on what the DSL emits.

Neither route needed new surface: `build()` hands back the module for a transform script to run on, and `compile(**kwargs)` already reaches `XRTBackend`.

## What is added

- **`air.sequential`** — a temporal `scf.for`. A Python `for` unrolls at trace time, leaving straight-line copies of the body over the same L1 buffers with the objectFifo locks stranded between them: exact for one trip, wrong for two.

- **`air.segment`** — L2 (memtile) staging, and, given an iteration space, the `air.launch` grid. Outer tiling has to live there because the L2 buffers are refilled per point. A segment is always emitted inside a launch: `air-insert-launch-around-herd` wraps a *bare* herd in both and skips one already inside a segment, so an explicit segment would otherwise get no launch, compile cleanly, and compute zeros for anything past a copy.

- **`<segment>.shared()`** — L1 with the segment's lifetime, for an accumulator carried across a reduction loop at segment scope. Charged per core, since the leading dimensions are the herd.

- **Micro-tiled layouts (`air.micro_tile`).** Packing is neither a memref layout nor a reshape. Every alloc in the reference is contiguous; the reordering is carried by a DMA access pattern whose *rank exceeds the memref it reads*. That pattern is derived from the micro-tile and the source's own strides rather than spelled out, so a wrong stride is an error instead of wrong output. A packed buffer is subscripted in logical coordinates, so the program keeps thinking in `[M, N]`.

- **`ops.dot` dispatches on operand rank**, as `numpy.dot` does: 1×1 → `linalg.dot`, 1×2 → `vecmat`, 2×1 → `matvec`, 2×2 → `matmul`, 6×6 → the blocked contraction — with the per-core `memref.subview` emitted by the DSL, because a core can only accumulate into its own slab. Zeroing a packed accumulator is one `linalg.fill`, not a six-deep scalar loop nest.

- **`air.extern`** — a call into a hand-written AIE kernel. Buffer types are inferred from the buffers; scalar element types must be declared, because `0.0` does not say whether the kernel wants `bf16` or `f32`.

Two emitter fixes found on the way: an integer scalar in a float expression aborted the process inside `cast<IntegerType>`, and a rank-0 destination (`linalg.dot`'s accumulator) indexed `shape[-1]`.

## Tests

`python/test/api/{dot,segment,pack}.py`. Every CHECK in `pack.py` is transcribed from the reference example's IR, so a failure means drift from a form known to run on hardware rather than from one that merely looked reasonable. Plus 30 must-raise cases in `errors.py` — a mismatched micro-tile, a whole-buffer drain of a packed buffer, an elementwise expression on a packed buffer, and so on. Each is a case where guessing would produce a kernel that runs and is silently wrong.

## Not in this PR

Converting `matrix_multiplication` itself. That is a deliberate follow-up: `bf16` alone is 830 lines and 16 lits, of which 11 are npu2-only (8 of them llama configs), so the A/B that licenses deleting the predecessor has to run on a Strix host. This PR is verifiable in full on npu1.
