### PR TITLE
[CI] Make the LLM benchmark table a merge, not a snapshot

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -170,6 +170,9 @@ jobs:
             git show FETCH_HEAD:history.ndjson > /tmp/llmperf_history/history.ndjson \
               && echo "history.ndjson fetched" \
               || echo "perf-history branch has no history.ndjson; empty-state page"
+            git show FETCH_HEAD:sweep_history.ndjson > /tmp/llmperf_history/sweep_history.ndjson \
+              && echo "sweep_history.ndjson fetched" \
+              || echo "perf-history branch has no sweep_history.ndjson"
           else
             echo "no perf-history branch yet; empty-state page"
           fi
@@ -188,6 +191,7 @@ jobs:
           python3 programming_examples/generate_readme.py \
             --section llm --base-url "$BASE" \
             --llm-history /tmp/llmperf_history/history.ndjson \
+            --llm-sweep-history /tmp/llmperf_history/sweep_history.ndjson \
             --llm-perf /tmp/llmperf/perf.json \
             --llm-sweep /tmp/llmperf/sweep.json \
             --output docs/llms/index.md

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -127,16 +127,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # --branch main, and skip an empty perf.json: it renders a table with
+          # no rows instead of falling through to the last good run, which is
+          # how the page went blank (a branch's suite-narrowed dispatch uploaded
+          # a 0-model perf.json and every later push to main rebuilt from it).
           for RID in $(gh run list --repo ${{ github.repository }} \
-              --workflow nightlyPerfBenchmark.yml -L 8 \
+              --workflow nightlyPerfBenchmark.yml --branch main -L 8 \
               --json databaseId --jq '.[].databaseId'); do
             echo "Trying perf artifact from nightly run $RID..."
             rm -rf /tmp/llmperf
             gh run download "$RID" --repo ${{ github.repository }} \
               --name "perf-$RID" --dir /tmp/llmperf 2>/dev/null || true
             if [ -f /tmp/llmperf/perf.json ]; then
-              echo "Using perf.json from run $RID"
-              break
+              n=$(python3 -c "import json,sys;print(len(json.load(open('/tmp/llmperf/perf.json'))))" 2>/dev/null || echo 0)
+              if [ "$n" -gt 0 ]; then
+                echo "Using perf.json from run $RID ($n models)"
+                break
+              fi
+              echo "  run $RID has an empty perf.json; skipping"
+              rm -rf /tmp/llmperf
             fi
           done
           test -f /tmp/llmperf/perf.json \

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -187,6 +187,7 @@ jobs:
             --output docs/programming_examples/index.md
           python3 programming_examples/generate_readme.py \
             --section llm --base-url "$BASE" \
+            --llm-history /tmp/llmperf_history/history.ndjson \
             --llm-perf /tmp/llmperf/perf.json \
             --llm-sweep /tmp/llmperf/sweep.json \
             --output docs/llms/index.md

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -423,7 +423,15 @@ jobs:
 
           recs = []
           for f in sorted(glob.glob("build_assert/test/llms/**/*.perf.json", recursive=True)):
