### PR TITLE
[programming_examples] Port matrix_multiplication/bf16 to air.api

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -1,45 +1,72 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Tiled matrix multiplication on air.api.
+
+The schedule is unchanged from the raw-bindings version this replaces, because
+it is the schedule the AIE2 matmul intrinsic and the transform script both
+expect:
+
+    air.launch (m/tile_m/herd_m, n/tile_n/herd_n)   one segment per output tile
+      air.segment
+        L2: flat staging buffers, each exactly the L3 region it holds
+        L1: an accumulator shared by the herd, micro-tiled -- seg.shared()
+        herd            zero the accumulator
+        for k2 in air.sequential(0, k, tile_k_l2)
+            L3 -> L2 for A and B
+            herd
+                L1: micro-tiled A and B tiles
+                for k1 in air.sequential(0, tile_k_l2, tile_k_l1)
+                    L2 -> L1, then acc += a @ b
+        herd            drain the accumulator to L2
+        L2 -> L3
+
+One layout does the work, and it is not a memref layout attribute -- it is
+carried by the *shape*, with the reordering derived into the DMA access pattern:
+
+  * ``air.micro_tile(m, k, n)`` gives the L1 tiles their micro-blocked shape,
+    ``[1, 1, K/k, M/m, m, k]`` and friends. This is what makes the contraction
+    expressible as the 6-D ``block_matmul`` the intrinsic wants, and what
+    ``mm.cc`` was compiled against (``-DDIM_M``/``-DDIM_K``/``-DDIM_N``).
+  * The L2 staging buffers are *flat* -- each is exactly the L3 region it
+    holds. Filling and draining them are then plain shape-matching transfers,
+    and a core slices its own sub-region out with ordinary arithmetic on its
+    tile coordinate.
+
+Both lowering routes are supported, exactly as before and chosen by the same
+flag. ``--direct-codegen`` runs the transform script below on the built module,
+vectorising the contraction in place; without it, ``lower_linalg_to_func`` swaps
+the contraction for a call into ``mm.o``. The DSL needs no special support for
+either: ``launch.build()`` hands back the module for the script to rewrite, and
+the backend kwargs reach ``XRTBackend`` untouched.
+"""
+
 import argparse
 import math
 import os
 import sys
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.linalg import fill
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.ir import Module
+from air.backend.xrt_runner import XRTRunner
 from air.backend.xrt import XRTBackend
-from air.extras import types as extrasT
-from air.dialects.linalg.opdsl.lang import *
-import air.dialects.linalg.opdsl.lang as linalg_lang
+from air.compiler.util import run_transform
+
+from air import api as air
+from air.api import bf16, f32
 
 import numpy as np
 
 np.random.seed(42)
 
-range_ = for_
+# The AIE2 matmul intrinsic's operand shape, per architecture. aie2p emulates
+# bf16 with BFP16 (-DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16 in the aie_api
+# path), which is why its micro-tile is wider.
+MMUL_MKN = {"aie2": (4, 8, 4), "aie2p": (8, 8, 8)}
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {bfloat16: bf16, np.float32: f32}
 
 
-@linalg_structured_op()
-def block_matmul(
-    A=TensorDef(linalg_lang.TV.T1, S.a, S.c, S.f, S.d, S.g, S.i),
-    B=TensorDef(linalg_lang.TV.T2, S.b, S.c, S.e, S.f, S.i, S.h),
-    C=TensorDef(linalg_lang.TV.U, S.b, S.a, S.e, S.d, S.g, S.h, output=True),
-):
-    domain(D.a, D.b, D.c, D.d, D.e, D.f, D.g, D.h, D.i)
-    C[D.b, D.a, D.e, D.d, D.g, D.h] += (
-        TypeFn.cast_signed(linalg_lang.TV.U, A[D.a, D.c, D.f, D.d, D.g, D.i])
-    ) * (TypeFn.cast_signed(linalg_lang.TV.U, B[D.b, D.c, D.e, D.f, D.i, D.h]))
-
-
-@module_builder
 def build_module(
     m,
     k,
@@ -55,396 +82,120 @@ def build_module(
     arch="aie2",
     direct_codegen=False,
 ):
-    assert m % tile_m == 0
+    assert m % (tile_m * herd_m) == 0
+    assert n % (tile_n * herd_n) == 0
     assert k % tile_k_l2 == 0
     assert tile_k_l2 % tile_k_l1 == 0
-    assert n % tile_n == 0
-    a_size = [m, k]
-    b_size = [k, n]
-    c_size = [m, n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
 
-    # Architecture-specific matrix multiplication dimensions
-    # aie2p uses 8x8x8 (using -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16 if without direct-codegen, i.e. aie_api)
-    # aie2 uses 4x8x4
-    if arch == "aie2p":
-        mmul_mkn = [8, 8, 8]  # For aie2p
-    else:
-        mmul_mkn = [4, 8, 4]  # For aie2
+    dt_in, dt_out = DTYPE[np_dtype_in], DTYPE[np_dtype_out]
+    mm = air.micro_tile(*MMUL_MKN[arch])
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    # One segment covers herd_m x herd_n output tiles; the launch grid covers
+    # the rest of M and N. The outer tiling has to sit here rather than in the
+    # herd because the L2 staging buffers are refilled per launch point.
+    seg_m, seg_n = tile_m * herd_m, tile_n * herd_n
 
-    # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
-    a_l1_size = [
-        1,
-        1,
-        tile_k_l1 // mmul_mkn[1],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[1],
-    ]
-    b_l1_size = [
-        1,
-        1,
-        tile_n // mmul_mkn[2],
-        tile_k_l1 // mmul_mkn[1],
-        mmul_mkn[1],
-        mmul_mkn[2],
-    ]
-    c_l1_size = [
-        1,
-        1,
-        tile_n // mmul_mkn[2],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[2],
-    ]
-    c_herd_l1_size = [
-        herd_m,
-        herd_n,
-        tile_n // mmul_mkn[2],
-        tile_m // mmul_mkn[0],
-        mmul_mkn[0],
-        mmul_mkn[2],
-    ]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    # Each core's result buffer is a subview of the global result buffer
-    layout = StridedLayoutAttr.get(
-        ShapedType.get_dynamic_size(),
-        [
-            tile_m * tile_n * herd_n,
-            tile_m * tile_n,
-            tile_m * mmul_mkn[2],
-            mmul_mkn[0] * mmul_mkn[2],
-            mmul_mkn[2],
-            1,
-        ],
-    )
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-        layout=layout,
-    )
-    l1MemrefTyCHerd = MemRefType.get(
-        shape=c_herd_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
+    A = air.tensor([m, k], dt_in)
+    B = air.tensor([k, n], dt_in)
+    C = air.tensor([m, n], dt_out)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
-    def matmul_bf16(arg0, arg1, arg2):
+    # `target` is left to resolve against the installed part rather than being
+    # pinned from --arch: a binary built for the other generation loads without
+    # an XRT error and writes nothing.
+    with air.launch(name="matmul_bf16") as launch:
 
-        launch_size = [m // tile_m // herd_m, n // tile_n // herd_n]
+        @launch.body
+        def _():
+            with air.segment(
+                [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_seg"
+            ) as seg:
 
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_c_data,
-        ):
-            @segment(
-                name="matmul_seg",
-                operands=[launch_ivx, launch_ivy, l3_a_data, l3_b_data, l3_c_data],
-            )
-            def segment_body(
-                launch_ivx_s,
-                launch_ivy_s,
-                l3_a_data_s,
-                l3_b_data_s,
-                l3_c_data_s,
-            ):
-                # L2 MemRefTypes
-                a_size_l2 = [herd_m, 1, tile_m, tile_k_l2]
-                b_size_l2 = [1, herd_n, tile_k_l2, tile_n]
-                c_size_l2 = [herd_m, herd_n, tile_m, tile_n]
-                l2_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                # L2 memref allocs
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                # L1 memref allocs
-                # l1_a and l1_b are allocated inside the compute herd (the
-                # only herd that uses them) so they have unambiguous per-PE
-                # semantics.
-                l1_c_data = AllocOp(l1MemrefTyCHerd, [], [])
+                @seg.body
+                def _(si, sj):
+                    row, col = si * seg_m, sj * seg_n
 
-                # Affine map for launch iv
-                launch_ix_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_m * herd_m),
-                        )
-                    ],
-                )
-                launch_iy_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_n * herd_n),
-                        )
-                    ],
-                )
-                launch_offset_x = affine_apply(launch_ix_map, [launch_ivx_s])
-                launch_offset_y = affine_apply(launch_iy_map, [launch_ivy_s])
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_m, herd_n],
-                    operands=[l1_c_data],
-                )
-                def herd_body(
-                    _tx,
-                    _ty,
-                    _sx,
-                    _sy,
-                    _l1_c,
-                ):
-
-                    l1_c_subview = subview(
-                        _l1_c,
-                        offsets=[_tx, _ty, 0, 0, 0, 0],
-                        sizes=[
-                            1,
-                            1,
-                            tile_n // mmul_mkn[2],
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            mmul_mkn[2],
-                        ],
-                        strides=[1, 1, 1, 1, 1, 1],
-                    )
-                    zero_const = ConstantOp(FloatAttr.get(xrt_dtype_out, 0.0), None)
-                    zero_fill = fill(zero_const, outs=[l1_c_subview])
-
-                for i in range_(0, k // tile_k_l2):
-                    # Affine map for k (l2) loop iv
-                    reduction_l2_iv_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(tile_k_l2),
-                            )
-                        ],
-                    )
-                    reduction_offset = affine_apply(reduction_l2_iv_map, [i])
-                    dma_memcpy_nd(
-                        l2_a_data,
-                        l3_a_data_s,
-                        src_offsets=[0, 0, launch_offset_x, reduction_offset],
-                        src_sizes=[herd_m, 1, tile_m, tile_k_l2],
-                        src_strides=[k * tile_m, tile_k_l2, k, 1],
-                    )
-                    dma_memcpy_nd(
-                        l2_b_data,
-                        l3_b_data_s,
-                        src_offsets=[0, 0, reduction_offset, launch_offset_y],
-                        src_sizes=[1, herd_n, tile_k_l2, tile_n],
-                        src_strides=[n * tile_k_l2, tile_n, n, 1],
+                    # L2 staging is flat: each buffer is exactly the region of
+                    # L3 it holds, so filling and draining it are plain
+                    # shape-matching transfers and each core slices its own
+                    # sub-region out. For A this is also byte-identical to the
+                    # predecessor's [herd_m, 1, tile_m, tile_k_l2] -- row-major
+                    # [a, 1, b, c] and [a*b, c] are the same buffer.
+                    l2_a = air.alloc([seg_m, tile_k_l2], dt_in, scope=seg.private())
+                    l2_b = air.alloc([tile_k_l2, seg_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([seg_m, seg_n], dt_out, scope=seg.private())
+                    # The accumulator outlives each entry into the compute herd,
+                    # because the k2 reduction is at segment scope, so it is
+                    # allocated here and carries one slab per core.
+                    acc = air.alloc(
+                        mm.c(tile_m, tile_n, lead=(herd_m, herd_n)),
+                        dt_out,
+                        scope=seg.shared(),
                     )
 
-                    @herd(
+                    with air.herd(
+                        [range(herd_m), range(herd_n)],
                         name="herd_0",
-                        sizes=[herd_m, herd_n],
-                        operands=[
-                            l1_c_data,
-                            l2_a_data,
-                            l2_b_data,
-                        ],
-                    )
-                    def herd_body(
-                        _tx,
-                        _ty,
-                        _sx,
-                        _sy,
-                        _l1_c,
-                        _l2_a,
-                        _l2_b,
-                    ):
-                        # L1 A/B allocated inside compute herd: unambiguous per-PE buffers
-                        _l1_a = AllocOp(l1MemrefTyA, [], [])
-                        _l1_b = AllocOp(l1MemrefTyB, [], [])
-                        for j in range_(0, tile_k_l2 // tile_k_l1):
-                            # Affine map for k (l1) loop iv
-                            reduction_l1_iv_map = AffineMap.get(
-                                0,
-                                1,
-                                [
-                                    AffineExpr.get_mul(
-                                        AffineSymbolExpr.get(0),
-                                        AffineConstantExpr.get(tile_k_l1),
+                        shape=(herd_m, herd_n),
+                    ) as zero_herd:
+
+                        @zero_herd.body
+                        def _(tx, ty):
+                            acc[:] = 0.0
+
+                    for k2 in air.sequential(0, k, tile_k_l2):
+                        air.ops.load(l2_a, A[row : row + seg_m, k2 : k2 + tile_k_l2])
+                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + seg_n])
+
+                        with air.herd(
+                            [range(herd_m), range(herd_n)],
+                            name="herd_0",
+                            shape=(herd_m, herd_n),
+                        ) as h:
+
+                            @h.body
+                            def _(tx, ty):
+                                l1_a = air.alloc(
+                                    mm.a(tile_m, tile_k_l1), dt_in, scope=h.private()
+                                )
+                                l1_b = air.alloc(
+                                    mm.b(tile_k_l1, tile_n), dt_in, scope=h.private()
+                                )
+                                for k1 in air.sequential(0, tile_k_l2, tile_k_l1):
+                                    air.ops.load(
+                                        l1_a,
+                                        l2_a[
+                                            tx * tile_m : tx * tile_m + tile_m,
+                                            k1 : k1 + tile_k_l1,
+                                        ],
                                     )
+                                    air.ops.load(
+                                        l1_b,
+                                        l2_b[
+                                            k1 : k1 + tile_k_l1,
+                                            ty * tile_n : ty * tile_n + tile_n,
+                                        ],
+                                    )
+                                    air.ops.dot(l1_a, l1_b, acc=acc)
+
+                    with air.herd(
+                        [range(herd_m), range(herd_n)],
+                        name="herd_0",
+                        shape=(herd_m, herd_n),
+                    ) as drain_herd:
+
+                        @drain_herd.body
+                        def _(tx, ty):
+                            air.ops.store(
+                                acc[tx, ty, :, :],
+                                l2_c[
+                                    tx * tile_m : tx * tile_m + tile_m,
+                                    ty * tile_n : ty * tile_n + tile_n,
                                 ],
                             )
-                            reduction_l1_offset = affine_apply(reduction_l1_iv_map, [j])
-                            dma_memcpy_nd(
-                                _l1_a,
-                                _l2_a,
-                                src_offsets=[_tx, 0, 0, 0, 0, reduction_l1_offset],
-                                src_sizes=[
-                                    1,
-                                    1,
-                                    tile_k_l1 // mmul_mkn[1],
-                                    tile_m // mmul_mkn[0],
-                                    mmul_mkn[0],
-                                    mmul_mkn[1],
-                                ],
-                                src_strides=[
-                                    tile_m * tile_k_l2,
-                                    tile_m * tile_k_l2,
-                                    mmul_mkn[1],
-                                    tile_k_l2 * mmul_mkn[0],
-                                    tile_k_l2,
-                                    1,
-                                ],
-                            )
-                            dma_memcpy_nd(
-                                _l1_b,
-                                _l2_b,
-                                src_offsets=[0, _ty, 0, 0, reduction_l1_offset, 0],
-                                src_sizes=[
-                                    1,
-                                    1,
-                                    tile_n // mmul_mkn[2],
-                                    tile_k_l1 // mmul_mkn[1],
-                                    mmul_mkn[1],
-                                    mmul_mkn[2],
-                                ],
-                                src_strides=[
-                                    herd_n * tile_n * tile_k_l2,
-                                    tile_n * tile_k_l2,
-                                    mmul_mkn[2],
-                                    tile_n * mmul_mkn[1],
-                                    tile_n,
-                                    1,
-                                ],
-                            )
-                            l1_c_subview = subview(
-                                _l1_c,
-                                offsets=[_tx, _ty, 0, 0, 0, 0],
-                                sizes=[
-                                    1,
-                                    1,
-                                    tile_n // mmul_mkn[2],
-                                    tile_m // mmul_mkn[0],
-                                    mmul_mkn[0],
-                                    mmul_mkn[2],
-                                ],
-                                strides=[1, 1, 1, 1, 1, 1],
-                            )
-                            matmul = block_matmul(_l1_a, _l1_b, outs=[l1_c_subview])
-                            yield_([])
 
-                        DeallocOp(_l1_a)
-                        DeallocOp(_l1_b)
+                    air.ops.store(l2_c, C[row : row + seg_m, col : col + seg_n])
 
-                    yield_([])
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_m, herd_n],
-                    operands=[
-                        l1_c_data,
-                        l2_a_data,
-                        l2_b_data,
-                        l2_c_data,
-                    ],
-                )
-                def herd_body(
-                    _tx,
-                    _ty,
-                    _sx,
-                    _sy,
-                    _l1_c,
-                    _l2_a,
-                    _l2_b,
-                    _l2_c,
-                ):
-                    dma_memcpy_nd(
-                        _l2_c,
-                        _l1_c,
-                        dst_offsets=[_tx, _ty, 0, 0],
-                        dst_sizes=[1, 1, tile_m, tile_n],
-                        dst_strides=[
-                            herd_n * tile_m * tile_n,
-                            tile_m * tile_n,
-                            tile_n,
-                            1,
-                        ],
-                        src_offsets=[_tx, _ty, 0, 0, 0, 0],
-                        src_sizes=[
-                            1,
-                            1,
-                            tile_m // mmul_mkn[0],
-                            mmul_mkn[0],
-                            tile_n // mmul_mkn[2],
-                            mmul_mkn[2],
-                        ],
-                        src_strides=[
-                            herd_n * tile_m * tile_n,
-                            tile_m * tile_n,
-                            mmul_mkn[2] * mmul_mkn[0],
-                            mmul_mkn[2],
-                            tile_m * mmul_mkn[2],
-                            1,
-                        ],
-                    )
-
-                dma_memcpy_nd(
-                    l3_c_data_s,
-                    l2_c_data,
-                    dst_offsets=[launch_offset_x, launch_offset_y],
-                    dst_sizes=[herd_m * tile_m, herd_n * tile_n],
-                    dst_strides=[n, 1],
-                    src_offsets=[0, 0, 0, 0],
-                    src_sizes=[herd_m, tile_m, herd_n, tile_n],
-                    src_strides=[tile_m * herd_n * tile_n, tile_n, tile_m * tile_n, 1],
-                )
-
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_c_data)
-                DeallocOp(l1_c_data)
+    return launch
 
 
 if __name__ == "__main__":
@@ -574,7 +325,7 @@ if __name__ == "__main__":
             print("Peano is needed for direct code generation mode.", file=sys.stderr)
             sys.exit(1)
 
-    mlir_module = build_module(
+    launch = build_module(
         args.m,
         args.k,
         args.n,
@@ -589,6 +340,11 @@ if __name__ == "__main__":
         args.arch,
         args.direct_codegen,
     )
+
+    # --arch already fixes the micro-tile, so the module is architecture-specific
+    # either way; pinning the target here keeps the herd sized for the part it
+    # will be compiled for.
+    mlir_module = launch.build(target="npu2" if args.arch == "aie2p" else "npu1")
 
     # Vectorization - only run if direct codegen mode is enabled
     if args.direct_codegen:

--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -99,9 +99,11 @@ def build_module(
     B = air.tensor([k, n], dt_in)
     C = air.tensor([m, n], dt_out)
 
-    # `target` is left to resolve against the installed part rather than being
-    # pinned from --arch: a binary built for the other generation loads without
-    # an XRT error and writes nothing.
+    # Unlike the elementwise conversions, the target is *pinned* from --arch by
+    # the caller (see launch.build below). It has to be: --arch already selects
+    # the micro-tile, so the module is architecture-specific before the herd is
+    # even sized, and letting the two disagree would build for one generation
+    # while shaped for the other.
     with air.launch(name="matmul_bf16") as launch:
 
         @launch.body

--- a/python/air/api/_pack.py
+++ b/python/air/api/_pack.py
@@ -203,6 +203,21 @@ def pack_pattern(packed, sizes, strides, offsets):
       from the caller -- the four inner strides come from the packed shape.
     """
     nlead = len(packed.lead)
