### PR TITLE
[python] air.api: bound broadcast channel indices by broadcast_shape

### DIFF
--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -158,7 +158,7 @@ class Channel:
             )
         self._declared = True
 
-    def _indices(self, indices):
+    def _indices(self, indices, direction):
         if indices is None:
             indices = ()
         if isinstance(indices, int):
@@ -185,12 +185,19 @@ class Channel:
         # be materialised into an index-typed Value; a constant folds back to a
         # Python int, which the op keeps static. Only the constant case can be
         # range-checked -- the herd shape already bounds the dynamic one.
-        # A broadcast channel is indexed over its *destinations*, not its
-        # sources: `size=[1, 1], broadcast_shape=[3, 1]` is one producer feeding
-        # a 3x1 grid, and each consumer names its own slot with indices=[n, 0].
-        # Bounding those against size would admit only [0, 0]. The hand-written
-        # broadcast/multi_herd example is exactly this shape.
-        bounds = self.broadcast_shape or self.size
+        # The two ends of a broadcast are indexed over different grids, so the
+        # bound depends on the direction. A consumer names its slot among the
+        # *destinations*: with `size=[1, 1], broadcast_shape=[3, 1]`, one
+        # producer feeds a 3x1 grid and the gets are [0,0], [1,0], [2,0] --
+        # bounding those by size would admit only [0, 0], which is what
+        # broadcast/multi_herd hit. A producer still indexes the *source*
+        # bundle, which is `size`, so widening the bound for puts as well would
+        # accept an out-of-range source and emit an invalid bundle index.
+        bounds = (
+            self.broadcast_shape
+            if (direction == "get" and self.broadcast_shape)
+            else self.size
+        )
         out = []
         for axis, (idx, extent) in enumerate(zip(indices, bounds)):
             value = coerce_index(idx).materialize()
@@ -200,7 +207,7 @@ class Channel:
                     f"on axis {axis}: "
                     + (
                         f"broadcast_shape is {self.broadcast_shape}"
-                        if self.broadcast_shape
+                        if bounds is self.broadcast_shape
                         else f"size is {self.size}"
                     )
                     + f", so that axis admits 0..{extent - 1}"
@@ -229,7 +236,7 @@ class Channel:
             )
 
         offsets, sizes, strides = endpoint.pattern or ([], [], [])
-        idx = self._indices(indices)
+        idx = self._indices(indices, direction)
 
         if direction == "get" and endpoint.tensor is not None:
             # Same rule ops.store applies: being written from the device is what

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -185,14 +185,25 @@ class Channel:
         # be materialised into an index-typed Value; a constant folds back to a
         # Python int, which the op keeps static. Only the constant case can be
         # range-checked -- the herd shape already bounds the dynamic one.
+        # A broadcast channel is indexed over its *destinations*, not its
+        # sources: `size=[1, 1], broadcast_shape=[3, 1]` is one producer feeding
+        # a 3x1 grid, and each consumer names its own slot with indices=[n, 0].
+        # Bounding those against size would admit only [0, 0]. The hand-written
+        # broadcast/multi_herd example is exactly this shape.
+        bounds = self.broadcast_shape or self.size
         out = []
