### PR TITLE
[python] air.api: packed channel puts, and the two vecmat i8 examples

### DIFF
--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -55,11 +55,38 @@ DTYPE = {np.int8: i8, np.float32: f32}
 # The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
 MMUL_MKN = (1, 16, 8)
 
+# What vm.cc was compiled for: vecmat_vectorized_1x16x8_i8_f32_i32_32<1, 96, 48>.
+KERNEL_TILE_K = 96
+KERNEL_TILE_N = 48
+KERNEL_BS = 32
+
 
 def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
     assert tile_k % bs == 0
+    # vm.cc instantiates exactly one shape and one block size:
+    #     combos(X) X(int8, i8, float, f32, int, i32, 32, 1, 16, 8)
+    #     vecmat_vectorized_1x16x8_i8_f32_i32_32<1, 96, 48>(...)
+    # so the tile is fixed at 96x48 and the only symbol that exists is
+    # vecmat_i8_f32_i32_32. A different --bs names a function nobody defined
+    # (a link failure); a different tile links and computes the wrong answer.
+    # K and N stay free -- they are how many tiles, not how big.
+    if bs != KERNEL_BS:
+        raise ValueError(
+            f"vm.cc defines vecmat_i8_f32_i32_{KERNEL_BS} only, so --bs "
+            f"{KERNEL_BS} is the only supported block size; got bs={bs}, which "
+            f"would call vecmat_i8_f32_i32_{bs} and fail to link. Rebuild vm.cc "
+            f"with a different group_size to change it."
+        )
+    if (tile_k, tile_n) != (KERNEL_TILE_K, KERNEL_TILE_N):
+        raise ValueError(
+            f"vm.cc instantiates vecmat_i8_f32_i32_{KERNEL_BS} for a "
+            f"{KERNEL_TILE_K}x{KERNEL_TILE_N} tile only, so --tile-k "
+            f"{KERNEL_TILE_K} --tile-n {KERNEL_TILE_N} is the only supported "
+            f"pair; got tile_k={tile_k}, tile_n={tile_n}. Rebuild vm.cc with "
+            f"different template arguments to change it."
+        )
 
     dt_in = DTYPE[np_dtype_in]
     dt_out = DTYPE[np_dtype_out]

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -1,401 +1,178 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Block-quantized vector-matrix multiplication on air.api.
+
+``C[N] = sum_g (A_i8[g] @ B_i8[g,N]) * a_scale[g] * b_scale[g,N]``: the operands
+are int8, accumulated in int32, and rescaled to f32 once per block of ``bs``
+elements along K. So every operand travels as a *pair* -- the quantized data and
+its per-block scale -- and the pair shares a channel:
+
+    A:  L3 --aL3ToL2--> L2 --aL2ToL1--> L1     (data, then scale)
+    B:  L3 --bL3ToL2--> L2 --bL2ToL1--> L1     (data, then scale)
+    C:  L1 --cL1ToL2--> L2 --cL2ToL3--> L3
+
+Two puts into one channel and two gets out of it, in the same order. That is
+ordinary channel semantics rather than a trick: a channel is a stream, each get
+takes the next chunk, and nothing requires the chunks to be the same shape --
+which is what lets ``[k]`` of data and ``[k/bs]`` of scale share ``aL3ToL2``.
+
+The B side is micro-tiled for the AIE2 int8 vecmat intrinsic (``m x k`` by
+``k x n``, here ``(1, 16, 8)``), so it reaches L1 as ``[N/8, K/16, 16, 8]``
+rather than row-major. The DMA does the pack, by walking the flat L2 buffer out
+of order, and ``pack=`` names that walk::
+
+    b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
+
+The B *scale* is packed the same way but with one scale per block instead of
+per element, which is exactly a micro-tile of ``k=1`` -- so it reuses the same
+derivation with a different micro-tile rather than a special case.
+
+Unchanged from the raw-bindings version this replaces, except for three things
+the DSL requires and one it fixes:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The L1 tiles are allocated above the K loop and reused across trips, rather
+  than a fresh set per trip.
+* ``linalg_fill_i32_view16x8xi32as2`` is declared with the signature ``vm.cc``
+  actually defines -- ``void linalg_fill_i32_view16x8xi32as2(float *)``, the
+  buffer alone. The predecessor declared it ``(f32, memref)`` and passed a zero
+  the callee never reads; harmless, since the C ABI drops the extra argument,
+  but untrue.
+"""
+
 import argparse
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
 import numpy as np
 
-np.random.seed(42)
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import f32, i8
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {np.int8: i8, np.float32: f32}
+
+# The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
+MMUL_MKN = (1, 16, 8)
 
 
-@module_builder
-def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_acc, np_dtype_out):
+def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
-    a_size = [k]
-    a_s_size = [k // bs]
-    b_size = [k, n]
-    b_s_size = [k // bs, n]
-    c_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_acc = type_mapper(np_dtype_acc)
-    xrt_dtype_out = type_mapper(np_dtype_out)
+    assert tile_k % bs == 0
 
-    mmul_mkn = [1, 16, 8]
+    dt_in = DTYPE[np_dtype_in]
+    dt_out = DTYPE[np_dtype_out]
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyAS = MemRefType.get(a_s_size, xrt_dtype_out)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyBS = MemRefType.get(b_s_size, xrt_dtype_out)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    m_u, k_u, n_u = MMUL_MKN
+    mm = air.micro_tile(m_u, k_u, n_u)
+    # One scale per block of bs elements along K, laid out in the same
+    # micro-tile order as the data it scales -- a k=1 micro-tile.
+    mm_scale = air.micro_tile(m_u, 1, n_u)
 
-    Channel("aL3ToL2")
-    Channel("bL3ToL2")
-    Channel("aL2ToL1")
-    Channel("bL2ToL1")
-    Channel("cL1ToL2")
-    Channel("cL2ToL3")
+    A = air.tensor([k], dt_in)
+    A_s = air.tensor([k // bs], dt_out)
+    B = air.tensor([k, n], dt_in)
+    B_s = air.tensor([k // bs, n], dt_out)
+    C = air.tensor([n], dt_out)
 
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l3_l2 = air.channel("aL3ToL2")
+    b_l3_l2 = air.channel("bL3ToL2")
+    a_l2_l1 = air.channel("aL2ToL1")
+    b_l2_l1 = air.channel("bL2ToL1")
+    c_l1_l2 = air.channel("cL1ToL2")
+    c_l2_l3 = air.channel("cL2ToL3")
 
-    a_l1_size = [tile_k // mmul_mkn[1], mmul_mkn[1]]
-    a_s_l1_size = [tile_k // bs]
-    b_l1_size = [tile_n // mmul_mkn[2], tile_k // mmul_mkn[1], mmul_mkn[1], mmul_mkn[2]]
-    b_s_l1_size = [tile_n // mmul_mkn[2], tile_k // bs, mmul_mkn[2]]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyAS = MemRefType.get(
-        shape=a_s_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyBS = MemRefType.get(
-        shape=b_s_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    c_l1_size = [tile_n // mmul_mkn[2], mmul_mkn[2]]
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_i32_view16x8xi32as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    vecmat_func = FuncOp(
-        "vecmat_i8_f32_i32_32",
-        ([l1MemrefTyA, l1MemrefTyAS, l1MemrefTyB, l1MemrefTyBS, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, vecmat_func]:
-        func.attributes["link_with"] = StringAttr.get("vm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    vecmat = air.extern(f"vecmat_i8_f32_i32_{bs}", object=link_with)
+    fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyAS, memrefTyB, memrefTyBS, memrefTyOut)
-    def vecmat_i8(arg0, arg1, arg2, arg3, arg4):
+    with air.launch(name="vecmat_i8") as launch:
 
-        launch_size = [1, n // tile_n]
+        @launch.body
+        def _():
+            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2, arg3, arg4], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_a_scale,
-            l3_b_data,
-            l3_b_scale,
-            l3_c_data,
-        ):
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_scale,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
+                @seg.body
+                def _(sj):
+                    col = sj * tile_n
 
-            # Affine map for launch iv
-            launch_ivy_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_n),
-                    )
-                ],
-            )
-            launch_offset_y = affine_apply(launch_ivy_map, [launch_ivy])
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_data,
-                offsets=[0, launch_offset_y],
-                sizes=[k, tile_n],
-                strides=[n, 1],
-            )
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_scale,
-                offsets=[0, launch_offset_y],
-                sizes=[k // bs, tile_n],
-                strides=[n, 1],
-            )
+                    l2_a = air.alloc([k], dt_in, scope=seg.private())
+                    l2_a_s = air.alloc([k // bs], dt_out, scope=seg.private())
+                    l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())
+                    l2_b_s = air.alloc([k // bs, tile_n], dt_out, scope=seg.private())
+                    l2_c = air.alloc([tile_n], dt_out, scope=seg.private())
 
-            @segment(name="vecmat_i8_0")
-            def segment_body():
-                # L2 MemRefTypes
-                a_size_l2 = [k]
-                a_s_size_l2 = [k // bs]
-                b_size_l2 = [k, tile_n]
-                b_s_size_l2 = [k // bs, tile_n]
-                c_size_l2 = [tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyAS = MemRefType.get(
-                    shape=a_s_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyBS = MemRefType.get(
-                    shape=b_s_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
-                l2_a_scale = AllocOp(l2MemrefTyAS, [], [])
+                    a_l3_l2.put(A)
+                    a_l3_l2.put(A_s)
+                    b_l3_l2.put(B[0:k, col : col + tile_n])
+                    b_l3_l2.put(B_s[0 : k // bs, col : col + tile_n])
+                    a_l3_l2.get(l2_a)
+                    a_l3_l2.get(l2_a_s)
+                    b_l3_l2.get(l2_b)
+                    b_l3_l2.get(l2_b_s)
 
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_scale,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                    # One slice per K tile, data then scale, on both sides.
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        ks = i * (tile_k // bs)
+                        a_l2_l1.put(l2_a[kk : kk + tile_k])
+                        a_l2_l1.put(l2_a_s[ks : ks + tile_k // bs])
 
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
-                l2_b_scale = AllocOp(l2MemrefTyBS, [], [])
-
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_scale,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                # L2 to L1 data packing and unpacking, using offsets, sizes and strides
-                a_l2l1_pack_size = [tile_k]
-                a_l2l1_pack_stride = [1]
-                a_s_l2l1_pack_size = [tile_k // bs]
-                a_s_l2l1_pack_stride = [1]
-                b_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k, mmul_mkn[2]]
-                b_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-                b_s_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k // bs, mmul_mkn[2]]
-                b_s_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-
-                for_iv_map_data = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k),
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        ks = i * (tile_k // bs)
+                        b_l2_l1.put(
+                            l2_b[kk : kk + tile_k, 0:tile_n],
+                            pack=mm.b(tile_k, tile_n, lead=()),
                         )
-                    ],
-                )
-                for_iv_map_scale = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k // bs),
-                        )
-                    ],
-                )
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    a_l2l1_pack_offset = [for_iv_data_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_data,
-                        offsets=a_l2l1_pack_offset,
-                        sizes=a_l2l1_pack_size,
-                        strides=a_l2l1_pack_stride,
-                    )
-                    for_iv_scale_offset = affine_apply(for_iv_map_scale, [i])
-                    a_s_l2l1_pack_offset = [for_iv_scale_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_scale,
-                        offsets=a_s_l2l1_pack_offset,
-                        sizes=a_s_l2l1_pack_size,
-                        strides=a_s_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    b_l2l1_pack_offset = [0, for_iv_data_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_data,
-                        offsets=b_l2l1_pack_offset,
-                        sizes=b_l2l1_pack_size,
-                        strides=b_l2l1_pack_stride,
-                    )
-                    for_iv_scale_offset = affine_apply(for_iv_map_scale, [i])
-                    b_s_l2l1_pack_offset = [0, for_iv_scale_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_scale,
-                        offsets=b_s_l2l1_pack_offset,
-                        sizes=b_s_l2l1_pack_size,
-                        strides=b_s_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                @herd(name="herd_0", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-
-                    l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                    zero_const = ConstantOp(FloatAttr.get(xrt_dtype_out, 0.0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_data])
-
-                    for i in range_(0, k, tile_k):
-                        l1_a_data = AllocOp(l1MemrefTyA, [], [])
-                        l1_a_scale = AllocOp(l1MemrefTyAS, [], [])
-
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_scale,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
+                        b_l2_l1.put(
+                            l2_b_s[ks : ks + tile_k // bs, 0:tile_n],
+                            pack=mm_scale.b(tile_k // bs, tile_n, lead=()),
                         )
 
-                        l1_b_data = AllocOp(l1MemrefTyB, [], [])
-                        l1_b_scale = AllocOp(l1MemrefTyBS, [], [])
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_scale,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
+                        @h.body
+                        def _(tx):
+                            l1_a = air.alloc(
+                                [tile_k // k_u, k_u], dt_in, scope=h.private()
+                            )
+                            l1_a_s = air.alloc(
+                                [tile_k // bs], dt_out, scope=h.private()
+                            )
+                            l1_b = air.alloc(
+                                [tile_n // n_u, tile_k // k_u, k_u, n_u],
+                                dt_in,
+                                scope=h.private(),
+                            )
+                            l1_b_s = air.alloc(
+                                [tile_n // n_u, tile_k // bs, n_u],
+                                dt_out,
+                                scope=h.private(),
+                            )
+                            l1_c = air.alloc(
+                                [tile_n // n_u, n_u], dt_out, scope=h.private()
+                            )
 
-                        vecmat = CallOp(
-                            vecmat_func,
-                            [l1_a_data, l1_a_scale, l1_b_data, l1_b_scale, l1_c_data],
-                        )
+                            fill(l1_c)
+                            for _j in air.sequential(0, k, tile_k):
+                                a_l2_l1.get(l1_a)
+                                a_l2_l1.get(l1_a_s)
+                                b_l2_l1.get(l1_b)
+                                b_l2_l1.get(l1_b_s)
+                                vecmat(l1_a, l1_a_s, l1_b, l1_b_s, l1_c)
 
-                        DeallocOp(l1_a_data)
-                        DeallocOp(l1_a_scale)
-                        DeallocOp(l1_b_data)
-                        DeallocOp(l1_b_scale)
+                            c_l1_l2.put(l1_c)
 
-                        yield_([])
+                    c_l1_l2.get(l2_c)
+                    c_l2_l3.put(l2_c)
+                    c_l2_l3.get(C[col : col + tile_n])
 
-                    ChannelPut(
-                        "cL1ToL2",
-                        l1_c_data,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                    )
-                    DeallocOp(l1_c_data)
-
-                herd_body.attributes["link_with"] = StringAttr.get("vm.o")
-
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                ChannelPut(
-                    "cL2ToL3",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_a_scale)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_b_scale)
-                DeallocOp(l2_c_data)
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
+    return launch
 
 
 if __name__ == "__main__":
     # Default values.
-    M = 1
     K = 288
     N = 48
     BS = 32
@@ -405,9 +182,11 @@ if __name__ == "__main__":
     ACC_DATATYPE = np.int32
     OUTPUT_DATATYPE = np.float32
 
+    np.random.seed(42)
+
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        prog="single_core.py",
+        description="Builds, runs, and tests the block-quantized int8 vector-matrix multiplication example",
     )
     parser.add_argument(
         "-v",
@@ -448,19 +227,26 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.k,
         args.n,
         args.bs,
         args.tile_k,
         args.tile_n,
         INPUT_DATATYPE,
-        ACC_DATATYPE,
         OUTPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -1,288 +1,155 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""int8 vector-matrix multiplication on air.api: C[N] = A[K] @ B[K,N], in i32.
+
+Six channels carry the whole schedule -- there is not a single
+``air.dma_memcpy_nd`` in it:
+
+    A:  L3 --aL3ToL2--> L2 --aL2ToL1--> L1
+    B:  L3 --bL3ToL2--> L2 --bL2ToL1--> L1
+    C:  L1 --cL1ToL2--> L2 --cL2ToL3--> L3
+
+and the herd names none of them as an operand: ``air.herd`` is
+``IsolatedFromAbove``, but a channel is a module-level symbol and resolves by
+name from any depth.
+
+What differs from the bf16 sibling is the layout. The AIE2 int8 vecmat
+intrinsic wants its operands micro-tiled -- ``m x k`` by ``k x n`` with
+``(1, 16, 8)`` -- so the B tile reaches L1 as ``[N/8, K/16, 16, 8]`` rather than
+row-major ``[K, N]``. Nothing reorders it in a core: the *DMA* does the pack,
+by walking the flat L2 buffer out of order. That walk is what ``pack=`` names::
+
+    b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
+
+``ops.load`` derives the same walk from its destination buffer, which it can
+see. A channel cannot -- put and get are separate ops and the packed side is at
+the far end of the stream -- so the pack is named at the put.
+
+A is micro-tiled too, but with ``m=1`` the pack is the identity: ``[K/16, 16]``
+is just ``[K]`` re-shaped, so its put is an ordinary contiguous slice.
+
+Unchanged from the raw-bindings version this replaces, except for three things
+the DSL requires and one it fixes:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The L1 tiles are allocated above the K loop and reused across trips, rather
+  than a fresh set per trip.
+* ``linalg_fill_i32_view16x8xi32as2`` is declared with the signature ``vm.cc``
+  actually defines -- ``void linalg_fill_i32_view16x8xi32as2(int *)``, the
+  buffer alone. The predecessor declared it ``(i32, memref)`` and passed a zero
+  the callee never reads; harmless, since the C ABI drops the extra argument,
+  but untrue.
+"""
+
 import argparse
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
 import numpy as np
 
