### PR TITLE
[programming_examples] Three more channel examples on air.api

### DIFF
--- a/programming_examples/channel_examples/broadcast/multi_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/multi_herd/broadcast.py
@@ -1,16 +1,40 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""One image broadcast to three separate herds, on air.api.
+
+    air.channel @ChanIn [1, 1] {broadcast_shape = [3, 1]}
+    air.channel @ChanOutB / @ChanOutC / @ChanOutD
+
+The sibling under ``broadcast/single_herd`` fans out to the three *cores* of one
+herd; this one fans out to three *herds*, each a 1x1 grid of its own. One put,
+three gets, each naming its own destination with ``indices=[n, 0]`` -- and each
+herd drains through a channel of its own, which is why there are three output
+channels rather than one array.
+
+Nothing about the fan-out changes between the two: ``broadcast_shape`` is a
+declaration-level attribute describing the grid of destinations, and it does not
+care whether that grid is cores or herds.
+
+Each herd adds its own index plus one, so the three outputs differ, which is
+what makes the broadcast observable rather than merely asserted.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side put and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The increment is written ``out[:] = in[:] + n`` rather than as a scalar loop
+  nest over every (i, j). ``vector=0`` keeps it scalar, as the predecessor was:
+  the image is 32 i32 wide and a <8 x i32> add is 256-bit, which does not
+  legalize.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -18,77 +42,61 @@ IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 
 INOUT_DATATYPE = np.int32
 
+HERDS = 3
 OUTPUT_HERD_NAMES = ["ChanOutB", "ChanOutC", "ChanOutD"]
 
 
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    outs = [air.tensor(IMAGE_SIZE, i32) for _ in range(HERDS)]
 
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    image_type_l1 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    chan_in = air.channel("ChanIn", size=[1, 1], broadcast_shape=[HERDS, 1])
+    chan_out = [air.channel(name) for name in OUTPUT_HERD_NAMES]
 
-    Channel("ChanIn", size=[1, 1], broadcast_shape=[3, 1])
-    for name in OUTPUT_HERD_NAMES:
-        Channel(name)
+    with air.launch(name="copy") as launch:
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut, memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1, arg2, arg3):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1, arg2, arg3])
-        def launch_body(a, b, c, d):
+                @seg.body
+                def _():
+                    chan_in.put(A)
 
-            ChannelPut("ChanIn", a)
-            ChannelGet(OUTPUT_HERD_NAMES[0], b)
-            ChannelGet(OUTPUT_HERD_NAMES[1], c)
-            ChannelGet(OUTPUT_HERD_NAMES[2], d)
+                    # A closure per herd rather than `def _(tx, n=n)`: the
+                    # body's positional arity is how air.api knows the grid's
+                    # rank, so a defaulted capture would read as a second
+                    # coordinate and raise.
+                    def one_herd(n):
+                        with air.herd(
+                            [range(1)], name=f"broadcastherd{n}", shape=(1,)
+                        ) as h:
 
