### PR TITLE
[AIRToAIE] Derive compute-tile DMA channel assignment, and retire air.tile_dma_channel

### DIFF
--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -343,6 +343,30 @@ public:
   // physical port its flows originate from. Returns failure if any chain is
   // rejected.
   LogicalResult verifyMM2SChains();
+
+  // Separate packet flows from circuit flows sharing a compute-tile DMA
+  // channel. The compute-tile twin of
+  // ShimDMAAllocator::spreadCollapsedPacketChannels, against the same bug in
+  // the same shape: simpleDmaChannelAlloc's packet-reuse branch fires BEFORE
+  // the free-channel search below it, so a core can end up with two flows
+  // queued on S2MM 0 while S2MM 1 sits idle.
+  //
+  // Unlike at the shim, most such collapse is harmless here and worth keeping:
+  // several flows on one channel is how the emitter folds a repeating chain
+  // into one BD with a repeat count. One case is not a preference but a
+  // hardware fact -- a channel's port is either statically connected or
+  // packet-switched, never both -- so a packet flow queued behind a circuit
+  // flow has its header ignored and is delivered to the circuit's destination.
+  // Only that case is broken up, onto a free channel of the tile or, failing
+  // that, onto one carrying packets already.
+  //
+  // Runs after repairS2MMChains, which answers a sharper question about the
+  // same chains and should not have its answer overwritten. Collapse the front
+  // end asked for is left alone; see the .cpp for what counts as immovable, and
+  // for why a shared ring is NOT broken up merely because its flows come from
+  // independent producers.
+  void
+  spreadCollapsedPacketChannels(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 };
 
 class ShimDMAAllocator : public DMAAllocator {

--- a/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
+++ b/mlir/include/air/Conversion/AIRToAIESchedulingUtils.h
@@ -338,33 +338,48 @@ public:
   // are connected.
   void repairS2MMChains(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
   // Reject MM2S chains whose BD ring cannot stay in step with the transfers the
-  // core actually issues. Diagnosis only: unlike the S2MM side there is nothing
-  // to repair, because moving a producer to another MM2S would change which
-  // physical port its flows originate from. Returns failure if any chain is
-  // rejected.
+  // core actually issues. Diagnosis only, and by the time it runs the repairs
+  // have had their turn: spreadCollapsedPacketChannels moves an MM2S flow onto
+  // a spare channel where the tile has one, so what reaches here is a chain no
+  // spare channel could fix. Moving a producer does change which physical port
+  // its flows leave from, which is why the move is made before flows are
+  // connected rather than after. Returns failure if any chain is rejected.
   LogicalResult verifyMM2SChains();
 
-  // Separate packet flows from circuit flows sharing a compute-tile DMA
-  // channel. The compute-tile twin of
+  // Separate the flows sharing a compute-tile DMA channel where sharing it is
+  // unsound. Applies to BOTH directions -- the pass walks mm2s_allocs and
+  // s2mm_allocs alike, since a ring is walked in order whichever way the data
+  // moves. The compute-tile twin of
   // ShimDMAAllocator::spreadCollapsedPacketChannels, against the same bug in
   // the same shape: simpleDmaChannelAlloc's packet-reuse branch fires BEFORE
-  // the free-channel search below it, so a core can end up with two flows
-  // queued on S2MM 0 while S2MM 1 sits idle.
+  // the free-channel search below it, and its fallback counts ALLOCATIONS
+  // rather than occupied channels, so a core ends up with several flows queued
+  // on channel 0 while channel 1 sits idle.
   //
-  // Unlike at the shim, most such collapse is harmless here and worth keeping:
-  // several flows on one channel is how the emitter folds a repeating chain
-  // into one BD with a repeat count. One case is not a preference but a
-  // hardware fact -- a channel's port is either statically connected or
-  // packet-switched, never both -- so a packet flow queued behind a circuit
-  // flow has its header ignored and is delivered to the circuit's destination.
-  // Only that case is broken up, onto a free channel of the tile or, failing
-  // that, onto one carrying packets already.
+  // Most such collapse is harmless and worth keeping: several flows on one
+  // channel is how the emitter folds a repeating chain into one BD with a
+  // repeat count. A channel is ONE BD ring walked strictly in order, and a
+  // packet header steers a transfer to the tile without choosing which BD
+  // receives it, so sharing is sound exactly when something fixes the arrival
+  // order. Three things can, and only their absence breaks a ring up:
+  //
+  //   - one switching kind. A switchbox port is statically connected OR
+  //     packet-arbitrated, never both, and a channel is one port.
+  //   - a ROUND-ROBIN ring: every flow owning exactly one BD of the repeating
+  //     unit, so a flow's k-th transfer always meets that same BD however the
+  //     arrivals interleave. This is why an AIR matmul's A and B legs may
+  //     share one.
+  //   - a single producer, whose own BD order fixes the arrival order.
+  //
+  // The repair is a free channel of the tile, one already carrying the same
+  // switching kind, or -- for unsynchronised producers -- a partition by
+  // producer. See the .cpp for what counts as immovable and for how the
+  // partition merges when producers outnumber channels.
   //
   // Runs after repairS2MMChains, which answers a sharper question about the
-  // same chains and should not have its answer overwritten. Collapse the front
-  // end asked for is left alone; see the .cpp for what counts as immovable, and
-  // for why a shared ring is NOT broken up merely because its flows come from
-  // independent producers.
+  // same chains and should not have its answer overwritten, and before
+  // verifyMM2SChains, so what that check refuses is only what no spare channel
+  // could fix.
   void
   spreadCollapsedPacketChannels(std::vector<MemcpyBundleAsFlow> &memcpy_flows);
 };

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -4967,16 +4967,32 @@ public:
     // arrivals onto a spare channel of the same tile.
     tile_dma_alloc.repairS2MMChains(memcpy_flows);
 
-    // Step 3c: the mirror check on the producer side. Nothing to repair there
-    // -- moving a producer to another MM2S would change which port its flows
-    // leave from -- so a chain that cannot stay in step is rejected rather
-    // than emitted as a design that hangs.
+    // Step 3c: packet multiplexing exists to exceed a tile's channel count, but
+    // the allocator applies it before it ever looks for a free channel, so a
+    // core can carry two independently-produced flows on one BD ring with its
+    // other channel idle -- an arrival-order dependence nothing in the design
+    // establishes, and a head-of-line deadlock when it goes the wrong way.
+    // Spread what is left over the channels still free.
+    //
+    // After the repair, not before: the repair answers a sharper question (this
+    // chain provably cannot stay in step) and picks its channel accordingly, so
+    // letting the spread move first only overwrites a better-informed decision
+    // with a positional one -- measurably, on three of the shipping decode
+    // models, whose BD rings changed shape for no gain.
+    tile_dma_alloc.spreadCollapsedPacketChannels(memcpy_flows);
+
+    // Step 3d: the mirror check on the producer side. What is left after the
+    // spread above is a chain the tile has no room to separate, and there is
+    // nothing further to repair -- moving a producer to another MM2S would
+    // change which port its flows leave from -- so a chain that still cannot
+    // stay in step is rejected rather than emitted as a design that hangs.
     if (failed(tile_dma_alloc.verifyMM2SChains()))
       return failure();
 
-    // Step 3d: packet multiplexing exists to exceed a tile's channel count,
-    // but the allocator applies it before it ever looks for a free channel, so
-    // a shim can carry four flows on MM2S 0 with MM2S 1 idle. Redistribute
+    // Step 3e: the same redistribution at the shim, where the cost of a
+    // needless collapse is not order but port diversity: flows squeezed
+    // through one switchbox slave port deny the pathfinder the routes a
+    // same-id convergent group elsewhere on the column needs. Redistribute
     // onto the free channels now that every allocation is known; collapse that
     // is load-bearing (bundled sub-channels, broadcasts, pinned/dedicated
     // flows) is left alone.

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1784,6 +1784,20 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     AIE::DMAChannelDir dir = allocs->front().dma_channel.direction;
     bool isMM2S = dir == AIE::DMAChannelDir::MM2S;
 
+    // Where each allocation sat before the pass ran. A split has to be APPENDED
+    // when it is made -- inserting into the vector mid-pass would invalidate
+    // the chain indices still to be visited -- but appending also reorders the
+    // allocations, and this vector is the order flows are later created in.
+    // The pathfinder is greedy, so that order decides routes: llama-3.2-1b
+    // routes under one order of the rope tile's two packet appends and fails to
+    // route under the other, on identical channels. Changing which channel a
+    // flow uses is this pass's business; changing the order they are emitted in
+    // is not. So a split remembers the position of the allocation it came from,
+    // and the vector is put back in that order at the end, each split sitting
+    // immediately after its parent.
+    SmallVector<size_t> origPos(allocs->size());
+    std::iota(origPos.begin(), origPos.end(), 0);
+
     // Chains are keyed exactly as the emitter groups them: one per
     // (tile, channel), over every allocation mapped to it. Rebuilt between
     // phases, since moving a flow changes the grouping.
@@ -1831,7 +1845,7 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
                         Operation *tileOp, int fromChan, int toChan) {
       touched.insert({tileOp, fromChan});
       touched.insert({tileOp, toChan});
-      SmallVector<allocation_info_t> splits;
+      SmallVector<std::pair<size_t, allocation_info_t>> splits;
       for (size_t i : allocIdxs) {
         std::vector<Operation *> keepOps, moveOps;
         for (auto *o : (*allocs)[i].memcpyOps)
@@ -1849,9 +1863,12 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
         split.tile_channel = toChan;
         split.memcpyOps = moveOps;
         (*allocs)[i].memcpyOps = keepOps;
-        splits.push_back(split);
+        splits.push_back({origPos[i], split});
       }
-      llvm::append_range(*allocs, splits);
+      for (auto &[parentPos, split] : splits) {
+        allocs->push_back(split);
+        origPos.push_back(parentPos);
+      }
 
       for (auto &f : memcpy_flows) {
         if (f.air_flow_op != moveDecl)
@@ -2099,8 +2116,25 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
           groups = merged;
         }
 
-        // The group that got here first keeps the channel; the others take the
-        // channels the tile was not using, one group each while they last.
+        // Which group KEEPS the channel it is on? Not simply the one that got
+        // here first. A group whose flows are each fed by ONE producer already
+        // has its arrival order fixed by that producer's BD order -- it is the
+        // well-behaved party. A CONVERGENT flow, one channel fed by several
+        // producers, is the party nothing orders, so that is what gets moved to
+        // the fresh channel and what the well-behaved group is protected from.
+        //
+        // This is also the choice the hand-written pins made. On the llama rms
+        // core @xnorm is convergent (rms core L1 + down_buffer L2) and
+        // @layerOut is not, and the pin moved @xnorm. Moving @layerOut instead
+        // leaves the same partition on swapped indices, which routes on some
+        // designs and not on others -- llama-3.2-1b, llama-3.1-8b and phi4-mini
+        // all fail to route (2,2) DMA0 -> (1,1) DMA2 that way.
+        llvm::stable_sort(groups, [](const auto &a, const auto &b) {
+          return a.first.size() < b.first.size();
+        });
+
+        // The keeper is now groups[0]; the others take the channels the tile
+        // was not using, one group each while they last.
         for (size_t gi = 1; gi < groups.size(); gi++) {
           if (llvm::any_of(groups[gi].second, isImmovable))
             continue;

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1704,6 +1704,287 @@ void air::TileDMAAllocator::repairS2MMChains(
   }
 }
 
+void air::TileDMAAllocator::spreadCollapsedPacketChannels(
+    std::vector<MemcpyBundleAsFlow> &memcpy_flows) {
+  auto declOf = [](Operation *o) -> Operation * {
+    auto chan = dyn_cast_if_present<air::ChannelInterface>(o);
+    if (!chan)
+      return nullptr;
+    auto decl = air::getChannelDeclarationThroughSymbol(chan);
+    return decl ? decl.getOperation() : nullptr;
+  };
+  // A decl the front end has already placed on this tile. Unlike at the shim,
+  // `air.tile_dma_channel` IS about this tile's channel, so it is honoured here
+  // as the explicit override it is documented to be. `broadcast_shape` is not
+  // consulted: a broadcast constrains the SOURCE port it fans out from, which
+  // says nothing about which channel each receiving core takes it in on.
+  auto isImmovable = [](Operation *decl) {
+    return decl->hasAttr(air::attrs::TileDmaChannel) ||
+           decl->hasAttr(air::attrs::DedicatedDmaChannel);
+  };
+  // Whether the flow this transfer belongs to travels as packets. Read from the
+  // memcpy op, the same way simpleDmaChannelAlloc decides whether to multiplex,
+  // so the two agree on what a packet flow is even after the pass has converted
+  // a circuit channel into one.
+  auto isPacket = [](Operation *o) {
+    auto mc = dyn_cast_if_present<air::MemcpyInterface>(o);
+    if (!mc)
+      return false;
+    auto ct = air::getChannelType(mc);
+    return succeeded(ct) && *ct == "npu_dma_packet";
+  };
+
+  // One chain as the emitter sees it: every allocation mapped to a
+  // (tile, channel), the flows on it in a deterministic order, and which of
+  // those flows are packet flows.
+  struct Chain {
+    SmallVector<size_t> allocIdxs;
+    SmallVector<Operation *> order;
+    llvm::SmallPtrSet<Operation *, 4> packetDecls;
+    bool unkeyed = false;
+  };
+
+  for (auto *allocs : {&mm2s_allocs, &s2mm_allocs}) {
+    if (allocs->empty())
+      continue;
+    AIE::DMAChannelDir dir = allocs->front().dma_channel.direction;
+    bool isMM2S = dir == AIE::DMAChannelDir::MM2S;
+
+    // Chains are keyed exactly as the emitter groups them: one per
+    // (tile, channel), over every allocation mapped to it. Rebuilt between
+    // phases, since moving a flow changes the grouping.
+    auto buildChains = [&]() {
+      llvm::MapVector<std::pair<Operation *, int>, Chain> chains;
+      for (auto [i, alloc] : llvm::enumerate(*allocs)) {
+        if (!alloc.dma_tile)
+          continue;
+        auto &c =
+            chains[{alloc.dma_tile.getOperation(), alloc.dma_channel.channel}];
+        c.allocIdxs.push_back(i);
+        for (auto *o : alloc.memcpyOps) {
+          auto *d = declOf(o);
+          if (!d) {
+            c.unkeyed = true; // not attributable to a flow: leave it alone
+            continue;
+          }
+          if (!llvm::is_contained(c.order, d))
+            c.order.push_back(d);
+          if (isPacket(o))
+            c.packetDecls.insert(d);
+        }
+      }
+      return chains;
+    };
+    auto channelsInUse = [&](Operation *tileOp) {
+      llvm::SmallDenseSet<int> used;
+      for (auto &alloc : *allocs)
+        if (alloc.dma_tile && alloc.dma_tile.getOperation() == tileOp)
+          used.insert(alloc.dma_channel.channel);
+      return used;
+    };
+
+    // (tile, channel) pairs this pass has written to, so program order can be
+    // restored on exactly those and nothing else.
+    llvm::SetVector<std::pair<Operation *, int>> touched;
+
+    // Move every transfer of `moveDecl` currently on (tileOp, fromChan) to
+    // `toChan`: retarget an allocation whose transfers all move, split the
+    // rest, and follow with the bundle's own copy -- the flows are connected
+    // from that copy, so leaving it behind would route the packet to the
+    // channel the BDs just left.
+    auto moveFlow = [&](ArrayRef<size_t> allocIdxs, Operation *moveDecl,
+                        Operation *tileOp, int fromChan, int toChan) {
+      touched.insert({tileOp, fromChan});
+      touched.insert({tileOp, toChan});
+      SmallVector<allocation_info_t> splits;
+      for (size_t i : allocIdxs) {
+        std::vector<Operation *> keepOps, moveOps;
+        for (auto *o : (*allocs)[i].memcpyOps)
+          (declOf(o) == moveDecl ? moveOps : keepOps).push_back(o);
+        if (moveOps.empty())
+          continue;
+        (*allocs)[i].packet_flow_id = -1; // reassigned on flow connection
+        if (keepOps.empty()) {
+          (*allocs)[i].dma_channel = {dir, toChan};
+          (*allocs)[i].tile_channel = toChan;
+          continue;
+        }
+        allocation_info_t split = (*allocs)[i];
+        split.dma_channel = {dir, toChan};
+        split.tile_channel = toChan;
+        split.memcpyOps = moveOps;
+        (*allocs)[i].memcpyOps = keepOps;
+        splits.push_back(split);
+      }
+      llvm::append_range(*allocs, splits);
+
+      for (auto &f : memcpy_flows) {
+        if (f.air_flow_op != moveDecl)
+          continue;
+        for (auto *side : {&f.MM2S_alloc, &f.S2MM_alloc})
+          for (auto &fa : *side) {
+            if (!fa.dma_tile || fa.dma_tile.getOperation() != tileOp)
+              continue;
+            if (fa.dma_channel.direction != dir ||
+                fa.dma_channel.channel != fromChan)
+              continue;
+            fa.dma_channel.channel = toChan;
+            fa.tile_channel = toChan;
+            fa.packet_flow_id = -1;
+          }
+      }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "TileDMAAllocator::spreadCollapsedPacketChannels: moved @"
+                 << cast<air::ChannelOp>(moveDecl).getSymName() << " to "
+                 << (isMM2S ? "MM2S" : "S2MM") << " " << toChan << "\n");
+    };
+
+    // Is sharing this ring a hazard, or merely a choice? Collapse is not free
+    // to undo -- several flows on one channel is how the emitter folds a
+    // repeating chain into a single BD with a repeat count -- so it is only
+    // worth breaking where the sharing is unsound.
+    //
+    // The test is a hardware fact, not a preference: a DMA channel's port is
+    // either statically connected or packet-switched, never both. A packet flow
+    // queued behind a circuit flow has its header ignored and is delivered to
+    // the circuit's destination -- the router usually refuses the placement,
+    // and where it does not the design is silently misrouted.
+    //
+    // Deliberately NOT tested here: whether the flows on a ring come from
+    // independent producers, which is the case diagnoseBDChain calls out and
+    // declines to check ("convergent flows are trusted to be time-disjoint").
+    // It is tempting, and it is what several of the hand-written pins are
+    // really guarding, but "two source tiles" does not imply "unordered": every
+    // AIR matmul feeds a core one A tile and one B tile per iteration from two
+    // memtiles, onto a ring that repeats in lockstep with them. Splitting those
+    // would spend both S2MM channels of every compute tile in the project to
+    // fix a hazard they do not have. Separating a genuinely unordered pair
+    // needs evidence this pass does not have; until then those stay pinned by
+    // hand.
+    auto isHazard = [&](const Chain &chain) {
+      return !chain.packetDecls.empty() &&
+             chain.packetDecls.size() != chain.order.size();
+    };
+
+    // Which decl KEEPS the channel, and which have to leave? A pinned decl has
+    // to stay -- it named this channel -- so if the chain carries any, the
+    // first of them is the keeper; otherwise the decl that got here first keeps
+    // it. What leaves is then determined, not chosen: the flows whose KIND
+    // differs from the keeper's are exactly the ones making the port both
+    // statically connected and packet-switched. Evicting anything else would
+    // move a flow that was not part of the problem and leave the problem
+    // behind.
+    auto keeperOf = [&](const Chain &chain) {
+      for (auto *d : chain.order)
+        if (isImmovable(d))
+          return d;
+      return chain.order.front();
+    };
+    auto evicteesOf = [&](const Chain &chain) {
+      SmallVector<Operation *> out;
+      bool keepPkt = chain.packetDecls.contains(keeperOf(chain));
+      for (auto *d : chain.order)
+        if (chain.packetDecls.contains(d) != keepPkt && !isImmovable(d))
+          out.push_back(d);
+      return out;
+    };
+
+    // Phase 1: move what has to leave onto a channel the tile was not using in
+    // this direction.
+    for (auto &[key, chain] : buildChains()) {
+      if (chain.unkeyed || chain.order.size() < 2 || !isHazard(chain))
+        continue;
+      Operation *tileOp = key.first;
+      auto tile = (*allocs)[chain.allocIdxs.front()].dma_tile;
+      auto used = channelsInUse(tileOp);
+      int numChans = isMM2S ? tile.getNumSourceConnections(AIE::WireBundle::DMA)
+                            : tile.getNumDestConnections(AIE::WireBundle::DMA);
+      for (auto *d : evicteesOf(chain)) {
+        int freeChan = -1;
+        for (int c = 0; c < numChans; c++)
+          if (!used.count(c)) {
+            freeChan = c;
+            break;
+          }
+        if (freeChan < 0)
+          break; // fully subscribed: phase 2 looks for somewhere to double up
+        moveFlow(chain.allocIdxs, d, tileOp, key.second, freeChan);
+        used.insert(freeChan);
+      }
+    }
+
+    // Phase 2: the same hazard on a tile with no channel to spare. Phase 1 has
+    // taken every free one, so double up instead -- move each evictee onto a
+    // channel of the tile carrying its OWN kind only. Two packet flows sharing
+    // a packet-switched port is what multiplexing is for and costs nothing
+    // beyond the shared ring; leaving one behind a circuit connection is wrong
+    // however few channels the tile has.
+    for (auto &[key, chain] : buildChains()) {
+      if (chain.unkeyed || chain.order.size() < 2 || !isHazard(chain))
+        continue;
+      Operation *tileOp = key.first;
+      for (auto *d : evicteesOf(chain)) {
+        bool wantPkt = chain.packetDecls.contains(d);
+        int target = -1;
+        for (auto &[k2, c2] : buildChains()) {
+          if (k2.first != tileOp || k2.second == key.second)
+            continue;
+          if (c2.unkeyed || c2.order.empty())
+            continue;
+          // Pure in the kind we are placing, or the move just relocates the
+          // mix.
+          if ((c2.packetDecls.size() == c2.order.size()) != wantPkt)
+            continue;
+          if (!wantPkt && !c2.packetDecls.empty())
+            continue;
+          if (target < 0 || k2.second < target)
+            target = k2.second;
+        }
+        if (target < 0)
+          continue; // nowhere unmixed to go; the router will have the last word
+        moveFlow(chain.allocIdxs, d, tileOp, key.second, target);
+      }
+    }
+
+    // A ring is walked strictly in order, and the emitter builds it by
+    // concatenating the allocations on a channel in the order they appear here.
+    // Splitting a flow off a shared allocation appends the remainder, so a flow
+    // that the core issues FIRST can end up emitted last -- the transfer then
+    // waits on a BD bound to the other flow's buffer and lock, which serializes
+    // the two and hangs outright when the consumer is blocking. Restore the
+    // order the core issues in, keyed on the same memcpy id `selection` sorts
+    // by within an allocation.
+    //
+    // Each touched group is permuted among ITS OWN slots, so allocations this
+    // pass never looked at keep their positions exactly, and a design where
+    // nothing moved is emitted byte for byte as before.
+    auto minId = [](const allocation_info_t &a) {
+      int64_t m = std::numeric_limits<int64_t>::max();
+      for (auto *o : a.memcpyOps)
+        if (auto mc = dyn_cast_if_present<air::MemcpyInterface>(o))
+          m = std::min(m, (int64_t)mc.getId());
+      return m;
+    };
+    for (auto &key : touched) {
+      SmallVector<size_t> slots;
+      for (auto [i, alloc] : llvm::enumerate(*allocs))
+        if (alloc.dma_tile && alloc.dma_tile.getOperation() == key.first &&
+            alloc.dma_channel.channel == key.second)
+          slots.push_back(i);
+      if (slots.size() < 2)
+        continue;
+      SmallVector<allocation_info_t> group;
+      for (size_t i : slots)
+        group.push_back((*allocs)[i]);
+      llvm::stable_sort(
+          group, [&](const allocation_info_t &a, const allocation_info_t &b) {
+            return minId(a) < minId(b);
+          });
+      for (auto [j, i] : llvm::enumerate(slots))
+        (*allocs)[i] = group[j];
+    }
+  }
+}
 LogicalResult air::TileDMAAllocator::verifyMM2SChains() {
   // Group exactly as the emitter does: one BD chain per (tile, channel), from
   // the concatenation of every allocation mapped to it in mm2s_allocs order.

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1734,6 +1734,39 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     return succeeded(ct) && *ct == "npu_dma_packet";
   };
 
