### PR TITLE
[CI] Publish what the nightly actually measured

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -8,14 +8,23 @@
 # uploading it as an artifact. Kept out of the per-PR matrix so perf numbers are
 # contention-free. The job goes red if any model's compile/verify fails.
 #
-# Numbers here are this runner's, and are not the figures the examples' READMEs
-# quote. llama32_1b_q4nx measures ~39-40 tok/s / ~1130ms TTFT on it, against
-# ~50 tok/s / ~910ms on a Ryzen AI 9 HX 370. That gap is a property of the
-# runner, not a regression: the identical build (same air SHA, mlir-aie wheel,
-# Peano and llvm-link, byte-identical decode insts.bin) hits ~50 on the HX 370,
-# and both machines report 51.0 TOPS from `xrt-smi validate --run gemm`, Turbo
-# power mode and DDR5-5600. The unexplained difference is the runner's ACPI
-# platform profile (`balanced`), which is why it is logged below.
+# Numbers here are this runner's (Ryzen AI 5 PRO 340, 2x32GB DDR5-5600 SODIMM)
+# and are not the figures the examples' READMEs quote. llama32_1b_q4nx measures
+# ~64 tok/s / ~894ms TTFT on it as of run 32458944539 (2026-08-21).
+#
+# It used to measure ~39-40 tok/s / ~1130ms, against ~50 tok/s / ~910ms on a
+# Ryzen AI 9 HX 370, off an identical build (same air SHA, mlir-aie wheel, Peano
+# and llvm-link, byte-identical decode insts.bin) with both machines reporting
+# 51.0 TOPS from `xrt-smi validate --run gemm`, Turbo power mode and DDR5-5600.
+# That difference was logged as unexplained, with the runner's ACPI platform
+# profile (`balanced`) as the suspect. The suspect was right: the profile became
+# `performance` during 2026-08-18 and the number stepped 42.51 -> 64.12 tok/s
+# between consecutive runs 32166148043 and 32193537561, holding at ~64 since.
+#
+# So the profile is still logged below, but now as the thing most likely to move
+# these numbers rather than as an open question. Power mode (Turbo) is logged for
+# the same reason. Decode streams the whole weight set per token, so both of
+# those and any unrelated load competing for DRAM bandwidth show up directly.
 
 name: Nightly LLM Perf Benchmark
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,11 @@ nav:
     - GEMM Case Study: GEMMCaseStudy.md
   - Programming Examples: programming_examples/index.md
   - LLMs on NPU:
-    - llms/index.md
+    # Labelled, like every other entry here. generate_readme.py leads the page
+    # with its "auto-generated, do not edit" comment, and a leading HTML comment
+    # stops MkDocs extracting the title from the first H1 -- so an unlabelled
+    # entry falls back to the filename and this one published as "Index".
+    - Overview: llms/index.md
     - Performance History: llms/perf-history.md
   - Official AI Skills: ai_skills.md
   - MLIR Reference:

--- a/programming_examples/generate_perf_history.py
+++ b/programming_examples/generate_perf_history.py
@@ -65,7 +65,7 @@ def load_history(history_path):
     if not p or not p.is_file():
         return []
     rows = []
-    for line in p.read_text().splitlines():
+    for line in p.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -341,9 +341,12 @@ def main():
     # Always write a page (empty-state when there are no rows) so the site's
     # link to this page is stable and never 404s.
     args.output.write_text(
-        generate_embed_md(rows, args.window)
-        if args.embed
-        else generate_html(rows, args.window)
+        (
+            generate_embed_md(rows, args.window)
+            if args.embed
+            else generate_html(rows, args.window)
+        ),
+        encoding="utf-8",
     )
     print(f"Generated {args.output} ({len(rows)} rows)")
     return 0

--- a/programming_examples/generate_perf_history.py
+++ b/programming_examples/generate_perf_history.py
@@ -169,10 +169,9 @@ HTML_TEMPLATE = """\
 <body>
 <p><a href="index.html">&larr; Back to Programming Examples dashboard</a></p>
 <h1>LLM Performance History (NPU2)</h1>
-<p class="sub">Per-nightly end-to-end inference performance on the AMD Ryzen AI (Krackan Point, NPU2)
-benchmark runner. Each point is one nightly build, labeled by date; hover to see the commit SHA and
-verify status. A <span style="color:{fail_color}; font-weight:700;">red &#10007; marker</span> flags a nightly
-whose correctness verify failed (the marker shape, not just its color, signals the failure).</p>
+<p class="sub">Per-nightly TTFT and decode throughput. Each point is one nightly, labeled by date;
+hover for the commit and verify status. A
+<span style="color:{fail_color}; font-weight:700;">red &#10007;</span> marks a nightly whose verify failed.</p>
 <p class="legend-note">Click a model in a legend to toggle its line.{window_note}</p>
 
 <div class="chart-box"><canvas id="ttft"></canvas></div>
@@ -240,8 +239,7 @@ EMPTY_TEMPLATE = """\
 <body>
 <p><a href="index.html">&larr; Back to Programming Examples dashboard</a></p>
 <h1>LLM Performance History (NPU2)</h1>