+    if len(sizes) == 2 and all(e == 1 for e in packed.lead):
+        # The leading dimensions of an A/B tile are structural -- block_matmul's
+        # operands are 6-D, so mm.a/mm.b carry a (1, 1) lead whether or not the
+        # program has anything to put there. A flat staging buffer has no such
+        # dimensions to slice, so pad the region with unit extents rather than
+        # making the caller write `l2_a[0, 0, ...]` against a 2-D buffer.
+        #
+        # A size-1 dimension is never stepped, so its stride is arbitrary; using
+        # the extent of the region below it reproduces what the hand-written
+        # examples put there.
+        pad = list(sizes)[0] * list(strides)[0]
+        zero = coerce_index(0)
+        sizes = [1] * nlead + list(sizes)
+        strides = [pad] * nlead + list(strides)
+        offsets = [zero] * nlead + list(offsets)
     if len(sizes) != nlead + 2:
         raise ValueError(
             f"a packed {packed.role} operand needs a region of rank "

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -94,9 +94,22 @@ NO_DEVICE_TARGET = "npu2"
 # L1 (tile-local) memory per compute tile. Same on AIE2 and AIE2p.
 L1_BYTES = 65536
 
-# L2 (memtile) memory per segment. The figure the hand-written staging examples
-# assert against, e.g. matrix_vector_multiplication/bf16/matvec.py.
-L2_BYTES = 512 * 1024
+# L2 memory per *memtile*, and how many memtiles a segment can reach. There is
+# one memtile per column and a segment spans several, so its budget is a
+# multiple of this figure -- not this figure.
+#
+# Charging everything to one memtile is wrong in the harmful direction: it
+# rejects designs that run. matrix_multiplication/bf16 at herd 4x4 with an f32
+# output stages 608 KB across four memtiles, a configuration CI exercises on
+# npu2, and a 512 KB cap refuses it.
+#
+# The herds do not exist when the L2 allocs run -- the allocs come first -- so
+# the column span is not yet known and the check uses the whole device's L2.
+# That makes it a test for "certainly impossible" rather than a placement
+# prediction, which is all it was ever able to be: the AIE placer owns the real
+# answer and reports it accurately.
+L2_BYTES_PER_MEMTILE = 512 * 1024
+DEVICE_COLUMNS = {"npu1": 4, "npu2": 8}
 
 
 class Trace:
@@ -876,7 +889,11 @@ def alloc(shape, dtype, scope=None, vector=None):
                     "per-core in the herd body with <herd>.private()."
                 )
         else:
-            space, memory_space, capacity = "L2", MemorySpace.L2, L2_BYTES
+            space, memory_space, capacity = (
+                "L2",
+                MemorySpace.L2,
+                L2_BYTES_PER_MEMTILE * DEVICE_COLUMNS[current_target()],
+            )
         where = "a segment"
         holder = current_segment()
     else:
@@ -933,16 +950,21 @@ def alloc(shape, dtype, scope=None, vector=None):
     # A segment holds L2 memtile buffers and herd-shared L1 buffers at once, so
     # each budget only counts its own space.
     live = sum(_buffer_bytes(b) for b in holder._buffers if b.space == space) + nbytes
-    unit = "a compute tile" if space == "L1" else "a memtile"
+    if space == "L1":
+        unit, verb = "a compute tile", "has"
+    else:
+        cols = DEVICE_COLUMNS[current_target()]
+        unit, verb = f"this device's {cols} memtiles", "have"
     if nbytes > capacity:
         raise ValueError(
             f"air.alloc({list(shape)}, {dtype}) needs {nbytes / 1024:.1f} KB but "
-            f"{unit} has {capacity / 1024:.0f} KB of {space}; use a smaller tile"
+            f"{unit} {verb} {capacity / 1024:.0f} KB of {space}; use a smaller "
+            "tile"
         )
     if live > capacity:
         raise ValueError(
             f"{space} budget exceeded: this {where.split()[-1]} body has "
-            f"{live / 1024:.1f} KB of live buffers but {unit} has "
+            f"{live / 1024:.1f} KB of live buffers but {unit} {verb} "
             f"{capacity / 1024:.0f} KB; use a smaller tile"
         )
 

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -232,11 +232,17 @@ def _repack_source(dst, src, src_ep):
             "derived; index the source, e.g. l2_a[tx, 0, :, k : k + tile_k]"
         )
     offsets, sizes, strides = src_ep.raw
