### PR TITLE
[CI] Add llama-3.1-8b to the decode sweep, and build the bench binary up front

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -356,6 +356,20 @@ jobs:
           # flattering end of a ~12x range and cannot see a KV-path regression.
           # Each sweep is ~4-5 min (a template build per context).
           if want sweep; then
+            # Build the shared bench binary BEFORE any timed work. Every model's
+            # `make clean` recurses into fused_decode's, which deletes it, so
+            # verify/profile above always leave it missing and the first model
+            # lit picks it up lazily -- a different model each night, since lit
+            # runs --order=random. Measured once locally on llama31-8b: a sweep
+            # that rebuilt the binary at its start read 11.24/11.77/10.67 tok/s
+            # at 1k/2k/4k, while the same sweep with the binary already present
+            # read 13.11/12.44/11.32, matching two quiet re-measures to 0.3%.
+            # The 8B models are the first big enough to show it. The mechanism
+            # is NOT understood -- the effect outlasts the process that caused
+            # it -- so this removes the condition rather than claiming a fix;
+            # if a head-of-curve dip recurs, this was not the cause.
+            make -C ../programming_examples/fused_decode bench-decode-exe \
+              XILINX_XRT="$XILINX_XRT" || rc=1
             LIT_OPTS="--timeout 3600" \
               ninja check-programming-examples-llms-sweep || rc=1
           fi


### PR DESCRIPTION
Adds the seventh model to the decode tok/s-vs-context sweep, and fixes a
measurement hazard that the 8B models are the first to expose.

### llama-3.1-8b needs only a lit

`llama31_8b_q4nx` (#1840) drives the same shared `fused_decode` engine through
the same `_compile_decode_build` contract as the rest, and it is the second
split-weight model, so the `--w-parts` path from #1839 covers it unchanged.

Worth noting as a check on the derivation: `decode_geometry.py` reproduces the
split this model's nightly memory note already records — 4 × 1.0156 GiB plus a
0.3125 GiB lm-head slab — by a different route (per-group `W_LAYER` versus the
packed-block total), on a model it had never seen.

### Measured

4X4 BOX-AI350 (Ryzen AI 7 350), full grid through the lit's own command line
with `PEANO_INSTALL_DIR` and `XILINX_XRT` unset:

| model | 1k | 2k | 4k | 8k | 16k | 32k | 64k | 128k |
|---|---|---|---|---|---|---|---|---|
| llama31_8b_q4nx | 13.11 | 12.44 | 11.32 | 9.58 | 7.32 | 4.98 | 3.04 | expected_fail |

128k is `expected_fail` here as for the other large models — 4.38 GiB of
weights before a byte of KV, and 16 GiB of KV at 128k.

### The bench binary must exist before any timed work

The first run of that curve came out **non-monotone** — 11.24 at 1k against
11.77 at 2k — with the head 5–16% low out to 4k. The one thing that
distinguished it: that run rebuilt `bench_decode.exe` at its start. With the
binary already present, the same sweep reads 13.11 / 12.44 / 11.32, matching
two quiet re-measures to within 0.3%.

| ctx | rebuilt at start | binary present | quiet re-measure |
|---|---|---|---|
| 1k | 11.24 | 13.11 | 13.09 |
| 2k | 11.77 | 12.44 | 12.42 |
| 4k | 10.67 | 11.32 | 11.29 |
| 8k | 9.54 | 9.58 | 9.55 |

**That condition is what CI hits every night.** Every model's `make clean`
recurses into `fused_decode`'s, which deletes `$(BENCH_EXE)`; verify and
profile both clean first, so the binary is always missing when the sweep suite
starts, and the first model's lit rebuilds it lazily. lit runs
`--order=random`, so that is a different model each night. The four original
curves look clean because those models are small enough not to show it — this
only became visible once the 8B models joined.

So the workflow now builds it once, before the suite.

**The mechanism is not understood.** The effect outlasts the process that
caused it and spans several minutes across separate bench processes, which a
g++ invocation does not obviously explain. This removes the correlated
condition rather than claiming a fix, and the comment in the workflow says so:
if a head-of-curve dip recurs, this was not the cause.

Latency only. `make verify` remains the sole correctness gate; these builds are
weight-free and the buffers are synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
