### PR TITLE
[air] Let a linalg contraction name the kernel it lowers to

### DIFF
--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -159,7 +159,15 @@ def AIRLinalgToFunc : Pass<"air-linalg-to-func", "ModuleOp"> {
     Option<"clLinkWith", "link-with", "std::string",
           /*default=*/"\"\"",
            "Path to the object file containing the functions that will be "
-           "called in place of the linalg operations.">
+           "called in place of the linalg operations.">,
+    Option<"clDeriveLibraryCall", "derive-library-call", "bool",
+          /*default=*/"false",
+           "Derive a callee name from the operation and its operand types when "
+           "the op does not carry one, instead of emitting MLIR's "
+           "\"op_has_no_registered_library_name\" placeholder. Only ops with no "
+           "library_call attribute are affected. Off by default: the placeholder "
+           "is the symbol every hand-written kernel in this tree currently "
+           "exports, so turning this on requires renaming them to match.">
   ];
 }
 

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -8364,14 +8364,40 @@ public:
 class AIRLinalgOpToLibraryCallRewrite
     : public OpInterfaceRewritePattern<linalg::LinalgOp> {
 public:
-  AIRLinalgOpToLibraryCallRewrite(MLIRContext *ctx, std::string &linkWith)
-      : OpInterfaceRewritePattern(ctx), linkWith(linkWith) {}
+  AIRLinalgOpToLibraryCallRewrite(MLIRContext *ctx, std::string &linkWith,
+                                  bool deriveLibraryCall)
+      : OpInterfaceRewritePattern(ctx), linkWith(linkWith),
+        deriveLibraryCall(deriveLibraryCall) {}
 
   LogicalResult matchAndRewrite(linalg::LinalgOp op,
                                 PatternRewriter &rewriter) const override {
     auto fnName = op.getLibraryCallName();
     if (fnName.empty())
       return failure();
+
+    // linalg.generic returns MLIR's "op_has_no_registered_library_name"
+    // placeholder unless it carries a library_call attribute, and the OpDSL
+    // emitter never sets one -- so every OpDSL-defined contraction in the tree
+    // resolves to that single symbol. Two consequences: a kernel compiled for
+    // different tile dimensions still links, and computes silently wrong
+    // results; and two differently shaped contractions cannot coexist in one
+    // core, which callers work around by renaming symbols in the object file.
+    //
+    // Deriving the name from the operation and its operand types fixes both:
+    // the mangling encodes shapes, element types and memory spaces, so a
+    // mismatch becomes a link error. generateLibraryCallName is MLIR's own
+    // routine, the one that gives linalg.fill its
+    // "linalg_fill_bf16_view1x1x8x8x4x4xbf16as2", so the derived names match
+    // house style rather than inventing a second convention.
+    //
+    // Off unless asked for: that placeholder is the symbol every hand-written
+    // kernel here exports today.
+    if (deriveLibraryCall && fnName == "op_has_no_registered_library_name") {
+      auto derived = linalg::generateLibraryCallName(op);
+      if (derived.empty())
+        return failure();
+      fnName = derived;
+    }
 
     // Function to get operands of the library call that will
     // replace the given linalg op.
@@ -8434,6 +8460,7 @@ public:
 
 private:
   std::string &linkWith;
+  bool deriveLibraryCall;
 };
 
 struct AIRLinalgToFuncPass
@@ -8450,7 +8477,8 @@ void AIRLinalgToFuncPass::runOnOperation() {
                          cf::ControlFlowDialect, ub::UBDialect>();
   target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
   RewritePatternSet patterns(&getContext());
-  patterns.insert<AIRLinalgOpToLibraryCallRewrite>(&getContext(), clLinkWith);
+  patterns.insert<AIRLinalgOpToLibraryCallRewrite>(&getContext(), clLinkWith,
+                                                   clDeriveLibraryCall);
   if (failed(applyFullConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }

--- a/mlir/test/Conversion/AIRLinalgToFunc/library_call.mlir
+++ b/mlir/test/Conversion/AIRLinalgToFunc/library_call.mlir
@@ -1,0 +1,58 @@
+//===- library_call.mlir ---------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// How air-linalg-to-func names the function it calls. Three cases, because a
+// linalg.generic only reports a library call name if it carries the attribute,
+// and the OpDSL emitter never sets one.
+
+// RUN: air-opt %s -air-linalg-to-func=link-with=mm.o | FileCheck %s --check-prefix=PLACEHOLDER
+// RUN: air-opt %s -air-linalg-to-func='link-with=mm.o derive-library-call=true' | FileCheck %s --check-prefix=DERIVED
+// RUN: air-opt %s -air-linalg-to-func='link-with=mm.o derive-library-call=true' | FileCheck %s --check-prefix=EXPLICIT
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// Default: MLIR's placeholder, which is the symbol every hand-written kernel in
+// this tree exports today. Unchanged so those keep linking.
+// PLACEHOLDER-LABEL: func.func @unnamed
+// PLACEHOLDER: call @op_has_no_registered_library_name
+func.func @unnamed(%a: memref<4x8xbf16>, %b: memref<8x4xbf16>, %c: memref<4x4xbf16>) {
+  linalg.generic {indexing_maps = [#map, #map1, #map2],
+                  iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%a, %b : memref<4x8xbf16>, memref<8x4xbf16>) outs(%c : memref<4x4xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %0 = arith.mulf %in, %in_0 : bf16
+    %1 = arith.addf %out, %0 : bf16
+    linalg.yield %1 : bf16
+  }
+  return
+}
+
+// Derived: the name mangles every operand type, so a kernel built for other
+// tile dimensions no longer links against the same symbol. The declaration
+// carries link_with and the C interface attribute, as before.
+// DERIVED-LABEL: func.func @unnamed
+// DERIVED: call @linalg_generic_view4x8xbf16_view8x4xbf16_view4x4xbf16
+// DERIVED: func.func private @linalg_generic_view4x8xbf16_view8x4xbf16_view4x4xbf16
+// DERIVED-SAME: attributes {link_with = "mm.o", llvm.emit_c_interface}
+
+// An explicit library_call always wins, derived or not: deriving only fills in
+// a name that is absent.
+// EXPLICIT: call @matmul_bf16_bf16_m4k8n4
+func.func @named(%a: memref<4x8xbf16>, %b: memref<8x4xbf16>, %c: memref<4x4xbf16>) {
+  linalg.generic {indexing_maps = [#map, #map1, #map2],
+                  iterator_types = ["parallel", "parallel", "reduction"],
+                  library_call = "matmul_bf16_bf16_m4k8n4"}
+    ins(%a, %b : memref<4x8xbf16>, memref<8x4xbf16>) outs(%c : memref<4x4xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %0 = arith.mulf %in, %in_0 : bf16
+    %1 = arith.addf %out, %0 : bf16
+    linalg.yield %1 : bf16
+  }
+  return
+}

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -526,7 +526,7 @@ def _check_packed_operands(a, b, acc):
         )
 
 
-def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
+def dot(a, b, acc=None, alpha=1.0, transpose_b=False, kernel=None, dependency=None):
     """``acc += a @ b`` over L1 tiles. Returns a :class:`Token`.
 
     This is a *statement*, not an expression, and the accumulator is a buffer
@@ -559,6 +559,18 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
 
     One rule covers all four: ``a``'s last axis contracts against ``b``'s first,
     and ``acc`` keeps what is left of each.
+
+    ``kernel=`` names the external function this contraction should lower to
+    under ``lower_linalg_to_func``, by setting linalg's ``library_call``
+    attribute. Without it a micro-tiled contraction lowers to
+    ``op_has_no_registered_library_name`` -- MLIR's placeholder for an op with no
+    registered name, which the OpDSL emitter never overrides and which every
+    hand-written kernel here therefore exports. Sharing one symbol means a
+    kernel compiled for the wrong tile dimensions still links and computes
+    silently wrong results, and two differently shaped contractions cannot
+    coexist in one core. Naming the kernel makes both of those link errors::
+
+        ops.dot(a, b, acc=acc, kernel="matmul_bf16_bf16_m32k16n32")
     """
     from air.dialects import linalg
 
@@ -600,6 +612,7 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
             )
         _check_packed_operands(a, b, acc)
         op = _block_matmul_op()(a.value, b.value, outs=[accumulator_subview(acc)])
+        _set_library_call(kernel)
         return Token(op)
 
     if ranks not in _CONTRACTIONS:
@@ -639,7 +652,32 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None):
         )
 
     op = getattr(linalg, op_name)(a.value, b.value, outs=[acc.value])
+    _set_library_call(kernel)
     return Token(op)
+
+
+def _set_library_call(kernel):
+    """Stamp ``library_call`` on the contraction just emitted.
+
+    The OpDSL emitter hardcodes ``library_call=None`` (a standing TODO in
+    upstream ``linalg/opdsl/lang/emitter.py``) and returns the op's *results*,
+    which is an empty list for memref semantics -- so there is no handle to set
+    the attribute on. The op is the last one written into the current block,
+    which is where this reaches for it.
+    """
+    if kernel is None:
+        return
+    if not isinstance(kernel, str) or not kernel:
+        raise TypeError(
+            f"air.api.ops.dot(kernel=...) takes the external function's symbol "
+            f"name, got {type(kernel).__name__}"
+        )
+    from air.ir import InsertionPoint, StringAttr
+
+    block = InsertionPoint.current.block
+    block.operations[len(block.operations) - 1].attributes["library_call"] = (
+        StringAttr.get(kernel)
+    )
 
 
 def _unimplemented(name, needs):

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -526,7 +526,7 @@ def _check_packed_operands(a, b, acc):
         )
 
 
