### PR TITLE
[python] air.api: named channels, and four examples converted onto them

### DIFF
--- a/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/single_herd/broadcast.py
@@ -1,16 +1,32 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""One image broadcast to every core of a herd, on air.api.
+
+    air.channel @ChanIn  [1, 1] {broadcast_shape = [1, 3]}
+    air.channel @ChanOut [1, 3]
+
+``ChanIn`` is declared once and read three times: ``broadcast_shape`` says the
+single source fans out to a 1x3 grid of destinations, and each core names its
+own with ``indices=[tx, ty]``. ``ChanOut`` is an ordinary channel *array* of the
+same shape -- three independent channels, one per core -- which is why the three
+gets on the L3 side each carry a constant index.
+
+The schedule is unchanged from the raw-bindings version this replaces. The only
+structural difference is that the L3 put and gets sit inside the segment rather
+than beside it: reaching L3 needs a shim DMA allocation, and outside a segment
+there is none to link to.
+
+Each core adds its own column index plus one, so the three outputs differ, which
+is what makes the broadcast observable rather than merely asserted.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 8
 IMAGE_HEIGHT = 6
@@ -18,67 +34,54 @@ IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 
 INOUT_DATATYPE = np.int32
 
+CORES = 3
 
-@module_builder
+
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    outs = [air.tensor(IMAGE_SIZE, i32) for _ in range(CORES)]
 
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    image_type_l1 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    chan_in = air.channel("ChanIn", size=[1, 1], broadcast_shape=[1, CORES])
+    chan_out = air.channel("ChanOut", size=[1, CORES])
 
-    Channel("ChanIn", size=[1, 1], broadcast_shape=[1, 3])
-    Channel("ChanOut", size=[1, 3])
+    with air.launch(name="copy") as launch:
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut, memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1, arg2, arg3):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1, arg2, arg3])
-        def launch_body(a, b, c, d):
+                @seg.body
+                def _():
+                    chan_in.put(A)
 
-            ChannelPut("ChanIn", a)
+                    with air.herd(
+                        [range(1), range(CORES)], name="broadcastherd", shape=(1, CORES)
+                    ) as h:
 
-            @segment(name="seg")
-            def segment_body():
+                        @h.body
+                        def _(tx, ty):
+                            image_in = air.alloc(IMAGE_SIZE, i32, scope=h.private())
+                            # vector=0 keeps the add scalar, as the predecessor
+                            # wrote it. The image is 8 i32 wide, and a
+                            # <8 x i32> add is 256-bit, which does not legalize:
+                            # "unable to legalize instruction: <8 x s32> G_ADD".
+                            # Nothing here is wide enough to vectorise usefully
+                            # anyway.
+                            image_out = air.alloc(
+                                IMAGE_SIZE, i32, scope=h.private(), vector=0
+                            )
 
-                @herd(name="broadcastherd", sizes=[1, 3])
-                def herd_body(tx, ty, _sx, _sy):
+                            chan_in.get(image_in, indices=[tx, ty])
+                            # ty is the core's own column, broadcast into the
+                            # expression as an index_cast -- so each core writes
+                            # a different image and the fan-out is observable.
+                            image_out[:] = image_in[:] + ty + 1
+                            chan_out.put(image_out, indices=[tx, ty])
 
-                    # We must allocate a buffer of image size for the input/output
-                    image_in = AllocOp(image_type_l1, [], [])
-                    image_out = AllocOp(image_type_l1, [], [])
+                    for i, out in enumerate(outs):
+                        chan_out.get(out, indices=[0, i])
 