-<p class="sub">No nightly performance history has been recorded yet. Charts will appear here once the
-nightly LLM benchmark has published its first datapoints.</p>
+<p class="sub">No nightly data recorded yet.</p>
 </body>
 </html>
 """
@@ -287,12 +285,7 @@ def generate_embed_md(rows, window=DEFAULT_WINDOW):
     theme chrome instead of restyling the whole page.
     """
     if not rows:
-        return (
-            "# LLM Performance History\n\n"
-            "No nightly performance history has been recorded yet. Charts will "
-            "appear here once the nightly LLM benchmark has published its first "
-            "datapoints.\n"
-        )
+        return "# LLM Performance History (NPU2)\n\nNo nightly data recorded yet.\n"
     import re
 
     html = generate_html(rows, window)
@@ -301,7 +294,7 @@ def generate_embed_md(rows, window=DEFAULT_WINDOW):
     if not cdn_m or not body_m:
         # Template shape changed unexpectedly; fall back to the standalone page
         # rather than raising, so the docs build never breaks on this page.
-        return "# LLM Performance History\n\n" + html
+        return "# LLM Performance History (NPU2)\n\n" + html
     body = body_m.group(1)
     body = re.sub(r'<p><a href="index.html">.*?</a></p>\s*', "", body, flags=re.S)
     body = re.sub(r"<h1>.*?</h1>\s*", "", body, count=1, flags=re.S)
@@ -309,7 +302,7 @@ def generate_embed_md(rows, window=DEFAULT_WINDOW):
     # <style> is deliberately NOT reused — its `body`/`h1`/`a` global selectors
     # would restyle the surrounding Material page chrome.
     style = "<style>.chart-box { position: relative; height: 380px; margin: 32px 0; }</style>"
-    return f"# LLM Performance History\n\n{cdn_m.group(0)}\n{style}\n{body}\n"
+    return f"# LLM Performance History (NPU2)\n\n{cdn_m.group(0)}\n{style}\n{body}\n"
 
 
 def main():

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -573,6 +573,7 @@ def load_llm_sweep_history(path):
     if not path or not Path(path).is_file():
         return []
     newest = {}
+    verify = {}
     for line in Path(path).read_text().splitlines():
         if not line.strip():
             continue
@@ -590,9 +591,22 @@ def load_llm_sweep_history(path):
         better = r.get("decode_tokens_per_sec") is not None
         if cur is None or (better, ts) >= (cur[0], cur[1]):
             newest[(model, ctx)] = (better, ts, r)
+        # Verify is a per-model property of the whole run, so it is tracked
+        # across the model's rows rather than taken from whichever point won
+        # above -- a stale-but-measured point must not drag a stale verify
+        # badge along with it. Strictly newest, with no preference for a
+        # non-empty value: unlike a throughput number, a correctness badge that
+        # silently goes stale is worse than one that is blank, and this table
+        # has no per-row date to reveal the staleness. Blank until the next
+        # nightly appends the field is the intended transition.
+        if model not in verify or ts >= verify[model][0]:
+            verify[model] = (ts, r.get("verify_status", ""))
     curves = {}
     for (model, ctx), (_, _, r) in sorted(newest.items()):
