### PR TITLE
[programming_examples] Fix SmolVLA's broken gelu import, and restore its 2-D herd

### DIFF
--- a/programming_examples/gelu/gelu.py
+++ b/programming_examples/gelu/gelu.py
@@ -98,25 +98,63 @@ def build_gelu(n, tile_n, herd_shape=None, vector=None):
 
     tile = air.symbol(hint=tile_n, name="tile_n")
 
+    # A 2-D herd_shape asks for a rectangular herd rather than a row of cores.
+    # It matters: a 1-D herd is emitted as sizes=[P, 1], so it is bounded by the
+    # column count -- 8 on npu2 -- while (8, 2) fills 16. SmolVLA's vision
+    # encoder wants the latter, so the shape is honoured rather than flattened.
+    grid_2d = herd_shape is not None and len(herd_shape) == 2
+
+    def compute(h, base, tn):
+        """One tile: stage in, apply gelu, stage out."""
+        window = slice(base, base + tn)
+        x_buf = air.alloc([tn], bf16, scope=h.private(), vector=vector)
+        out_buf = air.alloc([tn], bf16, scope=h.private(), vector=vector)
+        air.ops.load(x_buf, x[window])
+        out_buf[:] = air.ops.gelu(x_buf[:])
+        air.ops.store(out_buf, out[window])
+
     with air.launch(name="gelu") as launch:
 
         @launch.body
         def _():
-            with air.herd(range(0, n, tile), shape=herd_shape) as h:
+            if grid_2d:
+                cols, rows = int(herd_shape[0]), int(herd_shape[1])
+                cores = cols * rows
+                if n % (tile_n * cores):
+                    raise ValueError(
+                        f"n ({n}) must be divisible by tile_n * cores "
+                        f"({tile_n} * {cores}); every core takes the same number "
+                        "of tiles and air.api has no partial trips"
+                    )
 
-                @h.body
-                def _(tx):
-                    tn = h.tile_sizes[0]
-                    window = slice(tx * tn, tx * tn + tn)
+                with air.herd([range(cols), range(rows)], shape=(cols, rows)) as h:
 
-                    x_buf = air.alloc([tn], bf16, scope=h.private(), vector=vector)
-                    out_buf = air.alloc([tn], bf16, scope=h.private(), vector=vector)
+                    @h.body
+                    def _(tx, ty):
+                        # Each core owns every cores'th tile, as the predecessor
+                        # did: linear index tx*rows + ty, stepped by the whole
+                        # herd. Allocations sit above the loop so the herd's
+                        # deallocs still dominate them.
+                        lin = tx * rows + ty
+                        x_buf = air.alloc(
+                            [tile_n], bf16, scope=h.private(), vector=vector
+                        )
+                        out_buf = air.alloc(
+                            [tile_n], bf16, scope=h.private(), vector=vector
+                        )
+                        for iv in air.sequential(0, n, tile_n * cores):
+                            base = iv + lin * tile_n
+                            window = slice(base, base + tile_n)
+                            air.ops.load(x_buf, x[window])
+                            out_buf[:] = air.ops.gelu(x_buf[:])
+                            air.ops.store(out_buf, out[window])
 
-                    air.ops.load(x_buf, x[window])
+            else:
+                with air.herd(range(0, n, tile), shape=herd_shape) as h:
 
-                    out_buf[:] = air.ops.gelu(x_buf[:])
-
-                    air.ops.store(out_buf, out[window])
+                    @h.body
+                    def _(tx):
+                        compute(h, tx * h.tile_sizes[0], h.tile_sizes[0])
 
     return launch
 

--- a/programming_examples/gelu/gelu.py
+++ b/programming_examples/gelu/gelu.py
@@ -119,6 +119,10 @@ def build_gelu(n, tile_n, herd_shape=None, vector=None):
         def _():
             if grid_2d:
                 cols, rows = int(herd_shape[0]), int(herd_shape[1])
