### PR TITLE
[llms] Add Qwen2.5-7B Q4NX (prefill + fused decode)

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -54,10 +54,14 @@ env:
   # nightly rather than assuming.
   #
   # qwen25_7b_q4nx runs off Qwen/Qwen2.5-7B-Instruct directly (quantized on load --
-  # FastFlowLM publishes no Q4NX bundle for it), so it is the same shape as qwen3_8b
-  # above and its peak is likewise unmeasured here. Bound: ~15GB bf16 reference in
-  # the compare phase, ~6GB dequantized Q4NX weights plus five decode weight BOs
-  # (4x0.95GB + 0.32GB, see llms/qwen25_7b_q4nx) in the NPU phase.
+  # FastFlowLM publishes no Q4NX bundle for it). Its NPU phase peaks at ~33GB RSS,
+  # MEASURED (32.6GB for prefill alone on a 96GB dev box): the bf16 checkpoint, the
+  # Q4NX host dequant and the five resident decode weight BOs (4x0.95GB + 0.32GB)
+  # are all live across the load. That is the largest peak of any model here and
+  # over half this 64GB runner, so it must not run concurrently with another model
+  # -- the -j1 in the lit suites is what guarantees that. The compare phase holds
+  # the ~15GB bf16 reference in a separate subprocess, so it is not additive.
+  # Re-measure this if the weight preload's lifetime changes.
 
 jobs:
   benchmark:

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -52,6 +52,12 @@ env:
   # five decode weight BOs (4x1.01GB + 0.37GB, see llms/qwen3_8b_q4nx). Separate
   # subprocesses, so the peak is the larger, not the sum. Confirm against a
   # nightly rather than assuming.
+  #
+  # qwen25_7b_q4nx runs off Qwen/Qwen2.5-7B-Instruct directly (quantized on load --
+  # FastFlowLM publishes no Q4NX bundle for it), so it is the same shape as qwen3_8b
+  # above and its peak is likewise unmeasured here. Bound: ~15GB bf16 reference in
+  # the compare phase, ~6GB dequantized Q4NX weights plus five decode weight BOs
+  # (4x0.95GB + 0.32GB, see llms/qwen25_7b_q4nx) in the NPU phase.
 
 jobs:
   benchmark:

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -36,7 +36,8 @@ the instruction stream for any `L`, byte-identical to a native per-L build.
 
 ### Why Qwen has its own builder
 
-`fused_decode.py` covers Llama-3.2-1B/3B and Gemma3-4B, selected by
+`fused_decode.py` covers Llama-3.2-1B/3B, Gemma3-4B, Phi-4-mini, Qwen3-8B and
+Qwen2.5-7B, selected by
 `DECODE_MODEL`. Qwen2.5-3B is a separate file because its **on-device weight
 format differs**, not because its weights are packaged differently:
 

--- a/programming_examples/fused_decode/README.md
+++ b/programming_examples/fused_decode/README.md
@@ -34,14 +34,15 @@ the instruction stream for any `L`, byte-identical to a native per-L build.
 | `qwen25_3b_requant.py` | Q4_0 quantizer + weight cache for the Qwen decode |
 | `qwen_prefill_to_decode.py` | Hands `llms/qwen25_3b_q4`'s prefill KV to the Qwen decode |
 
-### Why Qwen has its own builder
+### Why Qwen2.5-3B has its own builder
 
 `fused_decode.py` covers Llama-3.2-1B/3B, Gemma3-4B, Phi-4-mini, Qwen3-8B and
-Qwen2.5-7B, selected by
-`DECODE_MODEL`. Qwen2.5-3B is a separate file because its **on-device weight
-format differs**, not because its weights are packaged differently:
+Qwen2.5-7B, selected by `DECODE_MODEL`. Qwen2.5-**3B** is a separate file because
+its **on-device weight format differs**, not because its weights are packaged
+differently -- and note the split is by codec, not by model family: Qwen2.5-7B is
+Q4NX and so sits in the left column with Llama and Gemma.
 
-| | Llama / Gemma | Qwen2.5 |
+| | `fused_decode.py` (Q4NX) | `fused_decode_qwen.py` (Qwen2.5-3B) |
 |---|---|---|
 | device format | unsigned int4 **+ per-group min** | signed int4, **scale only** |
 | dequant | `w = scale*q + min` | `w = q*scale` |

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -121,22 +121,38 @@ from air.dialects import arith
 from air.dialects.scf import for_, yield_, index_switch, ParallelOp, ReduceOp, IfOp
 from air.backend.xrt import XRTBackend
 
+# An AIE2/AIE2P lock counter is 6 bits (AIETargetModel getMaxLockValue() == 0x3F),
+# and the refeed count below becomes a lock init that nothing range-checks -- a
+# larger one truncates on the device and the re-broadcast deadlocks.
+MAX_REFEED = 0x3F
+
 
 def refeed(n, emit):
     """Re-send ONE resident buffer n times: an n-trip scf.for around a single
     air.channel.put. The body holds nothing but the put and no operand depends
     on the induction variable, so this is a re-broadcast, not n productions --
     air-annotate-refeed recognizes the shape, collapses the loop, and derives
-    the count for the lock init. n <= 1 emits the bare put."""
+    the count for the lock init. n <= 1 emits the bare put.
+
+    n > MAX_REFEED is split into equal lock-legal groups: the consumer still sees
+    n puts, but no single collapsed loop asks for a lock the hardware cannot hold.
+    One group (n <= 63) is every model shipped so far, and emits the same IR as
+    before this split existed."""
     if n <= 1:
         emit()
         return
-    c0 = arith.ConstantOp(IndexType.get(), 0).result
-    cn = arith.ConstantOp(IndexType.get(), n).result
-    c1 = arith.ConstantOp(IndexType.get(), 1).result
-    for _rf in for_(c0, cn, c1):
-        emit()
-        yield_([])
+    ngrp = -(-n // MAX_REFEED)
+    for g in range(ngrp):
+        cnt = n // ngrp + (1 if g < n % ngrp else 0)
+        if cnt <= 1:
+            emit()
+            continue
+        c0 = arith.ConstantOp(IndexType.get(), 0).result
+        cn = arith.ConstantOp(IndexType.get(), cnt).result
+        c1 = arith.ConstantOp(IndexType.get(), 1).result
+        for _rf in for_(c0, cn, c1):
+            emit()
+            yield_([])
 
 
 def parallel_(n):
@@ -320,6 +336,40 @@ _MODELS = {
         # The driver MUST set VOCAB_CHUNK_I2=8 (env) to match this UNI_LM.
         UNI_LM=19,  # vocab chunks per LM head (VOCAB_CHUNK_I2=8)
     ),
+    # Qwen2.5-7B-Instruct: the first HAS_QKV_BIAS model on this engine (q/k/v_proj
+    # carry a bias, added in-place before RoPE from a slab at rope_w+DH -- see
+    # ROPE_W_LEN). D=3584 is 7 col-blocks wide, which is odd in units of the paired
+    # egress, so PAIR_ROWS=1 (gemma-style non-paired) is forced: PAIR_ROWS=2 gives
+    # I2P[0] = 4608/1024 = 4.5. 28 q heads / 4 kv is 7 per group, padded to 8 by
+    # GQA_SEG (ATTN_IMPL_1x8x1), same padding gemma uses for 3 -> 4.
+    #   I2P = [M, D, 2*INTER, D]/(ROW_BLOCK*NCX*NCY*PAIR_ROWS) = [9,7,74,7]
+    #   J2P = [K, DQ, K, INTER]/(2*COL_BLOCK)                  = [7,7,7,37]
+    "qwen2.5-7b": dict(
+        K=3584,
+        M=4608,  # DQ+DK+DV = 3584+512+512
+        DH_A=128,
+        KV_PER_CU=1,  # 4 kv / 4 CU
+        N_ATTN_CU=4,
+        NPH=4,
+        I2P=[9, 7, 74, 7],  # blocks/tile per phase (non-paired)
+        J2P=[7, 7, 7, 37],  # col-block pairs per phase
+        DEST=["rope", "rms", "glu", "rms"],
+        GQA_SEG=8,  # ATTN_IMPL_1x8x1
+        PAIR_ROWS=1,  # NON-PAIRED egress (D=3584 is odd in paired units)
+        N_NORMS=2,  # standard pre-norm (input, post_attention)
+        HAS_QKV_BIAS=True,  # rope_w = [cos/sin(DH), q_bias|k_bias|v_bias(M)]
+        VOCAB_SIZE=152064,
+        UNI_DEC=28,  # 28 decoder layers
+        # LM-head vocab chunking: VOCAB_SIZE_PADDED_FULL = ceil(152064/3584)*3584 =
+        # 154112 -> 4816 rowblocks. VOCAB_ROWBLKS = 16*VOCAB_I2 (PAIR_ROWS=1) must
+        # divide 4816 -> UNI_LM*VOCAB_I2 = 301 = 7*43, so VOCAB_I2 in {1,7,43,301}.
+        # K/PAYLOAD = 3584/512 = 7 must divide VOCAB_RNDS = VOCAB_I2*PAIR_ROWS,
+        # dropping 1; the 2*VOCAB_I2 <= 63 envelope drops 43 and 301. VOCAB_I2=7 is
+        # therefore the ONLY legal chunk (RNDS=7 = exactly one relay round, as in
+        # gemma) -> 43 waves, 112 rowblocks/chunk.
+        # The driver MUST set VOCAB_CHUNK_I2=7 (env) to match this UNI_LM.
+        UNI_LM=43,  # vocab chunks per LM head (VOCAB_CHUNK_I2=7)
+    ),
 }
 MODEL_NAME = _os.environ.get("DECODE_MODEL", "llama-3.2-1b")
 MODEL = _MODELS[MODEL_NAME]
@@ -337,7 +387,20 @@ HAS_QK_NORM = MODEL.get("HAS_QK_NORM", False)
 # Must agree with PARTIAL_ROPE_DIM in the model's C++ header -- the kernel reads
 # sin at rope_w + ROPE_DIM/2. Partial rotary + qk-norm is rejected there.
 ROPE_DIM = MODEL.get("ROPE_DIM", DH)
-ROPE_W_LEN = (3 * DH) if HAS_QK_NORM else ROPE_DIM  # 64 / 768 / 96
+# Qwen2.5 has q/k/v_proj biases; the kernel adds them in-place before RoPE from a
+# [q(DQ)|k(DK)|v(DV)] slab it reads at rope_w+DH (rope.cc add_q_k_v_bias), so the
+# rope weight buffer carries the DH cos/sin LUT plus M = DQ+DK+DV bias elements.
+HAS_QKV_BIAS = MODEL.get("HAS_QKV_BIAS", False)
+ROPE_W_LEN = (
+    (DH + MODEL["M"]) if HAS_QKV_BIAS else (3 * DH) if HAS_QK_NORM else ROPE_DIM
+)  # 64 / 768 / 96 / 4736
+# Does rope_w DIFFER PER LAYER? Llama's is a single per-position cos/sin LUT shared
+# by every layer, so one slab suffices; qk-norm (gemma/qwen3) and q/k/v-bias
+# (qwen2.5) both append per-layer weights, so the RMS BO needs UNI_DEC slabs and
+# the feed has to index the current wave's. Getting this wrong DEADLOCKS: the host
+# writes UNI_DEC slabs and puts final_norm after them, so a device that sized the
+# region for one slab reads final_norm from inside the rope region.
+ROPE_W_PER_LAYER = HAS_QK_NORM or HAS_QKV_BIAS
 NUM_KV_HEADS = MODEL["N_ATTN_CU"] * MODEL["KV_PER_CU"]  # 8 / 4
 NUM_Q_HEADS = (MODEL["M"] - 2 * NUM_KV_HEADS * DH) // DH  # 32 / 8
 Q_HEADS_PER_CU = NUM_Q_HEADS // MODEL["N_ATTN_CU"]  # 8 / 2
@@ -838,10 +901,18 @@ GLU_DEST = DEST[GLU_PHASE] if GLU_PHASE >= 0 else -1
 FULL4 = NPH == 4 and DOWN_PHASE == 3 and DEST[1] == DEST[3] and NDEST == 3
 RMS_DEST = DEST[DOWN_PHASE] if FULL4 else -1
 HOST_DRAIN = [p for p in range(NDEST) if p != GLU_DEST and p != RMS_DEST]
-GLU_CHUNK = PAYLOAD  # 512 (gate-up packs up/gate interleaved in 512-row chunks)
-GLU_SLICE = 2 * PAYLOAD  # 1024 = [up 512 | gate 512] (TWO demux packets/BD)
-GLU_HID = PAYLOAD  # 512 out per 1024 slice
-NGLU = ROUNDS_PER_DEST[GLU_DEST] // 2 if GLU_DEST >= 0 else 0  # 16 slices (2 rnd/slice)
+# A slice pair is one rotation of the GLU BD ring, and the core's slot sequence is
+# statically unrolled and restarts every layer while the ring's rotation carries
+# over -- an ODD slice count leaves the two a slot apart and every other layer reads
+# a stale slice. Two demux packets per slice is the reference granularity, but when
+# that gives an odd count (qwen2.5-7b: INTERMEDIATE/512 = 37) drop to one packet per
+# slice: same 512-row interleave stride, half the slice, an even count, and the same
+# total. The kernel is generic in the slice length (pseduo_glu<GLU_SLICE>).
+GLU_PKTS = 2 if (ROUNDS_PER_DEST[GLU_DEST] // 2) % 2 == 0 else 1
+GLU_CHUNK = GLU_PKTS * PAYLOAD // 2  # gate-up interleaves up/gate in chunks this tall
+GLU_SLICE = GLU_PKTS * PAYLOAD  # 1024 = [up 512 | gate 512] (GLU_PKTS demux packets/BD)
+GLU_HID = GLU_SLICE // 2  # 512 out per 1024 slice
+NGLU = ROUNDS_PER_DEST[GLU_DEST] // GLU_PKTS if GLU_DEST >= 0 else 0  # 16 slices
 GLU_OUT = NGLU * GLU_HID  # 8192 (INTERMEDIATE) = down_buffer size = down K
 GLU_PCOL = 5  # GLU compute tile + down memtile column (reference: tile_5_x + mem_5_1;
 # moved 4->5 to free col4 for 4-CU attention, matching the reference layout)
@@ -909,12 +980,12 @@ def build_module():
         # rms weight (K). MULTIBLK appends the rope region AFTER all UNI_DEC rms slabs so
         # the score-path test gets a KNOWN q (q_roped = proj_q) WITHOUT corrupting
         # rms_w[0:K] (which proj_q depends on). Llama: ONE shared per-position LUT
-        # (ROPE_W_LEN=64). Gemma (HAS_QK_NORM): UNI_DEC per-layer rope_w slabs
+        # (ROPE_W_LEN=64). Per-layer models (ROPE_W_PER_LAYER): UNI_DEC rope_w slabs
         # (dual-theta + per-layer q/k-norm). L=1 ABI unchanged.
         rms_l3 = MemRefType.get(
             [
                 UNI_DEC * RMS_LAYER
-                + ((UNI_DEC if HAS_QK_NORM else 1) * ROPE_W_LEN if MULTIBLK else 0)
+                + ((UNI_DEC if ROPE_W_PER_LAYER else 1) * ROPE_W_LEN if MULTIBLK else 0)
                 + K  # dedicated final-norm slot for real lm_head (vocab)
             ],
             bf16,
@@ -1589,10 +1660,10 @@ def build_module():
                             # vocab rmsnorm uses the true final norm -- NOT layer-0's in_LN
                             # (mirrors decoding_layer's separate final_rms_weight).
                             # final norm sits AFTER the rope region: llama has ONE shared
-                            # rope LUT (ROPE_W_LEN), gemma has UNI_DEC per-layer rope_w slabs.
+                            # rope LUT (ROPE_W_LEN), per-layer models have UNI_DEC slabs.
                             _final_norm_off = (
                                 UNI_DEC * RMS_LAYER
-                                + (UNI_DEC if HAS_QK_NORM else 1) * ROPE_W_LEN
+                                + (UNI_DEC if ROPE_W_PER_LAYER else 1) * ROPE_W_LEN
                             )
                             if N_NORMS >= 4:
                                 # Gemma: rmsW/rmsW2 are 2K (two norms packed). Put final_norm
@@ -1714,15 +1785,15 @@ def build_module():
                                     )
                             # rope LUT: sits after all UNI_DEC rms slabs in arg2. Llama:
                             # ONE per-position LUT SHARED across layers (single theta) at a
-                            # layer-independent offset. Gemma (HAS_QK_NORM): the rope_w
-                            # (dual-theta cos/sin + per-layer q/k-norm) DIFFERS PER LAYER, so
+                            # layer-independent offset. ROPE_W_PER_LAYER (gemma/qwen3
+                            # qk-norm, qwen2.5 q/k/v bias): rope_w DIFFERS PER LAYER, so
                             # index a per-wave slab (UNI_DEC contiguous rope_w slabs, offset
                             # _lut_off + a_iv*ROPE_W_LEN). UNIFIED sizes arg2 for UNI_DEC decode
                             # waves (module-gen forces NLAYERS=1, which would misplace it).
                             _lut_off = (UNI_DEC * RMS_LAYER) if MULTIBLK else 0
                             _rope_off = (
                                 _lo(_lb(ROPE_W_LEN), _lut_off)
-                                if (HAS_QK_NORM and MULTIBLK)
+                                if (ROPE_W_PER_LAYER and MULTIBLK)
                                 else _lut_off
                             )
                             ChannelPut(
@@ -3040,6 +3111,14 @@ def build_module():
                                     DeallocOp(gx)
                                     DeallocOp(gh)
 
+                                # An odd slice count desyncs that ring: the core's
+                                # slot sequence restarts every layer while the ring's
+                                # rotation carries over, so every other layer reads a
+                                # stale slice. GLU_PKTS keeps the count even.
+                                assert NGLU % 2 == 0, (
+                                    f"odd NGLU={NGLU} desyncs the GLU BD ring "
+                                    f"(GLU_PKTS={GLU_PKTS})"
+                                )
                                 for _s in for_(idx(0), idx(NGLU // 2), idx(1)):
                                     _slice()  # ping
                                     _slice()  # pong

--- a/programming_examples/fused_decode/models/all_models.h
+++ b/programming_examples/fused_decode/models/all_models.h
@@ -25,6 +25,7 @@
 #define LLAMA_3_2_3B 3
 #define PHI4_4B 4
 #define QWEN3_8B 5
+#define QWEN2_5_7B 6
 
 #ifndef MODEL_TYPE
 #define MODEL_TYPE LLAMA_3_2_1B
@@ -35,6 +36,7 @@
 #include "../models/llama3.2-3b.h"
 #include "../models/phi4-4b.h"
 #include "../models/qwen2.5-3b.h"
+#include "../models/qwen2.5-7b.h"
 #include "../models/qwen3-8b.h"
 
 #endif // __ALL_MODELS_H__

--- a/programming_examples/fused_decode/models/qwen2.5-7b.h
+++ b/programming_examples/fused_decode/models/qwen2.5-7b.h
@@ -1,0 +1,29 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+///@file qwen2.5-7b.h
+///@brief Define the model parameters for the qwen2.5-7b model
+#ifndef __QWEN2_5_7B_H__
+#define __QWEN2_5_7B_H__
+
+#if MODEL_TYPE == QWEN2_5_7B
+constexpr int MODEL_DIM = 3584;
+constexpr int NUM_ATTN_HEADS = 28;
+constexpr int NUM_KV_HEADS = 4;
+constexpr int INTERMEDIATE_SIZE = 18944; // already a multiple of 512
+constexpr int GLU_SLICE =
+    512; // one demux packet: 18944/1024 = 37 slices is odd
+constexpr int DH = 128;
+constexpr int VOCAB_SIZE = 152064;
+constexpr float ATTN_SCALE = 0.08838834764831843f; // 1/sqrt(128)
+
+#define ATTN_IMPL ATTN_IMPL_1x8x1
+#define A_FUNC A_SILU
+#define HAS_QKV_BIAS
+
+constexpr int Q4NX_ROW_BLOCK_SIZE = 32;
+constexpr int Q4NX_COL_BLOCK_SIZE = 256;
+constexpr int Q4NX_GROUP_SIZE = 32;
+#endif
+
+#endif // __QWEN2_5_7B_H__

--- a/programming_examples/fused_decode/qwen25_3b_requant.py
+++ b/programming_examples/fused_decode/qwen25_3b_requant.py
@@ -125,12 +125,16 @@ def requant_q4_0(Wm, group=GROUP):
     return q.reshape(M, Kc).view(np.uint8), sc
 
 
-def pack_q4k_cascade_fast(q, scale, NCX, NCY, dual_chan=False):
+def pack_q4k_cascade_fast(q, scale, NCX, NCY, dual_chan=False, mins=None):
     """Vectorized iteration-major cascade pack; == proj_qmm_pack.pack_q4k_cascade
-    (iter_major=True) with all-zero mins, but packs every block at once.
+    (iter_major=True), but packs every block at once.
 
     The reference packer's per-block Python loops cost ~30 min for a 36-layer
     model; this is the same layout computed with numpy reshapes.
