### PR TITLE
[python] air.api: packed channel puts, and the two vecmat i8 examples

### DIFF
--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/output.mlir
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/output.mlir
@@ -1,0 +1,78 @@
+#map = affine_map<()[s0] -> (s0 * 48)>
+#map1 = affine_map<()[s0] -> (s0 * 96)>
+module {
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func private @linalg_fill_bf16(bf16, memref<48xbf16, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @vecmat_bf16_bf16(memref<96xbf16, 2 : i32>, memref<96x48xbf16, 2 : i32>, memref<48xbf16, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func @vecmat_bf16(%arg0: memref<288xbf16>, %arg1: memref<288x48xbf16>, %arg2: memref<48xbf16>) {
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1_0) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<288xbf16>, memref<288x48xbf16>, memref<48xbf16> {
+      air.channel.put  @aL3ToL2[] (%arg7[] [] []) : (memref<288xbf16>)
+      %0 = affine.apply #map()[%arg4]
+      %c0 = arith.constant 0 : index
+      %c288 = arith.constant 288 : index
+      %c48 = arith.constant 48 : index
+      %c48_1 = arith.constant 48 : index
+      %c1_2 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg8[%c0, %0] [%c288, %c48] [%c48_1, %c1_2]) : (memref<288x48xbf16>)
+      %c48_3 = arith.constant 48 : index
+      %c1_4 = arith.constant 1 : index
+      air.channel.get  @cL2ToL3[] (%arg9[%0] [%c48_3] [%c1_4]) : (memref<48xbf16>)
+      air.segment @vecmat_i8_0  {
+        %alloc = memref.alloc() : memref<288xbf16, 1 : i32>
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<288xbf16, 1 : i32>)
+        %alloc_5 = memref.alloc() : memref<288x48xbf16, 1 : i32>
+        air.channel.get  @bL3ToL2[] (%alloc_5[] [] []) : (memref<288x48xbf16, 1 : i32>)
+        %c0_6 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_7 = arith.constant 1 : index
+        scf.for %arg10 = %c0_6 to %c3 step %c1_7 {
+          %1 = affine.apply #map1()[%arg10]
+          air.channel.put  @aL2ToL1[] (%alloc[] [] []) : (memref<288xbf16, 1 : i32>)
+        }
+        %c0_8 = arith.constant 0 : index
+        %c3_9 = arith.constant 3 : index
+        %c1_10 = arith.constant 1 : index
+        scf.for %arg10 = %c0_8 to %c3_9 step %c1_10 {
+          %1 = affine.apply #map1()[%arg10]
+          air.channel.put  @bL2ToL1[] (%alloc_5[] [] []) : (memref<288x48xbf16, 1 : i32>)
+        }
+        %alloc_11 = memref.alloc() : memref<48xbf16, 1 : i32>
+        air.channel.get  @cL1ToL2[] (%alloc_11[] [] []) : (memref<48xbf16, 1 : i32>)
+        %c1_12 = arith.constant 1 : index
+        %c1_13 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c1_12, %arg13=%c1_13) attributes {link_with = "vm.o"} {
+          %alloc_14 = memref.alloc() : memref<48xbf16, 2 : i32>
+          %cst = arith.constant 0.000000e+00 : bf16
+          func.call @linalg_fill_bf16(%cst, %alloc_14) : (bf16, memref<48xbf16, 2 : i32>) -> ()
+          %c0_15 = arith.constant 0 : index
+          %c288_16 = arith.constant 288 : index
+          %c96 = arith.constant 96 : index
+          scf.for %arg14 = %c0_15 to %c288_16 step %c96 {
+            %alloc_17 = memref.alloc() : memref<96xbf16, 2 : i32>
+            air.channel.get  @aL2ToL1[] (%alloc_17[] [] []) : (memref<96xbf16, 2 : i32>)
+            %alloc_18 = memref.alloc() : memref<96x48xbf16, 2 : i32>
+            air.channel.get  @bL2ToL1[] (%alloc_18[] [] []) : (memref<96x48xbf16, 2 : i32>)
+            func.call @vecmat_bf16_bf16(%alloc_17, %alloc_18, %alloc_14) : (memref<96xbf16, 2 : i32>, memref<96x48xbf16, 2 : i32>, memref<48xbf16, 2 : i32>) -> ()
+            memref.dealloc %alloc_17 : memref<96xbf16, 2 : i32>
+            memref.dealloc %alloc_18 : memref<96x48xbf16, 2 : i32>
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_14[] [] []) : (memref<48xbf16, 2 : i32>)
+          memref.dealloc %alloc_14 : memref<48xbf16, 2 : i32>
+        }
+        air.channel.put  @cL2ToL3[] (%alloc_11[] [] []) : (memref<48xbf16, 1 : i32>)
+        memref.dealloc %alloc : memref<288xbf16, 1 : i32>
+        memref.dealloc %alloc_5 : memref<288x48xbf16, 1 : i32>
+        memref.dealloc %alloc_11 : memref<48xbf16, 1 : i32>
+      }
+    }
+    return
+  }
+}
+

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/Makefile_sweeped
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/Makefile_sweeped
@@ -1,0 +1,28 @@
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Determine build dir based on whether PEANO_INSTALL_DIR is set
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+all: run
+
+print:
+	${powershell} python3 ${srcdir}/single_core.py --k 288 --n 288 -p
+
+run:
+	mkdir -p $(BUILD_DIR)
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2 -c ${srcdir}/vm.cc -o vm.o
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py
+
+sweep:
+	mkdir -p $(BUILD_DIR)
+	# PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} xchesscc_wrapper aie2 -c ${srcdir}/vm.cc -o vm.o
+	PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR) cd $(BUILD_DIR) && ${powershell} python3 ${srcdir}/single_core.py --k 288 --n 288
+
+clean:
+	rm -rf $(BUILD_DIR) __pycache__

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/aie.mlir
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/aie.mlir
@@ -1,0 +1,251 @@
+python3 /home/erweiw/mlir-air/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py --k 576 --n 576 -p
+#map = affine_map<()[s0] -> (s0 * 48)>
+module {
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func private @linalg_fill_i32_view16x8xi32as2(f32, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @vecmat_i8_f32_i32_32(memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func @vecmat_i8(%arg0: memref<576xi8>, %arg1: memref<18xf32>, %arg2: memref<576x576xi8>, %arg3: memref<18x576xf32>, %arg4: memref<576xf32>) {
+    %c1 = arith.constant 1 : index
+    %c12 = arith.constant 12 : index
+    air.launch (%arg5, %arg6) in (%arg7=%c1, %arg8=%c12) args(%arg9=%arg0, %arg10=%arg1, %arg11=%arg2, %arg12=%arg3, %arg13=%arg4) : memref<576xi8>, memref<18xf32>, memref<576x576xi8>, memref<18x576xf32>, memref<576xf32> {
+      air.channel.put  @aL3ToL2[] (%arg9[] [] []) : (memref<576xi8>)
+      air.channel.put  @aL3ToL2[] (%arg10[] [] []) : (memref<18xf32>)
+      %0 = affine.apply #map()[%arg6]
+      %c0 = arith.constant 0 : index
+      %c576 = arith.constant 576 : index
+      %c48 = arith.constant 48 : index
+      %c576_0 = arith.constant 576 : index
+      %c1_1 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg11[%c0, %0] [%c576, %c48] [%c576_0, %c1_1]) : (memref<576x576xi8>)
+      %c0_2 = arith.constant 0 : index
+      %c18 = arith.constant 18 : index
+      %c48_3 = arith.constant 48 : index
+      %c576_4 = arith.constant 576 : index
+      %c1_5 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg12[%c0_2, %0] [%c18, %c48_3] [%c576_4, %c1_5]) : (memref<18x576xf32>)
+      %c48_6 = arith.constant 48 : index
+      %c1_7 = arith.constant 1 : index
+      air.channel.get  @cL2ToL3[] (%arg13[%0] [%c48_6] [%c1_7]) : (memref<576xf32>)
+      air.segment @vecmat_i8_0  {
+        %alloc = memref.alloc() : memref<576xi8, 1 : i32>
+        %alloc_8 = memref.alloc() : memref<18xf32, 1 : i32>
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<576xi8, 1 : i32>)
+        air.channel.get  @aL3ToL2[] (%alloc_8[] [] []) : (memref<18xf32, 1 : i32>)
+        %alloc_9 = memref.alloc() : memref<576x48xi8, 1 : i32>
+        %alloc_10 = memref.alloc() : memref<18x48xf32, 1 : i32>
+        air.channel.get  @bL3ToL2[] (%alloc_9[] [] []) : (memref<576x48xi8, 1 : i32>)
+        air.channel.get  @bL3ToL2[] (%alloc_10[] [] []) : (memref<18x48xf32, 1 : i32>)
+        %c0_11 = arith.constant 0 : index
+        %c96 = arith.constant 96 : index
+        %c1_12 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c0_11] [%c96] [%c1_12]) : (memref<576xi8, 1 : i32>)
+        %c0_13 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_14 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c0_13] [%c3] [%c1_14]) : (memref<18xf32, 1 : i32>)
+        %c96_15 = arith.constant 96 : index
+        %c96_16 = arith.constant 96 : index
+        %c1_17 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c96_15] [%c96_16] [%c1_17]) : (memref<576xi8, 1 : i32>)
+        %c3_18 = arith.constant 3 : index
+        %c3_19 = arith.constant 3 : index
+        %c1_20 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c3_18] [%c3_19] [%c1_20]) : (memref<18xf32, 1 : i32>)
+        %c192 = arith.constant 192 : index
+        %c96_21 = arith.constant 96 : index
+        %c1_22 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c192] [%c96_21] [%c1_22]) : (memref<576xi8, 1 : i32>)
+        %c6 = arith.constant 6 : index
+        %c3_23 = arith.constant 3 : index
+        %c1_24 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c6] [%c3_23] [%c1_24]) : (memref<18xf32, 1 : i32>)
+        %c288 = arith.constant 288 : index
+        %c96_25 = arith.constant 96 : index
+        %c1_26 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c288] [%c96_25] [%c1_26]) : (memref<576xi8, 1 : i32>)
+        %c9 = arith.constant 9 : index
+        %c3_27 = arith.constant 3 : index
+        %c1_28 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c9] [%c3_27] [%c1_28]) : (memref<18xf32, 1 : i32>)
+        %c384 = arith.constant 384 : index
+        %c96_29 = arith.constant 96 : index
+        %c1_30 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c384] [%c96_29] [%c1_30]) : (memref<576xi8, 1 : i32>)
+        %c12_31 = arith.constant 12 : index
+        %c3_32 = arith.constant 3 : index
+        %c1_33 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c12_31] [%c3_32] [%c1_33]) : (memref<18xf32, 1 : i32>)
+        %c480 = arith.constant 480 : index
+        %c96_34 = arith.constant 96 : index
+        %c1_35 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c480] [%c96_34] [%c1_35]) : (memref<576xi8, 1 : i32>)
+        %c15 = arith.constant 15 : index
+        %c3_36 = arith.constant 3 : index
+        %c1_37 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_8[%c15] [%c3_36] [%c1_37]) : (memref<18xf32, 1 : i32>)
+        %c0_38 = arith.constant 0 : index
+        %c0_39 = arith.constant 0 : index
+        %c0_40 = arith.constant 0 : index
+        %c6_41 = arith.constant 6 : index
+        %c96_42 = arith.constant 96 : index
+        %c8 = arith.constant 8 : index
+        %c8_43 = arith.constant 8 : index
+        %c48_44 = arith.constant 48 : index
+        %c1_45 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_38, %c0_39, %c0_40] [%c6_41, %c96_42, %c8] [%c8_43, %c48_44, %c1_45]) : (memref<576x48xi8, 1 : i32>)
+        %c0_46 = arith.constant 0 : index
+        %c0_47 = arith.constant 0 : index
+        %c0_48 = arith.constant 0 : index
+        %c6_49 = arith.constant 6 : index
+        %c3_50 = arith.constant 3 : index
+        %c8_51 = arith.constant 8 : index
+        %c8_52 = arith.constant 8 : index
+        %c48_53 = arith.constant 48 : index
+        %c1_54 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_46, %c0_47, %c0_48] [%c6_49, %c3_50, %c8_51] [%c8_52, %c48_53, %c1_54]) : (memref<18x48xf32, 1 : i32>)
+        %c0_55 = arith.constant 0 : index
+        %c96_56 = arith.constant 96 : index
+        %c0_57 = arith.constant 0 : index
+        %c6_58 = arith.constant 6 : index
+        %c96_59 = arith.constant 96 : index
+        %c8_60 = arith.constant 8 : index
+        %c8_61 = arith.constant 8 : index
+        %c48_62 = arith.constant 48 : index
+        %c1_63 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_55, %c96_56, %c0_57] [%c6_58, %c96_59, %c8_60] [%c8_61, %c48_62, %c1_63]) : (memref<576x48xi8, 1 : i32>)
+        %c0_64 = arith.constant 0 : index
+        %c3_65 = arith.constant 3 : index
+        %c0_66 = arith.constant 0 : index
+        %c6_67 = arith.constant 6 : index
+        %c3_68 = arith.constant 3 : index
+        %c8_69 = arith.constant 8 : index
+        %c8_70 = arith.constant 8 : index
+        %c48_71 = arith.constant 48 : index
+        %c1_72 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_64, %c3_65, %c0_66] [%c6_67, %c3_68, %c8_69] [%c8_70, %c48_71, %c1_72]) : (memref<18x48xf32, 1 : i32>)
+        %c0_73 = arith.constant 0 : index
+        %c192_74 = arith.constant 192 : index
+        %c0_75 = arith.constant 0 : index
+        %c6_76 = arith.constant 6 : index
+        %c96_77 = arith.constant 96 : index
+        %c8_78 = arith.constant 8 : index
+        %c8_79 = arith.constant 8 : index
+        %c48_80 = arith.constant 48 : index
+        %c1_81 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_73, %c192_74, %c0_75] [%c6_76, %c96_77, %c8_78] [%c8_79, %c48_80, %c1_81]) : (memref<576x48xi8, 1 : i32>)
+        %c0_82 = arith.constant 0 : index
+        %c6_83 = arith.constant 6 : index
+        %c0_84 = arith.constant 0 : index
+        %c6_85 = arith.constant 6 : index
+        %c3_86 = arith.constant 3 : index
+        %c8_87 = arith.constant 8 : index
+        %c8_88 = arith.constant 8 : index
+        %c48_89 = arith.constant 48 : index
+        %c1_90 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_82, %c6_83, %c0_84] [%c6_85, %c3_86, %c8_87] [%c8_88, %c48_89, %c1_90]) : (memref<18x48xf32, 1 : i32>)
+        %c0_91 = arith.constant 0 : index
+        %c288_92 = arith.constant 288 : index
+        %c0_93 = arith.constant 0 : index
+        %c6_94 = arith.constant 6 : index
+        %c96_95 = arith.constant 96 : index
+        %c8_96 = arith.constant 8 : index
+        %c8_97 = arith.constant 8 : index
+        %c48_98 = arith.constant 48 : index
+        %c1_99 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_91, %c288_92, %c0_93] [%c6_94, %c96_95, %c8_96] [%c8_97, %c48_98, %c1_99]) : (memref<576x48xi8, 1 : i32>)
+        %c0_100 = arith.constant 0 : index
+        %c9_101 = arith.constant 9 : index
+        %c0_102 = arith.constant 0 : index
+        %c6_103 = arith.constant 6 : index
+        %c3_104 = arith.constant 3 : index
+        %c8_105 = arith.constant 8 : index
+        %c8_106 = arith.constant 8 : index
+        %c48_107 = arith.constant 48 : index
+        %c1_108 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_100, %c9_101, %c0_102] [%c6_103, %c3_104, %c8_105] [%c8_106, %c48_107, %c1_108]) : (memref<18x48xf32, 1 : i32>)
+        %c0_109 = arith.constant 0 : index
+        %c384_110 = arith.constant 384 : index
+        %c0_111 = arith.constant 0 : index
+        %c6_112 = arith.constant 6 : index
+        %c96_113 = arith.constant 96 : index
+        %c8_114 = arith.constant 8 : index
+        %c8_115 = arith.constant 8 : index
+        %c48_116 = arith.constant 48 : index
+        %c1_117 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_109, %c384_110, %c0_111] [%c6_112, %c96_113, %c8_114] [%c8_115, %c48_116, %c1_117]) : (memref<576x48xi8, 1 : i32>)
+        %c0_118 = arith.constant 0 : index
+        %c12_119 = arith.constant 12 : index
+        %c0_120 = arith.constant 0 : index
+        %c6_121 = arith.constant 6 : index
+        %c3_122 = arith.constant 3 : index
+        %c8_123 = arith.constant 8 : index
+        %c8_124 = arith.constant 8 : index
+        %c48_125 = arith.constant 48 : index
+        %c1_126 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_118, %c12_119, %c0_120] [%c6_121, %c3_122, %c8_123] [%c8_124, %c48_125, %c1_126]) : (memref<18x48xf32, 1 : i32>)
+        %c0_127 = arith.constant 0 : index
+        %c480_128 = arith.constant 480 : index
+        %c0_129 = arith.constant 0 : index
+        %c6_130 = arith.constant 6 : index
+        %c96_131 = arith.constant 96 : index
+        %c8_132 = arith.constant 8 : index
+        %c8_133 = arith.constant 8 : index
+        %c48_134 = arith.constant 48 : index
+        %c1_135 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_9[%c0_127, %c480_128, %c0_129] [%c6_130, %c96_131, %c8_132] [%c8_133, %c48_134, %c1_135]) : (memref<576x48xi8, 1 : i32>)
+        %c0_136 = arith.constant 0 : index
+        %c15_137 = arith.constant 15 : index
+        %c0_138 = arith.constant 0 : index
+        %c6_139 = arith.constant 6 : index
+        %c3_140 = arith.constant 3 : index
+        %c8_141 = arith.constant 8 : index
+        %c8_142 = arith.constant 8 : index
+        %c48_143 = arith.constant 48 : index
+        %c1_144 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_10[%c0_136, %c15_137, %c0_138] [%c6_139, %c3_140, %c8_141] [%c8_142, %c48_143, %c1_144]) : (memref<18x48xf32, 1 : i32>)
+        %alloc_145 = memref.alloc() : memref<48xf32, 1 : i32>
+        air.channel.get  @cL1ToL2[] (%alloc_145[] [] []) : (memref<48xf32, 1 : i32>)
+        %c1_146 = arith.constant 1 : index
+        %c1_147 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg14, %arg15) in (%arg16=%c1_146, %arg17=%c1_147) attributes {link_with = "vm.o"} {
+          %alloc_148 = memref.alloc() : memref<6x8xf32, 2 : i32>
+          %cst = arith.constant 0.000000e+00 : f32
+          func.call @linalg_fill_i32_view16x8xi32as2(%cst, %alloc_148) : (f32, memref<6x8xf32, 2 : i32>) -> ()
+          %c0_149 = arith.constant 0 : index
+          %c576_150 = arith.constant 576 : index
+          %c96_151 = arith.constant 96 : index
+          scf.for %arg18 = %c0_149 to %c576_150 step %c96_151 {
+            %alloc_152 = memref.alloc() : memref<6x16xi8, 2 : i32>
+            %alloc_153 = memref.alloc() : memref<3xf32, 2 : i32>
+            air.channel.get  @aL2ToL1[] (%alloc_152[] [] []) : (memref<6x16xi8, 2 : i32>)
+            air.channel.get  @aL2ToL1[] (%alloc_153[] [] []) : (memref<3xf32, 2 : i32>)
+            %alloc_154 = memref.alloc() : memref<6x6x16x8xi8, 2 : i32>
+            %alloc_155 = memref.alloc() : memref<6x3x8xf32, 2 : i32>
+            air.channel.get  @bL2ToL1[] (%alloc_154[] [] []) : (memref<6x6x16x8xi8, 2 : i32>)
+            air.channel.get  @bL2ToL1[] (%alloc_155[] [] []) : (memref<6x3x8xf32, 2 : i32>)
+            func.call @vecmat_i8_f32_i32_32(%alloc_152, %alloc_153, %alloc_154, %alloc_155, %alloc_148) : (memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) -> ()
+            memref.dealloc %alloc_152 : memref<6x16xi8, 2 : i32>
+            memref.dealloc %alloc_153 : memref<3xf32, 2 : i32>
+            memref.dealloc %alloc_154 : memref<6x6x16x8xi8, 2 : i32>
+            memref.dealloc %alloc_155 : memref<6x3x8xf32, 2 : i32>
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_148[] [] []) : (memref<6x8xf32, 2 : i32>)
+          memref.dealloc %alloc_148 : memref<6x8xf32, 2 : i32>
+        }
+        air.channel.put  @cL2ToL3[] (%alloc_145[] [] []) : (memref<48xf32, 1 : i32>)
+        memref.dealloc %alloc : memref<576xi8, 1 : i32>
+        memref.dealloc %alloc_8 : memref<18xf32, 1 : i32>
+        memref.dealloc %alloc_9 : memref<576x48xi8, 1 : i32>
+        memref.dealloc %alloc_10 : memref<18x48xf32, 1 : i32>
+        memref.dealloc %alloc_145 : memref<48xf32, 1 : i32>
+      }
+    }
+    return
+  }
+}
+

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/aie_ref.mlir
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/aie_ref.mlir
@@ -1,0 +1,153 @@
+python3 /home/erweiw/mlir-air/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py -p
+module {
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func private @linalg_fill_i32_view16x8xi32as2(f32, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @vecmat_i8_f32_i32_32(memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func @vecmat_i8(%arg0: memref<288xi8>, %arg1: memref<9xf32>, %arg2: memref<288x48xi8>, %arg3: memref<9x48xf32>, %arg4: memref<48xf32>) {
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg5, %arg6) in (%arg7=%c1, %arg8=%c1_0) args(%arg9=%arg0, %arg10=%arg1, %arg11=%arg2, %arg12=%arg3, %arg13=%arg4) : memref<288xi8>, memref<9xf32>, memref<288x48xi8>, memref<9x48xf32>, memref<48xf32> {
+      air.channel.put  @aL3ToL2[] (%arg9[] [] []) : (memref<288xi8>)
+      air.channel.put  @aL3ToL2[] (%arg10[] [] []) : (memref<9xf32>)
+      air.channel.put  @bL3ToL2[] (%arg11[] [] []) : (memref<288x48xi8>)
+      air.channel.put  @bL3ToL2[] (%arg12[] [] []) : (memref<9x48xf32>)
+      air.channel.get  @cL2ToL3[] (%arg13[] [] []) : (memref<48xf32>)
+      air.segment @vecmat_i8_0  {
+        %alloc = memref.alloc() : memref<288xi8, 1 : i32>
+        %alloc_1 = memref.alloc() : memref<9xf32, 1 : i32>
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<288xi8, 1 : i32>)
+        air.channel.get  @aL3ToL2[] (%alloc_1[] [] []) : (memref<9xf32, 1 : i32>)
+        %alloc_2 = memref.alloc() : memref<288x48xi8, 1 : i32>
+        %alloc_3 = memref.alloc() : memref<9x48xf32, 1 : i32>
+        air.channel.get  @bL3ToL2[] (%alloc_2[] [] []) : (memref<288x48xi8, 1 : i32>)
+        air.channel.get  @bL3ToL2[] (%alloc_3[] [] []) : (memref<9x48xf32, 1 : i32>)
+        %c0 = arith.constant 0 : index
+        %c96 = arith.constant 96 : index
+        %c1_4 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c0] [%c96] [%c1_4]) : (memref<288xi8, 1 : i32>)
+        %c0_5 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_6 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_1[%c0_5] [%c3] [%c1_6]) : (memref<9xf32, 1 : i32>)
+        %c96_7 = arith.constant 96 : index
+        %c96_8 = arith.constant 96 : index
+        %c1_9 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c96_7] [%c96_8] [%c1_9]) : (memref<288xi8, 1 : i32>)
+        %c3_10 = arith.constant 3 : index
+        %c3_11 = arith.constant 3 : index
+        %c1_12 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_1[%c3_10] [%c3_11] [%c1_12]) : (memref<9xf32, 1 : i32>)
+        %c192 = arith.constant 192 : index
+        %c96_13 = arith.constant 96 : index
+        %c1_14 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc[%c192] [%c96_13] [%c1_14]) : (memref<288xi8, 1 : i32>)
+        %c6 = arith.constant 6 : index
+        %c3_15 = arith.constant 3 : index
+        %c1_16 = arith.constant 1 : index
+        air.channel.put  @aL2ToL1[] (%alloc_1[%c6] [%c3_15] [%c1_16]) : (memref<9xf32, 1 : i32>)
+        %c0_17 = arith.constant 0 : index
+        %c0_18 = arith.constant 0 : index
+        %c0_19 = arith.constant 0 : index
+        %c6_20 = arith.constant 6 : index
+        %c96_21 = arith.constant 96 : index
+        %c8 = arith.constant 8 : index
+        %c8_22 = arith.constant 8 : index
+        %c48 = arith.constant 48 : index
+        %c1_23 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_2[%c0_17, %c0_18, %c0_19] [%c6_20, %c96_21, %c8] [%c8_22, %c48, %c1_23]) : (memref<288x48xi8, 1 : i32>)
+        %c0_24 = arith.constant 0 : index
+        %c0_25 = arith.constant 0 : index
+        %c0_26 = arith.constant 0 : index
+        %c6_27 = arith.constant 6 : index
+        %c3_28 = arith.constant 3 : index
+        %c8_29 = arith.constant 8 : index
+        %c8_30 = arith.constant 8 : index
+        %c48_31 = arith.constant 48 : index
+        %c1_32 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_3[%c0_24, %c0_25, %c0_26] [%c6_27, %c3_28, %c8_29] [%c8_30, %c48_31, %c1_32]) : (memref<9x48xf32, 1 : i32>)
+        %c0_33 = arith.constant 0 : index
+        %c96_34 = arith.constant 96 : index
+        %c0_35 = arith.constant 0 : index
+        %c6_36 = arith.constant 6 : index
+        %c96_37 = arith.constant 96 : index
+        %c8_38 = arith.constant 8 : index
+        %c8_39 = arith.constant 8 : index
+        %c48_40 = arith.constant 48 : index
+        %c1_41 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_2[%c0_33, %c96_34, %c0_35] [%c6_36, %c96_37, %c8_38] [%c8_39, %c48_40, %c1_41]) : (memref<288x48xi8, 1 : i32>)
+        %c0_42 = arith.constant 0 : index
+        %c3_43 = arith.constant 3 : index
+        %c0_44 = arith.constant 0 : index
+        %c6_45 = arith.constant 6 : index
+        %c3_46 = arith.constant 3 : index
+        %c8_47 = arith.constant 8 : index
+        %c8_48 = arith.constant 8 : index
+        %c48_49 = arith.constant 48 : index
+        %c1_50 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_3[%c0_42, %c3_43, %c0_44] [%c6_45, %c3_46, %c8_47] [%c8_48, %c48_49, %c1_50]) : (memref<9x48xf32, 1 : i32>)
+        %c0_51 = arith.constant 0 : index
+        %c192_52 = arith.constant 192 : index
+        %c0_53 = arith.constant 0 : index
+        %c6_54 = arith.constant 6 : index
+        %c96_55 = arith.constant 96 : index
+        %c8_56 = arith.constant 8 : index
+        %c8_57 = arith.constant 8 : index
+        %c48_58 = arith.constant 48 : index
+        %c1_59 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_2[%c0_51, %c192_52, %c0_53] [%c6_54, %c96_55, %c8_56] [%c8_57, %c48_58, %c1_59]) : (memref<288x48xi8, 1 : i32>)
+        %c0_60 = arith.constant 0 : index
+        %c6_61 = arith.constant 6 : index
+        %c0_62 = arith.constant 0 : index
+        %c6_63 = arith.constant 6 : index
+        %c3_64 = arith.constant 3 : index
+        %c8_65 = arith.constant 8 : index
+        %c8_66 = arith.constant 8 : index
+        %c48_67 = arith.constant 48 : index
+        %c1_68 = arith.constant 1 : index
+        air.channel.put  @bL2ToL1[] (%alloc_3[%c0_60, %c6_61, %c0_62] [%c6_63, %c3_64, %c8_65] [%c8_66, %c48_67, %c1_68]) : (memref<9x48xf32, 1 : i32>)
+        %alloc_69 = memref.alloc() : memref<48xf32, 1 : i32>
+        air.channel.get  @cL1ToL2[] (%alloc_69[] [] []) : (memref<48xf32, 1 : i32>)
+        %c1_70 = arith.constant 1 : index
+        %c1_71 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg14, %arg15) in (%arg16=%c1_70, %arg17=%c1_71) attributes {link_with = "vm.o"} {
+          %alloc_72 = memref.alloc() : memref<6x8xf32, 2 : i32>
+          %cst = arith.constant 0.000000e+00 : f32
+          func.call @linalg_fill_i32_view16x8xi32as2(%cst, %alloc_72) : (f32, memref<6x8xf32, 2 : i32>) -> ()
+          %c0_73 = arith.constant 0 : index
+          %c288 = arith.constant 288 : index
+          %c96_74 = arith.constant 96 : index
+          scf.for %arg18 = %c0_73 to %c288 step %c96_74 {
+            %alloc_75 = memref.alloc() : memref<6x16xi8, 2 : i32>
+            %alloc_76 = memref.alloc() : memref<3xf32, 2 : i32>
+            air.channel.get  @aL2ToL1[] (%alloc_75[] [] []) : (memref<6x16xi8, 2 : i32>)
+            air.channel.get  @aL2ToL1[] (%alloc_76[] [] []) : (memref<3xf32, 2 : i32>)
+            %alloc_77 = memref.alloc() : memref<6x6x16x8xi8, 2 : i32>
+            %alloc_78 = memref.alloc() : memref<6x3x8xf32, 2 : i32>
+            air.channel.get  @bL2ToL1[] (%alloc_77[] [] []) : (memref<6x6x16x8xi8, 2 : i32>)
+            air.channel.get  @bL2ToL1[] (%alloc_78[] [] []) : (memref<6x3x8xf32, 2 : i32>)
+            func.call @vecmat_i8_f32_i32_32(%alloc_75, %alloc_76, %alloc_77, %alloc_78, %alloc_72) : (memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) -> ()
+            memref.dealloc %alloc_75 : memref<6x16xi8, 2 : i32>
+            memref.dealloc %alloc_76 : memref<3xf32, 2 : i32>
+            memref.dealloc %alloc_77 : memref<6x6x16x8xi8, 2 : i32>
+            memref.dealloc %alloc_78 : memref<6x3x8xf32, 2 : i32>
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_72[] [] []) : (memref<6x8xf32, 2 : i32>)
+          memref.dealloc %alloc_72 : memref<6x8xf32, 2 : i32>
+        }
+        air.channel.put  @cL2ToL3[] (%alloc_69[] [] []) : (memref<48xf32, 1 : i32>)
+        memref.dealloc %alloc : memref<288xi8, 1 : i32>
+        memref.dealloc %alloc_1 : memref<9xf32, 1 : i32>
+        memref.dealloc %alloc_2 : memref<288x48xi8, 1 : i32>
+        memref.dealloc %alloc_3 : memref<9x48xf32, 1 : i32>
+        memref.dealloc %alloc_69 : memref<48xf32, 1 : i32>
+      }
+    }
+    return
+  }
+}
+

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/output.mlir
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/output.mlir
@@ -1,0 +1,123 @@
+python3 /home/erweiw/mlir-air/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py -p
+#map = affine_map<()[s0] -> (s0 * 48)>
+#map1 = affine_map<()[s0] -> (s0 * 96)>
+#map2 = affine_map<()[s0] -> (s0 * 3)>
+module {
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func private @linalg_fill_i32_view16x8xi32as2(f32, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @vecmat_i8_f32_i32_32(memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func @vecmat_i8(%arg0: memref<288xi8>, %arg1: memref<9xf32>, %arg2: memref<288x48xi8>, %arg3: memref<9x48xf32>, %arg4: memref<48xf32>) {
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg5, %arg6) in (%arg7=%c1, %arg8=%c1_0) args(%arg9=%arg0, %arg10=%arg1, %arg11=%arg2, %arg12=%arg3, %arg13=%arg4) : memref<288xi8>, memref<9xf32>, memref<288x48xi8>, memref<9x48xf32>, memref<48xf32> {
+      air.channel.put  @aL3ToL2[] (%arg9[] [] []) : (memref<288xi8>)
+      air.channel.put  @aL3ToL2[] (%arg10[] [] []) : (memref<9xf32>)
+      %0 = affine.apply #map()[%arg6]
+      %c0 = arith.constant 0 : index
+      %c288 = arith.constant 288 : index
+      %c48 = arith.constant 48 : index
+      %c48_1 = arith.constant 48 : index
+      %c1_2 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg11[%c0, %0] [%c288, %c48] [%c48_1, %c1_2]) : (memref<288x48xi8>)
+      %c0_3 = arith.constant 0 : index
+      %c9 = arith.constant 9 : index
+      %c48_4 = arith.constant 48 : index
+      %c48_5 = arith.constant 48 : index
+      %c1_6 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg12[%c0_3, %0] [%c9, %c48_4] [%c48_5, %c1_6]) : (memref<9x48xf32>)
+      %c48_7 = arith.constant 48 : index
+      %c1_8 = arith.constant 1 : index
+      air.channel.get  @cL2ToL3[] (%arg13[%0] [%c48_7] [%c1_8]) : (memref<48xf32>)
+      air.segment @vecmat_i8_0  {
+        %alloc = memref.alloc() : memref<288xi8, 1 : i32>
+        %alloc_9 = memref.alloc() : memref<9xf32, 1 : i32>
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<288xi8, 1 : i32>)
+        air.channel.get  @aL3ToL2[] (%alloc_9[] [] []) : (memref<9xf32, 1 : i32>)
+        %alloc_10 = memref.alloc() : memref<288x48xi8, 1 : i32>
+        %alloc_11 = memref.alloc() : memref<9x48xf32, 1 : i32>
+        air.channel.get  @bL3ToL2[] (%alloc_10[] [] []) : (memref<288x48xi8, 1 : i32>)
+        air.channel.get  @bL3ToL2[] (%alloc_11[] [] []) : (memref<9x48xf32, 1 : i32>)
+        %c0_12 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_13 = arith.constant 1 : index
+        scf.for %arg14 = %c0_12 to %c3 step %c1_13 {
+          %1 = affine.apply #map1()[%arg14]
+          %c96 = arith.constant 96 : index
+          %c1_20 = arith.constant 1 : index
+          air.channel.put  @aL2ToL1[] (%alloc[%1] [%c96] [%c1_20]) : (memref<288xi8, 1 : i32>)
+          %2 = affine.apply #map2()[%arg14]
+          %c3_21 = arith.constant 3 : index
+          %c1_22 = arith.constant 1 : index
+          air.channel.put  @aL2ToL1[] (%alloc_9[%2] [%c3_21] [%c1_22]) : (memref<9xf32, 1 : i32>)
+        }
+        %c0_14 = arith.constant 0 : index
+        %c3_15 = arith.constant 3 : index
+        %c1_16 = arith.constant 1 : index
+        scf.for %arg14 = %c0_14 to %c3_15 step %c1_16 {
+          %1 = affine.apply #map1()[%arg14]
+          %c0_20 = arith.constant 0 : index
+          %c0_21 = arith.constant 0 : index
+          %c6 = arith.constant 6 : index
+          %c96 = arith.constant 96 : index
+          %c8 = arith.constant 8 : index
+          %c8_22 = arith.constant 8 : index
+          %c48_23 = arith.constant 48 : index
+          %c1_24 = arith.constant 1 : index
+          air.channel.put  @bL2ToL1[] (%alloc_10[%c0_20, %1, %c0_21] [%c6, %c96, %c8] [%c8_22, %c48_23, %c1_24]) : (memref<288x48xi8, 1 : i32>)
+          %2 = affine.apply #map2()[%arg14]
+          %c0_25 = arith.constant 0 : index
+          %c0_26 = arith.constant 0 : index
+          %c6_27 = arith.constant 6 : index
+          %c3_28 = arith.constant 3 : index
+          %c8_29 = arith.constant 8 : index
+          %c8_30 = arith.constant 8 : index
+          %c48_31 = arith.constant 48 : index
+          %c1_32 = arith.constant 1 : index
+          air.channel.put  @bL2ToL1[] (%alloc_11[%c0_25, %2, %c0_26] [%c6_27, %c3_28, %c8_29] [%c8_30, %c48_31, %c1_32]) : (memref<9x48xf32, 1 : i32>)
+        }
+        %alloc_17 = memref.alloc() : memref<48xf32, 1 : i32>
+        air.channel.get  @cL1ToL2[] (%alloc_17[] [] []) : (memref<48xf32, 1 : i32>)
+        %c1_18 = arith.constant 1 : index
+        %c1_19 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg14, %arg15) in (%arg16=%c1_18, %arg17=%c1_19) attributes {link_with = "vm.o"} {
+          %alloc_20 = memref.alloc() : memref<6x8xf32, 2 : i32>
+          %cst = arith.constant 0.000000e+00 : f32
+          func.call @linalg_fill_i32_view16x8xi32as2(%cst, %alloc_20) : (f32, memref<6x8xf32, 2 : i32>) -> ()
+          %c0_21 = arith.constant 0 : index
+          %c288_22 = arith.constant 288 : index
+          %c96 = arith.constant 96 : index
+          scf.for %arg18 = %c0_21 to %c288_22 step %c96 {
+            %alloc_23 = memref.alloc() : memref<6x16xi8, 2 : i32>
+            %alloc_24 = memref.alloc() : memref<3xf32, 2 : i32>
+            air.channel.get  @aL2ToL1[] (%alloc_23[] [] []) : (memref<6x16xi8, 2 : i32>)
+            air.channel.get  @aL2ToL1[] (%alloc_24[] [] []) : (memref<3xf32, 2 : i32>)
+            %alloc_25 = memref.alloc() : memref<6x6x16x8xi8, 2 : i32>
+            %alloc_26 = memref.alloc() : memref<6x3x8xf32, 2 : i32>
+            air.channel.get  @bL2ToL1[] (%alloc_25[] [] []) : (memref<6x6x16x8xi8, 2 : i32>)
+            air.channel.get  @bL2ToL1[] (%alloc_26[] [] []) : (memref<6x3x8xf32, 2 : i32>)
+            func.call @vecmat_i8_f32_i32_32(%alloc_23, %alloc_24, %alloc_25, %alloc_26, %alloc_20) : (memref<6x16xi8, 2 : i32>, memref<3xf32, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x3x8xf32, 2 : i32>, memref<6x8xf32, 2 : i32>) -> ()
+            memref.dealloc %alloc_23 : memref<6x16xi8, 2 : i32>
+            memref.dealloc %alloc_24 : memref<3xf32, 2 : i32>
+            memref.dealloc %alloc_25 : memref<6x6x16x8xi8, 2 : i32>
+            memref.dealloc %alloc_26 : memref<6x3x8xf32, 2 : i32>
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_20[] [] []) : (memref<6x8xf32, 2 : i32>)
+          memref.dealloc %alloc_20 : memref<6x8xf32, 2 : i32>
+        }
+        air.channel.put  @cL2ToL3[] (%alloc_17[] [] []) : (memref<48xf32, 1 : i32>)
+        memref.dealloc %alloc : memref<288xi8, 1 : i32>
+        memref.dealloc %alloc_9 : memref<9xf32, 1 : i32>
+        memref.dealloc %alloc_10 : memref<288x48xi8, 1 : i32>
+        memref.dealloc %alloc_11 : memref<9x48xf32, 1 : i32>
+        memref.dealloc %alloc_17 : memref<48xf32, 1 : i32>
+      }
+    }
+    return
+  }
+}
+

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -1,401 +1,178 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Block-quantized vector-matrix multiplication on air.api.
+
+``C[N] = sum_g (A_i8[g] @ B_i8[g,N]) * a_scale[g] * b_scale[g,N]``: the operands
+are int8, accumulated in int32, and rescaled to f32 once per block of ``bs``
+elements along K. So every operand travels as a *pair* -- the quantized data and
+its per-block scale -- and the pair shares a channel:
+
+    A:  L3 --aL3ToL2--> L2 --aL2ToL1--> L1     (data, then scale)
+    B:  L3 --bL3ToL2--> L2 --bL2ToL1--> L1     (data, then scale)
+    C:  L1 --cL1ToL2--> L2 --cL2ToL3--> L3
+
+Two puts into one channel and two gets out of it, in the same order. That is
+ordinary channel semantics rather than a trick: a channel is a stream, each get
+takes the next chunk, and nothing requires the chunks to be the same shape --
+which is what lets ``[k]`` of data and ``[k/bs]`` of scale share ``aL3ToL2``.
+
+The B side is micro-tiled for the AIE2 int8 vecmat intrinsic (``m x k`` by
+``k x n``, here ``(1, 16, 8)``), so it reaches L1 as ``[N/8, K/16, 16, 8]``
+rather than row-major. The DMA does the pack, by walking the flat L2 buffer out
+of order, and ``pack=`` names that walk::
+
+    b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
+
+The B *scale* is packed the same way but with one scale per block instead of
+per element, which is exactly a micro-tile of ``k=1`` -- so it reuses the same
+derivation with a different micro-tile rather than a special case.
+
+Unchanged from the raw-bindings version this replaces, except for three things
+the DSL requires and one it fixes:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The L1 tiles are allocated above the K loop and reused across trips, rather
+  than a fresh set per trip.
+* ``linalg_fill_i32_view16x8xi32as2`` is declared with the signature ``vm.cc``
+  actually defines -- ``void linalg_fill_i32_view16x8xi32as2(float *)``, the
+  buffer alone. The predecessor declared it ``(f32, memref)`` and passed a zero
+  the callee never reads; harmless, since the C ABI drops the extra argument,
+  but untrue.
+"""
+
 import argparse
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
 import numpy as np
 
-np.random.seed(42)
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import f32, i8
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {np.int8: i8, np.float32: f32}
+
+# The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
+MMUL_MKN = (1, 16, 8)
 
 
-@module_builder
-def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_out):
+def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
-    a_size = [k]
-    a_s_size = [k // bs]
-    b_size = [k, n]
-    b_s_size = [k // bs, n]
-    c_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_acc = type_mapper(np_dtype_acc)
-    xrt_dtype_out = type_mapper(np_dtype_out)
+    assert tile_k % bs == 0
 
-    mmul_mkn = [1, 16, 8]
+    dt_in = DTYPE[np_dtype_in]
+    dt_out = DTYPE[np_dtype_out]
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyAS = MemRefType.get(a_s_size, xrt_dtype_out)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyBS = MemRefType.get(b_s_size, xrt_dtype_out)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    m_u, k_u, n_u = MMUL_MKN
+    mm = air.micro_tile(m_u, k_u, n_u)
+    # One scale per block of bs elements along K, laid out in the same
+    # micro-tile order as the data it scales -- a k=1 micro-tile.
+    mm_scale = air.micro_tile(m_u, 1, n_u)
 
-    Channel("aL3ToL2")
-    Channel("bL3ToL2")
-    Channel("aL2ToL1")
-    Channel("bL2ToL1")
-    Channel("cL1ToL2")
-    Channel("cL2ToL3")
+    A = air.tensor([k], dt_in)
+    A_s = air.tensor([k // bs], dt_out)
+    B = air.tensor([k, n], dt_in)
+    B_s = air.tensor([k // bs, n], dt_out)
+    C = air.tensor([n], dt_out)
 
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l3_l2 = air.channel("aL3ToL2")
+    b_l3_l2 = air.channel("bL3ToL2")
+    a_l2_l1 = air.channel("aL2ToL1")
+    b_l2_l1 = air.channel("bL2ToL1")
+    c_l1_l2 = air.channel("cL1ToL2")
+    c_l2_l3 = air.channel("cL2ToL3")
 
-    a_l1_size = [tile_k // mmul_mkn[1], mmul_mkn[1]]
-    a_s_l1_size = [tile_k // bs]
-    b_l1_size = [tile_n // mmul_mkn[2], tile_k // mmul_mkn[1], mmul_mkn[1], mmul_mkn[2]]
-    b_s_l1_size = [tile_n // mmul_mkn[2], tile_k // bs, mmul_mkn[2]]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyAS = MemRefType.get(
-        shape=a_s_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyBS = MemRefType.get(
-        shape=b_s_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    c_l1_size = [tile_n // mmul_mkn[2], mmul_mkn[2]]
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_i32_view16x8xi32as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    vecmat_func = FuncOp(
-        "vecmat_i8_f32_i32_32",
-        ([l1MemrefTyA, l1MemrefTyAS, l1MemrefTyB, l1MemrefTyBS, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, vecmat_func]:
-        func.attributes["link_with"] = StringAttr.get("vm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    vecmat = air.extern(f"vecmat_i8_f32_i32_{bs}", object=link_with)
+    fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyAS, memrefTyB, memrefTyBS, memrefTyOut)
-    def vecmat_i8(arg0, arg1, arg2, arg3, arg4):
+    with air.launch(name="vecmat_i8") as launch:
 
-        launch_size = [1, n // tile_n]
+        @launch.body
+        def _():
+            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2, arg3, arg4], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_a_scale,
-            l3_b_data,
-            l3_b_scale,
-            l3_c_data,
-        ):
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_scale,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
+                @seg.body
+                def _(sj):
+                    col = sj * tile_n
 
-            # Affine map for launch iv
-            launch_ivy_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_n),
-                    )
-                ],
-            )
-            launch_offset_y = affine_apply(launch_ivy_map, [launch_ivy])
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_data,
-                offsets=[0, launch_offset_y],
-                sizes=[k, tile_n],
-                strides=[n, 1],
-            )
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_scale,
-                offsets=[0, launch_offset_y],
-                sizes=[k // bs, tile_n],
-                strides=[n, 1],
-            )
+                    l2_a = air.alloc([k], dt_in, scope=seg.private())
+                    l2_a_s = air.alloc([k // bs], dt_out, scope=seg.private())
+                    l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())
+                    l2_b_s = air.alloc([k // bs, tile_n], dt_out, scope=seg.private())
+                    l2_c = air.alloc([tile_n], dt_out, scope=seg.private())
 
-            @segment(name="vecmat_i8_0")
-            def segment_body():
-                # L2 MemRefTypes
-                a_size_l2 = [k]
-                a_s_size_l2 = [k // bs]
-                b_size_l2 = [k, tile_n]
-                b_s_size_l2 = [k // bs, tile_n]
-                c_size_l2 = [tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyAS = MemRefType.get(
-                    shape=a_s_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyBS = MemRefType.get(
-                    shape=b_s_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
-                l2_a_scale = AllocOp(l2MemrefTyAS, [], [])
+                    a_l3_l2.put(A)
+                    a_l3_l2.put(A_s)
+                    b_l3_l2.put(B[0:k, col : col + tile_n])
+                    b_l3_l2.put(B_s[0 : k // bs, col : col + tile_n])
+                    a_l3_l2.get(l2_a)
+                    a_l3_l2.get(l2_a_s)
+                    b_l3_l2.get(l2_b)
+                    b_l3_l2.get(l2_b_s)
 
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_scale,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                    # One slice per K tile, data then scale, on both sides.
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        ks = i * (tile_k // bs)
+                        a_l2_l1.put(l2_a[kk : kk + tile_k])
+                        a_l2_l1.put(l2_a_s[ks : ks + tile_k // bs])
 
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
-                l2_b_scale = AllocOp(l2MemrefTyBS, [], [])
-
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_scale,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                # L2 to L1 data packing and unpacking, using offsets, sizes and strides
-                a_l2l1_pack_size = [tile_k]
-                a_l2l1_pack_stride = [1]
-                a_s_l2l1_pack_size = [tile_k // bs]
-                a_s_l2l1_pack_stride = [1]
-                b_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k, mmul_mkn[2]]
-                b_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-                b_s_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k // bs, mmul_mkn[2]]
-                b_s_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-
-                for_iv_map_data = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k),
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        ks = i * (tile_k // bs)
+                        b_l2_l1.put(
+                            l2_b[kk : kk + tile_k, 0:tile_n],
+                            pack=mm.b(tile_k, tile_n, lead=()),
                         )
-                    ],
-                )
-                for_iv_map_scale = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k // bs),
-                        )
-                    ],
-                )
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    a_l2l1_pack_offset = [for_iv_data_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_data,
-                        offsets=a_l2l1_pack_offset,
-                        sizes=a_l2l1_pack_size,
-                        strides=a_l2l1_pack_stride,
-                    )
-                    for_iv_scale_offset = affine_apply(for_iv_map_scale, [i])
-                    a_s_l2l1_pack_offset = [for_iv_scale_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_scale,
-                        offsets=a_s_l2l1_pack_offset,
-                        sizes=a_s_l2l1_pack_size,
-                        strides=a_s_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    b_l2l1_pack_offset = [0, for_iv_data_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_data,
-                        offsets=b_l2l1_pack_offset,
-                        sizes=b_l2l1_pack_size,
-                        strides=b_l2l1_pack_stride,
-                    )
-                    for_iv_scale_offset = affine_apply(for_iv_map_scale, [i])
-                    b_s_l2l1_pack_offset = [0, for_iv_scale_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_scale,
-                        offsets=b_s_l2l1_pack_offset,
-                        sizes=b_s_l2l1_pack_size,
-                        strides=b_s_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                @herd(name="herd_0", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-
-                    l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                    zero_const = ConstantOp(FloatAttr.get(xrt_dtype_out, 0.0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_data])
-
-                    for i in range_(0, k, tile_k):
-                        l1_a_data = AllocOp(l1MemrefTyA, [], [])
-                        l1_a_scale = AllocOp(l1MemrefTyAS, [], [])
-
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_scale,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
+                        b_l2_l1.put(
+                            l2_b_s[ks : ks + tile_k // bs, 0:tile_n],
+                            pack=mm_scale.b(tile_k // bs, tile_n, lead=()),
                         )
 
-                        l1_b_data = AllocOp(l1MemrefTyB, [], [])
-                        l1_b_scale = AllocOp(l1MemrefTyBS, [], [])
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_scale,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
+                        @h.body
+                        def _(tx):
+                            l1_a = air.alloc(
+                                [tile_k // k_u, k_u], dt_in, scope=h.private()
+                            )
+                            l1_a_s = air.alloc(
+                                [tile_k // bs], dt_out, scope=h.private()
+                            )
+                            l1_b = air.alloc(
+                                [tile_n // n_u, tile_k // k_u, k_u, n_u],
+                                dt_in,
+                                scope=h.private(),
+                            )
+                            l1_b_s = air.alloc(
+                                [tile_n // n_u, tile_k // bs, n_u],
+                                dt_out,
+                                scope=h.private(),
+                            )
+                            l1_c = air.alloc(
+                                [tile_n // n_u, n_u], dt_out, scope=h.private()
+                            )
 
-                        vecmat = CallOp(
-                            vecmat_func,
-                            [l1_a_data, l1_a_scale, l1_b_data, l1_b_scale, l1_c_data],
-                        )
+                            fill(l1_c)
+                            for _j in air.sequential(0, k, tile_k):
+                                a_l2_l1.get(l1_a)
+                                a_l2_l1.get(l1_a_s)
+                                b_l2_l1.get(l1_b)
+                                b_l2_l1.get(l1_b_s)
+                                vecmat(l1_a, l1_a_s, l1_b, l1_b_s, l1_c)
 
-                        DeallocOp(l1_a_data)
-                        DeallocOp(l1_a_scale)
-                        DeallocOp(l1_b_data)
-                        DeallocOp(l1_b_scale)
+                            c_l1_l2.put(l1_c)
 
-                        yield_([])
+                    c_l1_l2.get(l2_c)
+                    c_l2_l3.put(l2_c)
+                    c_l2_l3.get(C[col : col + tile_n])
 
-                    ChannelPut(
-                        "cL1ToL2",
-                        l1_c_data,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                    )
-                    DeallocOp(l1_c_data)
-
-                herd_body.attributes["link_with"] = StringAttr.get("vm.o")
-
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                ChannelPut(
-                    "cL2ToL3",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_a_scale)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_b_scale)
-                DeallocOp(l2_c_data)
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
+    return launch
 
 
 if __name__ == "__main__":
     # Default values.
-    M = 1
     K = 288
     N = 48
     BS = 32
@@ -404,6 +181,8 @@ if __name__ == "__main__":
     INPUT_DATATYPE = np.int8
     ACC_DATATYPE = np.int32
     OUTPUT_DATATYPE = np.float32
+
+    np.random.seed(42)
 
     parser = argparse.ArgumentParser(
         prog="run.py",
@@ -448,19 +227,26 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.k,
         args.n,
         args.bs,
         args.tile_k,
         args.tile_n,
         INPUT_DATATYPE,
-        ACC_DATATYPE,
         OUTPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -185,8 +185,8 @@ if __name__ == "__main__":
     np.random.seed(42)
 
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        prog="single_core.py",
+        description="Builds, runs, and tests the block-quantized int8 vector-matrix multiplication example",
     )
     parser.add_argument(
         "-v",

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/air.mlir
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/air.mlir
@@ -1,0 +1,71 @@
+#map = affine_map<()[s0] -> (s0 * 48)>
+#map1 = affine_map<()[s0] -> (s0 * 96)>
+module {
+  func.func private @vecmat_i8_i32(memref<6x16xi8, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x8xi32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @linalg_fill_i32_view16x8xi32as2(memref<6x8xi32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func @vecmat_i8(%arg0: memref<288xi8>, %arg1: memref<288x48xi8>, %arg2: memref<48xi32>) {
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1_0) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<288xi8>, memref<288x48xi8>, memref<48xi32> {
+      air.segment @vecmat_i8_0  args(%arg10=%arg3, %arg11=%arg7, %arg12=%arg8, %arg13=%arg9) : index, memref<288xi8>, memref<288x48xi8>, memref<48xi32> {
+        %alloc = memref.alloc() : memref<288xi8, 1 : i32>
+        %alloc_1 = memref.alloc() : memref<288x48xi8, 1 : i32>
+        %alloc_2 = memref.alloc() : memref<48xi32, 1 : i32>
+        air.channel.put  @aL3ToL2[] (%arg11[] [] []) : (memref<288xi8>)
+        %0 = affine.apply #map()[%arg10]
+        air.channel.put  @bL3ToL2[] (%arg12[0, %0] [288, 48] [48, 1]) : (memref<288x48xi8>)
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<288xi8, 1 : i32>)
+        air.channel.get  @bL3ToL2[] (%alloc_1[] [] []) : (memref<288x48xi8, 1 : i32>)
+        %c0 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_3 = arith.constant 1 : index
+        scf.for %arg14 = %c0 to %c3 step %c1_3 {
+          %2 = affine.apply #map1()[%arg14]
+          air.channel.put  @aL2ToL1[] (%alloc[%2] [96] [1]) : (memref<288xi8, 1 : i32>)
+        }
+        %c0_4 = arith.constant 0 : index
+        %c3_5 = arith.constant 3 : index
+        %c1_6 = arith.constant 1 : index
+        scf.for %arg14 = %c0_4 to %c3_5 step %c1_6 {
+          %2 = affine.apply #map1()[%arg14]
+          %3 = affine.apply #map1()[%arg14]
+          air.channel.put  @bL2ToL1[] (%alloc_1[0, 0, %3, 0] [6, 6, 16, 8] [8, 768, 48, 1]) : (memref<288x48xi8, 1 : i32>)
+        }
+        %c1_7 = arith.constant 1 : index
+        %c1_8 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg14, %arg15) in (%arg16=%c1_7, %arg17=%c1_8) args(%arg18=%arg11, %arg19=%arg12, %arg20=%arg13, %arg21=%alloc, %arg22=%alloc_1, %arg23=%alloc_2) : memref<288xi8>, memref<288x48xi8>, memref<48xi32>, memref<288xi8, 1 : i32>, memref<288x48xi8, 1 : i32>, memref<48xi32, 1 : i32> attributes {link_with = "vm.o"} {
+          %alloc_9 = memref.alloc() : memref<6x16xi8, 2 : i32>
+          %alloc_10 = memref.alloc() : memref<6x6x16x8xi8, 2 : i32>
+          %alloc_11 = memref.alloc() : memref<6x8xi32, 2 : i32>
+          func.call @linalg_fill_i32_view16x8xi32as2(%alloc_11) : (memref<6x8xi32, 2 : i32>) -> ()
+          %c0_12 = arith.constant 0 : index
+          %c288 = arith.constant 288 : index
+          %c96 = arith.constant 96 : index
+          scf.for %arg24 = %c0_12 to %c288 step %c96 {
+            air.channel.get  @aL2ToL1[] (%alloc_9[] [] []) : (memref<6x16xi8, 2 : i32>)
+            air.channel.get  @bL2ToL1[] (%alloc_10[] [] []) : (memref<6x6x16x8xi8, 2 : i32>)
+            func.call @vecmat_i8_i32(%alloc_9, %alloc_10, %alloc_11) : (memref<6x16xi8, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x8xi32, 2 : i32>) -> ()
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_11[] [] []) : (memref<6x8xi32, 2 : i32>)
+          memref.dealloc %alloc_9 : memref<6x16xi8, 2 : i32>
+          memref.dealloc %alloc_10 : memref<6x6x16x8xi8, 2 : i32>
+          memref.dealloc %alloc_11 : memref<6x8xi32, 2 : i32>
+        }
+        air.channel.get  @cL1ToL2[] (%alloc_2[] [] []) : (memref<48xi32, 1 : i32>)
+        air.channel.put  @cL2ToL3[] (%alloc_2[] [] []) : (memref<48xi32, 1 : i32>)
+        %1 = affine.apply #map()[%arg10]
+        air.channel.get  @cL2ToL3[] (%arg13[%1] [48] [1]) : (memref<48xi32>)
+        memref.dealloc %alloc : memref<288xi8, 1 : i32>
+        memref.dealloc %alloc_1 : memref<288x48xi8, 1 : i32>
+        memref.dealloc %alloc_2 : memref<48xi32, 1 : i32>
+      }
+    }
+    return
+  }
+}

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/output.mlir
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/output.mlir
@@ -1,0 +1,89 @@
+python3 /home/erweiw/mlir-air/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py -p
+#map = affine_map<()[s0] -> (s0 * 48)>
+#map1 = affine_map<()[s0] -> (s0 * 96)>
+module {
+  air.channel @aL3ToL2 []
+  air.channel @bL3ToL2 []
+  air.channel @aL2ToL1 []
+  air.channel @bL2ToL1 []
+  air.channel @cL1ToL2 []
+  air.channel @cL2ToL3 []
+  func.func private @linalg_fill_i32_view16x8xi32as2(i32, memref<6x8xi32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func private @vecmat_i8_i32(memref<6x16xi8, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x8xi32, 2 : i32>) attributes {link_with = "vm.o", llvm.emit_c_interface}
+  func.func @vecmat_i8(%arg0: memref<288xi8>, %arg1: memref<288x48xi8>, %arg2: memref<48xi32>) {
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    air.launch (%arg3, %arg4) in (%arg5=%c1, %arg6=%c1_0) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<288xi8>, memref<288x48xi8>, memref<48xi32> {
+      air.channel.put  @aL3ToL2[] (%arg7[] [] []) : (memref<288xi8>)
+      %0 = affine.apply #map()[%arg4]
+      %c0 = arith.constant 0 : index
+      %c288 = arith.constant 288 : index
+      %c48 = arith.constant 48 : index
+      %c48_1 = arith.constant 48 : index
+      %c1_2 = arith.constant 1 : index
+      air.channel.put  @bL3ToL2[] (%arg8[%c0, %0] [%c288, %c48] [%c48_1, %c1_2]) : (memref<288x48xi8>)
+      %c48_3 = arith.constant 48 : index
+      %c1_4 = arith.constant 1 : index
+      air.channel.get  @cL2ToL3[] (%arg9[%0] [%c48_3] [%c1_4]) : (memref<48xi32>)
+      air.segment @vecmat_i8_0  {
+        %alloc = memref.alloc() : memref<288xi8, 1 : i32>
+        air.channel.get  @aL3ToL2[] (%alloc[] [] []) : (memref<288xi8, 1 : i32>)
+        %alloc_5 = memref.alloc() : memref<288x48xi8, 1 : i32>
+        air.channel.get  @bL3ToL2[] (%alloc_5[] [] []) : (memref<288x48xi8, 1 : i32>)
+        %c0_6 = arith.constant 0 : index
+        %c3 = arith.constant 3 : index
+        %c1_7 = arith.constant 1 : index
+        scf.for %arg10 = %c0_6 to %c3 step %c1_7 {
+          %1 = affine.apply #map1()[%arg10]
+          %c96 = arith.constant 96 : index
+          %c1_14 = arith.constant 1 : index
+          air.channel.put  @aL2ToL1[] (%alloc[%1] [%c96] [%c1_14]) : (memref<288xi8, 1 : i32>)
+        }
+        %c0_8 = arith.constant 0 : index
+        %c3_9 = arith.constant 3 : index
+        %c1_10 = arith.constant 1 : index
+        scf.for %arg10 = %c0_8 to %c3_9 step %c1_10 {
+          %1 = affine.apply #map1()[%arg10]
+          %c0_14 = arith.constant 0 : index
+          %c0_15 = arith.constant 0 : index
+          %c6 = arith.constant 6 : index
+          %c96 = arith.constant 96 : index
+          %c8 = arith.constant 8 : index
+          %c8_16 = arith.constant 8 : index
+          %c48_17 = arith.constant 48 : index
+          %c1_18 = arith.constant 1 : index
+          air.channel.put  @bL2ToL1[] (%alloc_5[%c0_14, %1, %c0_15] [%c6, %c96, %c8] [%c8_16, %c48_17, %c1_18]) : (memref<288x48xi8, 1 : i32>)
+        }
+        %alloc_11 = memref.alloc() : memref<48xi32, 1 : i32>
+        air.channel.get  @cL1ToL2[] (%alloc_11[] [] []) : (memref<48xi32, 1 : i32>)
+        %c1_12 = arith.constant 1 : index
+        %c1_13 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg10, %arg11) in (%arg12=%c1_12, %arg13=%c1_13) attributes {link_with = "vm.o"} {
+          %alloc_14 = memref.alloc() : memref<6x8xi32, 2 : i32>
+          %c0_i32 = arith.constant 0 : i32
+          func.call @linalg_fill_i32_view16x8xi32as2(%c0_i32, %alloc_14) : (i32, memref<6x8xi32, 2 : i32>) -> ()
+          %c0_15 = arith.constant 0 : index
+          %c288_16 = arith.constant 288 : index
+          %c96 = arith.constant 96 : index
+          scf.for %arg14 = %c0_15 to %c288_16 step %c96 {
+            %alloc_17 = memref.alloc() : memref<6x16xi8, 2 : i32>
+            air.channel.get  @aL2ToL1[] (%alloc_17[] [] []) : (memref<6x16xi8, 2 : i32>)
+            %alloc_18 = memref.alloc() : memref<6x6x16x8xi8, 2 : i32>
+            air.channel.get  @bL2ToL1[] (%alloc_18[] [] []) : (memref<6x6x16x8xi8, 2 : i32>)
+            func.call @vecmat_i8_i32(%alloc_17, %alloc_18, %alloc_14) : (memref<6x16xi8, 2 : i32>, memref<6x6x16x8xi8, 2 : i32>, memref<6x8xi32, 2 : i32>) -> ()
+            memref.dealloc %alloc_17 : memref<6x16xi8, 2 : i32>
+            memref.dealloc %alloc_18 : memref<6x6x16x8xi8, 2 : i32>
+          }
+          air.channel.put  @cL1ToL2[] (%alloc_14[] [] []) : (memref<6x8xi32, 2 : i32>)
+          memref.dealloc %alloc_14 : memref<6x8xi32, 2 : i32>
+        }
+        air.channel.put  @cL2ToL3[] (%alloc_11[] [] []) : (memref<48xi32, 1 : i32>)
+        memref.dealloc %alloc : memref<288xi8, 1 : i32>
+        memref.dealloc %alloc_5 : memref<288x48xi8, 1 : i32>
+        memref.dealloc %alloc_11 : memref<48xi32, 1 : i32>
+      }
+    }
+    return
+  }
+}
+

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -1,294 +1,163 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""int8 vector-matrix multiplication on air.api: C[N] = A[K] @ B[K,N], in i32.
+
+Six channels carry the whole schedule -- there is not a single
+``air.dma_memcpy_nd`` in it:
+
+    A:  L3 --aL3ToL2--> L2 --aL2ToL1--> L1
+    B:  L3 --bL3ToL2--> L2 --bL2ToL1--> L1
+    C:  L1 --cL1ToL2--> L2 --cL2ToL3--> L3
+
+and the herd names none of them as an operand: ``air.herd`` is
+``IsolatedFromAbove``, but a channel is a module-level symbol and resolves by
+name from any depth.
+
+What differs from the bf16 sibling is the layout. The AIE2 int8 vecmat
+intrinsic wants its operands micro-tiled -- ``m x k`` by ``k x n`` with
+``(1, 16, 8)`` -- so the B tile reaches L1 as ``[N/8, K/16, 16, 8]`` rather than
+row-major ``[K, N]``. Nothing reorders it in a core: the *DMA* does the pack,
+by walking the flat L2 buffer out of order. That walk is what ``pack=`` names::
+
+    b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
+
+``ops.load`` derives the same walk from its destination buffer, which it can
+see. A channel cannot -- put and get are separate ops and the packed side is at
+the far end of the stream -- so the pack is named at the put.
+
+A is micro-tiled too, but with ``m=1`` the pack is the identity: ``[K/16, 16]``
+is just ``[K]`` re-shaped, so its put is an ordinary contiguous slice.
+
+Unchanged from the raw-bindings version this replaces, except for three things
+the DSL requires and one it fixes:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The L1 tiles are allocated above the K loop and reused across trips, rather
+  than a fresh set per trip.
+* ``linalg_fill_i32_view16x8xi32as2`` is declared with the signature ``vm.cc``
+  actually defines -- ``void linalg_fill_i32_view16x8xi32as2(int *)``, the
+  buffer alone. The predecessor declared it ``(i32, memref)`` and passed a zero
+  the callee never reads; harmless, since the C ABI drops the extra argument,
+  but untrue.
+"""
+
 import argparse
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
 import numpy as np
 