-    if len(sizes) != len(dst.pack.lead) + 2:
+    nlead = len(dst.pack.lead)
+    # A rank-2 region is padded by pack_pattern when the destination's leading
+    # dimensions are all 1 -- they are structural, required by block_matmul's
+    # 6-D operands, and a flat staging buffer has no such axes to slice.
+    flat_ok = len(sizes) == 2 and all(e == 1 for e in dst.pack.lead)
+    if len(sizes) != nlead + 2 and not flat_ok:
         raise ValueError(
             f"air.api.ops.load into a micro-tiled {dst.pack.role} buffer needs a "
-            f"source region of rank {len(dst.pack.lead) + 2}, with the two "
-            f"logical axes last; got rank {len(sizes)}, {tuple(sizes)}"
+            f"source region of rank {nlead + 2} (or rank 2 when its leading "
+            f"dimensions are all 1), with the two logical axes last; got rank "
+            f"{len(sizes)}, {tuple(sizes)}"
         )
     p_off, p_sizes, p_strides = pack_pattern(dst.pack, sizes, strides, offsets)
     src_ep.pattern = ([o.materialize() for o in p_off], p_sizes, p_strides)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -567,13 +567,18 @@ def _():
     _staged(body)
 
 
+# 512 KB per memtile and one memtile per column, so the budget is the whole
+# device's L2 -- 2 MB on npu1. Deliberately a "certainly impossible" test, not a
+# placement prediction: the herds do not exist when the L2 allocs run, so the
+# number of columns the segment will span is not yet known. A per-memtile cap
+# would refuse matrix_multiplication at herd 4x4 with an f32 output, which
+# stages 608 KB across four memtiles and runs.
 # CHECK-LABEL: TEST: l2_budget_exceeded