-            @segment(name="seg")
-            def segment_body():
-
-                for herd_num in range(3):
-
-                    @herd(name="broadcastherd" + str(herd_num), sizes=[1, 1])
-                    def herd_body(_tx, _ty, _sx, _sy):
-
-                        # We must allocate a buffer of image size for the input/output
-                        image_in = AllocOp(image_type_l1, [], [])
-                        image_out = AllocOp(image_type_l1, [], [])
-
-                        ChannelGet("ChanIn", image_in, indices=[herd_num, 0])
-
-                        # Access every value in the image
-                        for i in range_(IMAGE_HEIGHT):
-                            for j in range_(IMAGE_WIDTH):
-                                # Load the input value
-                                val_in = load(image_in, [i, j])
-
-                                # Calculate the output value
-                                val_out = arith.addi(
-                                    val_in, arith.ConstantOp(T.i32(), herd_num + 1)
+                            @h.body
+                            def _(tx):
+                                image_in = air.alloc(
+                                    IMAGE_SIZE, i32, scope=h.private(), vector=0
+                                )
+                                image_out = air.alloc(
+                                    IMAGE_SIZE, i32, scope=h.private(), vector=0
                                 )
 
-                                # Store the output value
-                                store(val_out, image_out, [i, j])
-                                yield_([])
-                            yield_([])
+                                chan_in.get(image_in, indices=[n, 0])
+                                image_out[:] = image_in[:] + (n + 1)
+                                chan_out[n].put(image_out)
 
-                        ChannelPut(OUTPUT_HERD_NAMES[herd_num], image_out)
+                    for n in range(HERDS):
+                        one_herd(n)
 
-                        DeallocOp(image_in)
-                        DeallocOp(image_out)
+                    for n, out in enumerate(outs):
+                        chan_out[n].get(out)
+
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="broadcast.py",
         description="Builds, runs, and tests the channel broadcast multi herd example",
     )
     parser.add_argument(
@@ -110,9 +118,18 @@ if __name__ == "__main__":
         help="Output format for the compiled binary (default: xclbin)",
     )
 
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/channel_examples/hierarchical/hierarchical.py
+++ b/programming_examples/channel_examples/hierarchical/hierarchical.py
@@ -1,16 +1,36 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A four-channel hierarchy, one hop per level of memory, on air.api.
+
+    air.channel @ChanInL2    L3 -> L2
+    air.channel @ChanInL1    L2 -> L1
+    air.channel @ChanOutL1   L1 -> L2
+    air.channel @ChanOutL2   L2 -> L3
+
+Every hop is a channel, so there is not one ``air.dma_memcpy_nd`` in the
+example: it is the same journey ``ops.load``/``ops.store`` would make, written
+as four independent producer/consumer pairs instead of four copies. Each level
+stages into its own buffer and forwards, and the herd names none of the
+channels as an operand -- a channel is a module-level symbol and resolves by
+name from any depth.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side put and get sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The increment is written ``out[:] = in[:] + 1`` rather than as a scalar loop
+  nest over every (i, j). ``vector=0`` keeps it scalar, as the predecessor was:
+  the image is 32 i32 wide and a <8 x i32> add is 256-bit, which does not
+  legalize.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -19,86 +39,55 @@ IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 INOUT_DATATYPE = np.int32
 
 
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    mem_space_l2 = IntegerAttr.get(T.i32(), MemorySpace.L2)
+    in_l2 = air.channel("ChanInL2")
+    out_l2 = air.channel("ChanOutL2")
+    in_l1 = air.channel("ChanInL1")
+    out_l1 = air.channel("ChanOutL1")
 
-    image_type_l1 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
-    image_type_l2 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l2,
-    )
+    with air.launch(name="copy") as launch:
 
-    Channel("ChanInL2")
-    Channel("ChanOutL2")
-    Channel("ChanInL1")
-    Channel("ChanOutL1")
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+                @seg.body
+                def _():
+                    image_in_l2 = air.alloc(IMAGE_SIZE, i32, scope=seg.private())
+                    image_out_l2 = air.alloc(IMAGE_SIZE, i32, scope=seg.private())
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+                    in_l2.put(A)
+                    in_l2.get(image_in_l2)
+                    in_l1.put(image_in_l2)
 
-            ChannelPut("ChanInL2", a)
+                    with air.herd([range(1)], name="addherd", shape=(1,)) as h:
 
-            @segment(name="seg")
-            def segment_body():
-                image_in_l2 = AllocOp(image_type_l2, [], [])
-                ChannelGet("ChanInL2", image_in_l2)
-                ChannelPut("ChanInL1", image_in_l2)
-                DeallocOp(image_in_l2)
+                        @h.body
+                        def _(tx):
+                            image_in = air.alloc(
+                                IMAGE_SIZE, i32, scope=h.private(), vector=0
+                            )
+                            image_out = air.alloc(
+                                IMAGE_SIZE, i32, scope=h.private(), vector=0
+                            )
 
