### PR TITLE
[docs] Windows guide: cover npu1, and install the deps the build declares

### DIFF
--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -213,7 +213,7 @@ If you would rather not clone MLIR-AIE, you need the CMake modules and the `mlir
 ```bat
 git clone --depth 1 https://github.com/Xilinx/cmakeModules.git C:\dev\cmakeModules
 pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
-pip install -r utils\requirements_dev.txt
+pip install -r C:\dev\mlir-air\utils\requirements_dev.txt
 ```
 
 ### 6.2 Stage LLVM/MLIR

--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -216,12 +216,6 @@ pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_ass
 pip install -r utils\requirements_dev.txt
 ```
 
-`utils\requirements_dev.txt` is MLIR-AIR's own build-dependency list, so it stays
-in step with the build rather than with this page. Its constraints mirror
-mlir-aie's, which matters most for `nanobind`: it ABI-couples to the MLIR distro
-wheel staged in [section 6.2](#62-stage-llvmmlir), and an unpinned install
-resolves to a version that wheel was not built against.
-
 ### 6.2 Stage LLVM/MLIR
 
 MLIR-AIR consumes LLVM/MLIR as a prebuilt "distro wheel" rather than building it. Download the exact pinned version and unpack it:

--- a/docs/buildingRyzenWin.md
+++ b/docs/buildingRyzenWin.md
@@ -125,7 +125,7 @@ MLIR-AIR publishes **Windows AMD64** wheels. Backend dependencies are exposed as
    set "PYTHONPATH=%MLIR_AIR_INSTALL_DIR%\python;%MLIR_AIE_INSTALL_DIR%\python;%XRT_ROOT%\python"
    ```
 
-   > `C:\Windows\System32\AMD` is on `PATH` so that MLIR-AIR can find `xrt-smi` and select the target device from the NPU model it reports. Passing `target_device="npu2"` to `XRTBackend` / `XRTRunner` selects it explicitly instead.
+   > `C:\Windows\System32\AMD` is on `PATH` so that MLIR-AIR can find `xrt-smi` and select the target device from the NPU model it reports. Passing `target_device="npu1"` or `target_device="npu2"` to `XRTBackend` / `XRTRunner` selects it explicitly instead.
 
 4. **Verify the install:**
 
@@ -161,7 +161,23 @@ python ..\eltwise_add.py --output-format xclbin
 
 A final `PASS!` confirms the toolchain, XRT installation, and NPU are working together.
 
-On npu2 parts you can also exercise the full-ELF output path, which is npu2-only:
+Both NPU generations are supported. What differs between them:
+
+| | npu1 (Phoenix) | npu2 (Strix, Strix Halo, Krackan) |
+|---|---|---|
+| Core architecture | `aie2` (default) | `aie2p` |
+| `num_device_cols` | 0 (whole device) or 1–3 | 0 (whole device) or 1–7 |
+| `--output-format xclbin` / `pdi` | yes | yes |
+| `--output-format elf` (full ELF) | no | yes |
+
+Full ELF needs an `aiebu-asm` configuration that targets AIE2P. Asking for it on npu1 is rejected at compile time rather than failing on the device:
+
+```text
+output_format='elf' is not supported for npu1 target. ELF output format is
+only supported on npu2 and later devices.
+```
+
+On npu2 parts you can exercise that path:
 
 ```bat
 cd programming_examples\matrix_scalar_add\single_core_dma
@@ -197,8 +213,14 @@ If you would rather not clone MLIR-AIE, you need the CMake modules and the `mlir
 ```bat
 git clone --depth 1 https://github.com/Xilinx/cmakeModules.git C:\dev\cmakeModules
 pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
-pip install cmake ninja lit nanobind numpy
+pip install -r utils\requirements_dev.txt
 ```
+
+`utils\requirements_dev.txt` is MLIR-AIR's own build-dependency list, so it stays
+in step with the build rather than with this page. Its constraints mirror
+mlir-aie's, which matters most for `nanobind`: it ABI-couples to the MLIR distro
+wheel staged in [section 6.2](#62-stage-llvmmlir), and an unpinned install
+resolves to a version that wheel was not built against.
 
 ### 6.2 Stage LLVM/MLIR
 

--- a/utils/mlir_air_wheels/setup.py
+++ b/utils/mlir_air_wheels/setup.py
@@ -313,7 +313,14 @@ def get_extras_require():
     # so we can inject the build-time mlir_aie pin into the [aie] extra.
     extras = {
         # Mirrors utils/requirements_dev.txt; keep in sync.
-        "dev": ["cmake>=3.30", "pybind11", "nanobind>=2.9", "lit", "psutil"],
+        "dev": [
+            "cmake>=4.4.2, <5.0",
+            "ninja!=1.13.0",
+            "pybind11>=3.0.4",
+            "nanobind==2.12.0",
+            "lit",
+            "psutil",
+        ],
     }
     # AIR supports multiple backends (AIE, GPU, VCK5000), so backend
     # dependencies live under per-backend extras rather than as hard

--- a/utils/requirements_dev.txt
+++ b/utils/requirements_dev.txt
@@ -1,15 +1,8 @@
-# Build-time Python dependencies. Constraints mirror mlir-aie's
-# python/requirements_dev.txt: both projects build against the same prebuilt
-# MLIR distro wheel, and on Windows they share one environment. Keep the two
-# lists in step when either side moves.
+# Constraints mirror mlir-aie's python/requirements_dev.txt; keep them in step.
 cmake>=4.4.2, <5.0
 ninja!=1.13.0
 pybind11>=3.0.4
-# nanobind ABI-couples to the distro wheel, which is built against one specific
-# version. A mismatch is a runtime failure rather than a build one -- Value
-# subclasses stop being recognised while the build and the lit suites still
-# pass -- so a floor like >=2.9 is not enough: it resolves to the newest
-# release. 2.13.0 rejects passing an OpResult where a Value is declared.
+# Pinned, not a floor: nanobind ABI-couples to the MLIR distro wheel.
 nanobind==2.12.0
 lit
 # lit requires psutil to set timeouts

--- a/utils/requirements_dev.txt
+++ b/utils/requirements_dev.txt
@@ -1,6 +1,16 @@
-cmake>=3.30
-pybind11
-nanobind>=2.9
+# Build-time Python dependencies. Constraints mirror mlir-aie's
+# python/requirements_dev.txt: both projects build against the same prebuilt
+# MLIR distro wheel, and on Windows they share one environment. Keep the two
+# lists in step when either side moves.
+cmake>=4.4.2, <5.0
+ninja!=1.13.0
+pybind11>=3.0.4
+# nanobind ABI-couples to the distro wheel, which is built against one specific
+# version. A mismatch is a runtime failure rather than a build one -- Value
+# subclasses stop being recognised while the build and the lit suites still
+# pass -- so a floor like >=2.9 is not enough: it resolves to the newest
+# release. 2.13.0 rejects passing an OpResult where a Value is declared.
+nanobind==2.12.0
 lit
 # lit requires psutil to set timeouts
 psutil


### PR DESCRIPTION
Two Windows findings from bringing MLIR-AIR up on an **npu1 (Phoenix)** laptop — source build, six `programming_examples` running on hardware. Both are small; neither is npu1-only.

## `utils/requirements_dev.txt` couldn't be pointed at

This is the file `setup_python_packages.sh` and `buildAIRWheels.yml` already install, and the obvious thing for the Windows guide to reference instead of a hand-maintained pip list. Two constraints stopped it standing alone:

- **`nanobind>=2.9`** is a floor, so pip takes the newest release (2.15.0 today). nanobind ABI-couples to the prebuilt MLIR distro wheel, and a mismatch fails at *runtime*, not at build time — `Value` subclasses stop being recognised while the build and the lit suites still pass. A floor is the wrong constraint shape for an ABI coupling.
- **No `ninja`** — it comes from apt on Linux, so the file can't satisfy a `-G Ninja` configure by itself.

Constraints now mirror mlir-aie's `python/requirements_dev.txt`, including `cmake` and `pybind11` bounds: both projects build against the same distro wheel and share one environment on Windows, so a constraint that differs is a constraint that can conflict.

## The Windows guide only ever named npu2

`grep npu1 docs/buildingRyzenWin.md` returned nothing. Added a table of what actually differs — core architecture, `num_device_cols` range, and full-ELF output, which needs an `aiebu-asm` configuration targeting AIE2P and is therefore npu2-only. Asking for it on npu1 is rejected at compile time, so the error is quoted rather than left to be discovered on the device. `target_device` now shows both values.

§6.1's non-mlir-aie branch now installs from `utils\requirements_dev.txt`. The recommended branch is deliberately untouched: `iron_setup.py --dev` already reconciles the environment, and adding a second installer on top is how two sets of pins get to disagree.

## Verification

- Fresh Python 3.13 venv on Windows: `pip install -r utils/requirements_dev.txt` resolves cmake 4.4.2, ninja 1.11.1.4, nanobind 2.12.0, lit 18.1.8, psutil 7.2.2, pybind11 3.1.0; all four tools runnable.
- npu1 (Phoenix, driver 32.0.20102.3930, XRT 2.21.0), source build against the staged distro wheel: `check-air-cpp` and `check-air-python` pass; `check-air-mlir` 483 passed, 20 failed, 0 unresolved, with every remaining failure in `Util/Runner`.
- `eltwise_add_with_l2`, both `matrix_scalar_add` variants, `segment_alloc`, `passthrough_dma` and `channel_examples/channel_size` compile and `PASS!` on hardware.

Docs-and-constraints only; no compiler or runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