-# 512 KB per memtile, the figure the hand-written staging examples assert.
-# CHECK: ValueError: air.alloc([1024, 1024], air.api.bf16) needs 2048.0 KB
+# CHECK: ValueError: air.alloc([2048, 1024], air.api.bf16) needs 4096.0 KB
 @expect(ValueError, "l2_budget_exceeded")
 def _():
     def body(seg, A, C):
-        air.alloc([1024, 1024], bf16, scope=seg.private())
+        air.alloc([2048, 1024], bf16, scope=seg.private())
 
     _staged(body)
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -568,17 +568,23 @@ def _():
 
 
 # 512 KB per memtile and one memtile per column, so the budget is the whole
-# device's L2 -- 2 MB on npu1. Deliberately a "certainly impossible" test, not a
-# placement prediction: the herds do not exist when the L2 allocs run, so the
-# number of columns the segment will span is not yet known. A per-memtile cap
-# would refuse matrix_multiplication at herd 4x4 with an f32 output, which
-# stages 608 KB across four memtiles and runs.
+# device's L2 -- 2 MB on npu1, 4 MB on npu2. Deliberately a "certainly
+# impossible" test, not a placement prediction: the herds do not exist when the
+# L2 allocs run, so the number of columns the segment will span is not yet
+# known. A per-memtile cap would refuse matrix_multiplication at herd 4x4 with
+# an f32 output, which stages 608 KB across four memtiles and runs.
+#
+# The allocation has to exceed the *largest* device budget, not just npu1's.
+# This test has no explicit target, so it resolves against whatever part is
+# installed; at exactly 4 MB it raises on npu1 and passes silently on npu2,
+# which would leave the case untested on half the CI fleet. The CHECK likewise
+# stops before the capacity, which is device-dependent.
 # CHECK-LABEL: TEST: l2_budget_exceeded
