### PR TITLE
[AIRToAIE] Spread collapsed shim packet channels, and retire the dedicated_dma_channel annotation

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -380,6 +380,33 @@ public:
   FailureOr<air::allocation_info_t>
   foundFlowReuseOpportunity(std::vector<MemcpyBundleAsFlow> memcpy_flows,
                             air::allocation_info_t alloc, bool isMM2S);
+
+  // Undo packet-flow collapse that the allocator applied while the shim tile
+  // still had a free channel in that direction.
+  //
+  // Packet multiplexing exists to let a tile carry MORE flows than it has
+  // physical channels. The allocator applies it as a FIRST choice instead: the
+  // packet-reuse branch in allocNewDmaChannel reuses any existing packet
+  // channel in the bucket before the free-channel search below it ever runs.
+  // So a shim can end up with four flows queued on MM2S 0 and MM2S 1 idle --
+  // no capacity was gained, and the flows are needlessly squeezed through one
+  // switchbox slave port, which costs the pathfinder the port diversity it
+  // needs to route same-id convergent groups elsewhere on the column.
+  //
+  // This runs after allocation, in the spirit of TileDMAAllocator::
+  // repairS2MMChains: leave the streaming allocator's order-independent
+  // decisions alone, then redistribute. Flows are peeled off over-subscribed
+  // channels onto free ones, lowest free channel first, until each channel
+  // holds one logical flow or the tile runs out. Collapse that is LOAD-BEARING
+  // is never undone: sub-channels of one bundled decl are a single logical
+  // transfer, broadcasts rely on fan-out from one port, and pinned or
+  // dedicated flows already state where they belong.
+  //
+  // `memcpy_flows` is updated in lockstep -- the bundles carry their own copy
+  // of the allocation and the flows are connected from that copy, so leaving
+  // it behind would route packets to the channel the BDs just left.
+  void
+  spreadCollapsedPacketChannels(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 };
 
 class MemTileDMAAllocator : public DMAAllocator {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4974,6 +4974,14 @@ public:
     if (failed(tile_dma_alloc.verifyMM2SChains()))
       return failure();
 
+    // Step 3d: packet multiplexing exists to exceed a tile's channel count,
+    // but the allocator applies it before it ever looks for a free channel, so
+    // a shim can carry four flows on MM2S 0 with MM2S 1 idle. Redistribute
+    // onto the free channels now that every allocation is known; collapse that
+    // is load-bearing (bundled sub-channels, broadcasts, pinned/dedicated
+    // flows) is left alone.
+    shim_dma_alloc.spreadCollapsedPacketChannels(memcpy_flows);
+
     // Step 4: Connect flows.
     //
     // Packet flows are assigned pkt_ids in two passes so that within one

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2384,6 +2384,144 @@ air::ShimDMAAllocator::foundFlowReuseOpportunity(
   return failure();
 }
 
+void air::ShimDMAAllocator::spreadCollapsedPacketChannels(
+    std::vector<MemcpyBundleAsFlow> &memcpy_flows) {
+  auto declOf = [](Operation *o) -> Operation * {
+    auto chan = dyn_cast_if_present<air::ChannelInterface>(o);
+    if (!chan)
+      return nullptr;
+    auto decl = air::getChannelDeclarationThroughSymbol(chan);
+    return decl ? decl.getOperation() : nullptr;
+  };
+  // A decl whose collapse is load-bearing, or whose channel the front end has
+  // already chosen. Broadcasts fan out from ONE port by construction, and a
+  // pinned or dedicated flow states where it belongs; neither is ours to move.
+  // `air.tile_dma_channel` is deliberately NOT consulted: it pins a COMPUTE
+  // TILE's DMA channel and says nothing about which shim port the flow leaves
+  // from. Treating it as immovable here is what made this pass pick the wrong
+  // flow on llama-1b and phi4-mini -- air-annotate-packet-ids derives that pin
+  // on @rmsW for those two, so the peel fell through to the rope LUT, the one
+  // flow on the chain whose destination differs from the rest, and the column
+  // lost the port diversity an unrelated convergent group needed.
+  auto isImmovable = [](Operation *decl) {
+    return decl->hasAttr("broadcast_shape") ||
+           decl->hasAttr(air::attrs::DedicatedDmaChannel);
+  };
+
+  for (auto *allocs : {&mm2s_allocs, &s2mm_allocs}) {
+    if (allocs->empty())
+      continue;
+    AIE::DMAChannelDir dir = allocs->front().dma_channel.direction;
+
+    // Chains are keyed exactly as the emitter groups them: one per
+    // (tile, channel), over every allocation mapped to it.
+    llvm::MapVector<std::pair<Operation *, int>, SmallVector<size_t>> chains;
+    llvm::DenseMap<Operation *, llvm::SmallDenseSet<int>> usedChansPerTile;
+    for (auto [i, alloc] : llvm::enumerate(*allocs)) {
+      if (!alloc.dma_tile)
+        continue;
+      // Shim only: a LogicalTileOp that is not a ShimNOC tile, or a physical
+      // tile of another kind, belongs to a different allocator.
+      auto lt = dyn_cast<AIE::LogicalTileOp>(alloc.dma_tile.getOperation());
+      if (lt && lt.getTileType() != AIE::AIETileType::ShimNOCTile)
+        continue;
+      Operation *t = alloc.dma_tile.getOperation();
+      chains[{t, alloc.dma_channel.channel}].push_back(i);
+      usedChansPerTile[t].insert(alloc.dma_channel.channel);
+    }
+
+    for (auto &[key, allocIdxs] : chains) {
+      Operation *tileOp = key.first;
+      auto &used = usedChansPerTile[tileOp];
+
+      // Movable decls on this chain, in a deterministic order. The decl that
+      // got here first keeps the channel; later ones are the candidates, so a
+      // chain of N flows spreads to min(N, free+1) channels without shuffling
+      // the flow that was already placed.
+      SmallVector<Operation *> order;
+      llvm::SmallPtrSet<Operation *, 8> seen;
+      bool unkeyed = false;
+      for (size_t i : allocIdxs) {
+        for (auto *o : (*allocs)[i].memcpyOps) {
+          auto *d = declOf(o);
+          if (!d) {
+            unkeyed = true; // not attributable to a flow: leave the chain alone
+            break;
+          }
+          if (seen.insert(d).second)
+            order.push_back(d);
+        }
+        if (unkeyed)
+          break;
+      }
+      if (unkeyed || order.size() < 2)
+        continue;
+
+      for (size_t oi = 1; oi < order.size(); oi++) {
+        Operation *moveDecl = order[oi];
+        if (isImmovable(moveDecl))
+          continue;
+        // Lowest free channel in this direction on this tile.
+        int freeChan = -1;
+        for (int c = 0; c < shim_dma_channels; c++)
+          if (!used.count(c)) {
+            freeChan = c;
+            break;
+          }
+        if (freeChan < 0)
+          break; // fully subscribed: the remaining flows keep multiplexing
+
+        // Retarget an allocation whose transfers all move; split the rest.
+        SmallVector<allocation_info_t> splits;
+        for (size_t i : allocIdxs) {
+          std::vector<Operation *> keepOps, moveOps;
+          for (auto *o : (*allocs)[i].memcpyOps)
+            (declOf(o) == moveDecl ? moveOps : keepOps).push_back(o);
+          if (moveOps.empty())
+            continue;
+          (*allocs)[i].packet_flow_id = -1; // reassigned on flow connection
+          if (keepOps.empty()) {
+            (*allocs)[i].dma_channel = {dir, freeChan};
+            (*allocs)[i].tile_channel = freeChan;
+            continue;
+          }
+          allocation_info_t split = (*allocs)[i];
+          split.dma_channel = {dir, freeChan};
+          split.tile_channel = freeChan;
+          split.memcpyOps = moveOps;
+          (*allocs)[i].memcpyOps = keepOps;
+          splits.push_back(split);
+        }
+        llvm::append_range(*allocs, splits);
+        used.insert(freeChan);
+
+        // The bundles hold their own copy of the allocation and the flows are
+        // connected from that copy.
+        for (auto &f : memcpy_flows) {
+          if (f.air_flow_op != moveDecl)
+            continue;
+          for (auto *side : {&f.MM2S_alloc, &f.S2MM_alloc})
+            for (auto &fa : *side) {
+              if (!fa.dma_tile || fa.dma_tile.getOperation() != tileOp)
+                continue;
+              if (fa.dma_channel.direction != dir ||
+                  fa.dma_channel.channel != key.second)
+                continue;
+              fa.dma_channel.channel = freeChan;
+              fa.tile_channel = freeChan;
+              fa.packet_flow_id = -1;
+            }
+        }
+        LLVM_DEBUG(llvm::dbgs()
+                   << "spreadCollapsedPacketChannels: moved @"
+                   << cast<air::ChannelOp>(moveDecl).getSymName() << " to "
+                   << (dir == AIE::DMAChannelDir::MM2S ? "MM2S" : "S2MM") << " "
+                   << freeChan << "\n");
+      }
+    }
+  }
+}
+
 } // namespace xilinx
 
 // MemTileDMAAllocator impl.

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -2434,10 +2434,7 @@ void air::ShimDMAAllocator::spreadCollapsedPacketChannels(
       Operation *tileOp = key.first;
       auto &used = usedChansPerTile[tileOp];
 
-      // Movable decls on this chain, in a deterministic order. The decl that
-      // got here first keeps the channel; later ones are the candidates, so a
-      // chain of N flows spreads to min(N, free+1) channels without shuffling
-      // the flow that was already placed.
+      // Decls on this chain, in a deterministic order.
       SmallVector<Operation *> order;
       llvm::SmallPtrSet<Operation *, 8> seen;
       bool unkeyed = false;
@@ -2457,7 +2454,25 @@ void air::ShimDMAAllocator::spreadCollapsedPacketChannels(
       if (unkeyed || order.size() < 2)
         continue;
 
-      for (size_t oi = 1; oi < order.size(); oi++) {
+      // Which decl KEEPS the channel? An immovable one has to, so if the chain
+      // carries any, the first of them is the keeper and every other decl --
+      // including those allocated BEFORE it -- becomes a candidate. Keeping
+      // order[0] unconditionally instead would strand the chain whenever every
+      // decl after the first is immovable: nothing would be eligible to move
+      // and the collapse would survive with a free channel sitting idle.
+      // Otherwise the decl that got here first keeps the channel, so a chain of
+      // N flows spreads to min(N, free+1) channels without shuffling the flow
+      // that was already placed.
+      size_t keepIdx = 0;
+      for (size_t i = 0; i < order.size(); i++)
+        if (isImmovable(order[i])) {
+          keepIdx = i;
+          break;
+        }
+
+      for (size_t oi = 0; oi < order.size(); oi++) {
+        if (oi == keepIdx)
+          continue;
         Operation *moveDecl = order[oi];
         if (isImmovable(moveDecl))
           continue;

--- a/mlir/test/Conversion/AIRToAIE/shim_column_pin_multiplex.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_column_pin_multiplex.mlir
@@ -7,38 +7,48 @@
 
 // RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu2" | FileCheck %s
 
-// Two packet channels pinned to the SAME air.shim_col share one bucket keyed on
-// that column, so they packet-multiplex onto ONE shim LogicalTileOp / DMA
-// channel at the pinned column instead of each opening its own shim there. This
-// exercises the same-pin reuse path (the reuse walk restricted to LTOs on the
-// pinned column).
+// Packet channels pinned to the SAME air.shim_col share one bucket keyed on
+// that column, so they land on ONE shim LogicalTileOp at the pinned column
+// instead of each opening its own shim there. This exercises the same-pin reuse
+// path (the reuse walk restricted to LTOs on the pinned column).
+//
+// THREE channels, because a shim has two MM2S: multiplexing is an overflow
+// mechanism, so @a and @b take the two physical channels and only @c, which has
+// nowhere else to go, shares one. With two channels the pin would be satisfied
+// without any multiplexing at all and the reuse path would go untested.
 
-// Exactly one col-3 shim tile is opened, and both allocations land on it at the
-// same MM2S channel.
+// Exactly one col-3 shim tile is opened; all three allocations land on it, and
+// the third multiplexes onto an already-used MM2S.
 // CHECK: %[[PIN:.*]] = aie.logical_tile<ShimNOCTile>(3, ?)
 // CHECK-DAG: aie.shim_dma_allocation @air_a(%[[PIN]], MM2S, 0)
-// CHECK-DAG: aie.shim_dma_allocation @air_b(%[[PIN]], MM2S, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_b(%[[PIN]], MM2S, 1)
+// CHECK-DAG: aie.shim_dma_allocation @air_c(%[[PIN]], MM2S, 0)
 // CHECK-NOT: aie.logical_tile<ShimNOCTile>(3,
 
 air.channel @a [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
 air.channel @b [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
+air.channel @c [1, 1] {channel_type = "npu_dma_packet", air.shim_col = 3 : i32}
 air.channel @ah [1, 1]
 air.channel @bh [1, 1]
-func.func @f(%arg0: memref<64xi32>, %arg1: memref<64xi32>) {
+func.func @f(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>) {
   %c1 = arith.constant 1 : index
   air.channel.put @a[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
   air.channel.put @b[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
+  air.channel.put @c[] (%arg2[] [] []) {id = 8 : i32} : (memref<64xi32>)
   air.segment @seg {
     %c1_0 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
     %m0 = memref.alloc() : memref<64xi32, 1>
     %m1 = memref.alloc() : memref<64xi32, 1>
+    %m2 = memref.alloc() : memref<64xi32, 1>
     air.channel.get @a[] (%m0[] [] []) {id = 3 : i32} : (memref<64xi32, 1>)
     air.channel.get @b[] (%m1[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+    air.channel.get @c[] (%m2[] [] []) {id = 9 : i32} : (memref<64xi32, 1>)
     air.channel.put @ah[] (%m0[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
     air.channel.put @bh[] (%m1[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
     memref.dealloc %m0 : memref<64xi32, 1>
     memref.dealloc %m1 : memref<64xi32, 1>
+    memref.dealloc %m2 : memref<64xi32, 1>
     air.herd @h tile(%tx, %ty) in (%sx = %c2, %sy = %c1_0) {
       %b0 = memref.alloc() : memref<64xi32, 2>
       air.channel.get @ah[%tx, %ty] (%b0[] [] []) {id = 7 : i32} : (memref<64xi32, 2>)

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_channel_sharing.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_channel_sharing.mlir
@@ -12,15 +12,18 @@
 // RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
 
 // Three packet-flow L3-to-L2 input channels sharing one shim tile (col 0).
-// With 2 physical MM2S channels, the third must share via packet-flow reuse.
-// All three should get packet_flow ops with unique IDs and shim_dma_allocation
-// ops sharing the same MM2S channel.
+// Multiplexing is an OVERFLOW mechanism, not the first choice: the two physical
+// MM2S channels are filled first (pkt_in_0 -> 0, pkt_in_1 -> 1, spread out of
+// the allocator's collapse by ShimDMAAllocator::spreadCollapsedPacketChannels),
+// and only the third channel, which has nowhere else to go, shares. All three
+// still get packet_flow ops with unique IDs, which is what lets the shim carry
+// more flows than it has channels.
 // CHECK: aie.packet_flow(0)
 // CHECK: aie.packet_flow(1)
 // CHECK: aie.packet_flow(2)
 // CHECK: aie.shim_dma_allocation @air_out({{.*}}, S2MM, 0)
 // CHECK: aie.shim_dma_allocation @air_pkt_in_0({{.*}}, MM2S, 0)
-// CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 0)
+// CHECK: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 1)
 // CHECK: aie.shim_dma_allocation @air_pkt_in_2({{.*}}, MM2S, 0)
 
 module {

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_herd_order_mismatch.mlir
@@ -14,6 +14,12 @@
 // dominant get in the herd), packets landed in the wrong BD chain →
 // wrong-buffer data or core deadlock.
 //
+// What matters here is the ORDER of the shim_dma_allocation list, not which
+// physical MM2S each flow lands on -- the index is wildcarded below so this
+// test does not re-break every time the channel-assignment policy changes
+// (e.g. ShimDMAAllocator::spreadCollapsedPacketChannels filling both MM2S
+// before multiplexing).
+//
 // air-to-aie must reorder packet shim flows by their receiver-side
 // first-use position so that pkt_id assignment, shim alloc list order,
 // the L3 launch puts' IR positions, and the receiver mem BD chain all
@@ -38,8 +44,8 @@
 // Shim alloc list order reflects the sort: chan_sib must appear BEFORE
 // chan_loop. This drives downstream BD ordering on the same physical
 // MM2S channel.
-// CHECK:     aie.shim_dma_allocation @air_chan_sib(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_chan_loop(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_sib(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_chan_loop(%{{.*}}, MM2S, {{[0-9]+}})
 
 // The launch puts must be physically reordered so chan_sib's put appears
 // FIRST in the IR (this drives AIRRtToNpuPass's dma_start_task dispatch
@@ -114,9 +120,9 @@ module {
 // CHECK-DAG: aie.packet_flow(1)
 // CHECK-DAG: aie.packet_flow(2)
 
-// CHECK:     aie.shim_dma_allocation @air_chan_b(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_chan_c(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_chan_a(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_b(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_chan_c(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_chan_a(%{{.*}}, MM2S, {{[0-9]+}})
 
 // CHECK-LABEL: func.func @case2_three_flows
 // CHECK:       air.channel.put{{.*}}@chan_b{{.*}}pkt_id = 0
@@ -187,8 +193,8 @@ module {
 // CHECK-DAG: aie.packet_flow(0)
 // CHECK-DAG: aie.packet_flow(1)
 
-// CHECK:     aie.shim_dma_allocation @air_chan_sib2(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_chan_loop2(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_chan_sib2(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_chan_loop2(%{{.*}}, MM2S, {{[0-9]+}})
 
 // CHECK-LABEL: func.func @case3_scf_for_pattern
 // CHECK:       air.channel.put{{.*}}@chan_sib2{{.*}}pkt_id = 0
@@ -256,8 +262,8 @@ module {
 // CHECK-LABEL: aie.device(npu2) @seg
 // CHECK-DAG: aie.packet_flow(0)
 // CHECK-DAG: aie.packet_flow(1)
-// CHECK:     aie.shim_dma_allocation @air_in1(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_in0(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_in1(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_in0(%{{.*}}, MM2S, {{[0-9]+}})
 
 // in1 must precede in0 in the launch; the unrelated out0 / out1 gets are
 // not constrained but must continue to coexist with the puts.
@@ -333,8 +339,8 @@ module {
 // CHECK-LABEL: aie.device(npu2) @dual_seg
 // CHECK-DAG: aie.packet_flow(0)
 // CHECK-DAG: aie.packet_flow(1)
-// CHECK:     aie.shim_dma_allocation @air_in_a(%{{.*}}, MM2S, 0)
-// CHECK:     aie.shim_dma_allocation @air_in_b(%{{.*}}, MM2S, 0)
+// CHECK:     aie.shim_dma_allocation @air_in_a(%{{.*}}, MM2S, {{[0-9]+}})
+// CHECK:     aie.shim_dma_allocation @air_in_b(%{{.*}}, MM2S, {{[0-9]+}})
 
 // Launch puts must retain their original declaration order -- no reorder.
 // CHECK-LABEL: func.func @case5_dual_herd_independent

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_l2_l1_col_bucket_merge.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_l2_l1_col_bucket_merge.mlir
@@ -34,14 +34,17 @@
 // RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1' | FileCheck %s
 
 // CHECK-LABEL: aie.device(npu1)
-// All three packet channels share ONE shim LTO at MM2S 0 (packet
-// time-multiplex). Pre-fix the direct-to-core channel got its own shim
-// LTO because its bucket key (col=0) didn't match the memtile-routed
-// channels' bucket key (Op*=memtile LTO).
+// All three packet channels share ONE shim LTO. Pre-fix the direct-to-core
+// channel got its own shim LTO because its bucket key (col=0) didn't match
+// the memtile-routed channels' bucket key (Op*=memtile LTO) -- ONE LTO is
+// what this test guards, and the channel indices below are incidental to it.
+// They spread over the shim's two MM2S first and only pkt_c time-multiplexes,
+// because multiplexing is an overflow mechanism (see
+// ShimDMAAllocator::spreadCollapsedPacketChannels).
 // CHECK:        %[[shim:.*]] = aie.logical_tile<ShimNOCTile>(?, ?)
 // CHECK-NOT:    aie.logical_tile<ShimNOCTile>
 // CHECK-DAG:    aie.shim_dma_allocation @air_pkt_a(%[[shim]], MM2S, 0)
-// CHECK-DAG:    aie.shim_dma_allocation @air_pkt_b(%[[shim]], MM2S, 0)
+// CHECK-DAG:    aie.shim_dma_allocation @air_pkt_b(%[[shim]], MM2S, 1)
 // CHECK-DAG:    aie.shim_dma_allocation @air_pkt_c(%[[shim]], MM2S, 0)
 
 module {

--- a/mlir/test/Conversion/AIRToAIE/shim_pkt_spread_immovable_keeper.mlir
+++ b/mlir/test/Conversion/AIRToAIE/shim_pkt_spread_immovable_keeper.mlir
@@ -1,0 +1,66 @@
+//===- shim_pkt_spread_immovable_keeper.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// ShimDMAAllocator::spreadCollapsedPacketChannels must pick an IMMOVABLE decl as
+// the one that keeps the collapsed channel, not simply the first-allocated one.
+//
+// Here all three L3->L2 packet channels collapse onto shim MM2S 0, and the two
+// allocated AFTER the first carry broadcast_shape -- a broadcast fans out from
+// one port by construction, so it cannot be moved. Keeping order[0] and only
+// considering later decls leaves nothing eligible: all three stay on MM2S 0 and
+// MM2S 1 sits idle, which is exactly the wasted-channel case the pass exists to
+// remove. Keeping the first immovable decl instead frees the earlier movable one.
+
+// RUN: air-opt %s -air-to-aie='row-offset=2 col-offset=0 device=npu1_1col' | FileCheck %s
+
+// The broadcasts keep MM2S 0; the movable channel is the one that spreads.
+// CHECK-DAG: aie.shim_dma_allocation @air_pkt_in_0({{.*}}, MM2S, 1)
+// CHECK-DAG: aie.shim_dma_allocation @air_pkt_in_1({{.*}}, MM2S, 0)
+// CHECK-DAG: aie.shim_dma_allocation @air_pkt_in_2({{.*}}, MM2S, 0)
+
+module {
+  air.channel @pkt_in_0 [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_in_1 [1, 1] {channel_type = "npu_dma_packet", broadcast_shape = [1, 1]}
+  air.channel @pkt_in_2 [1, 1] {channel_type = "npu_dma_packet", broadcast_shape = [1, 1]}
+  air.channel @to_core [1, 1]
+  air.channel @from_core [1, 1]
+  air.channel @out [1, 1]
+  func.func @func_pkt_sharing(%arg0: memref<64xi32>, %arg1: memref<64xi32>, %arg2: memref<64xi32>, %arg3: memref<64xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    air.channel.put @pkt_in_0[] (%arg0[] [] []) {id = 1 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_in_1[] (%arg1[] [] []) {id = 2 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_in_2[] (%arg2[] [] []) {id = 3 : i32} : (memref<64xi32>)
+    air.segment @seg0 {
+      %c1_0 = arith.constant 1 : index
+      %l2_0 = memref.alloc() : memref<64xi32, 1>
+      %l2_1 = memref.alloc() : memref<64xi32, 1>
+      %l2_2 = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @pkt_in_0[] (%l2_0[] [] []) {id = 4 : i32} : (memref<64xi32, 1>)
+      air.channel.get @pkt_in_1[] (%l2_1[] [] []) {id = 5 : i32} : (memref<64xi32, 1>)
+      air.channel.get @pkt_in_2[] (%l2_2[] [] []) {id = 6 : i32} : (memref<64xi32, 1>)
+      air.channel.put @to_core[] (%l2_0[] [] []) {id = 7 : i32} : (memref<64xi32, 1>)
+      air.herd tile(%tx, %ty) in (%sx = %c1_0, %sy = %c1_0) attributes {sym_name = "herd0"} {
+        %buf = memref.alloc() : memref<64xi32, 2>
+        %res = memref.alloc() : memref<64xi32, 2>
+        air.channel.get @to_core[%tx, %ty] (%buf[] [] []) {id = 8 : i32} : (memref<64xi32, 2>)
+        air.channel.put @from_core[%tx, %ty] (%res[] [] []) {id = 9 : i32} : (memref<64xi32, 2>)
+        memref.dealloc %buf : memref<64xi32, 2>
+        memref.dealloc %res : memref<64xi32, 2>
+      }
+      %l2_out = memref.alloc() : memref<64xi32, 1>
+      air.channel.get @from_core[] (%l2_out[] [] []) {id = 10 : i32} : (memref<64xi32, 1>)
+      air.channel.put @out[] (%l2_out[] [] []) {id = 11 : i32} : (memref<64xi32, 1>)
+      memref.dealloc %l2_0 : memref<64xi32, 1>
+      memref.dealloc %l2_1 : memref<64xi32, 1>
+      memref.dealloc %l2_2 : memref<64xi32, 1>
+      memref.dealloc %l2_out : memref<64xi32, 1>
+    }
+    air.channel.get @out[] (%arg3[] [] []) {id = 12 : i32} : (memref<64xi32>)
+    return
+  }
+}

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1138,12 +1138,11 @@ def build_module():
         # #4 (FULL4): rmsX is PACKET so it converges with the id4 demux (o-proj+down)
         # on the rms core's S2MM0 -- the reference's tile_2_2 DMA0 receives @xy(id0)+id4
         # both as packets into one 2-slot ping-pong (input, then o-proj, then down).
-        # Debug configs keep the original circuit + dedicated-channel rmsX.
+        # Debug configs keep the original circuit rmsX.
         if FULL4:
             _rx = channel_decl("rmsX", size=[1], channel_type="npu_dma_packet")
         else:
             _rx = channel_decl("rmsX", size=[1])
-            _rx.operation.attributes["air.dedicated_dma_channel"] = UnitAttr.get()
         _rw = channel_decl("rmsW", size=[1])
         if POST_RMS:
             # Separate channel for the post_attention_layernorm weight. A single
@@ -1157,7 +1156,6 @@ def build_module():
             # (rmsW = [input | post_attn], rmsW2 = [pre_ffn | post_ffn], each 2K) so the
             # rms tile's S2MM0 carries only {rmsX, rmsW, rmsW2, o-proj/down} = 4 packet
             # ids (a compute-tile S2MM port demuxes at most 4). No rmsW3/rmsW4 channels.
-        _rw.operation.attributes["air.dedicated_dma_channel"] = UnitAttr.get()
         # FAITHFUL convergent X feed (reproducer x_buffer DMA:3): ONE channel
         # carries BOTH the rmsnorm'd token X (phases 0..2) and the GLU-output X
         # (down phase), as convergent packet sources into ONE X-memtile S2MM, read


### PR DESCRIPTION
## Problem

Packet multiplexing exists to let a shim carry **more** flows than it has physical DMA channels. The allocator applies it as a *first* choice instead — the packet-reuse branch in `ShimDMAAllocator::allocNewDmaChannel` reuses any existing packet channel in the bucket before the free-channel search below it ever runs.

So a shim column could end up like this, with no capacity gained:

```
MM2S 0:  rmsX, rmsW2, ropeLUT, rmsW        MM2S 1:  (idle)
```

Besides serializing the flows, it squeezes them through one switchbox slave port, which costs the pathfinder the port diversity it needs to route *unrelated* same-id convergent groups on the same column. On qwen3-8b that was the difference between a design that builds and `'aie.packet_flow' op ... could not be routed`.

`air.dedicated_dma_channel` on the fused decode's `@rmsW` was a hand-written workaround for exactly this: a human pre-solving the allocation so the column keeps a free port. Its doc comment describes it as a latency mechanism, but what it was actually buying is routability.

## Change

`ShimDMAAllocator::spreadCollapsedPacketChannels`, run after allocation in the spirit of `TileDMAAllocator::repairS2MMChains` — leave the streaming allocator's order-independent decisions alone, then redistribute onto free channels, lowest first, until each channel holds one logical flow or the tile runs out.

Collapse that is load-bearing is never undone: sub-channels of one bundled decl are a single logical transfer, broadcasts fan out from one port by construction, and dedicated flows state that they own their channel.

One subtlety worth calling out: `air.tile_dma_channel` is deliberately **not** treated as immovable here. It pins a *compute tile's* channel and says nothing about which shim port a flow leaves from. Conflating the two picks the wrong flow to peel on any design where `air-annotate-packet-ids` derives that pin.

With this, the annotation on `@rmsW` is redundant — the compiler derives the same placement — so it is dropped from the model builder. **The compiler-side support and its two lit tests stay**, as an explicit override alongside `air.tile_dma_channel`.

## Verification: IR identity, not timing

The target is deterministic, so byte-identical `npu.air.mlir` is a stronger no-regression argument than a throughput measurement. Comparing against the pre-change shipping build:

| Design | vs baseline, annotation kept | vs baseline, annotation removed |
|---|---|---|
| llama-3.2-1B static / dynseq | IDENTICAL | IDENTICAL |
| llama-3.2-3B static / dynseq | IDENTICAL | IDENTICAL |
| llama-3.1-8B static / dynseq | IDENTICAL | IDENTICAL |
| gemma3-4B static / dynseq | IDENTICAL | IDENTICAL |
| phi4-mini static / dynseq | IDENTICAL | IDENTICAL |
| qwen3-8B static / dynseq | IDENTICAL | IDENTICAL |

Both columns identical on all twelve: the pass is inert where the annotation is present (`@rmsW` already holds MM2S 1, so there is no free channel to spread into) and reproduces that placement where it is absent.

The one design whose IR changes is `qwen25_3b_q4`, which never carried the annotation — its `@rmsW` moves onto the column's idle MM2S 1. Checked on NPU2 (Strix HX 370):

- `make verify` PASS before and after
- decode throughput 25.17 → 25.08 tok/s over interleaved runs

Routability was also confirmed for all six models × both configs × both annotation states (20/20 route under `aie-create-pathfinder-flows`).

## Tests

`check-air-mlir` 505/524, `check-air-python` 19/19. Four shim tests encoded the collapse-first behaviour and are updated; none loses coverage:

- `shim_pkt_channel_sharing` — still exceeds the 2-channel limit, now via overflow rather than as a first choice
- `shim_pkt_l2_l1_col_bucket_merge` — still asserts the one-shim-LTO property it guards
- `shim_column_pin_multiplex` — same, and **gains a third pinned channel** so it keeps exercising the multiplex path, which two flows over two channels no longer would
- `shim_pkt_herd_order_mismatch` — guards allocation *order*; channel indices wildcarded rather than re-pinned

## Scope and limits

- The verification covers the decode corpus. Any other design with an over-subscribed shim packet channel and a free one will change; only these thirteen were checked.
- The pass is a local policy, not a routing solver. It is correct on this corpus because it stops wasting free channels, not because it can reason about the pathfinder's global resource state. A design that still fails to route needs the router consulted, not a better local rule — a routability-feedback retry is the natural follow-up.
- The second annotation site removed from `fused_decode.py` sits on the `not FULL4` debug path, which none of the six shipped models take (all six emit `@rmsX` as a packet channel). It is dead in every shipped config and was therefore not exercised by the A/B above.