-np.random.seed(42)
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i8, i32
+
+# air.api dtypes, keyed by the numpy dtype the harness works in.
+DTYPE = {np.int8: i8, np.int32: i32}
+
+# The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
+MMUL_MKN = (1, 16, 8)
 
 
-@module_builder
-def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out):
+def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
-    a_size = [k]
-    b_size = [k, n]
-    c_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
 
-    mmul_mkn = [1, 16, 8]
+    dt_in = DTYPE[np_dtype_in]
+    dt_out = DTYPE[np_dtype_out]
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get(a_size, xrt_dtype_in)
-    memrefTyB = MemRefType.get(b_size, xrt_dtype_in)
-    memrefTyOut = MemRefType.get(c_size, xrt_dtype_out)
+    m_u, k_u, n_u = MMUL_MKN
+    mm = air.micro_tile(m_u, k_u, n_u)
 
-    Channel("aL3ToL2")
-    Channel("bL3ToL2")
-    Channel("aL2ToL1")
-    Channel("bL2ToL1")
-    Channel("cL1ToL2")
-    Channel("cL2ToL3")
+    A = air.tensor([k], dt_in)
+    B = air.tensor([k, n], dt_in)
+    C = air.tensor([n], dt_out)
 
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    a_l3_l2 = air.channel("aL3ToL2")
+    b_l3_l2 = air.channel("bL3ToL2")
+    a_l2_l1 = air.channel("aL2ToL1")
+    b_l2_l1 = air.channel("bL2ToL1")
+    c_l1_l2 = air.channel("cL1ToL2")
+    c_l2_l3 = air.channel("cL2ToL3")
 