-np.random.seed(42)
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i8, i32
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {np.int8: i8, np.int32: i32}
+
+# The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
+MMUL_MKN = (1, 16, 8)
 
 
-@module_builder
-def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
+def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
-    a_size = [k]
-    b_size = [k, n]
-    c_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
 
-    mmul_mkn = [1, 16, 8]
+    dt_in = DTYPE[np_dtype_in]
+    dt_out = DTYPE[np_dtype_out]
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    m_u, k_u, n_u = MMUL_MKN
+    mm = air.micro_tile(m_u, k_u, n_u)
 
-    Channel("aL3ToL2")
-    Channel("bL3ToL2")
-    Channel("aL2ToL1")
-    Channel("bL2ToL1")
-    Channel("cL1ToL2")
-    Channel("cL2ToL3")
+    A = air.tensor([k], dt_in)
+    B = air.tensor([k, n], dt_in)
+    C = air.tensor([n], dt_out)
 
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l3_l2 = air.channel("aL3ToL2")
+    b_l3_l2 = air.channel("bL3ToL2")
+    a_l2_l1 = air.channel("aL2ToL1")
+    b_l2_l1 = air.channel("bL2ToL1")
+    c_l1_l2 = air.channel("cL1ToL2")
+    c_l2_l3 = air.channel("cL2ToL3")
 