+  // The tiles a flow is produced by. Taken from the bundle: an allocation only
+  // knows its own side of the flow.
+  auto sourceTilesOf = [&memcpy_flows](Operation *decl) {
+    llvm::SmallPtrSet<Operation *, 4> tiles;
+    for (auto &f : memcpy_flows) {
+      if (f.air_flow_op != decl)
+        continue;
+      for (auto &fa : f.MM2S_alloc)
+        if (fa.dma_tile)
+          tiles.insert(fa.dma_tile.getOperation());
+    }
+    return tiles;
+  };
+
+  // What KIND of thing produces a flow: the shim, or somewhere on the array.
+  // This is the grain the arrival-order question is really asked at. Shim
+  // traffic is DDR-backed and its timing depends on the host and the NoC, so
+  // nothing on the array bounds when it turns up; two on-array producers are
+  // driven by the same lock protocol as the consumer. So a ring may hold
+  // several on-array producers and still behave, while mixing shim traffic with
+  // on-array traffic on one ring is where the order actually comes apart. It is
+  // also the split the qwen2.5-3b pins encode by hand: {rmsIn, rmsW} from the
+  // host on one channel, {orms, outY} from two memtiles on the other.
+  auto producedOffArray = [&](Operation *decl) {
+    for (auto *t : sourceTilesOf(decl)) {
+      if (auto lt = dyn_cast<AIE::LogicalTileOp>(t))
+        return lt.getTileType() == AIE::AIETileType::ShimNOCTile;
+      if (auto pt = dyn_cast<AIE::TileOp>(t))
+        return pt.getRow() == 0;
+    }
+    return false;
+  };
+
   // One chain as the emitter sees it: every allocation mapped to a
   // (tile, channel), the flows on it in a deterministic order, and which of
   // those flows are packet flows.