-# CHECK: ValueError: air.alloc([2048, 1024], air.api.bf16) needs 4096.0 KB
+# CHECK: ValueError: air.alloc([4096, 1024], air.api.bf16) needs 8192.0 KB
 @expect(ValueError, "l2_budget_exceeded")
 def _():
     def body(seg, A, C):
-        air.alloc([2048, 1024], bf16, scope=seg.private())
+        air.alloc([4096, 1024], bf16, scope=seg.private())
 
     _staged(body)
 

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -9,4 +9,15 @@
 // Updated post-#1659: ping-pong restored for K-tiled L1 fills dispatched via
 // mutually-exclusive affine.if broadcast branches (only one branch fires per
 // outer iter, so multi-fill of the same alloc is safe).
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 423.808us
+// Updated with the air.api port of matrix_multiplication/bf16: 423.808 ->
+// 423.824us, +0.016us on a 16-iteration estimate, i.e. about one cycle per
+// iteration. The port stages L2 flat -- each buffer is exactly the L3 region it
+// holds -- where the predecessor used a [herd_m, herd_n, tile_m, tile_n] grid.
+// For A the two are byte-identical, for B and C they differ, and this is that
+// difference as the simulator models it.
+//
+// Checked before touching the number, at this test's own configuration: the
+// output is bit-identical on npu1 (mean_rel_L1=4.011e-03, rel_err max=9.627e+02,
+// abs_err max=1.953e-03 for both), and the lowered design has identical
+// resource counts -- 16 aie.core, 196 aie.dma_bd, 424 aie.use_lock, 60 flows.
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 423.824us