-                @herd(name="addherd", sizes=[1, 1])
-                def herd_body(tx, ty, sx, sy):
+                            in_l1.get(image_in)
+                            image_out[:] = image_in[:] + 1
+                            out_l1.put(image_out)
 
-                    # We must allocate a buffer of image size for the input/output
-                    image_in = AllocOp(image_type_l1, [], [])
-                    image_out = AllocOp(image_type_l1, [], [])
+                    out_l1.get(image_out_l2)
+                    out_l2.put(image_out_l2)
+                    out_l2.get(B)
 
-                    ChannelGet("ChanInL1", image_in)
-
-                    # Access every value in the image
-                    for i in range_(IMAGE_HEIGHT):
-                        for j in range_(IMAGE_WIDTH):
-                            # Load the input value
-                            val_in = load(image_in, [i, j])
-
-                            # Calculate the output value
-                            val_out = arith.addi(val_in, arith.ConstantOp(xrt_dtype, 1))
-
-                            # Store the output value
-                            store(val_out, image_out, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    ChannelPut("ChanOutL1", image_out)
-
-                    DeallocOp(image_in)
-                    DeallocOp(image_out)
-
-                image_out_l2 = AllocOp(image_type_l2, [], [])
-                ChannelGet("ChanOutL1", image_out_l2)
-                ChannelPut("ChanOutL2", image_out_l2)
-                DeallocOp(image_out_l2)
-
-            ChannelGet("ChanOutL2", b)
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="hierarchical.py",
         description="Builds, runs, and tests the channel hierarchical example",
     )
     parser.add_argument(
@@ -120,9 +109,18 @@ if __name__ == "__main__":
         help="Output format for the compiled binary (default: xclbin)",
     )
 
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/channel_examples/worker_to_self/worker_to_self.py
+++ b/programming_examples/channel_examples/worker_to_self/worker_to_self.py
@@ -1,16 +1,33 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A worker that sends data to itself through a channel, on air.api.
+
+    air.channel @ChanIn     L3 -> L2
+    air.channel @ToSelf     L2 -> L1, both ends inside the same herd body
+    air.channel @ChanOut    L1 -> L3
+
+``ToSelf`` is the point of the example: its put and its get are both in the herd
+body, one core talking to itself. That is legal precisely because a channel is
+not a value -- it is a module-level symbol, so the two ends need no common
+scope, not even a common operand. The staged L2 buffer is what the core puts,
+and air.api passes it into the herd for free.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side put and get sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The copy is written ``out[:] = in[:]`` rather than as a scalar loop nest over
+  every (i, j). Same transfer, one line. ``vector=0`` keeps it scalar: the image
+  is 32 i32 wide and a <8 x i32> add is 256-bit, which does not legalize.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -19,87 +36,55 @@ IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 INOUT_DATATYPE = np.int32
 
 
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # Type and method of input/output
-    memrefTyInOut = T.MemRefType.get(IMAGE_SIZE, xrt_dtype)
-    Channel("ChanIn")
-    Channel("ChanOut")
-    Channel("ToSelf")
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
+    to_self = air.channel("ToSelf")
 
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    image_type_l1 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    with air.launch(name="copy") as launch:
 
-    mem_space_l2 = IntegerAttr.get(T.i32(), MemorySpace.L2)
-    image_type_l2 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l2,
-    )
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+                @seg.body
+                def _():
+                    l2_in = air.alloc(IMAGE_SIZE, i32, scope=seg.private())
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            ChannelPut("ChanIn", a)
+                    chan_in.put(A)
+                    chan_in.get(l2_in)
 
-            # The arguments are still the input and the output
-            @segment(name="seg")
-            def segment_body():
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
 