-                    ChannelGet("ChanIn", image_in, indices=[tx, ty])
-
-                    # Access every value in the image
-                    for i in range_(IMAGE_HEIGHT):
-                        for j in range_(IMAGE_WIDTH):
-                            # Load the input value
-                            val_in = load(image_in, [i, j])
-
-                            # Calculate the output value
-                            val_out = arith.addi(val_in, arith.index_cast(T.i32(), ty))
-                            val_out = arith.addi(val_out, arith.ConstantOp(T.i32(), 1))
-
-                            # Store the output value
-                            store(val_out, image_out, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    ChannelPut("ChanOut", image_out, indices=[tx, ty])
-
-                    DeallocOp(image_in)
-                    DeallocOp(image_out)
-
-            ChannelGet("ChanOut", b, indices=[0, 0])
-            ChannelGet("ChanOut", c, indices=[0, 1])
-            ChannelGet("ChanOut", d, indices=[0, 2])
+    return launch
 
 
 if __name__ == "__main__":
@@ -104,24 +107,27 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
     input_a = np.arange(np.prod(IMAGE_SIZE), dtype=INOUT_DATATYPE).reshape(IMAGE_SIZE)
-    output_b = np.arange(1, np.prod(IMAGE_SIZE) + 1, dtype=INOUT_DATATYPE).reshape(
-        IMAGE_SIZE
-    )
-    output_c = np.arange(2, np.prod(IMAGE_SIZE) + 2, dtype=INOUT_DATATYPE).reshape(
-        IMAGE_SIZE
-    )
-    output_d = np.arange(3, np.prod(IMAGE_SIZE) + 3, dtype=INOUT_DATATYPE).reshape(
-        IMAGE_SIZE
-    )
+    expected = [
+        np.arange(n, np.prod(IMAGE_SIZE) + n, dtype=INOUT_DATATYPE).reshape(IMAGE_SIZE)
+        for n in range(1, CORES + 1)
+    ]
 
     runner = XRTRunner(
         verbose=args.verbose,
@@ -133,6 +139,6 @@ if __name__ == "__main__":
         runner.run_test(
             mlir_module,
             inputs=[input_a],
-            expected_outputs=[output_b, output_c, output_d],
+            expected_outputs=expected,
         )
     )

--- a/programming_examples/channel_examples/channel_size/channel_size.py
+++ b/programming_examples/channel_examples/channel_size/channel_size.py
@@ -1,18 +1,32 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A channel *array* -- one channel per worker -- on air.api.
+
+    air.channel @ChanIn  [2, 3]
+    air.channel @ChanOut [2, 3]
+
+``size=`` makes a channel an array rather than a single connection, and
+``indices=`` picks one of its members. There is no fan-out here and no sharing:
+the 2x3 grid of channels is matched one-for-one with the 2x3 herd, so each core
+has a private pair and the index is just its own tile coordinate.
+
+The L3 side puts one tile per channel, subscripted out of the image with the
+ordinary slice syntax -- ``A[h * TILE_H : ..., w * TILE_W : ...]`` -- and the
+offsets, sizes and strides that produces land on the channel op unchanged. The
+loops around it are plain Python: they run at trace time and emit one put per
+channel, which is what the predecessor does too.
+
+Unchanged from the raw-bindings version except that the L3 puts and gets sit
+inside the segment, which is where reaching L3 needs them to be.
+"""
+
 import argparse
 import numpy as np
 
-np.random.seed(42)
+from air.backend.xrt_runner import XRTRunner
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 48
 IMAGE_HEIGHT = 16
@@ -27,99 +41,59 @@ assert IMAGE_WIDTH % TILE_WIDTH == 0
 
 INOUT_DATATYPE = np.int32
 
+ROWS = IMAGE_HEIGHT // TILE_HEIGHT
+COLS = IMAGE_WIDTH // TILE_WIDTH
 
-@module_builder
+
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # Create an input/output channel pair per worker
-    Channel("ChanIn", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
-    Channel("ChanOut", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
+    # One input/output channel per worker.
+    chan_in = air.channel("ChanIn", size=[ROWS, COLS])
+    chan_out = air.channel("ChanOut", size=[ROWS, COLS])
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    def tile(t, h, w):
+        return t[
+            h * TILE_HEIGHT : (h + 1) * TILE_HEIGHT,
+            w * TILE_WIDTH : (w + 1) * TILE_WIDTH,
+        ]
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+    with air.launch(name="copy") as launch:
 
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-                    # Put data into the channel tile by tile
-                    ChannelPut(
-                        "ChanIn",
-                        a,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
+                @seg.body
+                def _():
+                    for h in range(ROWS):
+                        for w in range(COLS):
+                            chan_in.put(tile(A, h, w), indices=[h, w])
 
-            # The arguments are still the input and the output
-            @segment(name="seg")
-            def segment_body():
-                @herd(
-                    name="xaddherd",
-                    sizes=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH],
-                )
-                def herd_body(th, tw, _sx, _sy):
+                    with air.herd(
+                        [range(ROWS), range(COLS)], name="xaddherd", shape=(ROWS, COLS)
+                    ) as herd:
 
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+                        @herd.body
+                        def _(th, tw):
+                            tile_in = air.alloc(TILE_SIZE, i32, scope=herd.private())
+                            # vector=0: the tile is 16 i32 wide, and a 256-bit
+                            # <8 x i32> operation does not legalize on AIE2.
+                            # The predecessor's copy was scalar too.
+                            tile_out = air.alloc(
+                                TILE_SIZE, i32, scope=herd.private(), vector=0
+                            )
 
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=TILE_SIZE,
-                        element_type=xrt_dtype,
-                        memory_space=mem_space,
-                    )
+                            chan_in.get(tile_in, indices=[th, tw])
+                            tile_out[:] = tile_in[:]
+                            chan_out.put(tile_out, indices=[th, tw])
 
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in = AllocOp(tile_type, [], [])
-                    tile_out = AllocOp(tile_type, [], [])
+                    for h in range(ROWS):
+                        for w in range(COLS):
+                            chan_out.get(tile(B, h, w), indices=[h, w])
 
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    ChannelGet("ChanIn", tile_in, indices=[th, tw])
-
-                    # Access every value in the tile
-                    for i in range_(TILE_HEIGHT):
-                        for j in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val = load(tile_in, [i, j])
-
-                            # Store the output value in tile_out
-                            store(val, tile_out, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    # Copy the output tile into the output
-                    ChannelPut("ChanOut", tile_out, indices=[th, tw])
-
-                    # Deallocate our L1 buffers
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
-
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
+    return launch
 
 
 if __name__ == "__main__":
@@ -145,10 +119,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/passthrough/passthrough_channel/passthrough_channel.py
+++ b/programming_examples/passthrough/passthrough_channel/passthrough_channel.py
@@ -1,78 +1,90 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Passthrough over a pair of channels, on air.api.
+
+The vector goes L3 -> channel -> L1, is copied core-side, and comes back
+L1 -> channel -> L3. The schedule is unchanged from the raw-bindings version
+this replaces, and it is the smallest program that shows what a channel is for:
+
+    air.channel @ChanIn                    declared at module scope
+    air.channel @ChanOut
+      air.segment
+        ChanIn.put(A)                      the whole [n] vector, once
+        herd
+          for _ in air.sequential(subvectors)
+              ChanIn.get(tile_in)          one [n/subvectors] chunk per trip
+              tile_out[:] = tile_in[:]
+              ChanOut.put(tile_out)
+        ChanOut.get(B)
+
+Two things about channels are on display here, and both are why this is not
+just ``ops.load``/``ops.store``:
+
+* **The herd carries no channel operand.** ``air.herd`` is ``IsolatedFromAbove``
+  and the DSL threads staged L2 buffers in explicitly, but a channel is a
+  module-level symbol: the herd's ``get`` finds what the segment's ``put`` sent
+  by name alone.
+* **Put and get sizes differ, deliberately.** One put of the whole vector feeds
+  ``subvectors`` gets of a chunk each -- a channel is a stream, and each get
+  takes the next piece. A transfer would have to match shapes; a channel must
+  not.
+
+The put and get on the L3 side sit in the segment rather than beside it. That is
+load-bearing: reaching L3 needs a shim DMA allocation, and hoisting them out to
+function scope fails in air-to-aie with "failed to link to any shim dma
+allocation" -- measured on npu1 against this very example. air.api raises at the
+call site rather than letting that through.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i8
 
 INOUT_DATATYPE = np.uint8
 
 
-@module_builder
 def build_module(vector_size, num_subvectors):
     assert vector_size % num_subvectors == 0
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    chunk = vector_size // num_subvectors
 
-    # Type and method of input/output
-    memrefTyInOut = T.memref(vector_size, xrt_dtype)
-    Channel("ChanIn")
-    Channel("ChanOut")
+    A = air.tensor([vector_size], i8)
+    B = air.tensor([vector_size], i8)
 
-    # The compute core splits input into subvectors for processing
-    lineWidthInBytes = vector_size // num_subvectors
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
 
-    # Memref type definition used by the compute core and external function
-    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    tensor_type = MemRefType.get(
-        shape=[lineWidthInBytes],
-        element_type=xrt_dtype,
-        memory_space=mem_space,
-    )
+    with air.launch(name="copy") as launch:
 
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            ChannelPut("ChanIn", a)
+                @seg.body
+                def _():
+                    chan_in.put(A)
 
-            @segment(name="seg")
-            def segment_body():
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
 
-                @herd(name="copyherd", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
+                        @h.body
+                        def _(tx):
+                            # Hoisted above the loop and reused across trips,
+                            # which is what the loop is for; the predecessor
+                            # allocated a fresh pair per trip.
+                            tile_in = air.alloc([chunk], i8, scope=h.private())
+                            tile_out = air.alloc([chunk], i8, scope=h.private())
 
-                    # Process each subvector individually
-                    for _i in range_(num_subvectors):
-                        # We must allocate a buffer of image size for the input/output
-                        tensor_in = AllocOp(tensor_type, [], [])
-                        tensor_out = AllocOp(tensor_type, [], [])
+                            for _i in air.sequential(0, num_subvectors):
+                                chan_in.get(tile_in)
+                                tile_out[:] = tile_in[:]
+                                chan_out.put(tile_out)
 
-                        ChannelGet("ChanIn", tensor_in)
+                    chan_out.get(B)
 
-                        for j in range_(lineWidthInBytes):
-                            # Load the input value
-                            val = load(tensor_in, [j])
-
-                            # Store the output value
-                            store(val, tensor_out, [j])
-                            yield_([])
-
-                        ChannelPut("ChanOut", tensor_out)
-
-                        # Deallocate our L1 buffers
-                        DeallocOp(tensor_in)
-                        DeallocOp(tensor_out)
-                        yield_([])
-
-            ChannelGet("ChanOut", b)
+    return launch
 
 
 if __name__ == "__main__":
@@ -111,10 +123,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.vector_size, args.subvector_size)
+    launch = build_module(args.vector_size, args.subvector_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -85,12 +85,11 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
                     a_l3_l2.get(l2_a)
                     b_l3_l2.get(l2_b)
 
-                    # One put of the whole staged buffer per K tile; the core
-                    # takes a tile_k slice of it per trip.
-                    for _i in air.sequential(0, k // tile_k):
-                        a_l2_l1.put(l2_a)
-                    for _i in air.sequential(0, k // tile_k):
-                        b_l2_l1.put(l2_b)
+                    # One put each. A channel is a stream, so the single
+                    # [k] put feeds all k/tile_k gets of [tile_k] the core
+                    # makes, and likewise for b.
+                    a_l2_l1.put(l2_a)
+                    b_l2_l1.put(l2_b)
 
                     with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -1,271 +1,122 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Vector-matrix multiplication (GEMV^T) on air.api: C[N] = A[K] @ B[K,N].
+
+Six channels carry the whole schedule -- there is not a single
+``air.dma_memcpy_nd`` in it:
+
+    A:  L3 --aL3ToL2--> L2 --aL2ToL1--> L1
+    B:  L3 --bL3ToL2--> L2 --bL2ToL1--> L1
+    C:  L1 --cL1ToL2--> L2 --cL2ToL3--> L3
+
+and the herd names none of them as an operand. That is the point of a channel:
+``air.herd`` is ``IsolatedFromAbove``, so a buffer has to be threaded in, but a
+channel is a module-level symbol and resolves by name from any depth.
+
+The L2 -> L1 hops show the other half of it. Each puts the *whole* staged
+buffer, once per K tile, while the core gets one tile per trip -- ``[k]`` put
+against ``[tile_k]`` got. A channel is a stream and the get takes the next
+chunk, so the two sides are deliberately not the same shape; air.api validates
+them independently for exactly this reason.
+
+Unchanged from the raw-bindings version this replaces, except for three things
+the DSL requires and one it fixes:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The L1 tiles are allocated above the K loop and reused across trips, rather
+  than a fresh set per trip.
+* ``linalg_fill_bf16`` is declared with the signature ``vm.cc`` actually
+  defines -- ``void linalg_fill_bf16(bfloat16 *)``, the buffer alone. The
+  predecessor declared it ``(bf16, memref)`` and passed a zero the callee never
+  read; harmless, since the C ABI drops the extra argument, but untrue.
+"""
+
 import argparse
 from ml_dtypes import bfloat16
+import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import bf16
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {bfloat16: bf16}
 
 
-@module_builder
-def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
+def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
-    a_size = [k]
-    b_size = [k, n]
-    c_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    dt_in = DTYPE[np_dtype_in]
+    dt_out = DTYPE[np_dtype_out]
 
-    Channel("aL3ToL2")
-    Channel("bL3ToL2")
-    Channel("aL2ToL1")
-    Channel("bL2ToL1")
-    Channel("cL1ToL2")
-    Channel("cL2ToL3")
+    A = air.tensor([k], dt_in)
+    B = air.tensor([k, n], dt_in)
+    C = air.tensor([n], dt_out)
 
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l3_l2 = air.channel("aL3ToL2")
+    b_l3_l2 = air.channel("bL3ToL2")
+    a_l2_l1 = air.channel("aL2ToL1")
+    b_l2_l1 = air.channel("bL2ToL1")
+    c_l1_l2 = air.channel("cL1ToL2")
+    c_l2_l3 = air.channel("cL2ToL3")
 
-    a_l1_size = [tile_k]
-    b_l1_size = [tile_k, tile_n]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    c_l1_size = [tile_n]
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_bf16",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    vecmat_func = FuncOp(
-        "vecmat_bf16_bf16",
-        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, vecmat_func]:
-        func.attributes["link_with"] = StringAttr.get("vm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    vecmat = air.extern("vecmat_bf16_bf16", object=link_with)
+    fill = air.extern("linalg_fill_bf16", object=link_with)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
-    def vecmat_bf16(arg0, arg1, arg2):
+    with air.launch(name="vecmat_bf16") as launch:
 
-        launch_size = [1, n // tile_n]
+        @launch.body
+        def _():
+            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_c_data,
-        ):
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
+                @seg.body
+                def _(sj):
+                    col = sj * tile_n
 
-            # Affine map for launch iv
-            launch_ivy_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_n),
-                    )
-                ],
-            )
-            launch_offset_y = affine_apply(launch_ivy_map, [launch_ivy])
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_data,
-                offsets=[0, launch_offset_y],
-                sizes=[k, tile_n],
-                strides=[n, 1],
-            )
+                    l2_a = air.alloc([k], dt_in, scope=seg.private())
+                    l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([tile_n], dt_out, scope=seg.private())
 