-    a_l1_size = [tile_k // mmul_mkn[1], mmul_mkn[1]]
-    b_l1_size = [tile_n // mmul_mkn[2], tile_k // mmul_mkn[1], mmul_mkn[1], mmul_mkn[2]]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    c_l1_size = [tile_n // mmul_mkn[2], mmul_mkn[2]]
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_i32_view16x8xi32as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    vecmat_func = FuncOp(
-        "vecmat_i8_i32",
-        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, vecmat_func]:
-        func.attributes["link_with"] = StringAttr.get("vm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    vecmat = air.extern("vecmat_i8_i32", object=link_with)
+    fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
-    def vecmat_i8(arg0, arg1, arg2):
+    with air.launch(name="vecmat_i8") as launch:
 
-        launch_size = [1, n // tile_n]
+        @launch.body
+        def _():
+            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_c_data,
-        ):
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
+                @seg.body
+                def _(sj):
+                    col = sj * tile_n
 
-            # Affine map for launch iv
-            launch_ivy_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_n),
-                    )
-                ],
-            )
-            launch_offset_y = affine_apply(launch_ivy_map, [launch_ivy])
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_data,
-                offsets=[0, launch_offset_y],
-                sizes=[k, tile_n],
-                strides=[n, 1],
-            )
+                    l2_a = air.alloc([k], dt_in, scope=seg.private())
+                    l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([tile_n], dt_out, scope=seg.private())
 
