### PR TITLE
[programming_examples] Four more channel examples on air.api

### DIFF
--- a/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
+++ b/programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
@@ -1,127 +1,78 @@
-# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-#
-# Cross-herd broadcast: Herd A [1,1] puts data to a broadcast channel,
-# Herd B [N,1] gets the same data on all tiles.
-#
-# This exercises the pattern needed for RMSNorm[1,1] → GEMV[N,1] broadcast:
-# - Channel("bcast", size=[1, 1], broadcast_shape=[N, 1])
-# - Herd A [1,1]: ChannelPut("bcast", buf)           — single put, no indices
-# - Herd B [N,1]: ChannelGet("bcast", buf, [tx, ty]) — N gets via broadcast
-#
-# Test: Herd A reads input, adds 1, broadcasts.
-#       Herd B receives broadcast, each tile writes to its section of output.
-#       Output = N copies of (input + 1).
+"""A broadcast that crosses herds, on air.api.
+
+    air.channel @bcast [1, 1] {broadcast_shape = [4, 1]}
+
+One producer herd computes a vector and puts it once; a second herd of four
+cores each get the same data and write it to its own slice of the output. So
+this is the third shape of the same attribute: ``broadcast/single_herd`` fans
+out to the cores of one herd, ``broadcast/multi_herd`` to three separate 1x1
+herds, and this one from a herd to the cores of *another* herd. The producer
+and the consumer share no buffer and no operand -- only the symbol.
+
+Unchanged from the raw-bindings version this replaces, except that the
+producer's "add one" is written ``l1_out[:] = l1_in[:] + 1.0`` rather than as a
+hand-rolled loop over ``memref.subview`` + ``vector.transfer_read`` /
+``arith.addf`` / ``vector.transfer_write``. bf16 vectorises at 16 lanes, which
+is what the predecessor's ``VEC_SIZE`` picked by hand, and the DSL picks the
+same width for a 64-element buffer.
+"""
 
 import argparse
-import numpy as np
 from ml_dtypes import bfloat16
+import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.func import FuncOp
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import bf16
 
 VECTOR_LEN = 64  # Length of vector to broadcast (like head_dim or K)
 HERD_N = 4  # Number of consumer tiles (like HERD_M in GEMV)
-VEC_SIZE = 16  # SIMD width for bf16
 DTYPE = bfloat16
 
 
-def _make_mul_map(factor):
-    return AffineMap.get(
-        0,
-        1,
-        [AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(factor))],
-    )
-
-
-@module_builder
 def build_module():
-    xrt = type_mapper(DTYPE)
-    vecTy = VectorType.get([VEC_SIZE], xrt)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
+    A = air.tensor([VECTOR_LEN], bf16)
+    B = air.tensor([HERD_N * VECTOR_LEN], bf16)
 
-    # L3 types
-    in_ty = MemRefType.get([VECTOR_LEN], xrt)
-    out_ty = MemRefType.get([HERD_N * VECTOR_LEN], xrt)
+    bcast = air.channel("bcast", size=[1, 1], broadcast_shape=[HERD_N, 1])
 
-    # Memory spaces
-    l1s = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    with air.launch(name="cross_herd_broadcast") as launch:
 
-    # L1 types
-    l1_vec_ty = MemRefType.get([VECTOR_LEN], xrt, memory_space=l1s)
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-    # Cross-herd broadcast channel: 1 put from herd A, HERD_N gets in herd B
-    Channel("bcast", size=[1, 1], broadcast_shape=[HERD_N, 1])
+                @seg.body
+                def _():
 
-    @FuncOp.from_py_func(in_ty, out_ty)
-    def cross_herd_broadcast(data_in, data_out):
+                    with air.herd([range(1)], name="producer", shape=(1,)) as p:
 
-        @launch(operands=[data_in, data_out])
-        def launch_body(l_in, l_out):
+                        @p.body
+                        def _(tx):
+                            l1_in = air.alloc([VECTOR_LEN], bf16, scope=p.private())
+                            l1_out = air.alloc([VECTOR_LEN], bf16, scope=p.private())
 