-                tensor_in_l2 = AllocOp(image_type_l2, [], [])
-                ChannelGet("ChanIn", tensor_in_l2)
+                        @h.body
+                        def _(tx):
+                            l1_in = air.alloc(
+                                IMAGE_SIZE, i32, scope=h.private(), vector=0
+                            )
+                            l1_out = air.alloc(
+                                IMAGE_SIZE, i32, scope=h.private(), vector=0
+                            )
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We just need one compute core, so we ask for a 1x1 herd
-                @herd(
-                    name="copyherd",
-                    sizes=[1, 1],
-                    operands=[tensor_in_l2],
-                )
-                def herd_body(tx, ty, sx, sy, tensor_in_l2):
+                            # Both ends of @ToSelf, in one body: the core sends
+                            # the staged L2 tile and receives it into L1.
+                            to_self.put(l2_in)
+                            to_self.get(l1_in)
 
-                    # We must allocate a buffer of image size for the input/output
-                    tensor_in_l1 = AllocOp(image_type_l1, [], [])
-                    tensor_out_l1 = AllocOp(image_type_l1, [], [])
+                            l1_out[:] = l1_in[:]
 
-                    ChannelPut("ToSelf", tensor_in_l2)
-                    ChannelGet("ToSelf", tensor_in_l1)
+                            chan_out.put(l1_out)
 
-                    # Access every value in the tile
-                    for i in range_(IMAGE_HEIGHT):
-                        for j in range_(IMAGE_WIDTH):
-                            # Load the input value from tile_in
-                            val = load(tensor_in_l1, [i, j])
+                    chan_out.get(B)
 
-                            # Store the output value in tile_out
-                            store(val, tensor_out_l1, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    ChannelPut("ChanOut", tensor_out_l1)
-
-                    # Deallocate our L1 buffers
-                    DeallocOp(tensor_in_l1)
-                    DeallocOp(tensor_out_l1)
-
-                DeallocOp(tensor_in_l2)
-
-            ChannelGet("ChanOut", b)
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="worker_to_self.py",
         description="Builds, runs, and tests the channel worker_to_self example",
     )
     parser.add_argument(
@@ -120,10 +105,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)


### PR DESCRIPTION
Converts `channel_examples/worker_to_self`, `channel_examples/hierarchical`
and `channel_examples/broadcast/multi_herd` onto `air.api`, replacing the
raw-bindings versions. No new DSL surface: 146, 147 and 143 lines of bindings
become channel calls.

**Stacked on #1855.** The first commit here *is* #1855 — `broadcast/multi_herd`
does not build without it. Merge #1855 first and this rebases to the three
examples alone; the file lists below separate them.

Each exercises a different property of a channel:

- **worker_to_self** puts and gets `@ToSelf` inside the *same* herd body, one
  core to itself. Legal because a channel is a symbol, not a value: the two ends
  need no common scope and no shared operand.
- **hierarchical** is four channels, one per hop, L3 -> L2 -> L1 -> L2 -> L3,
  with no `air.dma_memcpy_nd` anywhere in it.
- **broadcast/multi_herd** fans one put out to three separate *herds* rather than
  to three cores of one herd, which the `single_herd` sibling already covered.
  Same `broadcast_shape` attribute; it does not care whether the destination
  grid is cores or herds. **This is the example that found the #1855 bug.**

In all three the copy or increment is written `out[:] = in[:] (+ n)` rather
than as a scalar loop nest over every (i, j), with `vector=0` to keep it scalar
as the predecessors were — the image is 32 i32 wide and a <8 x i32> add is
256-bit, which does not legalize. And the L3-side put and get move inside the
segment, since outside one there is no shim DMA allocation to link to.

## Evidence