-        for axis, (idx, extent) in enumerate(zip(indices, self.size)):
+        for axis, (idx, extent) in enumerate(zip(indices, bounds)):
             value = coerce_index(idx).materialize()
             if isinstance(value, int) and not 0 <= value < extent:
                 raise ValueError(
-                    f"air.channel {self.name!r} index {value} is out of range on "
-                    f"axis {axis}: size is {self.size}, so that axis admits "
-                    f"0..{extent - 1}"
+                    f"air.channel {self.name!r} index {value} is out of range "
+                    f"on axis {axis}: "
+                    + (
+                        f"broadcast_shape is {self.broadcast_shape}"
+                        if self.broadcast_shape
+                        else f"size is {self.size}"
+                    )
+                    + f", so that axis admits 0..{extent - 1}"
                 )
             out.append(value)
         return out

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1003,3 +1003,20 @@ def _():
         ch.get(buf, indices=[3, 0])
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: broadcast_put_still_bounded_by_size
+# The two ends of a broadcast are indexed over different grids. A *get* names a
+# destination, so broadcast_shape bounds it (above). A *put* names a slot in the
+# source bundle, which is `size` -- widening the bound for puts too would accept
+# an out-of-range source and emit an invalid bundle index.
+# CHECK: ValueError: air.channel 'BP' index 2 is out of range on axis 0: size is [1, 2], so that axis admits 0..0
+@expect(ValueError, "broadcast_put_still_bounded_by_size")
+def _():
+    ch = air.channel("BP", size=[1, 2], broadcast_shape=[3, 2])
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf, indices=[2, 0])
+
+    _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -986,3 +986,20 @@ def _():
         ops.load(small, A)
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: broadcast_index_bounded_by_broadcast_shape
+# A broadcast channel is indexed over its destinations, so the bound is
+# broadcast_shape, not size -- and the message has to say which, or it reads as
+# a contradiction ("index 1 out of range, size is [1, 1]") to someone whose
+# 3-destination fan-out is working exactly as declared.
+# CHECK: ValueError: air.channel 'BC' index 3 is out of range on axis 0: broadcast_shape is [3, 1], so that axis admits 0..2
+@expect(ValueError, "broadcast_index_bounded_by_broadcast_shape")
+def _():
+    ch = air.channel("BC", size=[1, 1], broadcast_shape=[3, 1])
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.get(buf, indices=[3, 0])
+
+    _trace(body)


### PR DESCRIPTION
Fixes a bug shipped in #1852.

A broadcast channel is indexed over its **destinations**, not its sources.
`size=[1, 1], broadcast_shape=[3, 1]` is one producer feeding a 3x1 grid, and
the consumers name slots `[0,0]`, `[1,0]`, `[2,0]`. The index check bounded
them by `size`, which admits only `[0, 0]`, so it rejected the canonical
fan-out:

```
air.channel 'ChanIn' index 1 is out of range on axis 0: size is [1, 1]
```

which reads as a contradiction when the three-way broadcast is declared exactly
as intended. Now bounded by `broadcast_shape` when there is one, and the
message names which bound it applied.

`channel_examples/broadcast/single_herd`, converted in #1852, missed this
because its indices are herd coordinates — dynamic, and so never range-checked.
The bug surfaced converting `broadcast/multi_herd`, whose three herds index
with constants.

## Evidence

```
$ git log --oneline origin/main..HEAD
0e3c8928 [python] air.api: bound broadcast channel indices by broadcast_shape

$ git show --name-status HEAD
M	python/air/api/_channel.py
M	python/test/api/errors.py

$ git diff --stat origin/main...HEAD
 python/air/api/_channel.py | 19 +++++++++++++++----
 python/test/api/errors.py  | 17 +++++++++++++++++
 2 files changed, 32 insertions(+), 4 deletions(-)

$ lit -v build/python/test/ --filter=api
PASS: AIRPYTHON :: api/segment.py (1 of 10)
PASS: AIRPYTHON :: api/leaky_relu.py (2 of 10)
PASS: AIRPYTHON :: api/pack.py (3 of 10)
PASS: AIRPYTHON :: api/axpy.py (4 of 10)
PASS: AIRPYTHON :: api/relu.py (5 of 10)
PASS: AIRPYTHON :: api/channel.py (6 of 10)
PASS: AIRPYTHON :: api/eltwise_add.py (7 of 10)
PASS: AIRPYTHON :: api/dot.py (8 of 10)
PASS: AIRPYTHON :: api/activations.py (9 of 10)
PASS: AIRPYTHON :: api/errors.py (10 of 10)
```

New negative case `broadcast_index_bounded_by_broadcast_shape` in
`errors.py` pins the bound and the message. No hardware run: this is a
trace-time check, and the emitted IR for an in-range index is unchanged.