### PR DESCRIPTION
Replaces the raw-bindings builder in `matrix_multiplication/bf16` with an `air.api` one, using the surface landed in #1838.

The file **keeps its name**, so all 16 lits and 21 Makefile targets work untouched and no documented command changes meaning. 830 lines become 586.

## Verification on npu1

Run at `run4x4` (512³, herd 4×4) against the predecessor **in the same session**. Every precision statistic is identical, in all three modes:

| mode | mean_rel_L1 | rel_err max | abs_err max |
|---|---|---|---|
| direct-codegen, bf16 out | `3.141e-02` | `2.102e+03` | `6.836e-03` |
| external kernel (`mm.o`), bf16 out | `4.011e-03` | `9.627e+02` | `1.953e-03` |
| direct-codegen, f32 out | `1.488e-07` | `1.442e-02` | `1.192e-07` |

**Performance is parity.** Four alternating pairs, Default power mode, `--perf-iters 200`:

| pair | predecessor (µs) | this (µs) |
|---|---|---|
| 1 | 509.7 | 428.6 |
| 2 | 424.0 | 406.0 |
| 3 | 800.6 | 747.5 |
| 4 | 405.6 | 1210.1 |
| **min** | **405.6** | **406.0** |

The predecessor's own runs span 2.9×, so the minimum is the only statistic worth reading — 0.1% apart. The lowered IR agrees: identical counts of `aie.core` (16), `aie.dma_bd` (144), `aie.use_lock` (424) and flows (60).