```
$ git log --oneline origin/main..HEAD
a4e39d02 [programming_examples] Three more channel examples on air.api
0e3c8928 [python] air.api: bound broadcast channel indices by broadcast_shape

$ git show --name-status HEAD
M	programming_examples/channel_examples/broadcast/multi_herd/broadcast.py
M	programming_examples/channel_examples/hierarchical/hierarchical.py
M	programming_examples/channel_examples/worker_to_self/worker_to_self.py

$ git show --name-status HEAD~1     # this is #1855's commit
M	python/air/api/_channel.py
M	python/test/api/errors.py

$ git diff --stat origin/main...HEAD
 .../broadcast/multi_herd/broadcast.py              | 151 ++++++++++++---------
 .../channel_examples/hierarchical/hierarchical.py  | 144 ++++++++++----------
 .../worker_to_self/worker_to_self.py               | 137 +++++++++----------
 python/air/api/_channel.py                         |  19 ++-
 python/test/api/errors.py                          |  17 +++
 5 files changed, 252 insertions(+), 216 deletions(-)

$ grep -H 'REQUIRES:' <the three examples>/*.lit
programming_examples/channel_examples/worker_to_self/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
programming_examples/channel_examples/worker_to_self/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
programming_examples/channel_examples/broadcast/multi_herd/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
programming_examples/channel_examples/hierarchical/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
programming_examples/channel_examples/hierarchical/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano
programming_examples/channel_examples/worker_to_self/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano
programming_examples/channel_examples/hierarchical/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
programming_examples/channel_examples/broadcast/multi_herd/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano

$ lit -v build/programming_examples --filter 'channel_examples.*(worker_to_self|hierarchical|multi_herd)'
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/worker_to_self/run_makefile_chess.lit (1 of 9)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/worker_to_self/run_makefile_peano_elf.lit (2 of 9)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/hierarchical/run_makefile_peano_elf.lit (3 of 9)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/broadcast/multi_herd/run_makefile_chess.lit (4 of 9)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/hierarchical/run_makefile_chess.lit (5 of 9)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/broadcast/multi_herd/run_makefile_peano_elf.lit (6 of 9)
PASS: AIR_PROGRAMMING_EXAMPLES :: channel_examples/worker_to_self/run_makefile_peano.lit (7 of 9)
PASS: AIR_PROGRAMMING_EXAMPLES :: channel_examples/hierarchical/run_makefile_peano.lit (8 of 9)
PASS: AIR_PROGRAMMING_EXAMPLES :: channel_examples/broadcast/multi_herd/run_makefile_peano.lit (9 of 9)

$ lit -v build/python/test/ --filter=api
PASS: AIRPYTHON :: api/pack.py (1 of 10)
PASS: AIRPYTHON :: api/segment.py (2 of 10)
PASS: AIRPYTHON :: api/leaky_relu.py (3 of 10)
PASS: AIRPYTHON :: api/axpy.py (4 of 10)
PASS: AIRPYTHON :: api/relu.py (5 of 10)
PASS: AIRPYTHON :: api/channel.py (6 of 10)
PASS: AIRPYTHON :: api/dot.py (7 of 10)
PASS: AIRPYTHON :: api/activations.py (8 of 10)
PASS: AIRPYTHON :: api/eltwise_add.py (9 of 10)
PASS: AIRPYTHON :: api/errors.py (10 of 10)
```

Hardware, npu1, `make run`: all three print `PASS!` (re-run after the rebase,
not carried over).

## npu2 is possible here, and would be worth having

Unlike #1856, these examples are pure MLIR with no `.cc` microkernel, and their
lits say so: `REQUIRES: ryzen_ai` admits both generations, and each has a
`ryzen_ai_npu2, peano` elf variant. Of the 6 `UNSUPPORTED` above, 3 are chess
(no Chess on this box) and **3 are npu2-elf, which an npu2 host can run**.

So an npu2 machine would genuinely add coverage here — `lit --filter
"channel_examples.*(worker_to_self|hierarchical|multi_herd)"` should give 6 of 9
there. The 3 chess lits remain unverified by anyone, needing a Vitis license.