### PR TITLE
[programming_examples] matvec build_module returns a Module again

### DIFF
--- a/programming_examples/matrix_vector_multiplication/bf16/matvec.py
+++ b/programming_examples/matrix_vector_multiplication/bf16/matvec.py
@@ -57,8 +57,25 @@ DTYPE = {bfloat16: bf16}
 
 
 def build_module(
-    m, k, tile_m, m_input, herd_m, np_dtype_in, np_dtype_out, link_with="mv.o"
+    m,
+    k,
+    tile_m,
+    m_input,
+    herd_m,
+    np_dtype_in,
+    np_dtype_out,
+    link_with="mv.o",
+    target="auto",
 ):
+    """Build the GEMV module. Returns an ``air.ir.Module``.
+
+    Returning a *module* rather than the air.api ``LaunchContext`` is part of
+    this function's contract, not an implementation detail: ten call sites in
+    ``programming_examples/llms/`` do ``str(build_gemv(...))`` and parse the
+    result as MLIR text. Returning the context stringified it as
+    ``<air.api._compile.LaunchContext object at 0x...>``, which those parsers
+    accepted silently and then failed on with an unrelated TypeError.
+    """
     assert (
         m % (tile_m * herd_m) == 0
     ), f"M ({m}) must be divisible by tile_m * herd_m ({tile_m * herd_m})"
@@ -146,7 +163,7 @@ def build_module(
 
                     air.ops.store(l2_c, C[row : row + seg_m])
 
-    return launch
+    return launch.build(target=target)
 
 
 if __name__ == "__main__":
@@ -248,7 +265,7 @@ if __name__ == "__main__":
     if args.perf_iters < 0:
         parser.error("--perf-iters must be >= 0")
 
-    launch = build_module(
+    mlir_module = build_module(
         args.m,
         args.k,
         args.tile_m,
@@ -256,8 +273,8 @@ if __name__ == "__main__":
         args.herd_m,
         INPUT_DATATYPE,
         OUTPUT_DATATYPE,
+        target=args.target,
     )
-    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)


### PR DESCRIPTION
**Fixes the nightly LLM benchmark, currently red on main.** Broken by #1849 (mine).

Run: https://github.com/Xilinx/mlir-air/actions/runs/32447192613 — six
`run_npu2_verify` lits failing: llama32_1b, llama32_1b_q4nx, smollm2_1_7b,
qwen3_4b, qwen25_1_5b, phi4_mini_q4nx.

## What broke

Porting `matvec.py` to `air.api` changed what `build_module` **returns**. The
predecessor's `@module_builder` returned an `air.ir.Module`; the port returned
the air.api `LaunchContext` and left `.build()` to `__main__`.

Ten call sites under `programming_examples/llms/` do:

```python
gemv_ir = str(build_gemv(...))
```

They got `<air.api._compile.LaunchContext object at 0x...>`. That is a string,
so nothing raised — it failed later, in the MLIR text parser:

```
File ".../llms/shared/infra/stitching.py", line 37, in _extract_between_func_and_return
    for i in range(len(lines) - 1, body_start, -1):
TypeError: 'NoneType' object cannot be interpreted as an integer
```

`body_start` stays `None` because no line matches `func.func @`. Four of the ten
call sites are in `llms/shared/builders/`, which is why models that never
mention matvec break too.

Reproduced locally with no device:

```
$ python3 -c "from shared.builders.lm_head_gemv_multi import build_lm_head_gemv_module; build_lm_head_gemv_module(2048)"
  Building 8-partition LM Head GEMV (M_part=16384, K=2048)...
REPRO TypeError: 'NoneType' object cannot be interpreted as an integer

$ # sl.ir, printed:
'<air.api._compile.LaunchContext object at 0x7f215b74fd70>'
```

## The fix

`build_module` takes `target=` and returns the built Module — the contract the
ten callers were written against. `__main__` passes `target=args.target` and
uses the result directly. The docstring now says the return type is part of the
contract, with the reason, so the next port does not undo it.

After:

```
  Module: 331 lines, 17 args, 8 launches, parsed OK    <- lm_head_gemv
  Module: 247 lines, 13 args, 6 launches, parsed OK    <- rms_gemv_rope
BOTH SHARED BUILDERS OK
```

Emitted IR is byte-identical to `origin/main`'s for the default configuration:

```
b7dfa9a5a85a4dcbea34dd7650d6346f  /tmp/mv_old.mlir
b7dfa9a5a85a4dcbea34dd7650d6346f  /tmp/mv_new.mlir
```

## A hardware caveat, and a retraction

An earlier revision of this description said matvec "currently times out on npu1
at origin/main". **That was wrong and is retracted.**

matvec does time out on my box, with and without this change — but my installed
compiler was built at `2026-08-20 10:53`, and #1851 (`AIRToAIE`) landed at
`23:06`, twelve hours later. So my build is not main, and that measurement says
nothing about main. CI on main is green on both Ryzen AI runners
(`amd8845hs`, `amdhx370`), which run matvec's npu1 lit — so matvec passes on
real main and the timeout is local to my stale build.

What that means for this PR: it is verified by the reproducer, by both shared
builders now building, and by the byte-identical IR — **not on hardware**. Since
the IR is unchanged, CI's existing npu1 lit is the hardware check.

## Why the consumer scan missed it

`lm_head_gemv_multi.py` reaches the example via

```python
sys.path.insert(0, os.path.join(..., "matrix_vector_multiplication", "bf16"))
from matvec import build_module as build_gemv
```

The path is assembled from separate fragments, so the string
`matrix_vector_multiplication/bf16` never appears in the file and a path-based
grep finds nothing; the imported name is the bare `matvec`. A scan has to look
for the *module basename* as well as the path, and `llms/` is nightly-only, so
PR CI could not have caught it either.