-        curves.setdefault(model, {"model": model, "points": []})["points"].append(
+        curves.setdefault(
+            model,
+            {"model": model, "points": [], "verify_status": verify[model][1]},
+        )["points"].append(
             {
                 "context_len": ctx,
                 "decode_tokens_per_sec": r.get("decode_tokens_per_sec"),

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -706,18 +706,8 @@ def render_llm_sweep(recs, base_url=""):
     legend = "\n\n".join(
         note
         for marker, note in (
-            (
-                "—",
-                "— context not reached on this runner (XRT would not pin enough "
-                "host memory for the KV cache; the limit is the machine's, not "
-                "the design's)",
-            ),
-            (
-                "✗",
-                "✗ the sweep did not produce a number here (build, template or "
-                "dispatch failure) — a defect to investigate, not a limit of the "
-                "machine",
-            ),
+            ("—", "— context not reached (KV cache exceeds what XRT will pin)."),
+            ("✗", "✗ sweep failed (build, template or dispatch)."),
         )
         if marker in markers
     )
@@ -875,13 +865,13 @@ def render_llm_benchmark(
 
 ## Nightly LLM Benchmark (NPU2)
 
-End-to-end LLM inference performance on the AMD Ryzen AI 5 PRO 340 (Krackan Point, NPU2) benchmark runner — 2×32 GB DDR5-5600 SODIMM — refreshed nightly. Decode streams the whole weight set per token, so it tracks DRAM bandwidth and these numbers do not transfer to a differently configured machine. **TTFT** is time to first token (prefill latency); **Decode** is steady-state generation throughput.
+End-to-end LLM inference performance on the AMD Ryzen AI 5 PRO 340 (Krackan Point, NPU2) benchmark runner — 2×32 GB DDR5-5600 SODIMM — refreshed nightly. **TTFT** is time to first token (prefill latency); **Decode** is steady-state generation throughput.
 
 | Model | Context | TTFT (ms) | Decode (tok/s) | Measured | Verify |
 |:------|--------:|----------:|---------------:|:---------|:------:|
 {table}
 
-\U0001f7e2 verify passed &nbsp; \U0001f534 verify failed &nbsp; ⚪ verify skipped &nbsp; — metric not captured (e.g. the model's profile run failed)
+Verify: \U0001f7e2 pass &nbsp; \U0001f534 fail &nbsp; ⚪ skipped. &nbsp; — not measured.
 
 {_sweep_table}
 \U0001f4c8 [Performance history over time]({perf_history_link}) — per-nightly TTFT and decode throughput plotted per model.

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -434,7 +434,7 @@ def parse_lit_file(filepath):
     """Extract REQUIRES tags and XFAIL presence from a .lit file."""
     requires_tags = set()
     has_xfail = False
-    with open(filepath, "r") as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         for line in f:
             m = re.search(r"//\s*REQUIRES:\s*(.+)", line)
             if m:
@@ -574,7 +574,7 @@ def load_llm_sweep_history(path):
         return []
     newest = {}
     verify = {}
-    for line in Path(path).read_text().splitlines():
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         try:
@@ -625,7 +625,7 @@ def load_llm_sweeps(sweep_path):
     if not p.is_file():
         return []
     try:
-        recs = json.loads(p.read_text())
+        recs = json.loads(p.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return []
     # The combined artifact is a list of per-model records. A single per-model
@@ -749,7 +749,7 @@ def load_llm_history(path):
     if not path or not Path(path).is_file():
         return []
     newest, measured = {}, {}
-    for line in Path(path).read_text().splitlines():
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         try:
@@ -806,7 +806,7 @@ def render_llm_benchmark(
     recs = load_llm_history(history_path)
     if not recs and perf_path and Path(perf_path).is_file():
         try:
-            recs = json.loads(Path(perf_path).read_text())
+            recs = json.loads(Path(perf_path).read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             recs = []
     if not recs:
@@ -1051,5 +1051,7 @@ if __name__ == "__main__":
         llm_sweep_history_path=args.llm_sweep_history,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(content)
+    # Explicit encoding: the tables carry the verify/status emoji, and on a
+    # Windows checkout the default (cp1252) raises UnicodeEncodeError on them.
+    args.output.write_text(content, encoding="utf-8")
     print(f"Generated {args.output}")

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -638,15 +638,35 @@ def load_llm_sweeps(sweep_path):
     return [r for r in recs if isinstance(r, dict)]
 
 
+def _sweep_cell(pt):
+    """One cell of the sweep table: the number, or a marker for why there isn't.
+
+    Two very different things can leave a point without a number, and they must
+    not share a marker. `expected_fail` (and a context a model simply did not
+    sweep) is benign: at 64k/128k it means XRT would not pin enough host memory
+    for the KV BO, which differs between otherwise similar boxes. Every other
+    status -- build_fail, no_template, run_fail, xrt_incomplete, stale_template,
+    and any status sweep_decode.py grows later -- is a defect.
+
+    Tested by exclusion rather than against a list of failures, so a new status
+    reads as a failure until someone decides otherwise. The inverse default is
+    how six qwen25_3b_q4 build failures at 1k-32k were published under a caption
+    calling them a limit of the runner.
+    """
+    tps = pt.get("decode_tokens_per_sec")
+    if isinstance(tps, (int, float)):
+        return f"{tps:.2f}"
+    return "—" if pt.get("status", "") in ("", "ok", "expected_fail") else "✗"
+
+
 def render_llm_sweep(recs, base_url=""):
     """Render decode tok/s against context length, one row per model.
 
     Models with a sweep are published here instead of in the single-point table:
     decode throughput is dominated by KV streaming and falls by more than 10x
-    across this axis, so one number cannot represent them. A blank cell is a
-    context this runner did not reach, which at 64k/128k means XRT would not pin
-    enough host memory for the KV BO -- a property of the machine rather than of
-    the design, and worth showing rather than hiding.
+    across this axis, so one number cannot represent them. Cells without a
+    number carry a marker for why (see _sweep_cell), and only the markers that
+    actually appear are explained below the table.
     """
     if not recs:
         return ""
@@ -665,20 +685,42 @@ def render_llm_sweep(recs, base_url=""):
     head = "| Model | " + " | ".join(_ctx_label(c) for c in ctxs) + " | Verify |"
     sep = "|:------|" + "".join("------:|" for _ in ctxs) + ":------:|"
 
-    rows = []
+    rows, markers = [], set()
     for d in sorted(recs, key=lambda r: r.get("model", "")):
         by_ctx = {pt.get("context_len"): pt for pt in d.get("points", []) or []}
         cells = []
         for c in ctxs:
-            pt = by_ctx.get(c) or {}
-            tps = pt.get("decode_tokens_per_sec")
-            cells.append(f"{tps:.2f}" if isinstance(tps, (int, float)) else "—")
+            cell = _sweep_cell(by_ctx.get(c) or {})
+            if cell in ("—", "✗"):
+                markers.add(cell)
+            cells.append(cell)
         verify = _VERIFY_EMOJI.get(d.get("verify_status", ""), "")
         rows.append(
             f'| {_llm_model_cell(d.get("model", ""), base_url)} | '
             + " | ".join(cells)
             + f" | {verify} |"
         )
+
+    # Only explain the markers that are actually on the table. A legend for a
+    # symbol no cell uses reads as a caveat about the numbers above it.
+    legend = "\n\n".join(
+        note
+        for marker, note in (
+            (
+                "—",
+                "— context not reached on this runner (XRT would not pin enough "
+                "host memory for the KV cache; the limit is the machine's, not "
+                "the design's)",
+            ),
+            (
+                "✗",
+                "✗ the sweep did not produce a number here (build, template or "
+                "dispatch failure) — a defect to investigate, not a limit of the "
+                "machine",
+            ),
+        )
+        if marker in markers
+    )
 
     return f"""
 
@@ -692,7 +734,7 @@ Verify column, which comes from the same nightly's `make verify`).
 {sep}
 {chr(10).join(rows)}
 
-— context not reached on this runner (XRT would not pin enough host memory for the KV cache; the limit is the machine's, not the design's)
+{legend}
 """
 
 

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -875,7 +875,7 @@ def render_llm_benchmark(
 
 ## Nightly LLM Benchmark (NPU2)
 
-End-to-end LLM inference performance on the AMD Ryzen AI (Krackan Point, NPU2) benchmark runner, refreshed nightly. **TTFT** is time to first token (prefill latency); **Decode** is steady-state generation throughput.
+End-to-end LLM inference performance on the AMD Ryzen AI 5 PRO 340 (Krackan Point, NPU2) benchmark runner — 2×32 GB DDR5-5600 SODIMM — refreshed nightly. Decode streams the whole weight set per token, so it tracks DRAM bandwidth and these numbers do not transfer to a differently configured machine. **TTFT** is time to first token (prefill latency); **Decode** is steady-state generation throughput.
 
 | Model | Context | TTFT (ms) | Decode (tok/s) | Measured | Verify |
 |:------|--------:|----------:|---------------:|:---------|:------:|

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -639,20 +639,7 @@ def load_llm_sweeps(sweep_path):
 
 
 def _sweep_cell(pt):
-    """One cell of the sweep table: the number, or a marker for why there isn't.
-
-    Two very different things can leave a point without a number, and they must
-    not share a marker. `expected_fail` (and a context a model simply did not
-    sweep) is benign: at 64k/128k it means XRT would not pin enough host memory
-    for the KV BO, which differs between otherwise similar boxes. Every other
-    status -- build_fail, no_template, run_fail, xrt_incomplete, stale_template,
-    and any status sweep_decode.py grows later -- is a defect.
-
-    Tested by exclusion rather than against a list of failures, so a new status
-    reads as a failure until someone decides otherwise. The inverse default is
-    how six qwen25_3b_q4 build failures at 1k-32k were published under a caption
-    calling them a limit of the runner.
-    """
+    """The point's tok/s, or a marker: — expected_fail, ✗ any other failure."""
     tps = pt.get("decode_tokens_per_sec")
     if isinstance(tps, (int, float)):
         return f"{tps:.2f}"
@@ -706,8 +693,8 @@ def render_llm_sweep(recs, base_url=""):
     legend = "\n\n".join(
         note
         for marker, note in (
-            ("—", "— context not reached (KV cache exceeds what XRT will pin)."),
-            ("✗", "✗ sweep failed (build, template or dispatch)."),
+            ("—", "— expected failure."),
+            ("✗", "✗ unexpected failure."),
         )
         if marker in markers
     )

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -639,7 +639,7 @@ def load_llm_sweeps(sweep_path):
 
 
 def _sweep_cell(pt):
-    """The point's tok/s, or a marker: — expected_fail, ✗ any other failure."""
+    """The point's tok/s, or a marker: ✗ for a failure, — otherwise."""
     tps = pt.get("decode_tokens_per_sec")
     if isinstance(tps, (int, float)):
         return f"{tps:.2f}"

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -703,9 +703,7 @@ def render_llm_sweep(recs, base_url=""):
 
 ### Decode throughput vs context (tok/s)
 
-Steady-state decode, measured against KV-cache depth rather than at a single
-context. Decode-only and synthetic: latency, not correctness (correctness is the
-Verify column, which comes from the same nightly's `make verify`).
+Steady-state decode throughput at increasing KV-cache depth.
 
 {head}
 {sep}
@@ -830,7 +828,6 @@ def render_llm_benchmark(
     )
     tc = prov.get("toolchain", {})
     date = max((r.get("timestamp_utc") or "" for r in recs), default="")[:10]
-    runner = prov.get("runner", "")
     air = (tc.get("mlir_air_sha") or "")[:7]
     aie = (tc.get("mlir_aie_hash") or "")[:7]
     peano = tc.get("llvm_aie_version") or ""
@@ -838,7 +835,6 @@ def render_llm_benchmark(
         s
         for s in [
             f"Last updated {date}" if date else "",
-            f"runner {runner}" if runner else "",
             f"mlir-air {air}" if air else "",
             f"mlir-aie {aie}" if aie else "",
             f"llvm-aie {peano}" if peano else "",
@@ -953,7 +949,7 @@ def generate_readme(
 
 # LLMs on NPU
 
-End-to-end decoder-only LLM inference (prefill + autoregressive decode) mapped to the AMD NPU2 in bf16 via MLIR-AIR. Model coverage and performance below are refreshed nightly by CI (correctness **verify** plus **TTFT**/**decode** capture). For per-model architecture details and source, see the [`programming_examples/llms/`]({base_url}llms/) directory.
+End-to-end decoder-only LLM inference (prefill + autoregressive decode) mapped to the AMD NPU2 in bf16 via MLIR-AIR. Coverage and performance below are refreshed nightly. Per-model details and source are in [`programming_examples/llms/`]({base_url}llms/).
 {llm_section}"""
 
     # section == "full" (legacy single-page dashboard)

--- a/programming_examples/llms/bench/append_history.py
+++ b/programming_examples/llms/bench/append_history.py
@@ -92,7 +92,7 @@ def _existing_run_ids(history_path):
     p = Path(history_path)
     if not p.is_file():
         return ids
-    with p.open() as f:
+    with p.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -130,7 +130,7 @@ def main():
         print(f"no {src_path.name}; nothing to append")
         return 0
     try:
-        recs = json.loads(src_path.read_text())
+        recs = json.loads(src_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
         # Best-effort: a missing/corrupt/partial input should not crash the CI
         # step (which is itself continue-on-error), just skip this run.
@@ -147,7 +147,7 @@ def main():
     rows = list(flatten(recs, run_id))
     hist = Path(args.history)
     hist.parent.mkdir(parents=True, exist_ok=True)
-    with hist.open("a") as f:
+    with hist.open("a", encoding="utf-8") as f:
         for row in rows:
             f.write(json.dumps(row) + "\n")
     print(f"appended {len(rows)} rows for run {run_id} to {hist}")

--- a/programming_examples/llms/bench/append_history.py
+++ b/programming_examples/llms/bench/append_history.py
@@ -42,6 +42,7 @@ def _flat_rows(recs, run_id):
             "aie_hash": tc.get("mlir_aie_hash", ""),
             "peano": tc.get("llvm_aie_version", ""),
             "model": d.get("model", ""),
+            "runner": d.get("runner", ""),
             "ttft_ms": m.get("ttft_ms"),
             "decode_tokens_per_sec": m.get("decode_tokens_per_sec"),
             "context_len": m.get("context_len"),
@@ -55,6 +56,11 @@ def _flat_sweep_rows(recs, run_id):
     Points that did not produce a number are still emitted, with a null metric
     and their status, so a context that starts failing is visible in the series
     rather than the curve just getting shorter.
+
+    `status` is the point's own outcome (did this context produce a number);
+    `verify_status` is the model's `make verify` result for the whole run, which
+    is what the published Verify column reports. They are different things, and
+    both are per-row here because the docs build reads only this file.
     """
     for d in recs:
         tc = d.get("toolchain", {}) or {}
@@ -68,10 +74,12 @@ def _flat_sweep_rows(recs, run_id):
                 "aie_hash": tc.get("mlir_aie_hash", ""),
                 "peano": tc.get("llvm_aie_version", ""),
                 "model": d.get("model", ""),
+                "runner": d.get("runner", ""),
                 "context_len": pt.get("context_len"),
                 "decode_tokens_per_sec": pt.get("decode_tokens_per_sec"),
                 "ms_per_token": pt.get("ms_per_token"),
                 "status": pt.get("status", ""),
+                "verify_status": d.get("verify_status", ""),
             }
 
 

--- a/programming_examples/test_perf_publish.py
+++ b/programming_examples/test_perf_publish.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Round-trip checks for the published LLM benchmark tables.
+
+The nightly's numbers reach the docs site through three hops:
+
+    perf.json / sweep.json  ->  append_history.py  ->  *history.ndjson
+                            ->  generate_readme.py ->  docs/llms/index.md
+
+Every published defect so far has been a field or a distinction lost at one of
+those hops while both ends kept working: an empty perf.json blanking the whole
+section, verify_status not surviving the sweep round-trip so the Verify column
+went empty, runner vanishing from the provenance line, and a build failure
+rendering as the same dash as a context the box could not reach. None of them
+fail loudly -- the page just quietly says less than the run measured.
+
+So these assert on the seams rather than on the numbers. No hardware, no build,
+no network:
+
+    python3 programming_examples/test_perf_publish.py
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+APPEND = HERE / "llms" / "bench" / "append_history.py"
+
+sys.path.insert(0, str(HERE))
+from generate_readme import (  # noqa: E402
+    load_llm_history,
+    load_llm_sweep_history,
+    render_llm_benchmark,
+    render_llm_sweep,
+)
+
+TOOLCHAIN = {
+    "mlir_air_sha": "d97d4e8c8eaeb54cb04289feb349221ed4a78bac",
+    "mlir_aie_hash": "7e00b57955e108fe9d8e9419f5828a0c7e650858",
+    "llvm_aie_version": "21.0.0.2026080601+f4a72c27",
+}
+RUNNER = "amdryzenai5pro340"
+
+PERF = [
+    {
+        "model": "toy_1b",
+        "timestamp_utc": "2026-08-21T10:31:45Z",
+        "runner": RUNNER,
+        "verify_status": "pass",
+        "metrics": {
+            "ttft_ms": 900.0,
+            "decode_tokens_per_sec": 42.0,
+            "context_len": 2048,
+        },
+        "toolchain": TOOLCHAIN,
+    }
+]
+
+SWEEP = [
+    {
+        "model": "toy_1b_q4nx",
+        "timestamp_utc": "2026-08-21T10:31:45Z",
+        "runner": RUNNER,
+        "verify_status": "pass",
+        "toolchain": TOOLCHAIN,
+        "points": [
+            {
+                "context_len": 1024,
+                "decode_tokens_per_sec": 60.0,
+                "ms_per_token": 16.6,
+                "status": "ok",
+            },
+            {
+                "context_len": 65536,
+                "decode_tokens_per_sec": None,
+                "ms_per_token": None,
+                "status": "expected_fail",
+            },
+        ],
+    },
+    {
+        "model": "toy_3b_q4nx",
+        "timestamp_utc": "2026-08-21T10:31:45Z",
+        "runner": RUNNER,
+        "verify_status": "skip",
+        "toolchain": TOOLCHAIN,
+        "points": [
+            {
+                "context_len": 1024,
+                "decode_tokens_per_sec": None,
+                "ms_per_token": None,
+                "status": "build_fail",
+            },
+            {
+                "context_len": 65536,
+                "decode_tokens_per_sec": None,
+                "ms_per_token": None,
+                "status": "expected_fail",
+            },
+        ],
+    },
+]
+
+FAILURES = []
+
+
+def check(cond, what):
+    print(f"  {'ok  ' if cond else 'FAIL'}  {what}")
+    if not cond:
+        FAILURES.append(what)
+
+
+def append(src_flag, payload, history, run_id):
+    """Run append_history.py the way nightlyPerfBenchmark.yml does."""
+    src = history.parent / f"{src_flag}.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(APPEND),
+            f"--{src_flag}",
+            str(src),
+            "--history",
+            str(history),
+            "--run-id",
+            str(run_id),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    return r.stdout.strip()
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        hist, shist = tmp / "history.ndjson", tmp / "sweep_history.ndjson"
+
+        print("append_history.py -> ndjson")
+        append("perf", PERF, hist, 1)
+        append("sweep", SWEEP, shist, 1)
+        prow = json.loads(hist.read_text(encoding="utf-8").splitlines()[0])
+        srow = json.loads(shist.read_text(encoding="utf-8").splitlines()[0])
+        # The two fields #1850 dropped. Asserted on the raw row, because the
+        # renderer defaults them to "" and a missing field looks identical to
+        # an empty one by the time it reaches the page.
+        check(prow.get("verify_status") == "pass", "perf row keeps verify_status")
+        check(prow.get("runner") == RUNNER, "perf row keeps runner")
+        check(srow.get("verify_status") == "pass", "sweep row keeps verify_status")
+        check(srow.get("runner") == RUNNER, "sweep row keeps runner")
+        check(srow.get("status") == "ok", "sweep row keeps the point's own status")
+
+        check("no change" in append("sweep", SWEEP, shist, 1), "re-append is a no-op")
+
+        print("ndjson -> loaders")
+        recs = load_llm_history(hist)
+        curves = load_llm_sweep_history(shist)
+        check(recs[0]["verify_status"] == "pass", "history load keeps verify_status")
+        check(recs[0]["runner"] == RUNNER, "history load keeps runner")
+        byname = {c["model"]: c for c in curves}
+        check(
+            byname["toy_1b_q4nx"].get("verify_status") == "pass"
+            and byname["toy_3b_q4nx"].get("verify_status") == "skip",
+            "sweep load carries verify_status onto each curve",
+        )
+
+        print("loaders -> rendered page")
+        page = render_llm_benchmark(
+            None, sweep_recs=curves, history_path=hist  # no perf.json at all
+        )
+        check(bool(page), "an absent perf.json does not blank the section")
+        check(f"runner {RUNNER}" in page, "provenance names the runner")
+        check("| 🟢 |" in page, "scalar table renders a verify badge")
+
+        sweep_md = render_llm_sweep(curves)
+        check(
+            sweep_md.count("🟢") == 1 and sweep_md.count("⚪") == 1,
+            "sweep table renders one badge per model",
+        )
+        check("| 60.00 |" in sweep_md, "a measured point renders its number")
+        check("✗" in sweep_md, "a build_fail renders as a failure, not a dash")
+        check("—" in sweep_md, "an expected_fail still renders as a dash")
+        check(
+            "not a limit of the machine" in sweep_md
+            and "the limit is the machine's" in sweep_md,
+            "both markers present -> both legends shown",
+        )
+
+        # Legend must not explain a marker no cell uses.
+        clean = render_llm_sweep(
+            [
+                {
+                    "model": "m",
+                    "verify_status": "pass",
+                    "points": [
+                        {
+                            "context_len": 1024,
+                            "decode_tokens_per_sec": 1.0,
+                            "status": "ok",
+                        }
+                    ],
+                }
+            ]
+        )
+        check(
+            "✗" not in clean and "—" not in clean,
+            "an all-measured table carries no legend",
+        )
+
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} check(s) failed:")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/programming_examples/test_perf_publish.py
+++ b/programming_examples/test_perf_publish.py
@@ -185,7 +185,7 @@ def main():
         check("✗" in sweep_md, "a build_fail renders as a failure, not a dash")
         check("—" in sweep_md, "an expected_fail still renders as a dash")
         check(
-            "context not reached" in sweep_md and "sweep failed" in sweep_md,
+            "— expected failure" in sweep_md and "✗ unexpected failure" in sweep_md,
             "both markers present -> both legends shown",
         )
 

--- a/programming_examples/test_perf_publish.py
+++ b/programming_examples/test_perf_publish.py
@@ -185,8 +185,7 @@ def main():
         check("✗" in sweep_md, "a build_fail renders as a failure, not a dash")
         check("—" in sweep_md, "an expected_fail still renders as a dash")
         check(
-            "not a limit of the machine" in sweep_md
-            and "the limit is the machine's" in sweep_md,
+            "context not reached" in sweep_md and "sweep failed" in sweep_md,
             "both markers present -> both legends shown",
         )
 

--- a/programming_examples/test_perf_publish.py
+++ b/programming_examples/test_perf_publish.py
@@ -173,7 +173,7 @@ def main():
             None, sweep_recs=curves, history_path=hist  # no perf.json at all
         )
         check(bool(page), "an absent perf.json does not blank the section")
-        check(f"runner {RUNNER}" in page, "provenance names the runner")
+        check(RUNNER not in page, "the CI runner label stays off the page")
         check("| 🟢 |" in page, "scalar table renders a verify badge")
 
         sweep_md = render_llm_sweep(curves)


### PR DESCRIPTION
The LLM benchmark tables were reporting less than the nightly measured, and in
one case something the nightly did not measure at all. Making them history-backed
(#1850) routed them through `history.ndjson` / `sweep_history.ndjson`, and fields
that both ends handle correctly are dropped in between.

Found while investigating why the perf table vanished from the docs site; #1850
fixed that, these are what it left behind plus what turned up alongside.

## Published defects

**The Verify column on "Decode throughput vs context" was empty for every model.**
`_flat_sweep_rows` never wrote `verify_status`, so `render_llm_sweep`'s emoji
lookup got `""`. The nightly's `sweep.json` has the field and the old
`load_llm_sweeps` fallback used it; the history path that now always wins does
not. Last night's run has `verify_status: pass` for 7 of 8 swept models — none of
it reached the page.

**Provenance lost the runner.** Neither history row carried `runner`.

**A build failure and a memory limit rendered as the same dash.**
`render_llm_sweep` printed `—` for any null, and the legend attributed it to XRT
declining to pin the KV BO. Of the 8 null points on record, 6 are `qwen25_3b_q4`
build failures at 1k–32k, published under a caption calling them a limit of the
machine. The marker now splits: `—` expected failure, `✗` unexpected. Classified
by exclusion, so a status added to `sweep_decode.py` later reads as a failure
until someone decides otherwise.

**The "LLMs on NPU" page published as "Index".** MkDocs takes a title from the
first H1 only when that H1 is the document's first element, and `generate_readme.py`
leads with an "auto-generated" HTML comment. `llms/index.md` was the one nav entry
without an explicit label, so it was the one page that showed the filename
fallback.

## Accuracy of what the page claims

The runner is now named with the part and memory config — Ryzen AI 5 PRO 340,
2×32 GB DDR5-5600 SODIMM — since decode throughput here is as much a DRAM
measurement as an NPU one.

Two claims in `nightlyPerfBenchmark.yml`'s header had stopped being true. It said
`llama32_1b_q4nx` measures ~39-40 tok/s / ~1130 ms and called the gap against an
HX 370 unexplained, naming the `balanced` ACPI profile as the suspect. The suspect
was right: run 32166148043 logs `balanced` at 42.51 tok/s, run 32193537561 five
hours later logs `performance` at 64.12, and it has held at ~64 tok/s / ~894 ms
since. Corrected, and the profile is still logged — now as the thing most likely
to move these numbers rather than an open question.

## Prose

Cut from the published pages: `make verify` (a build target a reader cannot run),
"refreshed nightly by CI (correctness verify plus TTFT/decode capture)", the CI
runner's internal label `amdryzenai5pro340`, and the causal captions above. The
history page had drifted to describing the machine differently from the benchmark
page; it is named once now, where the tables are.

## Testing

`programming_examples/test_perf_publish.py` — appends both artifact shapes through
the real CLI, reads them back through both loaders, renders, and asserts the
fields and markers survive. No hardware, no build, no network; exit 0/1.

Confirmed to fail on each regression it covers, not merely to pass now: dropping
sweep `verify_status` trips 3 checks, collapsing the markers trips 2, dropping
`runner` trips 3.

There is no existing harness for the docs generators or bench scripts, so it is
standalone rather than wired to a `check-*` target. Hooking it to one is worth a
follow-up.

Also verified by replaying run 32458944539's artifact against a copy of the
`perf-history` branch and building the site locally: Verify fills to 7 🟢 + 1 ⚪,
scalar table unchanged, appender still idempotent on `run_id`.

## Not in this PR

- `sweep_decode.py` overwrites the real status with `expected_fail` when the
  context is in `--expect-fail`, keeping the cause only in an unpublished `detail`
  field. That is why `—` cannot yet distinguish a real memory limit from a build
  failure. Worth fixing separately.
- `qwen25_7b_q4nx` (#1854) skips verify on `Missing required feature(s):
  hfweights_qwen_qwen2_5_7b_instruct` and has been publishing sweep numbers
  without passing its gate. The ⚪ this PR restores is what surfaces it; the fix is
  seeding the runner's HF cache via `downloadLLMWeights.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