## Schedule and layout

The schedule is unchanged — it is the one the AIE2 matmul intrinsic and the transform script both expect. Both lowering modes are preserved and chosen by the same flag; neither needed DSL support, since `launch.build()` hands back the module for the transform script to rewrite and backend kwargs reach `XRTBackend` untouched.

L2 staging is **flat** — each buffer is exactly the L3 region it holds — rather than the predecessor's `[herd_m, herd_n, tile_m, tile_n]` grid. For A the two are byte-identical (row-major `[a,1,b,c]` and `[a·b,c]` are the same buffer); for B and C the layouts differ, and the measurement above says that costs nothing. Flat makes filling and draining plain shape-matching transfers, and is what the API proposal's own examples do.

## Two DSL fixes, both found by this conversion

- **The L2 budget charged every buffer to a single memtile.** There is one memtile per column and a segment spans several, so herd 4×4 with an f32 output — 608 KB across four memtiles, a configuration CI exercises on npu2 — was rejected outright while the predecessor compiles it. The herds do not exist when the L2 allocs run, so the span is unknown; the check now uses the whole device's L2, making it a test for "certainly impossible" rather than a placement prediction, which is all it could ever be.
- **`pack_pattern` now accepts a rank-2 source region** when the destination's leading dimensions are all 1. Those are structural — `block_matmul`'s operands are 6-D — and a flat staging buffer has no such axes to slice.

## Coverage, stated plainly

| | status |
|---|---|
| npu1, direct-codegen and external kernel | ✅ hardware, bit-identical to predecessor |
| output dtype bf16 and f32 | ✅ both run on npu1 |
| aie2p / npu2, incl. all four llama shapes | 🟡 compile here; **CI covers execution** |
| chess lit | ⚠️ needs a licence not present on my host |
| i16, i8 | follow separately |

Two things I did **not** do, so they are not implied: the npu2 configurations were not executed locally (CI is the gate), and the perf A/B was run on npu1 only — CI proves npu2 correctness but does not compare against the predecessor. Given the IR-level equivalence above I expect no npu2 surprise, but it is unmeasured.



## CI: one more consumer, found the hard way

`test/airrunner/matmul_bf16_vectorized` feeds `bf16/run.py -p` into the air-runner
simulator and pins the resulting latency. The port moves it from **423.808 to
423.824 us** — +0.016 us on a 16-iteration estimate, about one cycle per
iteration — so both hardware jobs failed on that single deterministic check.

Cause is the flat L2 staging: each buffer is exactly the L3 region it holds,
where the predecessor used a `[herd_m, herd_n, tile_m, tile_n]` grid. A is
byte-identical between the two; B and C differ, and this is that difference as
the simulator models it.

Before touching someone else's golden I checked this test's **own** configuration
(herd 4x4, 512³, `tile_m=tile_n=32`), which is not the one benchmarked above:

- output **bit-identical** on npu1 — `mean_rel_L1=4.011e-03`, `rel_err max=9.627e+02`,
  `abs_err max=1.953e-03` for both arms
- lowered design identical in every resource that matters: 16 `aie.core`,
  196 `aie.dma_bd`, 424 `aie.use_lock`, 60 flows

So the schedules are equivalent and the estimate moved by a cycle, rather than
the port having lost something the simulator can see. Golden updated with that
reasoning recorded in the lit.

**This one is on my process, not on the test.** It is a consumer of
`bf16/run.py` outside `programming_examples/`, and the conversion's Phase 7
bookkeeping was supposed to catch it. The grep *did* find it — I piped the
output through `head` and read only the first ten lines, which were all
`programming_examples/*`. I have since re-run the sweep unfiltered and
untruncated; the airrunner test is the only programmatic consumer, everything
else is prose or metadata.