@@ -1855,91 +1888,130 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     // tile and one B tile per iteration from two memtiles, onto a ring that
     // repeats in lockstep with them. Splitting on source count alone was tried
     // and spends both S2MM channels of every compute tile in the project.
+    // Does the ring visit each of its flows exactly once per cycle? That is the
+    // condition under which a shared in-order ring stays synchronised with
+    // producers that are not synchronised with each other: if every flow owns
+    // exactly one BD of the repeating unit, then a flow's k-th transfer always
+    // meets that same BD, whatever order the arrivals interleave in. Let one
+    // flow own two BDs of a cycle and the ring position stops being a function
+    // of how many rounds have happened, so an arrival can land on a BD bound to
+    // another flow's buffer and lock.
+    //
+    // getUniqueBDPattern is the BD emitter's own notion of the repeating unit,
+    // so this asks the question in the emitter's terms rather than inventing a
+    // second one.
+    auto isRoundRobin = [&](const Chain &chain) {
+      llvm::SetVector<Operation *> opSet;
+      for (auto *o : chain.ops)
+        opSet.insert(o);
+      auto unit = air::getUniqueBDPattern(opSet);
+      if (unit.empty())
+        return false; // does not repeat at all
+      llvm::SmallPtrSet<Operation *, 4> seen;
+      for (auto *o : unit)
+        if (!seen.insert(declOf(o)).second)
+          return false; // a flow owning two BDs of one cycle
+      return seen.size() == chain.order.size();
+    };
+
     auto isHazard = [&](const Chain &chain) {
-      // 1. An MM2S port has ONE outgoing connection, and it is either static or
-      //    packet-switched. A packet flow leaving behind a circuit flow is
-      //    carried by the circuit connection and delivered to its destination,
-      //    header unread. Only MM2S: a DESTINATION port is fed by a switchbox
-      //    arbiter and takes both kinds happily, which the shipped qwen rms
-      //    tile relies on (one packet BD and two circuit BDs on S2MM 0).
-      if (isMM2S && !chain.packetDecls.empty() &&
+      // 1. A switchbox port is either statically connected or
+      // packet-arbitrated,
+      //    never both, and a DMA channel is one port. Mixing the kinds asks the
+      //    same port for a static connection AND an arbiter.
+      if (!chain.packetDecls.empty() &&
           chain.packetDecls.size() != chain.order.size())
         return true;
-      // 2. The ring cannot stay in step with the transfers crossing it. Not a
-      //    new judgement: diagnoseBDChain is the BD emitter's own foldability
-      //    test, and this pass's neighbours already call it on both directions
-      //    -- to repair on S2MM, and on MM2S only to REFUSE the design. Being
-      //    refused is what made a front end name a channel by hand; a tile with
-      //    a channel to spare can be handed the answer instead.
+      // 2. Independent producers on a ring that is not a round-robin. Neither
+      //    half is sufficient on its own, which is why both are here:
       //
-      //    `emptyPathsOk` splits the directions exactly as those two callers
-      //    do: a consumer that skips an arrival still receives it and the ring
-      //    slips, whereas a producer that issues nothing on some arm simply
-      //    leaves the ring where it was.
+      //    - producers alone would split every AIR matmul, where two memtiles
+      //      feed a core one A tile and one B tile per iteration. That ring IS
+      //      a round-robin (one BD each) and is safe however the two
+      //      interleave.
+      //    - a non-round-robin ring alone is not a hazard either, as long as
+      //    one
+      //      producer emits the whole cycle: its own BD order then fixes the
+      //      arrival order, which is what lets @appendK and @appendV share.
+      //
+      //    This is the case diagnoseBDChain explicitly declines to judge
+      //    ("convergent flows are trusted to be time-disjoint"). The qwen2.5-3b
+      //    rms core is where that trust is misplaced: four flows, six
+      //    transfers, from the shim and two different memtiles, and it
+      //    deadlocks on device.
+      llvm::SmallPtrSet<Operation *, 4> srcs;
+      for (auto *d : chain.order)
+        for (auto *t : sourceTilesOf(d))
+          srcs.insert(t);
+      if (srcs.size() >= 2 && !isRoundRobin(chain))
+        return true;
+      // 3. The ring cannot stay in step with the transfers crossing it, by the
+      //    emitter's own foldability oracle. repairS2MMChains already acts on
+      //    this; verifyMM2SChains only refuses, and being refused is what made
+      //    a front end name a channel by hand.
       Operation *stopAt = chain.ops.front()->getParentOfType<air::HerdOp>();
       return !diagnoseBDChain(chain.ops, stopAt, /*emptyPathsOk=*/isMM2S)
                   .empty();
     };
 
-    // Which decl KEEPS the channel, and which have to leave? A pinned decl has
-    // to stay -- it named this channel -- so if the chain carries any, the
-    // first of them is the keeper; otherwise the decl that got here first keeps
-    // it. What leaves is then determined, not chosen: the flows whose KIND
-    // differs from the keeper's are exactly the ones making the port both
-    // statically connected and packet-switched. Evicting anything else would
-    // move a flow that was not part of the problem and leave the problem
-    // behind.
-    auto keeperOf = [&](const Chain &chain) {
-      for (auto *d : chain.order)
-        if (isImmovable(d))
-          return d;
-      return chain.order.front();
-    };
-    auto evicteesOf = [&](const Chain &chain) {
-      SmallVector<Operation *> out;
-      // Mixed kinds: what leaves is determined, not chosen -- the flows whose
-      // kind differs from the keeper's are exactly the ones making the port
-      // both statically connected and packet-switched. Evicting anything else
-      // would move a flow that was not part of the problem and leave the
-      // problem behind.
-      if (isMM2S && !chain.packetDecls.empty() &&
-          chain.packetDecls.size() != chain.order.size()) {
-        bool keepPkt = chain.packetDecls.contains(keeperOf(chain));
-        for (auto *d : chain.order)
-          if (chain.packetDecls.contains(d) != keepPkt && !isImmovable(d))
-            out.push_back(d);
-        return out;
+    // Every channel of a tile that is homogeneous in one switching kind, so an
+    // evicted group has somewhere legal to land.
+    auto homogeneousChans = [&](Operation *tileOp, bool wantPkt, int notChan) {
+      SmallVector<int> out;
+      for (auto &[k, c] : buildChains()) {
+        if (k.first != tileOp || k.second == notChan || c.unkeyed ||
+            c.order.empty())
+          continue;
+        if ((c.packetDecls.size() == c.order.size()) == wantPkt)
+          out.push_back(k.second);
       }
-      // A ring out of step: peel the one flow whose removal leaves BOTH halves
-      // in step, exactly as repairS2MMChains chooses. A half carrying a single
-      // flow is out of scope for the same reason the whole chain would be -- it
-      // has no other flow's BD to land on.
-      Operation *stopAt = chain.ops.front()->getParentOfType<air::HerdOp>();
-      auto halfInStep = [&](ArrayRef<Operation *> half) {
-        llvm::SetVector<Operation *> hd;
-        for (auto *o : half)
-          hd.insert(declOf(o));
-        return hd.size() < 2 ||
-               diagnoseBDChain(half, stopAt, /*emptyPathsOk=*/isMM2S).empty();
-      };
-      for (auto *d : chain.order) {
-        if (isImmovable(d))
+      llvm::sort(out);
+      return out;
+    };
+
+    // What has to leave a mixed chain, and where it goes. The channel must end
+    // up homogeneous, and there are exactly two ways to get there: move the
+    // packet flows off, or move the circuit flows off. Which one is not a
+    // preference -- it is whichever the tile can actually accommodate, on a
+    // free channel or one already homogeneous in that kind. Both feasible, the
+    // smaller group moves, because disturbing fewer flows is the weaker change.
+    //
+    // Getting this backwards is not harmless: the qwen2.5-3b rms core ends up
+    // with @rmsIn(circuit) sharing with @orms/@outY(packet) while
+    // @rmsW(circuit) sits alone on the other channel. Evicting the two packets
+    // has nowhere to go and leaves the mix; moving the ONE circuit flow next to
+    // @rmsW makes both channels homogeneous, and is what the hand-written pins
+    // encoded.
+    struct Plan {
+      SmallVector<Operation *> movers;
+      int dest;
+    };
+    auto planFor = [&](const Chain &chain, Operation *tileOp, int chan,
+                       const llvm::SmallDenseSet<int> &used, int numChans) {
+      SmallVector<Operation *> pkt, circ;
+      for (auto *d : chain.order)
+        (chain.packetDecls.contains(d) ? pkt : circ).push_back(d);
+      bool pktFirst = pkt.size() <= circ.size();
+      SmallVector<Plan> out;
+      for (bool wantPkt : {pktFirst, !pktFirst}) {
+        auto &group = wantPkt ? pkt : circ;
+        if (group.empty() || llvm::any_of(group, isImmovable))
           continue;
-        std::vector<Operation *> m, r;
-        for (auto *o : chain.ops)
-          (declOf(o) == d ? m : r).push_back(o);
-        if (m.empty() || r.empty())
-          continue;
-        if (!halfInStep(m) || !halfInStep(r))
-          continue;
-        out.push_back(d);
-        break; // one peel is what fixes it; taking more would be gratuitous
+        int dest = -1;
+        for (int c = 0; c < numChans && dest < 0; c++)
+          if (!used.count(c))
+            dest = c; // a channel nobody is using takes the group whole
+        if (dest < 0) {
+          auto same = homogeneousChans(tileOp, wantPkt, chan);
+          if (!same.empty())
+            dest = same.front();
+        }
+        if (dest >= 0)
+          out.push_back({group, dest});
       }
       return out;
     };
 
-    // Phase 1: move what has to leave onto a channel the tile was not using in
-    // this direction.
     for (auto &[key, chain] : buildChains()) {
       if (chain.unkeyed || chain.order.size() < 2 || !isHazard(chain))
         continue;
@@ -1948,50 +2020,132 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
       auto used = channelsInUse(tileOp);
       int numChans = isMM2S ? tile.getNumSourceConnections(AIE::WireBundle::DMA)
                             : tile.getNumDestConnections(AIE::WireBundle::DMA);
-      for (auto *d : evicteesOf(chain)) {
-        int freeChan = -1;
-        for (int c = 0; c < numChans; c++)
-          if (!used.count(c)) {
-            freeChan = c;
-            break;
-          }
-        if (freeChan < 0)
-          break; // fully subscribed: phase 2 looks for somewhere to double up
-        moveFlow(chain.allocIdxs, d, tileOp, key.second, freeChan);
-        used.insert(freeChan);
-      }
-    }
 
-    // Phase 2: the same hazard on a tile with no channel to spare. Phase 1 has
-    // taken every free one, so double up instead -- move each evictee onto a
-    // channel of the tile carrying its OWN kind only. Two packet flows sharing
-    // a packet-switched port is what multiplexing is for and costs nothing
-    // beyond the shared ring; leaving one behind a circuit connection is wrong
-    // however few channels the tile has.
-    for (auto &[key, chain] : buildChains()) {
-      if (chain.unkeyed || chain.order.size() < 2 || !isHazard(chain))
+      bool mixed = !chain.packetDecls.empty() &&
+                   chain.packetDecls.size() != chain.order.size();
+      if (mixed) {
+        auto plans = planFor(chain, tileOp, key.second, used, numChans);
+        if (plans.empty())
+          continue; // no legal home; the router will have the last word
+        for (auto *d : plans.front().movers)
+          moveFlow(chain.allocIdxs, d, tileOp, key.second, plans.front().dest);
         continue;
-      Operation *tileOp = key.first;
-      for (auto *d : evicteesOf(chain)) {
-        bool wantPkt = chain.packetDecls.contains(d);
-        int target = -1;
-        for (auto &[k2, c2] : buildChains()) {
-          if (k2.first != tileOp || k2.second == key.second)
-            continue;
-          if (c2.unkeyed || c2.order.empty())
-            continue;
-          // Pure in the kind we are placing, or the move just relocates the
-          // mix.
-          if ((c2.packetDecls.size() == c2.order.size()) != wantPkt)
-            continue;
-          if (!wantPkt && !c2.packetDecls.empty())
-            continue;
-          if (target < 0 || k2.second < target)
-            target = k2.second;
+      }
+
+      // Unsynchronised producers on a ring that is not a round-robin. The
+      // repair is not a peel but a PARTITION BY PRODUCER: give each producer
+      // its own channel, and the arrival order on each ring is then fixed by
+      // that producer's own BD order, which is the property the ring needs.
+      // Peeling one flow instead leaves the rest of the group sharing with a
+      // stranger -- on the qwen2.5-3b rms core that leaves three flows and two
+      // producers on one channel, having spent the only spare.
+      llvm::SmallPtrSet<Operation *, 4> srcs;
+      for (auto *d : chain.order)
+        for (auto *t : sourceTilesOf(d))
+          srcs.insert(t);
+      if (srcs.size() >= 2 && !isRoundRobin(chain)) {
+        SmallVector<
+            std::pair<SmallVector<Operation *>, SmallVector<Operation *>>>
+            groups; // (producer signature, flows produced there)
+        for (auto *d : chain.order) {
+          auto st = sourceTilesOf(d);
+          SmallVector<Operation *> sig(st.begin(), st.end());
+          llvm::sort(sig);
+          bool placed = false;
+          for (auto &g : groups)
+            if (g.first == sig) {
+              g.second.push_back(d);
+              placed = true;
+              break;
+            }
+          if (!placed)
+            groups.push_back({sig, {d}});
         }
-        if (target < 0)
-          continue; // nowhere unmixed to go; the router will have the last word
-        moveFlow(chain.allocIdxs, d, tileOp, key.second, target);
+
+        int spare = 0;
+        for (int c = 0; c < numChans; c++)
+          if (!used.count(c))
+            spare++;
+        // More producers than channels: something must double up, and the
+        // choice is not free. Coalesce the ON-ARRAY producers and keep the shim
+        // apart -- shim traffic is DDR-backed and its timing depends on the
+        // host and the NoC, so nothing on the array bounds when it turns up,
+        // whereas two on-array producers run under the same lock protocol as
+        // the consumer. This is the merge the qwen2.5-3b rms core needs: three
+        // producers, two channels, and the working split is {rmsIn, rmsW} from
+        // the host against {orms, outY} from two different memtiles.
+        if ((int)groups.size() > spare + 1) {
+          SmallVector<Operation *> onArray;
+          SmallVector<
+              std::pair<SmallVector<Operation *>, SmallVector<Operation *>>>
+              merged;
+          for (auto &g : groups) {
+            if (g.second.empty())
+              continue;
+            if (producedOffArray(g.second.front()))
+              merged.push_back(g);
+            else
+              llvm::append_range(onArray, g.second);
+          }
+          if (!onArray.empty())
+            merged.push_back({{}, onArray});
+          // Keep the group holding the first-allocated flow in front, so it is
+          // the one that keeps the channel it already has.
+          for (size_t i = 0; i < merged.size(); i++)
+            if (llvm::is_contained(merged[i].second, chain.order.front())) {
+              std::swap(merged[0], merged[i]);
+              break;
+            }
+          groups = merged;
+        }
+
+        // The group that got here first keeps the channel; the others take the
+        // channels the tile was not using, one group each while they last.
+        for (size_t gi = 1; gi < groups.size(); gi++) {
+          if (llvm::any_of(groups[gi].second, isImmovable))
+            continue;
+          int dest = -1;
+          for (int c = 0; c < numChans && dest < 0; c++)
+            if (!used.count(c))
+              dest = c;
+          if (dest < 0)
+            break;
+          for (auto *d : groups[gi].second)
+            moveFlow(chain.allocIdxs, d, tileOp, key.second, dest);
+          used.insert(dest);
+        }
+        continue;
+      }
+
+      // Out of step by the emitter's oracle: peel the one flow whose removal
+      // leaves BOTH halves in step, exactly as repairS2MMChains chooses, onto a
+      // channel the tile was not using. A half carrying a single flow is out of
+      // scope for the same reason the whole chain would be -- it has no other
+      // flow's BD to land on.
+      Operation *stopAt = chain.ops.front()->getParentOfType<air::HerdOp>();
+      auto halfInStep = [&](ArrayRef<Operation *> half) {
+        llvm::SetVector<Operation *> hd;
+        for (auto *o : half)
+          hd.insert(declOf(o));
+        return hd.size() < 2 ||
+               diagnoseBDChain(half, stopAt, /*emptyPathsOk=*/isMM2S).empty();
+      };
+      int freeChan = -1;
+      for (int c = 0; c < numChans && freeChan < 0; c++)
+        if (!used.count(c))
+          freeChan = c;
+      if (freeChan < 0)
+        continue;
+      for (auto *d : chain.order) {
+        if (isImmovable(d))
+          continue;
+        std::vector<Operation *> m, r;
+        for (auto *o : chain.ops)
+          (declOf(o) == d ? m : r).push_back(o);
+        if (m.empty() || r.empty() || !halfInStep(m) || !halfInStep(r))
+          continue;
+        moveFlow(chain.allocIdxs, d, tileOp, key.second, freeChan);
+        break;
       }
     }
 

--- a/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
+++ b/mlir/lib/Conversion/AIRToAIESchedulingUtils.cpp
@@ -1741,6 +1741,7 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     SmallVector<size_t> allocIdxs;
     SmallVector<Operation *> order;
     llvm::SmallPtrSet<Operation *, 4> packetDecls;
+    std::vector<Operation *> ops;
     bool unkeyed = false;
   };
 
@@ -1762,6 +1763,7 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
             chains[{alloc.dma_tile.getOperation(), alloc.dma_channel.channel}];
         c.allocIdxs.push_back(i);
         for (auto *o : alloc.memcpyOps) {
+          c.ops.push_back(o);
           auto *d = declOf(o);
           if (!d) {
             c.unkeyed = true; // not attributable to a flow: leave it alone
@@ -1842,28 +1844,41 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     // Is sharing this ring a hazard, or merely a choice? Collapse is not free
     // to undo -- several flows on one channel is how the emitter folds a
     // repeating chain into a single BD with a repeat count -- so it is only
-    // worth breaking where the sharing is unsound.
+    // worth breaking where the sharing is unsound. Two things make it so, and
+    // both are decided by rules already in this file rather than guessed at
+    // here.
     //
-    // The test is a hardware fact, not a preference: a DMA channel's port is
-    // either statically connected or packet-switched, never both. A packet flow
-    // queued behind a circuit flow has its header ignored and is delivered to
-    // the circuit's destination -- the router usually refuses the placement,
-    // and where it does not the design is silently misrouted.
-    //
-    // Deliberately NOT tested here: whether the flows on a ring come from
-    // independent producers, which is the case diagnoseBDChain calls out and
-    // declines to check ("convergent flows are trusted to be time-disjoint").
-    // It is tempting, and it is what several of the hand-written pins are
-    // really guarding, but "two source tiles" does not imply "unordered": every
-    // AIR matmul feeds a core one A tile and one B tile per iteration from two
-    // memtiles, onto a ring that repeats in lockstep with them. Splitting those
-    // would spend both S2MM channels of every compute tile in the project to
-    // fix a hazard they do not have. Separating a genuinely unordered pair
-    // needs evidence this pass does not have; until then those stay pinned by
-    // hand.
+    // Deliberately NOT a criterion: that the flows come from independent
+    // producers. diagnoseBDChain names it as the thing it does not check, and
+    // it is what some of the remaining hand-written pins guard, but "two source
+    // tiles" does not imply "unordered": every AIR matmul feeds a core one A
+    // tile and one B tile per iteration from two memtiles, onto a ring that
+    // repeats in lockstep with them. Splitting on source count alone was tried
+    // and spends both S2MM channels of every compute tile in the project.
     auto isHazard = [&](const Chain &chain) {
-      return !chain.packetDecls.empty() &&
-             chain.packetDecls.size() != chain.order.size();
+      // 1. An MM2S port has ONE outgoing connection, and it is either static or
+      //    packet-switched. A packet flow leaving behind a circuit flow is
+      //    carried by the circuit connection and delivered to its destination,
+      //    header unread. Only MM2S: a DESTINATION port is fed by a switchbox
+      //    arbiter and takes both kinds happily, which the shipped qwen rms
+      //    tile relies on (one packet BD and two circuit BDs on S2MM 0).
+      if (isMM2S && !chain.packetDecls.empty() &&
+          chain.packetDecls.size() != chain.order.size())
+        return true;
+      // 2. The ring cannot stay in step with the transfers crossing it. Not a
+      //    new judgement: diagnoseBDChain is the BD emitter's own foldability
+      //    test, and this pass's neighbours already call it on both directions
+      //    -- to repair on S2MM, and on MM2S only to REFUSE the design. Being
+      //    refused is what made a front end name a channel by hand; a tile with
+      //    a channel to spare can be handed the answer instead.
+      //
+      //    `emptyPathsOk` splits the directions exactly as those two callers
+      //    do: a consumer that skips an arrival still receives it and the ring
+      //    slips, whereas a producer that issues nothing on some arm simply
+      //    leaves the ring where it was.
+      Operation *stopAt = chain.ops.front()->getParentOfType<air::HerdOp>();
+      return !diagnoseBDChain(chain.ops, stopAt, /*emptyPathsOk=*/isMM2S)
+                  .empty();
     };
 
     // Which decl KEEPS the channel, and which have to leave? A pinned decl has
@@ -1882,10 +1897,44 @@ void air::TileDMAAllocator::spreadCollapsedPacketChannels(
     };
     auto evicteesOf = [&](const Chain &chain) {
       SmallVector<Operation *> out;
-      bool keepPkt = chain.packetDecls.contains(keeperOf(chain));
-      for (auto *d : chain.order)
-        if (chain.packetDecls.contains(d) != keepPkt && !isImmovable(d))
-          out.push_back(d);
+      // Mixed kinds: what leaves is determined, not chosen -- the flows whose
+      // kind differs from the keeper's are exactly the ones making the port
+      // both statically connected and packet-switched. Evicting anything else
+      // would move a flow that was not part of the problem and leave the
+      // problem behind.
+      if (isMM2S && !chain.packetDecls.empty() &&
+          chain.packetDecls.size() != chain.order.size()) {
+        bool keepPkt = chain.packetDecls.contains(keeperOf(chain));
+        for (auto *d : chain.order)
+          if (chain.packetDecls.contains(d) != keepPkt && !isImmovable(d))
+            out.push_back(d);
+        return out;
+      }
+      // A ring out of step: peel the one flow whose removal leaves BOTH halves
+      // in step, exactly as repairS2MMChains chooses. A half carrying a single
+      // flow is out of scope for the same reason the whole chain would be -- it
+      // has no other flow's BD to land on.
+      Operation *stopAt = chain.ops.front()->getParentOfType<air::HerdOp>();
+      auto halfInStep = [&](ArrayRef<Operation *> half) {
+        llvm::SetVector<Operation *> hd;
+        for (auto *o : half)
+          hd.insert(declOf(o));
+        return hd.size() < 2 ||
+               diagnoseBDChain(half, stopAt, /*emptyPathsOk=*/isMM2S).empty();
+      };
+      for (auto *d : chain.order) {
+        if (isImmovable(d))
+          continue;
+        std::vector<Operation *> m, r;
+        for (auto *o : chain.ops)
+          (declOf(o) == d ? m : r).push_back(o);
+        if (m.empty() || r.empty())
+          continue;
+        if (!halfInStep(m) || !halfInStep(r))
+          continue;
+        out.push_back(d);
+        break; // one peel is what fixes it; taking more would be gratuitous
+      }
       return out;
     };
 

--- a/mlir/test/Conversion/AIRToAIE/tile_packet_circuit_channel_split.mlir
+++ b/mlir/test/Conversion/AIRToAIE/tile_packet_circuit_channel_split.mlir
@@ -9,20 +9,27 @@
 
 // TileDMAAllocator::spreadCollapsedPacketChannels.
 //
-// A DMA channel's port is either statically connected or packet-switched, and
-// never both: the static connection carries whatever leaves the port, so a
-// packet queued behind a circuit flow is delivered to the CIRCUIT's
-// destination and its header is never consulted.
+// A compute-tile DMA channel is ONE BD ring walked strictly in order, and a
+// packet header steers a transfer to the tile without choosing which BD
+// receives it. Sharing a ring is therefore safe exactly when something fixes
+// the arrival order, and three things can:
 //
-// The allocator produces exactly that. simpleDmaChannelAlloc reuses an existing
-// packet channel on the tile before it looks for a free one, so two packet
-// flows collapse onto one allocation; the next flow then falls through to
-// `chan = num_allocs % tile_dma_channels`, which counts ALLOCATIONS rather than
-// occupied channels and so hands out a channel that is already in use while
-// another sits idle. A circuit flow landing there is the hazard.
+//   - one switching kind. A switchbox port is statically connected OR
+//     packet-arbitrated, never both, and a channel is one port.
+//   - a ROUND-ROBIN ring: every flow owns exactly one BD of the repeating
+//     unit, so a flow's k-th transfer always meets that same BD however the
+//     arrivals interleave.
+//   - a single producer, whose own BD order fixes the arrival order.
 //
-// This pass separates them. Only that case: collapse where every flow on the
-// ring packetizes is what multiplexing is for and is left alone.
+// Absent all three the pass separates the ring; otherwise it leaves it alone,
+// because collapse is how the emitter folds a repeating chain into one BD with
+// a repeat count (see mm2s_flows_program_order.mlir).
+//
+// simpleDmaChannelAlloc produces the unsafe cases on its own: it reuses an
+// existing packet channel before it looks for a free one, and its fallback
+// `chan = num_allocs % tile_dma_channels` counts ALLOCATIONS rather than
+// occupied channels, so it hands out a channel already in use while another
+// sits idle.
 
 // -----
 

--- a/mlir/test/Conversion/AIRToAIE/tile_packet_circuit_channel_split.mlir
+++ b/mlir/test/Conversion/AIRToAIE/tile_packet_circuit_channel_split.mlir
@@ -1,0 +1,154 @@
+//===- tile_packet_circuit_channel_split.mlir -------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu1_1col" -split-input-file | FileCheck %s
+
+// TileDMAAllocator::spreadCollapsedPacketChannels.
+//
+// A DMA channel's port is either statically connected or packet-switched, and
+// never both: the static connection carries whatever leaves the port, so a
+// packet queued behind a circuit flow is delivered to the CIRCUIT's
+// destination and its header is never consulted.
+//
+// The allocator produces exactly that. simpleDmaChannelAlloc reuses an existing
+// packet channel on the tile before it looks for a free one, so two packet
+// flows collapse onto one allocation; the next flow then falls through to
+// `chan = num_allocs % tile_dma_channels`, which counts ALLOCATIONS rather than
+// occupied channels and so hands out a channel that is already in use while
+// another sits idle. A circuit flow landing there is the hazard.
+//
+// This pass separates them. Only that case: collapse where every flow on the
+// ring packetizes is what multiplexing is for and is left alone.
+
+// -----
+
+// The shape above, and the one the llama-3.2-1B q4nx decode rope tile produces:
+// @k pinned to MM2S 1, @v collapsing onto it, then the CIRCUIT @q computing
+// 1 % 2 = 1 and joining them while MM2S 0 is idle.
+//
+// @q is what leaves -- it is the flow whose kind differs from the keeper's.
+// Evicting @v instead would move a flow that was not part of the problem and
+// leave @k sharing with @q. The two packets stay in program order (@k issued
+// before @v), which is what the ring delivers in.
+
+// CHECK-LABEL: aie.device
+// CHECK:      aie.mem(%[[T:.*]])
+// CHECK:        aie.dma_start(MM2S, 1
+// CHECK:        aie.dma_bd(%[[K:.*]] :{{.*}}pkt_id = 0
+// CHECK:        aie.dma_bd(%[[V:.*]] :{{.*}}pkt_id = 1
+// CHECK:        aie.dma_start(MM2S, 0
+// CHECK-NOT:    packet
+// CHECK:        aie.dma_bd(%{{.*}} : memref<8xbf16, 2> offset = 0 len = 8) {task_id
+
+air.channel @k [1] {air.tile_dma_channel = 1 : i32, channel_type = "npu_dma_packet"}
+air.channel @v [1] {channel_type = "npu_dma_packet"}
+air.channel @q [1]
+func.func @circuit_joins_collapsed_packets(%ext: memref<8xbf16>) {
+  %c1 = arith.constant 1 : index
+  air.launch (%l0, %l1) in (%s0=%c1, %s1=%c1) args(%e=%ext) : memref<8xbf16> {
+    air.segment @seg args(%se=%e) : memref<8xbf16> {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h tile(%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) {
+        %bk = memref.alloc() : memref<8xbf16, 2>
+        %bv = memref.alloc() : memref<8xbf16, 2>
+        %bq = memref.alloc() : memref<8xbf16, 2>
+        air.channel.put @k[%tx, %ty] (%bk[] [] []) {id = 1 : i32} : (memref<8xbf16, 2>)
+        air.channel.put @v[%tx, %ty] (%bv[] [] []) {id = 2 : i32} : (memref<8xbf16, 2>)
+        air.channel.put @q[%tx, %ty] (%bq[] [] []) {id = 3 : i32} : (memref<8xbf16, 2>)
+        memref.dealloc %bk : memref<8xbf16, 2>
+        memref.dealloc %bv : memref<8xbf16, 2>
+        memref.dealloc %bq : memref<8xbf16, 2>
+      }
+      %lk = memref.alloc() : memref<8xbf16, 1>
+      %lv = memref.alloc() : memref<8xbf16, 1>
+      %lq = memref.alloc() : memref<8xbf16, 1>
+      air.channel.get @k[] (%lk[] [] []) {id = 4 : i32} : (memref<8xbf16, 1>)
+      air.channel.get @v[] (%lv[] [] []) {id = 5 : i32} : (memref<8xbf16, 1>)
+      air.channel.get @q[] (%lq[] [] []) {id = 6 : i32} : (memref<8xbf16, 1>)
+      memref.dealloc %lk : memref<8xbf16, 1>
+      memref.dealloc %lv : memref<8xbf16, 1>
+      memref.dealloc %lq : memref<8xbf16, 1>
+    }
+  }
+  return
+}
+
+// -----
+
+// Not a hazard: every flow on the ring packetizes, so one packet-switched port
+// carries them all and multiplexing is doing its job. This must stay collapsed
+// on ONE channel -- breaking up every shared ring would cost the repeat-count
+// fold the emitter gets from it (see mm2s_flows_program_order.mlir).
+
+// CHECK-LABEL: aie.device
+// CHECK:      aie.mem
+// CHECK:        aie.dma_start(MM2S, 0
+// CHECK-NOT:    aie.dma_start(MM2S, 1
+
+air.channel @k3 [1] {channel_type = "npu_dma_packet"}
+air.channel @v3 [1] {channel_type = "npu_dma_packet"}
+func.func @two_packets_share(%ext: memref<8xbf16>) {
+  %c1 = arith.constant 1 : index
+  air.launch (%l0, %l1) in (%s0=%c1, %s1=%c1) args(%e=%ext) : memref<8xbf16> {
+    air.segment @seg3 args(%se=%e) : memref<8xbf16> {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h3 tile(%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) {
+        %bk = memref.alloc() : memref<8xbf16, 2>
+        %bv = memref.alloc() : memref<8xbf16, 2>
+        air.channel.put @k3[%tx, %ty] (%bk[] [] []) {id = 1 : i32} : (memref<8xbf16, 2>)
+        air.channel.put @v3[%tx, %ty] (%bv[] [] []) {id = 2 : i32} : (memref<8xbf16, 2>)
+        memref.dealloc %bk : memref<8xbf16, 2>
+        memref.dealloc %bv : memref<8xbf16, 2>
+      }
+      %lk = memref.alloc() : memref<8xbf16, 1>
+      %lv = memref.alloc() : memref<8xbf16, 1>
+      air.channel.get @k3[] (%lk[] [] []) {id = 3 : i32} : (memref<8xbf16, 1>)
+      air.channel.get @v3[] (%lv[] [] []) {id = 4 : i32} : (memref<8xbf16, 1>)
+      memref.dealloc %lk : memref<8xbf16, 1>
+      memref.dealloc %lv : memref<8xbf16, 1>
+    }
+  }
+  return
+}
+
+// -----
+
+// `air.tile_dma_channel` still overrides. Both flows are pinned to MM2S 0, one
+// packet and one circuit, and the pass leaves them there: the attribute is the
+// explicit escape hatch and outranks the rule. It is simply no longer needed to
+// obtain the separation in the first case.
+
+// CHECK-LABEL: aie.device
+// CHECK:      aie.mem
+// CHECK:        aie.dma_start(MM2S, 0
+// CHECK-NOT:    aie.dma_start(MM2S, 1
+
+air.channel @q4 [1] {air.tile_dma_channel = 0 : i32}
+air.channel @k4 [1] {air.tile_dma_channel = 0 : i32, channel_type = "npu_dma_packet"}
+func.func @pin_overrides(%ext: memref<8xbf16>) {
+  %c1 = arith.constant 1 : index
+  air.launch (%l0, %l1) in (%s0=%c1, %s1=%c1) args(%e=%ext) : memref<8xbf16> {
+    air.segment @seg4 args(%se=%e) : memref<8xbf16> {
+      %c1_0 = arith.constant 1 : index
+      air.herd @h4 tile(%tx, %ty) in (%sx=%c1_0, %sy=%c1_0) {
+        %bq = memref.alloc() : memref<8xbf16, 2>
+        %bk = memref.alloc() : memref<8xbf16, 2>
+        air.channel.put @q4[%tx, %ty] (%bq[] [] []) {id = 1 : i32} : (memref<8xbf16, 2>)
+        air.channel.put @k4[%tx, %ty] (%bk[] [] []) {id = 2 : i32} : (memref<8xbf16, 2>)
+        memref.dealloc %bq : memref<8xbf16, 2>
+        memref.dealloc %bk : memref<8xbf16, 2>
+      }
+      %lq = memref.alloc() : memref<8xbf16, 1>
+      %lk = memref.alloc() : memref<8xbf16, 1>
+      air.channel.get @q4[] (%lq[] [] []) {id = 3 : i32} : (memref<8xbf16, 1>)
+      air.channel.get @k4[] (%lk[] [] []) {id = 4 : i32} : (memref<8xbf16, 1>)
+      memref.dealloc %lq : memref<8xbf16, 1>
+      memref.dealloc %lk : memref<8xbf16, 1>
+    }
+  }
+  return
+}

--- a/mlir/test/Conversion/AIRToAIE/tile_producer_partition.mlir
+++ b/mlir/test/Conversion/AIRToAIE/tile_producer_partition.mlir
@@ -1,0 +1,139 @@
+//===- tile_producer_partition.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-to-aie="row-offset=2 col-offset=0 device=npu1" -split-input-file | FileCheck %s
+
+// TileDMAAllocator::spreadCollapsedPacketChannels, producer rule.
+//
+// A compute-tile DMA channel is ONE BD ring walked strictly in order, and a
+// packet header steers a transfer to the tile without choosing which BD takes
+// it. When the flows on a ring come from producers that are not synchronised
+// with each other, what keeps it correct is that the ring is a ROUND-ROBIN:
+// every flow owning exactly one BD of the repeating unit, so a flow's k-th
+// transfer always meets that same BD however the arrivals interleave.
+//
+// Let one flow own two BDs of a cycle and that stops holding -- the ring
+// position is no longer a function of how many rounds have happened, and an
+// arrival can land on a BD bound to another flow's buffer and lock. The repair
+// is a partition by producer, after which each ring is ordered by its own
+// producer again.
+//
+// Both cases below need more than one column, because the two L2 buckets have
+// to land on DIFFERENT memtiles to be different producers at all. On
+// npu1_1col they share one memtile, become one producer, and correctly stay
+// collapsed -- which is the same rule giving the other answer.
+
+// -----
+
+// Two producers, NOT a round-robin: the a-leg owns two BDs of the cycle. This
+// is the shape the qwen2.5-3b rms core produces; left collapsed it builds,
+// ROUTES, passes diagnoseBDChain, and deadlocks on device.
+
+// CHECK-LABEL: aie.device
+// CHECK:      aie.mem
+// CHECK:        aie.dma_start(S2MM, 0
+// CHECK:        aie.dma_bd(%{{.*}} : memref<8x8xi32, 2>
+// CHECK:        aie.dma_bd(%{{.*}} : memref<8x8xi32, 2>
+// CHECK:        aie.dma_start(S2MM, 1
+// CHECK:        aie.dma_bd(%{{.*}} : memref<4x16xi32, 2>
+
+  // Two L3->L2 packet channels feeding col 0 via memtiles (operand
+  // classes A and B). Two buckets at col 0 trigger the saturation
+  // fallback in L2MemrefToMemTileMap, leaving memtiles col-unhinted.
+  air.channel @pkt_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_b [1, 1] {channel_type = "npu_dma_packet"}
+  // One L3->L1 direct packet channel feeding col 0.
+  // L2->L1 legs anchoring the memtile-routed flows to col 0 cores.
+  air.channel @a_l2_to_core [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @b_l2_to_core [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @func_shared_col(%a: memref<64xi32>, %b: memref<64xi32>,
+                              %c: memref<64xi32>) {
+    air.channel.put @pkt_a[] (%a[] [] []) {id = 1 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_b[] (%b[] [] []) {id = 2 : i32} : (memref<64xi32>)
+    air.segment @seg attributes {x_loc = 0 : i64, x_size = 4 : i64,
+                                  y_loc = 2 : i64, y_size = 1 : i64} {
+      %c1 = arith.constant 1 : index
+      // Two distinct operand-class shapes (8 vs 16 elements) so the two
+      // buckets stay disjoint in L2MemrefToMemTileMap.
+      %l2_a = memref.alloc() : memref<8x8xi32, 1>
+      %l2_b = memref.alloc() : memref<4x16xi32, 1>
+      air.channel.get @pkt_a[] (%l2_a[] [] []) {id = 4 : i32} : (memref<8x8xi32, 1>)
+      air.channel.get @pkt_b[] (%l2_b[] [] []) {id = 5 : i32} : (memref<4x16xi32, 1>)
+      air.channel.put @a_l2_to_core[] (%l2_a[] [] []) {id = 6 : i32} : (memref<8x8xi32, 1>)
+      air.channel.put @a_l2_to_core[] (%l2_a[] [] []) {id = 12 : i32} : (memref<8x8xi32, 1>)
+      air.channel.put @b_l2_to_core[] (%l2_b[] [] []) {id = 7 : i32} : (memref<4x16xi32, 1>)
+      air.herd @h tile(%tx, %ty) in (%sx = %c1, %sy = %c1)
+          attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+        %l1_a = memref.alloc() : memref<8x8xi32, 2>
+        %l1_b = memref.alloc() : memref<4x16xi32, 2>
+        %l1_a2 = memref.alloc() : memref<8x8xi32, 2>
+        air.channel.get @a_l2_to_core[%tx, %ty] (%l1_a[] [] []) {id = 8 : i32} : (memref<8x8xi32, 2>)
+        air.channel.get @a_l2_to_core[%tx, %ty] (%l1_a2[] [] []) {id = 11 : i32} : (memref<8x8xi32, 2>)
+        memref.dealloc %l1_a2 : memref<8x8xi32, 2>
+        air.channel.get @b_l2_to_core[%tx, %ty] (%l1_b[] [] []) {id = 9 : i32} : (memref<4x16xi32, 2>)
+        memref.dealloc %l1_a : memref<8x8xi32, 2>
+        memref.dealloc %l1_b : memref<4x16xi32, 2>
+      }
+      memref.dealloc %l2_a : memref<8x8xi32, 1>
+      memref.dealloc %l2_b : memref<4x16xi32, 1>
+    }
+    return
+  }
+
+// -----
+
+// The same two producers with one BD each: a round-robin, safe however the two
+// interleave, and left collapsed. Every AIR matmul is this shape -- two
+// memtiles feeding a core one A tile and one B tile per iteration -- so
+// splitting on producer count alone would spend both S2MM channels of every
+// compute tile in the project.
+
+// CHECK-LABEL: aie.device
+// CHECK:      aie.mem
+// CHECK:        aie.dma_start(S2MM, 0
+// CHECK-NOT:    aie.dma_start(S2MM, 1
+
+  // Two L3->L2 packet channels feeding col 0 via memtiles (operand
+  // classes A and B). Two buckets at col 0 trigger the saturation
+  // fallback in L2MemrefToMemTileMap, leaving memtiles col-unhinted.
+  air.channel @pkt_a [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @pkt_b [1, 1] {channel_type = "npu_dma_packet"}
+  // One L3->L1 direct packet channel feeding col 0.
+  // L2->L1 legs anchoring the memtile-routed flows to col 0 cores.
+  air.channel @a_l2_to_core [1, 1] {channel_type = "npu_dma_packet"}
+  air.channel @b_l2_to_core [1, 1] {channel_type = "npu_dma_packet"}
+
+  func.func @func_shared_col(%a: memref<64xi32>, %b: memref<64xi32>,
+                              %c: memref<64xi32>) {
+    air.channel.put @pkt_a[] (%a[] [] []) {id = 1 : i32} : (memref<64xi32>)
+    air.channel.put @pkt_b[] (%b[] [] []) {id = 2 : i32} : (memref<64xi32>)
+    air.segment @seg attributes {x_loc = 0 : i64, x_size = 4 : i64,
+                                  y_loc = 2 : i64, y_size = 1 : i64} {
+      %c1 = arith.constant 1 : index
+      // Two distinct operand-class shapes (8 vs 16 elements) so the two
+      // buckets stay disjoint in L2MemrefToMemTileMap.
+      %l2_a = memref.alloc() : memref<8x8xi32, 1>
+      %l2_b = memref.alloc() : memref<4x16xi32, 1>
+      air.channel.get @pkt_a[] (%l2_a[] [] []) {id = 4 : i32} : (memref<8x8xi32, 1>)
+      air.channel.get @pkt_b[] (%l2_b[] [] []) {id = 5 : i32} : (memref<4x16xi32, 1>)
+      air.channel.put @a_l2_to_core[] (%l2_a[] [] []) {id = 6 : i32} : (memref<8x8xi32, 1>)
+      air.channel.put @b_l2_to_core[] (%l2_b[] [] []) {id = 7 : i32} : (memref<4x16xi32, 1>)
+      air.herd @h tile(%tx, %ty) in (%sx = %c1, %sy = %c1)
+          attributes {x_loc = 0 : i64, y_loc = 2 : i64} {
+        %l1_a = memref.alloc() : memref<8x8xi32, 2>
+        %l1_b = memref.alloc() : memref<4x16xi32, 2>
+        air.channel.get @a_l2_to_core[%tx, %ty] (%l1_a[] [] []) {id = 8 : i32} : (memref<8x8xi32, 2>)
+        air.channel.get @b_l2_to_core[%tx, %ty] (%l1_b[] [] []) {id = 9 : i32} : (memref<4x16xi32, 2>)
+        memref.dealloc %l1_a : memref<8x8xi32, 2>
+        memref.dealloc %l1_b : memref<4x16xi32, 2>
+      }
+      memref.dealloc %l2_a : memref<8x8xi32, 1>
+      memref.dealloc %l2_b : memref<4x16xi32, 1>
+    }
+    return
+  }

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1235,17 +1235,14 @@ def build_module():
         # stale-rebroadcast deadlock). Two separate feed loops (the prior bug)
         # lowered to two repeat_count tasks. Packet (npu_dma_packet) so the two
         # producers (rms core L1 + down_buffer L2, time-disjoint, same id) converge.
-        _xn = channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
-        if KV_APPEND:
-            # Pin the rms core's two outputs (xnorm o-proj-X feedback -> mem_2_1 on
-            # MM2S1; layerOut -> shim on MM2S0) to their known-good split. Adding the
-            # append channels otherwise perturbs the global placer into packing BOTH
-            # onto rms MM2S0 (dual-fan packet), which flips layerOut circuit->packet
-            # and deadlocks. Only the rms core is a compute-tile endpoint of these
-            # channels (consumers are memtile/shim), so the pin is local to it.
-            _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                T.i32(), 1
-            )
+        # The rms core's two outputs (this xnorm o-proj-X feedback -> mem_2_1, and
+        # layerOut -> shim) used to be pinned to a known-good split, because
+        # adding the append channels packed BOTH onto rms MM2S0 and deadlocked.
+        # AIRToAIE reaches the same split by itself now: that packing is a ring
+        # its own diagnoseBDChain calls out of step, and rather than only
+        # refusing it, spreadCollapsedPacketChannels peels one flow onto the
+        # channel that was sitting idle.
+        channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
         # (FAITHFUL ph2): no toBufP2 / buf_ph2 channel -- the rms core emits ph2 X
         # = rmsnorm(x+oproj) directly on @xnorm. Every re-feed on this channel is
         # written as an n-trip loop around the put (see refeed()); the counts are

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1296,10 +1296,7 @@ def build_module():
                 # independent packet readbacks over distinct shim tiles, keeping
                 # the append off rope's own col2 (whose congestion deadlocks the
                 # front-end) without air.shim_col.
-                _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
-                _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                    T.i32(), 1
-                )
+                channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
                 # Only appendK names a channel. It is what holds the pair on
                 # rope's second MM2S, clear of the circuit ropeQ; appendV joins
                 # it there on its own.

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1265,14 +1265,12 @@ def build_module():
         _ropeQ = channel_decl(
             "ropeQ", size=[1]
         )  # rope q (whole 2048) -> q broadcast memtile
-        if KV_APPEND:
-            # Pin roped Q to rope MM2S0 so the K/V append (pinned to MM2S1
-            # below) does not steal it -- matches the reference (Q on 1st MM2S, K/V append
-            # on 2nd). Without this the placer puts the packet append on MM2S0
-            # (allocated first) and shoves Q to MM2S1, deadlocking the front-end.
-            _ropeQ.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                T.i32(), 0
-            )
+        # Q used to be pinned to rope MM2S0 here, to keep the packet K/V append
+        # off the channel carrying this circuit flow. The compiler derives that
+        # now: a DMA channel's port is either statically connected or packet-
+        # switched, never both, so AIRToAIE separates the two by itself
+        # (TileDMAAllocator::spreadCollapsedPacketChannels) and reproduces this
+        # exact placement.
         channel_decl("toAttnQ", size=[N_ATTN_CU])
         # rope k/v -> kv memtiles. PACKET so one rope MM2S can fan to memtiles on
         # MULTIPLE cols (mem_3_1 + mem_4_1) -- the reference routes rope k/v as
@@ -1305,10 +1303,10 @@ def build_module():
                 _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
                     T.i32(), 1
                 )
+                # Only appendK names a channel. It is what holds the pair on
+                # rope's second MM2S, clear of the circuit ropeQ; appendV joins
+                # it there on its own.
                 _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
-                _apV.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                    T.i32(), 1
-                )
             if KV_SPLIT:
                 # the reference mem_3_1: K and V on SEPARATE shim->memtile flows (one each per
                 # col group of 2 CUs), so their memtile S2MM fills are independent.
@@ -1366,13 +1364,9 @@ def build_module():
         channel_decl("toShim", size=[NDEST])
         # #4: layer output (residual2 = h + down) drained to host from the rms core.
         if FULL4:
-            _lo = channel_decl("layerOut", size=[1])
-            if KV_APPEND:
-                # Keep layerOut on rms MM2S0 (circuit) so xnorm (pinned to MM2S1)
-                # does not share/flip it to packet. See xnorm pin above.
-                _lo.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                    T.i32(), 0
-                )
+            # layerOut takes rms MM2S0 without being told to: the xnorm pin
+            # above claims MM2S1, and this is the only other flow on the tile.
+            channel_decl("layerOut", size=[1])
         # GLU path: id-demux delivers gate-up DIRECTLY to the GLU herd (no relay);
         # GLU -> gluOut -> down memtile accumulate (8192). FAITHFUL: that 8192 is
         # fed back on-chip as the DOWN phase X by the down_buffer re-broadcasting it

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -1211,10 +1211,10 @@ def build_module():
         # both as packets into one 2-slot ping-pong (input, then o-proj, then down).
         # Debug configs keep the original circuit rmsX.
         if FULL4:
-            _rx = channel_decl("rmsX", size=[1], channel_type="npu_dma_packet")
+            channel_decl("rmsX", size=[1], channel_type="npu_dma_packet")
         else:
-            _rx = channel_decl("rmsX", size=[1])
-        _rw = channel_decl("rmsW", size=[1])
+            channel_decl("rmsX", size=[1])
+        channel_decl("rmsW", size=[1])
         if POST_RMS:
             # Separate channel for the post_attention_layernorm weight. A single
             # rmsW FIFO re-fed twice does NOT pair in AIR (both gets read the same
@@ -1259,9 +1259,7 @@ def build_module():
         channel_decl("ropeLUT", size=[1])
         # S3a flash-attn dataflow: rope q -> qk tile (direct); rope k|v -> KV
         # staging memtile (rope's single k/v MM2S) which splits k->qk, v->kv.
-        _ropeQ = channel_decl(
-            "ropeQ", size=[1]
-        )  # rope q (whole 2048) -> q broadcast memtile
+        channel_decl("ropeQ", size=[1])  # rope q (whole 2048) -> q broadcast memtile
         # Q used to be pinned to rope MM2S0 here, to keep the packet K/V append
         # off the channel carrying this circuit flow. The compiler derives that
         # now: a DMA channel's port is either statically connected or packet-
@@ -1300,7 +1298,7 @@ def build_module():
                 # Only appendK names a channel. It is what holds the pair on
                 # rope's second MM2S, clear of the circuit ropeQ; appendV joins
                 # it there on its own.
-                _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
+                channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
             if KV_SPLIT:
                 # the reference mem_3_1: K and V on SEPARATE shim->memtile flows (one each per
                 # col group of 2 CUs), so their memtile S2MM fills are independent.
@@ -1358,8 +1356,10 @@ def build_module():
         channel_decl("toShim", size=[NDEST])
         # #4: layer output (residual2 = h + down) drained to host from the rms core.
         if FULL4:
-            # layerOut takes rms MM2S0 without being told to: the xnorm pin
-            # above claims MM2S1, and this is the only other flow on the tile.
+            # layerOut and the xnorm above are the rms core's only two outputs,
+            # and AIRToAIE gives them a channel each: collapsed onto one they
+            # form a ring its diagnoseBDChain oracle calls out of step, and
+            # spreadCollapsedPacketChannels peels one onto the idle channel.
             channel_decl("layerOut", size=[1])
         # GLU path: id-demux delivers gate-up DIRECTLY to the GLU herd (no relay);
         # GLU -> gluOut -> down memtile accumulate (8192). FAITHFUL: that 8192 is

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -740,22 +740,18 @@ def build_module():
         # No packet_ids either. air-annotate-packet-ids allocates them from the
         # top of the id space (so nothing else is renumbered) and rewrites the
         # ordinals the kernel stamps to match.
-        # Keep the hub demux on S2MM0 at every consumer tile; the shim-sourced feeds
-        # (ropeLUT/rmsIn/rmsW) are pinned to S2MM1 below. Without an explicit pin,
-        # unpinned packet flows REUSE whatever packet channel the tile already has
-        # (AIRToAIESchedulingUtils.cpp:1391), which merges two independent producers
-        # (hub + shim) into ONE ordered BD chain = head-of-line deadlock.
+        # The hub demux and the shim-sourced feeds (ropeLUT/rmsIn/rmsW) end up on
+        # separate S2MM channels at each consumer tile, and AIRToAIE works that
+        # out for itself. These used to carry air.tile_dma_channel pins: the
+        # allocator reuses whatever packet channel a tile already has before it
+        # looks for a free one, which merged two INDEPENDENT producers (hub +
+        # shim) into ONE strictly-ordered BD chain -- head-of-line deadlock,
+        # device-confirmed 2026-08-05j as the only difference between the hanging
+        # LOOPCLOSE build and the working host-toX one. spreadCollapsedPacketChannels
+        # now partitions such a ring by producer, so each ring's arrival order is
+        # fixed by the one producer feeding it.
         _lut = channel_decl("ropeLUT", size=[1])  # host cos/sin LUT -> rope core
-        # Pin the LUT feed to the rope tile's S2MM1 (the outY QKV demux keeps S2MM0).
-        # Under LOOPCLOSE the rms core adds two shim packet feeds (rmsIn/rmsW) which
-        # oversubscribe shim col 1, so AIR converts ropeLUT from a circuit flow into a
-        # PACKET flow -- and packet flows on one tile reuse a single physical channel
-        # (AIRToAIESchedulingUtils.cpp:1391) unless pinned. That merged ropeLUT and the
-        # outY QKV payload into ONE strictly-ordered 6-BD chain on rope S2MM0 fed by TWO
-        # INDEPENDENT producers (shim + hub mem_1_1) -> head-of-line deadlock (device-
-        # confirmed 2026-08-05j: the ONLY diff between the hanging LOOPCLOSE build and
-        # the working host-toX build). The pin restores the two-separate-channel layout.
-        # ...and feed it from a FREE shim column: the packetization above is triggered by
+        # Feed the LUT from a FREE shim column: the packetization above is triggered by
         # shim col 1 being oversubscribed (ropeLUT + rmsIn + rmsW + layerOut + qDrain).
         # Off col 1 the LUT feed stays circuit-switched, which cannot share the rope
         # tile's packet S2MM at all.
@@ -763,9 +759,7 @@ def build_module():
         channel_decl(
             "gluDrain", size=[1]
         )  # glu out (down-X) -> shim (Step C; loopclose D)
-        _rmsin = channel_decl(
-            "rmsIn", size=[1]
-        )  # host raw input activation -> rms core
+        channel_decl("rmsIn", size=[1])  # host raw input activation -> rms core
         channel_decl("layerOut", size=[1])  # rms residual2 (layer output) -> shim
         # ---- attention channels (reference-mirroring: rope q -> mem_6_1 q-broadcast tile ->
         # per-CU qk; K/V via KV staging mem_7_1). Ports fused_decode.py exactly. ----
@@ -828,9 +822,10 @@ def build_module():
         # ONE convergent packet channel carries all 4 phase X sources (rms ph0/ph2,
         # attn-o ph1, glu-down ph3) into the X memtile, read by ONE feed loop. Every
         # re-feed on it is written as an n-trip loop around the put (see refeed()).
-        # Pin the rms core's xnorm output to tile MM2S1 (layerOut keeps MM2S0) so the
-        # placer does not flip layerOut circuit->packet.
-        _xn = channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
+        # This and layerOut are the rms core's two outputs, and they take a
+        # channel each rather than collapsing onto one -- which used to need a
+        # pin, and would otherwise flip layerOut circuit->packet.
+        channel_decl("xnorm", size=[1], channel_type="npu_dma_packet")
         if OREF_2HOP:
             channel_decl("oref2", size=[1], channel_type="npu_dma_packet")
         if OREF_HOSTSRC:
@@ -840,23 +835,26 @@ def build_module():
             _od = channel_decl("orefDrain", size=[1])
             _od.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 6)
         if OREF_VIA_RMS:
-            # attn-o gather memtile -> rms core. PIN to the rms tile's S2MM0.
-            # Unpinned, the packet-flow channel reuse collapses it onto S2MM1, which already
-            # carries rmsIn (pkt2) and rmsW (pkt3) as a rigid 3-BD POSITIONAL chain over
-            # three DIFFERENT buffers with different lock pairs. A memtile-sourced @orms then
-            # arrives on a different switchbox port than the shim-sourced rmsIn/rmsW while
-            # both rules target the SAME amsel, so the arbiter interleaves the two streams at
-            # packet granularity and the positional chain desynchronizes -> deadlock.
-            # (device+routed-IR confirmed 2026-08-05x: passing shim-fed @orms has ONE slave
-            # port on tile_1_2 masterset DMA:1; every failing memtile-fed variant has TWO,
-            # independent of oref column and of the attn dependency.)
-            # S2MM0 carries only the o-proj outY get, and the @orms get is emitted BEFORE it
-            # in _rms_body, so the chain order [orms, outY] matches the dataflow order.
-            _orms = channel_decl("orms", size=[1], channel_type="npu_dma_packet")
+            # attn-o gather memtile -> rms core. This must not share a channel
+            # with the shim-sourced rmsIn/rmsW, and AIRToAIE now derives that.
+            # Collapsed onto their channel, a memtile-sourced @orms arrives on a
+            # different switchbox port than they do while both rules target the
+            # SAME amsel, so the arbiter interleaves the two streams at packet
+            # granularity and the positional BD chain -- three different buffers
+            # with different lock pairs -- desynchronizes into a deadlock.
+            # (device+routed-IR confirmed 2026-08-05x: the passing shim-fed @orms
+            # has ONE slave port on tile_1_2 masterset DMA:1; every failing
+            # memtile-fed variant has TWO, independent of oref column and of the
+            # attn dependency.) That is the hazard spreadCollapsedPacketChannels
+            # partitions by producer: on-array @orms/@outY on one channel, the
+            # host-fed @rmsIn/@rmsW on the other.
+            channel_decl("orms", size=[1], channel_type="npu_dma_packet")
         if PH1_XCHAN:
             channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
-        # rmsW lands on the rms core's S2MM1 alongside rmsIn, which is pinned
-        # above; it does not need to say so itself.
+        # rmsW shares the rms core's inbound channel with rmsIn, which is right:
+        # both are fed by the host, so one producer's BD order fixes the arrival
+        # order for the pair. It is only the on-array feeds they must be kept
+        # apart from, which the partition above does.
         channel_decl("rmsW", size=[1])  # host rms weight -> rms core
         channel_decl("gluOut", size=[1])  # glu-down -> down-X refeed memtile (ph3)
 

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -787,26 +787,21 @@ def build_module():
                 # rope's roped-K / raw-V leave on ONE dedicated rope MM2S as PACKET flows
                 # pinned to the attn shim col (7) -> DDR cache. Qwen has ONE col group
                 # (NGRP=1) so both K and V transit col 7 (Llama split cols 3/4).
-                # CHANNEL 0, NOT 1: rope also emits ropeQ as a CIRCUIT flow (-> the col-6
-                # q-broadcast memtile). Pinning the appends to MM2S1 left ropeQ to land on
-                # MM2S1 TOO, so one physical output port carried a static circuit route AND
-                # two packet routes -- the packet BDs would be steered by the circuit
-                # connection instead of their packet dests. Llama keeps them apart (circuit
-                # ropeQ on MM2S0, packets on MM2S1); pinning the appends to 0 gives Qwen the
-                # same separation with ropeQ taking the remaining channel.
+                #
+                # Which rope MM2S they take is no longer stated. rope also emits ropeQ
+                # as a CIRCUIT flow (-> the col-6 q-broadcast memtile), and a physical
+                # output port cannot carry both a static circuit route and packet
+                # routes -- the packet BDs would be steered by the circuit connection
+                # instead of their packet dests. AIRToAIE separates them itself now
+                # (TileDMAAllocator::spreadCollapsedPacketChannels), reaching the same
+                # placement this used to name.
                 _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
                 _apK.operation.attributes["air.shim_col"] = IntegerAttr.get(
                     i32, ATTN_COL
                 )
-                _apK.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                    i32, 0
-                )
                 _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
                 _apV.operation.attributes["air.shim_col"] = IntegerAttr.get(
                     i32, ATTN_COL
-                )
-                _apV.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(
-                    i32, 0
                 )
             channel_decl(
                 "toK", size=[N_ATTN_CU]
@@ -865,8 +860,9 @@ def build_module():
         if PH1_XCHAN:
             channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
         _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
-        _rmsw = channel_decl("rmsW", size=[1])  # host rms weight -> rms core
-        _rmsw.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
+        # rmsW lands on the rms core's S2MM1 alongside rmsIn, which is pinned
+        # above; it does not need to say so itself.
+        channel_decl("rmsW", size=[1])  # host rms weight -> rms core
         channel_decl("gluOut", size=[1])  # glu-down -> down-X refeed memtile (ph3)
 
         # ============================ proj grid core ============================

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -745,7 +745,6 @@ def build_module():
         # unpinned packet flows REUSE whatever packet channel the tile already has
         # (AIRToAIESchedulingUtils.cpp:1391), which merges two independent producers
         # (hub + shim) into ONE ordered BD chain = head-of-line deadlock.
-        _outY.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 0)
         _lut = channel_decl("ropeLUT", size=[1])  # host cos/sin LUT -> rope core
         # Pin the LUT feed to the rope tile's S2MM1 (the outY QKV demux keeps S2MM0).
         # Under LOOPCLOSE the rms core adds two shim packet feeds (rmsIn/rmsW) which
@@ -756,7 +755,6 @@ def build_module():
         # INDEPENDENT producers (shim + hub mem_1_1) -> head-of-line deadlock (device-
         # confirmed 2026-08-05j: the ONLY diff between the hanging LOOPCLOSE build and
         # the working host-toX build). The pin restores the two-separate-channel layout.
-        _lut.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
         # ...and feed it from a FREE shim column: the packetization above is triggered by
         # shim col 1 being oversubscribed (ropeLUT + rmsIn + rmsW + layerOut + qDrain).
         # Off col 1 the LUT feed stays circuit-switched, which cannot share the rope
@@ -768,7 +766,6 @@ def build_module():
         _rmsin = channel_decl(
             "rmsIn", size=[1]
         )  # host raw input activation -> rms core
-        _rmsin.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
         channel_decl("layerOut", size=[1])  # rms residual2 (layer output) -> shim
         # ---- attention channels (reference-mirroring: rope q -> mem_6_1 q-broadcast tile ->
         # per-CU qk; K/V via KV staging mem_7_1). Ports fused_decode.py exactly. ----
@@ -856,10 +853,8 @@ def build_module():
             # S2MM0 carries only the o-proj outY get, and the @orms get is emitted BEFORE it
             # in _rms_body, so the chain order [orms, outY] matches the dataflow order.
             _orms = channel_decl("orms", size=[1], channel_type="npu_dma_packet")
-            _orms.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 0)
         if PH1_XCHAN:
             channel_decl("xnorm2", size=[1], channel_type="npu_dma_packet")
-        _xn.operation.attributes["air.tile_dma_channel"] = IntegerAttr.get(i32, 1)
         # rmsW lands on the rms core's S2MM1 alongside rmsIn, which is pinned
         # above; it does not need to say so itself.
         channel_decl("rmsW", size=[1])  # host rms weight -> rms core


### PR DESCRIPTION
Follow-on to #1851, which did this for the shim. This does it for compute tiles, and retires `air.tile_dma_channel` from both fused-decode builders — 13 hand-written pins, now derived.

## The question the pass answers

A compute-tile DMA channel is **one BD ring walked strictly in order**, and a packet header steers a transfer to the *tile* without choosing which BD receives it. Sharing a ring is therefore safe exactly when something fixes the arrival order. Three things can:

- **one switching kind** — a switchbox port is statically connected or packet-arbitrated, never both, and a channel is one port;
- **a round-robin ring** — every flow owning exactly one BD of the repeating unit, so a flow's k-th transfer always meets that same BD however the arrivals interleave;
- **a single producer**, whose own BD order fixes the arrival order.

Absent all three, the ring is separated: by kind, or by a partition by producer. Otherwise it is left alone, because collapse is how the emitter folds a repeating chain into one BD with a repeat count.

Where there are more producers than channels the merge is not free either. The on-array producers coalesce and the shim is kept apart: shim traffic is DDR-backed and its timing depends on the host and the NoC, so nothing on the array bounds when it arrives, whereas two on-array producers run under the same lock protocol as the consumer.

`getUniqueBDPattern` supplies the repeating unit and `diagnoseBDChain` the in-step test, so both questions are asked in the BD emitter's own terms rather than a second set invented here.

## Why the allocator needs it

`simpleDmaChannelAlloc` reuses an existing packet channel *before* it looks for a free one, and its fallback `chan = num_allocs % tile_dma_channels` counts **allocations** rather than occupied channels — so it hands back a channel already in use while another sits idle. Both are why cores ended up with several unrelated flows queued on one ring.

Fixing that at allocation time was tried and is wrong: taking a free channel unconditionally breaks four tests, because collapse is frequently what you want. The decision needs the whole allocation in view, so it is made after it, in the spirit of `repairS2MMChains`.

## Evidence

The forcing case is the qwen2.5-3b rms core: four flows and six transfers arriving from the shim and two different memtiles on one ring, with the other channel idle. Unpinned it builds, **routes**, and passes every static check including `diagnoseBDChain` — and deadlocks on device (`ERT_CMD_STATE_TIMEOUT`, first dispatch). With this it partitions to `{rmsIn, rmsW}` against `{orms, outY}`, which is what the pins encoded.

- **All eight model directories build**, gated on each model's real `make compile-decode`.
- **Flow partition unchanged** across the designs, except qwen3-8b where a ten-BD collapsed chain splits onto a channel that was sitting idle (10 BDs -> 4). Elsewhere only which index a group lands on differs.
- lit and `check-air-python` green.

**Correction to an earlier version of this description.** It claimed llama-3.2-1b, llama-3.2-3b and gemma3-4b verify PASS 2/2 with no pins. That result was real but taken at `fb0d7563`, before the producer rule landed in `337208c4`, and was not re-taken at head -- so it should not have been presented as current. At head those three designs, plus llama-3.1-8b and phi4-mini, did not route at all; that is fixed in `bc81af01` and the gate that missed it has been replaced. Thanks to the second session that caught this with an independent A/B.

Device status now: llama-3.2-3b verifies 2/2 on this branch, matching main. Note that llama-3.2-1b currently fails `make verify` 0/2 on **clean main** as well (it builds and runs, but the tokens are wrong), so it cannot serve as a gate for this or any other PR until that is bisected -- llama-3.2-3b passes on main, so it is llama-1b-specific and unrelated to this PR.

`air.tile_dma_channel` remains supported as an explicit override; the front ends simply no longer need it. A test covers the pin still winning over the derived answer.

## What is deliberately not done

A ring is **not** split merely because its flows come from independent producers. `diagnoseBDChain` names that as the thing it does not check, and it is tempting since it is what several of the pins were really guarding — but "two source tiles" does not imply "unordered". Every AIR matmul feeds a core one A tile and one B tile per iteration from two memtiles, onto a ring that repeats in lockstep. Splitting on producer count alone would spend both S2MM channels of every compute tile in the project; `tile_producer_partition.mlir` pins both sides of that distinction.