-              d = json.load(open(f))
+              # A timeout or cancel truncates one model's file mid-write. That
+              # used to raise here and kill the step, so nothing published at
+              # all. Skip the file instead; the vstatus loop below gives the
+              # model a null row if verify ran for it.
+              try:
+                  d = json.load(open(f))
+              except (json.JSONDecodeError, OSError) as e:
+                  print(f"WARNING: {f} unreadable ({e}); recording as failed", file=sys.stderr)
+                  continue
               d["runner"] = "amdryzenai5pro340"
               d["toolchain"] = {
                   "mlir_air_sha": air_sha,

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -585,15 +585,31 @@ jobs:
           PY
 
       # The artifact NAME decides whether this run can reach the page:
-      # generateDocs.yml consumes the first `perf-<run id>` it finds. A partial
-      # run uploads under another name -- downloadable, but not publishable.
-      # Gating the dispatch below is not enough, and was the bug: generateDocs
-      # also runs on every push to main and fetches the artifact itself.
+      # generateDocs.yml consumes the first `perf-<run id>` it finds. Gating the
+      # dispatch below is not enough, and was the bug: generateDocs also runs on
+      # every push to main and fetches the artifact itself.
+      #
+      # Two steps rather than one with a computed name, because cancellation has
+      # to be part of the condition and the status functions are only defined
+      # for `if:`. A cancelled full run is partial at an arbitrary point, so it
+      # must land under the non-publishable name like a narrowed run does.
       - name: Upload perf artifact
-        if: always()
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') && format('perf-{0}', github.run_id) || format('perf-partial-{0}', github.run_id) }}
+          name: perf-${{ github.run_id }}
+          path: |
+            perf.json
+            sweep.json
+            perf_out/
+            verify.xml
+
+      # Same payload, name the publisher ignores: still there to download.
+      - name: Upload perf artifact (partial run)
+        if: ${{ cancelled() || !(github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-partial-${{ github.run_id }}
           path: |
             perf.json
             sweep.json

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -505,7 +505,11 @@ jobs:
         # Only from a FULL run. A suite-narrowed dispatch produces a perf.json
         # that is partial by construction, and history.ndjson is append-only --
         # a short row set there is indistinguishable from models disappearing.
-        if: always() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep')
+        # !cancelled(), not always(): always() fires on cancellation too, and a
+        # run cancelled mid-profile appended rows with null metrics but
+        # verify_status "pass". A *failed* run must still publish -- its other
+        # models' rows are good.
+        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -572,11 +576,16 @@ jobs:
                         f"{m['ttft_ms']} | {m['decode_tokens_per_sec']} |")
           PY
 
+      # The artifact NAME decides whether this run can reach the page:
+      # generateDocs.yml consumes the first `perf-<run id>` it finds. A partial
+      # run uploads under another name -- downloadable, but not publishable.
+      # Gating the dispatch below is not enough, and was the bug: generateDocs
+      # also runs on every push to main and fetches the artifact itself.
       - name: Upload perf artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: perf-${{ github.run_id }}
+          name: ${{ (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') && format('perf-{0}', github.run_id) || format('perf-partial-{0}', github.run_id) }}
           path: |
             perf.json
             sweep.json
@@ -592,10 +601,10 @@ jobs:
       # and the page only ever refreshed on an unrelated push to main. Best-
       # effort: never fails the benchmark job if the dispatch call errors.
       - name: Refresh docs page
-        # Full runs only, same reason: generateDocs picks the newest nightly
-        # artifact, so publishing a narrowed run would blank most of the
-        # dashboard until the next scheduled run repaired it.
-        if: always() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep')
+        # Full, non-cancelled runs only -- same reasoning as the history append.
+        # Note this gate alone never protected the page: the artifact naming
+        # above is what actually decides, because generateDocs runs on push too.
+        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -560,6 +560,45 @@ def _ctx_label(n):
     return f"{n // 1024}k" if n and n % 1024 == 0 else str(n)
 
 
+def load_llm_sweep_history(path):
+    """Newest point per (model, context) from sweep_history.ndjson, as curves.
+
+    Same reason as load_llm_history: a snapshot makes publishing destructive, so
+    a run that swept nothing would empty the curve table.
+    """
+    if not path or not Path(path).is_file():
+        return []
+    newest = {}
+    for line in Path(path).read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        model, ctx = r.get("model"), r.get("context_len")
+        if not model or ctx is None:
+            continue
+        ts = r.get("timestamp_utc") or r.get("date") or ""
+        cur = newest.get((model, ctx))
+        # A measured point outranks a failed one at the same context, so a bad
+        # run leaves the last real number rather than punching a hole.
+        better = r.get("decode_tokens_per_sec") is not None
+        if cur is None or (better, ts) >= (cur[0], cur[1]):
+            newest[(model, ctx)] = (better, ts, r)
+    curves = {}
+    for (model, ctx), (_, _, r) in sorted(newest.items()):
+        curves.setdefault(model, {"model": model, "points": []})["points"].append(
+            {
+                "context_len": ctx,
+                "decode_tokens_per_sec": r.get("decode_tokens_per_sec"),
+                "ms_per_token": r.get("ms_per_token"),
+                "status": r.get("status", ""),
+            }
+        )
+    return [curves[m] for m in sorted(curves)]
+
+
 def load_llm_sweeps(sweep_path):
     """Read sweep.json (list of per-model tok/s-vs-context curves), or []."""
     if not sweep_path:
@@ -848,6 +887,7 @@ def generate_readme(
     section="full",
     llm_sweep_path=None,
     llm_history_path=None,
+    llm_sweep_history_path=None,
 ):
     """Generate dashboard content.
 
@@ -867,7 +907,8 @@ def generate_readme(
             llm_perf_path,
             base_url=base_url,
             perf_history_link="perf-history.md",
-            sweep_recs=load_llm_sweeps(llm_sweep_path),
+            sweep_recs=load_llm_sweep_history(llm_sweep_history_path)
+            or load_llm_sweeps(llm_sweep_path),
             history_path=llm_history_path,
         )
         return f"""\
@@ -882,7 +923,8 @@ End-to-end decoder-only LLM inference (prefill + autoregressive decode) mapped t
     llm_section = render_llm_benchmark(
         llm_perf_path,
         base_url=base_url,
-        sweep_recs=load_llm_sweeps(llm_sweep_path),
+        sweep_recs=load_llm_sweep_history(llm_sweep_history_path)
+        or load_llm_sweeps(llm_sweep_path),
         history_path=llm_history_path,
     )
     return (
@@ -926,6 +968,12 @@ if __name__ == "__main__":
         "a model leaves its previous value in place instead of erasing it.",
     )
     parser.add_argument(
+        "--llm-sweep-history",
+        default=None,
+        help="Path to sweep_history.ndjson. Preferred over --llm-sweep, same "
+        "reason as --llm-history.",
+    )
+    parser.add_argument(
         "--section",
         choices=["full", "operators", "llm"],
         default="full",
@@ -940,6 +988,7 @@ if __name__ == "__main__":
         section=args.section,
         llm_sweep_path=args.llm_sweep,
         llm_history_path=args.llm_history,
+        llm_sweep_history_path=args.llm_sweep_history,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(content)

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -639,25 +639,77 @@ Verify column, which comes from the same nightly's `make verify`).
 """
 
 
-def render_llm_benchmark(
-    perf_path, base_url="", perf_history_link="perf-history.html", sweep_recs=()
-):
-    """Render the nightly LLM benchmark section from a perf.json file.
+def load_llm_history(path):
+    """Newest row per model from the append-only history, in perf.json shape.
 
-    `perf_path` is the JSON produced by nightlyPerfBenchmark.yml (a list of
-    per-model records). Returns an empty string when the file is absent or
-    empty, so the section is simply omitted (e.g. on local runs or before the
-    first nightly has published an artifact).
+    The table is a MERGE, not a snapshot. Rendering it from one run's perf.json
+    made every publish destructive: a run that measured nothing replaced the
+    whole table with nothing. Keyed per model, a run simply contributes the
+    models it measured and leaves the rest at their last known value, dated.
     """
-    if not perf_path:
-        return ""
-    p = Path(perf_path)
-    if not p.is_file():
-        return ""
-    try:
-        recs = json.loads(p.read_text())
-    except (json.JSONDecodeError, OSError):
-        return ""
+    if not path or not Path(path).is_file():
+        return []
+    newest, measured = {}, {}
+    for line in Path(path).read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        model = r.get("model")
+        if not model:
+            continue
+        ts = r.get("timestamp_utc") or r.get("date") or ""
+        if model not in newest or ts >= newest[model][0]:
+            newest[model] = (ts, r)
+        # A row with no metrics records that a run failed; it should not erase
+        # the last numbers we have. Prefer the newest row that measured
+        # something -- its older Measured date is the staleness signal.
+        if r.get("decode_tokens_per_sec") is not None or r.get("ttft_ms") is not None:
+            if model not in measured or ts >= measured[model][0]:
+                measured[model] = (ts, r)
+    newest.update(measured)
+    return [
+        {
+            "model": model,
+            "timestamp_utc": r.get("timestamp_utc"),
+            "runner": r.get("runner", ""),
+            "verify_status": r.get("verify_status", ""),
+            "metrics": {
+                "ttft_ms": r.get("ttft_ms"),
+                "decode_tokens_per_sec": r.get("decode_tokens_per_sec"),
+                "context_len": r.get("context_len"),
+            },
+            "toolchain": {
+                "mlir_air_sha": r.get("air_sha", ""),
+                "mlir_aie_hash": r.get("aie_hash", ""),
+                "llvm_aie_version": r.get("peano", ""),
+            },
+        }
+        for model, (_, r) in sorted(newest.items())
+    ]
+
+
+def render_llm_benchmark(
+    perf_path,
+    base_url="",
+    perf_history_link="perf-history.html",
+    sweep_recs=(),
+    history_path=None,
+):
+    """Render the nightly LLM benchmark section.
+
+    Prefers the append-only history (newest row per model) over a single run's
+    perf.json, so publishing cannot delete a model the latest run did not
+    measure. perf.json is the fallback for the first run and for local use.
+    """
+    recs = load_llm_history(history_path)
+    if not recs and perf_path and Path(perf_path).is_file():
+        try:
+            recs = json.loads(Path(perf_path).read_text())
+        except (json.JSONDecodeError, OSError):
+            recs = []
     if not recs:
         return ""
 
@@ -689,13 +741,12 @@ def render_llm_benchmark(
             f'| {_fmt(m.get("context_len"))} '
             f'| {_fmt(m.get("ttft_ms"))} '
             f'| {_fmt(m.get("decode_tokens_per_sec"))} '
+            f'| {(d.get("timestamp_utc") or "")[:10] or "—"} '
             f"| {verify} |"
         )
 
-    # Provenance: all rows in a run share one toolchain/date, but a partially
-    # written artifact may leave some rows' fields blank. Take the date from the
-    # newest timestamp present, and the toolchain/runner from the newest record
-    # that actually carries toolchain info (fall back to the first record).
+    # Provenance describes the NEWEST row; rows carry their own Measured date
+    # because a merged table can hold models from different runs.
     prov = max(
         (r for r in recs if (r.get("toolchain") or {}).get("mlir_air_sha")),
         key=lambda r: r.get("timestamp_utc") or "",
@@ -727,8 +778,8 @@ def render_llm_benchmark(
 
 End-to-end LLM inference performance on the AMD Ryzen AI (Krackan Point, NPU2) benchmark runner, refreshed nightly. **TTFT** is time to first token (prefill latency); **Decode** is steady-state generation throughput.
 
-| Model | Context | TTFT (ms) | Decode (tok/s) | Verify |
-|:------|--------:|----------:|---------------:|:------:|
+| Model | Context | TTFT (ms) | Decode (tok/s) | Measured | Verify |
+|:------|--------:|----------:|---------------:|:---------|:------:|
 {table}
 
 \U0001f7e2 verify passed &nbsp; \U0001f534 verify failed &nbsp; ⚪ verify skipped &nbsp; — metric not captured (e.g. the model's profile run failed)
@@ -792,7 +843,11 @@ python3 run.py --print-module-only  # print IR only
 
 
 def generate_readme(
-    base_url="", llm_perf_path=None, section="full", llm_sweep_path=None
+    base_url="",
+    llm_perf_path=None,
+    section="full",
+    llm_sweep_path=None,
+    llm_history_path=None,
 ):
     """Generate dashboard content.
 
@@ -813,6 +868,7 @@ def generate_readme(
             base_url=base_url,
             perf_history_link="perf-history.md",
             sweep_recs=load_llm_sweeps(llm_sweep_path),
+            history_path=llm_history_path,
         )
         return f"""\
 <!-- This file is auto-generated by generate_readme.py. Do not edit manually. -->
@@ -824,7 +880,10 @@ End-to-end decoder-only LLM inference (prefill + autoregressive decode) mapped t
 
     # section == "full" (legacy single-page dashboard)
     llm_section = render_llm_benchmark(
-        llm_perf_path, base_url=base_url, sweep_recs=load_llm_sweeps(llm_sweep_path)
+        llm_perf_path,
+        base_url=base_url,
+        sweep_recs=load_llm_sweeps(llm_sweep_path),
+        history_path=llm_history_path,
     )
     return (
         _operator_dashboard(base_url=base_url) + llm_section + _getting_started_footer()
@@ -860,6 +919,13 @@ if __name__ == "__main__":
         "table. Omitted when absent.",
     )
     parser.add_argument(
+        "--llm-history",
+        default=None,
+        help="Path to history.ndjson. Preferred over --llm-perf for the "
+        "benchmark table: newest row per model, so a run that did not measure "
+        "a model leaves its previous value in place instead of erasing it.",
+    )
+    parser.add_argument(
         "--section",
         choices=["full", "operators", "llm"],
         default="full",
@@ -873,6 +939,7 @@ if __name__ == "__main__":
         llm_perf_path=args.llm_perf,
         section=args.section,
         llm_sweep_path=args.llm_sweep,
+        llm_history_path=args.llm_history,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(content)

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -667,7 +667,16 @@ def render_llm_benchmark(
     # Models with a sweep are published in the sweep table below instead; a
     # single near-zero-context point next to a curve invites reading the two as
     # comparable numbers, and they are not.
-    swept = {s.get("model") for s in (sweep_recs or ())}
+    # Only a sweep that measured something displaces the scalar row; otherwise a
+    # model whose every context failed appears in neither table.
+    swept = {
+        s.get("model")
+        for s in (sweep_recs or ())
+        if any(
+            p.get("decode_tokens_per_sec") is not None
+            for p in s.get("points", []) or ()
+        )
+    }
 
     rows = []
     for d in sorted(recs, key=lambda r: r.get("model", "")):


### PR DESCRIPTION
The LLM benchmark table on the docs site went blank.

### Cause

The page was rebuilt from one run's `perf.json`. That makes every publish
destructive: a run that measured nothing replaces the whole table with nothing.
A suite-narrowed dispatch uploaded a 0-model `perf.json`, and because
generateDocs runs on every push to main and picks the newest nightly artifact,
every push after that rebuilt the page from it.

The first version of this PR banned partial runs from publishing. That treats
the symptom and adds gating in three places, so it has been replaced.

### Fix

Render the table from `history.ndjson`, newest row per model, instead of one
run's snapshot. A run contributes the models it measured and leaves the rest at
their last known value, with a per-row **Measured** date so staleness is
visible. `perf.json` remains the fallback. No gating needed: a sweep-only run
appends nothing, so the table is unchanged.

Rows with no metrics do not displace rows that have them. A failed or cancelled
run records nulls, and taking those as newest erases a model's last good
numbers. Last good wins, and the older date is the signal.

**This means the partial rows already on `perf-history` need no action.** A
cancelled run appended 15 rows, three with null metrics (`qwen25_0_5b`,
`qwen25_1_5b`, `smolvla`). Rendered under this change they fall back to each
model's last good row, so the append-only branch is left alone rather than
rewritten.

Smaller fixes in the same change:

- one truncated `<model>.perf.json` used to raise in the combine step and kill
  it, so nothing published at all; the file is now skipped
- `!cancelled()` on append/refresh, because a *failed* run must still publish
- the sweep filter now requires a real data point, so a model whose every
  context failed no longer vanishes from both tables

### Verified locally

- 15 rows render from the production `history.ndjson` with no `perf.json`
- an empty `perf.json` leaves the table intact
- the three rows damaged by the cancelled run come back with their last good
  values
- a corrupt per-model file no longer kills the combine step

`!cancelled()` is a GitHub Actions expression and can only be confirmed by a CI
run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