-def dot(a, b, acc=None, alpha=1.0, transpose_b=False, kernel=None, dependency=None):
+def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None, *, kernel=None):
     """``acc += a @ b`` over L1 tiles. Returns a :class:`Token`.
 
     This is a *statement*, not an expression, and the accumulator is a buffer
@@ -560,7 +560,10 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, kernel=None, dependency=No
     One rule covers all four: ``a``'s last axis contracts against ``b``'s first,
     and ``acc`` keeps what is left of each.
 
-    ``kernel=`` names the external function this contraction should lower to
+    ``kernel=`` is keyword-only, and sits after ``dependency`` so that every
+    existing positional binding is unchanged: inserting it earlier would have
+    silently rebound a positionally-passed ``dependency`` to it. It names the
+    external function this contraction should lower to
     under ``lower_linalg_to_func``, by setting linalg's ``library_call``
     attribute. Without it a micro-tiled contraction lowers to
     ``op_has_no_registered_library_name`` -- MLIR's placeholder for an op with no

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -211,6 +211,7 @@ class XRTBackend(AirBackend):
         omit_while_true_loop: bool = False,
         omit_pingpong: str = "",
         lower_linalg_to_func: str = None,
+        derive_library_call: bool = False,
         air_loop_fusion: bool = False,
         runtime_loop_tiling_sizes: list[int] = [],
         omit_auto_broadcast: bool = False,
@@ -241,6 +242,7 @@ class XRTBackend(AirBackend):
             omit_while_true_loop: configure aircc to omit the while true loop it traditionally emits.
             omit_pingpong: configure aircc to omit the generation of ping-pong buffering for specific memory levels. Supported values: "", "L1", "L2", "all". Empty string means no omission (default).
             lower_linalg_to_func: configure aircc to lower linalg.generic to function calls, or loops.
+            derive_library_call: with lower_linalg_to_func, name the callee after the op and its operand types rather than MLIR's "op_has_no_registered_library_name" placeholder. The kernel object must export the derived name.
             air_loop_fusion: configure aircc to add air-loop-fusion experimental pass.
             runtime_loop_tiling_sizes: tile sizes forwarded to aircc as --air-runtime-loop-tiling-sizes, which the shim DMA BD optimization pass (air-opt-shim-dma-bds) consumes as shim-dma-tile-sizes. Omit or pass an empty list to skip tiling.
             omit_auto_broadcast: configure aircc to omit the detection and lowering of broadcast data movements.
@@ -284,6 +286,7 @@ class XRTBackend(AirBackend):
         else:
             self.omit_pingpong = omit_pingpong
         self.lower_linalg_to_func = lower_linalg_to_func
+        self.derive_library_call = derive_library_call
         self.air_loop_fusion = air_loop_fusion
         self.runtime_loop_tiling_sizes = runtime_loop_tiling_sizes
         self.omit_auto_broadcast = omit_auto_broadcast
@@ -459,6 +462,8 @@ class XRTBackend(AirBackend):
             if self.lower_linalg_to_func:
                 aircc_options += ["--lower-linalg-to-func"]
                 aircc_options += [self.lower_linalg_to_func]
+                if self.derive_library_call:
+                    aircc_options += ["--derive-library-call"]
 
             if self.air_loop_fusion:
                 aircc_options += ["--air-loop-fusion"]

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -811,3 +811,15 @@ def _():
         air.alloc([1, 1, 32, 32], bf16, scope=seg.shared())
 
     _staged(body)
+
+
+# CHECK-LABEL: TEST: dot_kernel_must_be_a_name
+# CHECK: TypeError: air.api.ops.dot(kernel=...) takes the external function's symbol name
+@expect(TypeError, "dot_kernel_must_be_a_name")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 32], bf16, scope=h.private())
+        acc = air.alloc([32, 32], f32, scope=h.private())
+        ops.dot(a, a, acc=acc, kernel=42)
+
+    _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -823,3 +823,13 @@ def _():
         ops.dot(a, a, acc=acc, kernel=42)
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_kernel_is_keyword_only
+# kernel= sits after dependency and is keyword-only, so adding it did not shift
+# any existing positional binding. Passing it positionally is refused rather
+# than silently rebinding whatever was in that slot.
+# CHECK: TypeError: dot() takes from 2 to 6 positional arguments but 7 were given
+@expect(TypeError, "dot_kernel_is_keyword_only")
+def _():
+    ops.dot(None, None, None, 1.0, False, None, "matmul_bf16")

--- a/python/test/api/pack.py
+++ b/python/test/api/pack.py
@@ -147,3 +147,59 @@ def build():
 
 
 print(build().build(target="npu1"))
+
+
+# ---------------------------------------------------------------------------
+# ops.dot(kernel=...): naming the external function.
+#
+# Without it a micro-tiled contraction lowers to MLIR's
+# "op_has_no_registered_library_name" placeholder -- the OpDSL emitter hardcodes
+# library_call=None -- so every such contraction in the tree resolves to one
+# symbol. A kernel compiled for the wrong tile dimensions then links anyway and
+# computes silently wrong results.
+# ---------------------------------------------------------------------------
+
+
+def build_named_kernel():
+    mm = air.micro_tile(m=4, k=8, n=4)
+    A = air.tensor([32, 32], bf16)
+    C = air.tensor([32, 32], bf16)
+
+    with air.launch(name="named", target="npu1") as launch:
+
+        @launch.body
+        def _():
+            with air.segment([range(0, 32, 32)], name="seg") as seg:
+
+                @seg.body
+                def _(si):
+                    acc = air.alloc(mm.c(32, 32), bf16, scope=seg.shared())
+                    l2 = air.alloc([32, 32], bf16, scope=seg.private())
+                    air.ops.load(l2, A[0:32, 0:32])
+
+                    with air.herd([range(1), range(1)], name="mm") as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            a = air.alloc(mm.a(32, 16), bf16, scope=h.private())
+                            b = air.alloc(mm.b(16, 32), bf16, scope=h.private())
+                            air.ops.dot(a, b, acc=acc, kernel="matmul_bf16_m32k16n32")
+
+                    with air.herd([range(1), range(1)], name="drain") as h2:
+
+                        @h2.body
+                        def _(tx, ty):
+                            air.ops.store(acc[tx, ty, :, :], l2[0:32, 0:32])
+
+                    air.ops.store(l2, C[0:32, 0:32])
+
+    return launch
+
+
+# The name rides on the contraction as linalg's own attribute, so
+# air-linalg-to-func picks it up without any air-specific plumbing.
+# CHECK-LABEL: func.func @named
+# CHECK: linalg.generic
+# CHECK-SAME: library_call = "matmul_bf16_m32k16n32"
+
+print(build_named_kernel().build(target="npu1"))

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -200,6 +200,14 @@ static cl::opt<std::string>
                                "given object file"),
                       cl::init(""), cl::cat(airCompilerOptions));
 
+static cl::opt<bool> deriveLibraryCall(
+    "derive-library-call",
+    cl::desc("With --lower-linalg-to-func, name the callee after the operation "
+             "and its operand types instead of MLIR's "
+             "\"op_has_no_registered_library_name\" placeholder. Requires the "
+             "kernel object to export the derived name."),
+    cl::init(false), cl::cat(airCompilerOptions));
+
 static cl::opt<bool>
     airLoopFusion("air-loop-fusion",
                   cl::desc("Add air-loop-fusion pass to the pipeline"),
@@ -971,8 +979,10 @@ static std::string buildOptimizationPipeline(int resolvedNumCols) {
 
   // Linalg lowering
   if (!lowerLinalgToFunc.empty()) {
-    os << ",air-linalg-to-func{link-with=" << lowerLinalgToFunc.getValue()
-       << "}";
+    os << ",air-linalg-to-func{link-with=" << lowerLinalgToFunc.getValue();
+    if (deriveLibraryCall)
+      os << " derive-library-call=true";
+    os << "}";
   } else {
     os << ",func.func(convert-linalg-to-loops)";
   }


### PR DESCRIPTION
Under `lower_linalg_to_func`, `air-linalg-to-func` replaces a linalg op with a call to `op.getLibraryCallName()`. For `linalg.generic` that returns MLIR's **`op_has_no_registered_library_name`** placeholder unless the op carries a `library_call` attribute — and the OpDSL emitter hardcodes `library_call=None` (a standing TODO upstream in `linalg/opdsl/lang/emitter.py:259`).

So every OpDSL-defined contraction in this tree — every `block_matmul` — resolves to that one symbol. MLIR's *"I don't know this op"* string is load-bearing as a linker symbol, and 11 `.cc` kernels export it deliberately.

## Why that matters

**A kernel compiled for the wrong tile dimensions still links, and computes silently wrong results.** `mm.cc`'s `DIM_M`/`DIM_N`/`DIM_K` are baked in at compile time, and `llms/shared/infra/external_kernels.py` documents them as *"MUST match the tile_m/tile_n/tile_k_l1 passed to the GEMM module builder"* — with nothing enforcing it.

**Two differently shaped contractions cannot coexist in one core.** Callers already work around this by rewriting symbols in the object file; the same file grew a `sym_suffix` parameter for it:

> `sym_suffix="_m64"` (→ `@op_has_no_registered_library_name_m64` etc.) and a distinct `out_name="mm_m64.o"` … to link TWO mm.o variants into ONE ELF, the symbols must not collide

13 call sites do that string surgery.

## What this adds

Two ways to give the call a real name. **Neither changes behaviour by default.**

**1. `ops.dot(..., kernel=...)`** sets `library_call` on the emitted contraction:

```python
ops.dot(a, b, acc=acc, kernel="matmul_bf16_m32k16n32")
```

Nothing air-specific is needed downstream — the attribute is linalg's own and the existing pass already honours it.

**2. `air-linalg-to-func{derive-library-call=true}`** derives a name for ops that have none, using `mlir::linalg::generateLibraryCallName` — the same routine that gives `linalg.fill` its `linalg_fill_bf16_view1x1x8x8x4x4xbf16as2`, so derived names match house style instead of inventing a second convention. The mangling encodes shapes, element types and memory spaces, so **a tile-size mismatch becomes a link error**. Reachable as `aircc --derive-library-call` and `XRTBackend(derive_library_call=True)`.

## Why off by default

The placeholder is the symbol all 11 hand-written kernels export today, and 13 sites do string surgery on it. Turning either mechanism on requires renaming the kernel to match, so **migration is per example rather than tree-wide** — most of the affected consumers are npu2-only LLM pipelines whose tests run in the nightly, not on PRs. The int matmul conversions are next and will be the first users.

## Verification

Three behaviours, covered by `mlir/test/Conversion/AIRLinalgToFunc/library_call.mlir`:

| input | flag | callee |
|---|---|---|
| no `library_call` | off (default) | `op_has_no_registered_library_name` |
| no `library_call` | `derive-library-call=true` | `linalg_generic_view4x8xbf16_view8x4xbf16_view4x4xbf16` |
| has `library_call` | either | the explicit name — deriving only fills in what is absent |

End to end through the real pipeline: `matrix_multiplication/bf16` at its 1×1 configuration with `derive_library_call=True` emits

```
func.call @linalg_generic_view1x1x2x8x4x8xbf16as2_view1x1x8x2x8x4xbf16as2_view1x1x8x8x4x4xbf16as2
```

and links against `mm.o` rebuilt to export that name (`-Dop_has_no_registered_library_name=<derived>`). `ops.dot(kernel=...)` is covered in `python/test/api/pack.py`, with a negative case in `errors.py`.

All 9 api suites pass, the 207 existing `Conversion/` lits are unaffected, `black` and `clang-format` clean.