-            @segment(name="seg", operands=[l_in, l_out])
-            def seg(s_in, s_out):
+                            air.ops.load(l1_in, A)
+                            l1_out[:] = l1_in[:] + 1.0
+                            bcast.put(l1_out)
 
-                # === Herd A [1,1]: producer — read, transform, broadcast ===
-                @herd(name="producer", sizes=[1, 1], operands=[s_in])
-                def producer(_tx, _ty, _sx, _sy, h_in):
-                    l1_in = AllocOp(l1_vec_ty, [], [])
-                    l1_out = AllocOp(l1_vec_ty, [], [])
+                    with air.herd(
+                        [range(HERD_N), range(1)], name="consumer", shape=(HERD_N, 1)
+                    ) as c:
 
-                    # Load from L3
-                    dma_memcpy_nd(l1_in, h_in)
+                        @c.body
+                        def _(tx, ty):
+                            l1_buf = air.alloc([VECTOR_LEN], bf16, scope=c.private())
 
-                    # Add 1 to each element (vectorized)
-                    c0 = ConstantOp(T.index(), 0)
-                    cst0 = ConstantOp(xrt, 0.0)
-                    one_scalar = ConstantOp(xrt, 1.0)
-                    v_one = BroadcastOp(vecTy, one_scalar)
-                    for j in range_(0, VECTOR_LEN, VEC_SIZE):
-                        sv_in = subview(l1_in.result, [j], [VEC_SIZE], [1])
-                        sv_out = subview(l1_out.result, [j], [VEC_SIZE], [1])
-                        v = transfer_read(
-                            vecTy, sv_in, [c0], identity_map, cst0, [True]
-                        )
-                        v_plus = arith.addf(v, v_one)
-                        transfer_write(None, v_plus, sv_out, [c0], identity_map, [True])
-                        yield_([])
+                            bcast.get(l1_buf, indices=[tx, ty])
 
-                    # Broadcast to all consumer tiles
-                    ChannelPut("bcast", l1_out)
+                            off = tx * VECTOR_LEN
+                            air.ops.store(l1_buf, B[off : off + VECTOR_LEN])
 
-                    DeallocOp(l1_in)
-                    DeallocOp(l1_out)
-
-                # === Herd B [HERD_N, 1]: consumer — receive broadcast, write output ===
-                @herd(name="consumer", sizes=[HERD_N, 1], operands=[s_out])
-                def consumer(_tx, _ty, _sx, _sy, h_out):
-                    l1_buf = AllocOp(l1_vec_ty, [], [])
-
-                    # Get broadcast data (each tile gets the same data)
-                    ChannelGet("bcast", l1_buf, indices=[_tx, _ty])
-
-                    # Write to output at tile-specific offset
-                    mul_map = _make_mul_map(VECTOR_LEN)
-                    out_off = affine_apply(mul_map, [_tx])
-                    dma_memcpy_nd(
-                        h_out,
-                        l1_buf,
-                        dst_offsets=[out_off],
-                        dst_sizes=[VECTOR_LEN],
-                        dst_strides=[1],
-                    )
-
-                    DeallocOp(l1_buf)
+    return launch
 
 
 if __name__ == "__main__":
@@ -138,9 +89,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
+++ b/programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py
@@ -1,17 +1,39 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Two herds in one segment, wired together by a channel, on air.api.
+
+    air.channel @ChanIn      L3 -> L1, into the producer
+    air.channel @Herd2Herd   L1 -> L1, producer herd to consumer herd
+    air.channel @ChanOut     L1 -> L3, out of the consumer
+
+``Herd2Herd`` is the point. Its put is in one herd body and its get is in
+another, and the two herds share nothing else -- no operand, no buffer, no
+enclosing scope beyond the segment they happen to sit in. That works because a
+channel is a module-level symbol rather than a value: `air.herd` is
+``IsolatedFromAbove``, so anything passed as data would have to be threaded
+through as an operand, and a channel simply is not.
+
+The producer squares its tile and the consumer adds one, so the two stages are
+distinguishable in the result: an input of 2 leaves as (2*2)+1 = 5.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side put and get sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The two kernels are written as whole-tile expressions rather than, in the
+  producer, a hand-declared `linalg_structured_op` standing in for a deprecated
+  upstream `elemwise_binary`, and in the consumer a scalar loop nest over every
+  (i, j). ``vector=0`` keeps them scalar as the predecessor was: the image is
+  32 i32 wide and a <8 x i32> op is 256-bit, which does not legalize.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-import air.dialects.linalg.opdsl.lang as linalg_lang
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -20,116 +42,62 @@ IMAGE_SIZE = [IMAGE_HEIGHT, IMAGE_WIDTH]
 INOUT_DATATYPE = np.int32
 
 