-            @segment(name="vecmat_i8_0")
-            def segment_body():
-                # L2 MemRefTypes
-                a_size_l2 = [k]
-                b_size_l2 = [k, tile_n]
-                c_size_l2 = [tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
+                    a_l3_l2.put(A)
+                    b_l3_l2.put(B[0:k, col : col + tile_n])
+                    a_l3_l2.get(l2_a)
+                    b_l3_l2.get(l2_b)
 
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                    # One slice per K tile, on both sides. Unlike the bf16
+                    # sibling -- where a single whole-buffer put feeds every get
+                    # because the stream is consumed in order -- B is packed
+                    # here, and the pack is per tile: the walk visits all of N
+                    # before advancing in K, so the tiles are not prefixes of
+                    # one whole-buffer walk and have to be sent one at a time.
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        a_l2_l1.put(l2_a[kk : kk + tile_k])
 
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
-
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                # L2 to L1 data packing and unpacking, using offsets, sizes and strides
-                a_l2l1_pack_size = [tile_k]
-                a_l2l1_pack_stride = [1]
-                b_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k, mmul_mkn[2]]
-                b_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-
-                for_iv_map_data = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k),
-                        )
-                    ],
-                )
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    a_l2l1_pack_offset = [for_iv_data_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_data,
-                        offsets=a_l2l1_pack_offset,
-                        sizes=a_l2l1_pack_size,
-                        strides=a_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    b_l2l1_pack_offset = [0, for_iv_data_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_data,
-                        offsets=b_l2l1_pack_offset,
-                        sizes=b_l2l1_pack_size,
-                        strides=b_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                @herd(name="herd_0", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-
-                    l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                    zero_const = ConstantOp(IntegerAttr.get(xrt_dtype_out, 0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_data])
-
-                    for i in range_(0, k, tile_k):
-                        l1_a_data = AllocOp(l1MemrefTyA, [], [])
-
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        b_l2_l1.put(
+                            l2_b[kk : kk + tile_k, 0:tile_n],
+                            pack=mm.b(tile_k, tile_n, lead=()),
                         )
 
-                        l1_b_data = AllocOp(l1MemrefTyB, [], [])
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
+                        @h.body
+                        def _(tx):
+                            l1_a = air.alloc(
+                                [tile_k // k_u, k_u], dt_in, scope=h.private()
+                            )
+                            l1_b = air.alloc(
+                                [tile_n // n_u, tile_k // k_u, k_u, n_u],
+                                dt_in,
+                                scope=h.private(),
+                            )
+                            l1_c = air.alloc(
+                                [tile_n // n_u, n_u], dt_out, scope=h.private()
+                            )
 
-                        vecmat = CallOp(
-                            vecmat_func,
-                            [l1_a_data, l1_b_data, l1_c_data],
-                        )
+                            fill(l1_c)
+                            for _j in air.sequential(0, k, tile_k):
+                                a_l2_l1.get(l1_a)
+                                b_l2_l1.get(l1_b)
+                                vecmat(l1_a, l1_b, l1_c)
 
-                        DeallocOp(l1_a_data)
-                        DeallocOp(l1_b_data)
+                            c_l1_l2.put(l1_c)
 
-                        yield_([])
+                    c_l1_l2.get(l2_c)
+                    c_l2_l3.put(l2_c)
+                    c_l2_l3.get(C[col : col + tile_n])
 
-                    ChannelPut(
-                        "cL1ToL2",
-                        l1_c_data,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                    )
-                    DeallocOp(l1_c_data)
-
-                herd_body.attributes["link_with"] = StringAttr.get("vm.o")
-
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                ChannelPut(
-                    "cL2ToL3",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_c_data)
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
+    return launch
 
 
 if __name__ == "__main__":
     # Default values.
-    M = 1
     K = 288
     N = 48
     TILE_K = 96
     TILE_N = 48
     INPUT_DATATYPE = np.int8
     OUTPUT_DATATYPE = np.int32
+
+    np.random.seed(42)
 
     parser = argparse.ArgumentParser(
         prog="run.py",
@@ -327,10 +196,17 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.k,
         args.n,
         args.tile_k,
@@ -338,6 +214,7 @@ if __name__ == "__main__":
         INPUT_DATATYPE,
         OUTPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -348,14 +225,12 @@ if __name__ == "__main__":
         size=(args.k),
         dtype=INPUT_DATATYPE,
     )
-    input_a = input_a.astype(INPUT_DATATYPE)
     input_b = np.random.randint(
         np.iinfo(INPUT_DATATYPE).min,
         np.iinfo(INPUT_DATATYPE).max,
         size=(args.k, args.n),
         dtype=INPUT_DATATYPE,
     )
-    input_b = input_b.astype(INPUT_DATATYPE)
     output_c = np.dot(input_a.astype(OUTPUT_DATATYPE), input_b.astype(OUTPUT_DATATYPE))
 
     runner = XRTRunner(

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -160,8 +160,8 @@ if __name__ == "__main__":
     np.random.seed(42)
 
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        prog="single_core.py",
+        description="Builds, runs, and tests the int8 vector-matrix multiplication example",
     )
     parser.add_argument(
         "-v",

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -197,7 +197,7 @@ class Channel:
             out.append(value)
         return out
 
-    def _emit(self, obj, indices, dependency, direction):
+    def _emit(self, obj, indices, dependency, direction, pack=None):
         from ._trace import current_segment
         from .ops import _check_dependency, _endpoint
 
@@ -218,6 +218,10 @@ class Channel:
             )
 
         offsets, sizes, strides = endpoint.pattern or ([], [], [])
+        if pack is not None:
+            offsets, sizes, strides = self._packed_pattern(
+                endpoint, pack, direction, obj
+            )
         idx = self._indices(indices)
 
         if direction == "get" and endpoint.tensor is not None:
@@ -239,17 +243,73 @@ class Channel:
             )
         )
 
+    def _packed_pattern(self, endpoint, pack, direction, obj):
+        """Walk a flat region in micro-tile order, so the DMA does the pack.
+
+        ``ops.load`` derives this from its *destination* buffer, which it can
+        see. A channel cannot: put and get are separate ops, and the packed side
+        is at the far end of the stream, possibly in another scope. So the walk
+        is named where it happens::
+
+            mm = air.micro_tile(m=1, k=16, n=8)
+            b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n))
+
+        The consumer then does a plain whole-buffer ``get`` into an L1 tile of
+        whatever shape holds those elements contiguously -- which is why this
+        takes the *shape* rather than the destination buffer. The two vecmat i8
+        kernels declare their B tile 4-D and their B-scale tile 3-D, and both
+        are the same contiguous run of micro-tiles.
+        """
+        from ._pack import PackedShape, pack_pattern
+
+        if not isinstance(pack, PackedShape):
+            raise TypeError(
+                f"air.channel.{direction}(pack=...) takes a packed shape from "
+                "air.micro_tile(...).a/.b/.c, e.g. "
+                "pack=air.micro_tile(1, 16, 8).b(tile_k, tile_n); got "
+                f"{type(pack).__name__}"
+            )
+        if pack.role == "C":
+            raise NotImplementedError(
+                f"air.channel.{direction}(pack=...) packs an A or B operand. A C "
+                "accumulator is drained the other way round -- the pattern goes "
+                "on the packed buffer itself -- so put the region on that side "
+                "instead of asking the channel to pack it."
+            )
+        if endpoint.raw is None:
+            raise TypeError(
+                f"air.channel.{direction}(pack=...) needs a *region* to walk, not "
+                f"a whole {endpoint.what}: the pack reorders a slice of a flat "
+                "staging buffer, so index it, e.g. l2_b[kk : kk + tile_k, :]"
+            )
+        offsets, sizes, strides = endpoint.raw
+        nlead = len(pack.lead)
+        flat_ok = len(sizes) == 2 and all(e == 1 for e in pack.lead)
+        if len(sizes) != nlead + 2 and not flat_ok:
+            # The "or rank 2" alternative only exists when the packed shape has
+            # leading dimensions to pad away; with lead=() it is the same rank.
+            either = (
+                " (or rank 2 when its leading dimensions are all 1)" if nlead else ""
+            )
+            raise ValueError(
+                f"air.channel.{direction}(pack=...) needs a region of rank "
+                f"{nlead + 2} for a {pack.role} operand{either}, with the two "
+                f"logical axes last; got rank {len(sizes)}, {tuple(sizes)}"
+            )
+        p_off, p_sizes, p_strides = pack_pattern(pack, sizes, strides, offsets)
+        return [o.materialize() for o in p_off], p_sizes, p_strides
+
     # -- public ------------------------------------------------------------
 
-    def put(self, obj, indices=None, dependency=None, **unsupported):
+    def put(self, obj, indices=None, dependency=None, pack=None, **unsupported):
         """Send a tensor, a buffer, or a region of either into the channel."""
         _reject_unsupported(unsupported)
-        return self._emit(obj, indices, dependency, "put")
+        return self._emit(obj, indices, dependency, "put", pack=pack)
 
-    def get(self, obj, indices=None, dependency=None, **unsupported):
+    def get(self, obj, indices=None, dependency=None, pack=None, **unsupported):
         """Receive the channel's next chunk into a tensor, buffer, or region."""
         _reject_unsupported(unsupported)
-        return self._emit(obj, indices, dependency, "get")
+        return self._emit(obj, indices, dependency, "get", pack=pack)
 
 
 # Keywords the underlying ops accept and this DSL does not lower. They raise

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -265,7 +265,7 @@ class Channel:
         if not isinstance(pack, PackedShape):
             raise TypeError(
                 f"air.channel.{direction}(pack=...) takes a packed shape from "
-                "air.micro_tile(...).a/.b/.c, e.g. "
+                "air.micro_tile(...).a or .b, e.g. "
                 "pack=air.micro_tile(1, 16, 8).b(tile_k, tile_n); got "
                 f"{type(pack).__name__}"
             )

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -232,3 +232,52 @@ def whole_tensor_transfer():
                     air.ops.store(buf, B)
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: channel_pack
+# pack= walks a flat L2 region in micro-tile order, so the DMA performs the
+# pack and the consumer does a plain whole-buffer get. ops.load derives the
+# same walk from its destination buffer; a channel cannot see that far, because
+# put and get are separate ops with the packed side at the other end of the
+# stream, so the walk is named at the put.
+#
+# The B pack of a [K, N] region with micro-tile (k, n) is
+# [N/n, K/k, k, n] over strides [n, k*N, N, 1] -- here [6, 6, 16, 8] over
+# [8, 768, 48, 1] for a [96, 48] region, which is the same walk the
+# hand-written kernel spells collapsed as [6, 96, 8] over [8, 48, 1].
+# CHECK: air.channel.put @Bpack[] (%{{.*}}[0, 0, 0, 0] [6, 6, 16, 8] [8, 768, 48, 1])
+# CHECK: air.channel.get @Bpack[] (%{{.*}}[] [] [])
+@run
+def channel_pack():
+    TILE_K, TILE_N = 96, 48
+    mm = air.micro_tile(1, 16, 8)
+
+    A = air.tensor([TILE_K, TILE_N], i8)
+    Out = air.tensor([TILE_K, TILE_N], i8)
+    pack = air.channel("Bpack")
+
+    with air.launch(name="packed") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    l2_b = air.alloc([TILE_K, TILE_N], i8, scope=seg.private())
+                    air.ops.load(l2_b, A)
+                    pack.put(
+                        l2_b[0:TILE_K, 0:TILE_N],
+                        pack=mm.b(TILE_K, TILE_N, lead=()),
+                    )
+
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            l1_b = air.alloc([6, 6, 16, 8], i8, scope=h.private())
+                            pack.get(l1_b)
+
+                    air.ops.store(l2_b, Out)
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -986,3 +986,83 @@ def _():
         ops.load(small, A)
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_not_a_packed_shape
+# pack= takes a shape from air.micro_tile(...).a/.b, not a plain list: the
+# micro-tile is what the walk is derived from, and a bare list carries none.
+# CHECK: TypeError: air.channel.put(pack=...) takes a packed shape from air.micro_tile
+@expect(TypeError, "channel_pack_not_a_packed_shape")
+def _():
+    ch = air.channel("P")
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf[0:16, 0:8], pack=[2, 2, 8, 8])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_needs_a_region
+# The pack reorders a *slice* of a flat staging buffer, so there has to be one
+# to reorder; a whole buffer carries no pattern to rewrite.
+# CHECK: TypeError: air.channel.put(pack=...) needs a *region* to walk
+@expect(TypeError, "channel_pack_needs_a_region")
+def _():
+    ch = air.channel("Q")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf, pack=mm.b(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_c_operand
+# A C accumulator unpacks the other way round -- the pattern belongs on the
+# packed buffer, not on the channel -- so asking a channel to pack one raises
+# instead of emitting a walk that would drain it in the wrong order.
+# CHECK: NotImplementedError: air.channel.put(pack=...) packs an A or B operand
+@expect(NotImplementedError, "channel_pack_c_operand")
+def _():
+    ch = air.channel("R")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf[0:16, 0:8], pack=mm.c(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_wrong_rank
+# The region has to end in the operand's two logical axes; a rank-1 slice has
+# only one, so there is nothing to split into micro-tiles.
+# CHECK: ValueError: air.channel.put(pack=...) needs a region of rank 2 for a B operand
+@expect(ValueError, "channel_pack_wrong_rank")
+def _():
+    ch = air.channel("S")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([128], bf16, scope=h.private())
+        ch.put(buf[0:128], pack=mm.b(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_indivisible
+# The region's extents must be whole micro-tiles: 20 is not a multiple of the
+# k=16 the buffer would be packed with.
+# CHECK: ValueError: operand B's K extent 20 is not a multiple of the micro-tile k=16
+@expect(ValueError, "channel_pack_indivisible")
+def _():
+    ch = air.channel("T")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([20, 8], bf16, scope=h.private())
+        ch.put(buf[0:20, 0:8], pack=mm.b(20, 8, lead=()))
+
+    _trace(body)


### PR DESCRIPTION
Converts `vector_matrix_multiplication/i8/single_core` and its block-quantized
sibling onto `air.api`, replacing the raw-bindings versions. They are the two
remaining siblings of the bf16 vecmat that landed in #1852.

## The one piece of new surface: `pack=` on `Channel.put`/`get`

Both examples stage B through L2 flat and micro-tile it on the way into L1, so
the **DMA** performs the pack by walking the staging buffer out of order.
`ops.load` derives that walk from its destination buffer, which it can see. A
channel cannot: put and get are separate ops, and the packed side is at the far
end of the stream, possibly in another scope. So the walk is named where it
happens:

```python
mm = air.micro_tile(1, 16, 8)
b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
```

It takes a shape from `air.micro_tile(...).a/.b` and reuses `_pack.pack_pattern`
— the same derivation `ops.load` already uses, not a second implementation.

The block-quantized example's B *scale* is that same walk with one scale per
block of `bs` rather than per element, which is exactly a `k=1` micro-tile. It
reuses the derivation with a different argument rather than needing a special
case, which is the main evidence that the knob is the right shape.

`pack=` on a C operand raises: C unpacks the other way round, with the pattern
on the packed buffer itself.

## Verification, on npu1

|  | i8 | block_quantized_i8 |
|---|---|---|
| channel ops vs predecessor, SSA normalised | identical | identical |
| buffers / locks / flows / dma_bds / tiles / shim allocs / dma_starts / use_locks | 10/12/6/13/6/3/9/40, both arms | 18/16/6/31/6/3/9/88, both arms |
| runtime-sequence access patterns | same set | same set |
| hardware | `PASS!` | `PASS!` |
| lits | peano passes; chess unsupported on this box | peano passes; chess unsupported on this box |
| consumers | none | none |

One deliberate difference: the B pack emits **rank 4** — `[6, 6, 16, 8]` over
`[8, 768, 48, 1]` — where the predecessors hand-collapsed it to rank 3,
`[6, 96, 8]` over `[8, 48, 1]`. Same walk, since `768 = 16 x 48`; the identical
resource counts and runtime patterns confirm it lowers to the same thing.

Regression: all 10 `python/test/api` suites green, and the 15 examples already
on `air.api` emit byte-identical IR. Six new tests — one IR case for the pack
and five negative cases (not a packed shape, not a region, a C operand, wrong
rank, indivisible extent).

## Also fixed

Each example declared `linalg_fill_i32_view16x8xi32as2` as `(scalar, memref)`
and passed a zero the callee never reads. `vm.cc` defines it taking the buffer
alone. Harmless under the C ABI, but untrue, and it is now declared as defined —
the same fix the bf16 sibling took.

## Coverage limits, stated plainly

**These two examples are npu1-only by construction, and no npu2 run is
possible.** I originally wrote that npu2 coverage was being collected
separately; that was wrong, and an npu2 box has since confirmed why:

- All four lits gate on `ryzen_ai_npu1` — including the two chess ones, which
  require `ryzen_ai_npu1, valid_xchess_license`. An npu2 machine can never run
  them however it is licensed.
- Both Makefiles carry only `--target=aie2-none-unknown-elf`. The bf16 sibling
  has a real `AIE_TARGET=aie2p` path and three npu2 lits; these do not.
- Forcing the aie2p triple fails in the microkernels, not in this PR:
  `aie::detail::mmul_8_8<1, 16, 8, signed char, signed char, 32>` has no AIE2P
  specialization, and block_quantized's `aie2_fp32_conf_shim.h` does not compile
  for aie2p (`undeclared identifier '__int128_t'`). Both build cleanly for aie2.

All of that is inherited from the predecessors — the conversion neither adds nor
removes a target. But it means the honest statement is:

| lit | who can run it | status |
|---|---|---|
| `i8` peano, `block_quantized_i8` peano | npu1 + peano | **pass** (this box) |
| `i8` chess, `block_quantized_i8` chess | npu1 + Vitis license | **unverified by anyone** |

The chess pair needs an npu1 box with a Vitis license. CI will not close that
gap, and neither will an npu2 machine. Giving these examples npu2 coverage would
mean writing an aie2p microkernel, which is a separate piece of work.