+
+    `mins` is the affine Q4NX min term, shaped like `scale`. Omit it for the
+    symmetric Q4_0 codec, whose mins are all zero -- that is the default and
+    keeps the Q4_0 callers byte-identical.
     """
     M, K = q.shape
     assert M % ROW_BLOCK == 0 and K % COL_BLOCK == 0
@@ -140,14 +144,17 @@ def pack_q4k_cascade_fast(q, scale, NCX, NCY, dual_chan=False):
     nbi_pc = nbi // n_cores
     G = ROW_BLOCK // PARALLEL  # row groups per block (2)
 
-    # scales[block][group(8)][row(32)] as bf16 (mins stay zero for Q4_0)
-    sc = (
-        scale.reshape(nbi, ROW_BLOCK, nbj, N_GROUPS)
-        .transpose(0, 2, 3, 1)  # [nbi][nbj][group][row]
-        .astype(bfloat16)
-        .view(np.int16)
-    )
-    mn = np.zeros_like(sc)
+    # scales[block][group(8)][row(32)] as bf16; mins identically, or zero (Q4_0)
+    def _per_block(a):
+        return (
+            a.reshape(nbi, ROW_BLOCK, nbj, N_GROUPS)
+            .transpose(0, 2, 3, 1)  # [nbi][nbj][group][row]
+            .astype(bfloat16)
+            .view(np.int16)
+        )
+
+    sc = _per_block(scale)
+    mn = np.zeros_like(sc) if mins is None else _per_block(mins)
 
     # qs[block][rowgrp(2)][col(256)][pair(8)] = (odd<<4) | even
     qv = q.reshape(nbi, ROW_BLOCK, nbj, COL_BLOCK).transpose(

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -534,6 +534,10 @@ LLM_HF_MODELS = {
     # Instruct variant -- the example's own default (MODEL_DEFAULT in
     # qwen25_3b_q4_prefill.py) -- not the base repo the qwen25_3b row above uses.
     "qwen25_3b_q4": "Qwen/Qwen2.5-3B-Instruct",
+    # Q4NX, but FastFlowLM has not published a Qwen2.5-7B NPU2 bundle, so the
+    # weights are quantized on load from the Instruct checkpoint -- which is
+    # also the verify reference, as in the qwen25_3b_q4 row.
+    "qwen25_7b_q4nx": "Qwen/Qwen2.5-7B-Instruct",
     "qwen3_0_6b": "Qwen/Qwen3-0.6B",
     "qwen3_1_7b": "Qwen/Qwen3-1.7B",
     "qwen3_4b": "Qwen/Qwen3-4B",

--- a/programming_examples/kernel_registry/details/GEMM_bf16_in_bf16_out.json
+++ b/programming_examples/kernel_registry/details/GEMM_bf16_in_bf16_out.json
@@ -1885,6 +1885,110 @@
       "best": {
         "high": "fused-cast"
       }
+    },
+    {
+      "M": 2048,
+      "K": 3584,
+      "N": 3584,
+      "used_by": "Qwen2.5-7B Q/O proj (emb=3584, q_dim=28*128=3584 -> square o_proj)",
+      "methods": {
+        "fused-cast": {
+          "tile": {
+            "tile_m": 64,
+            "tile_k_l2": 128,
+            "tile_k_l1": 32,
+            "tile_n": 128
+          },
+          "gflops": 6106,
+          "mean_rel_L1": 0.00988,
+          "tier": "high"
+        }
+      },
+      "best": {
+        "high": "fused-cast"
+      },
+      "_note": "tile_k_l2 matters far more here than for the other emb widths: 256 places but collapses to 575 GFLOP/s (91.4 ms), ~10x off 128. K=3584=512*7; the sweep of placeable values gives 64 -> 5815, 128 -> 6106, 256 -> 575, and 512 overflows the memtile. Do not carry the 256 that the 4096-wide Qwen3-8B rows use."
+    },
+    {
+      "M": 2048,
+      "K": 3584,
+      "N": 512,
+      "used_by": "Qwen2.5-7B K/V proj (emb=3584, kv_dim=4*128=512)",
+      "methods": {
+        "drain": {
+          "tile": {
+            "tile_m": 32,
+            "tile_k_l2": 256,
+            "tile_k_l1": 32,
+            "tile_n": 64
+          },
+          "gflops": 4635,
+          "mean_rel_L1": 0.00944,
+          "tier": "high"
+        }
+      },
+      "best": {
+        "high": "drain"
+      },
+      "_note": "M*K*N = 3.76e9 < 4e9, so --method auto selects drain (tile_m=32), as for the other narrow-N K/V rows. tile_n=128 at tile_m=64 exceeds L1."
+    },
+    {
+      "M": 2048,
+      "K": 3584,
+      "N": 18944,
+      "used_by": "Qwen2.5-7B Gate/Up proj (emb=3584, ffn=18944)",
+      "methods": {
+        "fused-cast": {
+          "tile": {
+            "tile_m": 64,
+            "tile_k_l2": 64,
+            "tile_k_l1": 32,
+            "tile_n": 128
+          },
+          "gflops": 5711,
+          "mean_rel_L1": 0.00988,
+          "tier": "high"
+        },
+        "direct": {
+          "tile": {
+            "tile_m": 64,
+            "tile_k_l2": 32,
+            "tile_k_l1": 32,
+            "tile_n": 64
+          },
+          "gflops": 3346,
+          "mean_rel_L1": 0.01484,
+          "tier": "low"
+        }
+      },
+      "best": {
+        "high": "fused-cast",
+        "low": "direct"
+      },
+      "_note": "The low-precision (direct) path is stride-bound, not tile-bound: its B-matrix descriptor needs stride tile_k_l2*N, and aie.dma_bd caps strides at 1048576. At N=18944 that forces tile_k_l2 <= 55, so 32 is the only legal value (64 gives 1212416, 128 gives 2424832 and fails to build). Hence 3346 GFLOP/s here vs the ~4400 the narrower Gate/Up rows reach at tile_k_l2=128. The high-precision fused-cast method above is unaffected (tile_n=128 decomposes differently)."
+    },
+    {
+      "M": 2048,
+      "K": 18944,
+      "N": 3584,
+      "used_by": "Qwen2.5-7B Down proj (ffn=18944 -> emb=3584)",
+      "methods": {
+        "fused-cast": {
+          "tile": {
+            "tile_m": 64,
+            "tile_k_l2": 256,
+            "tile_k_l1": 32,
+            "tile_n": 128
+          },
+          "gflops": 9740,
+          "mean_rel_L1": 0.00988,
+          "tier": "high"
+        }
+      },
+      "best": {
+        "high": "fused-cast"
+      },
+      "_note": "tile_k_l2=256 is the largest memtile-legal value at K=18944 (512 overflows), so it is also the fewest L2 steps and the cheapest compile."
     }
   ]
 }

--- a/programming_examples/llms/README.md
+++ b/programming_examples/llms/README.md
@@ -90,6 +90,7 @@ top of quantization error:
 | `gemma3_4b_q4nx` | `FastFlowLM/Gemma3-4B-NPU2` | `unsloth/gemma-3-4b-it` |
 | `qwen3_8b_q4nx` | `FastFlowLM/Qwen3-8B-NPU2` | `Qwen/Qwen3-8B` |
 | `qwen25_3b_q4` | Q4_0, quantized on the host from the reference | `Qwen/Qwen2.5-3B-Instruct` |
+| `qwen25_7b_q4nx` | Q4NX, quantized on load from the reference | `Qwen/Qwen2.5-7B-Instruct` |
 
 Two cheaper lenses sit beside the gate, and neither is a substitute for it:
 `make verify-paris` is a prefill-only first-token smoke that needs no decode
@@ -113,6 +114,7 @@ llms/
 ├── qwen25_1_5b/        # Qwen2.5-1.5B  (QKV bias, head_dim=128)
 ├── qwen25_3b/          # Qwen2.5-3B    (QKV bias, head_dim=128)
 ├── qwen25_3b_q4/       # Q4_0 4-bit Qwen2.5-3B (prefill + fused NPU decode)
+├── qwen25_7b_q4nx/     # Q4NX 4-bit Qwen2.5-7B (fused decode, QKV bias)
 ├── qwen3_0_6b/         # Qwen3-0.6B    (QK-norm, head_dim=128)
 ├── qwen3_1_7b/         # Qwen3-1.7B    (QK-norm, head_dim=128)
 ├── qwen3_4b/           # Qwen3-4B      (QK-norm, decoupled q_dim=4096)

--- a/programming_examples/llms/hf_models.txt
+++ b/programming_examples/llms/hf_models.txt
@@ -54,6 +54,11 @@ unsloth/gemma-3-4b-it
 FastFlowLM/Qwen3-8B-NPU2
 Qwen/Qwen3-8B
 
+# Qwen2.5-7B-Instruct is listed ONCE, not as a pair: FastFlowLM publishes no
+# Qwen2.5-7B bundle, so llms/qwen25_7b_q4nx quantizes this checkpoint to Q4NX on
+# load and `make verify` compares against the same repo in bf16. Ungated.
+Qwen/Qwen2.5-7B-Instruct
+
 # Same Q4NX packaging of Phi-4-mini-instruct. Used by llms/phi4_mini_q4nx (the
 # fused decode loads weights from this repo), plus the bf16 reference `make
 # verify` compares against -- microsoft/Phi-4-mini-instruct is ungated, and is

--- a/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
+++ b/programming_examples/llms/qwen25_3b/qwen25_3b_prefill.py
@@ -464,16 +464,56 @@ def _swiglu_tile_n(seq_len, hidden_dim, herd_x=8):
     raise RuntimeError(f"No SwiGLU tile_n for seq={seq_len} hidden={hidden_dim}")
 
 
+# Largest per-launch iteration count known to place. Above this the shim runs out
+# of simultaneously-active buffer descriptors ("Too many simultaneously active
+# buffer descriptors on tile (0,0), which supports up to 16"). The shipped models
+# sit at 448 (8960), 512 (9728) and 688 (11008), so 688 is the observed ceiling.
+_SWIGLU_MAX_ITERS = 688
+
+
+def swiglu_plan(seq_len, hidden_dim, herd_x=8):
+    """(n_chunks, rows_per_chunk) for the SwiGLU launch.
+
+    iters = seq*hidden/(tile_n*herd_x) is bounded below by the hardware: herd_x
+    caps at 8 (a 3-DMA/tile kernel cannot place herd_y>1) and tile_n at ~5120
+    (tile_n * 2B * 3 buffers * ping-pong must fit a 64 KiB L1). At hidden_dim
+    18944 that floors iters at 1024, past the BD budget, so the launch is split
+    over row chunks -- SwiGLU is elementwise, so a row split is exact.
+
+    Returns (1, seq_len) whenever one launch fits, which is every hidden_dim
+    shipped before Qwen2.5-7B; that path is unchanged and emits identical IR."""
+    tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
+    n = 1
+    while (
+        seq_len // n * hidden_dim // (tile_n * herd_x) > _SWIGLU_MAX_ITERS
+        and (seq_len // n) % 2 == 0
+    ):
+        n *= 2
+    iters = seq_len // n * hidden_dim // (tile_n * herd_x)
+    if iters > _SWIGLU_MAX_ITERS:
+        raise RuntimeError(
+            f"No SwiGLU row split for seq={seq_len} hidden={hidden_dim}: "
+            f"{iters} iters/launch exceeds {_SWIGLU_MAX_ITERS} and seq_len is "
+            f"not further divisible by 2"
+        )
+    return n, seq_len // n
+
+
 def build_swiglu_module(seq_len, hidden_dim, herd_x=8, herd_y=1):
-    """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (seq x hidden)."""
+    """Standalone NPU SwiGLU ELF: silu(gate)*up -> swiglu (rows x hidden).
+
+    Built for ONE row chunk (see swiglu_plan); the driver dispatches it
+    n_chunks times over row slices. n_chunks==1 for every pre-Qwen2.5-7B model."""
     from silu_and_mul.silu_and_mul import build_module_2d as build_swiglu
 
     tile_n = _swiglu_tile_n(seq_len, hidden_dim, herd_x)
+    n_chunks, rows = swiglu_plan(seq_len, hidden_dim, herd_x)
+    split = "" if n_chunks == 1 else f" x{n_chunks} row chunks"
     print(
-        f"  [swiglu] SwiGLU {seq_len}x{hidden_dim} (tile_n={tile_n}, "
-        f"iters={seq_len * hidden_dim // (tile_n * herd_x)})..."
+        f"  [swiglu] SwiGLU {rows}x{hidden_dim}{split} (tile_n={tile_n}, "
+        f"iters={rows * hidden_dim // (tile_n * herd_x)})..."
     )
-    module = build_swiglu(seq_len, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
+    module = build_swiglu(rows, hidden_dim, tile_n, bfloat16, herd_x, herd_y)
     print(f"  swiglu module: {len(str(module).splitlines())} lines, parsed OK")
     return module
 
@@ -1034,12 +1074,14 @@ def preload_prefill_weights(weights, config, cache, seq_len, rope_lut_bf16):
         )
 
         # SwiGLU: NPU ELF (no static weights — only warms the per-layer BO set).
+        # Sized to one row chunk, matching the ELF build (see swiglu_plan).
+        _, sw_rows = swiglu_plan(seq_len, hidden_dim)
         cache.load_and_run(
             "swiglu",
             _swiglu_backend(),
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
-            np.zeros((seq_len, hidden_dim), dtype=bfloat16),
+            np.zeros((sw_rows, hidden_dim), dtype=bfloat16),
+            np.zeros((sw_rows, hidden_dim), dtype=bfloat16),
+            np.zeros((sw_rows, hidden_dim), dtype=bfloat16),
             output_indices=[2],
             intermediate_indices={2},
             bo_key=f"swiglu_L{layer_idx}",
@@ -1229,19 +1271,25 @@ def run_transformer_block_qwen25(
     )
     up = up_res[2].reshape(seq_len, hidden_dim)
 
-    # ELF A4: swiglu (NPU silu(gate)*up).
-    sw_res = cache.load_and_run(
-        "swiglu",
-        _swiglu_backend(verbose),
-        np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 0 gate
-        np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim),  # 1 up
-        np.zeros((seq_len, hidden_dim), dtype=bfloat16),  # 2 swiglu (out)
-        output_indices=[2],
-        intermediate_indices={2},
-        bo_key=f"swiglu_L{layer_idx}",
-        shared_nonstatic=True,
-    )
-    swiglu = sw_res[2].reshape(seq_len, hidden_dim)
+    # ELF A4: swiglu (NPU silu(gate)*up), dispatched once per row chunk.
+    n_sw, sw_rows = swiglu_plan(seq_len, hidden_dim)
+    gate_2d = np.asarray(gate, dtype=bfloat16).reshape(seq_len, hidden_dim)
+    up_2d = np.asarray(up, dtype=bfloat16).reshape(seq_len, hidden_dim)
+    swiglu = np.zeros((seq_len, hidden_dim), dtype=bfloat16)
+    for c in range(n_sw):
+        r0 = c * sw_rows
+        sw_res = cache.load_and_run(
+            "swiglu",
+            _swiglu_backend(verbose),
+            np.ascontiguousarray(gate_2d[r0 : r0 + sw_rows]),  # 0 gate
+            np.ascontiguousarray(up_2d[r0 : r0 + sw_rows]),  # 1 up
+            np.zeros((sw_rows, hidden_dim), dtype=bfloat16),  # 2 swiglu (out)
+            output_indices=[2],
+            intermediate_indices={2},
+            bo_key=f"swiglu_L{layer_idx}",
+            shared_nonstatic=True,
+        )
+        swiglu[r0 : r0 + sw_rows] = sw_res[2].reshape(sw_rows, hidden_dim)
 
     # ELF B: down_add → output (arg4). Down GEMM is launch 0 (K=hidden NaN fix).
     down_args = [

--- a/programming_examples/llms/qwen25_7b_q4nx/.gitignore
+++ b/programming_examples/llms/qwen25_7b_q4nx/.gitignore
@@ -1,0 +1,34 @@
+# Build / kernel cache artifacts
+build_peano/
+build_chess/
+__pycache__/
+*.pyc
+_q4nx_*/
+.wcache/
+kernel_cache/
+air_project/
+
+# Compiled kernels + decode templates (reproduced by `make compile-decode`; never committed).
+*.o
+*.ll
+decode.xclbin
+decode.insts.bin
+decode_L*.xclbin
+decode_L*.insts.bin
+
+# Stray artifacts from running the driver outside build_*/ (xrt.py +
+# external_kernels.py write these to CWD by design).
+air.mlir
+air.elf
+air.xclbin
+air.insts.bin
+
+# Golden / weight caches produced at runtime (external data; see README.md).
+*.npz
+diag_cache/
+
+# build-flag stamp: makes the decode-template skip W_DUAL_CHAN-aware
+.decode_flags
+
+# Staircase window manifest (which ATTN_MAXL pairs this dir holds).
+.decode_windows

--- a/programming_examples/llms/qwen25_7b_q4nx/.gitignore
+++ b/programming_examples/llms/qwen25_7b_q4nx/.gitignore
@@ -15,6 +15,9 @@ decode.xclbin
 decode.insts.bin
 decode_L*.xclbin
 decode_L*.insts.bin
+decode_dyn_L*.xclbin
+decode_dyn_L*.insts.bin
+decode_dyn_L*.txn.h
 
 # Stray artifacts from running the driver outside build_*/ (xrt.py +
 # external_kernels.py write these to CWD by design).

--- a/programming_examples/llms/qwen25_7b_q4nx/Makefile
+++ b/programming_examples/llms/qwen25_7b_q4nx/Makefile
@@ -250,9 +250,9 @@ chat:
 ## k=5) -- the same gate, through the same shared verify/ subsystem, as the other
 ## quantized examples.
 ##
-## REFERENCE. The Q4NX bundle is converted from the bartowski
-## Qwen2.5-7B-Instruct Q4_0 GGUF, so the bf16 reference is
-## `Qwen/Qwen2.5-7B-Instruct` and both MODEL_CHOICE keys map to it -- a base-model
+## REFERENCE. The NPU side quantizes `Qwen/Qwen2.5-7B-Instruct` onto the Q4NX
+## grid at load (FastFlowLM publishes no Qwen2.5-7B bundle), so the bf16
+## reference is that same checkpoint and both MODEL_CHOICE keys map to it -- a base-model
 ## reference would disagree with the instruct weights it is checking. It is
 ## ungated and loads directly with AutoModelForCausalLM. NOT the -1M variant:
 ## same geometry, but rope_theta 1e7 instead of 1e6.

--- a/programming_examples/llms/qwen25_7b_q4nx/Makefile
+++ b/programming_examples/llms/qwen25_7b_q4nx/Makefile
@@ -1,0 +1,314 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-7B Q4NX end-to-end decode on NPU2 (MLIR-AIR), FLM-faithful.
+#
+# Same driver contract as the other llms/ examples (run/profile/ask drive the inference
+# driver; compile/compile-decode are weight-free builds).
+#
+# ONE dispatch = 28 decoder layers + the untied LM head, reading and appending a shared per-layer
+# KV cache. Drives the shared fused_decode engine (DECODE_MODEL=qwen2.5-7b): 2-norm pre-norm,
+# single-theta RoPE with a q/k/v projection bias, SwiGLU, DH=128 GQA7 attention.
+#
+# The weights are split over several BOs (DECODE_WGROUP below): 28 layers is 3.80 GiB and
+# the lm-head adds 0.32 GiB, and a shim BD's byte offset is a uint32, so one BO only
+# reaches 4 GiB.
+#
+# The KV seed + greedy first-token golden come from a numpy reference forward
+# (qwen25_7b_q4nx_weights.forward_prompt); the fused per-token decode then generates.
+#
+# Python deps beyond the mlir-air base environment: see requirements.txt.
+#
+# Quick start:
+#   make compile-decode LBUILD=16   Build the Qwen2.5-7B decode templates (small, for the Paris gate)
+#   make gen                        Run the Paris gate (first token 12095 " Paris")
+#   make compile-decode             Build production templates (ATTN_MAXL=2048, ~15 min)
+
+srcdir     := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+DEC        := $(srcdir)/../../fused_decode
+DECODE_DRIVER := $(DEC)/fused_decode.py
+PREFILL_DRIVER := $(srcdir)/qwen25_7b_q4nx_prefill.py
+AIEOPT_DIR := $(shell realpath $(dir $(shell which aie-opt))/..)
+
+ifdef PEANO_INSTALL_DIR
+  BUILD_DIR := build_peano
+else
+  BUILD_DIR := build_chess
+endif
+
+# Prefill context length (padded). The GEMM registry carries the Qwen2.5-7B shapes at
+# M=2048; other lengths need matching registry entries.
+CTX ?= 2048
+export Q4NX_SEQ_LEN   := $(CTX)
+export Q4NX_CACHE_DIR := $(srcdir)/$(BUILD_DIR)/q4nx_kernel_cache_$(CTX)
+
+# Per-kernel -O is LOAD-BEARING (see fused_decode/Makefile): proj_qmm/rms_residual/glu/rope
+# -O2; attn_qk/attn_kv inline .ll -O1. Qwen2.5-7B differs only by -DMODEL_TYPE=QWEN2_5_7B (the
+# header auto-sets A_FUNC=A_SILU, HAS_QKV_BIAS, ATTN_IMPL, dims/vocab).
+NONATTN_KERNELS := proj_qmm rms_residual glu rope
+ATTN_LL_KERNELS := attn_qk attn_kv
+PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
+  -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-deprecated-declarations \
+  -DNDEBUG -DMODEL_TYPE=QWEN2_5_7B -D__AIE_API_AIE_ADF_HPP__ \
+  -I $(AIEOPT_DIR)/include -I $(DEC)/kernels -I $(DEC)/models \
+  -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+
+# Qwen2.5-7B decode env (module-level constants read these): 28 layers, vocab-152064 chunking.
+# DECODE_STACK: at K=3584 the seven K-wide L1 activation buffers (7*7 KiB) leave
+# under 8 KiB of the 64 KiB core memory, so the engine's default 10240 overflows.
+DECODE_STACK ?= 6144
+# DECODE_WGROUP: decode layers per weight BO. Must match DECODE_WGROUP in
+# qwen25_7b_q4nx_inference.py -- the host slices the weights the same way.
+DECODE_WGROUP ?= 7
+DECODE_ENV := DECODE_MODEL=qwen2.5-7b VOCAB_CHUNK_I2=7 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1 \
+              DECODE_STACK=$(DECODE_STACK) DECODE_WGROUP=$(DECODE_WGROUP)
+
+# ATTN_MAXL to build for. 16 = the Paris gate (P + a few tokens <= 16); 2048 = production.
+LBUILD ?= 2048
+LREF   := $(shell echo $$(($(LBUILD) - 1)))
+
+# Shared driver contract (same variable names as the other llms/ examples).
+# NTOK is kept as a back-compat alias for N_TOKENS.
+NTOK     ?=
+N_TOKENS ?= $(if $(NTOK),$(NTOK),64)
+# Prompt for `make run` / `make ask`. Empty = the canonical Paris prompt, which is
+# the only prompt the *** PARIS *** gate is defined for.
+PROMPT   ?=
+PROMPT_ARG := $(if $(PROMPT),--prompt "$(PROMPT)",)
+# `profile` publishes context_len to the nightly dashboard, so it measures a real
+# prompt rather than the 5-token Paris gate one. PROMPT overrides it.
+PROFILE_PROMPT := $(if $(PROMPT),$(PROMPT),What is the capital of France?)
+
+# Weight source, read by the driver as Q4NX_MODEL_SOURCE. Default: the upstream
+# bf16 checkpoint, quantized onto the Q4NX grid on load (FastFlowLM publishes no
+# Qwen2.5-7B bundle). A local dir/file holding a model.q4nx is also accepted.
+MODEL_SOURCE ?= Qwen/Qwen2.5-7B-Instruct
+export Q4NX_MODEL_SOURCE := $(MODEL_SOURCE)
+
+# Dual-MM2S weight feed for the fused decode (fused_decode/fused_decode.py).
+# ON by default. The BUILD and the RUN must agree -- the flag selects both the
+# shim channel split and the DDR weight cascade order -- so export it here and let
+# it reach the delegated decode build AND the inference driver. The requant cache
+# is keyed on it, so flipping it needs no manual cache purge.
+W_DUAL_CHAN ?= 1
+export W_DUAL_CHAN
+
+
+# ---- shared verify subsystem (programming_examples/llms/verify/) ----
+VERIFY_RUNNER  := $(srcdir)/../verify/verify_runner.py
+RUNNER_ADAPTER := qwen25_7b_q4nx.verify_adapter
+MODEL_CHOICE   ?= instruct
+MAX_PROMPTS    ?= 2
+
+.PHONY: help compile compile-prefill compile-decode compile-decode-dynseq compile-decode-windows _compile_decode_build prefill \
+        run ask chat verify verify-full verify-paris diagnosis profile profile-prefill gen clean
+
+help:
+	@echo "============================================================"
+	@echo " QWEN2.5-7B Q4NX decode on NPU2 (MLIR-AIR)"
+	@echo "============================================================"
+	@echo ""
+	@echo "  make compile LBUILD=16   Prefill ELFs + decode templates, small (Paris gate)"
+	@echo "  make compile             Production build (ATTN_MAXL=2048, ~15 min)"
+	@echo "  make compile-prefill     Prefill ELFs only (weight-free)"
+	@echo "  make compile-decode      Decode templates only (weight-free)"
+	@echo "  make run                 Decode 'The capital of France is' -> Paris gate"
+	@echo "  make ask PROMPT=\"...\"    Single Q&A turn"
+	@echo "  make chat                Interactive chat REPL (streaming output)"
+	@echo "  make verify              Top-k token-set gate vs HF bf16 (2 prompts x 32 tokens, k=5)"
+	@echo "  make verify-full         Same over every prompt in the shared prompt file"
+	@echo "  make verify-paris        Fast prefill-only weight-integrity gate"
+	@echo "  make diagnosis           Single-prompt lens through the shared runner (informational)"
+	@echo "  make profile             TTFT + decode throughput over N_TOKENS tokens"
+	@echo "  make profile-prefill     Warm prefill TTFT at CTX"
+	@echo "  make clean               Remove build artifacts, caches, Qwen2.5-7B kernels"
+	@echo ""
+	@echo "Options (override with make VAR=value):"
+	@echo "  LBUILD=2048              ATTN_MAXL to build the templates for"
+	@echo "  N_TOKENS=64              Tokens generated by 'make profile' / 'make ask'"
+	@echo "  PROMPT=\"...\"             Prompt for 'make run' / 'make ask'"
+	@echo "  CTX=2048                 Prefill context length (padded)"
+	@echo "  MODEL_SOURCE=<repo|dir>  weight source (default Qwen/Qwen2.5-7B-Instruct)"
+	@echo "  DECODE_WGROUP=$(DECODE_WGROUP)          Decode layers per weight BO (one BO reaches only 4 GiB)"
+	@echo "  DECODE_STACK=$(DECODE_STACK)        Decode core stack; K=3584 needs less than the 10240 default"
+
+## Build the Qwen2.5-7B decode: kernels (QWEN2_5_7B) + two same-ATTN_MAXL templates
+## (decode_L$(LBUILD) + decode_L$(LREF)) into this dir. Weight-free build.
+##
+## Skips when both templates are already present, matching fused_decode's
+## compile-decode. The guard is keyed on the LBUILD-encoded filenames, so a build
+## at a different LBUILD is never silently reused.
+# W_DUAL_CHAN changes the DDR weight layout, so a warm template built with the
+# other setting must NOT be reused -- it would be fed the wrong blocks and produce
+# silent garbage. The stamp makes the skip below flag-aware.
+DECODE_FLAGS_STAMP := $(srcdir)/.decode_flags
+DECODE_FLAGS       := W_DUAL_CHAN=$(W_DUAL_CHAN) DECODE_STACK=$(DECODE_STACK) DECODE_WGROUP=$(DECODE_WGROUP)
+
+compile-decode:
+	@if [ -f $(srcdir)/decode_L$(LBUILD).xclbin ] && [ -f $(srcdir)/decode_L$(LBUILD).insts.bin ] \
+	    && [ -f $(srcdir)/decode_L$(LREF).xclbin ] && [ -f $(srcdir)/decode_L$(LREF).insts.bin ] \
+	    && [ "`cat $(DECODE_FLAGS_STAMP) 2>/dev/null`" = "$(DECODE_FLAGS)" ]; then \
+	  echo "Qwen2.5-7B decode templates already built (decode_L$(LBUILD) + decode_L$(LREF), $(DECODE_FLAGS)); skipping. Run 'make clean' to force a rebuild."; \
+	else \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build \
+	    && echo "$(DECODE_FLAGS)" > $(DECODE_FLAGS_STAMP); \
+	fi
+
+## Staircase templates: one pair per ATTN_MAXL window; each token dispatches on the
+## smallest one covering the context. Writes $(DECODE_WINDOWS_STAMP) so a stray pair is
+## rejected at load rather than silently changing which window is selected.
+WINDOWS ?= 64 128 256 512 1024 2048
+DECODE_WINDOWS_STAMP := $(srcdir)/.decode_windows
+
+compile-decode-windows:
+	@for W in $(WINDOWS); do \
+	  echo ">>> staircase window ATTN_MAXL=$$W"; \
+	  $(MAKE) --no-print-directory -f $(srcdir)/Makefile _compile_decode_build LBUILD=$$W \
+	    || exit 1; \
+	done
+	@echo "$(WINDOWS)" > $(DECODE_WINDOWS_STAMP)
+	@echo "Staircase templates built (ATTN_MAXL: $(WINDOWS)). Run with DECODE_STAIRCASE=1."
+
+## Dynamic-runtime-sequence template: ONE build for every context length. The
+## context length becomes a runtime scalar, so a single xclbin plus the emitted
+## TXN builder serves any L and the readback moves only this token's context.
+## Run with DECODE_DYNSEQ=1. No pair: there is no slope to calibrate.
+compile-decode-dynseq:
+	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
+	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
+	@echo ">>> qwen2.5-7b non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
+	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	@echo ">>> qwen2.5-7b attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
+	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
+	@echo ">>> qwen2.5-7b dynseq template decode_dyn_L$(LBUILD)"
+	@cd $(DEC) && $(DECODE_ENV) DECODE_DYNSEQ=1 DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/q7b_decode_dyn_L$(LBUILD).log 2>&1; \
+	  if [ -f decode.xclbin ] && [ -f air_project/npu.air.txn.h ]; then \
+	    mv -f decode.xclbin $(srcdir)/decode_dyn_L$(LBUILD).xclbin; \
+	    cp -f air_project/npu.air.txn.h $(srcdir)/decode_dyn_L$(LBUILD).txn.h; \
+	    rm -f npu_seq_*.mlir; \
+	  else echo "decode_dyn_L$(LBUILD) FAILED (see /tmp/q7b_decode_dyn_L$(LBUILD).log)"; tail -30 /tmp/q7b_decode_dyn_L$(LBUILD).log; exit 1; fi
+	@echo "Qwen2.5-7B dynseq build complete: decode_dyn_L$(LBUILD). Run with DECODE_DYNSEQ=1."
+
+_compile_decode_build:
+	@# Delegate the llvm-link version preflight to the engine that owns it rather
+	@# than keeping a copy here: the rule (LLVM <23) must stay in one place, in
+	@# sync with lit.cfg.py's llvm_link_pre23 feature that gates this example's
+	@# lit tests (fused_decode/Makefile: preflight-llvm-link).
+	@$(MAKE) --no-print-directory -C $(DEC) preflight-llvm-link \
+	  PEANO_INSTALL_DIR=$(PEANO_INSTALL_DIR)
+	@echo ">>> qwen2.5-7b non-attn decode kernels (Peano -O2): $(NONATTN_KERNELS)"
+	@for k in $(NONATTN_KERNELS); do echo "    $$k.cc (-O2)"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O2 -c $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.o || exit 1; done
+	@echo ">>> qwen2.5-7b attn decode kernels (Peano -O1, inline .ll only): $(ATTN_LL_KERNELS)"
+	@for k in $(ATTN_LL_KERNELS); do echo "    $$k.ll"; \
+	  $(PEANO_INSTALL_DIR)/bin/clang++ $(PEANO_KBASE) -O1 -DDECODE_INLINE_ATTN -S -emit-llvm \
+	    $(DEC)/kernels/$$k.cc -o $(DEC)/$$k.ll || exit 1; done
+	@echo ">>> qwen2.5-7b template decode_L$(LBUILD) (+ L$(LREF) slope ref)"
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LBUILD) python3 $(DECODE_DRIVER) >/tmp/q7b_decode_L$(LBUILD).log 2>&1; \
+	  if [ -f decode.xclbin ]; then mv -f decode.xclbin $(srcdir)/decode_L$(LBUILD).xclbin; mv -f decode.insts.bin $(srcdir)/decode_L$(LBUILD).insts.bin; \
+	  else echo "decode_L$(LBUILD) FAILED (see /tmp/q7b_decode_L$(LBUILD).log)"; tail -30 /tmp/q7b_decode_L$(LBUILD).log; exit 1; fi
+	@cd $(DEC) && $(DECODE_ENV) DECODE_GOLDEN_L=$(LREF) python3 $(DECODE_DRIVER) >/tmp/q7b_decode_L$(LREF).log 2>&1; \
+	  if [ -f decode.insts.bin ]; then mv -f decode.insts.bin $(srcdir)/decode_L$(LREF).insts.bin; mv -f decode.xclbin $(srcdir)/decode_L$(LREF).xclbin; \
+	  else echo "decode_L$(LREF) FAILED (see /tmp/q7b_decode_L$(LREF).log)"; tail -30 /tmp/q7b_decode_L$(LREF).log; exit 1; fi
+	@echo "Qwen2.5-7B decode build complete: decode_L$(LBUILD) + decode_L$(LREF) templates."
+
+## Build/cache the 8 prefill ELFs (rms_qkv_qknorm_rope + flash_attn + o_res_norm +
+## gate + up + swiglu + down_add + lm_head_gemv). Weight-free build, no NPU dispatch.
+compile-prefill:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(PREFILL_DRIVER) --compile-only
+
+## Prefill-only Paris gate: PASS iff the first token argmax is 12095 (" Paris").
+prefill:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && python3 $(PREFILL_DRIVER)
+
+## Build everything the end-to-end chatbot needs: the prefill ELFs and the
+## decode templates.
+compile: compile-prefill compile-decode
+
+## Run inference (NPU prefill + fused NPU decode). With no PROMPT this is the
+## canonical Paris gate: PASS iff the first token is 12095 (" Paris").
+run:
+	@cd $(srcdir) && python3 qwen25_7b_q4nx_inference.py --n-tokens 9 $(PROMPT_ARG)
+
+## Single Q&A turn:  make ask PROMPT="What is the capital of France?"
+ask:
+	@cd $(srcdir) && python3 qwen25_7b_q4nx_inference.py \
+		--n-tokens $(N_TOKENS) $(PROMPT_ARG)
+
+## Interactive chat REPL (streaming). The prefill engine and decode templates are
+## built once and held across turns, so only the first turn pays the model load.
+chat:
+	@cd $(srcdir) && python3 qwen25_7b_q4nx_inference.py \
+		--interactive --n-tokens $(N_TOKENS)
+
+## Top-k token-set inclusion gate (NPU q4nx vs HF bf16, 2 prompts x 32 tokens,
+## k=5) -- the same gate, through the same shared verify/ subsystem, as the other
+## quantized examples.
+##
+## REFERENCE. The Q4NX bundle is converted from the bartowski
+## Qwen2.5-7B-Instruct Q4_0 GGUF, so the bf16 reference is
+## `Qwen/Qwen2.5-7B-Instruct` and both MODEL_CHOICE keys map to it -- a base-model
+## reference would disagree with the instruct weights it is checking. It is
+## ungated and loads directly with AutoModelForCausalLM. NOT the -1M variant:
+## same geometry, but rope_theta 1e7 instead of 1e6.
+verify:
+	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL_CHOICE) --max-prompts $(MAX_PROMPTS)
+
+## Full-sweep variant of `make verify` (all prompts in the prompt file).
+verify-full:
+	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts topk_token --model $(MODEL_CHOICE)
+
+## Fast weight-integrity smoke: prefill only, PASS iff the first-token argmax is
+## 12095 (" Paris"). Cheap -- no decode templates, no HF reference needed.
+verify-paris: prefill
+
+## Diagnosis lens (single prompt through the shared runner, informational).
+## The Q4NX prefill does not expose per-layer ffn_out and the decode runs all 28
+## layers in one dispatch, so this reports the token-level view, not per-layer
+## cosines.
+##
+## Its own prompt variable: PROMPT is empty by default (that is what selects the
+## canonical Paris prompt for `make run`), and an empty --prompt is not a prompt.
+DIAG_PROMPT ?= What is the capital of France?
+diagnosis:
+	cd $(srcdir)/.. && python3 $(VERIFY_RUNNER) --runner=$(RUNNER_ADAPTER) \
+		--prompts single --prompt "$(if $(PROMPT),$(PROMPT),$(DIAG_PROMPT))" \
+		--model $(MODEL_CHOICE)
+
+## Warm prefill TTFT at CTX (warmup pass, then a timed one). Isolates the
+## prefill dispatch from the one-time weight load the e2e path also pays.
+profile-prefill:
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && Q4NX_BENCH_L=$(CTX) python3 $(PREFILL_DRIVER)
+
+## End-to-end: TTFT + decode throughput over N_TOKENS tokens (prints the TTFT and
+## Tokens/second lines the nightly LLM benchmark extracts). Needs production
+## templates: make compile.
+profile:
+	@cd $(srcdir) && python3 qwen25_7b_q4nx_inference.py \
+		--n-tokens $(N_TOKENS) --no-eos-stop --prompt "$(PROFILE_PROMPT)"
+
+## Back-compat alias for the Paris gate.
+gen: run
+
+## Remove build artifacts, kernel/weight caches, and the decode templates. Also
+## removes the QWEN2_5_7B-compiled kernels this Makefile writes into the shared
+## fused_decode/ dir -- leaving them there makes another model's build silently
+## link Qwen2.5-7B objects.
+clean:
+	rm -f $(srcdir)/decode_L*.xclbin $(srcdir)/decode_L*.insts.bin 2>/dev/null || true
+	rm -f $(srcdir)/decode_dyn_L*.xclbin $(srcdir)/decode_dyn_L*.insts.bin \
+	      $(srcdir)/decode_dyn_L*.txn.h 2>/dev/null || true
+	rm -f $(DECODE_FLAGS_STAMP) $(DECODE_WINDOWS_STAMP) 2>/dev/null || true
+	rm -f $(addprefix $(DEC)/,$(addsuffix .o,$(NONATTN_KERNELS))) \
+	      $(addprefix $(DEC)/,$(addsuffix .ll,$(ATTN_LL_KERNELS))) 2>/dev/null || true
+	rm -rf $(srcdir)/build_peano $(srcdir)/build_chess $(srcdir)/__pycache__ \
+	       $(srcdir)/_q4nx_* 2>/dev/null || true
+	@echo "Qwen2.5-7B decode templates, build dirs and shared-dir kernels removed."

--- a/programming_examples/llms/qwen25_7b_q4nx/README.md
+++ b/programming_examples/llms/qwen25_7b_q4nx/README.md
@@ -1,0 +1,248 @@
+# QWEN2.5-7B Q4NX prefill + decode on AMD NPU2
+
+Qwen2.5-7B-Instruct in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
+the NPU:
+
+- **prefill** — a batched pass over the padded context: RMSNorm, Q/K/V GEMMs, the
+  q/k/v projection bias, RoPE, GQA flash attention, SwiGLU and the LM head, all on
+  device with resident weight BOs.
+- **decode** — **one NPU dispatch = 28 decoder layers + the LM head**, reading and
+  appending a shared per-layer KV cache seeded by the prefill.
+
+Weights are Q4NX throughout (dequantized on device for decode, on the host at load
+for prefill).
+
+This is the first **`HAS_QKV_BIAS`** model on the shared superkernel engine in
+[`programming_examples/fused_decode`](../../fused_decode/), selected with
+`DECODE_MODEL=qwen2.5-7b`.
+
+## Weights
+
+Unlike the [Qwen3-8B sibling](../qwen3_8b_q4nx/), there is no bundle to
+download: **FastFlowLM publishes no Qwen2.5-7B NPU2 model** — their Qwen2.5 line
+stops at 3B. So this example quantizes the upstream bf16 checkpoint itself, the
+way the [Qwen2.5-3B Q4_0 sibling](../qwen25_3b_q4/) does for the analogous
+reason, and needs nothing beyond an ungated HF repo:
+
+```bash
+make run                                   # MODEL_SOURCE=Qwen/Qwen2.5-7B-Instruct
+make run MODEL_SOURCE=/path/to/checkpoint  # or a local checkpoint dir
+```
+
+Every projection is rounded onto the Q4NX grid at load by
+`quantize_dequantize_q4nx` — the **same** quantizer the decode cascade cache
+uses — so the prefill and the fused decode see bit-identical weights, and the
+prefill models the 4-bit datapath the hardware actually runs rather than
+flattering it with bf16. Norms and the q/k/v biases stay bf16, as in the
+reference design.
+
+A `model.q4nx` bundle is still accepted (`MODEL_SOURCE=<dir with model.q4nx>`)
+for anyone who has one. Note that FastFlowLM's converter writes its Qwen2.5
+output through a custom nibble interleave
+(`q4nx/gguf_tensor.py: transform_nibble_layout`) that their Llama/Qwen3 bundles
+do not use, so a Qwen2.5 bundle is **not** byte-interchangeable with those — the
+loader here implements the Llama/Qwen3 layout.
+
+## Architecture
+
+Verified against the HF `config.json` and FastFlowLM's own
+`generic_decoding_layer/models/qwen2.5-7b.h`:
+
+| | |
+|---|---|
+| model dim / head dim | 3584 / 128 |
+| attention | 28 query heads, 4 KV heads (GQA 7), scale 1/sqrt(128) |
+| MLP | intermediate 18944, SwiGLU |
+| layers / vocab | 28 / 152064 (**untied** — a separate Q4NX `lm_head`) |
+| norms | 2 per layer (input, post-attention), plain `w`, eps 1e-6 |
+| RoPE | single theta 1e6, half-split |
+| extras | **q/k/v projection bias**; no qk-norm, no sliding window, no embed scale |
+
+## Performance (NPU2, 28 layers, warm)
+
+Measured on an **AMD Ryzen AI 9 HX 370** (Strix Point, XDNA2 / NPU2), 96 GB,
+Ubuntu 25.04, XRT 2.23.0 (engine built, weights resident):
+
+| | |
+|---|---|
+| prefill (TTFT) | **10.0 s** at CTX=2048 (205 tok/s); 9.99 s on-device, 10 ms host |
+| decode | **11.46 tok/s** (87.2 ms/token), ATTN_MAXL=2048, 64 tokens |
+
+FastFlowLM publishes no Qwen2.5-7B bundle, so there is no vendor decode number to
+compare against here — unlike the Qwen3-8B and Gemma3-4B siblings.
+
+Prefill runs at a fixed padded context (`CTX`), so its cost is roughly constant in
+prompt length rather than proportional to it. Measure it with `make
+profile-prefill`. On-device time per op at CTX=2048 (summed over 28 layers):
+
+| gate | up | flash_attn | down_add | rms_qkv_bias_rope | o_res_norm | swiglu | lm_head_gemv |
+|---|---|---|---|---|---|---|---|
+| 2353 ms | 2340 | 1120 | 826 | 464 | 311 | 279 | 31 (x1) |
+
+Of the ~8.4 s of measured XRT time, 91% is NPU execution, 7% host→DDR writes of the
+dynamic inputs and 2% readback. Unlike the Gemma3-4B sibling the lever here is not
+attention: the two FFN GEMMs are 61% of device time on their own, because
+`INTERMEDIATE_SIZE=18944` is 5.3x hidden (2.7-4.0x for every other model in
+`llms/`).
+
+Separately, loading the model — Q4NX host dequant of ~6 GB of weights plus the
+one-time write into resident BOs — takes ~130 s per process with a warm HF cache.
+That is a startup cost, not part of TTFT; the driver reports the two separately.
+
+## Prerequisites
+
+- NPU2 (Strix / AIE2P) + XRT, and a Peano (llvm-aie) install
+- `source utils/env_setup.sh` (see the repo README)
+- Weights: nothing to fetch beyond the ungated `Qwen/Qwen2.5-7B-Instruct`
+  checkpoint (see [Weights](#weights))
+- Python deps on top of the base environment: `pip install -r requirements.txt`
+- ~5 GB of host memory for the decode weight BOs (five buffers, see below)
+
+## Quick Start
+
+```bash
+# Build everything, weight-free: the prefill ELFs + the decode templates.
+# Production decode templates are ATTN_MAXL=2048.
+make compile
+
+# ...or just one half:
+make compile-prefill            # the prefill ELFs (CTX=2048)
+make compile-decode LBUILD=64   # small decode templates (much faster)
+
+# Correctness gate: top-k token-set inclusion vs HF bf16 (k=5, 32 tokens).
+make verify       # 2-prompt CI slice;  make verify-full  sweeps every prompt
+
+# Demo run: greedy decode, prints a *** PARIS *** verdict.
+make run
+
+# Prefill only (no decode loop, no reference) -- first-token 12095 smoke.
+make prefill      # or: make verify-paris
+
+# A single Q&A turn on your own prompt.
+make ask PROMPT="What is the capital of France?" N_TOKENS=32
+
+# Interactive chat, streaming. The engine is built once and held across turns.
+make chat N_TOKENS=64
+
+# Decode throughput over N_TOKENS tokens (needs the production templates).
+make profile N_TOKENS=64
+
+# A local bundle instead of the default repo id.
+make run MODEL_SOURCE=/path/to/qwen25_7b_q4nx_bundle
+```
+
+## Correctness
+
+`make verify` is the shared gate every `llms/` example uses: top-k token-set
+inclusion (k=5, first divergence over 32 greedy tokens) of the NPU q4nx run
+against an HF **bf16** reference, driven through
+[`verify_adapter.py`](verify_adapter.py) and `llms/verify/`.
+
+**The reference is `Qwen/Qwen2.5-7B-Instruct`** — the very checkpoint the NPU
+weights are quantized from, so the gate measures the 4-bit loss and nothing else.
+Ungated, so CI needs no license grant. Not `Qwen2.5-7B-Instruct-1M`: same
+geometry, but it ropes at theta 1e7 instead of 1e6.
+
+## How it works
+
+### Prefill
+
+The prefill is a **thin driver over the config-parameterized builders in
+[`qwen25_3b`](../qwen25_3b/)** — same Qwen2.5 block shape, different constants —
+rather than a self-contained clone. `qwen25_7b_q4nx_weights.py` supplies the
+config and builds that example's `LlamaWeights`/`LayerWeights` from the
+quantized checkpoint; those containers already carry the `bq`/`bk`/`bv` fields the
+`rms_qkv_bias_rope` kernel needs.
+
+Two things at 7B are not just bigger constants:
+
+- **`q_dim == emb_dim`.** Both are 3584, so the O-projection is a square
+  2048x3584x3584 GEMM.
+- **A separate `lm_head`.** Qwen2.5-7B sets `tie_word_embeddings=false` (the 3B
+  ties), so the requant emits a real vocab weight slab rather than reusing the
+  embedding.
+- **SwiGLU has to be split.** At hidden=18944 a single launch needs 1024 DMA
+  iterations and exhausts the shim's 16 buffer descriptors; `herd_x` caps at 8
+  and `tile_n` at ~5120 (L1), so the floor is 1024. `swiglu_plan` in
+  `qwen25_3b/qwen25_3b_prefill.py` splits it into 2 row chunks of 512 iters
+  (SwiGLU is elementwise, so a row split is exact) and returns a single chunk —
+  the unchanged path — for every smaller hidden_dim.
+
+Unlike Qwen3-8B at K=4096, the LM-head GEMV needs no unusual tile knobs: the L2 A
+stage needs `herd_m * tile_m * (K+1) * 2 <= 512 KiB`, which at K=3584 allows
+`herd_m * tile_m <= 73`, so the default 64 fits. Only `m_input` comes down to 2,
+because `m_input=4` would put the ping-pong L1 A tiles at 2x28 KiB of a 64 KiB L1.
+`tile_m` stays 8, so the default `mv.o` is reused as-is.
+
+All four GEMM shapes (2048x3584x{3584,512,18944} and 2048x18944x3584) are in
+`kernel_registry/details/GEMM_bf16_in_bf16_out.json`; `gemm_config` raises on an
+unregistered shape, so they must be there before the prefill will build.
+
+### Decode
+
+The decode engine is shared with the other q4nx examples. Qwen2.5-7B differs in
+two model-level ways and one engine-level way:
+
+**The q/k/v projection bias (`HAS_QKV_BIAS`).** Qwen2.5 is the only family here
+whose Q/K/V projections carry a bias. The kernel side already existed
+(`fused_decode/kernels/rope.cc::add_q_k_v_bias`, added for the Qwen2.5-3B Q4_0
+example) and adds the bias in place *before* RoPE, reading it at `rope_w + DH`.
+What was missing was the engine allocating that slab: `ROPE_W_LEN` was
+`(3*DH) if HAS_QK_NORM else ROPE_DIM`, with no bias branch, so this model adds
+`DH + (DQ+DK+DV) = 128 + 4608 = 4736`. The driver rewrites the whole slab each
+position (the cos/sin half changes; the bias half is constant).
+
+**Non-paired proj egress (`PAIR_ROWS=1`).** D=3584 is 7 col-blocks wide, which is
+odd in units of the paired egress: `PAIR_ROWS=2` would need
+`I2P[0] = 4608/1024 = 4.5`. So this model takes the gemma-style non-paired path,
+where each compute tile emits one block into a 4-way memtile gather.
+
+**LM-head vocab chunking is forced, not chosen.** `VOCAB_SIZE_PADDED_FULL =
+ceil(152064/3584)*3584 = 154112` → 4816 rowblocks, and `VOCAB_ROWBLKS =
+16*VOCAB_I2` at `PAIR_ROWS=1` must divide it, so `UNI_LM * VOCAB_I2 = 301 = 7*43`
+and `VOCAB_I2 ∈ {1,7,43,301}`. `K/PAYLOAD = 3584/512 = 7` must divide
+`VOCAB_RNDS = VOCAB_I2*PAIR_ROWS`, which drops 1; the tested `2*VOCAB_I2 <= 63`
+envelope drops 43 and 301. **`VOCAB_I2=7` is the only legal chunk** → 43 waves of
+112 rowblocks. Getting this wrong deadlocks the vocab wave rather than failing
+loudly, so the driver must set `VOCAB_CHUNK_I2=7` to match `UNI_LM=43`.
+
+**The weight buffer is split (`DECODE_WGROUP`).** A shim BD's byte offset is a
+`uint32` all the way down, so **one BO is only addressable over a 4 GiB span**.
+28 layers of Q4NX weights are 3.80 GiB and the lm-head adds 0.32 GiB, so the total
+crosses the line. `DECODE_WGROUP=7` splits the layers over four 0.95 GiB buffers
+plus a dedicated lm-head buffer — nine buffer args, still **one dispatch**. See
+the [Qwen3-8B README](../qwen3_8b_q4nx/README.md#decode) for the mechanism and its
+two load-bearing constraints (the selector must fold, and the switch must wrap the
+whole phase fan).
+
+## Decode staircase (opt-in)
+
+The decode template streams `ATTN_MAXL` KV positions per token regardless of the
+real context length, so a 2048-window build wastes most of that readback at short
+context. Building one template pair per window and dispatching each token on the
+smallest covering window recovers it, with a token stream identical to the
+single-window baseline.
+
+```bash
+make compile-decode-windows      # once; WINDOWS="64 512 2048" to override the set
+DECODE_STAIRCASE=1 make run
+```
+
+Off by default, and not benchmarked for this model — the numbers in
+[Performance](#performance-npu2-28-layers-warm) are single-window. See
+[`programming_examples/fused_decode/README.md`](../../fused_decode/README.md) for
+the mechanism, the measurements on its sibling models and the `.decode_windows`
+manifest guard.
+
+## Key Files
+
+| file | role |
+|---|---|
+| `qwen25_7b_q4nx_inference.py` | driver: AIR prefill (KV seed + first token) + fused NPU decode loop; owns `DECODE_WGROUP` |
+| `qwen25_7b_q4nx_prefill.py` | thin driver over the `qwen25_3b` builders + its `causal_lm` interface |
+| `qwen25_7b_q4nx_weights.py` | weight sources (HF quantize-on-load, or a `model.q4nx` bundle), RoPE LUTs, numpy reference |
+| `qwen25_7b_q4nx_requant.py` | the Q4NX quantizer + the decode cascade cache (2 norm stacks + the untied lm_head) |
+| `Makefile` | build / run / verify / verify-full / verify-paris / diagnosis / profile |
+| `verify_adapter.py` | Binds the Q4NX prefill + fused decode to the shared `verify/` runner contract |
+| `../../fused_decode/models/qwen2.5-7b.h` | kernel-side model config |
+| `../../fused_decode/fused_decode.py` | the shared superkernel IR builder |

--- a/programming_examples/llms/qwen25_7b_q4nx/README.md
+++ b/programming_examples/llms/qwen25_7b_q4nx/README.md
@@ -61,33 +61,38 @@ Verified against the HF `config.json` and FastFlowLM's own
 ## Performance (NPU2, 28 layers, warm)
 
 Measured on an **AMD Ryzen AI 9 HX 370** (Strix Point, XDNA2 / NPU2), 96 GB,
-Ubuntu 25.04, XRT 2.23.0 (engine built, weights resident):
+Ubuntu 25.04, XRT 2.23.0 (engine built, weights resident). Every prefill figure
+below is from a single `make profile-prefill` run, so they reconcile:
 
 | | |
 |---|---|
-| prefill (TTFT) | **10.0 s** at CTX=2048 (205 tok/s); 9.99 s on-device, 10 ms host |
+| prefill (TTFT) | **9.59 s** at CTX=2048 (214 tok/s); 9.58 s on-device, 8 ms host |
 | decode | **11.46 tok/s** (87.2 ms/token), ATTN_MAXL=2048, 64 tokens |
 
 FastFlowLM publishes no Qwen2.5-7B bundle, so there is no vendor decode number to
 compare against here — unlike the Qwen3-8B and Gemma3-4B siblings.
 
 Prefill runs at a fixed padded context (`CTX`), so its cost is roughly constant in
-prompt length rather than proportional to it. Measure it with `make
-profile-prefill`. On-device time per op at CTX=2048 (summed over 28 layers):
+prompt length rather than proportional to it. On-device time per op at CTX=2048
+(NPU-execution only, summed over 28 layers):
 
-| gate | up | flash_attn | down_add | rms_qkv_bias_rope | o_res_norm | swiglu | lm_head_gemv |
+| up | gate | flash_attn | down_add | rms_qkv_bias_rope | o_res_norm | swiglu | lm_head_gemv |
 |---|---|---|---|---|---|---|---|
-| 2353 ms | 2340 | 1120 | 826 | 464 | 311 | 279 | 31 (x1) |
+| 2368 ms | 2358 | 1135 | 837 | 451 | 311 | 286 | 31 (x1) |
 
-Of the ~8.4 s of measured XRT time, 91% is NPU execution, 7% host→DDR writes of the
-dynamic inputs and 2% readback. Unlike the Gemma3-4B sibling the lever here is not
-attention: the two FFN GEMMs are 61% of device time on their own, because
-`INTERMEDIATE_SIZE=18944` is 5.3x hidden (2.7-4.0x for every other model in
-`llms/`).
+Those sum to 7776 ms. The three prefill totals are different scopes, which is why
+they differ: **7.78 s** of NPU execution, **8.50 s** of instrumented XRT call time
+(adds 577 ms of host→DDR writes of the dynamic inputs and 142 ms of readback), and
+**9.59 s** of wall TTFT (adds ~1.1 s of host-side Python between dispatches).
 
-Separately, loading the model — Q4NX host dequant of ~6 GB of weights plus the
-one-time write into resident BOs — takes ~130 s per process with a warm HF cache.
-That is a startup cost, not part of TTFT; the driver reports the two separately.
+Unlike the Gemma3-4B sibling the lever here is not attention: `up` + `gate` alone
+are 61% of NPU time, because `INTERMEDIATE_SIZE=18944` is 5.3x hidden (2.7-4.0x
+for every other model in `llms/`).
+
+Separately, loading the model — the HF bf16 read, the Q4NX host dequant, and the
+write into resident BOs — takes ~130 s per process with a warm HF cache and peaks
+at **~33 GB RSS** (measured: 32.6 GB for the prefill path alone). That is a
+startup cost, not part of TTFT; the driver reports the two separately.
 
 ## Prerequisites
 
@@ -96,7 +101,9 @@ That is a startup cost, not part of TTFT; the driver reports the two separately.
 - Weights: nothing to fetch beyond the ungated `Qwen/Qwen2.5-7B-Instruct`
   checkpoint (see [Weights](#weights))
 - Python deps on top of the base environment: `pip install -r requirements.txt`
-- ~5 GB of host memory for the decode weight BOs (five buffers, see below)
+- **~33 GB of host RAM.** Peak is the load phase, not the run: the bf16
+  checkpoint, the Q4NX dequant and the resident BOs (five decode weight
+  buffers, 4x0.95 GB + 0.32 GB) are live together. Measured 32.6 GB peak RSS.
 
 ## Quick Start
 

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_inference.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_inference.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""qwen25_7b_q4nx full inference -- FLM-faithful Qwen2.5-7B prefill + decode.
+
+Reproduces FastFlowLM's Qwen2.5-7B mechanism end to end on the NPU:
+
+  prefill: the batched AIR prefill (qwen25_7b_q4nx_prefill.Qwen25Q4nxPrefill) -- a
+    thin driver over the qwen25_3b builders (rms+QKV+bias+RoPE, head-first
+    flash attention, O+residual+RMSNorm, gate/up/SwiGLU, down+add) with resident
+    weight BOs, plus an on-device 10-partition LM head GEMV. Produces the
+    per-layer roped-K / raw-V KV seed and the greedy first token.
+  decode: the shared fused_decode engine (DECODE_MODEL=qwen2.5-7b) -- 28 decoder
+    layers + the UNTIED lm-head in ONE dispatch, standard 2-norm pre-norm, SiLU
+    GLU, single-theta RoPE with the q/k/v projection bias added before rotation,
+    appending each new token's K/V in place.
+
+`--numpy-prefill` swaps the NPU prefill for the numpy reference forward
+(qwen25_7b_q4nx_weights.forward_prompt) -- the oracle the prefill is checked
+against, kept as a fallback and for debugging (it takes tens of seconds).
+
+The decode is ONE xclbin built at ATTN_MAXL (=16*ceil(L/16)); DecodeInstsGen patches
+the L-dependent insts words (attention RTP-L + KV-append offset) per token. The RMS BO
+holds UNI_DEC per-layer norm slabs [input|post_attn], then UNI_DEC per-layer rope_w
+slabs [cos/sin | q_bias | k_bias | v_bias] (rewritten per position), then the final norm.
+
+Run:
+  python3 qwen25_7b_q4nx_inference.py                 # Paris gate (greedy, PARIS_GREEDY)
+  python3 qwen25_7b_q4nx_inference.py --prompt "The capital of France is" --n-tokens 12
+  python3 qwen25_7b_q4nx_inference.py --numpy-prefill # numpy-oracle prefill instead
+"""
+
+import os
+import sys
+import argparse
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PE = _HERE.parent.parent  # programming_examples
+_DEC = _PE / "fused_decode"  # shared fused superkernel decode engine
+sys.path.insert(0, str(_HERE))
+
+# HF repo id of the self-contained model.q4nx bundle, or a local dir/file
+# (qwen25_7b_q4nx_weights resolves all three).
+MODEL_DEFAULT = os.environ.get("Q4NX_MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
+# "The capital of France is" (Qwen2.5 tokenizer, no BOS); prefill -> 12095 " Paris".
+PARIS_PROMPT = [785, 6722, 315, 9625, 374]
+PARIS_FIRST = 12095
+# Greedy continuation at the gate shape (`make run` uses --n-tokens 9). The gate checks
+# this, not just PARIS_FIRST: a decode that starts right and then drifts is a real
+# failure mode here -- a stale decode template yields a correct first token and fluent
+# garbage after it, which a first-token gate passes. Greedy, so deterministic; re-record
+# from `make run` if a deliberate numerics change moves it. None until first recorded,
+# in which case the gate checks the first token only and prints the run to paste back.
+PARIS_GREEDY = [12095, 13, 1084, 374, 7407, 304, 279, 18172, 949, 315]
+EOS_IDS = (151643, 151645)  # <|endoftext|>, <|im_end|>
+# Decode layers per weight BO. A shim BD's byte offset is a uint32, so ONE buffer
+# is only addressable over 4 GiB; 28 layers of Q4NX weights are 3.80 GiB and the
+# 0.32 GiB lm-head pushes the total past the line. 7 gives four 0.95 GiB groups
+# plus the lm-head on its own. Must match the value the templates were built with.
+DECODE_WGROUP = 7
+_Q4NX_CACHE = os.path.expanduser("~/.cache/q4nx_qwen25_7b")
+
+
+def _ensure_requant_cache(fd, model):
+    """Return the decode q4k-cascade cache path, building it from model.q4nx on first
+    use (one-time ~pack of 28 layers + lm-head). Honors Q4NX_QWEN25_7B_DECODE_NPZ."""
+    rc = os.environ.get("Q4NX_QWEN25_7B_DECODE_NPZ")
+    if rc and os.path.exists(rc):
+        return rc
+    import qwen25_7b_q4nx_requant as rq
+
+    # W_DUAL_CHAN reorders the cascade (the two-MM2S weight feed splits it by
+    # cascade pair into [low-row half | high-row half]), so it gets its own cache
+    # entry -- a warm single-channel cache would feed the dual-channel xclbin the
+    # wrong blocks.
+    _w2 = "_w2ch" if getattr(fd, "W_DUAL_CHAN", 0) else ""
+    rc = rc or os.path.join(_Q4NX_CACHE, f"requant{_w2}.npz")
+    if not os.path.exists(rc):
+        rq.build_requant_cache(model, fd, rc)
+    os.environ["Q4NX_QWEN25_7B_DECODE_NPZ"] = rc
+    return rc
+
+
+# Qwen2.5-7B decode xclbins (decode_L<N>) live in this example's own artifact dir so they
+# don't collide with the Llama builds in fused_decode/. DecodeInstsGen (the L->insts
+# affine specializer) is imported from fused_decode/ but scans this dir for templates.
+_DECODE_DIR = Path(os.environ.get("Q4NX_QWEN25_7B_DECODE_DIR", str(_HERE)))
+
+# decode_staircase lives in fused_decode/, which joins sys.path in _pick_decode_gen;
+# imported lazily and cached for the methods that need it.
+_stair = None
+
+
+def _load_stair():
+    global _stair
+    if _stair is None:
+        import decode_staircase
+
+        _stair = decode_staircase
+    return _stair
+
+
+_dyn = None  # set by _pick_decode_gen, which joins fused_decode/ to sys.path
+
+
+def _pick_decode_gen(dec_dir, max_L=None):
+    sys.path.insert(0, str(_DEC))
+    global _dyn
+    import decode_dynseq as _dyn
+    from decode_dynseq import pick_insts_gen
+
+    return pick_insts_gen(str(dec_dir), max_L=max_L)
+
+
+class FusedDecoder:
+    """One-xclbin Qwen2.5-7B fused decode. A SINGLE decode xclbin built at ATTN_MAXL serves
+    every L in [1, ATTN_MAXL] via a per-token RTP-L + KV-append insts patch (DecodeInstsGen).
+    The weight + KV BOs are uploaded once; the kernel appends each new token's K/V in place.
+    """
+
+    def __init__(self, model=MODEL_DEFAULT, max_L=None, staircase=False):
+        import importlib.util
+        import numpy as np
+        from ml_dtypes import bfloat16
+        import pyxrt as xrt
+        import qwen25_7b_q4nx_weights as gw
+
+        self.np = np
+        self.bf16 = bfloat16
+        self.xrt = xrt
+        self.gw = gw
+
+        self.gen = _pick_decode_gen(_DECODE_DIR, max_L)
+        _load_stair()
+        # Staircase: hold every calibrated ATTN_MAXL window and dispatch each token on the
+        # smallest one covering L (the readback streams ATTN_MAXL positions regardless).
+        # Off by default -- one window, identical to the single-template path.
+        self.windows = _stair.resolve_windows(self.gen, staircase)
+        self.ATTN_MAXL = max(self.windows)
+        self.maxL = min(int(max_L), self.ATTN_MAXL) if max_L else self.ATTN_MAXL
+
+        # DECODE_MODEL / geometry env must be set BEFORE importing fused_decode.py (its
+        # module-level constants read them). Matches the Llama driver's env block.
+        os.environ.update(
+            DECODE_MODEL="qwen2.5-7b",
+            UNIFIED="1",
+            VOCAB_CHUNK_I2="7",
+            LM_HEAD="0",
+            NLAYERS="1",
+            DECODE_GOLDEN="1",
+            DECODE_GOLDEN_L=str(self.ATTN_MAXL),
+            DECODE_WGROUP=str(DECODE_WGROUP),
+        )
+        spec = importlib.util.spec_from_file_location(
+            "fu_qwen25_7b", str(_DEC / "fused_decode.py")
+        )
+        fd = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(fd)
+        _ensure_requant_cache(fd, model)
+
+        self.UNI_DEC = fd.UNI_DEC
+        self.UNI_LM = fd.UNI_LM
+        self.K = fd.K
+        self.DH = fd.DH
+        self.RMS_LAYER = fd.RMS_LAYER
+        self.ROPE_W_LEN = fd.ROPE_W_LEN
+        self.KVSZ_TOK = fd.KVSZ_TOK
+        self.DK_TOT_A = fd.DK_TOT_A
+        self.NGRP = fd.NGRP
+        self.REGION_W = fd.REGION_W
+        self.REGION_STRIDE = fd.REGION_STRIDE
+        self.VP = fd.VOCAB_SIZE_PADDED
+        self.VOCAB_SIZE = fd.VOCAB_SIZE
+        self.decode_y = (fd.HOST_ROUNDS + fd.LAYER_RNDS) * fd.PAYLOAD
+        self.ny = self.decode_y + self.UNI_LM * self.VP
+        # RMS BO: [UNI_DEC per-layer norm slabs | UNI_DEC per-layer rope_w slabs | final_norm]
+        self._rope_base = self.UNI_DEC * self.RMS_LAYER
+        self._final_off = self._rope_base + self.UNI_DEC * self.ROPE_W_LEN
+        self._RMS_SIZE = self._final_off + self.K
+        self.LREG = self.ATTN_MAXL * self.KVSZ_TOK
+
+        # host weights: embed (x0 gather), final_norm (RMS BO), per-layer q/k/v bias (rope_w).
+        self.qm = gw.open_weight_source(model)
+        # Fetch embed/norm directly rather than via embed_norm_lmhead(): the decode
+        # reads its lm-head from the requant cache, and on the quantize-on-load
+        # source that accessor would quantize all 545M lm_head params just to
+        # discard them.
+        self.embed = np.asarray(
+            self.qm.bf16("model.embed_tokens.weight"), bfloat16
+        ).reshape(-1, self.K)
+        self.final_norm = np.asarray(self.qm.bf16("model.norm.weight"), bfloat16)
+        self.bias = [
+            self.qm.layer_qkv_bias(L) for L in range(self.UNI_DEC)
+        ]  # (bq[DQ], bk[DK], bv[DV])
+
+        # decode weights (q4k-cascade) + the 2 RMS norm stacks from the requant cache.
+        _z = np.load(os.environ["Q4NX_QWEN25_7B_DECODE_NPZ"])
+        W = _z["W"].view(bfloat16)
+        self.Wv16 = W.view(np.int16) if W.dtype != np.int16 else W
+        _rms = {n: list(_z[n].view(bfloat16)) for n in ("RMS_in", "RMS_post")}
+        self.rms_slabs = np.concatenate(
+            [
+                np.concatenate([_rms["RMS_in"][k], _rms["RMS_post"][k]])
+                for k in range(self.UNI_DEC)
+            ]
+        )
+        assert self.rms_slabs.size == self._rope_base, (
+            self.rms_slabs.size,
+            self._rope_base,
+        )
+
+        print(
+            f"[decode] qwen2.5-7b ONE xclbin: ATTN_MAXL={self.ATTN_MAXL}, serves "
+            f"L in [1,{self.maxL}]; {self.UNI_DEC} layers + lm-head/dispatch",
+            flush=True,
+        )
+
+        # ONE xclbin + ONE self-contained BO set (weight BO uploaded once)
+        self.dev = xrt.device(0)
+        TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        self._kern = _stair.open_windows(self.dev, xrt, self.gen, self.windows)
+        self.cur_maxl = self.ATTN_MAXL
+        self.kern = self._kern[self.cur_maxl][1]
+        g = self.kern.group_id
+        HO = xrt.bo.host_only
+        self.x_bo = xrt.bo(self.dev, self.K * 2, HO, g(3))
+        # DECODE_WGROUP: the engine splits the weights over ceil(UNI_DEC/G) layer
+        # buffers plus a dedicated lm-head buffer, because one BO can only be
+        # addressed over a 4 GiB span (the shim BD byte offset is a uint32). Group 0
+        # stays on the original arg (g(4)); the rest are appended after kvc, so every
+        # pre-existing binding position is unchanged.
+        # Taken from the engine, not the environment, so the host slicing cannot
+        # disagree with what the template was built for.
+        _G, self._wsplit, _ng = fd.W_GROUP, fd.W_SPLIT, fd.N_WGRP
+        if self._wsplit:
+            _WL = fd.W_LAYER
+            _parts = [
+                W[gi * _G * _WL : min((gi + 1) * _G, self.UNI_DEC) * _WL]
+                for gi in range(_ng)
+            ]
+            _parts.append(W[self.UNI_DEC * _WL :])  # lm-head slabs
+            assert sum(p.size for p in _parts) == W.size, "weight split lost data"
+            # group 0 -> g(4); groups 1.. and lm-head -> g(8), g(9), ...
+            self.w_bos = [
+                xrt.bo(self.dev, p.size * 2, HO, g(4 if i == 0 else 7 + i))
+                for i, p in enumerate(_parts)
+            ]
+            for bo, p in zip(self.w_bos, _parts):
+                bo.write(np.ascontiguousarray(p).view(np.int16), 0)
+                bo.sync(TO)
+            print(
+                f"[decode] weight split G={_G}: "
+                + ", ".join(f"{p.size*2/2**30:.2f}GiB" for p in _parts),
+                flush=True,
+            )
+            self.w_bo = self.w_bos[0]
+        else:
+            self.w_bos = None
+            self.w_bo = xrt.bo(self.dev, W.size * 2, HO, g(4))
+        self.r_bo = xrt.bo(self.dev, self._RMS_SIZE * 2, HO, g(5))
+        self.y_bo = xrt.bo(self.dev, self.ny * 2, HO, g(6))
+        self.kvc = xrt.bo(self.dev, self.UNI_DEC * self.LREG * 2, HO, g(7))
+        self._ist = _stair.make_insts_states(
+            self.gen, xrt, self.dev, g(1), self.windows
+        )
+        self._geom = _stair.KVGeometry(
+            self.UNI_DEC, self.KVSZ_TOK, self.REGION_W, self.NGRP, self.LREG
+        )
+        self._use_window(self.cur_maxl)
+        if not self._wsplit:
+            self.w_bo.write(self.Wv16, 0)
+            self.w_bo.sync(TO)
+        self.KV = np.zeros((self.UNI_DEC, self.LREG), dtype=bfloat16)
+
+    def _use_window(self, m):
+        """Point the active kernel / insts state at window `m` (no KV movement)."""
+        self._st = self._ist[m]
+        self.cur_maxl = m
+        self.kern = self._kern[m][1]
+        self.ib = self._st["ib"]
+
+    def seed_kv(self, fk, fv, P):
+        """Place the numpy-prefill K/V (fk/fv: [UNI_DEC,P,DK_TOT_A]) into the device KV cache
+        region-major, then prefetch to the device (before the timed decode loop)."""
+        np = self.np
+        if len(self.windows) > 1:
+            self._use_window(self.gen.window_for_L(P + 1))
+        RW, NG = self.REGION_W, self.NGRP
+        RS = self.cur_maxl * RW
+        self.KV[:] = 0
+        for Lyr in range(self.UNI_DEC):
+            for gi in range(NG):
+                self.KV[Lyr, gi * RS : gi * RS + P * RW].reshape(P, RW)[:] = fk[
+                    Lyr, :P, gi * RW : (gi + 1) * RW
+                ].astype(self.bf16)
+                self.KV[Lyr, (NG + gi) * RS : (NG + gi) * RS + P * RW].reshape(P, RW)[
+                    :
+                ] = fv[Lyr, :P, gi * RW : (gi + 1) * RW].astype(self.bf16)
+        TO = self.xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        _lreg = self._geom.lreg(self.cur_maxl)
+        for Lyr in range(self.UNI_DEC):
+            boff = Lyr * _lreg * 2
+            self.kvc.write(self.KV[Lyr, :_lreg].view(np.int16), boff)
+            self.kvc.sync(TO, _lreg * 2, boff)
+        self._kv_dirty = False
+
+    def _rope_slab(self, p):
+        """Build the UNI_DEC per-layer rope_w slabs for position p (single-theta cos/sin +
+        the per-layer q/k/v bias), concatenated: [layer0 (ROPE_W_LEN) | layer1 | ...].
+        """
+        np = self.np
+        return np.concatenate(
+            [self.gw.rope_w_layer(p, L, *self.bias[L]) for L in range(self.UNI_DEC)]
+        ).astype(self.bf16)
+
+    def dispatch(self, tok, p):
+        """One decode step at L=p+1: patch insts for L, write x0/rope, dispatch (28 layers +
+        lm-head), return logits. Appends the new token's K/V at slot p on-device."""
+        np = self.np
+        xrt = self.xrt
+        TO = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+        FROM = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
+        L = p + 1
+        # insts: write full stream once, then patch only the L-dependent [lo:hi] slice.
+        if len(self.windows) > 1:
+            _w = self.gen.window_for_L(L)
+            if _w != self.cur_maxl:
+                # `p` positions are live; this token's K/V is appended by the dispatch.
+                _stair.respace_kv(self.kvc, self._geom, self.cur_maxl, _w, p, xrt)
+                self._use_window(_w)
+        insts_size = _stair.patch_insts(self._st, L, xrt, TO)
+        # KV uploaded once (seed), then device-resident (kernel appends in place).
+        if getattr(self, "_kv_dirty", True):
+            packed = np.ascontiguousarray(self.KV).reshape(-1)
+            self.kvc.write(packed.view(np.int16), 0)
+            self.kvc.sync(TO)
+            self._kv_dirty = False
+        x0 = np.asarray(self.embed[tok], self.bf16)  # Qwen2.5 has no embedding scale
+        # RMS BO: norm slabs + final_norm constant; write once, then patch the per-layer
+        # rope region each token (positions change cos/sin).
+        if not hasattr(self, "_rms_init"):
+            _rmsbuf = np.concatenate(
+                [
+                    self.rms_slabs,
+                    np.zeros(self.UNI_DEC * self.ROPE_W_LEN, self.bf16),
+                    self.final_norm,
+                ]
+            )
+            assert _rmsbuf.size == self._RMS_SIZE, (_rmsbuf.size, self._RMS_SIZE)
+            self.r_bo.write(_rmsbuf.view(np.int16), 0)
+            self.r_bo.sync(TO)
+            self._rms_init = True
+        rope = self._rope_slab(p)
+        self.r_bo.write(rope.view(np.int16), self._rope_base * 2)
+        self.r_bo.sync(TO, rope.size * 2, self._rope_base * 2)
+        self.x_bo.write(x0.view(np.int16), 0)
+        self.x_bo.sync(TO)
+        st = self.kern(
+            3,
+            self.ib,
+            insts_size,
+            self.x_bo,
+            self.w_bo,
+            self.r_bo,
+            self.y_bo,
+            self.kvc,
+            *(self.w_bos[1:] if self._wsplit else ()),
+            *_dyn.dispatch_args(self.gen, L),
+        ).wait(60000)
+        _voc_n = self.UNI_LM * self.VP
+        self.y_bo.sync(FROM, _voc_n * 2, self.decode_y * 2)
+        # Zero-copy view into the BO (the shared infra's readback idiom): bo.read()
+        # returns a buffer whose stride metadata is pyxrt-build dependent, and
+        # .view() on it raises on some runners.
+        yv = np.frombuffer(
+            self.y_bo.map(), dtype=self.bf16, count=_voc_n, offset=self.decode_y * 2
+        ).astype(np.float32)
+        if not str(st).endswith("COMPLETED"):
+            raise RuntimeError(f"decode dispatch pos{p} state={st}")
+        return yv[: self.VOCAB_SIZE]
+
+
+def _build_prefiller(model, seq_len=None):
+    """Construct the AIR prefill engine and load its resident weight BOs.
+
+    This is the model-load cost -- the ELF cache plus the Q4NX host dequant of
+    ~6 GB and the one-time write of every weight into its BO. Split out from the
+    per-turn prefill so an interactive session pays it once."""
+    import os
+    import time
+
+    from qwen25_7b_q4nx_prefill import Qwen25Q4nxPrefill
+
+    seq_len = seq_len or int(os.environ.get("Q4NX_SEQ_LEN", "2048"))
+    t_load = time.perf_counter()
+    pf = Qwen25Q4nxPrefill(
+        seq_len=seq_len, cache_dir=os.environ.get("Q4NX_CACHE_DIR") or None
+    )
+    pf.load_weights(model=model)
+    print(
+        f"[inference] model load (dequant + resident BOs): "
+        f"{time.perf_counter() - t_load:.1f}s",
+        flush=True,
+    )
+    return pf
+
+
+def _prefill_turn(pf, prompt):
+    """One batched AIR prefill dispatch -> (Kc, Vc, first_token, ttft_s).
+
+    Kc/Vc are [NUM_LAYERS, P, DK] roped-K / raw-V, the layout FusedDecoder.seed_kv
+    consumes. The prefill runs at a fixed padded seq_len (the GEMM registry carries
+    the Qwen2.5-7B shapes at M=2048), so its cost is ~constant in prompt length.
+    ttft_s times this dispatch only; the model load is reported separately."""
+    import time
+
+    t0 = time.perf_counter()
+    logits = pf.prefill(prompt)
+    ttft = time.perf_counter() - t0
+    Kc, Vc = pf.kv_stack()
+    return Kc, Vc, int(logits.argmax()), ttft
+
+
+def _prefill_npu(prompt, model, seq_len=None):
+    """Load the prefill engine and run one prompt through it (the one-shot path)."""
+    return _prefill_turn(_build_prefiller(model, seq_len), prompt)
+
+
+def _decode_loop(dec, prompt, first, n_tokens, Kc, Vc, on_token=None, stop_on_eos=True):
+    """Seed the KV cache and run the fused per-token decode -> (gen_ids, seconds).
+
+    gen_ids[0] is `first` (the prefill's own token), so n_generated is len-1.
+    `on_token` is called with each newly decoded id, for streaming."""
+    import time
+
+    P = Kc.shape[1]
+    dec.seed_kv(Kc, Vc, P)
+    tokens = list(prompt) + [first]
+    gen_ids = [first]
+    n_eff = min(n_tokens, dec.ATTN_MAXL - P)
+    t_dec0 = time.perf_counter()
+    for p in range(P, P + n_eff):
+        lg = dec.dispatch(tokens[p], p)
+        pred = int(lg.argmax())
+        if pred in EOS_IDS and stop_on_eos:
+            print(f"[inference] pos{p} L={p+1} -> EOS ({pred}), stop", flush=True)
+            break
+        gen_ids.append(pred)
+        if on_token:
+            on_token(pred)
+        if p + 1 >= len(tokens):
+            tokens.append(pred)
+    return gen_ids, time.perf_counter() - t_dec0
+
+
+def generate(
+    prompt,
+    n_tokens,
+    model=MODEL_DEFAULT,
+    greedy=True,
+    numpy_prefill=False,
+    stop_on_eos=True,
+):
+    import numpy as np, time
+    import qwen25_7b_q4nx_weights as gw
+
+    src = "numpy reference" if numpy_prefill else "AIR NPU"
+    print(
+        f"[inference] {src} prefill (KV seed + first token), "
+        f"prompt_len={len(prompt)}...",
+        flush=True,
+    )
+    if numpy_prefill:
+        t0 = time.perf_counter()
+        qm = gw.open_weight_source(model)
+        Kc, Vc, logits = gw.forward_prompt(qm, prompt)
+        first = int(logits[-1].argmax())
+        ttft = time.perf_counter() - t0  # the numpy path fuses load and compute
+    else:
+        Kc, Vc, first, ttft = _prefill_npu(prompt, model)
+    P = Kc.shape[1]
+    print(
+        f"[inference] prefill first token = {first} (Paris={PARIS_FIRST})", flush=True
+    )
+    # Machine-readable line for bench/extract_perf.py (nightly LLM dashboard).
+    print(f"Time to first token (TTFT): {ttft:.3f}s", flush=True)
+
+    dec = FusedDecoder(
+        model=model,
+        max_L=P + n_tokens,
+        staircase=os.environ.get("DECODE_STAIRCASE") == "1",
+    )
+    if P >= dec.ATTN_MAXL:
+        print(f"[inference] P={P} >= ATTN_MAXL={dec.ATTN_MAXL}; abort")
+        return [first]
+    gen_ids, t_dec = _decode_loop(
+        dec, prompt, first, n_tokens, Kc, Vc, stop_on_eos=stop_on_eos
+    )
+    n_gen = len(gen_ids) - 1
+    if n_gen > 0:
+        print(
+            f"[inference] decode: {n_gen} tokens in {t_dec:.2f}s "
+            f"{n_gen/t_dec:.2f} tok/s ({t_dec/n_gen*1000:.1f} ms/token)",
+            flush=True,
+        )
+        # Machine-readable lines for bench/extract_perf.py (nightly LLM dashboard).
+        print(
+            f"[inference] Inference: prompt_len={len(prompt)}, n_tokens={n_gen}",
+            flush=True,
+        )
+        print(f"Tokens/second: {n_gen/t_dec:.2f}", flush=True)
+    return gen_ids
+
+
+def _first_diff(got, want):
+    """Index of the first differing token, or the length of the shorter run."""
+    for i, (g, w) in enumerate(zip(got, want)):
+        if g != w:
+            return i
+    return min(len(got), len(want))
+
+
+def _paris_verdict(gen_ids):
+    """Lines to print for the Paris gate. The two misses are separated because they
+    point at different halves: the first token comes out of the prefill, the rest
+    out of the decode loop."""
+    if not gen_ids or gen_ids[0] != PARIS_FIRST:
+        return [f"*** MISS *** first token {gen_ids[:1]}, expected [{PARIS_FIRST}]"]
+    if PARIS_GREEDY is None:
+        return [
+            "*** PARIS (first token only) ***",
+            f"    record the continuation: PARIS_GREEDY = {gen_ids}",
+        ]
+    n = min(len(gen_ids), len(PARIS_GREEDY))
+    if gen_ids[:n] != PARIS_GREEDY[:n]:
+        return [
+            f"*** MISS *** decode drifted at token {_first_diff(gen_ids, PARIS_GREEDY)}",
+            f"    expected {PARIS_GREEDY[:n]}",
+            f"    got      {gen_ids[:n]}",
+        ]
+    return ["*** PARIS ***"]
+
+
+def _detok(ids, model=MODEL_DEFAULT):
+    try:
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(model).decode(ids)
+    except Exception as e:
+        return f"(no detok: {e}) ids={ids}"
+
+
+def _format_prompt(tokenizer, text):
+    """Chat-template one turn -> a flat list of ids.
+
+    `user_system_prompt` is passed because the FastFlowLM bundle's template
+    references that variable unguarded and raises without it; a stock Qwen2.5
+    tokenizer ignores it. Unlike Qwen3 there is no thinking mode to disable.
+    Degrades to plain kwargs, then to raw encoding."""
+    msg = [{"role": "user", "content": text}]
+    out = None
+    for kw in ({"user_system_prompt": ""}, {}):
+        try:
+            out = tokenizer.apply_chat_template(
+                msg, tokenize=True, add_generation_prompt=True, **kw
+            )
+            break
+        except Exception:
+            continue
+    if out is None:
+        out = tokenizer(text)["input_ids"]
+    # tokenize=True returns a BatchEncoding on current transformers and a plain
+    # list on older ones; either may be batched.
+    ids = out["input_ids"] if hasattr(out, "keys") else out
+    if len(ids) and isinstance(ids[0], (list, tuple)):
+        ids = ids[0]
+    return [int(t) for t in ids]
+
+
+def repl(model=MODEL_DEFAULT, n_tokens=64):
+    """Interactive chat. The prefill engine and the decode templates are built once
+    and held across turns, so only the first turn pays the model load."""
+    import os
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    pf = _build_prefiller(model)
+    dec = FusedDecoder(model=model, staircase=os.environ.get("DECODE_STAIRCASE") == "1")
+    print(
+        f"\nInteractive chat (Ctrl-D or 'exit' to quit). "
+        f"{n_tokens} tokens/turn, context <= {dec.ATTN_MAXL}."
+    )
+    while True:
+        try:
+            line = input("\n> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line or line in ("exit", "quit"):
+            break
+        ids = _format_prompt(tokenizer, line)
+        if len(ids) >= dec.ATTN_MAXL:
+            print(f"[prompt is {len(ids)} tokens, limit {dec.ATTN_MAXL}]")
+            continue
+        # prefill() APPENDS to the prefiller's KV (the causal_lm contract the verify
+        # runner needs), so without this turn 2 reports a context of turn1+turn2 for
+        # a turn-2-length prompt. Turns are independent: the decode's cache is seeded
+        # from this turn's prefill alone, so carrying history would mean re-prefilling
+        # the whole conversation as one prompt. Same single-turn shape as the llama
+        # examples' REPL.
+        pf.clear_context()
+        Kc, Vc, first, ttft = _prefill_turn(pf, ids)
+        out = [first]
+        print(tokenizer.decode(out), end="", flush=True)
+
+        def _emit(tok, _out=out):
+            prev = tokenizer.decode(_out)
+            _out.append(tok)
+            print(tokenizer.decode(_out)[len(prev) :], end="", flush=True)
+
+        gen_ids, t_dec = _decode_loop(dec, ids, first, n_tokens, Kc, Vc, on_token=_emit)
+        n_gen = len(gen_ids) - 1
+        rate = f"{n_gen / t_dec:.2f} tok/s" if n_gen and t_dec else "-"
+        print(f"\n[{len(ids)} prompt tok, TTFT {ttft:.2f}s | {n_gen} gen, {rate}]")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="qwen25_7b_q4nx full inference (decode)")
+    ap.add_argument("--prompt", type=str, default=None, help="prompt text")
+    ap.add_argument("--prompt-ids", type=str, default=None, help="comma-separated ids")
+    ap.add_argument("--n-tokens", type=int, default=9, help="tokens to generate")
+    ap.add_argument(
+        "--model", type=str, default=MODEL_DEFAULT, help="model.q4nx dir/path"
+    )
+    ap.add_argument(
+        "--numpy-prefill",
+        action="store_true",
+        help="seed the KV cache with the numpy reference forward instead of the "
+        "AIR NPU prefill (the oracle it is checked against; tens of seconds)",
+    )
+    ap.add_argument(
+        "--no-eos-stop",
+        action="store_true",
+        help="keep generating past EOS, so the decode rate is measured over the "
+        "full --n-tokens (what `make profile` wants)",
+    )
+    ap.add_argument(
+        "--interactive",
+        action="store_true",
+        help="chat REPL: build the engine once and hold it across turns",
+    )
+    args = ap.parse_args()
+
+    if args.interactive:
+        if args.numpy_prefill:
+            ap.error("--interactive cannot be combined with --numpy-prefill")
+        repl(model=args.model, n_tokens=args.n_tokens)
+        return
+
+    if args.prompt_ids:
+        prompt = [int(x) for x in args.prompt_ids.split(",")]
+    elif args.prompt:
+        from transformers import AutoTokenizer
+
+        # Chat-templated, same as the REPL: raw-encoding an instruction gives a
+        # continuation rather than an answer. --prompt-ids stays literal.
+        prompt = _format_prompt(AutoTokenizer.from_pretrained(args.model), args.prompt)
+    else:
+        prompt = PARIS_PROMPT
+    print(f"[inference] prompt = {len(prompt)} tokens: {prompt}", flush=True)
+
+    gen_ids = generate(
+        prompt,
+        args.n_tokens,
+        model=args.model,
+        numpy_prefill=args.numpy_prefill,
+        stop_on_eos=not args.no_eos_stop,
+    )
+    print("=" * 60)
+    print(f"[inference] gen ids: {gen_ids}")
+    print(f"[inference] TEXT: {_detok(gen_ids, args.model)!r}")
+    if prompt == PARIS_PROMPT:
+        for line in _paris_verdict(gen_ids):
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_inference.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_inference.py
@@ -40,7 +40,8 @@ _PE = _HERE.parent.parent  # programming_examples
 _DEC = _PE / "fused_decode"  # shared fused superkernel decode engine
 sys.path.insert(0, str(_HERE))
 
-# HF repo id of the self-contained model.q4nx bundle, or a local dir/file
+# Weight source: by default an HF repo id quantized onto the Q4NX grid at load;
+# a local dir containing model.q4nx, or a direct model.q4nx path, also work
 # (qwen25_7b_q4nx_weights resolves all three).
 MODEL_DEFAULT = os.environ.get("Q4NX_MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
 # "The capital of France is" (Qwen2.5 tokenizer, no BOS); prefill -> 12095 " Paris".

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_prefill.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_prefill.py
@@ -1,0 +1,446 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Qwen2.5-7B Q4NX prefill in mlir-air.
+#
+# A thin driver over the config-parameterized qwen25_3b prefill builders -- same
+# Qwen2.5 block shape (RMSNorm -> Q/K/V GEMM + bias -> RoPE -> causal GQA flash
+# attention -> SwiGLU), different constants -- rather than a self-contained
+# clone. Weights come from a FastFlowLM Q4NX bundle, dequantized on the host at
+# load and written once into resident per-layer BOs; every op then runs on the
+# NPU.
+#
+# Deltas vs the Qwen2.5-3B Q4_0 sibling, all model-driven:
+#   codec   Q4NX (unsigned int4, affine scale+min) from a pre-quantized
+#           FastFlowLM bundle, instead of quantizing an HF bf16 checkpoint to
+#           Q4_0 on the fly. Same codec the fused decode consumes -> prefill and
+#           decode agree bit-for-bit on the weights.
+#   shape   28 layers, 28 heads x head_dim 128, 4 kv heads (GQA group 7),
+#           hidden 18944, vocab 152064, rope_theta 1e6.
+#   lm head UNTIED -- the bundle ships a separate Q4NX lm_head, where the 3B
+#           reuses the embedding table.
+#
+# The GEMM registry shapes exist at M=2048, so the whole prefill runs at
+# seq_len=2048 (pad the prompt, read the last real token's row for the logit).
+#
+# Weight source (env-overridable): MODEL_SOURCE -- an HF repo id, a local dir
+# containing model.q4nx, or a direct model.q4nx path.
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+_HERE = Path(__file__).resolve().parent
+_PROG = str(_HERE.parent.parent)  # programming_examples
+_LLMS = str(_HERE.parent)  # llms
+_QWEN = str(_HERE.parent / "qwen25_3b")  # prefill builders + block runner
+for _p in (_PROG, _LLMS, _QWEN, str(_HERE)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from shared.infra.cache import KernelCache  # noqa: E402
+
+from qwen25_7b_q4nx_weights import (  # noqa: E402
+    D,
+    DK,
+    DV,
+    VOCAB,
+    NUM_LAYERS,
+    load_q4nx_weights,
+    qwen25_7b_config,
+)
+
+MODEL_DEFAULT = os.environ.get("MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
+EPS = 1e-6
+
+# On-device LM head GEMV: 10 partitions of M=16384 (10*16384=163840 >= VOCAB).
+_LM_N_PART = 16384
+_LM_N_PARTITIONS = 10
+# K=3584 clears the L2 A-stage budget (herd_m*tile_m*(K+1)*2 <= 512 KiB allows
+# herd_m*tile_m <= 73, so the default 64 fits -- unlike Qwen3-8B at K=4096, which
+# misses it by 128 B and has to halve tile_m). Only m_input has to come down:
+# m_input=4 would put the ping-pong L1 A tiles at 2*28 KiB of a 64 KiB L1.
+# tile_m stays 8, so the default mv.o (DIM_M_OUTPUT=8) is reused as-is.
+_LM_HERD_M = 8
+_LM_TILE_M = 8
+_LM_M_INPUT = 2
+
+# "The capital of France is" (Qwen2.5 BPE). Gate: the next token is " Paris".
+PROMPT = [785, 6722, 315, 9625, 374]
+EXPECT_FIRST = 12095  # " Paris"
+
+
+def _bf(a):
+    return np.asarray(a, bfloat16)
+
+
+class Qwen25Q4nxPrefill:
+    """AIR realization of the Q4NX causal-LM prefill interface (Qwen2.5-7B)."""
+
+    def __init__(
+        self, seq_len=2048, n_layers=NUM_LAYERS, cache_dir=None, verbose=False
+    ):
+        self.seq = seq_len
+        self.n_layers = n_layers
+        self.MAX_L = seq_len
+        self.current_context_length = 0
+        self.D = D
+
+        from qwen25_3b_weights import generate_rope_lut
+        from qwen25_3b_prefill import compile_all_kernels
+        from shared.infra.backend_presets import LM_GEMV_BACKEND
+
+        self.config = qwen25_7b_config(n_layers=n_layers)
+        # Attention on the NPU (head-first FA, head_dim=128). Q4NX_CPU_ATTN=1
+        # falls back to the fp32 host reference -- correct but ~50x slower.
+        self.cpu_attn = os.environ.get("Q4NX_CPU_ATTN") == "1"
+        self._rope_lut = generate_rope_lut(self.config, seq_len=seq_len)  # theta 1e6
+        self._lm_backend = dict(LM_GEMV_BACKEND)
+
+        # seq_len-specific cache: the ELFs are compiled for this padded context
+        # length but the KernelCache is keyed by kernel NAME only, so a shared dir
+        # would let a shorter-context build be silently reused for a longer request
+        # -> all-zero logits beyond the built length. Isolate by seq_len (and by
+        # attention backend, since only one of the two builds flash_attn).
+        _att = "cpu" if self.cpu_attn else "fa"
+        cache_dir = cache_dir or str(_HERE / f"_q4nx_cache_seq{seq_len}_{_att}")
+        self.cache = KernelCache(cache_dir=cache_dir, verbose=verbose)
+
+        # Compile (or reuse cached) the prefill ELFs + flash_attn, plus the
+        # 10-partition lm_head GEMV. Q4NX_FORCE_COMPILE=1 forces a rebuild.
+        force = os.environ.get("Q4NX_FORCE_COMPILE") == "1"
+        if not force:
+            self.cache.load_manifest()
+        cached = set() if force else set(self.cache.artifacts)
+        need = {
+            "rms_qkv_bias_rope",
+            "o_res_norm",
+            "gate",
+            "up",
+            "swiglu",
+            "down_add",
+        }
+        if not self.cpu_attn:
+            need.add("flash_attn")
+        if not need.issubset(cached):
+            compile_all_kernels(
+                self.cache, self.config, seq_len, cpu_attn=self.cpu_attn
+            )
+        else:
+            print("[q4nx_prefill] using cached prefill ELFs (skip compile)", flush=True)
+        if "lm_head_gemv" not in cached:
+            from shared.builders.lm_head_gemv_multi import build_lm_head_gemv_module
+
+            self.cache.compile_and_cache(
+                "lm_head_gemv",
+                build_lm_head_gemv_module(
+                    emb_dim=D,
+                    n_partitions=_LM_N_PARTITIONS,
+                    n_part=_LM_N_PART,
+                    herd_m=_LM_HERD_M,
+                    tile_m=_LM_TILE_M,
+                    m_input=_LM_M_INPUT,
+                ),
+                {"verbose": self.cache.verbose, **self._lm_backend},
+            )
+            self.cache._save_manifest()
+
+        # Per-layer KV cache (roped K + biased raw V), [MAX_L, n_kv*head_dim].
+        self.kv_k = [np.zeros((self.MAX_L, DK), bfloat16) for _ in range(n_layers)]
+        self.kv_v = [np.zeros((self.MAX_L, DV), bfloat16) for _ in range(n_layers)]
+        self._weights = None
+        self._lm_head = None
+        self._dev_t = 0.0  # accumulated NPU dispatch time (s)
+        self._op_t = {}  # per-op NPU dispatch time (s)
+
+    def _dev(self, fn, *a, tag="?"):
+        import time
+
+        t = time.time()
+        r = fn(*a)
+        dt = time.time() - t
+        self._dev_t += dt
+        self._op_t[tag] = self._op_t.get(tag, 0.0) + dt
+        return r
+
+    # ---- causal_lm interface ----
+    def load_weights(self, model=None):
+        """Load the Q4NX bundle, dequant to bf16 on the host, and pre-load every
+        projection into resident per-layer BOs."""
+        model = model or MODEL_DEFAULT
+        self._weights = load_q4nx_weights(model, config=self.config)
+        self._lm_head = self._weights.lm_head
+        self._preload()
+
+    def _preload(self):
+        """Resident BOs: prefill block weights (written once, then skipped via
+        static_input_indices) + the LM-head partitions."""
+        from qwen25_3b_prefill import preload_prefill_weights
+
+        for i, lw in enumerate(self._weights.layers):
+            lw._layer_idx = i  # per-layer BO isolation
+        preload_prefill_weights(
+            self._weights, self.config, self.cache, self.seq, self._rope_lut
+        )
+        self._preload_lm_head_gemv()
+
+    def _preload_lm_head_gemv(self):
+        """Build the padded bf16 lm_head partitions [_LM_N_PART, D] and write them
+        into resident BOs once (static; skipped thereafter)."""
+        self._lm_parts = []
+        for p in range(_LM_N_PARTITIONS):
+            n0 = p * _LM_N_PART
+            n1 = min(n0 + _LM_N_PART, VOCAB)
+            w = np.zeros((_LM_N_PART, D), bfloat16)
+            if n1 > n0:
+                w[: n1 - n0] = _bf(self._lm_head[n0:n1])
+            self._lm_parts.append(w)
+        self._lm_head_npu(np.zeros(D, bfloat16))  # warm/allocate resident BOs
+
+    def _lm_head_npu(self, hidden_bf16):
+        """On-device final logits from a single bf16 hidden row [D] -> [VOCAB]."""
+        lm_inputs = [np.ascontiguousarray(hidden_bf16, bfloat16)]
+        for p in range(_LM_N_PARTITIONS):
+            lm_inputs.append(self._lm_parts[p])
+            lm_inputs.append(np.zeros(_LM_N_PART, bfloat16))
+        res = self.cache.load_and_run(
+            "lm_head_gemv",
+            self._lm_backend,
+            *lm_inputs,
+            output_indices=[2 + 2 * p for p in range(_LM_N_PARTITIONS)],
+            static_input_indices={1 + 2 * p for p in range(_LM_N_PARTITIONS)},
+            intermediate_indices={2 + 2 * p for p in range(_LM_N_PARTITIONS)},
+        )
+        return np.concatenate(
+            [np.asarray(res[2 + 2 * p], np.float32) for p in range(_LM_N_PARTITIONS)]
+        )[:VOCAB]
+
+    def _run_layer(self, x, k, N):
+        """One Qwen2.5 transformer block fully on-device. Captures roped-K and
+        biased-V into the KV cache (the decode hand-off)."""
+        from qwen25_3b_prefill import run_transformer_block_qwen25
+
+        out, inter = self._dev(
+            run_transformer_block_qwen25,
+            x,
+            self._weights.layers[k],
+            self._rope_lut,
+            self.config,
+            self.cache,
+            k,
+            self.cpu_attn,
+            False,  # verbose
+            tag="layer",
+        )
+        self.kv_k[k][:N] = np.asarray(inter["k_roped"], bfloat16).reshape(-1, DK)[:N]
+        self.kv_v[k][:N] = np.asarray(inter["v"], bfloat16).reshape(-1, DV)[:N]
+        return out
+
+    def prefill(self, ids, payload=None):
+        assert self._weights is not None, "call load_weights() first"
+        N = len(ids)
+        assert N <= self.seq, (N, self.seq)
+        # Single-shot prefill only: the embedding write and every layer's KV
+        # write below are indexed from row 0, so a second call would silently
+        # overwrite the cache from the start while current_context_length kept
+        # accumulating. Fail loudly instead of corrupting.
+        base = self.current_context_length
+        assert base == 0, (
+            f"incremental prefill is not supported (already prefilled {base} "
+            f"tokens); construct a new instance or clear_context() first"
+        )
+        x = np.zeros((self.seq, D), bfloat16)
+        x[:N] = np.asarray(self._weights.embed_table[list(ids)], bfloat16)
+        for k in range(self.n_layers):
+            x = self._run_layer(x, k, N)
+        self.current_context_length = base + N
+        # Final RMSNorm on the single prediction row (host, <1ms) + NPU LM head.
+        xf = np.asarray(x[N - 1], np.float32)
+        xn = (
+            xf
+            / np.sqrt((xf * xf).mean() + EPS)
+            * np.asarray(self._weights.final_norm, np.float32)
+        )
+        self._last_hidden = xf
+        return self._dev(self._lm_head_npu, _bf(xn), tag="lm_head")
+
+    # ---- KV cache (causal_lm) ----
+    def get_k_cache(self, layer_idx, idx):
+        """Roped-K vector at position idx of a layer."""
+        return self.kv_k[layer_idx][idx]
+
+    def get_v_cache(self, layer_idx, idx):
+        """Biased raw-V vector at position idx of a layer."""
+        return self.kv_v[layer_idx][idx]
+
+    def kv_stack(self):
+        """(K, V) stacked over layers as [n_layers, ctx, kv_dim] -- the layout the
+        fused decode's seed_kv consumes."""
+        c = self.current_context_length
+        return (
+            np.stack([self.kv_k[L][:c] for L in range(self.n_layers)]),
+            np.stack([self.kv_v[L][:c] for L in range(self.n_layers)]),
+        )
+
+    def kv_view(self, layer_idx):
+        """(roped_K, biased_V) for the filled context [0:ctx] -> decode hand-off."""
+        c = self.current_context_length
+        return self.kv_k[layer_idx][:c], self.kv_v[layer_idx][:c]
+
+    def clear_context(self):
+        self.current_context_length = 0
+        for k in range(self.n_layers):
+            self.kv_k[k][:] = 0
+            self.kv_v[k][:] = 0
+
+    def get_current_context_length(self):
+        return self.current_context_length
+
+    def set_context_length(self, L):
+        self.current_context_length = L
+
+
+def _main():
+    ap = argparse.ArgumentParser(description="Qwen2.5-7B Q4NX prefill on NPU2")
+    ap.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="build/cache the prefill ELFs and exit (no weights, no NPU dispatch)",
+    )
+    ap.add_argument(
+        "--n-layers", type=int, default=int(os.environ.get("NLAYERS", str(NUM_LAYERS)))
+    )
+    ap.add_argument(
+        "--seq-len",
+        type=int,
+        default=int(os.environ.get("Q4NX_SEQ_LEN", "2048")),
+        help="padded prefill length",
+    )
+    ap.add_argument("--cache-dir", default=os.environ.get("Q4NX_CACHE_DIR") or None)
+    ap.add_argument(
+        "--bench-l",
+        type=int,
+        default=int(os.environ.get("Q4NX_BENCH_L", "0")),
+        help="warm TTFT benchmark at this context length",
+    )
+    ap.add_argument("--prompt", default=None, help="text prompt (needs transformers)")
+    ap.add_argument(
+        "--dump-kv",
+        default=None,
+        metavar="PATH.npz",
+        help="write the prefill KV cache (roped K + biased V, per layer) plus the "
+        "prompt ids to PATH.npz -- the hand-off to the fused NPU decode. Written "
+        "as raw uint16 so the bf16 payload survives np.savez unchanged.",
+    )
+    ap.add_argument("--model", default=MODEL_DEFAULT)
+    args = ap.parse_args()
+
+    print(
+        f"[q4nx_prefill] constructing seq_len={args.seq_len} "
+        f"n_layers={args.n_layers} (compiling engines)...",
+        flush=True,
+    )
+    model = Qwen25Q4nxPrefill(
+        seq_len=args.seq_len, n_layers=args.n_layers, cache_dir=args.cache_dir
+    )
+    if args.compile_only:
+        print("Compilation passed.", flush=True)
+        return 0
+
+    print("[q4nx_prefill] loading Q4NX weights (host dequant)...", flush=True)
+    model.load_weights(model=args.model)
+
+    ids = PROMPT
+    tok = None
+    if args.prompt:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(args.model)
+        ids = tok(args.prompt, return_tensors=None)["input_ids"]
+    print(f"[q4nx_prefill] prefill prompt N={len(ids)} ...", flush=True)
+    logits = model.prefill(ids)
+    top = int(np.asarray(logits).argmax())
+    txt = f" ({tok.decode([top])!r})" if tok else ""
+    print(f"[q4nx_prefill] first-token argmax={top}{txt}", flush=True)
+    ok = True
+    if ids == PROMPT:
+        ok = top == EXPECT_FIRST
+        print(
+            (
+                "[q4nx_prefill] *** PARIS ***"
+                if ok
+                else f"[q4nx_prefill] MISS (expect {EXPECT_FIRST})"
+            ),
+            flush=True,
+        )
+
+    if args.dump_kv:
+        c = model.get_current_context_length()
+        np.savez(
+            args.dump_kv,
+            ids=np.asarray(ids, np.int64),
+            ctx=np.int64(c),
+            # bf16 payloads move as raw uint16: np.savez does not round-trip the
+            # ml_dtypes bf16 dtype tag.
+            k=np.stack([model.kv_k[l][:c] for l in range(model.n_layers)]).view(
+                np.uint16
+            ),
+            v=np.stack([model.kv_v[l][:c] for l in range(model.n_layers)]).view(
+                np.uint16
+            ),
+            hidden=np.asarray(model._last_hidden, np.float32),
+        )
+        print(
+            f"[q4nx_prefill] KV dumped -> {args.dump_kv} "
+            f"({model.n_layers} layers x {c} tokens)",
+            flush=True,
+        )
+
+    if args.bench_l:
+        import time
+
+        model.clear_context()
+        bench_ids = [int(t % VOCAB) for t in range(args.bench_l)]  # timing only
+        print(f"[bench] warmup prefill L={args.bench_l}...", flush=True)
+        model.prefill(bench_ids)
+        model.clear_context()
+        model._dev_t = 0.0
+        model._op_t.clear()
+        model.cache.profiler.enabled = True
+        for d in (
+            model.cache.profiler.kernel_times,
+            model.cache.profiler.cpu_times,
+            model.cache.profiler.kernel_breakdowns,
+        ):
+            d.clear()
+        model.cache.profiler.layer_times.clear()
+        print(f"[bench] timed prefill L={args.bench_l}...", flush=True)
+        t0 = time.time()
+        model.prefill(bench_ids)
+        wall = time.time() - t0
+        npu = model._dev_t
+        print(
+            f"\n[bench] L={args.bench_l}: WALL={wall*1000:.0f}ms "
+            f"{args.bench_l/wall:.0f} tok/s prefill  |  "
+            f"NPU-dispatch={npu*1000:.0f}ms {args.bench_l/npu:.0f} tok/s  |  "
+            f"host={(wall-npu)*1000:.0f}ms",
+            flush=True,
+        )
+        print(f"Time to first token (TTFT): {wall:.3f}s", flush=True)
+        print(
+            "[bench] per-op NPU: "
+            + "  ".join(
+                f"{k}={v*1000:.0f}ms"
+                for k, v in sorted(model._op_t.items(), key=lambda x: -x[1])
+            ),
+            flush=True,
+        )
+        model.cache.profiler.report()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_prefill.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_prefill.py
@@ -6,14 +6,14 @@
 # A thin driver over the config-parameterized qwen25_3b prefill builders -- same
 # Qwen2.5 block shape (RMSNorm -> Q/K/V GEMM + bias -> RoPE -> causal GQA flash
 # attention -> SwiGLU), different constants -- rather than a self-contained
-# clone. Weights come from a FastFlowLM Q4NX bundle, dequantized on the host at
-# load and written once into resident per-layer BOs; every op then runs on the
-# NPU.
+# clone. Weights are Q4NX: by default the upstream HF bf16 checkpoint rounded
+# onto the Q4NX grid at load (FastFlowLM publishes no Qwen2.5-7B bundle), or a
+# local model.q4nx bundle if one is given. Either way they are dequantized on the
+# host and written once into resident per-layer BOs; every op then runs on the NPU.
 #
 # Deltas vs the Qwen2.5-3B Q4_0 sibling, all model-driven:
-#   codec   Q4NX (unsigned int4, affine scale+min) from a pre-quantized
-#           FastFlowLM bundle, instead of quantizing an HF bf16 checkpoint to
-#           Q4_0 on the fly. Same codec the fused decode consumes -> prefill and
+#   codec   Q4NX (unsigned int4, affine scale+min) instead of Q4_0 (signed,
+#           scale only). Both quantize the HF bf16 checkpoint on load. Same codec the fused decode consumes -> prefill and
 #           decode agree bit-for-bit on the weights.
 #   shape   28 layers, 28 heads x head_dim 128, 4 kv heads (GQA group 7),
 #           hidden 18944, vocab 152064, rope_theta 1e6.
@@ -23,8 +23,10 @@
 # The GEMM registry shapes exist at M=2048, so the whole prefill runs at
 # seq_len=2048 (pad the prompt, read the last real token's row for the logit).
 #
-# Weight source (env-overridable): MODEL_SOURCE -- an HF repo id, a local dir
-# containing model.q4nx, or a direct model.q4nx path.
+# Weight source (env-overridable): Q4NX_MODEL_SOURCE -- the name the Makefile
+# exports, and what `make run` / `make prefill MODEL_SOURCE=...` end up setting.
+# An HF repo id (quantized onto the Q4NX grid at load), a local dir containing
+# model.q4nx, or a direct model.q4nx path.
 import argparse
 import os
 import sys
@@ -53,7 +55,9 @@ from qwen25_7b_q4nx_weights import (  # noqa: E402
     qwen25_7b_config,
 )
 
-MODEL_DEFAULT = os.environ.get("MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
+MODEL_DEFAULT = os.environ.get(
+    "Q4NX_MODEL_SOURCE", os.environ.get("MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
+)
 EPS = 1e-6
 
 # On-device LM head GEMV: 10 partitions of M=16384 (10*16384=163840 >= VOCAB).
@@ -168,8 +172,9 @@ class Qwen25Q4nxPrefill:
 
     # ---- causal_lm interface ----
     def load_weights(self, model=None):
-        """Load the Q4NX bundle, dequant to bf16 on the host, and pre-load every
-        projection into resident per-layer BOs."""
+        """Load the weights -- an HF checkpoint quantized onto the Q4NX grid at
+        load (the default) or a local model.q4nx bundle -- dequant to bf16 on the
+        host, and pre-load every projection into resident per-layer BOs."""
         model = model or MODEL_DEFAULT
         self._weights = load_q4nx_weights(model, config=self.config)
         self._lm_head = self._weights.lm_head

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_requant.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_requant.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Build the Qwen2.5-7B fused-decode requant cache (q4k-cascade weights .npz).
+# Mirrors qwen3_8b_q4nx_requant.py; Qwen2.5-7B deltas:
+#   - 28 layers, TWO RMSNorm weights/layer (input, post_attention) -- the standard
+#     pre-norm pair.
+#   - the LM head is UNTIED, so it gets its own vocab weight slab.
+#   - the weight source is normally the bf16 HF checkpoint quantized on load (no
+#     FastFlowLM Qwen2.5-7B bundle exists); open_weight_source hides which.
+#   - the q/k/v projection biases are NOT packed here; they ride in the
+#     per-position rope_w slab the driver rewrites each step (see
+#     qwen25_7b_q4nx_inference), the same way Qwen3-8B carries its qk-norm.
+import os
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+
+def _requant_q4k(Wm, group):
+    """Per-32-column-group min/max 4-bit re-quant of a matrix [M,K] -> (q, sc, mn).
+
+    The Q4NX affine codec: w ~= sc*q + mn, q in [0,15], one (sc, mn) per group of
+    `group` elements along the reduction axis. This is the ONLY quantizer in the
+    example -- the prefill weights and the decode cascade cache both go through
+    it, so the two see bit-identical values."""
+    M, Kc = Wm.shape
+    Wg = Wm.reshape(M, Kc // group, group)
+    mn = Wg.min(2)
+    mx = Wg.max(2)
+    sc = (mx - mn) / 15.0
+    sc = np.where(sc <= 0, 1.0, sc).astype(np.float32)
+    q = np.clip(np.round((Wg - mn[..., None]) / sc[..., None]), 0, 15).astype(np.uint8)
+    return q.reshape(M, Kc), sc, mn.astype(np.float32)
+
+
+def _dequant_q4k(q, sc, mn, group):
+    """Inverse of _requant_q4k: (q[M,K] uint8, sc[M,K/g], mn[M,K/g]) -> f32 [M,K]."""
+    M, Kc = q.shape
+    return (
+        q.reshape(M, Kc // group, group).astype(np.float32) * sc[..., None]
+        + mn[..., None]
+    ).reshape(M, Kc)
+
+
+def quantize_dequantize_q4nx(W, group=None):
+    """Round a full-precision [M,K] matrix onto the Q4NX grid.
+
+    Deliberately quantize-then-dequantize rather than using the bf16 weights
+    directly: the device computes on the 4-bit grid, so the prefill's host-side
+    bf16 copy has to sit on that same grid or prefill and decode would disagree
+    (and the prefill would look better than the hardware it models)."""
+    from proj_qmm_pack import GROUP as _G
+
+    g = group or _G
+    q, sc, mn = _requant_q4k(np.asarray(W, np.float32), g)
+    return _dequant_q4k(q, sc, mn, g)
+
+
+def _interleave512(up_t, gate_t, glu_chunk):
+    """Interleave up/gate in GLU_CHUNK-row halves (the decode's GLU stream order)."""
+    n = up_t[0].shape[0] // glu_chunk
+
+    def il(a, b):
+        return np.concatenate(
+            [
+                (a if h == 0 else b)[s * glu_chunk : (s + 1) * glu_chunk]
+                for s in range(n)
+                for h in (0, 1)
+            ]
+        )
+
+    return tuple(il(up_t[i], gate_t[i]) for i in range(3))
+
+
+def build_requant_cache(model, fd, cache_path, verbose=True):
+    """Re-quantize + cascade-pack the Qwen2.5-7B weights into the decode .npz.
+
+    `fd` = the loaded fused_decode module (DECODE_MODEL=qwen2.5-7b) supplying the
+    cascade geometry and phase indices."""
+    from qwen25_7b_q4nx_weights import open_weight_source, D, VOCAB
+
+    qm_model = open_weight_source(model)
+    G, NCX, NCY, NPH = fd.GROUP, fd.NCX, fd.NCY, fd.NPH
+    OP, GP, DP = fd.OPROJ_PHASE, fd.GLU_PHASE, fd.DOWN_PHASE
+    GLU_CHUNK, W_LAYER = fd.GLU_CHUNK, fd.W_LAYER
+    VP, VPF, UNI_LM = fd.VOCAB_SIZE_PADDED, fd.VOCAB_SIZE_PADDED_FULL, fd.UNI_LM
+    n_layers = fd.UNI_DEC
+    # Dual-MM2S weight feed: the decode splits each column's slab across the
+    # column's two shim channels by cascade pair, which needs the cascade laid out
+    # as [low-row half | high-row half]. Keyed off the SAME flag the decode was
+    # built with (fd.W_DUAL_CHAN) so the pack can never disagree with the xclbin.
+    DUAL = bool(getattr(fd, "W_DUAL_CHAN", 0))
+    # The reference per-block Python packer costs ~65 s per projection (~2 h for
+    # this model); the vectorized one is bit-identical and ~1000x faster.
+    from qwen25_3b_requant import pack_q4k_cascade_fast
+
+    def _pack(q, sc, mn):
+        return pack_q4k_cascade_fast(q, sc, NCX, NCY, dual_chan=DUAL, mins=mn)
+
+    PROJ = qm_model._PROJ  # {nm: (suffix, out, in)}
+
+    def _dq(k, nm):
+        """Full-precision [out, K] for one projection, whichever source backs it."""
+        return qm_model.proj_fp(k, nm)
+
+    W_all, RMS_in, RMS_post = [], [], []
+    for k in range(n_layers):
+        R = {nm: _dq(k, nm) for nm in PROJ}
+        qm = [None] * NPH
+        qm[0] = _requant_q4k(np.concatenate([R["q"], R["k"], R["v"]], 0), G)
+        qm[OP] = _requant_q4k(R["o"], G)
+        qm[GP] = _interleave512(
+            _requant_q4k(R["up"], G), _requant_q4k(R["gate"], G), GLU_CHUNK
+        )
+        qm[DP] = _requant_q4k(R["down"], G)
+        W_all.append(np.concatenate([_pack(*qm[p]) for p in range(NPH)]))
+        r_in, r_post = qm_model.layer_rms(k)
+        RMS_in.append(np.asarray(r_in, bfloat16))
+        RMS_post.append(np.asarray(r_post, bfloat16))
+        assert W_all[-1].size == W_LAYER, (W_all[-1].size, W_LAYER)
+        if verbose:
+            print(f"[qwen2.5-7b requant] layer {k} requantized", flush=True)
+
+    # LM head: UNTIED (Qwen2.5-7B sets tie_word_embeddings=false), padded to VPF rows.
+    lm = qm_model.lm_head_fp()
+    lm_pad = np.zeros((VPF, D), np.float32)
+    lm_pad[:VOCAB] = lm[:VOCAB]
+    lq, ls, lm_ = _requant_q4k(lm_pad, G)
+    Wv = [
+        _pack(
+            lq[w * VP : (w + 1) * VP],
+            ls[w * VP : (w + 1) * VP],
+            lm_[w * VP : (w + 1) * VP],
+        )
+        for w in range(UNI_LM)
+    ]
+    W = np.concatenate([np.asarray(w) for w in W_all] + Wv)
+    os.makedirs(os.path.dirname(os.path.abspath(cache_path)), exist_ok=True)
+    np.savez(
+        cache_path,
+        W=np.asarray(W).view(np.int16),
+        RMS_in=np.stack(RMS_in).view(np.int16),
+        RMS_post=np.stack(RMS_post).view(np.int16),
+    )
+    if verbose:
+        print(f"[qwen2.5-7b requant] wrote {cache_path}", flush=True)
+    return cache_path

--- a/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_weights.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/qwen25_7b_q4nx_weights.py
@@ -1,0 +1,516 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Q4NX weight loader + dequant for the Qwen2.5-7B Q4NX example.
+#
+# Same Q4NX codec as the llama / Qwen3-8B q4nx examples (reuses proj_qmm_pack),
+# and the same LLAMA-shaped topology (DH=128, standard 2-norm pre-norm, SiLU GLU,
+# single-theta half-split RoPE). Two Qwen2.5 deltas:
+#   - q/k/v projection BIAS (bf16, unquantized), packed after the cos/sin LUT
+#     into rope_w = [cos/sin(DH), q_bias(DQ), k_bias(DK), v_bias(DV)]; the kernel
+#     adds it in place before RoPE (fused_decode/kernels/rope.cc add_q_k_v_bias).
+#   - no qk-norm (that is the Qwen3 convention).
+#
+# The lm_head is NOT tied (unlike Qwen2.5-3B), so the bundle ships a separate
+# Q4NX-packed lm_head at 152064x3584.
+import sys
+from pathlib import Path
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+# The Q4NX block packer/dequant reference lives in the standalone fused_decode
+# example (this dir depends on it for the decode path), same as qwen3_8b_q4nx.
+_FUSED_DECODE = str(Path(__file__).resolve().parents[2] / "fused_decode")
+if _FUSED_DECODE not in sys.path:
+    sys.path.insert(0, _FUSED_DECODE)
+from proj_qmm_pack import (  # noqa: E402
+    ROW_BLOCK,
+    COL_BLOCK,
+    GROUP,
+    N_GROUPS,
+    PARALLEL,
+    BLOCK_BF16,
+)
+
+# Qwen2.5-7B-Instruct dims (HF config.json; matches FLM's
+# generic_decoding_layer/models/qwen2.5-7b.h).
+D = 3584  # hidden_size
+DH = 128  # head_dim
+N_Q_HEADS = 28
+N_KV_HEADS = 4
+Q_PER_KV = N_Q_HEADS // N_KV_HEADS  # 7 (GQA)
+DQ = N_Q_HEADS * DH  # 3584  q proj out (== D, so o_proj is square)
+DK = N_KV_HEADS * DH  # 512   k proj out
+DV = DK  # 512
+INTER = 18944  # mlp intermediate
+NUM_LAYERS = 28
+VOCAB = 152064
+RMS_EPS = 1e-6
+
+# Single-theta RoPE. NOTE 1e6, not the 1e7 of the -1M long-context variant.
+ROPE_THETA = 1000000.0
+
+
+def _bf(a):
+    return a.astype(bfloat16).astype(np.float32)
+
+
+def resolve_q4nx_model(model):
+    """Resolve `model` to a local model.q4nx path. `model` may be an HF repo id
+    (contains '/'), a directory containing model.q4nx, or a direct file path."""
+    import os
+
+    if os.path.isfile(model):
+        return model
+    if os.path.isdir(model):
+        p = os.path.join(model, "model.q4nx")
+        if os.path.isfile(p):
+            return p
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(model, "model.q4nx")
+
+
+# Row-group reorder (identical Q4NX codec to llama; w = scale*q + min, 32x256
+# blocks, parallel=16 -> 2 row-groups/block interleaved even/odd).
+_G = ROW_BLOCK // PARALLEL  # 2
+_EVEN = np.array(
+    [g * PARALLEL + 2 * k for g in range(_G) for k in range(PARALLEL // 2)]
+)
+_ODD = _EVEN + 1
+
+
+class Q4nxModel:
+    """mmap + parse a model.q4nx safetensors file; vectorized Q4NX dequant.
+
+    The codec half mirrors qwen3_8b_q4nx_weights.Q4nxModel (I8-packed bundle:
+    `shape` is [n_blocks, bytes_per_block], so the logical (M, K) comes from the
+    caller). The accessors are Qwen2.5-specific: a 2-norm pre-norm layer with
+    plain weights, q/k/v projection biases, no qk-norm, and an untied Q4NX
+    lm_head."""
+
+    def __init__(self, model):
+        import json
+
+        path = resolve_q4nx_model(model)
+        self._mm = np.memmap(path, dtype=np.uint8, mode="r")
+        hlen = int(np.frombuffer(self._mm[:8].tobytes(), dtype="<u8")[0])
+        self._hdr = json.loads(self._mm[8 : 8 + hlen].tobytes())
+        self._base = 8 + hlen
+
+    def _raw_i16(self, name):
+        o0, o1 = self._hdr[name]["data_offsets"]
+        return np.frombuffer(
+            self._mm[self._base + o0 : self._base + o1].tobytes(), dtype=np.int16
+        )
+
+    def has(self, name):
+        return name in self._hdr
+
+    def bf16(self, name):
+        """A BF16 tensor as float32, in its declared shape."""
+        o0, o1 = self._hdr[name]["data_offsets"]
+        v = np.frombuffer(
+            self._mm[self._base + o0 : self._base + o1].tobytes(), dtype=bfloat16
+        )
+        return v.astype(np.float32).reshape(self._hdr[name]["shape"])
+
+    def dequant(self, name, M, K):
+        """A Q4NX tensor dequantized to float32 [M, K] (w = scale*q + min).
+
+        The FLM bundle stores each Q4NX tensor block-major as [nb, block_bytes]
+        (nb = (M/32)*(K/256), block = 256 scales + 256 mins + 32*256 nibbles =
+        2560 int16), so the logical [M,K] must be supplied by the caller."""
+        nbi, nbj = M // ROW_BLOCK, K // COL_BLOCK
+        nb = nbi * nbj
+        assert (
+            self._hdr[name]["shape"][0] == nb
+        ), f"{name}: header nb={self._hdr[name]['shape'][0]} != (M/32)*(K/256)={nb}"
+        i16 = self._raw_i16(name).reshape(nb, BLOCK_BF16)
+        sc = (
+            i16[:, 0:256]
+            .copy()
+            .view(bfloat16)
+            .astype(np.float32)
+            .reshape(nb, N_GROUPS, ROW_BLOCK)
+        )
+        mn = (
+            i16[:, 256:512]
+            .copy()
+            .view(bfloat16)
+            .astype(np.float32)
+            .reshape(nb, N_GROUPS, ROW_BLOCK)
+        )
+        qb = (
+            i16[:, 512:BLOCK_BF16]
+            .copy()
+            .view(np.uint8)
+            .reshape(nb, _G, COL_BLOCK, PARALLEL // 2)
+        )
+        lo = (qb & 0xF).transpose(0, 1, 3, 2).reshape(nb, ROW_BLOCK // 2, COL_BLOCK)
+        hi = (qb >> 4).transpose(0, 1, 3, 2).reshape(nb, ROW_BLOCK // 2, COL_BLOCK)
+        q = np.zeros((nb, ROW_BLOCK, COL_BLOCK), np.float32)
+        q[:, _EVEN, :] = lo
+        q[:, _ODD, :] = hi
+        w = np.repeat(sc.transpose(0, 2, 1), GROUP, axis=2) * q + np.repeat(
+            mn.transpose(0, 2, 1), GROUP, axis=2
+        )
+        return (
+            w.reshape(nbi, nbj, ROW_BLOCK, COL_BLOCK)
+            .transpose(0, 2, 1, 3)
+            .reshape(M, K)
+        )
+
+    # name -> (tensor suffix, out, in) logical dims (bundle is block-major).
+    _PROJ = {
+        "q": ("self_attn.q_proj", DQ, D),
+        "k": ("self_attn.k_proj", DK, D),
+        "v": ("self_attn.v_proj", DV, D),
+        "o": ("self_attn.o_proj", D, DQ),
+        "up": ("mlp.up_proj", INTER, D),
+        "gate": ("mlp.gate_proj", INTER, D),
+        "down": ("mlp.down_proj", D, INTER),
+    }
+
+    def proj_fp(self, k, nm):
+        """Full-precision [out, K] for one projection (the requant cache's input)."""
+        t, M, K = self._PROJ[nm]
+        return self.dequant(f"model.layers.{k}.{t}.weight", M, K)
+
+    def lm_head_fp(self):
+        """Full-precision lm_head [VOCAB, D]."""
+        return self.dequant("lm_head.weight", VOCAB, D)
+
+    def layer_weights(self, k):
+        """Dequantized bf16 GEMM input-B [K, out] per projection for layer k."""
+        out = {}
+        for nm in self._PROJ:
+            wt = self.proj_fp(k, nm)  # [out, K]
+            out[nm] = np.ascontiguousarray(wt.T, dtype=bfloat16)  # [K, out]
+        return out
+
+    def layer_rms(self, k):
+        """The two Qwen2.5 pre-norm weights for layer k (input, post_attention),
+        plain `w` -- no Gemma-style (1+w) fold."""
+        return tuple(
+            self.bf16(f"model.layers.{k}.{n}.weight").astype(np.float32)
+            for n in ("input_layernorm", "post_attention_layernorm")
+        )
+
+    def layer_qkv_bias(self, k):
+        """The q/k/v projection biases (bf16, unquantized) for layer k, as
+        (bq[DQ], bk[DK], bv[DV]) float32."""
+        return tuple(
+            self.bf16(f"model.layers.{k}.self_attn.{n}_proj.bias").astype(np.float32)
+            for n in ("q", "k", "v")
+        )
+
+    def embed_norm_lmhead(self):
+        """(embed_in [VOCAB,D] bf16, final_norm [D] f32, lm_head [VOCAB,D] f32).
+
+        Qwen2.5-7B does NOT tie (unlike the 3B): the bundle carries a bf16
+        `model.embed_tokens` for the input gather and a SEPARATE Q4NX-packed
+        `lm_head` (66528x5120 int8 = 152064x3584 at 0.625 B/param)."""
+        embed_in = self.bf16("model.embed_tokens.weight")
+        norm = self.bf16("model.norm.weight").astype(np.float32)
+        lm_head = self.dequant("lm_head.weight", VOCAB, D)
+        return embed_in, norm, lm_head
+
+
+class HFQ4nxModel:
+    """A full-precision HF checkpoint, rounded onto the Q4NX grid on load.
+
+    The DEFAULT source. FastFlowLM publishes no Qwen2.5-7B NPU2 bundle (their
+    Qwen2.5 line stops at 3B), so there is nothing to download in the Q4NX
+    packing the AIR decode expects -- and their converter's Qwen2.5 output uses a
+    custom nibble interleave (q4nx/gguf_tensor.py transform_nibble_layout) that
+    the Llama/Qwen3 bundles do not, so it is not interchangeable either.
+
+    Quantizing here instead makes the example self-contained and reproducible
+    from an ungated upstream checkpoint. Same shape of decision as the
+    Qwen2.5-3B Q4_0 sibling, which quantizes from HF for the analogous reason
+    (its device codec disagrees with the bundle's).
+
+    Every projection goes through `quantize_dequantize_q4nx` -- the same
+    quantizer the decode cascade cache uses -- so prefill and decode see
+    BIT-IDENTICAL weights. Norms and the q/k/v biases stay bf16 (the reference
+    design does not quantize them either)."""
+
+    _PROJ = Q4nxModel._PROJ
+
+    def __init__(self, model):
+        _FD = str(Path(__file__).resolve().parents[2] / "fused_decode")
+        if _FD not in sys.path:
+            sys.path.insert(0, _FD)
+        from qwen25_3b_requant import HFModel
+
+        self._hf = HFModel(model)
+
+    def has(self, name):
+        return self._hf.has(name)
+
+    def bf16(self, name):
+        return self._hf.bf16(name)
+
+    def proj_fp(self, k, nm):
+        """Q4NX-rounded [out, K] for one projection of layer k."""
+        from qwen25_7b_q4nx_requant import quantize_dequantize_q4nx
+
+        t, _M, _K = self._PROJ[nm]
+        return quantize_dequantize_q4nx(self.bf16(f"model.layers.{k}.{t}.weight"))
+
+    def lm_head_fp(self):
+        from qwen25_7b_q4nx_requant import quantize_dequantize_q4nx
+
+        return quantize_dequantize_q4nx(self.bf16("lm_head.weight"))
+
+    def layer_weights(self, k):
+        """Q4NX-rounded bf16 GEMM input-B [K, out] per projection for layer k."""
+        return {
+            nm: np.ascontiguousarray(self.proj_fp(k, nm).T, dtype=bfloat16)
+            for nm in self._PROJ
+        }
+
+    def layer_rms(self, k):
+        return tuple(
+            self.bf16(f"model.layers.{k}.{n}.weight").astype(np.float32)
+            for n in ("input_layernorm", "post_attention_layernorm")
+        )
+
+    def layer_qkv_bias(self, k):
+        return tuple(
+            self.bf16(f"model.layers.{k}.self_attn.{n}_proj.bias").astype(np.float32)
+            for n in ("q", "k", "v")
+        )
+
+    def embed_norm_lmhead(self):
+        return (
+            self.bf16("model.embed_tokens.weight"),
+            self.bf16("model.norm.weight").astype(np.float32),
+            self.lm_head_fp(),
+        )
+
+
+def open_weight_source(model):
+    """Q4nxModel for a `model.q4nx` bundle, HFQ4nxModel for anything else.
+
+    Only a path that actually resolves to a model.q4nx takes the bundle path;
+    an HF repo id or a checkpoint directory gets quantized on load."""
+    import os
+
+    if os.path.isfile(model) and model.endswith(".q4nx"):
+        return Q4nxModel(model)
+    if os.path.isdir(model) and os.path.isfile(os.path.join(model, "model.q4nx")):
+        return Q4nxModel(model)
+    return HFQ4nxModel(model)
+
+
+def _proj_dims(c):
+    """Logical (out, K) per projection, for I8-packed Q4NX headers."""
+    dq = c.n_heads * c.head_dim
+    dkv = c.n_kv_heads * c.head_dim
+    return {
+        "q": (dq, c.emb_dim),
+        "k": (dkv, c.emb_dim),
+        "v": (dkv, c.emb_dim),
+        "o": (c.emb_dim, dq),
+        "gate": (c.hidden_dim, c.emb_dim),
+        "up": (c.hidden_dim, c.emb_dim),
+        "down": (c.emb_dim, c.hidden_dim),
+    }
+
+
+def load_q4nx_weights(model_source, config=None):
+    """Load Qwen2.5-7B weights into a LlamaWeights, Q4NX-rounded.
+
+    `model_source` is an HF repo id / checkpoint dir (quantized on load, the
+    default) or a `model.q4nx` bundle -- see open_weight_source. Either way the
+    matrices land in the `qwen25_3b` containers, so the config-parameterized
+    qwen25_3b prefill builders run unchanged; those containers already carry the
+    q/k/v bias fields (bq/bk/bv) the rms_qkv_bias_rope kernel needs."""
+    _QWEN25_3B = str(Path(__file__).resolve().parents[1] / "qwen25_3b")
+    if _QWEN25_3B not in sys.path:
+        sys.path.insert(0, _QWEN25_3B)
+    from qwen25_3b_weights import LayerWeights, LlamaWeights
+
+    if config is None:
+        config = qwen25_7b_config()
+
+    qm = open_weight_source(model_source)
+    dims = _proj_dims(config)
+    assert dims == {
+        k: (m, kk) for k, (_, m, kk) in Q4nxModel._PROJ.items()
+    }, "config dims disagree with the bundle's projection table"
+    embed, norm, lm_head = qm.embed_norm_lmhead()
+
+    layers = []
+    for k in range(config.n_layers):
+        w = qm.layer_weights(k)  # each [K, out] bf16
+        rms_in, rms_post = qm.layer_rms(k)
+        bq, bk, bv = qm.layer_qkv_bias(k)
+        layers.append(
+            LayerWeights(
+                attn_norm=np.asarray(rms_in, bfloat16),
+                wq=np.asarray(w["q"], bfloat16),
+                wk=np.asarray(w["k"], bfloat16),
+                wv=np.asarray(w["v"], bfloat16),
+                wo=np.asarray(w["o"], bfloat16),
+                ffn_norm=np.asarray(rms_post, bfloat16),
+                w_gate=np.asarray(w["gate"], bfloat16),
+                w_up=np.asarray(w["up"], bfloat16),
+                w_down=np.asarray(w["down"], bfloat16),
+                bq=np.asarray(bq, bfloat16),
+                bk=np.asarray(bk, bfloat16),
+                bv=np.asarray(bv, bfloat16),
+            )
+        )
+
+    return LlamaWeights(
+        embed_table=np.asarray(embed, bfloat16),
+        layers=layers,
+        final_norm=np.asarray(norm, bfloat16),
+        lm_head=np.asarray(lm_head, bfloat16),
+    )
+
+
+def qwen25_7b_config(n_layers=NUM_LAYERS):
+    """The qwen25_3b LlamaConfig re-parameterized to Qwen2.5-7B."""
+    _QWEN25_3B = str(Path(__file__).resolve().parents[1] / "qwen25_3b")
+    if _QWEN25_3B not in sys.path:
+        sys.path.insert(0, _QWEN25_3B)
+    from qwen25_3b_weights import LlamaConfig
+
+    return LlamaConfig(
+        n_layers=n_layers,
+        emb_dim=D,
+        n_heads=N_Q_HEADS,
+        head_dim=DH,
+        n_kv_heads=N_KV_HEADS,
+        hidden_dim=INTER,
+        vocab_size=VOCAB,
+        rope_base=ROPE_THETA,
+        qkv_bias=True,
+        qk_norm=False,
+        tie_word_embeddings=False,  # 7B ships a separate Q4NX lm_head
+    )
+
+
+def generate_rope_lut(position, theta=ROPE_THETA):
+    """Half-split (NEOX) RoPE cos/sin LUT for a single decode position, matching
+    fused_decode/kernels/rope.cc apply_rope: rope_w[:DH] = [cos(DH/2) ++ sin(DH/2)]."""
+    half = DH // 2
+    inv_freq = 1.0 / (theta ** (np.arange(0, half, dtype=np.float64) / half))
+    ang = position * inv_freq
+    cos = np.cos(ang).astype(bfloat16).astype(np.float32)
+    sin = np.sin(ang).astype(bfloat16).astype(np.float32)
+    return np.concatenate([cos, sin]).astype(np.float32)  # length DH
+
+
+def rope_w_layer(position, layer_idx, bq, bk, bv):
+    """The DH+DQ+DK+DV rope weight buffer for a position: the cos/sin LUT followed
+    by the q/k/v bias slab. Matches rope.cc, which reads the bias at rope_w+DH and
+    adds it to the concatenated qkv before applying RoPE.
+    `layer_idx` is unused (single-theta) but kept for driver call-site parity."""
+    del layer_idx
+    return np.concatenate([generate_rope_lut(position), bq, bk, bv]).astype(bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# NumPy reference forward (the decode gate's golden + KV seed).
+#
+# Runs the prompt through the 28 layers to produce (a) per-layer roped-K / raw-V
+# for the AIR decode KV seed and (b) the per-position logits for the HF-cross-check
+# golden. Intermediates are bf16-rounded at each GEMM output to approximate the
+# device datapath. Math is matched to the kernels: rms_residual.cc (norm*w, eps
+# 1e-6, plain w), rope.cc (q/k/v bias add, then half-split NEOX apply_rope, no
+# qk-norm), glu.cc (SiLU), attn scale 1/sqrt(128).
+ATTN_SCALE = 0.08838834764831843  # 1/sqrt(128)
+_DH_2 = DH // 2
+
+
+def _rmsnorm(x, w, eps=RMS_EPS):
+    """RMSNorm over the last axis: x/sqrt(mean(x^2)+eps) * w (plain w)."""
+    x = x.astype(np.float32)
+    ms = np.mean(x * x, axis=-1, keepdims=True)
+    return _bf(x * (1.0 / np.sqrt(ms + eps)) * w.astype(np.float32))
+
+
+def _apply_rope_halfsplit(x, cos, sin):
+    """Half-split NEOX rope on a [..., DH] vector, matching rope.cc apply_rope:
+    y[:DH/2] = x1*cos - x2*sin ; y[DH/2:] = x1*sin + x2*cos (cos/sin length DH/2)."""
+    x1 = x[..., :_DH_2]
+    x2 = x[..., _DH_2:]
+    return np.concatenate([x1 * cos - x2 * sin, x1 * sin + x2 * cos], axis=-1)
+
+
+def _silu(x):
+    """SiLU / swish: x * sigmoid(x)."""
+    x = x.astype(np.float32)
+    return x / (1.0 + np.exp(-x))
+
+
+def forward_prompt(model, prompt_ids):
+    """Run the prompt through all NUM_LAYERS Qwen2.5-7B layers in numpy.
+
+    Returns (Kc, Vc, logits):
+      Kc, Vc : float32 [NUM_LAYERS, P, DK] -- per-layer ROPED-K / RAW-V (the AIR
+               decode KV seed; heads concatenated in CU order [h0|h1|h2|h3]).
+      logits : float32 [P, VOCAB] -- lm-head logits per position (final-norm
+               applied); logits[-1] argmax is the greedy first token (HF golden)."""
+    embed, final_norm, lm_head = model.embed_norm_lmhead()
+    ids = np.asarray(prompt_ids, dtype=np.int64)
+    P = ids.shape[0]
+    x = _bf(embed[ids].astype(np.float32))  # [P, D]
+
+    Kc = np.zeros((NUM_LAYERS, P, DK), np.float32)
+    Vc = np.zeros((NUM_LAYERS, P, DK), np.float32)
+    pos = np.arange(P)
+
+    inv = 1.0 / (ROPE_THETA ** (np.arange(_DH_2) / _DH_2))
+    ang = pos[:, None] * inv[None, :]  # [P, DH/2]
+    cos = np.cos(ang).astype(bfloat16).astype(np.float32)[:, None, :]
+    sin = np.sin(ang).astype(bfloat16).astype(np.float32)[:, None, :]
+
+    for L in range(NUM_LAYERS):
+        w = model.layer_weights(L)  # {q,k,v,o,gate,up,down} [K, out] bf16
+        n_in, n_pa = model.layer_rms(L)  # 2 norms [D]
+        bq, bk, bv = model.layer_qkv_bias(L)  # q/k/v bias
+
+        # ---- attention sublayer (pre-norm in, residual) ----
+        residual = x
+        h = _rmsnorm(x, n_in)  # input_layernorm
+        # Bias is added to the raw projection output, before RoPE (rope.cc order).
+        q = _bf(_bf(h @ w["q"]) + bq).reshape(P, N_Q_HEADS, DH).astype(np.float32)
+        k = _bf(_bf(h @ w["k"]) + bk).reshape(P, N_KV_HEADS, DH).astype(np.float32)
+        v = _bf(_bf(h @ w["v"]) + bv).reshape(P, N_KV_HEADS, DH).astype(np.float32)
+
+        # Half-split rope (no qk-norm -- that is Qwen3).
+        q = _apply_rope_halfsplit(q, cos, sin)
+        k = _apply_rope_halfsplit(k, cos, sin)
+        Kc[L] = _bf(k).reshape(P, DK)
+        Vc[L] = _bf(v).reshape(P, DK)
+
+        # GQA attention: causal (Qwen2.5-7B has no sliding window).
+        o = np.zeros((P, N_Q_HEADS, DH), np.float32)
+        for hq in range(N_Q_HEADS):
+            hk = hq // Q_PER_KV
+            scores = (q[:, hq, :] @ k[:, hk, :].T) * ATTN_SCALE  # [P, P]
+            mask = pos[None, :] > pos[:, None]  # causal (future)
+            scores = np.where(mask, -1e30, scores)
+            scores -= scores.max(axis=-1, keepdims=True)
+            e = np.exp(scores)
+            attn = e / e.sum(axis=-1, keepdims=True)
+            o[:, hq, :] = attn @ v[:, hk, :]
+        attn_out = _bf(o.reshape(P, DQ) @ w["o"])  # o_proj [P, D]
+        x = _bf(residual + attn_out)
+
+        # ---- MLP sublayer (standard pre-norm, no post-norm) ----
+        residual = x
+        h2 = _rmsnorm(x, n_pa)  # post_attention_layernorm == FFN pre-norm
+        act = _bf(_silu(_bf(h2 @ w["gate"])) * _bf(h2 @ w["up"]))
+        x = _bf(residual + _bf(act @ w["down"]))
+
+    xf = _rmsnorm(x, final_norm)  # model.norm
+    logits = xf @ lm_head.T.astype(np.float32)  # untied lm-head [P, VOCAB]
+    return Kc, Vc, logits.astype(np.float32)

--- a/programming_examples/llms/qwen25_7b_q4nx/requirements.txt
+++ b/programming_examples/llms/qwen25_7b_q4nx/requirements.txt
@@ -1,0 +1,15 @@
+# Additional Python packages for the QWEN2.5-7B Q4NX example.
+#
+# These are *on top of* the mlir-air base environment (which already provides
+# numpy, ml_dtypes, filelock, pyxrt, etc.). Install with:
+#     pip install -r requirements.txt
+#
+# The nightly LLM benchmark installs every llms/*/requirements.txt before running
+# the lit suites, so anything imported by the drivers belongs here.
+
+# Download the model.q4nx weight bundle from the Hub (MODEL_SOURCE).
+huggingface_hub
+
+# Tokenizer for `make ask` / `make chat` and for detokenizing generated ids;
+# also loads the Qwen/Qwen2.5-7B-Instruct bf16 reference used by `make verify`.
+transformers

--- a/programming_examples/llms/qwen25_7b_q4nx/run_npu2_compile.lit
+++ b/programming_examples/llms/qwen25_7b_q4nx/run_npu2_compile.lit
@@ -1,0 +1,19 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// QWEN2.5-7B Q4NX decode compile-only smoke test: builds the two decode
+// templates (decode_L$LBUILD + decode_L$LREF) through the AIR -> AIE -> aiecc
+// -> Peano pipeline. No NPU dispatch and no weight data (weights are runtime
+// BOs), so this is the signal CI can always give without the external Q4NX
+// weights. Built at LBUILD=16 to keep the smoke test short; the production
+// templates (ATTN_MAXL=2048) are what run_npu2_profile.lit builds. Pairs with
+// run_npu2_compile_prefill.lit (the prefill half) and run_npu2_verify.lit
+// (end-to-end top-k correctness vs HF bf16, gated on the weight data).
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23
+//
+// RUN: mkdir -p test_npu2_compile
+// RUN: cd test_npu2_compile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-decode LBUILD=16 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Qwen2.5-7B decode build complete

--- a/programming_examples/llms/qwen25_7b_q4nx/run_npu2_compile_prefill.lit
+++ b/programming_examples/llms/qwen25_7b_q4nx/run_npu2_compile_prefill.lit
@@ -1,0 +1,18 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// QWEN2.5-7B Q4NX prefill compile-only smoke test: builds the prefill ELFs
+// (rms_qkv_bias_rope + flash attention + o_res_norm + gate + up + swiglu +
+// down_add + lm_head_gemv) through the AIR -> AIE -> aiecc -> Peano pipeline.
+// No NPU dispatch and no weight data (weights are runtime BOs), so this is the
+// signal CI can always give without the external Q4NX weights. Pairs with
+// run_npu2_compile.lit (the decode half) and run_npu2_verify.lit (end-to-end
+// top-k vs HF bf16).
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_npu2_compile_prefill
+// RUN: cd test_npu2_compile_prefill
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile-prefill PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: Compilation passed.

--- a/programming_examples/llms/qwen25_7b_q4nx/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_7b_q4nx/run_npu2_profile.lit
@@ -1,0 +1,26 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// QWEN2.5-7B Q4NX profiling: build the prefill ELFs and the production decode
+// templates (ATTN_MAXL=2048), then run the AIR prefill + generate N_TOKENS tokens
+// and capture TTFT and decode throughput into qwen25_7b_q4nx.perf.json via
+// bench/extract_perf.py (collected by the nightly LLM benchmark). Weights come from the HF
+// checkpoint pre-seeded into the runner's cache and quantized on load. Perf is
+// best-effort; this test gates only that profiling ran end to end.
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_7b_instruct
+//
+// RUN: mkdir -p test_npu2_profile
+// RUN: cd test_npu2_profile
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile profile PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR N_TOKENS=64 PROMPT="What is the capital of France?" | tee profile.txt
+// RUN: %PYTHON %S/../bench/extract_perf.py profile.txt --model qwen25_7b_q4nx --n-tokens 64 > qwen25_7b_q4nx.perf.json
+// RUN: FileCheck %s < qwen25_7b_q4nx.perf.json
+// CHECK: "model": "qwen25_7b_q4nx"
+// A parsed number, not just a well-formed file: if a driver's print format drifts
+// out of extract_perf.py's regexes the metric goes null and the published
+// benchmark row silently blanks while the test stays green.
+// CHECK: "ttft_ms": {{[0-9]}}
+// CHECK: "decode_tokens_per_sec": {{[0-9]}}
+// CHECK: "context_len": {{[0-9]}}

--- a/programming_examples/llms/qwen25_7b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_7b_q4nx/run_npu2_verify.lit
@@ -8,10 +8,11 @@
 // HF checkpoint rounded onto the Q4NX grid; the reference is that checkpoint in
 // bf16, so the gate measures the 4-bit loss and nothing else.
 //
-// REFERENCE. The Q4NX bundle is converted from the bartowski
-// Qwen2.5-7B-Instruct Q4_0 GGUF, so the reference is `Qwen/Qwen2.5-7B-Instruct`
-// -- ungated, so CI needs no license grant. Both MODEL_CHOICES map to it. NOT
-// the -1M variant (same geometry, rope_theta 1e7). See verify_adapter.py.
+// REFERENCE. The NPU side quantizes `Qwen/Qwen2.5-7B-Instruct` onto the Q4NX
+// grid at load (FastFlowLM publishes no Qwen2.5-7B bundle), so the bf16
+// reference is that same checkpoint -- ungated, so CI needs no license grant.
+// Both MODEL_CHOICES map to it. NOT the -1M variant (same geometry, rope_theta
+// 1e7). See verify_adapter.py.
 //
 // (The fast prefill-only Paris-argmax smoke lives at `make verify-paris`, and
 // `make run` still prints its own greedy PARIS_GREEDY verdict as a demo check.)

--- a/programming_examples/llms/qwen25_7b_q4nx/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_7b_q4nx/run_npu2_verify.lit
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Qwen2.5-7B Q4NX verify gate: top-k token-level inclusion check, NPU q4nx vs HF
+// bf16, 2 prompts x 32 greedy tokens, k=5 (use `make verify-full` for the full
+// sweep locally). Exercises the full production prefill + fused decode path
+// through the verify subsystem (verify/verify_runner.py); NPU weights are the same
+// HF checkpoint rounded onto the Q4NX grid; the reference is that checkpoint in
+// bf16, so the gate measures the 4-bit loss and nothing else.
+//
+// REFERENCE. The Q4NX bundle is converted from the bartowski
+// Qwen2.5-7B-Instruct Q4_0 GGUF, so the reference is `Qwen/Qwen2.5-7B-Instruct`
+// -- ungated, so CI needs no license grant. Both MODEL_CHOICES map to it. NOT
+// the -1M variant (same geometry, rope_theta 1e7). See verify_adapter.py.
+//
+// (The fast prefill-only Paris-argmax smoke lives at `make verify-paris`, and
+// `make run` still prints its own greedy PARIS_GREEDY verdict as a demo check.)
+//
+// LBUILD=128 sizes the decode KV cache for CI only: the gate's longest prompt
+// plus its 32 generated tokens fits well inside it, and the templates build far
+// faster than at the 2048 default.
+//
+// Skips cleanly when HF_TOKEN is unset (reference + tokenizer downloads need it).
+//
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_7b_instruct
+//
+// RUN: mkdir -p test_npu2_verify
+// RUN: cd test_npu2_verify
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile compile LBUILD=128 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR
+// RUN: make -f %S/Makefile verify PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s
+// CHECK: [verify] PASS

--- a/programming_examples/llms/qwen25_7b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/verify_adapter.py
@@ -1,0 +1,173 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Verify adapter for the Q4NX Qwen2.5-7B example (FLM-faithful prefill + decode).
+
+Drives the SAME on-device path `make run` uses: the batched AIR prefill for the
+prompt, then the fused_decode superkernel (28 layers + the untied LM head in one
+dispatch, attention + KV cache on the AIE array) for each new token.
+
+REFERENCE. The Q4NX bundle is converted from the bartowski Qwen2.5-7B-Instruct
+Q4_0 GGUF (the GGUF family FastFlowLM's own converter consumes), so the bf16
+reference is `Qwen/Qwen2.5-7B-Instruct` -- ungated, rope_theta 1e6. NOT the
+-1M long-context variant, which shares the geometry but ropes at 1e7.
+
+`prefill()` runs `Qwen25Q4nxPrefill` (full logits + per-layer roped-K / raw-V) and
+seeds the decode's device KV cache from it; each `decode_step()` then dispatches
+one fused token.
+
+Pointed at via `--runner=qwen25_7b_q4nx.verify_adapter`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LLMS_DIR = _THIS_DIR.parent
+_VERIFY = _LLMS_DIR / "verify"
+for _p in (str(_LLMS_DIR), str(_VERIFY), str(_THIS_DIR)):
+    while _p in sys.path:
+        sys.path.remove(_p)
+    sys.path.insert(0, _p)
+
+from runners._records import DecodeStepRecord, PrefillRecord  # noqa: E402
+
+# Qwen2.5-7B geometry. Taken from qwen25_7b_q4nx_weights rather than restated, so
+# it cannot drift from the loader (and so a clone of this file for another model
+# fails loudly instead of silently describing the wrong one). The shared runner
+# reads only n_layers today; the rest are here for diagnosis/probing.
+import qwen25_7b_q4nx_weights as _w  # noqa: E402
+
+_N_LAYERS = _w.NUM_LAYERS
+
+
+@dataclass
+class Qwen25Config:
+    n_layers: int = _N_LAYERS
+    emb_dim: int = _w.D
+    n_heads: int = _w.N_Q_HEADS
+    head_dim: int = _w.DH
+    n_kv_heads: int = _w.N_KV_HEADS
+    hidden_dim: int = _w.INTER
+    vocab_size: int = _w.VOCAB
+
+
+# The NPU weights come from the *Instruct* GGUF, so both keys map to it: a
+# base-model reference would disagree with the bundle it is checking.
+MODEL_CHOICES = {
+    "base": "Qwen/Qwen2.5-7B-Instruct",
+    "instruct": "Qwen/Qwen2.5-7B-Instruct",
+}
+DEFAULT_MODEL = "instruct"
+
+# NPU weight source: the FastFlowLM Q4NX bundle (NOT the bf16 reference above).
+# Same default as the inference driver / Makefile.
+Q4NX_MODEL_SOURCE = os.environ.get("Q4NX_MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
+
+# Padded prefill length. The Qwen2.5-7B GEMM registry shapes exist at M=2048, so the
+# whole prefill runs there (same constraint as the other Q4NX examples).
+_SEQ_LEN = int(os.environ.get("Q4NX_SEQ_LEN", "2048"))
+
+
+def build_config():
+    return Qwen25Config()
+
+
+def resolve_model(model_choice_or_id: str) -> str:
+    return MODEL_CHOICES.get(model_choice_or_id, model_choice_or_id)
+
+
+def hf_reference(npu_model_name: str) -> str:
+    """The bf16 reference. The NPU weights come from a separate Q4NX bundle
+    (converted from a GGUF), so the two differ."""
+    return npu_model_name
+
+
+def build_runner(
+    model_name: str,
+    config,
+    max_seq: int,
+    tokenizer,
+    *,
+    npu_attn: bool = True,
+    lite_mode: bool = False,
+):
+    """Compile/load the Q4NX prefill + the fused Qwen2.5-7B decode, return an NpuRunner."""
+    return NpuRunner(tokenizer=tokenizer, lite_mode=lite_mode)
+
+
+class NpuRunner:
+    """Adapter over the Q4NX batched prefill + one-xclbin fused Qwen2.5-7B decode.
+
+    prefill() runs `Qwen25Q4nxPrefill` (full logits + per-layer roped-K / raw-V)
+    and seeds the decoder's KV cache; decode_step() dispatches one fused token
+    (28 layers + the untied LM head) through `FusedDecoder`. Mirrors the loop in
+    `qwen25_7b_q4nx_inference.generate`."""
+
+    name = "npu_q4nx"
+
+    def __init__(self, tokenizer, lite_mode: bool = False):
+        self.lite_mode = lite_mode
+        self._tokenizer = tokenizer
+
+        from qwen25_7b_q4nx_prefill import Qwen25Q4nxPrefill
+        from qwen25_7b_q4nx_inference import FusedDecoder
+
+        self.prefiller = Qwen25Q4nxPrefill(
+            seq_len=_SEQ_LEN, cache_dir=os.environ.get("Q4NX_CACHE_DIR") or None
+        )
+        self.prefiller.load_weights(model=Q4NX_MODEL_SOURCE)
+        self.dec = FusedDecoder(model=Q4NX_MODEL_SOURCE)
+        self.attn_maxl = self.dec.gen.attn_maxl
+        self._P = 0
+
+    def prefill(self, prompt_tokens: np.ndarray) -> PrefillRecord:
+        ids = [int(t) for t in prompt_tokens]
+        if len(ids) > self.attn_maxl:
+            raise SystemExit(
+                f"prompt is {len(ids)} tokens but the fused Qwen2.5-7B decode KV cache "
+                f"caps at {self.attn_maxl}. Rebuild with a larger cap "
+                f"(`make compile-decode LBUILD=...`)."
+            )
+        self.prefiller.clear_context()
+        logits = np.asarray(self.prefiller.prefill(ids), np.float32)
+        first = int(logits.argmax())
+        Kc, Vc = self.prefiller.kv_stack()
+        self._P = Kc.shape[1]
+        self.dec.seed_kv(Kc, Vc, self._P)
+
+        # The prefill produces the first token; the decode continues from it, so
+        # (unlike the Qwen2.5-3B hand-off) no priming dispatch is needed here -- the
+        # runner's first decode_step is that token at position P.
+
+        # The Q4NX prefill does not expose per-layer ffn_out, and the decode runs
+        # all 28 layers inside one dispatch, so the diagnosis lens has no
+        # per-layer data. Return one empty dict per layer (len == n_layers) rather
+        # than an empty list: the diagnosis path indexes layer_intermediates[li]
+        # per layer, and `.get("ffn_out")` on an empty dict yields None, which the
+        # shared runner skips gracefully (an empty list would IndexError).
+        empty = np.empty((0,), dtype=np.float32)
+        return PrefillRecord(
+            layer_intermediates=[{} for _ in range(_N_LAYERS)],
+            final_hidden_normed=empty,
+            logits_at_pred=logits,
+            top1_token=first,
+        )
+
+    def decode_step(self, input_token: int, current_pos: int) -> DecodeStepRecord:
+        # `current_pos` is the absolute position of `input_token` (the runner
+        # passes len(prompt) for the first generated token), which is what
+        # dispatch() wants.
+        logits = np.asarray(
+            self.dec.dispatch(int(input_token), int(current_pos)), np.float32
+        )
+        return DecodeStepRecord(
+            lm_head_logits=logits,
+            top1_token=int(logits.argmax()),
+        )

--- a/programming_examples/llms/qwen25_7b_q4nx/verify_adapter.py
+++ b/programming_examples/llms/qwen25_7b_q4nx/verify_adapter.py
@@ -7,10 +7,11 @@ Drives the SAME on-device path `make run` uses: the batched AIR prefill for the
 prompt, then the fused_decode superkernel (28 layers + the untied LM head in one
 dispatch, attention + KV cache on the AIE array) for each new token.
 
-REFERENCE. The Q4NX bundle is converted from the bartowski Qwen2.5-7B-Instruct
-Q4_0 GGUF (the GGUF family FastFlowLM's own converter consumes), so the bf16
-reference is `Qwen/Qwen2.5-7B-Instruct` -- ungated, rope_theta 1e6. NOT the
--1M long-context variant, which shares the geometry but ropes at 1e7.
+REFERENCE. The NPU weights are `Qwen/Qwen2.5-7B-Instruct` rounded onto the Q4NX
+grid at load (FastFlowLM publishes no Qwen2.5-7B bundle), so the bf16 reference
+is that same checkpoint and the gate measures the 4-bit loss and nothing else --
+ungated, rope_theta 1e6. NOT the -1M long-context variant, which shares the
+geometry but ropes at 1e7.
 
 `prefill()` runs `Qwen25Q4nxPrefill` (full logits + per-layer roped-K / raw-V) and
 seeds the decode's device KV cache from it; each `decode_step()` then dispatches
@@ -58,16 +59,17 @@ class Qwen25Config:
     vocab_size: int = _w.VOCAB
 
 
-# The NPU weights come from the *Instruct* GGUF, so both keys map to it: a
-# base-model reference would disagree with the bundle it is checking.
+# The NPU weights are quantized from the *Instruct* checkpoint, so both keys map
+# to it: a base-model reference would disagree with the weights it is checking.
 MODEL_CHOICES = {
     "base": "Qwen/Qwen2.5-7B-Instruct",
     "instruct": "Qwen/Qwen2.5-7B-Instruct",
 }
 DEFAULT_MODEL = "instruct"
 
-# NPU weight source: the FastFlowLM Q4NX bundle (NOT the bf16 reference above).
-# Same default as the inference driver / Makefile.
+# NPU weight source. By default the same repo id as the bf16 reference above --
+# the NPU side quantizes it to Q4NX on load, the reference side reads it in bf16.
+# A local model.q4nx bundle is also accepted. Same default as the driver/Makefile.
 Q4NX_MODEL_SOURCE = os.environ.get("Q4NX_MODEL_SOURCE", "Qwen/Qwen2.5-7B-Instruct")
 
 # Padded prefill length. The Qwen2.5-7B GEMM registry shapes exist at M=2048, so the
@@ -84,8 +86,8 @@ def resolve_model(model_choice_or_id: str) -> str:
 
 
 def hf_reference(npu_model_name: str) -> str:
-    """The bf16 reference. The NPU weights come from a separate Q4NX bundle
-    (converted from a GGUF), so the two differ."""
+    """The bf16 reference: the same checkpoint the NPU side quantizes to Q4NX on
+    load, so the gate isolates quantization error."""
     return npu_model_name
 
 


### PR DESCRIPTION
Qwen2.5-7B-Instruct end to end on NPU2: an AIR prefill over the padded context, and a fused decode that dispatches **all 28 layers plus the LM head in one call**.

Two firsts for the shared [`fused_decode`](programming_examples/fused_decode/) engine: the first `HAS_QKV_BIAS` model, and the first with no FastFlowLM bundle to load — weights are Q4NX quantized on load from the ungated `Qwen/Qwen2.5-7B-Instruct`, which is also the bf16 verify reference.

## Engine fixes

Both are no-ops for the five models already on this engine: **their emitted IR is byte-identical before and after** (checked by re-emitting each model's module on both revisions).

**1. `refeed()` splits counts above 63.** An AIE2/AIE2P lock counter is 6 bits (`AIETargetModel::getMaxLockValue() == 0x3F`), and the refeed count becomes a lock init that nothing range-checks. This model's gate-up refeed is 74, which truncated on the device and deadlocked the re-broadcast. Counts ≤ 63 — every model shipped so far — emit exactly the IR they did before.

**2. The GLU slice granularity adapts so the slice count stays even.** The GLU core's buffer-slot sequence is statically unrolled and restarts every layer, while the BD ring's rotation carries over — so an *odd* slice count leaves the two a slot apart and every other layer reads a stale slice. `INTERMEDIATE_SIZE=18944` is the first that is an odd number of 1024-row slices (37); dropping to one demux packet per slice makes it 74, same total, same interleave stride. An assert now states the invariant.

The failure was reproducible as exact dispatch-parity (`OK,BAD,OK,BAD` on repeated identical dispatches), which is what pinned it to ring phase rather than to the data.

## Also here

- Conditional SwiGLU row split in the shared `qwen25_3b` prefill builder: at hidden=18944 a single launch needs 1024 DMA iterations and exhausts the shim's 16 BDs. Returns the single unchanged chunk for every smaller `hidden_dim`.
- Vectorized affine Q4NX packer (bit-identical to the reference packer, ~1000x faster).
- Five GEMM kernel-registry entries.

## Results

Measured on an **AMD Ryzen AI 9 HX 370** (Strix Point, XDNA2/NPU2), warm:

| | |
|---|---|
| prefill (TTFT) | 10.0 s at CTX=2048 (205 tok/s) |
| decode | 11.46 tok/s (87.2 ms/token), ATTN_MAXL=2048 |

- `make verify` — PASS, top-k token-set gate vs `Qwen/Qwen2.5-7B-Instruct` bf16 (2 prompts x 32 tokens, k=5)
- `make run` — `*** PARIS ***`, reproducible

The example is wired into the nightly LLM perf CI and the GitHub Pages dashboard the same way its siblings are: path-globbed `run_npu2_{verify,profile}.lit`, an `hf_models.txt` entry for the weight pre-fetch, and an `LLM_HF_MODELS` entry for the dashboard link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)