### PR TITLE
[test] Resolve the NPU generation once per lit run, not once per test

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -130,11 +130,17 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         if any(k in out_lc for k in npu2_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu2")
+            # Resolved once here so the ~230 test processes in a suite run do not
+            # each re-run xrt-smi examine. That probe has a 10 s timeout and
+            # intermittently exceeds it under load; on timeout the backend falls
+            # back to npu1 and silently builds a 4-column design for an 8-column part.
+            config.environment["AIR_TARGET_DEVICE"] = "npu2"
             run_on_npu2 = run_on_npu
             print("Running tests on NPU2 with command line: ", run_on_npu2 or "(none)")
         elif any(k in out_lc for k in npu1_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu1")
+            config.environment["AIR_TARGET_DEVICE"] = "npu1"
             run_on_npu1 = run_on_npu
             print("Running tests on NPU1 with command line: ", run_on_npu or "(none)")
         else:

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -142,7 +142,7 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
             config.available_features.add("ryzen_ai_npu1")
             config.environment["AIR_TARGET_DEVICE"] = "npu1"
             run_on_npu1 = run_on_npu
-            print("Running tests on NPU1 with command line: ", run_on_npu or "(none)")
+            print("Running tests on NPU1 with command line: ", run_on_npu1 or "(none)")
         else:
             # No recognized model: dump xrt-smi output so the cause (format
             # change, or a driver error such as an mmap/memlock failure) is

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -70,7 +70,24 @@ def detect_target_device(verbose=False, default="npu1"):
     installed is not diagnosed anywhere downstream -- an aie.device(npu1) binary
     loads on npu2 without error and computes nothing -- so guessing is worse
     than asking.
+
+    AIR_TARGET_DEVICE short-circuits the probe. It exists for callers that
+    already know the answer and would otherwise pay for it once per process:
+    the lit configs resolve the generation when the suite is configured and
+    pass it down, rather than having every test shell out to xrt-smi again.
+    An explicit target_device= argument still takes precedence over both.
     """
+    override = os.environ.get("AIR_TARGET_DEVICE", "").strip()
+    if override:
+        if override not in NPU_MODELS:
+            raise ValueError(
+                f"AIR_TARGET_DEVICE={override!r} is not a known NPU "
+                f"generation; expected one of {sorted(NPU_MODELS)}"
+            )
+        if verbose:
+            print(f"Target device from AIR_TARGET_DEVICE: {override}")
+        return override
+
     try:
         xrtsmi = shutil.which("xrt-smi") or _xrt_smi_fallback()
         result = subprocess.run(

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -155,11 +155,17 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         if any(k in out_lc for k in npu2_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu2")
+            # Resolved once here so the ~230 test processes in a suite run do not
+            # each re-run xrt-smi examine. That probe has a 10 s timeout and
+            # intermittently exceeds it under load; on timeout the backend falls
+            # back to npu1 and silently builds a 4-column design for an 8-column part.
+            config.environment["AIR_TARGET_DEVICE"] = "npu2"
             run_on_npu2 = run_on_npu
             print("Running tests on NPU2 with command line: ", run_on_npu2 or "(none)")
         elif any(k in out_lc for k in npu1_models):
             config.available_features.add("ryzen_ai")
             config.available_features.add("ryzen_ai_npu1")
+            config.environment["AIR_TARGET_DEVICE"] = "npu1"
             run_on_npu1 = run_on_npu
             print("Running tests on NPU1 with command line: ", run_on_npu1 or "(none)")
         else:


### PR DESCRIPTION
## Problem

`detect_target_device` runs `xrt-smi examine` with a 10 s timeout every time a design is built without an explicit `target_device`. Under lit that is roughly 230 subprocess launches per suite run, and the probe intermittently exceeds the timeout — observed on a Krackan Point NPU2 both under load and at `-j1`.

On timeout the backend falls back to `npu1` and builds a 4-column design for an 8-column part:

```
error: 'aie.tile' op column index (4) must be less than the number of columns in the device (4)
Error: pass pipeline failed: ...air-to-aie{... device=npu1 ...}
```

Nothing in that ties back to a device probe. Two examples failed this way in a full run and passed on retry.

## Change

The lit configs already resolve the generation once, at configure time, to decide the `ryzen_ai_npu*` features. Export it as `AIR_TARGET_DEVICE`; `detect_target_device` returns it instead of probing.

One `xrt-smi` call per suite run instead of ~230, and no test process races the tool. It also lets a compile-only host with no `xrt-smi` build for the right generation rather than silently defaulting to `npu1`.

The value is validated against `NPU_MODELS`, so a typo raises rather than travelling downstream as a device name. An explicit `target_device=` argument still wins — this replaces detection, not intent. Both callers benefit: `XRTBackend.compile()` and `air.api`'s target resolution, which had drifted to different fallback defaults (`npu1` and `npu2`).

## Verification

On a Krackan Point NPU2, `check-programming-examples-peano` went **215 passed / 8 failed → 216 / 7**.

A passing test proves little for an intermittent bug, so the mechanism was checked directly:

1. **The probe never runs.** Temporarily made the probe path `raise`, reinstalled, ran 21 hardware tests: **0 hits**.
2. **The exported value is consumed.** Temporarily exported `npu1` on npu2 hardware: all 4 affected tests failed with the column-index error above; reverted, they pass.
3. **Observed in situ.** The one remaining flaky test's `aircc` command line now reads `--device npu2`.

Unit behaviour: `npu1`/`npu2` returned as-is, surrounding whitespace tolerated, `npu9` raises `ValueError`, empty or unset falls through to the probe.

## Not covered

- `test/lit.cfg.py`'s half is unexercised here — that tree is not built on Windows. Included for symmetry.
- No Linux run. The change is inert there by construction (variable unset → today's code path), but that is an argument, not a test.

## Unrelated issue found

`matrix_vector_multiplication/bf16_cascade/...8col_4cascade` still fails in a full suite run, now with `aircc.exe` taking an access violation (`0xC0000005`, `FallbackTypeIDResolver::registerImplicitTypeID` on top of the stack). It passes **4/4** run alone, so it is load-dependent and pre-existing — the `npu1` fallback was previously masking it by failing first. Worth its own investigation; not addressed here.
