### PR TITLE
[aircc] Only serialize aiecc core compilation for Chess

### DIFF
--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1447,10 +1447,13 @@ static LogicalResult runAieCompilation() {
 
     aieccCmd.push_back("-O");
     aieccCmd.push_back("3");
-    // aiecc defaults to -j 0 (auto CPU count) since mlir-aie commit 1ba5b5c.
-    // Force sequential core compilation to avoid parallel xchesscc crashes.
-    aieccCmd.push_back("-j");
-    aieccCmd.push_back("1");
+    // Chess is not parallel-safe -- concurrent xchesscc/noodle instances die
+    // with a kill signal -- so it stays sequential. Peano has no such limit, so
+    // leave aiecc on its default -j 0 (auto CPU count) and build cores at once.
+    if (xchesscc || xbridge) {
+      aieccCmd.push_back("-j");
+      aieccCmd.push_back("1");
+    }
 
     // bf16 emulation
     if (bf16Emulation)

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1448,12 +1448,11 @@ static LogicalResult runAieCompilation() {
     aieccCmd.push_back("-O");
     aieccCmd.push_back("3");
     // Chess is not parallel-safe -- concurrent xchesscc/noodle instances die
-    // with a kill signal -- so it stays sequential. Peano has no such limit, so
-    // leave aiecc on its default -j 0 (auto CPU count) and build cores at once.
-    if (xchesscc || xbridge) {
-      aieccCmd.push_back("-j");
-      aieccCmd.push_back("1");
-    }
+    // with a kill signal -- so it stays sequential. Peano has no such limit and
+    // builds cores in parallel. Both halves are stated rather than left to
+    // aiecc's default, which has flipped before (mlir-aie 1ba5b5c).
+    aieccCmd.push_back("-j");
+    aieccCmd.push_back((xchesscc || xbridge) ? "1" : "0");
 
     // bf16 emulation
     if (bf16Emulation)


### PR DESCRIPTION
`aircc` has passed aiecc `-j 1` unconditionally since #1732, which added it when
mlir-aie `1ba5b5c` flipped aiecc's default from `-j 1` to `-j 0`. That commit's
reason was specific:

> Chess is not fully parallel-safe and crashes with a kill signal when run
> concurrently

Peano has no such constraint, so the workaround only ever needed to cover the
Chess path. Applied unconditionally it serializes core compilation for every
Peano build — which is the default backend, and the one every `programming_examples`
lit and every model build goes through.

This scopes the flag to `xchesscc || xbridge`, the same condition that already
selects the Chess backend a few lines above, and leaves aiecc on its default
`-j 0` (auto CPU count) otherwise. Chess behaviour is unchanged.

## Measurements

aiecc invoked directly on the same `npu.air.mlir`, a 32-core aie2p design
(8×4 herd, `matrix_multiplication/bf16`), on a 24-CPU host — two runs each:

| `-j` | run 1 | run 2 |
|---|---|---|
| `1` (today) | 6.74 s | 6.43 s |
| `0` (this PR) | 3.35 s | 3.33 s |

**~1.95×**, and the parallel arm is the tighter of the two (0.02 s spread vs
0.31 s). Through `aircc` the same build now peaks at **22 concurrent core
compiles instead of 1**.

The win scales with core count, so it is largest exactly where builds hurt most
— the 8×4 herds used by the LLM examples.

## Correctness

Unchanged on NPU2 hardware with Peano:

- `matrix_multiplication/bf16` 8×4, 32 cores — `PASS!`
- `channel_examples/herd_to_herd/single_segment` — `PASS!`
- `channel_examples/broadcast/cross_herd` — `PASS!`
- `matrix_scalar_add/multi_core_channel` — `PASS!`

## Not covered

The Chess path is unchanged by construction but is **not exercised here**: this
host has no Vitis (`xchesscc: command not found`), so the `valid_xchess_license`
lits are UNSUPPORTED. The conditional keeps `-j 1` for `--xchesscc`/`--xbridge`,
so Chess sees exactly what it saw before.
