### PR TITLE
[mlir] Don't spread a strip-mined loop when splitting an L2 memref

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -2418,6 +2418,49 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
         rootStrideFactor = *getConstantIntValue(forOp.getStep());
       return rootStrideFactor;
     };
+    // How many slices of the split dimension one trip of the enclosing
+    // scf.for advances the offset by. The loop's step is not that number: the
+    // offset is usually an affine.apply, either scaling the induction
+    // variable (`s0 * 4` over a unit-step loop) or folding it in beside a herd
+    // coordinate (`s0 * 8 + s1` over a loop that steps by the tile height).
+    // Evaluate the map at iv = 0 and iv = step with every other operand pinned
+    // to 0 and subtract; std::nullopt when the induction variable does not
+    // reach the map directly, which leaves the caller on its old behaviour.
+    auto getSplitDimAdvancePerTrip =
+        [&](air::ChannelInterface ci, int offsetDim) -> std::optional<int64_t> {
+      auto forOp = getScfForFromVal(air::getOffsetsAsValues(ci)[offsetDim]);
+      if (!forOp)
+        return std::nullopt;
+      auto step = getConstantIntValue(forOp.getStep());
+      if (!step)
+        return std::nullopt;
+      auto apply = getAffineMapOnMemrefSplitDim(ci, offsetDim);
+      if (!apply)
+        return *step; // The offset is the induction variable itself.
+      AffineMap map = apply.getAffineMap();
+      SmallVector<std::optional<int64_t>> symsLo(map.getNumSymbols(),
+                                                 int64_t{0}),
+          dimsLo(map.getNumDims(), int64_t{0});
+      auto symsHi = symsLo, dimsHi = dimsLo;
+      bool found = false;
+      for (auto [pos, oper] : llvm::enumerate(apply.getSymbolOperands()))
+        if (oper == forOp.getInductionVar()) {
+          symsHi[pos] = *step;
+          found = true;
+        }
+      for (auto [pos, oper] : llvm::enumerate(apply.getDimOperands()))
+        if (oper == forOp.getInductionVar()) {
+          dimsHi[pos] = *step;
+          found = true;
+        }
+      if (!found)
+        return std::nullopt;
+      auto lo = air::evaluateConstantsInMap(map, symsLo, dimsLo, ctx);
+      auto hi = air::evaluateConstantsInMap(map, symsHi, dimsHi, ctx);
+      if (!lo || !hi)
+        return std::nullopt;
+      return *hi - *lo;
+    };
 
     for (unsigned i = 0; i < putgets.size(); i++) {
       // Infer the size at splitDim for both overlapping and non-overlapping
@@ -2443,7 +2486,24 @@ AIRSplitL2MemrefForBufferConstraintPass::getTargetMemrefAllocs(
       auto rootStrideFactor =
           getRootStrideFactor(air::getOffsetsAsValues(ci)[*offsetDimOpt],
                               air::getStridesAsValues(ci)[*offsetDimOpt]);
-      if (rootStrideFactor && air::getOffsetsAsValues(ci).size() > 1) {
+      // ... unless the loop is strip-mining a contiguous run rather than
+      // distributing: when each trip advances by exactly the slices it takes,
+      // the trips abut and the split dimension is already contiguous. Spread
+      // it anyway and the L3 side gathers every step-th slice while the loop
+      // bound is rewritten as if a trip took one slice, so the partition ends
+      // up holding the wrong rows -- the bf16 GEMV at herd_m=8, m_input=4 got
+      // 3 of every 4 outputs wrong that way. Only the step, not the advance,
+      // distinguishes the two, and a strip-mining loop written as
+      // `for j in range(0, tile_m, m_input)` carries the tile height in its
+      // step while one written as `for jj in range(tile_m / m_input)` carries
+      // it in an affine.apply -- the same access pattern, so neither may
+      // decide this on its own.
+      auto advance = getSplitDimAdvancePerTrip(ci, *offsetDimOpt);
+      auto accessSize =
+          getConstantIntValue(air::getSizesAsValues(ci)[*offsetDimOpt]);
+      bool contiguousWalk = advance && accessSize && *advance == *accessSize;
+      if (rootStrideFactor && air::getOffsetsAsValues(ci).size() > 1 &&
+          !contiguousWalk) {
         splitDimStrideFactor = *rootStrideFactor;
         // Cancel out the non-unit step size on the for loop, to get contiguous
         // access pattern on memrefs after split.

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_strip_mined_loop.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref_strip_mined_loop.mlir
@@ -1,0 +1,167 @@
+//===- air_split_l2_memref_strip_mined_loop.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --air-split-l2-memref="max-launch-channels-mm2s=16 max-launch-channels-s2mm=16" --split-input-file | FileCheck %s
+
+// A loop over the split dimension means one of two things, and the pass has to
+// tell them apart from the access pattern alone.
+//
+//   * Distribution: each trip takes one slice, trips are `step` apart. The
+//     partition then holds slices that are NOT adjacent in L3, so the L3-side
+//     transfer grows a dimension to gather them.
+//   * Strip-mining: each trip takes `step` adjacent slices. The trips abut, the
+//     partition is a contiguous run, and the L3 side must stay as it was.
+//
+// Both loops carry a non-unit step, so the step alone does not distinguish them
+// -- what does is how far a trip advances the offset relative to how much it
+// takes. Gathering a strip-mined run puts the wrong rows in the partition: the
+// bf16 GEMV example at herd_m=8, m_input=4 came back with 3 of every 4 output
+// rows wrong.
+//
+// The advance is not the step either. The same strip-mined access is written
+// `for j = 0 to 8 step 4` with the offset folded into an affine.apply beside the
+// herd coordinate, or `for jj = 0 to 2 step 1` with the tile height in the map;
+// the first carries the height in the step, the second in the map.
+
+// Strip-mining: `for %arg11 = 0 to 8 step 4` where the trip takes 4 of the 8
+// rows the partition owns. Contiguous, so the L3 put keeps its 2-D
+// [8, 2048] [2048, 1] pattern and the loop keeps its step.
+
+// CHECK-LABEL: func.func @strip_mined
+// CHECK: air.channel.put{{.*}}@channel_1{{.*}}[%c8{{[_0-9]*}}, %c2048{{[_0-9]*}}] [%c2048{{[_0-9]*}}, %c1{{[_0-9]*}}]
+// CHECK-COUNT-8: memref.alloc() : memref<8x2048xbf16, 1 : i32>
+// CHECK-NOT: memref.alloc() : memref<64x2048xbf16, 1 : i32>
+// CHECK: scf.for %{{.*}} = %c0{{[_0-9]*}} to %c8{{[_0-9]*}} step %c4{{[_0-9]*}}
+
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0, s1] -> (s0 * 8 + s1)>
+module {
+  air.channel @channel_0 []
+  air.channel @channel_2 [8, 1]
+  func.func @strip_mined(%arg0: memref<16384x2048xbf16>) {
+    %c256 = arith.constant 256 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c256, %arg6=%c1) args(%arg7=%arg0) : memref<16384x2048xbf16> attributes {id = 1 : i32} {
+      %1 = affine.apply #map()[%arg3]
+      %2 = air.channel.put async  @channel_0[] (%arg7[%1, 0] [64, 2048] [2048, 1]) {id = 1 : i32} : (memref<16384x2048xbf16>)
+      %6 = air.segment @seg async  attributes {id = 2 : i32} {
+        %c0_0 = arith.constant 0 : index
+        %c4_1 = arith.constant 4 : index
+        %c1_2 = arith.constant 1 : index
+        %c8_3 = arith.constant 8 : index
+        %async_token, %results = air.execute -> (memref<64x2048xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x2048xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x2048xbf16, 1 : i32>
+        }
+        %7 = air.channel.get async [%async_token]  @channel_0[] (%results[] [] []) {id = 4 : i32} : (memref<64x2048xbf16, 1 : i32>)
+        %9 = scf.parallel (%arg10) = (%c0_0) to (%c8_3) step (%c1_2) init (%7) -> !air.async.token {
+          %14 = scf.for %arg11 = %c0_0 to %c8_3 step %c4_1 iter_args(%arg12 = %7) -> (!air.async.token) {
+            %15 = affine.apply #map1()[%arg10, %arg11]
+            %16 = air.channel.put async [%arg12]  @channel_2[%arg10, %c0_0] (%results[%15, 0] [4, 2048] [2048, 1]) {id = 5 : i32} : (memref<64x2048xbf16, 1 : i32>)
+            scf.yield %16 : !air.async.token
+          }
+          scf.reduce(%14 : !air.async.token) {
+          ^bb0(%arg11: !air.async.token, %arg12: !air.async.token):
+            %15 = air.wait_all async [%arg11, %arg12]
+            scf.reduce.return %15 : !air.async.token
+          }
+        }
+        %11 = air.herd @herd_0 async  tile (%arg10, %arg11) in (%arg12=%c8_3, %arg13=%c1_2) attributes {id = 3 : i32} {
+          %c4_8 = arith.constant 4 : index
+          %c8_9 = arith.constant 8 : index
+          %c0_10 = arith.constant 0 : index
+          %async_token_11, %results_12 = air.execute -> (memref<4x2048xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<4x2048xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<4x2048xbf16, 2 : i32>
+          }
+          %14 = scf.for %arg14 = %c0_10 to %c8_9 step %c4_8 iter_args(%arg15 = %async_token_11) -> (!air.async.token) {
+            %17 = air.channel.get async [%arg15]  @channel_2[%arg10, %arg11] (%results_12[] [] []) {id = 8 : i32} : (memref<4x2048xbf16, 2 : i32>)
+            scf.yield %17 : !air.async.token
+          }
+          %async_token_18 = air.execute [%14] {
+            memref.dealloc %results_12 : memref<4x2048xbf16, 2 : i32>
+          }
+        }
+        %async_token_6 = air.execute [%9, %11] {
+          memref.dealloc %results : memref<64x2048xbf16, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Distribution: the same loop, but a trip takes a single row. The partition's
+// two rows are 4 apart in L3, so the L3 put grows a dimension whose stride is
+// the original one times the step, and the loop is rewritten to walk the
+// partition's rows one at a time. This is the pattern the stride factor exists
+// for; the strip-mined case above must not be folded into it.
+
+// CHECK-LABEL: func.func @distributed
+// CHECK: air.channel.put{{.*}}@channel_1{{.*}}[%c1{{[_0-9]*}}, %c2{{[_0-9]*}}, %c2048{{[_0-9]*}}] [%c2048{{[_0-9]*}}, %c8192{{[_0-9]*}}, %c1{{[_0-9]*}}]
+// CHECK-COUNT-8: memref.alloc() : memref<2x2048xbf16, 1 : i32>
+// CHECK: scf.for %{{.*}} = %c0{{[_0-9]*}} to %c2{{[_0-9]*}} step %c1{{[_0-9]*}}
+
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0, s1] -> (s0 * 8 + s1)>
+module {
+  air.channel @channel_0 []
+  air.channel @channel_2 [8, 1]
+  func.func @distributed(%arg0: memref<16384x2048xbf16>) {
+    %c256 = arith.constant 256 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c256, %arg6=%c1) args(%arg7=%arg0) : memref<16384x2048xbf16> attributes {id = 1 : i32} {
+      %1 = affine.apply #map()[%arg3]
+      %2 = air.channel.put async  @channel_0[] (%arg7[%1, 0] [64, 2048] [2048, 1]) {id = 1 : i32} : (memref<16384x2048xbf16>)
+      %6 = air.segment @seg async  attributes {id = 2 : i32} {
+        %c0_0 = arith.constant 0 : index
+        %c4_1 = arith.constant 4 : index
+        %c1_2 = arith.constant 1 : index
+        %c8_3 = arith.constant 8 : index
+        %async_token, %results = air.execute -> (memref<64x2048xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x2048xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x2048xbf16, 1 : i32>
+        }
+        %7 = air.channel.get async [%async_token]  @channel_0[] (%results[] [] []) {id = 4 : i32} : (memref<64x2048xbf16, 1 : i32>)
+        %9 = scf.parallel (%arg10) = (%c0_0) to (%c8_3) step (%c1_2) init (%7) -> !air.async.token {
+          %14 = scf.for %arg11 = %c0_0 to %c8_3 step %c4_1 iter_args(%arg12 = %7) -> (!air.async.token) {
+            %15 = affine.apply #map1()[%arg10, %arg11]
+            %16 = air.channel.put async [%arg12]  @channel_2[%arg10, %c0_0] (%results[%15, 0] [1, 2048] [2048, 1]) {id = 5 : i32} : (memref<64x2048xbf16, 1 : i32>)
+            scf.yield %16 : !air.async.token
+          }
+          scf.reduce(%14 : !air.async.token) {
+          ^bb0(%arg11: !air.async.token, %arg12: !air.async.token):
+            %15 = air.wait_all async [%arg11, %arg12]
+            scf.reduce.return %15 : !air.async.token
+          }
+        }
+        %11 = air.herd @herd_0 async  tile (%arg10, %arg11) in (%arg12=%c8_3, %arg13=%c1_2) attributes {id = 3 : i32} {
+          %c4_8 = arith.constant 4 : index
+          %c8_9 = arith.constant 8 : index
+          %c0_10 = arith.constant 0 : index
+          %async_token_11, %results_12 = air.execute -> (memref<1x2048xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<1x2048xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<1x2048xbf16, 2 : i32>
+          }
+          %14 = scf.for %arg14 = %c0_10 to %c8_9 step %c4_8 iter_args(%arg15 = %async_token_11) -> (!air.async.token) {
+            %17 = air.channel.get async [%arg15]  @channel_2[%arg10, %arg11] (%results_12[] [] []) {id = 8 : i32} : (memref<1x2048xbf16, 2 : i32>)
+            scf.yield %17 : !air.async.token
+          }
+          %async_token_18 = air.execute [%14] {
+            memref.dealloc %results_12 : memref<1x2048xbf16, 2 : i32>
+          }
+        }
+        %async_token_6 = air.execute [%9, %11] {
+          memref.dealloc %results : memref<64x2048xbf16, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}

--- a/programming_examples/matrix_vector_multiplication/bf16/run_npu2_makefile_peano.lit
+++ b/programming_examples/matrix_vector_multiplication/bf16/run_npu2_makefile_peano.lit
@@ -15,6 +15,15 @@
 // RUN: make -f %S/Makefile run M=8192 K=2048 TILE_M=16 M_INPUT=4 HERD_M=4 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s --check-prefix=RUN2
 // RUN2: PASS!
 //
+// Correctness: M=16384, K=2048, 8 columns. This is the shape the LLM lm_head
+// GEMV builder asks for (llms/shared/builders/lm_head_gemv_multi.py), and the
+// only one nine callers under llms/ use -- but until #1849 this file stopped at
+// HERD_M=4, so a port that got herd_m=8 wrong shipped green and took every LLM
+// with it. Eight columns is also where air-split-l2-memref starts partitioning
+// the A panel, so this is the first case that exercises the split at all.
+// RUN: make -f %S/Makefile run M=16384 K=2048 TILE_M=8 M_INPUT=4 HERD_M=8 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s --check-prefix=RUN8COL
+// RUN8COL: PASS!
+//
 // Correctness: M=2048, K=8192, single column (backward compat)
 // RUN: make -f %S/Makefile run M=2048 K=8192 TILE_M=4 M_INPUT=1 HERD_M=1 PEANO_INSTALL_DIR=%PEANO_INSTALL_DIR | FileCheck %s --check-prefix=RUN3
 // RUN3: PASS!


### PR DESCRIPTION
`air-split-l2-memref` reads a loop over the split dimension as a *distribution*: each trip takes one slice, trips sit `step` apart, so the partition holds slices that are not adjacent in L3 and the L3-side transfer grows a dimension to gather them. A loop whose trips take `step` *adjacent* slices is strip-mining the partition instead — the trips abut, the run is contiguous, and the L3 side must be left alone.

`getRootStrideFactor` could not tell the two apart, because it read the loop's step and nothing else. Worse, the step is not even the quantity that separates them: the same strip-mined access is written

```
for j  = 0 to 8 step 4     with the offset folded into an affine.apply
                           beside the herd coordinate (s0 * 8 + s1)
for jj = 0 to 2 step 1     with the tile height inside the map (s0 * 4)
```

Only the second form had ever reached the pass, and it happens to yield a factor of 1, so the bug sat dormant until an example was written in the first form.

## Fix

Compute how far one trip actually advances the offset — evaluate the affine map at `iv = 0` and `iv = step` with every other operand pinned to 0 — and suppress the stride factor when that advance equals the slices the trip takes. This only ever turns the factor *off*, and only for a provably contiguous walk. Every other path keeps its behaviour and no existing test moves.

## Symptom

Silent wrong data, not a crash. The bf16 GEMV at `herd_m=8, m_input=4` (M=16384, K=2048) returned 12214 of 16384 outputs wrong, in the pattern `act[i] == exp[i + 3*(i%4)]`. The L3-side put had become

```mlir
%arg7[%1, 0, 0] [1, 8, 2048] [2048, 8192, 1]     // want [8, 2048] [2048, 1]
```

so memtile *tx* was filled with A rows `base, base+4, base+8, …` instead of `base…base+7`, and the consumer loop was rewritten `0..8 step 4` → `0..2 step 1` so its two reads overlapped.

Varying only `m_input` isolates it: 1 passes (factor 1), 2 gives 49.71 % wrong, 4 gives 74.55 %, 8 passes (single trip, loop folded away). `herd_m=4` passed throughout because a 128 KiB A panel is under the split threshold and the pass never ran.

That configuration — `TILE_M=8 M_INPUT=4 HERD_M=8` — is the one every lm_head GEMV caller under `programming_examples/llms/` asks for (`llms/shared/builders/lm_head_gemv_multi.py`), so all nine of them were decoding garbage. The GEMV example's own npu2 lit stopped at `HERD_M=4`, which is why the port that first wrote the loop this way shipped green.

## Verification

All measured on a Ryzen AI 7 350 (Krackan Point) with Peano.

| check | result |
|---|---|
| `check-air-mlir` | 525 tests, 507 passed, 0 unexpected failures — no CHECK churn on existing tests |
| GEMV, all 4 npu2 lit correctness configs via `make run` | PASS, including the new `HERD_M=8` case |
| GEMV sweep, `m_input` ∈ {1,2,4,8} × `herd_m` ∈ {4,8} | PASS |
| `matrix_multiplication/bf16 run4x4` | PASS |
| **`llama32_1b_q4nx` verify**, clean → compile-decode → verify | **PASS 2/2** (was 0/2 on `c37cbb82`) |

The verify gate completes the bisect: `2c4f2a1a` (parent of #1849) 2/2 → `45c69ab5`, `c37cbb82` 0/2 → this branch 2/2.

The new lit test pins both directions and is perturbation-tested: forcing the factor on fails the strip-mined case, forcing it off fails the distributed case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