+                if cols <= 0 or rows <= 0:
+                    raise ValueError(
+                        f"herd_shape extents must be positive, got " f"({cols}, {rows})"
+                    )
                 cores = cols * rows
                 if n % (tile_n * cores):
                     raise ValueError(

--- a/programming_examples/gelu/run_makefile_peano.lit
+++ b/programming_examples/gelu/run_makefile_peano.lit
@@ -14,4 +14,12 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
 // RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N=131072 TILE_N=2048 | FileCheck %s
+//
+// A 2-D herd, which is a separate code path: a 1-D herd is emitted as
+// sizes=[P, 1] and so is bounded by the column count, where (8, 2) fills 16
+// cores. SmolVLA's vision encoder is the consumer, and its own tests run only
+// in the nightly -- which is how the port that dropped this path reached main
+// unnoticed. Exercised here so PR CI covers it.
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile run PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N=262144 TILE_N=4096 HERD_SHAPE="8 2" | FileCheck %s
 // CHECK: PASS!

--- a/programming_examples/llms/smolvla/smolvla_vision_encoder.py
+++ b/programming_examples/llms/smolvla/smolvla_vision_encoder.py
@@ -381,7 +381,7 @@ def compile_all_kernels(
     from shared.infra.external_kernels import compile_gemm_mm
     from matrix_multiplication.bf16_in_bf16_out.run import build_module as build_gemm
     from layer_norm.layer_norm import build_module as build_layer_norm
-    from gelu.gelu import build_module as build_gelu
+    from gelu.gelu import build_gelu
     from flash_attention.kernel_fusion_based.attn_npu2_seqfirst import (
         build_module as build_attn,
     )
@@ -446,7 +446,11 @@ def compile_all_kernels(
     # --- 3. GELU-tanh (1D, N = seq_len * hidden_dim) ---
     gelu_n = seq_len * hidden_dim
     print(f"  Compiling gelu: N={gelu_n} (tile_n=4096, herd 8x2)")
-    gelu_mod = build_gelu(gelu_n, 4096, bfloat16, herd_x=8, herd_y=2)
+    # air.api builder: returns a launch, and .build() resolves the herd for the
+    # target. Pinned to npu2 -- this encoder is npu2-only (see the lit's
+    # REQUIRES) and the herd width depends on the generation, so leaving it to
+    # autodetect would make the compiled shape depend on the build host.
+    gelu_mod = build_gelu(gelu_n, 4096, herd_shape=(8, 2)).build(target="npu2")
     cache.compile_and_cache(
         "gelu", gelu_mod, {"verbose": cache.verbose, **_gelu_backend()}
     )

--- a/programming_examples/llms/smolvla/smolvla_vision_encoder.py
+++ b/programming_examples/llms/smolvla/smolvla_vision_encoder.py
@@ -81,6 +81,13 @@ def _gelu_backend():
         "output_format": "elf",
         "instance_name": "gelu",
         "runtime_loop_tiling_sizes": [4, 4],
+        # Pinned, because the air.api builder pins the module it hands over and
+        # the two must agree. They do not agree by default: XRTBackend's
+        # detect_target_device falls back to npu1 when xrt-smi cannot answer,
+        # while air.api's falls back to npu2, so a build host without a device
+        # would compile an npu2 module for npu1 -- which loads and computes
+        # nothing rather than failing.
+        "target_device": "npu2",
     }
 
 


### PR DESCRIPTION
**Hotfix.** The nightly LLM benchmark has been failing on `main` since #1832.

```
smolvla_vision_encoder.py:384: from gelu.gelu import build_module as build_gelu
ImportError: cannot import name 'build_module' from 'gelu.gelu'
```

Porting gelu to `air.api` (#1832) renamed its builder from `build_module` to `build_gelu`. SmolVLA is the only consumer outside the example's own directory.

**Why PR CI didn't catch it:** the LLM verify and profile lits run in the **nightly scheduled workflow only**, not on PRs. #1832 went green and the breakage surfaced hours later on `main`. Both `llms/smolvla/run_npu2_verify.lit` and `run_npu2_profile.lit` fail at the compile step.

## Fixed at the call site, not by restoring `build_module`

That name is the reason this was invisible. **157 files define a function called `build_module`**, and **43 import sites immediately alias it** to something meaningful:

```python
from gelu.gelu               import build_module as build_gelu
from layer_norm.layer_norm   import build_module as build_layer_norm
from matvec                  import build_module as build_gemv
from matmul_int4_packed      import build_module as build_int4_gemm
```

An import that says `build_module` carries no information about which contract is being depended on, so a rename looks like nothing to a reviewer and to grep. Re-adding it would have restored the failure mode along with the symbol. `build_gelu` is now imported under its own name.

## The import was not the only regression

SmolVLA asked for `herd_x=8, herd_y=2` — 16 cores. The ported example built a **1-D herd only**, and a 1-D herd is emitted as `sizes=[P, 1]`, so it is bounded by the column count: 8 on npu2. Restoring just the symbol would have quietly halved the parallelism of a kernel sitting on a benchmarked path.

`build_gelu` now honours a 2-D `herd_shape`, handing each core every *cores*'th tile exactly as the predecessor did. SmolVLA gets its 8×2 back.

## Verification, done locally

`math.tanh` only lowers on npu2, so gelu itself cannot run on an npu1 host. But
the gelu *math* is unchanged from #1832 and was verified there; what this PR
changes is the 2-D herd's tiling and index arithmetic. That part **is** testable
here, by substituting an npu1-legal op into `gelu.py`'s real code path:

```python
import air.api.ops as ops
ops.gelu = lambda x: x * 2.0          # npu1-legal stand-in
from gelu.gelu import build_gelu      # exercises the actual 2-D path
```

Run on npu1 hardware, herd (4, 2) — the widest 2-D herd 4 columns allow:

```
[precision] Output 0 (49152 elements): mean_rel_L1=0.000e+00 |
  rel_err max=0.000e+00 | abs_err max=0.000e+00 | rtol=0.0e+00 atol=0.0e+00
PASS!
```

**Exact, at zero tolerance.** A tiling bug — a skipped or duplicated tile — would
leave stale elements and fail immediately at `atol=0`, so this establishes that
every element is visited exactly once.

Also checked:

- **The emitted signature is identical to the predecessor's**, which is what the
  runtime binds to: `func.func @gelu(%arg0: memref<3145728xbf16>, %arg1:
  memref<3145728xbf16>)` — same symbol, same two arguments, same order.
- **SmolVLA's exact expression at its real shape** (`seq_len=1024`,
  `hidden_dim=3072`, herd 8x2) compiles to an **npu2 ELF** with SmolVLA's own
  backend kwargs.
- The 1-D path is untouched, so the gelu example's own lits are unaffected.

Not verifiable on this host, and left to the nightly: the gelu transcendental on
npu2 (unchanged by this PR) and SmolVLA end to end (needs npu2 plus HF weights).

## Follow-up worth doing separately

The LLM lits not running in PR CI is what let this reach `main`. Any example conversion can break an LLM consumer invisibly, and there are two more conversions queued (i16, i8). Either those lits should run on PRs that touch `programming_examples/`, or the conversions need an explicit cross-consumer grep as a gate.