-    a_l1_size = [tile_k // mmul_mkn[1], mmul_mkn[1]]
-    b_l1_size = [tile_n // mmul_mkn[2], tile_k // mmul_mkn[1], mmul_mkn[1], mmul_mkn[2]]
-    l1MemrefTyA = MemRefType.get(
-        shape=a_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=b_l1_size,
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    c_l1_size = [tile_n // mmul_mkn[2], mmul_mkn[2]]
-    l1MemrefTyC = MemRefType.get(
-        shape=c_l1_size,
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    linalg_fill_func = FuncOp(
-        "linalg_fill_i32_view16x8xi32as2",
-        ([xrt_dtype_out, l1MemrefTyC], []),
-        visibility="private",
-    )
-    vecmat_func = FuncOp(
-        "vecmat_i8_i32",
-        ([l1MemrefTyA, l1MemrefTyB, l1MemrefTyC], []),
-        visibility="private",
-    )
-    for func in [linalg_fill_func, vecmat_func]:
-        func.attributes["link_with"] = StringAttr.get("vm.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    vecmat = air.extern("vecmat_i8_i32", object=link_with)
+    fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyOut)
-    def vecmat_i8(arg0, arg1, arg2):
+    with air.launch(name="vecmat_i8") as launch:
 
-        launch_size = [1, n // tile_n]
+        @launch.body
+        def _():
+            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_c_data,
-        ):
-            ChannelPut(
-                "aL3ToL2",
-                l3_a_data,
-                offsets=[],
-                sizes=[],
-                strides=[],
-            )
+                @seg.body
+                def _(sj):
+                    col = sj * tile_n
 
-            # Affine map for launch iv
-            launch_ivy_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_n),
-                    )
-                ],
-            )
-            launch_offset_y = affine_apply(launch_ivy_map, [launch_ivy])
-            ChannelPut(
-                "bL3ToL2",
-                l3_b_data,
-                offsets=[0, launch_offset_y],
-                sizes=[k, tile_n],
-                strides=[n, 1],
-            )
+                    l2_a = air.alloc([k], dt_in, scope=seg.private())
+                    l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([tile_n], dt_out, scope=seg.private())
 
-            @segment(name="vecmat_i8_0")
-            def segment_body():
-                # L2 MemRefTypes
-                a_size_l2 = [k]
-                b_size_l2 = [k, tile_n]
-                c_size_l2 = [tile_n]
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyA = MemRefType.get(
-                    shape=a_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyB = MemRefType.get(
-                    shape=b_size_l2,
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyC = MemRefType.get(
-                    shape=c_size_l2,
-                    element_type=xrt_dtype_out,
-                    memory_space=l2_mem_space,
-                )
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
+                    a_l3_l2.put(A)
+                    b_l3_l2.put(B[0:k, col : col + tile_n])
+                    a_l3_l2.get(l2_a)
+                    b_l3_l2.get(l2_b)
 
-                ChannelGet(
-                    "aL3ToL2",
-                    l2_a_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
+                    # One slice per K tile, on both sides. Unlike the bf16
+                    # sibling -- where a single whole-buffer put feeds every get
+                    # because the stream is consumed in order -- B is packed
+                    # here, and the pack is per tile: the walk visits all of N
+                    # before advancing in K, so the tiles are not prefixes of
+                    # one whole-buffer walk and have to be sent one at a time.
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        a_l2_l1.put(l2_a[kk : kk + tile_k])
 
-                l2_b_data = AllocOp(l2MemrefTyB, [], [])
-
-                ChannelGet(
-                    "bL3ToL2",
-                    l2_b_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                # L2 to L1 data packing and unpacking, using offsets, sizes and strides
-                a_l2l1_pack_size = [tile_k]
-                a_l2l1_pack_stride = [1]
-                b_l2l1_pack_size = [tile_n // mmul_mkn[2], tile_k, mmul_mkn[2]]
-                b_l2l1_pack_stride = [mmul_mkn[2], tile_n, 1]
-
-                for_iv_map_data = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_k),
-                        )
-                    ],
-                )
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    a_l2l1_pack_offset = [for_iv_data_offset]
-                    ChannelPut(
-                        "aL2ToL1",
-                        l2_a_data,
-                        offsets=a_l2l1_pack_offset,
-                        sizes=a_l2l1_pack_size,
-                        strides=a_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                for i in range_(0, k // tile_k):
-                    for_iv_data_offset = affine_apply(for_iv_map_data, [i])
-                    b_l2l1_pack_offset = [0, for_iv_data_offset, 0]
-                    ChannelPut(
-                        "bL2ToL1",
-                        l2_b_data,
-                        offsets=b_l2l1_pack_offset,
-                        sizes=b_l2l1_pack_size,
-                        strides=b_l2l1_pack_stride,
-                    )
-                    yield_([])
-
-                @herd(name="herd_0", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-
-                    l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                    zero_const = ConstantOp(IntegerAttr.get(xrt_dtype_out, 0), None)
-                    zero_fill = CallOp(linalg_fill_func, [zero_const, l1_c_data])
-
-                    for i in range_(0, k, tile_k):
-                        l1_a_data = AllocOp(l1MemrefTyA, [], [])
-
-                        ChannelGet(
-                            "aL2ToL1",
-                            l1_a_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
+                    for i in air.sequential(0, k // tile_k):
+                        kk = i * tile_k
+                        b_l2_l1.put(
+                            l2_b[kk : kk + tile_k, 0:tile_n],
+                            pack=mm.b(tile_k, tile_n, lead=()),
                         )
 
-                        l1_b_data = AllocOp(l1MemrefTyB, [], [])
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
 
-                        ChannelGet(
-                            "bL2ToL1",
-                            l1_b_data,
-                            offsets=[],
-                            sizes=[],
-                            strides=[],
-                        )
+                        @h.body
+                        def _(tx):
+                            l1_a = air.alloc(
+                                [tile_k // k_u, k_u], dt_in, scope=h.private()
+                            )
+                            l1_b = air.alloc(
+                                [tile_n // n_u, tile_k // k_u, k_u, n_u],
+                                dt_in,
+                                scope=h.private(),
+                            )
+                            l1_c = air.alloc(
+                                [tile_n // n_u, n_u], dt_out, scope=h.private()
+                            )
 
-                        vecmat = CallOp(
-                            vecmat_func,
-                            [l1_a_data, l1_b_data, l1_c_data],
-                        )
+                            fill(l1_c)
+                            for _j in air.sequential(0, k, tile_k):
+                                a_l2_l1.get(l1_a)
+                                b_l2_l1.get(l1_b)
+                                vecmat(l1_a, l1_b, l1_c)
 
-                        DeallocOp(l1_a_data)
-                        DeallocOp(l1_b_data)
+                            c_l1_l2.put(l1_c)
 
-                        yield_([])
+                    c_l1_l2.get(l2_c)
+                    c_l2_l3.put(l2_c)
+                    c_l2_l3.get(C[col : col + tile_n])
 
-                    ChannelPut(
-                        "cL1ToL2",
-                        l1_c_data,
-                        offsets=[],
-                        sizes=[],
-                        strides=[],
-                    )
-                    DeallocOp(l1_c_data)
-
-                herd_body.attributes["link_with"] = StringAttr.get("vm.o")
-
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-                ChannelGet(
-                    "cL1ToL2",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-
-                ChannelPut(
-                    "cL2ToL3",
-                    l2_c_data,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
-                )
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_b_data)
-                DeallocOp(l2_c_data)
-
-            ChannelGet(
-                "cL2ToL3",
-                l3_c_data,
-                offsets=[launch_offset_y],
-                sizes=[tile_n],
-                strides=[1],
-            )
+    return launch
 
 
 if __name__ == "__main__":
     # Default values.
-    M = 1
     K = 288
     N = 48
     TILE_K = 96
@@ -290,9 +157,11 @@ if __name__ == "__main__":
     INPUT_DATATYPE = np.int8
     OUTPUT_DATATYPE = np.int32
 
+    np.random.seed(42)
+
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        prog="single_core.py",
+        description="Builds, runs, and tests the int8 vector-matrix multiplication example",
     )
     parser.add_argument(
         "-v",
@@ -327,10 +196,17 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.k,
         args.n,
         args.tile_k,
@@ -338,6 +214,7 @@ if __name__ == "__main__":
         INPUT_DATATYPE,
         OUTPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -348,14 +225,12 @@ if __name__ == "__main__":
         size=(args.k),
         dtype=INPUT_DATATYPE,
     )
-    input_a = input_a.astype(INPUT_DATATYPE)
     input_b = np.random.randint(
         np.iinfo(INPUT_DATATYPE).min,
         np.iinfo(INPUT_DATATYPE).max,
         size=(args.k, args.n),
         dtype=INPUT_DATATYPE,
     )
-    input_b = input_b.astype(INPUT_DATATYPE)
     output_c = np.dot(input_a.astype(OUTPUT_DATATYPE), input_b.astype(OUTPUT_DATATYPE))
 
     runner = XRTRunner(

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -56,10 +56,28 @@ DTYPE = {np.int8: i8, np.int32: i32}
 # The AIE2 int8 vecmat intrinsic's operand shape: m x k by k x n.
 MMUL_MKN = (1, 16, 8)
 
+# The L1 tile vm.cc was compiled for: vecmat_vectorized_1x16x8_i8_i32<1, 96, 48>.
+KERNEL_TILE_K = 96
+KERNEL_TILE_N = 48
+
 
 def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.o"):
     assert k % tile_k == 0
     assert n % tile_n == 0
+    # vm.cc instantiates exactly one shape:
+    #     vecmat_vectorized_1x16x8_i8_i32<1, 96, 48>(a_in, b_in, c_out)
+    # so the L1 tile is fixed at 96x48 by the object this links against, not by
+    # anything here. Any other --tile-k/--tile-n builds a launch that calls a
+    # kernel expecting different extents: it links, and it computes the wrong
+    # answer. K and N above stay free -- they are how many tiles, not how big.
+    if (tile_k, tile_n) != (KERNEL_TILE_K, KERNEL_TILE_N):
+        raise ValueError(
+            f"vm.cc instantiates vecmat_i8_i32 for a "
+            f"{KERNEL_TILE_K}x{KERNEL_TILE_N} tile only, so --tile-k "
+            f"{KERNEL_TILE_K} --tile-n {KERNEL_TILE_N} is the only supported "
+            f"pair; got tile_k={tile_k}, tile_n={tile_n}. Rebuild vm.cc with "
+            f"different template arguments to change it."
+        )
 
     dt_in = DTYPE[np_dtype_in]
     dt_out = DTYPE[np_dtype_out]

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -215,7 +215,7 @@ class Channel:
             out.append(value)
         return out
 
-    def _emit(self, obj, indices, dependency, direction):
+    def _emit(self, obj, indices, dependency, direction, pack=None):
         from ._trace import current_segment
         from .ops import _check_dependency, _endpoint
 
@@ -236,6 +236,10 @@ class Channel:
             )
 
         offsets, sizes, strides = endpoint.pattern or ([], [], [])
+        if pack is not None:
+            offsets, sizes, strides = self._packed_pattern(
+                endpoint, pack, direction, obj
+            )
         idx = self._indices(indices, direction)
 
         if direction == "get" and endpoint.tensor is not None:
@@ -257,17 +261,73 @@ class Channel:
             )
         )
 
+    def _packed_pattern(self, endpoint, pack, direction, obj):
+        """Walk a flat region in micro-tile order, so the DMA does the pack.
+
+        ``ops.load`` derives this from its *destination* buffer, which it can
+        see. A channel cannot: put and get are separate ops, and the packed side
+        is at the far end of the stream, possibly in another scope. So the walk
+        is named where it happens::
+
+            mm = air.micro_tile(m=1, k=16, n=8)
+            b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n))
+
+        The consumer then does a plain whole-buffer ``get`` into an L1 tile of
+        whatever shape holds those elements contiguously -- which is why this
+        takes the *shape* rather than the destination buffer. The two vecmat i8
+        kernels declare their B tile 4-D and their B-scale tile 3-D, and both
+        are the same contiguous run of micro-tiles.
+        """
+        from ._pack import PackedShape, pack_pattern
+
+        if not isinstance(pack, PackedShape):
+            raise TypeError(
+                f"air.channel.{direction}(pack=...) takes a packed shape from "
+                "air.micro_tile(...).a or .b, e.g. "
+                "pack=air.micro_tile(1, 16, 8).b(tile_k, tile_n); got "
+                f"{type(pack).__name__}"
+            )
+        if pack.role == "C":
+            raise NotImplementedError(
+                f"air.channel.{direction}(pack=...) packs an A or B operand. A C "
+                "accumulator is drained the other way round -- the pattern goes "
+                "on the packed buffer itself -- so put the region on that side "
+                "instead of asking the channel to pack it."
+            )
+        if endpoint.raw is None:
+            raise TypeError(
+                f"air.channel.{direction}(pack=...) needs a *region* to walk, not "
+                f"a whole {endpoint.what}: the pack reorders a slice of a flat "
+                "staging buffer, so index it, e.g. l2_b[kk : kk + tile_k, :]"
+            )
+        offsets, sizes, strides = endpoint.raw
+        nlead = len(pack.lead)
+        flat_ok = len(sizes) == 2 and all(e == 1 for e in pack.lead)
+        if len(sizes) != nlead + 2 and not flat_ok:
+            # The "or rank 2" alternative only exists when the packed shape has
+            # leading dimensions to pad away; with lead=() it is the same rank.
+            either = (
+                " (or rank 2 when its leading dimensions are all 1)" if nlead else ""
+            )
+            raise ValueError(
+                f"air.channel.{direction}(pack=...) needs a region of rank "
+                f"{nlead + 2} for a {pack.role} operand{either}, with the two "
+                f"logical axes last; got rank {len(sizes)}, {tuple(sizes)}"
+            )
+        p_off, p_sizes, p_strides = pack_pattern(pack, sizes, strides, offsets)
+        return [o.materialize() for o in p_off], p_sizes, p_strides
+
     # -- public ------------------------------------------------------------
 
-    def put(self, obj, indices=None, dependency=None, **unsupported):
+    def put(self, obj, indices=None, dependency=None, pack=None, **unsupported):
         """Send a tensor, a buffer, or a region of either into the channel."""
         _reject_unsupported(unsupported)
-        return self._emit(obj, indices, dependency, "put")
+        return self._emit(obj, indices, dependency, "put", pack=pack)
 
-    def get(self, obj, indices=None, dependency=None, **unsupported):
+    def get(self, obj, indices=None, dependency=None, pack=None, **unsupported):
         """Receive the channel's next chunk into a tensor, buffer, or region."""
         _reject_unsupported(unsupported)
-        return self._emit(obj, indices, dependency, "get")
+        return self._emit(obj, indices, dependency, "get", pack=pack)
 
 
 # Keywords the underlying ops accept and this DSL does not lower. They raise

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -232,3 +232,52 @@ def whole_tensor_transfer():
                     air.ops.store(buf, B)
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: channel_pack
+# pack= walks a flat L2 region in micro-tile order, so the DMA performs the
+# pack and the consumer does a plain whole-buffer get. ops.load derives the
+# same walk from its destination buffer; a channel cannot see that far, because
+# put and get are separate ops with the packed side at the other end of the
+# stream, so the walk is named at the put.
+#
+# The B pack of a [K, N] region with micro-tile (k, n) is
+# [N/n, K/k, k, n] over strides [n, k*N, N, 1] -- here [6, 6, 16, 8] over
+# [8, 768, 48, 1] for a [96, 48] region, which is the same walk the
+# hand-written kernel spells collapsed as [6, 96, 8] over [8, 48, 1].
+# CHECK: air.channel.put @Bpack[] (%{{.*}}[0, 0, 0, 0] [6, 6, 16, 8] [8, 768, 48, 1])
+# CHECK: air.channel.get @Bpack[] (%{{.*}}[] [] [])
+@run
+def channel_pack():
+    TILE_K, TILE_N = 96, 48
+    mm = air.micro_tile(1, 16, 8)
+
+    A = air.tensor([TILE_K, TILE_N], i8)
+    Out = air.tensor([TILE_K, TILE_N], i8)
+    pack = air.channel("Bpack")
+
+    with air.launch(name="packed") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    l2_b = air.alloc([TILE_K, TILE_N], i8, scope=seg.private())
+                    air.ops.load(l2_b, A)
+                    pack.put(
+                        l2_b[0:TILE_K, 0:TILE_N],
+                        pack=mm.b(TILE_K, TILE_N, lead=()),
+                    )
+
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            l1_b = air.alloc([6, 6, 16, 8], i8, scope=h.private())
+                            pack.get(l1_b)
+
+                    air.ops.store(l2_b, Out)
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1020,3 +1020,83 @@ def _():
         ch.put(buf, indices=[2, 0])
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_not_a_packed_shape
+# pack= takes a shape from air.micro_tile(...).a/.b, not a plain list: the
+# micro-tile is what the walk is derived from, and a bare list carries none.
+# CHECK: TypeError: air.channel.put(pack=...) takes a packed shape from air.micro_tile
+@expect(TypeError, "channel_pack_not_a_packed_shape")
+def _():
+    ch = air.channel("P")
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf[0:16, 0:8], pack=[2, 2, 8, 8])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_needs_a_region
+# The pack reorders a *slice* of a flat staging buffer, so there has to be one
+# to reorder; a whole buffer carries no pattern to rewrite.
+# CHECK: TypeError: air.channel.put(pack=...) needs a *region* to walk
+@expect(TypeError, "channel_pack_needs_a_region")
+def _():
+    ch = air.channel("Q")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf, pack=mm.b(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_c_operand
+# A C accumulator unpacks the other way round -- the pattern belongs on the
+# packed buffer, not on the channel -- so asking a channel to pack one raises
+# instead of emitting a walk that would drain it in the wrong order.
+# CHECK: NotImplementedError: air.channel.put(pack=...) packs an A or B operand
+@expect(NotImplementedError, "channel_pack_c_operand")
+def _():
+    ch = air.channel("R")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([16, 8], bf16, scope=h.private())
+        ch.put(buf[0:16, 0:8], pack=mm.c(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_wrong_rank
+# The region has to end in the operand's two logical axes; a rank-1 slice has
+# only one, so there is nothing to split into micro-tiles.
+# CHECK: ValueError: air.channel.put(pack=...) needs a region of rank 2 for a B operand
+@expect(ValueError, "channel_pack_wrong_rank")
+def _():
+    ch = air.channel("S")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([128], bf16, scope=h.private())
+        ch.put(buf[0:128], pack=mm.b(16, 8, lead=()))
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: channel_pack_indivisible
+# The region's extents must be whole micro-tiles: 20 is not a multiple of the
+# k=16 the buffer would be packed with.
+# CHECK: ValueError: operand B's K extent 20 is not a multiple of the micro-tile k=16
+@expect(ValueError, "channel_pack_indivisible")
+def _():
+    ch = air.channel("T")
+    mm = air.micro_tile(1, 16, 8)
+
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([20, 8], bf16, scope=h.private())
+        ch.put(buf[0:20, 0:8], pack=mm.b(20, 8, lead=()))
+
+    _trace(body)


### PR DESCRIPTION
Re-submission of #1853 with clean history. **The code is byte-identical**; that
PR's branch carried 793 lines of debug scratch swept in by `git add -A`, and
its review thread contains a retracted perf regression and a retracted npu2
coverage claim, so amending it in place would leave a PR contradicting itself.

The broadcast-index bug found alongside this work is separately in #1855.

## What it does

Converts `vector_matrix_multiplication/i8/single_core` and
`.../block_quantized_i8/single_core` onto `air.api`, replacing the
raw-bindings versions. Last two siblings of the bf16 vecmat from #1852.

One new piece of surface: **`pack=` on `Channel.put`/`get`**. Both examples
stage B through L2 flat and micro-tile it into L1 for the AIE2 int8 vecmat
intrinsic, so the *DMA* performs the pack by walking the staging buffer out of
order. `ops.load` derives that walk from its destination buffer; a channel
cannot, because put and get are separate ops with the packed side at the far end
of the stream. So the walk is named at the put:

```python
mm = air.micro_tile(1, 16, 8)
b_l2_l1.put(l2_b[kk : kk + tile_k, :], pack=mm.b(tile_k, tile_n, lead=()))
```

It reuses `_pack.pack_pattern`, the same derivation `ops.load` uses. The
block-quantized example's B *scale* is the same walk with one scale per block
rather than per element -- a `k=1` micro-tile, a different argument rather than
a special case. `pack=` on a C operand raises: C unpacks the other way round.

Also: each example declared `linalg_fill_i32_view16x8xi32as2` as
`(scalar, memref)` and passed a zero the callee never reads. `vm.cc` defines
it taking the buffer alone. Same fix as the bf16 sibling.

## Evidence

```
$ git log --oneline origin/main..HEAD
aba4a4ee [python] air.api: packed channel puts, and the two vecmat i8 examples

$ git show --name-status HEAD
M	programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
M	programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
M	python/air/api/_channel.py
M	python/test/api/channel.py
M	python/test/api/errors.py

$ git diff --stat origin/main...HEAD
 .../block_quantized_i8/single_core/single_core.py  | 554 +++++++--------------
 .../i8/single_core/single_core.py                  | 415 ++++++---------
 python/air/api/_channel.py                         |  70 ++-
 python/test/api/channel.py                         |  49 ++
 python/test/api/errors.py                          |  80 +++
 5 files changed, 509 insertions(+), 659 deletions(-)

$ diff <(git show air-api-vecmat-i8:...) <(...)  # code identical to the closed PR's tip
identical  programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
identical  programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
identical  python/air/api/_channel.py
identical  python/test/api/channel.py
identical  python/test/api/errors.py

$ grep -H 'REQUIRES:' <both examples>/*.lit
programming_examples/vector_matrix_multiplication/i8/single_core/run_makefile_peano.lit:// REQUIRES: ryzen_ai_npu1, peano
programming_examples/vector_matrix_multiplication/i8/single_core/run_makefile_chess.lit:// REQUIRES: ryzen_ai_npu1, valid_xchess_license
programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/run_makefile_chess.lit:// REQUIRES: ryzen_ai_npu1, valid_xchess_license
programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/run_makefile_peano.lit:// REQUIRES: ryzen_ai_npu1, peano

$ lit -v build/programming_examples --filter 'vector_matrix_multiplication.*(i8|block_quantized)'
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: vector_matrix_multiplication/block_quantized_i8/single_core/run_makefile_chess.lit (1 of 4)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: vector_matrix_multiplication/i8/single_core/run_makefile_chess.lit (2 of 4)
PASS: AIR_PROGRAMMING_EXAMPLES :: vector_matrix_multiplication/i8/single_core/run_makefile_peano.lit (3 of 4)
PASS: AIR_PROGRAMMING_EXAMPLES :: vector_matrix_multiplication/block_quantized_i8/single_core/run_makefile_peano.lit (4 of 4)

$ lit -v build/python/test/ --filter=api
PASS: AIRPYTHON :: api/segment.py (1 of 10)
PASS: AIRPYTHON :: api/pack.py (2 of 10)
PASS: AIRPYTHON :: api/leaky_relu.py (3 of 10)
PASS: AIRPYTHON :: api/axpy.py (4 of 10)
PASS: AIRPYTHON :: api/relu.py (5 of 10)
PASS: AIRPYTHON :: api/activations.py (6 of 10)
PASS: AIRPYTHON :: api/eltwise_add.py (7 of 10)
PASS: AIRPYTHON :: api/channel.py (8 of 10)
PASS: AIRPYTHON :: api/dot.py (9 of 10)
PASS: AIRPYTHON :: api/errors.py (10 of 10)
```

Hardware, npu1, `make run PEANO_INSTALL_DIR=...`, both examples: `PASS!`.

Lowered IR equivalent to the predecessors' on both: buffers, locks, flows,
dma_bds, tiles, shim allocations, dma_starts and use_locks all match, and the
rank-4 pattern `pack=` emits canonicalizes back to the predecessor's
hand-collapsed rank-3 BD character for character --
`[0, 96, 0] [6, 96, 8] [8, 48, 1]` on both sides.

Perf, block_quantized, 8 reps, one driver process, same inputs, same `vm.o`,
only the parsed `.mlir` differing:

```
                 best   median   mean    spread
predecessor     214.3   234.6   307.1    509.8
port            185.3   213.3   211.9     56.4
```

Port faster in 8/8 paired reps.

## Coverage limits

**npu1-only by construction; no npu2 run is possible.** All four lits gate on
`ryzen_ai_npu1` (see the `REQUIRES:` grep above) -- including the chess pair,
so an npu2 host is excluded however it is licensed. Both Makefiles carry only
`--target=aie2-none-unknown-elf`; the bf16 sibling has an `aie2p` path and
npu2 lits, these do not. Forcing the aie2p triple fails in the microkernels:
`mmul_8_8<1, 16, 8, signed char, signed char, 32>` has no AIE2P specialization,
and block_quantized's `aie2_fp32_conf_shim.h` does not compile for aie2p. All
inherited from the predecessors.

So: the two peano lits pass here; **the two chess lits are unverified by anyone**
and need an npu1 box with a Vitis license. CI will not close that gap.