-            @segment(name="vecmat_i8_0")
-            def segment_body():
-                # L2 MemRefTypes
-                a_size_l2 = [k]
-                b_size_l2 = [k, tile_n]
-                c_size_l2 = [tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
+                    a_l3_l2.put(A)
+                    b_l3_l2.put(B[0:k, col : col + tile_n])
+                    a_l3_l2.get(l2_a)
+                    b_l3_l2.get(l2_b)
 
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                    # One put of the whole staged buffer per K tile; the core
+                    # takes a tile_k slice of it per trip.
+                    for _i in air.sequential(0, k // tile_k):
+                        a_l2_l1.put(l2_a)
+                    for _i in air.sequential(0, k // tile_k):
+                        b_l2_l1.put(l2_b)
 
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                        @h.body
+                        def _(tx):
+                            l1_a = air.alloc([tile_k], dt_in, scope=h.private())
+                            l1_b = air.alloc([tile_k, tile_n], dt_in, scope=h.private())
+                            l1_c = air.alloc([tile_n], dt_out, scope=h.private())
 
-                for_iv_map_data = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k),
-                        )
-                    ],
-                )
+                            fill(l1_c)
+                            for _j in air.sequential(0, k, tile_k):
+                                a_l2_l1.get(l1_a)
+                                b_l2_l1.get(l1_b)
+                                vecmat(l1_a, l1_b, l1_c)
 
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    a_l2l1_pack_offset = [for_iv_data_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_data,
-                    )
-                    yield_([])
+                            c_l1_l2.put(l1_c)
 
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    b_l2l1_pack_offset = [0, for_iv_data_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_data,
-                    )
-                    yield_([])
+                    c_l1_l2.get(l2_c)
+                    c_l2_l3.put(l2_c)
+                    c_l2_l3.get(C[col : col + tile_n])
 
