### PR TITLE
[python] air.api: affine index arithmetic, buffer lifetime, and worker_to_worker

### DIFF
--- a/programming_examples/channel_examples/README.md
+++ b/programming_examples/channel_examples/README.md
@@ -28,11 +28,9 @@ This example ([worker_to_self/worker_to_self.py](worker_to_self/worker_to_self.p
 
 WARNING: This example currently fails for unknown reasons.
 
-#### WIP: ```worker-to-worker```:
+#### ```worker-to-worker```:
 
-This example ([worker_to_worker/worker_to_worker.py](worker_to_worker/worker_to_worker.py)) is a work-in-progress data passthrough example using the same tiling structure as the [matrix_scalar_add/multi_core_channel](../matrix_scalar_add/multi_core_channel.py) examples, only the each worker trades a tile of input data to another worker in the herd by sending it via channel.
-
-WARNING: This example currently fails for unknown reasons.
+This example ([worker_to_worker/worker_to_worker.py](worker_to_worker/worker_to_worker.py)) uses the same tiling structure as the [matrix_scalar_add/multi_core_channel](../matrix_scalar_add/multi_core_channel.py) examples, only each worker trades its tile of data to another worker in the herd by sending it via channel. A worker stamps its own tile number on its tile before handing it on, so the output records the permutation rather than only the copy.
 
 #### ```broadcast```:
 

--- a/programming_examples/channel_examples/worker_to_worker/worker_to_worker.py
+++ b/programming_examples/channel_examples/worker_to_worker/worker_to_worker.py
@@ -1,17 +1,45 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A ring of workers passing tiles to their neighbours, on air.api.
+
+    air.channel @ChanIn          L3 -> L1, one bundle member per worker
+    air.channel @WorkerToWorker  L1 -> L1, worker (th, tw) -> its successor
+    air.channel @ChanOut         L1 -> L3, one bundle member per worker
+
+Each worker stamps its own tile number onto its tile and hands the result not
+to itself but to the *next* worker in row-major order, which then writes it
+out. So the tile that lands at (th, tw) in the output carries the tile number
+of the worker *before* it -- the test's expected output is built from exactly
+that permutation, and a kernel that quietly kept its own tile would fail it.
+
+The successor is where the index arithmetic comes in:
+
+    tw_next = (tw + 1) % W
+    th_next = (th + (tw + 1) // W) % H
+
+Both must reach the IR as affine expressions rather than a chain of arith ops,
+because the AIR dependency analysis and the DMA specialisation passes read
+affine offsets directly. The raw-bindings version this replaces built them by
+hand -- three ``AffineMap.get`` calls with ``AffineExpr.get_mod`` and
+``get_floor_div``, forty lines of them. Written as ordinary Python operators on
+the herd coordinates, ``IndexExpr`` produces the same two maps.
+
+Unchanged from the predecessor, except for two things:
+
+* The L3-side put and get sit inside the segment. Reaching L3 needs a shim DMA
+  allocation, and outside a segment there is none to link to.
+* The two per-tile kernels are whole-tile expressions rather than scalar loop
+  nests over every (i, j). ``vector=0`` keeps them scalar as the predecessor
+  was: a tile row is 4 i32 wide, well under a vector.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.affine import apply as affine_apply
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 12
 IMAGE_HEIGHT = 4
@@ -24,179 +52,100 @@ TILE_SIZE = [TILE_HEIGHT, TILE_WIDTH]
 assert IMAGE_HEIGHT % TILE_HEIGHT == 0
 assert IMAGE_WIDTH % TILE_WIDTH == 0
 
+# The worker grid: one worker per tile.
+GRID_HEIGHT = IMAGE_HEIGHT // TILE_HEIGHT
+GRID_WIDTH = IMAGE_WIDTH // TILE_WIDTH
+
 INOUT_DATATYPE = np.int32
 
 
-@module_builder
+def next_worker(th, tw):
+    """The successor of worker (th, tw) in row-major order, wrapping around.
+
+    Shared by the kernel and the test's expected output, so the two cannot
+    drift: the same expression runs on herd coordinates in the kernel and on
+    Python ints in the check below.
+    """
+    tw_next = (tw + 1) % GRID_WIDTH
+    th_next = (th + (tw + 1) // GRID_WIDTH) % GRID_HEIGHT
+    return th_next, tw_next
+
+
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # Create an input/output channel pair per worker
-    Channel("ChanIn", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
-    Channel("ChanOut", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH])
-    Channel(
-        "WorkerToWorker", size=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH]
-    )
+    # An input and an output channel per worker, plus the ring between them.
+    chan_in = air.channel("ChanIn", size=[GRID_HEIGHT, GRID_WIDTH])
+    chan_out = air.channel("ChanOut", size=[GRID_HEIGHT, GRID_WIDTH])
+    ring = air.channel("WorkerToWorker", size=[GRID_HEIGHT, GRID_WIDTH])
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
-
-                    # Put data into the channel tile by tile
-                    ChannelPut(
-                        "ChanIn",
-                        a,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
-
-            # The arguments are still the input and the output
-            @segment(name="seg")
-            def segment_body():
-
-                @herd(
-                    name="xaddherd",
-                    sizes=[IMAGE_HEIGHT // TILE_HEIGHT, IMAGE_WIDTH // TILE_WIDTH],
-                )
-                def herd_body(th, tw, sh, sw):
-                    get_tile_num = AffineMap.get(
-                        0,
-                        3,
-                        [
-                            AffineExpr.get_add(
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(0),
-                                    AffineSymbolExpr.get(1),
-                                ),
-                                AffineSymbolExpr.get(2),
-                            )
-                        ],
-                    )
-                    tile_num = affine_apply(get_tile_num, [th, sw, tw])
-                    get_tile_width_next = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_mod(
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(0),
-                                    AffineConstantExpr.get(1),
-                                ),
-                                AffineSymbolExpr.get(1),
-                            )
-                        ],
-                    )
-                    tw_next = affine_apply(get_tile_width_next, [tw, sw])
-                    # th_next = (th + ((tw + 1) // sw)) % sh
-                    get_tile_height_next = AffineMap.get(
-                        0,
-                        4,
-                        [
-                            AffineExpr.get_mod(
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(2),
-                                    AffineExpr.get_floor_div(
-                                        AffineExpr.get_add(
-                                            AffineSymbolExpr.get(0),
-                                            AffineConstantExpr.get(1),
-                                        ),
-                                        AffineSymbolExpr.get(1),
-                                    ),
-                                ),
-                                AffineSymbolExpr.get(3),
-                            )
-                        ],
-                    )
-                    th_next = affine_apply(get_tile_height_next, [tw, sw, th, sh])
-
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=TILE_SIZE,
-                        element_type=xrt_dtype,
-                        memory_space=mem_space,
-                    )
-
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in = AllocOp(tile_type, [], [])
-                    tile_out = AllocOp(tile_type, [], [])
-
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    ChannelGet("ChanIn", tile_in, indices=[th, tw])
-
-                    # Access every value in the tile
-                    for i in range_(TILE_HEIGHT):
-                        for j in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val_in = load(tile_in, [i, j])
-
-                            val_out = arith.AddIOp(
-                                arith.index_cast(xrt_dtype, tile_num), val_in
+                @seg.body
+                def _():
+                    # One tile of the image into each worker's bundle member.
+                    for i in range(GRID_HEIGHT):
+                        for j in range(GRID_WIDTH):
+                            chan_in.put(
+                                A[
+                                    i * TILE_HEIGHT : (i + 1) * TILE_HEIGHT,
+                                    j * TILE_WIDTH : (j + 1) * TILE_WIDTH,
+                                ],
+                                indices=[i, j],
                             )
 
-                            # Store the output value in tile_out
-                            store(val_out, tile_out, [i, j])
-                            yield_([])
-                        yield_([])
+                    with air.herd(
+                        [range(GRID_HEIGHT), range(GRID_WIDTH)],
+                        name="xaddherd",
+                        shape=(GRID_HEIGHT, GRID_WIDTH),
+                    ) as h:
 
-                    ChannelPut("WorkerToWorker", tile_out, indices=[th_next, tw_next])
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
+                        @h.body
+                        def _(th, tw):
+                            tile_num = th * GRID_WIDTH + tw
+                            th_next, tw_next = next_worker(th, tw)
 
-                    tile_in2 = AllocOp(tile_type, [], [])
-                    tile_out2 = AllocOp(tile_type, [], [])
-                    ChannelGet("WorkerToWorker", tile_in2, indices=[th, tw])
+                            # Stamp this worker's number on its own tile, then
+                            # hand it to the next worker rather than keeping it.
+                            tile_in = air.alloc(TILE_SIZE, i32, scope=h.private())
+                            tile_out = air.alloc(
+                                TILE_SIZE, i32, scope=h.private(), vector=0
+                            )
+                            chan_in.get(tile_in, indices=[th, tw])
+                            tile_out[:] = tile_in[:] + tile_num
+                            ring.put(tile_out, indices=[th_next, tw_next])
 
-                    for i in range_(TILE_HEIGHT):
-                        for j in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val = load(tile_in2, [i, j])
+                            # ...and what arrives here came from the previous
+                            # worker, carrying that worker's number.
+                            tile_in2 = air.alloc(TILE_SIZE, i32, scope=h.private())
+                            tile_out2 = air.alloc(
+                                TILE_SIZE, i32, scope=h.private(), vector=0
+                            )
+                            ring.get(tile_in2, indices=[th, tw])
+                            tile_out2[:] = tile_in2[:]
+                            chan_out.put(tile_out2, indices=[th, tw])
 
-                            # Store the output value in tile_out
-                            store(val, tile_out2, [i, j])
-                            yield_([])
-                        yield_([])
+                    for i in range(GRID_HEIGHT):
+                        for j in range(GRID_WIDTH):
+                            chan_out.get(
+                                B[
+                                    i * TILE_HEIGHT : (i + 1) * TILE_HEIGHT,
+                                    j * TILE_WIDTH : (j + 1) * TILE_WIDTH,
+                                ],
+                                indices=[i, j],
+                            )
 
-                    # Copy the output tile into the output
-                    ChannelPut("ChanOut", tile_out2, indices=[th, tw])
-                    DeallocOp(tile_in2)
-                    DeallocOp(tile_out2)
-
-            # Transfer one tile of data per worker
-            for h in range(IMAGE_HEIGHT // TILE_HEIGHT):
-                for w in range(IMAGE_WIDTH // TILE_WIDTH):
-                    offset0 = TILE_HEIGHT * h
-                    offset1 = TILE_WIDTH * w
-
-                    # Write data back out to the channel tile by tile
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        indices=[h, w],
-                        offsets=[offset0, offset1],
-                        sizes=TILE_SIZE,
-                        strides=[IMAGE_WIDTH, 1],
-                    )
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="worker_to_worker.py",
         description="Builds, runs, and tests the channel worker_to_worker example",
     )
     parser.add_argument(
@@ -217,10 +166,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -228,33 +185,17 @@ if __name__ == "__main__":
     input_matrix = np.full(IMAGE_SIZE, 0x5, dtype=INOUT_DATATYPE)
     output_matrix = np.full(IMAGE_SIZE, 0x5, dtype=INOUT_DATATYPE)
 
-    def get_next_tile_num(tile_height, tile_width):
-        # This should be the same math for how tile next values are calculated in the herd
-        tw_next = (tile_width + 1) % (IMAGE_WIDTH // TILE_WIDTH)
-        th_next = (tile_height + ((tile_width + 1) // (IMAGE_WIDTH // TILE_WIDTH))) % (
-            IMAGE_HEIGHT // TILE_HEIGHT
-        )
-        assert tw_next >= 0 and tw_next <= (IMAGE_WIDTH // TILE_WIDTH)
-        assert th_next >= 0 and th_next <= (IMAGE_HEIGHT // TILE_HEIGHT)
-        print(f"{tile_height}, {tile_width} => {th_next}, {tw_next}")
-        return th_next, tw_next
+    # The tile that lands at (th, tw) was stamped by that worker's
+    # *predecessor*, so invert next_worker to find whose number to expect.
+    stamped_by = {}
+    for th in range(GRID_HEIGHT):
+        for tw in range(GRID_WIDTH):
+            stamped_by[next_worker(th, tw)] = th * GRID_WIDTH + tw
 
-    # Create a map of current tile coordinates to the tile_num of the "previous" tile num
-    tile_num_map = {}
-    for tile_height in range(IMAGE_HEIGHT // TILE_HEIGHT):
-        for tile_width in range(IMAGE_WIDTH // TILE_WIDTH):
-            next_tile_coords = get_next_tile_num(tile_height, tile_width)
-            tile_num_map[next_tile_coords] = (
-                # This should be the same math for how tile_num is calculated in the herd
-                tile_height * (IMAGE_WIDTH // TILE_WIDTH)
-                + tile_width
-            )
-
-    # Add the tile num of the "previous" tile to each value in each tile in the output data
     for i in range(IMAGE_HEIGHT):
         for j in range(IMAGE_WIDTH):
             output_matrix[i, j] = (
-                input_matrix[i, j] + tile_num_map[(i // TILE_HEIGHT, j // TILE_WIDTH)]
+                input_matrix[i, j] + stamped_by[(i // TILE_HEIGHT, j // TILE_WIDTH)]
             )
 
     runner = XRTRunner(

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -86,6 +86,7 @@ from ._trace import (
     SegmentContext,
     Symbol,
     alloc,
+    dealloc,
     herd,
     segment,
     symbol,
@@ -105,6 +106,7 @@ __all__ = [
     # declarations
     "tensor",
     "alloc",
+    "dealloc",
     "symbol",
     "extern",
     "channel",

--- a/python/air/api/_index.py
+++ b/python/air/api/_index.py
@@ -23,11 +23,20 @@ tracer needs cheap and exact:
     ``split_static_dynamic`` then keeps in the static half of a memcpy's
     access pattern instead of materialising an SSA operand.
 
-Non-linear combinations (leaf * leaf, floordiv/mod by a leaf) are rejected with
-an explicit error rather than silently degraded.
+``x // k`` and ``x % k`` for a *constant* ``k`` are affine too, but they are not
+linear, so they cannot be a coefficient on a leaf. They become a
+:class:`DerivedLeaf` -- an opaque term that the linear form treats exactly like
+a coordinate, and that expands back into ``affine.floordiv``/``affine.mod``
+only at materialisation. That keeps ``((tw + 1) % sw) * 2`` linear in the thing
+it is actually linear in, and it keeps the whole expression a single
+``affine.apply``, which is what ``worker_to_worker`` builds by hand.
+
+Genuinely non-affine combinations -- leaf * leaf, and floordiv/mod by a
+coordinate -- are rejected with an explicit error rather than silently
+degraded.
 """
 
-__all__ = ["IndexExpr", "Leaf", "coerce_index", "materialize_index"]
+__all__ = ["IndexExpr", "Leaf", "DerivedLeaf", "coerce_index", "materialize_index"]
 
 
 class Leaf:
@@ -44,8 +53,57 @@ class Leaf:
         self.value = value
         self.name = name
 
+    def leaves(self):
+        return (self,)
+
+    def _affine(self, symbol_of):
+        return symbol_of(self)
+
     def __repr__(self):
         return self.name
+
+
+class DerivedLeaf:
+    """``expr // k`` or ``expr % k`` for a constant ``k``, used as a leaf.
+
+    Neither operation is linear, so it cannot live in :class:`IndexExpr`'s
+    coefficient map directly. Wrapping it makes it opaque to the linear form
+    while remaining fully affine in the IR.
+
+    Unlike :class:`Leaf`, identity here is *structural*: two separately built
+    copies of ``(tw + 1) % sw`` must share a term so that they cancel under
+    subtraction and materialise once.
+    """
+
+    __slots__ = ("kind", "expr", "k", "_key")
+
+    def __init__(self, kind, expr, k):
+        self.kind = kind
+        self.expr = expr
+        self.k = int(k)
+        self._key = (kind, expr._key(), self.k)
+
+    def leaves(self):
+        return self.expr.leaves()
+
+    def _affine(self, symbol_of):
+        from air.ir import AffineExpr, AffineConstantExpr
+
+        lhs = self.expr._affine(symbol_of)
+        rhs = AffineConstantExpr.get(self.k)
+        if self.kind == "mod":
+            return AffineExpr.get_mod(lhs, rhs)
+        return AffineExpr.get_floor_div(lhs, rhs)
+
+    def __eq__(self, other):
+        return isinstance(other, DerivedLeaf) and self._key == other._key
+
+    def __hash__(self):
+        return hash(self._key)
+
+    def __repr__(self):
+        op = "mod" if self.kind == "mod" else "floordiv"
+        return f"({self.expr} {op} {self.k})"
 
 
 class IndexExpr:
@@ -108,29 +166,73 @@ class IndexExpr:
     def __neg__(self):
         return IndexExpr({leaf: -c for leaf, c in self.terms.items()}, -self.const)
 
-    def __floordiv__(self, other):
+    def _divide(self, other, kind):
         other = coerce_index(other)
-        if not self.terms and not other.terms:
-            return IndexExpr({}, self.const // other.const)
-        raise NotImplementedError(
-            "floordiv on a tile coordinate is not supported by air.api yet; "
-            "restructure the index as a linear expression"
-        )
+        if other.terms:
+            raise TypeError(
+                f"non-affine index expression: cannot take {kind} of {self} by "
+                f"{other} (the divisor must be a constant, not a tile "
+                "coordinate)"
+            )
+        k = other.const
+        if k <= 0:
+            raise ValueError(
+                f"index {kind} by {k}: the divisor must be a positive constant"
+            )
+        if not self.terms:
+            # Python's // and % are floor-based, which is what affine.floordiv
+            # and affine.mod implement, so the folded and emitted forms agree.
+            return IndexExpr(
+                {}, self.const // k if kind == "floordiv" else self.const % k
+            )
+        if k == 1:
+            return IndexExpr({}, 0) if kind == "mod" else self
+        return IndexExpr({DerivedLeaf(kind, self, k): 1}, 0)
+
+    def __floordiv__(self, other):
+        return self._divide(other, "floordiv")
 
     def __mod__(self, other):
-        other = coerce_index(other)
-        if not self.terms and not other.terms:
-            return IndexExpr({}, self.const % other.const)
-        raise NotImplementedError(
-            "mod on a tile coordinate is not supported by air.api yet; "
-            "restructure the index as a linear expression"
-        )
+        return self._divide(other, "mod")
+
+    def __rfloordiv__(self, other):
+        return coerce_index(other)._divide(self, "floordiv")
+
+    def __rmod__(self, other):
+        return coerce_index(other)._divide(self, "mod")
 
     # -- queries ------------------------------------------------------------
 
     def as_const(self):
         """The Python int value, or None if the expression is coordinate-dependent."""
         return self.const if not self.terms else None
+
+    def _key(self):
+        """A hashable structural key, so equal expressions share a DerivedLeaf."""
+        return (frozenset(self.terms.items()), self.const)
+
+    def leaves(self):
+        """The distinct real :class:`Leaf` values this expression reads, in order."""
+        seen = {}
+        for term in self.terms:
+            for leaf in term.leaves():
+                seen.setdefault(leaf, None)
+        return list(seen)
+
+    def _affine(self, symbol_of):
+        from air.ir import AffineExpr, AffineConstantExpr
+
+        expr = None
+        for term, coeff in self.terms.items():
+            part = term._affine(symbol_of)
+            if coeff != 1:
+                part = AffineExpr.get_mul(part, AffineConstantExpr.get(coeff))
+            expr = part if expr is None else AffineExpr.get_add(expr, part)
+        if expr is None:
+            return AffineConstantExpr.get(self.const)
+        if self.const:
+            expr = AffineExpr.get_add(expr, AffineConstantExpr.get(self.const))
+        return expr
 
     def __repr__(self):
         parts = [
@@ -152,19 +254,15 @@ class IndexExpr:
         if not self.terms:
             return self.const
 
-        from air.ir import AffineMap, AffineExpr, AffineSymbolExpr, AffineConstantExpr
+        from air.ir import AffineMap, AffineSymbolExpr
         from air.dialects.affine import apply as affine_apply
 
-        leaves = list(self.terms)
-        expr = None
-        for i, leaf in enumerate(leaves):
-            term = AffineSymbolExpr.get(i)
-            coeff = self.terms[leaf]
-            if coeff != 1:
-                term = AffineExpr.get_mul(term, AffineConstantExpr.get(coeff))
-            expr = term if expr is None else AffineExpr.get_add(expr, term)
-        if self.const:
-            expr = AffineExpr.get_add(expr, AffineConstantExpr.get(self.const))
+        # One symbol per distinct real leaf, shared across every term -- a
+        # DerivedLeaf expands in place rather than taking a symbol of its own,
+        # so `(tw + 1) % sw` and `tw` reach the map as the same symbol.
+        leaves = self.leaves()
+        position = {leaf: i for i, leaf in enumerate(leaves)}
+        expr = self._affine(lambda leaf: AffineSymbolExpr.get(position[leaf]))
 
         amap = AffineMap.get(0, len(leaves), [expr])
         return affine_apply(amap, [leaf.value for leaf in leaves])

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -44,6 +44,7 @@ __all__ = [
     "herd",
     "segment",
     "alloc",
+    "dealloc",
     "tensor",
     "symbol",
     "wait",
@@ -252,23 +253,6 @@ def open_launch_region(launch, tensors, counts, body):
         finally:
             for t, v in zip(tensors, saved):
                 t.value = v
-
-
-def infer_name(fallback, depth=2):
-    """Recover ``tile_m`` from the source line ``tile_m = air.symbol()``.
-
-    Cosmetic only: it affects how ``launch.search_space`` and error messages
-    read back, never what is emitted.
-    """
-    try:
-        frame = inspect.stack()[depth]
-        line = (frame.code_context or [""])[0]
-        match = re.match(r"\s*([A-Za-z_]\w*)\s*=", line)
-        if match:
-            return match.group(1)
-    except Exception:
-        pass
-    return fallback
 
 
 def infer_name(fallback, depth=2):
@@ -526,6 +510,123 @@ def _positional_arity(fn):
     )
 
 
+def _block_position(block, op):
+    for i, other in enumerate(block.operations):
+        if other.operation == op:
+            return i
+    raise AssertionError("operation is not in the block it reports as its parent")
+
+
+def _last_use_anchor(value, ignore=None):
+    """The op in ``value``'s own block after which ``value`` is no longer read.
+
+    A use nested inside a loop keeps the buffer live until the loop as a whole
+    is finished, so each use is walked out to the ancestor that sits directly
+    in the block the alloc was emitted into. ``ignore`` drops one op from the
+    scan, so that a dealloc can ask where the last *other* use was.
+    """
+    home = value.owner.operation.block
+    anchor = value.owner.operation
+    best = _block_position(home, anchor)
+    for use in value.uses:
+        op = use.owner.operation
+        if ignore is not None and op == ignore:
+            continue
+        while op.block != home:
+            op = op.parent
+        position = _block_position(home, op)
+        if position > best:
+            anchor, best = op, position
+    return home, anchor
+
+
+def free_buffers(buffers):
+    """End the life of every buffer that ``air.dealloc`` did not already end.
+
+    A buffer's lifetime is a logical property the tracer can see: it ends at
+    the last op that reads or writes it. Emitting every dealloc at the end of
+    the body instead overstates that lifetime, and the overstatement is not
+    free -- it tells the compiler a value is still needed when it is not, so
+    the schedule it builds has to keep the buffer available for longer than the
+    program requires. In a design where each worker hands its tile to a
+    neighbour, that is enough to serialise the hand-off into a cycle and hang
+    the herd (``channel_examples/worker_to_worker``).
+
+    Inference is the default rather than the only option: ``air.dealloc``
+    exists for a program that wants to say where a buffer dies. This also
+    checks those explicit calls, which is the one thing inference cannot get
+    wrong and a hand-placed release can.
+
+    Every anchor is computed before any dealloc is emitted, so the deallocs
+    this adds cannot themselves count as uses.
+    """
+    from air.dialects.memref import DeallocOp
+    from air.ir import InsertionPoint
+
+    pending = []
+    for buf in buffers:
+        if buf.released is not None:
+            _check_released(buf)
+        else:
+            pending.append((buf, *_last_use_anchor(buf.value)))
+
+    for buf, home, anchor in pending:
+        successor, seen = None, False
+        for op in home.operations:
+            if seen:
+                successor = op.operation
+                break
+            seen = op.operation == anchor
+        # No successor means the anchor is currently last in the block; the
+        # region's terminator has not been appended yet, so the end is right.
+        with InsertionPoint(successor) if successor else InsertionPoint(home):
+            DeallocOp(buf.value)
+
+
+def _check_released(buf):
+    """Reject an air.dealloc that a later use contradicts."""
+    release = buf.released
+    home, anchor = _last_use_anchor(buf.value, ignore=release)
+    if release.block != home:
+        raise ValueError(
+            "air.dealloc released a buffer from a different region than the "
+            "one it was allocated in; release it in the body that allocated "
+            "it, so the dealloc is dominated by its alloc"
+        )
+    if _block_position(home, anchor) > _block_position(home, release):
+        raise ValueError(
+            f"air.dealloc released this buffer before its last use "
+            f"({anchor.name}): a released buffer cannot be read or written "
+            "again. Move the air.dealloc after the last op that touches it, "
+            "or drop it and let air.api place it there."
+        )
+
+
+def dealloc(buffer):
+    """End a buffer's life here, rather than letting the tracer infer it.
+
+    The counterpart to :func:`alloc`. Without it the tracer places the release
+    after the last use it observes, which is what a program that does not care
+    wants; call this when the program has something to say about the point
+    itself -- and on a target with a real allocator behind ``memref.dealloc``,
+    that point is a free rather than a scheduling hint.
+
+    Using the buffer afterwards is an error, reported when the body is finished
+    rather than at this call: the tracer has to see the rest of the body before
+    it can know whether a later use exists.
+    """
+    from air.dialects.memref import DeallocOp
+
+    if not isinstance(buffer, Buffer):
+        raise TypeError(
+            f"air.dealloc takes a buffer from air.alloc, got "
+            f"{type(buffer).__name__}"
+        )
+    if buffer.released is not None:
+        raise ValueError("air.dealloc: this buffer has already been released")
+    buffer.released = DeallocOp(buffer.value).operation
+
+
 # ---------------------------------------------------------------------------
 # Segment
 # ---------------------------------------------------------------------------
@@ -659,7 +760,6 @@ class SegmentContext:
         global _CURRENT_SEGMENT
 
         from air.dialects.air import segment as segment_region
-        from air.dialects.memref import DeallocOp
 
         tensors = trace.tensors
         segment_self = self
@@ -690,8 +790,7 @@ class SegmentContext:
             previous, _CURRENT_SEGMENT = _CURRENT_SEGMENT, segment_self
             try:
                 fn(*coords)
-                for buf in segment_self._buffers:
-                    DeallocOp(buf.value)
+                free_buffers(segment_self._buffers)
             finally:
                 segment_self._buffers.clear()
                 for t, v in zip(tensors, saved):
@@ -823,7 +922,6 @@ class HerdContext:
             )
 
         from air.dialects.air import herd as herd_region
-        from air.dialects.memref import DeallocOp
         from air.dialects.scf import for_ as range_, yield_
 
         from ._loop import aborted_loops, enter_body, exit_body
@@ -881,11 +979,11 @@ class HerdContext:
                         tile = tile + IndexExpr.leaf(strip_ivs[axis], f"i{axis}")
                     tile_ids.append(tile)
                 fn(*tile_ids)
-                # Free within the same region the allocs were emitted into: with
-                # strip-mining that region is the innermost scf.for body, and a
-                # dealloc hoisted above it would not be dominated by its alloc.
-                for buf in herd_self._buffers:
-                    DeallocOp(buf.value)
+                # Each dealloc lands in the block its alloc was emitted into,
+                # which under strip-mining is the innermost scf.for body: a
+                # dealloc hoisted above that would not be dominated by its
+                # alloc.
+                free_buffers(herd_self._buffers)
                 herd_self._buffers.clear()
 
             outer_depth = enter_body()

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -175,6 +175,10 @@ class Buffer:
         # The memref SSA value produced by memref.alloc.
         self.value = value
         self.strides = _row_major_strides(self.shape)
+        # The memref.dealloc that ended this buffer's life, if air.dealloc was
+        # called on it. None means the tracer will place one itself, after the
+        # last use it observes.
+        self.released = None
 
     # -- reading: whole tile is a lazy expression, a region is a DMA slice ---
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -294,6 +294,75 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: nonaffine_divisor
+# `x // k` and `x % k` are affine for a constant k, and only for a constant k:
+# affine.floordiv and affine.mod both require a literal right-hand side. A
+# coordinate divisor has to say so, rather than reporting the operation itself
+# as unsupported -- it is the divisor that is the problem.
+# CHECK: TypeError: non-affine index expression: cannot take floordiv of {{.*}} by {{.*}} (the divisor must be a constant, not a tile coordinate)
+@expect(TypeError, "nonaffine_divisor")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 64], bf16, scope=h.private())
+        row = tx // ty
+        air.ops.load(a, A[row : row + 64, 0:64])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: nonpositive_divisor
+# CHECK: ValueError: index mod by 0: the divisor must be a positive constant
+@expect(ValueError, "nonpositive_divisor")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 64], bf16, scope=h.private())
+        row = tx % 0
+        air.ops.load(a, A[row : row + 64, 0:64])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: use_after_dealloc
+# air.dealloc ends a buffer's life, so a later read is a use of something the
+# program has said is gone. It is reported when the body finishes rather than
+# at the air.dealloc call: whether a later use exists is not knowable until the
+# rest of the body has been traced.
+# CHECK: ValueError: air.dealloc released this buffer before its last use
+@expect(ValueError, "use_after_dealloc")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 64], bf16, scope=h.private())
+        b = air.alloc([64, 64], bf16, scope=h.private())
+        air.ops.load(a, A[0:64, 0:64])
+        air.dealloc(a)
+        b[:] = a[:] + 1.0
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: double_dealloc
+# CHECK: ValueError: air.dealloc: this buffer has already been released
+@expect(ValueError, "double_dealloc")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 64], bf16, scope=h.private())
+        air.ops.load(a, A[0:64, 0:64])
+        air.dealloc(a)
+        air.dealloc(a)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dealloc_not_a_buffer
+# CHECK: TypeError: air.dealloc takes a buffer from air.alloc, got Tensor
+@expect(TypeError, "dealloc_not_a_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        air.dealloc(A)
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: bad_grid_type
 # CHECK: TypeError: cannot use list as a herd iteration space
 @expect(TypeError, "bad_grid_type")

--- a/python/test/api/index.py
+++ b/python/test/api/index.py
@@ -1,0 +1,157 @@
+# ./python/test/api/index.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Index arithmetic on a tile coordinate reaches the IR as one affine.apply.
+
+``IndexExpr`` keeps an expression as an affine *linear* form -- coefficients on
+leaves, plus a constant -- because that is what makes a slice like
+``A[row : row + tm]`` recover its static size by cancellation. ``//`` and ``%``
+are affine but not linear, so they cannot be a coefficient on a leaf; they
+become a ``DerivedLeaf``, which the linear form carries like a coordinate and
+expands only at materialisation.
+
+Two consequences are pinned below. The whole expression still lowers to a
+single ``affine.apply`` -- the AIR dependency analysis and the DMA
+specialisation passes read affine offsets directly and lose track of them when
+the arithmetic is scattered across ``arith`` ops. And a ``DerivedLeaf`` is
+compared *structurally*, not by identity, so two separately built copies of
+``(tw + 1) % W`` are one term and cancel.
+
+``channel_examples/worker_to_worker`` is the example this exists for: it builds
+exactly the two maps below by hand, with ``AffineExpr.get_mod`` and
+``get_floor_div``.
+"""
+
+from air import api as air
+from air.api.types import i32
+
+H, W = 2, 3
+TH, TW = 2, 4
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: ring_neighbour
+#
+# The worker's successor on a row-major ring:
+#     tw_next = (tw + 1) % W
+#     th_next = (th + (tw + 1) // W) % H
+# Each is one map over the herd coordinates -- the floordiv nests *inside* the
+# mod rather than being materialised as its own affine.apply, because the
+# DerivedLeaf expands in place.
+# CHECK-DAG: #[[NEXTW:.*]] = affine_map<()[s0] -> ((s0 + 1) mod 3)>
+# CHECK-DAG: #[[NEXTH:.*]] = affine_map<()[s0, s1] -> ((s0 + (s1 + 1) floordiv 3) mod 2)>
+#
+# Both coordinates feed one map, sharing a symbol each: a DerivedLeaf takes no
+# symbol of its own.
+# CHECK: air.herd @ring
+# CHECK-DAG: %[[TWN:.*]] = affine.apply #[[NEXTW]]()[%[[TW:.*]]]
+# CHECK-DAG: %[[THN:.*]] = affine.apply #[[NEXTH]]()[%{{.*}}, %[[TW]]]
+# CHECK: air.channel.put @Ring[%{{.*}}, %{{.*}}]
+@run
+def ring_neighbour():
+    A = air.tensor([H * TH, W * TW], i32)
+    ring = air.channel("Ring", size=[H, W])
+    back = air.channel("Back", size=[H, W])
+
+    with air.launch(name="ring_launch") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    with air.herd([range(H), range(W)], name="ring", shape=(H, W)) as h:
+
+                        @h.body
+                        def _(th, tw):
+                            buf = air.alloc([TH, TW], i32, scope=h.private())
+                            ring.put(
+                                buf, indices=[(th + (tw + 1) // W) % H, (tw + 1) % W]
+                            )
+                            ring.get(buf, indices=[th, tw])
+                            back.put(buf, indices=[th, tw])
+
+                    for i in range(H):
+                        for j in range(W):
+                            back.get(
+                                A[i * TH : (i + 1) * TH, j * TW : (j + 1) * TW],
+                                indices=[i, j],
+                            )
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: structural_cancellation
+# A DerivedLeaf is keyed on the expression it wraps, not on object identity, so
+# the two independently built copies of (tw + 1) % W below are one term and
+# subtract to zero. The offset is then a plain Python int and stays in the
+# static half of the access pattern -- which is the whole reason the linear
+# form exists, and it has to keep working with a non-linear term present.
+# CHECK: air.herd @cancel
+# CHECK-NOT: mod
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[0, %{{.*}}] [2, 4] [12, 1])
+@run
+def structural_cancellation():
+    A = air.tensor([H * TH, W * TW], i32)
+    B = air.tensor([H * TH, W * TW], i32)
+
+    with air.launch(name="cancel_launch") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(W)], name="cancel", shape=(W,)) as h:
+
+                @h.body
+                def _(tw):
+                    buf = air.alloc([TH, TW], i32, scope=h.private())
+                    # Built twice, deliberately, rather than computed once and
+                    # subtracted from itself: two calls produce two distinct
+                    # DerivedLeaf objects, so they only collapse into one term
+                    # if the key is the expression. Reusing a single value would
+                    # cancel under object identity too and prove nothing.
+                    row = ((tw + 1) % W) - ((tw + 1) % W)
+                    col = tw * TW
+                    air.ops.load(buf, A[row : row + TH, col : col + TW])
+                    air.ops.store(buf, B[row : row + TH, col : col + TW])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: trivial_divisor
+# Dividing by 1 is folded rather than emitted: `x // 1` is x, and `x % 1` is
+# the constant 0. So the row offset below is static and the column is the bare
+# coordinate, with neither a floordiv nor a mod reaching the IR.
+# CHECK: air.herd @trivial
+# CHECK-NOT: floordiv
+# CHECK-NOT: mod
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[0, %{{.*}}] [2, 4] [12, 1])
+@run
+def trivial_divisor():
+    A = air.tensor([H * TH, W * TW], i32)
+    B = air.tensor([H * TH, W * TW], i32)
+
+    with air.launch(name="trivial_launch") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(W)], name="trivial", shape=(W,)) as h:
+
+                @h.body
+                def _(tw):
+                    buf = air.alloc([TH, TW], i32, scope=h.private())
+                    row = tw % 1
+                    col = (tw // 1) * TW
+                    air.ops.load(buf, A[row : row + TH, col : col + TW])
+                    air.ops.store(buf, B[row : row + TH, col : col + TW])
+
+    print(launch.mlir())

--- a/python/test/api/lifetime.py
+++ b/python/test/api/lifetime.py
@@ -1,0 +1,119 @@
+# ./python/test/api/lifetime.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""A buffer's life ends at its last use, and ``air.dealloc`` can say so.
+
+``air.alloc`` has a counterpart. Most programs never need to write it: the
+tracer sees every op that touches a buffer, so it knows where the buffer stops
+being needed and places the ``memref.dealloc`` there. Programs that have
+something to say about the point call ``air.dealloc``.
+
+What the placement is *for* depends on the target, which is why it belongs in
+the program and not in a backend heuristic. Lowered to AIE it is a scheduling
+fact -- it tells the compiler the value is no longer needed, so the schedule
+does not have to keep it available. Lowered through the ROCDL path it is a
+free. Holding every buffer to the end of the body asserts the opposite of both,
+and in ``channel_examples/worker_to_worker`` that assertion is enough to
+serialise a ring of workers into a cycle and hang the herd.
+"""
+
+from air import api as air
+from air.api.types import i32
+
+N = 8
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def _kernel(release=None):
+    """A -> a -> b -> B, where `release` may free `a` mid-body."""
+    A = air.tensor([N, N], i32)
+    B = air.tensor([N, N], i32)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([N, N], i32, scope=h.private())
+                    b = air.alloc([N, N], i32, scope=h.private(), vector=0)
+                    air.ops.load(a, A)
+                    b[:] = a[:] + 1
+                    if release:
+                        air.dealloc(a)
+                    air.ops.store(b, B)
+
+    return launch
+
+
+# CHECK-LABEL: TEST: inferred_at_last_use
+# `a` is dead once the elementwise loop has read it, so it is freed there --
+# before the store that reads `b`, not alongside it at the end of the body.
+# `b` stays live across that store, because the store is its last use.
+# CHECK: %[[A:.*]] = memref.alloc() : memref<8x8xi32, 2 : i32>
+# CHECK: %[[B:.*]] = memref.alloc() : memref<8x8xi32, 2 : i32>
+# CHECK: air.dma_memcpy_nd (%[[A]][] [] []
+# CHECK: arith.addi
+# CHECK: memref.dealloc %[[A]] : memref<8x8xi32, 2 : i32>
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %[[B]][] [] [])
+# CHECK: memref.dealloc %[[B]] : memref<8x8xi32, 2 : i32>
+@run
+def inferred_at_last_use():
+    print(_kernel().mlir())
+
+
+# CHECK-LABEL: TEST: explicit_matches_inferred
+# Writing the release out by hand at the point the tracer would have chosen
+# produces the same module. That is the property that makes air.dealloc safe to
+# add to an existing kernel: it pins the placement rather than changing it.
+# CHECK: identical to inferred: True
+# CHECK: memref.dealloc
+# CHECK: air.dma_memcpy_nd
+# CHECK: memref.dealloc
+@run
+def explicit_matches_inferred():
+    inferred = _kernel().mlir()
+    explicit = _kernel(release=True).mlir()
+    print("identical to inferred:", str(inferred) == str(explicit))
+    print(explicit)
+
+
+# CHECK-LABEL: TEST: use_inside_a_loop_holds_it
+# A use nested in a loop keeps the buffer live until the loop as a whole is
+# done: the release lands after the scf.for, never inside it, where it would
+# free the buffer on the first trip and leave the rest reading dead memory.
+# CHECK: scf.for
+# CHECK: memref.dealloc
+# CHECK-NOT: scf.for
+@run
+def use_inside_a_loop_holds_it():
+    A = air.tensor([N, N], i32)
+    B = air.tensor([N, N], i32)
+
+    with air.launch(name="looped") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([N], i32, scope=h.private())
+                    b = air.alloc([N], i32, scope=h.private(), vector=0)
+                    for i in air.sequential(0, N):
+                        air.ops.load(a, A[i : i + 1, 0:N])
+                        b[:] = a[:] + 1
+                        air.ops.store(b, B[i : i + 1, 0:N])
+
+    print(launch.mlir())

--- a/python/test/api/segment.py
+++ b/python/test/api/segment.py
@@ -108,9 +108,15 @@ def run(f):
 # L1 -> L2 writeback into the same window, then L2 -> L3 once, after the herd.
 # CHECK: air.dma_memcpy_nd (%{{.*}}[%{{.*}}, 0] [1, 64] [64, 1], %{{.*}}[] [] []) : (memref<4x64xi32, 1 : i32>, memref<64xi32, 2 : i32>)
 # CHECK: memref.dealloc {{.*}} : memref<64xi32, 2 : i32>
-# CHECK: air.dma_memcpy_nd (%{{.*}}[0, 0] [4, 64] [64, 1], %{{.*}}[] [] []) : (memref<4x64xi32>, memref<4x64xi32, 1 : i32>)
-# CHECK: memref.dealloc {{.*}} : memref<4x64xi32, 1 : i32>
-# CHECK: memref.dealloc {{.*}} : memref<4x64xi32, 1 : i32>
+#
+# Each buffer is freed after its own last use, not all of them together at the
+# end of the body. The input staging buffer is dead once the herd has run, so
+# it is freed there; the output one stays live across the L2 -> L3 write that
+# reads it. Holding both to the end would tell the compiler two values are
+# still needed when only one is.
+# CHECK: memref.dealloc %[[IN:.*]] : memref<4x64xi32, 1 : i32>
+# CHECK: air.dma_memcpy_nd (%{{.*}}[0, 0] [4, 64] [64, 1], %[[OUT:.*]][] [] []) : (memref<4x64xi32>, memref<4x64xi32, 1 : i32>)
+# CHECK: memref.dealloc %[[OUT]] : memref<4x64xi32, 1 : i32>
 @run
 def staged_passthrough():
     print(build().mlir())


### PR DESCRIPTION
Converts `channel_examples/worker_to_worker` onto `air.api`, replacing the raw-bindings version. It needed two things the DSL could not express.

## 1. `%` and `//` on a tile coordinate

Neither is linear, so neither can be a coefficient on a leaf in `IndexExpr`'s affine form. Both now become a `DerivedLeaf`, which the linear form carries like a coordinate and expands into `affine.mod` / `affine.floordiv` only at materialisation — so the whole expression still lowers to one `affine.apply`, and a `DerivedLeaf` takes no symbol of its own.

The maps are the ones the predecessor built by hand with `AffineExpr.get_mod` and `get_floor_div`:

```
                     predecessor (hand-built AffineMap)   air.api (Python operators)
tile_num          →  ()[s0, s1] -> (s0 * 3 + s1)          ()[s0, s1] -> (s0 * 3 + s1)
th_next           →  ((s0 + (s1 + 1) floordiv 3) mod 2)   ((s0 + (s1 + 1) floordiv 3) mod 2)
tw_next           →  ((s0 + 1) mod 3)                     ((s0 + 1) mod 3)
```

A coordinate divisor is still rejected — affine requires a literal — but the message now names the divisor as the problem rather than reporting the operation as unsupported.

**None of this runs on the NPU.** `air-to-aie` clones the herd body per core with the coordinates folded to constants. In the final `npu.air.mlir`:

```
affine.apply anywhere in the module:  0
mod / floordiv in any affine_map:     0
aie.core bodies:                      6
aie.flow (static routes):            18
```

A core body is loads, stores, one `addi` and lock ops; the tile number arrives as `arith.constant 5`. The affine form exists to carry the expression from trace time — where the body is walked once, symbolically — to specialisation.

## 2. Buffer lifetime

Every dealloc used to be emitted at the end of the body. That overstates the lifetime — it tells the compiler a value is still needed when it is not — and the overstatement is not free. Each dealloc now lands after the buffer's own last use, walked out to the ancestor sitting in the block the alloc was emitted into, so a use nested in a loop still holds the buffer until the loop is done.

`air.dealloc(buf)` is added alongside, for a program that wants to name the point rather than let the tracer infer it. This is not an AIE detail: the in-tree ROCDL path (`AIRToROCDLPass.cpp`) has a real allocator behind `memref.dealloc`. Releasing before the last use, releasing twice, and passing a non-buffer all raise; the first is reported when the body finishes, since whether a later use exists is not knowable at the call.

**No new MLIR op is emitted.** `memref.dealloc` was already emitted, just later.

### How the deadlock was isolated

The conversion timed out while the predecessor passed. Six raw-bindings variants of the predecessor, one change each:

| variant | change | npu1 |
|---|---|---|
| predecessor | — | **PASS** |
| v1 | L3 put/get moved inside the segment | PASS |
| v2 | v1 + unused L3 memrefs as herd operands | PASS |
| v3 | v2 + a 1×1 `air.launch` grid | PASS |
| v4 | v2 + identity `affine.apply` on channel indices | PASS |
| v5 | v3 + **all deallocs deferred to the end of the body** | **TIMEOUT** |
| v6 | v3 + `tile_num` computed inside the loop nest | PASS |

Diffing the two final `npu.air.mlir` files — 562 lines each, identical `aie.buffer` (24) and `aie.lock` (48) counts — the only difference is the position of two `aie.use_lock(..., Release, ...)` per core. Deferring the release makes every core acquire its predecessor's tile before releasing its own to its successor: a six-core circular wait.

## Verification, on npu1 (Phoenix)

- `worker_to_worker`: **`PASS!`**. Its predecessor also passes, so the README's *"This example currently fails for unknown reasons"* is stale and is dropped along with the WIP marker.
- `lit -sv build/python/test/ --filter=api` → `Passed : 12 (36.36%)`, including the two new files.
- The 24 previously converted examples: IR differs from baseline **only** in dealloc position, and **no file changed its dealloc count**. Across the `air.dealloc` addition they are byte-identical (24/24).
- npu1 lit sweep over every converted example: **29 pass, 1 fails.** The failure is `matrix_vector_multiplication/bf16/run_npu1_makefile_peano.lit`, at `PROFILE1`, with `xrt/xrt_bo.h: No such file or directory`. Its three correctness runs (`RUN1`/`RUN2`/`RUN3`) pass, and a rebuild **without** this change reproduces the identical failure — the local build was configured without XRT, so lit passes `XILINX_XRT=XRT_DIR-NOTFOUND` to the C++ profiling harness. Not a regression and not related to this change.

Not verified here: the `chess` and `ryzen_ai_npu2` lits, which this box cannot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)