-# elemwise_binary (with operand type cast) is deprecated from upstream. Definition is moved here as a custom linalg structured op.
-@linalg_lang.linalg_structured_op
-def elemwise_binary(
-    lhs=linalg_lang.TensorDef(linalg_lang.TV.T1),
-    rhs=linalg_lang.TensorDef(linalg_lang.TV.T2),
-    O=linalg_lang.TensorDef(linalg_lang.U, output=True),
-    fun=linalg_lang.BinaryFnAttrDef(default=linalg_lang.BinaryFn.add),
-    cast=linalg_lang.TypeFnAttrDef(default=linalg_lang.TypeFn.cast_signed),
-):
-    """Applies the binary function fun elementwise.
-    Numeric casting is performed on the input operand, promoting it to the same
-    data type as the accumulator/output.
-    """
-    O[None] = fun(cast(linalg_lang.U, lhs[None]), cast(linalg_lang.U, rhs[None]))
-
-
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # We want to store our data in L1 memory
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
+    herd2herd = air.channel("Herd2Herd")
 
-    # This is the type definition of the tile
-    image_type_l1 = MemRefType.get(
-        shape=IMAGE_SIZE,
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    with air.launch(name="copy") as launch:
 
-    # Create two channels which will send/receive the
-    # input/output data respectively
-    Channel("ChanIn")
-    Channel("ChanOut")
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-    # Create a channel we will use to pass data between works in two herds
-    Channel("Herd2Herd")
+                @seg.body
+                def _():
+                    chan_in.put(A)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+                    with air.herd([range(1)], name="producer_herd", shape=(1,)) as p:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+                        @p.body
+                        def _(tx):
+                            image_in = air.alloc(
+                                IMAGE_SIZE, i32, scope=p.private(), vector=0
+                            )
+                            image_out = air.alloc(
+                                IMAGE_SIZE, i32, scope=p.private(), vector=0
+                            )
 
-            # Fetch all input data into the channel
-            ChannelPut("ChanIn", a)
+                            chan_in.get(image_in)
+                            image_out[:] = image_in[:] * image_in[:]
+                            herd2herd.put(image_out)
 
-            @segment(name="seg")
-            def segment_body():
+                    with air.herd([range(1)], name="consumer_herd", shape=(1,)) as c:
 
-                @herd(name="producer_herd", sizes=[1, 1])
-                def herd_body(tx, ty, sx, sy):
+                        @c.body
+                        def _(tx):
+                            image_in = air.alloc(
+                                IMAGE_SIZE, i32, scope=c.private(), vector=0
+                            )
+                            image_out = air.alloc(
+                                IMAGE_SIZE, i32, scope=c.private(), vector=0
+                            )
 
-                    # We must allocate a buffer of tilße size for the input/output
-                    image_in = AllocOp(image_type_l1, [], [])
-                    image_out = AllocOp(image_type_l1, [], [])
+                            herd2herd.get(image_in)
+                            image_out[:] = image_in[:] + 1
+                            chan_out.put(image_out)
 
-                    ChannelGet("ChanIn", image_in)
+                    chan_out.get(B)
 
-                    elemwise_binary(
-                        image_in,
-                        image_in,
-                        outs=[image_out],
-                        fun=linalg_lang.BinaryFn.mul,
-                        cast=linalg_lang.TypeFn.cast_unsigned,
-                    )
-
-                    ChannelPut("Herd2Herd", image_out)
-
-                    DeallocOp(image_in)
-                    DeallocOp(image_out)
-
-                @herd(name="consumer_herd", sizes=[1, 1])
-                def herd_body(tx, ty, sx, sy):
-
-                    # We must allocate a buffer of image size for the input/output
-                    image_in = AllocOp(image_type_l1, [], [])
-                    image_out = AllocOp(image_type_l1, [], [])
-
-                    ChannelGet("Herd2Herd", image_in)
-
-                    # Access every value in the image
-                    for i in range_(IMAGE_HEIGHT):
-                        for j in range_(IMAGE_WIDTH):
-                            # Load the input value
-                            val_in = load(image_in, [i, j])
-
-                            # Calculate the output value
-                            val_out = arith.addi(val_in, arith.ConstantOp(xrt_dtype, 1))
-
-                            # Store the output value
-                            store(val_out, image_out, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    ChannelPut("ChanOut", image_out)
-
-                    DeallocOp(image_in)
-                    DeallocOp(image_out)
-
-            # Push all output data out of the channel
-            ChannelGet("ChanOut", b)
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="herd_to_herd.py",
         description="Builds, runs, and tests the herd_to_herd channel example",
     )
     parser.add_argument(
@@ -151,9 +119,18 @@ if __name__ == "__main__":
         help="Output format for the compiled binary (default: xclbin)",
     )
 
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
+++ b/programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
@@ -1,128 +1,109 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""One worker per tile, each on its own channel pair, on air.api.
+
+    air.channel @ChanInHHWW / @ChanOutHHWW    one pair per tile
+
+The sibling ``single_core_channel`` streams every tile through one channel and
+lets ordering do the indexing. This one goes the other way: a channel pair and a
+1x1 herd *per tile*, all unrolled at trace time, so each worker has a private
+connection and the tile index is baked into the symbol name rather than carried
+by arrival order.
+
+Both spellings are worth having -- the first scales in tiles, the second in
+cores -- and they are the two ends of the same trade.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The per-tile add is written ``tile_out[:] = tile_in[:] + n`` rather than a
+  scalar loop nest over every (i, j). ``vector=0`` keeps it scalar as the
+  predecessor was: a <8 x i32> add is 256-bit and does not legalize.
+"""
+
 import argparse
+import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
+
+DTYPE = {np.int32: i32}
 
 
 def format_name(prefix, index_0, index_1):
     return f"{prefix}{index_0:02}{index_1:02}"
 
 
-@module_builder
 def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
     assert image_height % tile_height == 0
     assert image_width % tile_width == 0
-    image_size = [image_height, image_width]
+    dt = DTYPE[np_dtype]
     tile_size = [tile_height, tile_width]
-    xrt_dtype = type_mapper(np_dtype)
+    rows = image_height // tile_height
+    cols = image_width // tile_width
 
-    memrefTyInOut = MemRefType.get(image_size, xrt_dtype)
+    A = air.tensor([image_height, image_width], dt)
+    B = air.tensor([image_height, image_width], dt)
 
-    # Create an input/output channel pair per worker
-    for h in range(image_height // tile_height):
-        for w in range(image_width // tile_width):
-            Channel(format_name("ChanIn", h, w))
-            Channel(format_name("ChanOut", h, w))
+    chan_in = {}
+    chan_out = {}
+    for h in range(rows):
+        for w in range(cols):
+            chan_in[h, w] = air.channel(format_name("ChanIn", h, w))
+            chan_out[h, w] = air.channel(format_name("ChanOut", h, w))
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # Transfer one tile of data per worker
-            for h in range(image_height // tile_height):
-                for w in range(image_width // tile_width):
-                    offset0 = tile_height * h
-                    offset1 = tile_width * w
-
-                    # Put data into the channel tile by tile
-                    ChannelPut(
-                        format_name("ChanIn", h, w),
-                        a,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
-
-            # The arguments are still the input and the output
-            @segment(name="seg")
-            def segment_body():
-
-                # Transfer one tile of data per worker
-                for h in range(image_height // tile_height):
-                    for w in range(image_width // tile_width):
-
-                        @herd(name=format_name("xaddherd", h, w), sizes=[1, 1])
-                        def herd_body(_tx, _ty, _sx, _sy):
-                            # We want to store our data in L1 memory
-                            mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-
-                            # This is the type definition of the tile
-                            tile_type = MemRefType.get(
-                                shape=tile_size,
-                                element_type=xrt_dtype,
-                                memory_space=mem_space,
+                @seg.body
+                def _():
+                    for h in range(rows):
+                        for w in range(cols):
+                            i0, j0 = tile_height * h, tile_width * w
+                            chan_in[h, w].put(
+                                A[i0 : i0 + tile_height, j0 : j0 + tile_width]
                             )
 
-                            # We must allocate a buffer of tile size for the input/output
-                            tile_in = AllocOp(tile_type, [], [])
-                            tile_out = AllocOp(tile_type, [], [])
+                    # A closure per worker rather than a defaulted capture in
+                    # the body signature: air.api reads the body's positional
+                    # arity to get the grid rank, so `def _(tx, h=h)` would read
+                    # as a second coordinate.
+                    def one_worker(h, w):
+                        with air.herd(
+                            [range(1)], name=format_name("xaddherd", h, w), shape=(1,)
+                        ) as hd:
 
-                            # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                            ChannelGet(format_name("ChanIn", h, w), tile_in)
+                            @hd.body
+                            def _(tx):
+                                tile_in = air.alloc(
+                                    tile_size, dt, scope=hd.private(), vector=0
+                                )
+                                tile_out = air.alloc(
+                                    tile_size, dt, scope=hd.private(), vector=0
+                                )
 
-                            # Access every value in the tile
-                            for i in range_(tile_height):
-                                for j in range_(tile_width):
-                                    # Load the input value from tile_in
-                                    val_in = load(tile_in, [i, j])
+                                chan_in[h, w].get(tile_in)
+                                tile_out[:] = tile_in[:] + (rows * h + w)
+                                chan_out[h, w].put(tile_out)
 
-                                    # Compute the output value
-                                    val_out = arith.addi(
-                                        val_in,
-                                        arith.ConstantOp(
-                                            xrt_dtype,
-                                            (image_height // tile_height) * h + w,
-                                        ),
-                                    )
+                    for h in range(rows):
+                        for w in range(cols):
+                            one_worker(h, w)
 
-                                    # Store the output value in tile_out
-                                    store(val_out, tile_out, [i, j])
-                                    yield_([])
-                                yield_([])
+                    for h in range(rows):
+                        for w in range(cols):
+                            i0, j0 = tile_height * h, tile_width * w
+                            chan_out[h, w].get(
+                                B[i0 : i0 + tile_height, j0 : j0 + tile_width]
+                            )
 
-                            # Copy the output tile into the output
-                            ChannelPut(format_name("ChanOut", h, w), tile_out)
-
-                            # Deallocate our L1 buffers
-                            DeallocOp(tile_in)
-                            DeallocOp(tile_out)
-
-            # Transfer one tile of data per worker
-            for h in range(image_height // tile_height):
-                for w in range(image_width // tile_width):
-                    offset0 = tile_height * h
-                    offset1 = tile_width * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        format_name("ChanOut", h, w),
-                        b,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
+    return launch
 
 
 if __name__ == "__main__":
@@ -171,15 +152,24 @@ if __name__ == "__main__":
         help="Output format for the compiled binary (default: xclbin)",
     )
 
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.image_height,
         args.image_width,
         args.tile_height,
         args.tile_width,
         INOUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
+++ b/programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
@@ -1,130 +1,91 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Add each tile's index to that tile, streamed through channels, on air.api.
+
+    air.channel @ChanIn     L3 -> L1, one put per tile
+    air.channel @ChanOut    L1 -> L3, one put per tile
+
+The image is cut into tiles on the *producer* side: a loop nest at segment scope
+puts one tile region per trip, and the single core does one get per trip. So
+neither end names a tile index -- the channel carries them in order, and the
+core's `tile_num` is just its trip counter. That is the ordering guarantee a
+channel gives, used as the whole indexing scheme.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The L3-side puts and gets sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The per-tile add is written ``tile_out[:] = tile_in[:] + tile_num`` rather
+  than a scalar loop nest over every (i, j); the trip counter broadcasts into
+  the expression as an index_cast, which is what the predecessor spelled by
+  hand. ``vector=0`` keeps it scalar as it was: a <8 x i32> add is 256-bit and
+  does not legalize.
+"""
+
 import argparse
+import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
+
+DTYPE = {np.int32: i32}
 
 
-@module_builder
 def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
     assert image_height % tile_height == 0
     assert image_width % tile_width == 0
-    image_size = [image_height, image_width]
+    dt = DTYPE[np_dtype]
     tile_size = [tile_height, tile_width]
-    xrt_dtype = type_mapper(np_dtype)
+    rows = image_height // tile_height
+    cols = image_width // tile_width
 
-    memrefTyInOut = MemRefType.get(image_size, xrt_dtype)
+    A = air.tensor([image_height, image_width], dt)
+    B = air.tensor([image_height, image_width], dt)
 
-    # Create two channels which will send/receive the
-    # input/output data respectively
-    Channel("ChanIn")
-    Channel("ChanOut")
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # Transform data into contiguous tiles
-            for offset0 in range_(
-                0, tile_height * (image_height // tile_height), tile_height
-            ):
-                for offset1 in range_(
-                    0, tile_width * (image_width // tile_width), tile_width
-                ):
-                    # Put data into the channel tile by tile
-                    ChannelPut(
-                        "ChanIn",
-                        a,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
-                    yield_([])
-                yield_([])
+                @seg.body
+                def _():
+                    # One put per tile, row-major -- the order the core's gets
+                    # consume them in.
+                    for r in air.sequential(0, rows):
+                        for c in air.sequential(0, cols):
+                            i0 = r * tile_height
+                            j0 = c * tile_width
+                            chan_in.put(A[i0 : i0 + tile_height, j0 : j0 + tile_width])
 
-            # The arguments are still the input and the output
-            @segment(name="seg")
-            def segment_body():
+                    with air.herd([range(1)], name="xaddherd", shape=(1,)) as h:
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We just need one compute core, so we ask for a 1x1 herd
-                @herd(name="xaddherd", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
+                            )
+                            tile_out = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
+                            )
 
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+                            for tile_num in air.sequential(0, rows * cols):
+                                chan_in.get(tile_in)
+                                tile_out[:] = tile_in[:] + tile_num
+                                chan_out.put(tile_out)
 
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=tile_size,
-                        element_type=xrt_dtype,
-                        memory_space=mem_space,
-                    )
+                    for r in air.sequential(0, rows):
+                        for c in air.sequential(0, cols):
+                            i0 = r * tile_height
+                            j0 = c * tile_width
+                            chan_out.get(B[i0 : i0 + tile_height, j0 : j0 + tile_width])
 
-                    # Loop over columns and rows of tiles
-                    for tile_num in range_(
-                        (image_width // tile_width) * (image_height // tile_height)
-                    ):
-
-                        # We must allocate a buffer of tile size for the input/output
-                        tile_in = AllocOp(tile_type, [], [])
-                        tile_out = AllocOp(tile_type, [], [])
-
-                        # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                        ChannelGet("ChanIn", tile_in)
-
-                        # Access every value in the tile
-                        for i in range_(tile_height):
-                            for j in range_(tile_width):
-                                # Load the input value from tile_in
-                                val_in = load(tile_in, [i, j])
-
-                                # Compute the output value
-                                val_out = arith.addi(
-                                    val_in, arith.index_cast(xrt_dtype, tile_num)
-                                )
-
-                                # Store the output value in tile_out
-                                store(val_out, tile_out, [i, j])
-                                yield_([])
-                            yield_([])
-
-                        # Copy the output tile into the output
-                        ChannelPut("ChanOut", tile_out)
-
-                        # Deallocate our L1 buffers
-                        DeallocOp(tile_in)
-                        DeallocOp(tile_out)
-
-                        yield_([])
-
-            # Write data back out to the channel tile by tile
-            for offset0 in range_(
-                0, tile_height * (image_height // tile_height), tile_height
-            ):
-                for offset1 in range_(
-                    0, tile_width * (image_width // tile_width), tile_width
-                ):
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        offsets=[offset0, offset1],
-                        sizes=tile_size,
-                        strides=[image_width, 1],
-                    )
-                    yield_([])
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -173,15 +134,24 @@ if __name__ == "__main__":
         help="Output format for the compiled binary (default: xclbin)",
     )
 
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.image_height,
         args.image_width,
         args.tile_height,
         args.tile_width,
         INOUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)


### PR DESCRIPTION
Converts four more channel examples onto `air.api`, replacing the raw-bindings
versions. **No new DSL surface** — everything here is expressible against what
#1852, #1855 and #1856 already landed.

| example | what it exercises |
|---|---|
| `channel_examples/herd_to_herd/single_segment` | `@Herd2Herd`: put in one herd body, get in another. The herds share no operand and no buffer — the property a channel exists for, since `air.herd` is `IsolatedFromAbove` and a symbol is not data. |
| `channel_examples/broadcast/cross_herd` | the third shape of `broadcast_shape`: producer herd to the cores of a *different* herd. `single_herd` fans out within one herd, `multi_herd` to three 1x1 herds. |
| `matrix_scalar_add/single_core_channel` | one channel for every tile — arrival order *is* the index, and the core's tile number is just its trip counter. |
| `matrix_scalar_add/multi_core_channel` | the opposite trade: a channel pair and a 1x1 herd per tile, unrolled at trace time, index baked into the symbol name. |

Most of the deletion is ceremony. `herd_to_herd`'s producer carried a
hand-declared `linalg_structured_op` — 20 lines of `TensorDef` and
`BinaryFnAttrDef` standing in for a deprecated upstream `elemwise_binary` — to
say `a * a`. `cross_herd`'s producer was a hand-rolled loop over
`memref.subview` + `transfer_read`/`addf`/`transfer_write`; bf16 vectorises
at 16 lanes and the DSL picks the width the author chose by hand. The i32
examples pass `vector=0` to stay scalar as they were — a <8 x i32> op is
256-bit and does not legalize.

`multi_core_channel` builds its herds through a closure rather than
`def _(tx, h=h)`: air.api reads the body's positional arity to get the grid
rank, so a defaulted capture reads as a second coordinate.

## Evidence

```
$ git log --oneline origin/main..HEAD
db1cfd7e [programming_examples] Two matrix_scalar_add channel examples on air.api
f27cefc7 [programming_examples] herd_to_herd and cross_herd on air.api

$ git show --name-status HEAD
M	programming_examples/matrix_scalar_add/multi_core_channel/multi_core_channel.py
M	programming_examples/matrix_scalar_add/single_core_channel/single_core_channel.py
$ git show --name-status HEAD~1
M	programming_examples/channel_examples/broadcast/cross_herd/broadcast.py
M	programming_examples/channel_examples/herd_to_herd/single_segment/herd_to_herd.py

$ git diff --stat origin/main...HEAD
 .../broadcast/cross_herd/broadcast.py              | 182 +++++++-----------
 .../herd_to_herd/single_segment/herd_to_herd.py    | 181 ++++++++----------
 .../multi_core_channel/multi_core_channel.py       | 208 ++++++++++-----------
 .../single_core_channel/single_core_channel.py     | 204 +++++++++-----------
 4 files changed, 336 insertions(+), 439 deletions(-)

$ grep -H 'REQUIRES:' <the four examples>/*.lit
channel_examples/herd_to_herd/single_segment/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
channel_examples/broadcast/cross_herd/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
matrix_scalar_add/multi_core_channel/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano
matrix_scalar_add/multi_core_channel/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
matrix_scalar_add/single_core_channel/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
channel_examples/herd_to_herd/single_segment/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
matrix_scalar_add/single_core_channel/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano
channel_examples/herd_to_herd/single_segment/run_makefile_peano.lit:// REQUIRES: ryzen_ai, peano
matrix_scalar_add/multi_core_channel/run_makefile_chess.lit:// REQUIRES: ryzen_ai, valid_xchess_license
matrix_scalar_add/single_core_channel/run_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano

$ lit -v build/programming_examples --filter '(matrix_scalar_add/(single|multi)_core_channel|channel_examples.*(herd_to_herd/single_segment|cross_herd))'
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/multi_core_channel/run_makefile_peano_elf.lit (1 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/single_core_channel/run_makefile_peano_elf.lit (2 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/herd_to_herd/single_segment/run_makefile_chess.lit (3 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/single_core_channel/run_makefile_chess.lit (4 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/multi_core_channel/run_makefile_chess.lit (5 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/herd_to_herd/single_segment/run_makefile_peano_elf.lit (6 of 10)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: channel_examples/broadcast/cross_herd/run_makefile_peano_elf.lit (7 of 10)
PASS: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/single_core_channel/run_makefile_peano.lit (8 of 10)
PASS: AIR_PROGRAMMING_EXAMPLES :: channel_examples/herd_to_herd/single_segment/run_makefile_peano.lit (9 of 10)
PASS: AIR_PROGRAMMING_EXAMPLES :: matrix_scalar_add/multi_core_channel/run_makefile_peano.lit (10 of 10)

$ lit -v build/python/test/ --filter=api
PASS: AIRPYTHON :: api/pack.py (1 of 10)
PASS: AIRPYTHON :: api/segment.py (2 of 10)
PASS: AIRPYTHON :: api/leaky_relu.py (3 of 10)
PASS: AIRPYTHON :: api/axpy.py (4 of 10)
PASS: AIRPYTHON :: api/relu.py (5 of 10)
PASS: AIRPYTHON :: api/activations.py (6 of 10)
PASS: AIRPYTHON :: api/eltwise_add.py (7 of 10)
PASS: AIRPYTHON :: api/dot.py (8 of 10)
PASS: AIRPYTHON :: api/channel.py (9 of 10)
PASS: AIRPYTHON :: api/errors.py (10 of 10)
```

Hardware, npu1, `make run`: all four print `PASS!`.

Of the 10 lits, 3 pass here, and the 7 `UNSUPPORTED` are 4 chess (no Chess on
this box) and 3 npu2-elf. **`cross_herd`'s only lit is npu2-elf**, so on npu1 it
is verified by `make run` rather than by its gate; an npu2 host would cover
that one plus the other two elf variants.

## Not converted, and why

Seven more channel examples remain; each is blocked on something specific, and
I attempted two of these and reverted rather than approximate them:

| example | blocker |
|---|---|
| `worker_to_worker` | `(tw + 1) % COLS` on a herd coordinate. `IndexExpr.__mod__` exists but raises `NotImplementedError`. The predecessor builds the same expression as a hand-written `AffineMap`, so this is a lowering that already exists elsewhere. |
| `passthrough/passthrough_kernel` | `np.uint8` throughout; air.api has no unsigned dtypes. Using `i8` would declare `passThroughLine` with a signature `passThrough.cc` does not define. |
| `broadcast_selective_capture` | `scf.if` on a runtime predicate; no conditional in the DSL. |
| `shared_l1_{single,multi}_herd` | per-core `memref.subview` of a shared L1 buffer. |
| `data_transfer_transpose/channel` | a transposing DMA walk, `sizes=[1,k,m] strides=[1,1,k]` on a flat buffer. |
| `herd_to_herd/multi_segment`, `multi_segment/multi_segment_channel`, `matrix_scalar_add/multi_launch_channel` | already `XFAIL: *` upstream. `multi_segment` fails in `air-to-aie` with `'air.channel.get' op failed to get MM2S tile for L3 allocation` — its L3 endpoints sit at launch scope, which is the very thing air.api forbids by construction. |

The first two look small and each unblocks exactly one example.