### PR TITLE
[llms] Sweep llama31_8b_q4nx too, and check its weight split

### DIFF
--- a/programming_examples/llms/bench/decode_geometry.py
+++ b/programming_examples/llms/bench/decode_geometry.py
@@ -43,17 +43,28 @@ _CHECK_W_ELEMS = [
     ("llama-3.2-3b", "9", 28, 1004666880),
     ("gemma3-4b", "5", 34, 1213644800),
 ]
-# The one split model. Its parts summing to w_elems checks the part that can
+# The split models. Their parts summing to w_elems checks the part that can
 # actually be wrong: that the per-group `min(G, UNI_DEC - g*G)` covers exactly
 # UNI_DEC layers, with no gap and no overlap. The head term is shared by both
-# routes, so it is the grouping arithmetic that is under test here.
-_CHECK_SPLIT = (
-    "qwen3-8b",
-    "8",
-    36,
-    dict(DECODE_STACK="6144", DECODE_WGROUP="9"),
-    [542638080, 542638080, 542638080, 542638080, 199229440],
-)
+# routes, so it is the grouping arithmetic that is under test here. Both cases
+# are kept because they divide differently -- 36 into 9 is exact, 32 into 8 is
+# exact at a different group count -- and a gap/overlap bug need not hit both.
+_CHECK_SPLITS = [
+    (
+        "qwen3-8b",
+        "8",
+        36,
+        dict(DECODE_STACK="6144", DECODE_WGROUP="9"),
+        [542638080, 542638080, 542638080, 542638080, 199229440],
+    ),
+    (
+        "llama-3.1-8b",
+        "16",
+        32,
+        dict(DECODE_STACK="8064", DECODE_WGROUP="8"),
+        [545259520, 545259520, 545259520, 545259520, 167772160],
+    ),
+]
 _CHECK_WANT = dict(
     k=2048,
     w_elems=386662400,
@@ -218,10 +229,10 @@ def main():
             got = geometry(model, i2, 2048, n_layers=nl)["w_elems"]
             if got != want:
                 bad[f"w_elems[{model}]"] = (want, got)
-        model, i2, nl, extra, want = _CHECK_SPLIT
-        got = geometry(model, i2, 2048, n_layers=nl, env_extra=extra).get("w_parts")
-        if got != want:
-            bad[f"w_parts[{model}]"] = (want, got)
+        for model, i2, nl, extra, want in _CHECK_SPLITS:
+            got = geometry(model, i2, 2048, n_layers=nl, env_extra=extra).get("w_parts")
+            if got != want:
+                bad[f"w_parts[{model}]"] = (want, got)
         print("SELF-CHECK", "PASS" if not bad else f"FAIL {bad}")
         return 0 if not bad else 1
 

--- a/programming_examples/llms/llama31_8b_q4nx/run_npu2_sweep.lit
+++ b/programming_examples/llms/llama31_8b_q4nx/run_npu2_sweep.lit
@@ -1,0 +1,43 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// LLAMA-3.1-8B Q4NX decode throughput vs context length, into
+// llama31_8b_q4nx.sweep.json (collected by the nightly LLM benchmark).
+//
+// Complements run_npu2_profile.lit rather than repeating it: that test profiles
+// the real prefill+decode path at the profile prompt's ~6 tokens of context.
+// Decode tok/s is dominated by KV streaming and falls steeply
+// between 1k and 128k on this design, so a single near-zero-context point
+// cannot see a KV-path regression.
+//
+// Decode-only and synthetic (latency, never correctness -- run_npu2_verify.lit
+// is the correctness gate), so unlike the profile test this needs no HF weights
+// and no hf_token: the context is set by sizing the KV cache, not by prefilling
+// a real prompt of that length. llvm_link_pre23 is still required because the
+// build goes through fused_decode's inline-attn merge.
+//
+// DECODE_WGROUP / DECODE_STACK are passed rather than left to the Makefile's
+// defaults because they reach two places that have to agree: the device build
+// (how many weight args the signature carries) and the host BO split. Passing
+// them here sends one value to both.
+//
+// 64k and 128k are swept but allowed to fail. Whether a model reaches them
+// depends on how much host memory XRT will pin for its KV BO, which differs
+// between machines. This model carries 4.38 GiB of weights before a byte of KV,
+// second only to qwen3-8b's 4.41 GiB, and its KV at 128k is the same 16 GiB as
+// the other 8-kv-head DH=128 Llamas. The point is recorded with its status
+// either way rather than reddening CI on a property of the host.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_peano_sweep
+// RUN: cd test_peano_sweep
+// RUN: %PYTHON %S/../bench/sweep_decode.py --model-name llama31_8b_q4nx --makefile %S/Makefile --template-dir %S --bench-model llama-3.1-8b --vocab-chunk-i2 16 --n-layers 32 --builder-env DECODE_WGROUP=8 --builder-env DECODE_STACK=8064 --contexts 1024,2048,4096,8192,16384,32768,65536,131072 --expect-fail 65536,131072 --peano-dir %PEANO_INSTALL_DIR --xrt-dir %XRT_DIR --out llama31_8b_q4nx.sweep.json
+// RUN: FileCheck %s < llama31_8b_q4nx.sweep.json
+// CHECK: "model": "llama31_8b_q4nx"
+// CHECK: "axis": "context_len"
+// A parsed number at the reference context, not just a well-formed file: if the
+// bench line format drifts out of sweep_decode.py's regex every point goes null
+// and the published curve silently empties while the test stays green.
+// CHECK: "context_len": 2048
+// CHECK-NEXT: "decode_tokens_per_sec": {{[0-9]}}


### PR DESCRIPTION
Two gaps left by merge ordering. #1839 extended the decode tok/s-vs-context
sweep to "the fused-decode models" about twenty minutes before #1840 added
`llama31_8b_q4nx`, so the new model was invisible to it.

## Sweep lit

`llama31_8b_q4nx` was the only fused-decode q4nx model without a
`run_npu2_sweep.lit` — the other six all have one. It appeared in the
single-point profile table but not the published curve, which is exactly the
blind spot the sweep exists to close: decode tok/s is dominated by KV streaming,
and the profile's ~6-token context cannot see a KV-path regression.

The gap is not academic for this model. Measured on NPU2 while writing this:

| context | tok/s |
|---|---|
| 1024 | 10.9 |
| 2048 | 6.89 |

Like `qwen3-8b` it passes `DECODE_WGROUP` / `DECODE_STACK` explicitly rather
than leaving them to the Makefile defaults, because they reach both the device
build (how many weight args the signature carries) and the host BO split, and
the two have to agree.

## Weight-split check

`decode_geometry.py`'s `_CHECK_SPLIT` called `qwen3-8b` "the one split model".
There are two now. Generalized to a list and added this model.

Keeping both is not redundant. They exercise different divisibility — 36 layers
into groups of 9 versus 32 into 8 — and the invariant under test is that the
per-group `min(G, UNI_DEC - g*G)` covers exactly `UNI_DEC` layers with no gap
and no overlap. A grouping bug need not hit both cases. That arithmetic is what
the whole 4 GiB weight split rests on, and getting it wrong is what produced the
all-NaN decode #1840 started from, so it should not be guarded on one model
only.

## Verification

- `decode_geometry.py --check` passes with both split models.
- It still **fails**, naming the model and printing the expected-vs-got parts,
  when a single element of the new model's expected split is perturbed — so the
  new entry is live, not vacuously passing.
- The sweep was run on NPU2 at 1k and 2k (distinct `xclbin_md5` per context, so
  each point genuinely rebuilt its template), and its JSON passes the lit's own
  FileCheck lines.