-                @herd(name="herd_0", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-
-                    l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                    zero_const = ConstantOp(FloatAttr.get(xrt_dtype_out, 0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_data])
-
-                    for i in range_(0, k, tile_k):
-                        l1_a_data = AllocOp(l1MemrefTyA, [], [])
-
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-
-                        l1_b_data = AllocOp(l1MemrefTyB, [], [])
-
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-
-                        vecmat = CallOp(
-                            vecmat_func,
-                            [l1_a_data, l1_b_data, l1_c_data],
-                        )
-
-                        DeallocOp(l1_a_data)
-                        DeallocOp(l1_b_data)
-
-                        yield_([])
-
-                    ChannelPut(
-                        "cL1ToL2",
-                        l1_c_data,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                    )
-                    DeallocOp(l1_c_data)
-
-                herd_body.attributes["link_with"] = StringAttr.get("vm.o")
-
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                ChannelPut(
-                    "cL2ToL3",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_c_data)
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
+    return launch
 
 
 if __name__ == "__main__":
     # Default values.
-    M = 1
     K = 288
     N = 48
     TILE_K = 96
@@ -310,10 +161,17 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.k,
         args.n,
         args.tile_k,
@@ -321,6 +179,7 @@ if __name__ == "__main__":
         INPUT_DATATYPE,
         OUTPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -46,6 +46,7 @@ if(AIE_ENABLE_BINDINGS_PYTHON)
     ROOT_DIR "${AIR_PYTHON_ROOT_DIR}"
     SOURCES
       api/__init__.py
+      api/_channel.py
       api/_compile.py
       api/_emit.py
       api/_extern.py

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -75,6 +75,7 @@ every hand-written matmul in the tree does; a 1-D herd is also unaffected.
 """
 
 from . import ops
+from ._channel import Channel, channel
 from ._compile import CompiledKernel, LaunchContext, compile, launch
 from ._extern import ExternKernel, extern
 from ._loop import sequential
@@ -106,6 +107,7 @@ __all__ = [
     "alloc",
     "symbol",
     "extern",
+    "channel",
     # control flow
     "sequential",
     "wait",
@@ -128,6 +130,7 @@ __all__ = [
     "SegmentContext",
     "HerdContext",
     "ExternKernel",
+    "Channel",
     "CompiledKernel",
     "Buffer",
     "BufferSlice",
@@ -166,7 +169,14 @@ Field = _unimplemented("Field", "block floating-point types")
 Scratchpad = _unimplemented("Scratchpad", "fabric property gating")
 Cascade = _unimplemented("Cascade", "cascade interconnect support")
 Adjacency = _unimplemented("Adjacency", "placement constraints")
-Broadcast = _unimplemented("Broadcast", "broadcast channel support")
+# Broadcasting is a property of the channel, not a free-standing capability:
+# air.channel(size=[...], broadcast_shape=[...]) is the spelling, matching the
+# broadcast_shape attribute on air.channel itself.
+Broadcast = _unimplemented(
+    "Broadcast",
+    "a standalone broadcast capability; pass broadcast_shape= to air.channel() "
+    "instead",
+)
 CacheDomain = _unimplemented("CacheDomain", "GPU/XCD cache domains")
 Disjoint = _unimplemented("Disjoint", "placement constraints")
 Fabric = _unimplemented("Fabric", "fabric descriptors")

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -1,0 +1,283 @@
+# ./python/air/api/_channel.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Named data channels: ``air.channel`` plus ``put`` and ``get``.
+
+A channel is a point-to-point connection between two memrefs, named by a
+module-level symbol::
+
+    stream = air.channel("ChanIn")
+    ...
+    stream.put(A)                    # from a segment, an L3 tensor
+    ...
+    stream.get(l1_tile)              # from a herd, into an L1 buffer
+
+Why this is not just a DMA
+--------------------------
+
+Two properties make a channel a different thing from ``ops.load``/``ops.store``,
+and both come straight from the hand-written examples this models.
+
+**It crosses scopes without being an operand.** ``air.herd`` and ``air.segment``
+are ``IsolatedFromAbove``, so a buffer has to be threaded in explicitly -- which
+is what the DSL already does for staged L2 tiles. A channel does not: it is a
+module-level ``Symbol`` referenced by name, so a herd can consume what a segment
+produced with no plumbing at all. That is the whole point of the abstraction.
+
+**Put and get sizes need not match.** ``passthrough_channel`` puts one whole
+``[4096]`` tensor and the herd takes four gets of ``[1024]``;
+``vector_matrix_multiplication`` puts ``[k]`` and gets ``[tile_k]`` at a time. A
+channel is a *stream* -- each get takes the next chunk -- so the two sides are
+validated independently and the pairing is the compiler's business. Imposing
+``ops.load``'s shape-equality rule here would reject every canonical example.
+
+Where a put or get may appear
+-----------------------------
+
+An endpoint in L3 -- a tensor or a slice of one -- has to sit inside an
+``air.segment``. Measured on npu1, not assumed: the same passthrough with its
+put and get hoisted to function scope, outside ``air.launch``, fails to compile
+with ``'air.channel.get' op failed to link to any shim dma allocation``, while
+at segment scope it passes with resource counts identical to the original's.
+The check below turns that into an error naming the fix.
+
+An L1 endpoint inside a herd body is the consumer side and is always fine.
+"""
+
+from ._value import Buffer, Tensor, TensorSlice, Token
+
+__all__ = ["Channel", "channel"]
+
+
+def _as_dims(value, what):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        raise TypeError(
+            f"air.channel({what}=...) takes a list of extents, e.g. {what}=[2, 3]; "
+            f"got the bare integer {value}. A 1-D channel array is {what}=[{value}]."
+        )
+    dims = [int(v) for v in value]
+    for d in dims:
+        if d <= 0:
+            raise ValueError(
+                f"air.channel({what}=...) extents must be positive, got {dims}"
+            )
+    return dims
+
+
+class Channel:
+    """A named channel; ``put`` and ``get`` move data through it."""
+
+    __slots__ = ("name", "size", "broadcast_shape", "_declared")
+
+    def __init__(self, name, size=None, broadcast_shape=None, **unsupported):
+        if not isinstance(name, str) or not name:
+            raise TypeError(
+                "air.channel(name) takes the channel's symbol name, e.g. "
+                'air.channel("ChanIn")'
+            )
+        _reject_unsupported(unsupported)
+
+        self.size = _as_dims(size, "size")
+        self.broadcast_shape = _as_dims(broadcast_shape, "broadcast_shape")
+
+        if self.broadcast_shape is not None:
+            if self.size is None:
+                raise ValueError(
+                    "air.channel(broadcast_shape=...) also needs size=: the "
+                    "broadcast is described relative to the channel's own "
+                    "extents, so a 1-to-N fan-out is "
+                    f"size=[1]*{len(self.broadcast_shape)}, "
+                    f"broadcast_shape={self.broadcast_shape}."
+                )
+            if len(self.broadcast_shape) != len(self.size):
+                raise ValueError(
+                    f"air.channel: broadcast_shape {self.broadcast_shape} has "
+                    f"rank {len(self.broadcast_shape)} but size {self.size} has "
+                    f"rank {len(self.size)}; they describe the same axes"
+                )
+            for axis, (s, b) in enumerate(zip(self.size, self.broadcast_shape)):
+                if b % s:
+                    raise ValueError(
+                        f"air.channel: broadcast_shape {self.broadcast_shape} is "
+                        f"not a whole multiple of size {self.size} on axis "
+                        f"{axis} ({b} % {s} != 0), so the fan-out is not an "
+                        "integer number of destinations per source"
+                    )
+
+        self.name = name
+        self._declared = False
+
+    def __repr__(self):
+        extra = f", size={self.size}" if self.size is not None else ""
+        if self.broadcast_shape is not None:
+            extra += f", broadcast_shape={self.broadcast_shape}"
+        return f"air.api.channel({self.name!r}{extra})"
+
+    # -- emission ----------------------------------------------------------
+
+    def _declare(self):
+        """Materialise the ``air.channel`` symbol at module scope, once.
+
+        Deferred to first use for the same reason ``air.extern`` defers its
+        private ``func.func``: the module does not exist until a trace is
+        active, and this way a channel declared but never used emits nothing.
+        """
+        if self._declared:
+            return
+        from air.ir import InsertionPoint
+        from air.dialects.air import Channel as ChannelOp
+
+        from ._trace import active_trace
+
+        trace = active_trace()
+        # Before the func rather than at the top of the module: the func already
+        # exists by the time a body runs, so this lands each new channel after
+        # the ones already declared. at_block_begin would reverse them.
+        anchor = next(
+            (
+                op
+                for op in trace.module.body.operations
+                if op.operation.name != "air.channel"
+            ),
+            None,
+        )
+        ip = (
+            InsertionPoint(anchor)
+            if anchor is not None
+            else InsertionPoint(trace.module.body)
+        )
+        with ip:
+            ChannelOp(
+                self.name,
+                size=self.size,
+                broadcast_shape=self.broadcast_shape,
+            )
+        self._declared = True
+
+    def _indices(self, indices):
+        if indices is None:
+            indices = ()
+        if isinstance(indices, int):
+            indices = (indices,)
+        indices = list(indices)
+        if not indices:
+            return []
+        if self.size is None:
+            raise ValueError(
+                f"air.channel {self.name!r} was declared without size=, so it is "
+                f"a single channel and takes no indices; got indices={indices}. "
+                f"Declare it as air.channel({self.name!r}, size=[...]) to make it "
+                "an array."
+            )
+        if len(indices) != len(self.size):
+            raise ValueError(
+                f"air.channel {self.name!r} has size {self.size}, so it takes "
+                f"{len(self.size)} index/indices; got {len(indices)} "
+                f"({indices})"
+            )
+        from ._index import coerce_index
+
+        # A herd coordinate or loop variable arrives as an IndexExpr and has to
+        # be materialised into an index-typed Value; a constant folds back to a
+        # Python int, which the op keeps static. Only the constant case can be
+        # range-checked -- the herd shape already bounds the dynamic one.
+        out = []
+        for axis, (idx, extent) in enumerate(zip(indices, self.size)):
+            value = coerce_index(idx).materialize()
+            if isinstance(value, int) and not 0 <= value < extent:
+                raise ValueError(
+                    f"air.channel {self.name!r} index {value} is out of range on "
+                    f"axis {axis}: size is {self.size}, so that axis admits "
+                    f"0..{extent - 1}"
+                )
+            out.append(value)
+        return out
+
+    def _emit(self, obj, indices, dependency, direction):
+        from ._trace import current_segment
+        from .ops import _check_dependency, _endpoint
+
+        _check_dependency(dependency)
+        self._declare()
+        endpoint = _endpoint(obj, f"channel.{direction}", "argument")
+
+        # An L3 endpoint needs the shim DMA allocation that only a segment
+        # brings; see the module docstring for the measurement.
+        if endpoint.tensor is not None and current_segment(required=False) is None:
+            raise RuntimeError(
+                f"air.channel.{direction} on an L3 {endpoint.what} has to be inside "
+                "an air.segment: reaching L3 needs a shim DMA allocation, "
+                "and outside a segment the compiler has none to link to (it "
+                f"fails with \"'air.channel.{direction}' op failed to link to any "
+                'shim dma allocation"). Wrap the body in '
+                "`with air.segment(...) as seg:` and move it there."
+            )
+
+        offsets, sizes, strides = endpoint.pattern or ([], [], [])
+        idx = self._indices(indices)
+
+        if direction == "get" and endpoint.tensor is not None:
+            # Same rule ops.store applies: being written from the device is what
+            # makes a tensor an output, which fixes the calling convention.
+            endpoint.tensor.is_output = True
+
+        from air.dialects.air import ChannelGet, ChannelPut
+
+        op = ChannelGet if direction == "get" else ChannelPut
+        return Token(
+            op(
+                self.name,
+                endpoint.value,
+                offsets=offsets,
+                sizes=sizes,
+                strides=strides,
+                indices=idx,
+            )
+        )
+
+    # -- public ------------------------------------------------------------
+
+    def put(self, obj, indices=None, dependency=None, **unsupported):
+        """Send a tensor, a buffer, or a region of either into the channel."""
+        _reject_unsupported(unsupported)
+        return self._emit(obj, indices, dependency, "put")
+
+    def get(self, obj, indices=None, dependency=None, **unsupported):
+        """Receive the channel's next chunk into a tensor, buffer, or region."""
+        _reject_unsupported(unsupported)
+        return self._emit(obj, indices, dependency, "get")
+
+
+# Keywords the underlying ops accept and this DSL does not lower. They raise
+# rather than being dropped: a channel that silently ignores `channel_type` is
+# one that compiles as a stream and was asked for a cascade.
+_UNSUPPORTED = {
+    "channel_type": (
+        "channel types other than the default npu_dma_stream (npu_dma_packet, "
+        "npu_cascade, npu_mmio, gpu_symmetric_heap). Each has its own lowering "
+        "and its own verifier rules -- mmio, for instance, requires an L3 put, "
+        "an L1 get and a constant memref.get_global source"
+    ),
+    "dest": "the packet-demux destination index, which needs npu_dma_packet",
+    "packet_ids": "explicit packet routing ids, which need npu_dma_packet",
+    "buffer_resources": "the objectFifo depth knob",
+    "pad_before": "padded transfers",
+    "pad_after": "padded transfers",
+}
+
+
+def _reject_unsupported(kwargs):
+    for key in kwargs:
+        what = _UNSUPPORTED.get(key)
+        if what is None:
+            raise TypeError(f"air.channel got an unexpected keyword {key!r}")
+        raise NotImplementedError(f"air.api does not implement {key}=: {what}")
+
+
+def channel(name, size=None, broadcast_shape=None, **unsupported):
+    """Declare a named channel; ``put`` into it and ``get`` out of it."""
+    return Channel(name, size=size, broadcast_shape=broadcast_shape, **unsupported)

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -134,22 +134,22 @@ class Channel:
         from ._trace import active_trace
 
         trace = active_trace()
-        # Before the func rather than at the top of the module: the func already
-        # exists by the time a body runs, so this lands each new channel after
-        # the ones already declared. at_block_begin would reverse them.
-        anchor = next(
-            (
-                op
-                for op in trace.module.body.operations
-                if op.operation.name != "air.channel"
-            ),
-            None,
+        # Immediately after the last channel already declared, so several read
+        # in declaration order; at_block_begin alone would reverse them. The
+        # anchor is the last *channel* rather than the first non-channel,
+        # because air.extern prepends its private func.func decls at block
+        # begin -- anchoring on "the first thing that is not a channel" would
+        # start inserting above them once a kernel had been called.
+        ops = list(trace.module.body.operations)
+        last = max(
+            (i for i, op in enumerate(ops) if op.operation.name == "air.channel"),
+            default=None,
         )
-        ip = (
-            InsertionPoint(anchor)
-            if anchor is not None
-            else InsertionPoint(trace.module.body)
-        )
+        if last is None:
+            ip = InsertionPoint.at_block_begin(trace.module.body)
+        else:
+            # The enclosing func always follows, so there is a next sibling.
+            ip = InsertionPoint(ops[last + 1])
         with ip:
             ChannelOp(
                 self.name,

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -175,6 +175,24 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
 
     if node.kind == "scalar":
         value = node.scalar
+        from ._index import IndexExpr
+
+        if isinstance(value, IndexExpr):
+            # Materialise first: a constant expression folds back to a Python
+            # int and takes the ordinary constant path below, so only a genuine
+            # coordinate costs an index_cast.
+            value = value.materialize()
+            if not isinstance(value, int):
+                if ops is not _INT_OPS:
+                    raise NotImplementedError(
+                        "a herd coordinate or loop variable can be broadcast "
+                        "into an integer elementwise expression but not a "
+                        f"floating-point one ({ety} here): it would need an "
+                        "index_cast followed by a conversion to float, which "
+                        "nothing has required yet"
+                    )
+                scalar = _result(arith.index_cast(ety, value))
+                return _result(broadcast(vec_ty, scalar)) if vectorized else scalar
         if ops is _FLOAT_OPS and isinstance(value, int) and not isinstance(value, bool):
             # arith.constant of a float type with a Python int does not raise --
             # it fails an assertion inside cast<IntegerType> and aborts the

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -343,6 +343,15 @@ class BufferExpr:
             return BufferExpr.leaf(value)
         if isinstance(value, (int, float)):
             return BufferExpr("scalar", scalar=value)
+        from ._index import IndexExpr
+
+        if isinstance(value, IndexExpr):
+            # A herd coordinate or loop variable used as a broadcast scalar:
+            # `out[:] = in[:] + ty`. It folds to a Python int when constant and
+            # otherwise materialises as an index Value the emitter casts to the
+            # buffer's element type -- which is what the hand-written channel
+            # examples spell as arith.index_cast(T.i32(), ty).
+            return BufferExpr("scalar", scalar=value)
         if isinstance(value, BufferSlice):
             raise TypeError(
                 f"cannot use {value!r} in an elementwise expression: a partial "

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -34,7 +34,7 @@ from ``tanh``, which has a checked lowering, so nothing has needed a vector
 ``exp`` yet.
 """
 
-from ._value import Buffer, BufferExpr, BufferSlice, TensorSlice, Token
+from ._value import Buffer, BufferExpr, BufferSlice, Tensor, TensorSlice, Token
 
 __all__ = [
     "load",
@@ -124,6 +124,19 @@ def _endpoint(obj, direction, role):
             tensor=obj.tensor,
             what="tensor slice",
             raw=(list(obj.offsets), list(obj.sizes), list(obj.strides)),
+        )
+    if isinstance(obj, Tensor):
+        # A whole tensor, which channel put/get take routinely --
+        # `ChannelPut("ChanIn", a)` is the commonest line in the hand-written
+        # channel examples. There is no access pattern: the transfer is the
+        # whole memref, which the op prints as [] [] [].
+        if obj.value is None:
+            raise RuntimeError(
+                "tensor used before the function was traced; air.tensor(...) "
+                "declares an argument, and it is bound when the launch body runs"
+            )
+        return _Endpoint(
+            obj.value, obj.dtype, obj.shape, None, tensor=obj, what="tensor"
         )
     raise TypeError(
         f"air.api.ops.{direction} expects its {role} to be a buffer from "

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -130,6 +130,13 @@ def _endpoint(obj, direction, role):
         # `ChannelPut("ChanIn", a)` is the commonest line in the hand-written
         # channel examples. There is no access pattern: the transfer is the
         # whole memref, which the op prints as [] [] [].
+        #
+        # This also widens load/store, which share this function: `ops.load(buf,
+        # A)` is now the whole of A rather than an error. That is deliberate --
+        # it is the same transfer as `ops.load(buf, A[:, :])` and reads better
+        # -- and it stays safe because _check_pair still requires the shapes to
+        # agree, and store still marks the tensor an output through
+        # `_Endpoint.tensor` below.
         if obj.value is None:
             raise RuntimeError(
                 "tensor used before the function was traced; air.tensor(...) "
@@ -195,7 +202,8 @@ def load(dst, src, pad_before=None, pad_after=None, dependency=None):
 
     ``load(l1, A[i:i+n])`` is L3 to L1; ``load(l1, staged[tx, 0:n, :])`` is L2 to
     L1; ``load(l2, A[i:i+n])`` is L3 to L2. The destination is always the buffer
-    being filled.
+    being filled. A bare tensor means the whole of it, so ``load(l2, A)`` and
+    ``load(l2, A[:, :])`` are the same transfer.
     """
     _check_dependency(dependency)
     _check_padding(pad_before, pad_after)
@@ -275,7 +283,7 @@ def store(src, dst, pad_before=None, pad_after=None, dependency=None):
 
     ``store(l1, C[i:i+n])`` is L1 to L3; ``store(l1, staged[tx, :])`` is L1 to
     L2; ``store(l2, C[i:i+n])`` is L2 to L3. The source is always the buffer
-    being drained.
+    being drained. A bare tensor destination means the whole of it.
     """
     _check_dependency(dependency)
     _check_padding(pad_before, pad_after)

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -1,0 +1,196 @@
+# ./python/test/api/channel.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api moves data through named channels.
+
+A channel differs from ``ops.load``/``ops.store`` in two ways that this file is
+written to pin down.
+
+**It crosses scopes without being an operand.** ``air.herd`` and ``air.segment``
+are ``IsolatedFromAbove``, so the DSL threads staged L2 buffers in explicitly. A
+channel needs none of that: it is a module-level ``Symbol``, so the herd's
+``get`` finds what the segment's ``put`` sent by name alone.
+
+**Put and get sizes need not match.** Below, one put of the whole ``[4096]``
+tensor feeds four gets of ``[1024]`` -- a channel is a stream, and each get
+takes the next chunk. This is the shape ``passthrough_channel`` uses, and
+applying ``ops.load``'s shape-equality rule to it would reject it.
+
+An endpoint in L3 has to sit inside an ``air.segment``: reaching L3 needs a shim
+DMA allocation, and outside a segment there is none to link to. That is measured
+rather than assumed -- see ``_channel.py`` -- and ``errors.py`` pins the message.
+"""
+
+from air import api as air
+from air.api.types import i8, i32
+
+N = 4096
+SUB = 4
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: plain_channels
+#
+# Both channels are declared at module scope, ahead of the func, and in the
+# order they were written -- they are materialised on first use, which happens
+# deep inside the body, so the ordering is deliberate rather than incidental.
+# CHECK: air.channel @ChanIn []
+# CHECK: air.channel @ChanOut []
+# CHECK: func.func @copy(%{{.*}}: memref<4096xi8>, %{{.*}}: memref<4096xi8>)
+#
+# The put is at segment scope and sends the whole tensor: no access pattern, so
+# the op prints [] [] [].
+# CHECK: air.segment @seg
+# CHECK: air.channel.put @ChanIn[] (%{{.*}}[] [] []) : (memref<4096xi8>)
+#
+# The herd carries no channel operand -- only the two tensors the DSL passes
+# everywhere -- yet its get resolves @ChanIn by name.
+# CHECK: air.herd @copyherd
+# CHECK: scf.for
+# CHECK: air.channel.get @ChanIn[] (%{{.*}}[] [] []) : (memref<1024xi8, 2 : i32>)
+# CHECK: air.channel.put @ChanOut[] (%{{.*}}[] [] []) : (memref<1024xi8, 2 : i32>)
+#
+# ...and the matching get is back at segment scope, into L3.
+# CHECK: air.channel.get @ChanOut[] (%{{.*}}[] [] []) : (memref<4096xi8>)
+@run
+def plain_channels():
+    A = air.tensor([N], i8)
+    B = air.tensor([N], i8)
+    cin = air.channel("ChanIn")
+    cout = air.channel("ChanOut")
+
+    with air.launch(name="copy") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    cin.put(A)
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            tin = air.alloc([N // SUB], i8, scope=h.private())
+                            tout = air.alloc([N // SUB], i8, scope=h.private())
+                            for _i in air.sequential(0, SUB):
+                                cin.get(tin)
+                                tout[:] = tin[:]
+                                cout.put(tout)
+
+                    cout.get(B)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: channel_slice
+# A region endpoint reuses the same slice machinery ops.load/store use, so the
+# offsets, sizes and strides land on the channel op unchanged.
+# CHECK: air.channel.put @Tiles[] (%{{.*}}[0, 8] [16, 8] [64, 1]) : (memref<32x64xi32>)
+@run
+def channel_slice():
+    A = air.tensor([32, 64], i32)
+    B = air.tensor([16, 8], i32)
+    tiles = air.channel("Tiles")
+    back = air.channel("Back")
+
+    with air.launch(name="sliced") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    tiles.put(A[0:16, 8:16])
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            buf = air.alloc([16, 8], i32, scope=h.private())
+                            tiles.get(buf)
+                            back.put(buf)
+
+                    back.get(B)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: channel_array
+# size= makes the channel an array, and indices= selects one of its members.
+# The herd coordinate is a legitimate index, so the subscript is dynamic.
+# CHECK: air.channel @Grid [2, 2]
+# CHECK: air.channel.put @Grid[%c0{{.*}}, %c1{{.*}}] (%{{.*}}[0, 8] [16, 8] [64, 1])
+# CHECK: air.channel.get @Grid[%{{.*}}, %{{.*}}] (%{{.*}}[] [] [])
+@run
+def channel_array():
+    A = air.tensor([32, 64], i32)
+    B = air.tensor([16, 8], i32)
+    grid = air.channel("Grid", size=[2, 2])
+    back = air.channel("Back")
+
+    with air.launch(name="arrayed") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    grid.put(A[0:16, 8:16], indices=[0, 1])
+                    with air.herd([range(2), range(2)], name="h", shape=(2, 2)) as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            buf = air.alloc([16, 8], i32, scope=h.private())
+                            grid.get(buf, indices=[tx, ty])
+                            back.put(buf)
+
+                    back.get(B)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: channel_broadcast
+# broadcast_shape is a declaration-level attribute: one put fans out to the
+# three gets that follow, each naming its own destination with indices=.
+# CHECK: air.channel @Bcast [1, 1] {broadcast_shape = [1 : index, 3 : index]}
+# CHECK: air.channel.put @Bcast[] (%{{.*}}[] [] []) : (memref<64xi32>)
+# CHECK: air.channel.get @Bcast[%{{.*}}, %{{.*}}] (%{{.*}}[] [] []) : (memref<64xi32, 2 : i32>)
+@run
+def channel_broadcast():
+    A = air.tensor([64], i32)
+    B = air.tensor([64], i32)
+    bcast = air.channel("Bcast", size=[1, 1], broadcast_shape=[1, 3])
+    back = air.channel("Back")
+
+    with air.launch(name="fanout") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    bcast.put(A)
+                    with air.herd([range(1), range(3)], name="h", shape=(1, 3)) as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            buf = air.alloc([64], i32, scope=h.private())
+                            bcast.get(buf, indices=[tx, ty])
+                            back.put(buf)
+
+                    back.get(B)
+
+    print(launch.mlir())

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -167,6 +167,14 @@ def channel_array():
 # CHECK: air.channel @Bcast [1, 1] {broadcast_shape = [1 : index, 3 : index]}
 # CHECK: air.channel.put @Bcast[] (%{{.*}}[] [] []) : (memref<64xi32>)
 # CHECK: air.channel.get @Bcast[%{{.*}}, %{{.*}}] (%{{.*}}[] [] []) : (memref<64xi32, 2 : i32>)
+#
+# Each core adds its own coordinate, so the fan-out is observable rather than
+# merely asserted. A herd coordinate broadcast into an elementwise expression
+# materialises as an affine.apply and an index_cast to the buffer's element
+# type -- which is what the hand-written broadcast example spells by hand.
+# CHECK: affine.apply
+# CHECK: arith.index_cast %{{.*}} : index to i32
+# CHECK: arith.addi
 @run
 def channel_broadcast():
     A = air.tensor([64], i32)
@@ -188,8 +196,10 @@ def channel_broadcast():
                         @h.body
                         def _(tx, ty):
                             buf = air.alloc([64], i32, scope=h.private())
+                            out = air.alloc([64], i32, scope=h.private(), vector=0)
                             bcast.get(buf, indices=[tx, ty])
-                            back.put(buf)
+                            out[:] = buf[:] + ty
+                            back.put(out)
 
                     back.get(B)
 

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -204,3 +204,31 @@ def channel_broadcast():
                     back.get(B)
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: whole_tensor_transfer
+# Channels take a bare tensor, and they share ops._endpoint with load/store, so
+# load/store take one too: `ops.load(buf, A)` is the whole of A. Pinned here
+# because it is a widening of those two, not only of the channel ops -- the
+# shape check still applies (errors.py) and store still marks its tensor an
+# output, which is what fixes the kernel's calling convention.
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[] [] []) : (memref<4x64xi32, 2 : i32>, memref<4x64xi32>)
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[] [] []) : (memref<4x64xi32>, memref<4x64xi32, 2 : i32>)
+@run
+def whole_tensor_transfer():
+    A = air.tensor([4, 64], i32)
+    B = air.tensor([4, 64], i32)
+
+    with air.launch(name="whole") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    buf = air.alloc([4, 64], i32, scope=h.private())
+                    air.ops.load(buf, A)
+                    air.ops.store(buf, B)
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -974,3 +974,15 @@ def _():
         a[:] = a[:] + ty
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: whole_tensor_shape_checked
+# The bare-tensor spelling is a convenience, not an escape from the shape check.
+# CHECK: ValueError: transfer shape mismatch in air.api.ops.load
+@expect(ValueError, "whole_tensor_shape_checked")
+def _():
+    def body(h, tx, ty, A, B, C):
+        small = air.alloc([2, 8], bf16, scope=h.private())
+        ops.load(small, A)
+
+    _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -844,3 +844,119 @@ def _():
 @expect(TypeError, "dot_kernel_is_keyword_only")
 def _():
     ops.dot(None, None, None, 1.0, False, None, "matmul_bf16")
+
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+
+
+# CHECK-LABEL: TEST: channel_broadcast_needs_size
+# broadcast_shape describes a fan-out relative to the channel's own extents, so
+# it is meaningless without them.
+# CHECK: ValueError: air.channel(broadcast_shape=...) also needs size=
+@expect(ValueError, "channel_broadcast_needs_size")
+def _():
+    air.channel("C", broadcast_shape=[1, 3])
+
+
+# CHECK-LABEL: TEST: channel_broadcast_rank
+# CHECK: ValueError: air.channel: broadcast_shape [1, 3, 3] has rank 3 but size [1, 1] has rank 2
+@expect(ValueError, "channel_broadcast_rank")
+def _():
+    air.channel("C", size=[1, 1], broadcast_shape=[1, 3, 3])
+
+
+# CHECK-LABEL: TEST: channel_broadcast_not_multiple
+# A fan-out has to be a whole number of destinations per source.
+# CHECK: ValueError: air.channel: broadcast_shape [1, 3] is not a whole multiple of size [1, 2]
+@expect(ValueError, "channel_broadcast_not_multiple")
+def _():
+    air.channel("C", size=[1, 2], broadcast_shape=[1, 3])
+
+
+# CHECK-LABEL: TEST: channel_size_scalar
+# size=[2] is a 1-D array of two channels; size=2 is a mistake worth naming,
+# because it would otherwise iterate an int and fail somewhere less obvious.
+# CHECK: TypeError: air.channel(size=...) takes a list of extents
+@expect(TypeError, "channel_size_scalar")
+def _():
+    air.channel("C", size=2)
+
+
+# CHECK-LABEL: TEST: channel_type_unsupported
+# Accepting channel_type and ignoring it would compile a cascade request as a
+# DMA stream -- the silent-wrongness this package exists to avoid.
+# CHECK: NotImplementedError: air.api does not implement channel_type=
+@expect(NotImplementedError, "channel_type_unsupported")
+def _():
+    air.channel("C", channel_type="npu_cascade")
+
+
+# CHECK-LABEL: TEST: channel_indices_without_size
+# CHECK: ValueError: air.channel 'C' was declared without size=
+@expect(ValueError, "channel_indices_without_size")
+def _():
+    ch = air.channel("C")
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([64], bf16, scope=h.private())
+        ch.get(buf, indices=[0])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_indices_rank
+# CHECK: ValueError: air.channel 'C' has size [2, 2], so it takes 2 index/indices; got 1
+@expect(ValueError, "channel_indices_rank")
+def _():
+    ch = air.channel("C", size=[2, 2])
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([64], bf16, scope=h.private())
+        ch.get(buf, indices=[0])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_index_out_of_range
+# Only a constant index can be checked here; a herd coordinate is bounded by the
+# herd shape instead.
+# CHECK: ValueError: air.channel 'C' index 3 is out of range on axis 0
+@expect(ValueError, "channel_index_out_of_range")
+def _():
+    ch = air.channel("C", size=[2, 2])
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([64], bf16, scope=h.private())
+        ch.get(buf, indices=[3, 0])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_l3_needs_segment
+# Reaching L3 needs a shim DMA allocation, which only a segment brings. Measured
+# on npu1: the same design with its put hoisted out of the segment fails in
+# air-to-aie with "failed to link to any shim dma allocation", so this raises at
+# the call site instead, naming the fix.
+# CHECK: RuntimeError: air.channel.put on an L3 tensor has to be inside an air.segment
+@expect(RuntimeError, "channel_l3_needs_segment")
+def _():
+    ch = air.channel("C")
+
+    def body(h, tx, ty, A, B, C):
+        ch.put(A)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_bad_endpoint
+# CHECK: TypeError: air.api.ops.channel.get expects its argument to be a buffer
+@expect(TypeError, "channel_bad_endpoint")
+def _():
+    ch = air.channel("C")
+
+    def body(h, tx, ty, A, B, C):
+        ch.get([1, 2, 3])
+
+    _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -960,3 +960,17 @@ def _():
         ch.get([1, 2, 3])
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: coord_scalar_into_float
+# A herd coordinate broadcasts into an integer expression with an index_cast.
+# Into a float one it would need a conversion as well, which nothing has
+# required, so it raises rather than guessing a rounding mode.
+# CHECK: NotImplementedError: a herd coordinate or loop variable can be broadcast into an integer elementwise expression but not a floating-point one
+@expect(NotImplementedError, "coord_scalar_into_float")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        a[:] = a[:] + ty
+
+    _trace(body)


### PR DESCRIPTION
Adds named channels to `air.api`, and converts four examples onto them.

Channels were the largest remaining gap in the DSL's coverage: **37 of the 131
raw-bindings examples use `air.channel`, gating 137 lits** — all of
`channel_examples/`, all three `vector_matrix_multiplication/*/single_core`,
`flash_attention/dataflow_based`, `llama2_mha`, `decode_ffn_swiglu`. `air.api`
had no channel surface at all, so every one of them failed the scope gate.

```python
stream = air.channel("ChanIn")
grid   = air.channel("Tiles", size=[H, W])
fan    = air.channel("Q", size=[1, 1], broadcast_shape=[1, 3])

stream.put(A)                      # a whole tensor
stream.put(A[row : row + m, :])    # or a region
grid.get(tile, indices=[tx, ty])
```

## What makes a channel not a transfer

Two properties, both taken from the examples rather than from taste, and both
load-bearing in the implementation.

**It crosses scopes without being an operand.** `air.herd` and `air.segment` are
`IsolatedFromAbove` and the DSL threads staged L2 buffers in explicitly. A
channel is a module-level `Symbol`: the herd's `get` finds what the segment's
`put` sent by name alone, with no plumbing.

**Put and get sizes need not match, and are not checked against each other.**
`passthrough_channel` puts one whole `[4096]` tensor and takes four `[1024]`
gets; `vector_matrix_multiplication` puts `[k]` and gets `[tile_k]`. A channel
is a stream — each get takes the next chunk — so the two sides are validated
independently. Applying `ops.load`'s `_check_pair` shape-equality rule here
would reject every canonical example.

## Where a put or get may appear — measured, not assumed

An L3 endpoint has to sit inside an `air.segment`. `SegmentContext` emits
`air.launch` and nests `air.segment` immediately inside it with nothing between,
so a put written at launch scope would land at function scope — and that
**fails**: `'air.channel.get' op failed to link to any shim dma allocation`. At
segment scope it passes with resource counts identical to the launch-scope
original.

I probed this before writing any DSL code, on a passthrough *and* on a
compute-bearing `matrix_scalar_add`, because the record shows a passthrough-only
probe giving a false all-clear once before. The DSL now raises at the call site
naming the fix rather than letting that error through.

## Design

The prototype on `sambayliss/python/airapi-dsl` settles the spelling — an object
with `put`/`get` methods, and `indices=` as a keyword (its `__getitem__` exists
but is used at no call site, so this adds one spelling, not two). Three of its
choices are stubs that do not survive the real op, and are not followed:

- **`get()` returning a fresh buffer** — `air.channel.get` writes into an
  existing memref, and every example reuses a pre-allocated L1 tile across
  trips; a functional `get()` would allocate per trip.
- **Scope-owned channels (`h.channel(...)`)** — a channel exists to cross
  scopes, and `air.channel` is a module-level symbol.
- **`shape`/`dtype` on the declaration** — `air.channel` carries neither, and
  given the stream semantics a declared payload shape would be actively wrong.

The emitter reuses `ops._endpoint`, which already normalises `Buffer` /
`BufferSlice` / `TensorSlice` into `(value, dtype, sizes, pattern)`; a channel op
is one endpoint plus a name and indices. `_endpoint` gains a bare-`Tensor` case,
since `put(A)` on a whole tensor is the commonest line in these examples.

Two smaller pieces came out of the conversions:

- **A herd coordinate as an elementwise scalar** (`out[:] = in[:] + ty`), which
  `broadcast` and `channel_size` both need and spell by hand as
  `arith.index_cast(T.i32(), ty)`. Integer buffers only; a float target raises
  rather than guessing a conversion.
- **A declaration-ordering fix.** Channels anchor after the last one declared;
  the first anchor was "the first op that is not a channel", which holds until
  `air.extern` prepends a private `func.func` at block begin. Only
  `vector_matrix_multiplication`, with six channels *and* two extern kernels,
  exposed it.

## The four conversions

`passthrough_channel`, `channel_examples/broadcast/single_herd`,
`channel_examples/channel_size`, and
`vector_matrix_multiplication/bf16/single_core` — chosen to cover the whole new
surface between them. The last is the one that matters: six channels carry every
hop, there is not one `air.dma_memcpy_nd` in it, and its L2→L1 puts are the
asymmetric case above.

Verified on npu1, for each example:

- channel declarations and the full put/get sequence **identical** to the
  predecessor's, SSA names normalised — 6 declarations and 12 ops for vecmat, 2
  and 6 for broadcast, 2 and 14 for channel_size, 2 and 4 for passthrough;
- `air_project/npu.air.mlir` resource counts **identical**: tiles, cores,
  buffers, locks, `dma_bd`, `use_lock`, flows, shim allocations, `func.call`;
- every lit runnable on this host passes — **4 of 14**; the other 10 are chess
  or npu2 variants and are correctly reported unsupported.

Regression: all 10 `python/test/api` suites pass, and the emitted IR of the seven
already-converted examples is unchanged, diffed against `origin/main` in a
worktree.

Deliberate differences from the predecessors, all in the commit messages: the
L3-side put/get move into the segment; L1 tiles are allocated above the loop and
reused, because `air.api` refuses allocation inside `air.sequential`;
`broadcast` and `channel_size` pass `vector=0` on their copy destination, since
`<8 x i32>` does not legalize and their predecessors were scalar there too; and
`vm.cc`'s `linalg_fill_bf16` is declared with the signature it actually has,
as in #1849.

## Not covered

`channel_type` (packet / cascade / mmio), `dest=`, `packet_ids`,
`buffer_resources`, `pad_before`/`pad_after`. Each **raises** at the call site
naming what is missing rather than being accepted and ignored. `channel_type` is
excluded because it is a different feature per value, with its own lowering and
verifier rules — mmio, for instance, requires an L3 put, an L1 get and a constant
`memref.get_global` source. That leaves roughly 33 channel examples still
blocked on it.

**No perf A/B here.** None of these four has a `profile` target or `test.cpp`,
and `--perf-iters` times out on *both* arms even at three iterations
(`ERT_CMD_STATE_TIMEOUT`) — these designs are not re-runnable in-process without
re-priming their channels. That is pre-existing and unrelated to the ports. The
evidence for no regression is the identical channel op sequences and identical
DMA/lock/flow resources. An npu2 session is picking up what can be measured
there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
