### PR TITLE
[python] air.api: each hierarchy op owns its own iteration space

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -104,16 +104,16 @@ def build_module(
     # the micro-tile, so the module is architecture-specific before the herd is
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
-    with air.launch(name="matmul_bf16") as launch:
+    with air.launch(
+        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_bf16"
+    ) as launch:
 
         @launch.body
-        def _():
-            with air.segment(
-                [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_seg"
-            ) as seg:
+        def _(si, sj):
+            with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
-                def _(si, sj):
+                def _():
                     row, col = si * seg_m, sj * seg_n
 
                     # L2 staging is flat: each buffer is exactly the region of

--- a/programming_examples/matrix_multiplication/i16/run.py
+++ b/programming_examples/matrix_multiplication/i16/run.py
@@ -100,16 +100,16 @@ def build_module(
     # the micro-tile, so the module is architecture-specific before the herd is
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
-    with air.launch(name="matmul_i16") as launch:
+    with air.launch(
+        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_i16"
+    ) as launch:
 
         @launch.body
-        def _():
-            with air.segment(
-                [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_seg"
-            ) as seg:
+        def _(si, sj):
+            with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
-                def _(si, sj):
+                def _():
                     row, col = si * seg_m, sj * seg_n
 
                     # L2 staging is flat: each buffer is exactly the region of

--- a/programming_examples/matrix_multiplication/i8/run.py
+++ b/programming_examples/matrix_multiplication/i8/run.py
@@ -102,16 +102,16 @@ def build_module(
     # the micro-tile, so the module is architecture-specific before the herd is
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
-    with air.launch(name="matmul_i8") as launch:
+    with air.launch(
+        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_i8"
+    ) as launch:
 
         @launch.body
-        def _():
-            with air.segment(
-                [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_seg"
-            ) as seg:
+        def _(si, sj):
+            with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
-                def _(si, sj):
+                def _():
                     row, col = si * seg_m, sj * seg_n
 
                     # L2 staging is flat: each buffer is exactly the region of

--- a/programming_examples/matrix_vector_multiplication/bf16/matvec.py
+++ b/programming_examples/matrix_vector_multiplication/bf16/matvec.py
@@ -116,14 +116,14 @@ def build_module(
     B = air.tensor([k], dt_in)
     C = air.tensor([m], dt_out)
 
-    with air.launch(name="matvec_bf16") as launch:
+    with air.launch([range(0, m, seg_m)], name="matvec_bf16") as launch:
 
         @launch.body
-        def _():
-            with air.segment([range(0, m, seg_m)], name="matvec_bf16_0") as seg:
+        def _(si):
+            with air.segment(name="matvec_bf16_0") as seg:
 
                 @seg.body
-                def _(si):
+                def _():
                     row = si * seg_m
 
                     # L3 -> L2: the A panel for this chunk, and the C panel it

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -66,14 +66,14 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
     vecmat = air.extern("vecmat_bf16_bf16", object=link_with)
     fill = air.extern("linalg_fill_bf16", object=link_with)
 
-    with air.launch(name="vecmat_bf16") as launch:
+    with air.launch([range(0, n, tile_n)], name="vecmat_bf16") as launch:
 
         @launch.body
-        def _():
-            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
+        def _(sj):
+            with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
-                def _(sj):
+                def _():
                     col = sj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -113,14 +113,14 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with=
     vecmat = air.extern(f"vecmat_i8_f32_i32_{bs}", object=link_with)
     fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    with air.launch(name="vecmat_i8") as launch:
+    with air.launch([range(0, n, tile_n)], name="vecmat_i8") as launch:
 
         @launch.body
-        def _():
-            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
+        def _(sj):
+            with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
-                def _(sj):
+                def _():
                     col = sj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -99,14 +99,14 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
     vecmat = air.extern("vecmat_i8_i32", object=link_with)
     fill = air.extern("linalg_fill_i32_view16x8xi32as2", object=link_with)
 
-    with air.launch(name="vecmat_i8") as launch:
+    with air.launch([range(0, n, tile_n)], name="vecmat_i8") as launch:
 
         @launch.body
-        def _():
-            with air.segment([range(0, n, tile_n)], name="vecmat_i8_0") as seg:
+        def _(sj):
+            with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
-                def _(sj):
+                def _():
                     col = sj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())

--- a/python/air/api/_compile.py
+++ b/python/air/api/_compile.py
@@ -25,9 +25,14 @@ from ._trace import (
     DEFAULT_TARGET,
     PENDING_SYMBOLS,
     PENDING_TENSORS,
+    LaunchState,
     Trace,
+    _positional_arity,
+    open_launch_region,
+    parse_grid,
     resolve_target,
     set_active_trace,
+    set_launch,
     set_target,
 )
 
@@ -37,7 +42,18 @@ __all__ = ["LaunchContext", "CompiledKernel", "launch", "compile"]
 class LaunchContext:
     """A traced kernel: an interface, a body, and a compiler entry point."""
 
-    def __init__(self, name="kernel", target=None):
+    def __init__(self, grid=None, name="kernel", target=None):
+        # This launch's own iteration space -- air.launch's `sizes`. One point
+        # is one replay of everything inside, so outer tiling belongs here:
+        # a segment's L2 staging is refilled per point. air.segment and
+        # air.herd each own a separate one; see LaunchState.
+        self.dims = parse_grid(grid) if grid is not None else ()
+        if len(self.dims) > 2:
+            raise NotImplementedError(
+                f"air.launch is 1-D or 2-D; got {len(self.dims)}-D"
+            )
+        self.grid = tuple(d.count for d in self.dims)
+        self.tile_sizes = tuple(d.step for d in self.dims)
         self.name = name
         self.target = target or DEFAULT_TARGET
         self.tensors = list(PENDING_TENSORS)
@@ -116,9 +132,12 @@ class LaunchContext:
                     trace = Trace(self.tensors, module=module)
                     previous = set_active_trace(trace)
                     previous_target = set_target(self.target)
+                    state = LaunchState(self)
+                    previous_launch = set_launch(state)
                     try:
-                        self._body()
+                        self._run_body(state)
                     finally:
+                        set_launch(previous_launch)
                         self._l1_peak = trace.l1_peak
                         set_target(previous_target)
                         set_active_trace(previous)
@@ -128,6 +147,35 @@ class LaunchContext:
         self._module = module
         self._check_interface()
         return module
+
+    def _run_body(self, state):
+        """Run the launch body, opening air.launch first if this launch has a grid.
+
+        With no grid there is nothing for air.launch to say, so nothing is
+        emitted until a segment needs a launch to sit inside -- which keeps a
+        kernel that stages nothing at the plain `func` + `air.herd` shape its
+        hand-written predecessor had.
+        """
+        n_expected = len(self.dims)
+        if _positional_arity(self._body) != n_expected:
+            raise TypeError(
+                f"launch body takes {_positional_arity(self._body)} coordinate "
+                f"argument(s) but the launch iteration space is {n_expected}-D"
+                + (
+                    "; a launch with no grid runs once and its body takes no "
+                    "arguments"
+                    if n_expected == 0
+                    else ""
+                )
+            )
+        if not self.dims:
+            self._body()
+            return
+        # air.launch is always 2-D; a 1-D grid pads with 1.
+        counts = list(self.grid) + [1] * (2 - len(self.grid))
+        open_launch_region(
+            state, self.tensors, counts, lambda: self._body(*state.coords)
+        )
 
     def _check_interface(self):
         outputs = self.outputs
@@ -256,12 +304,16 @@ class CompiledKernel:
         self.backend.unload()
 
 
-def launch(name="kernel", target=None):
+def launch(grid=None, name="kernel", target=None):
     """Open a launch; claims every tensor declared since the last launch.
+
+    `grid` is the launch's own iteration space -- one point is one replay of
+    everything inside, with a segment's L2 staging refilled each time, so outer
+    tiling goes here. `air.segment` and `air.herd` each take their own.
 
     `target` names an NPU generation, or "auto"/None to use the installed one.
     """
-    return LaunchContext(name=name, target=target)
+    return LaunchContext(grid=grid, name=name, target=target)
 
 
 def compile(launch_ctx, **kwargs):

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -32,7 +32,7 @@ import inspect
 import itertools
 import re
 
-from ._index import IndexExpr
+from ._index import IndexExpr, Leaf
 from ._pack import PackedShape
 from ._value import Buffer, Tensor, Token
 
@@ -49,6 +49,10 @@ __all__ = [
     "wait",
     "current_herd",
     "current_segment",
+    "current_launch",
+    "set_launch",
+    "LaunchState",
+    "open_launch_region",
 ]
 
 
@@ -64,6 +68,7 @@ PENDING_SYMBOLS = []
 # The herd currently being traced, and the launch currently being traced.
 _CURRENT_HERD = None
 _CURRENT_SEGMENT = None
+_CURRENT_LAUNCH = None
 _ACTIVE_TRACE = None
 
 # The device being traced for. A herd resolves its physical shape when it is
@@ -186,6 +191,84 @@ def current_segment(required=True):
             "this operation must be used inside a segment body (@segment.body)"
         )
     return _CURRENT_SEGMENT
+
+
+class LaunchState:
+    """The air.launch region being emitted, and whether it is open yet.
+
+    air.launch, air.segment and air.herd each own an iteration space, and each
+    is written on the op that has it. A launch with a grid opens its region
+    itself, before the body runs. A launch without one opens nothing until a
+    segment needs somewhere to sit -- which keeps a kernel that stages nothing
+    at the plain `func` + `air.herd` shape its hand-written predecessors have.
+    """
+
+    __slots__ = ("ctx", "opened", "coords", "leaves")
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self.opened = False
+        # This launch's coordinates, as expressions handed to the body, plus the
+        # leaves behind them. A nested IsolatedFromAbove region rebinds each
+        # leaf's .value to its own block argument.
+        self.coords = []
+        self.leaves = []
+
+
+def set_launch(state):
+    global _CURRENT_LAUNCH
+    previous, _CURRENT_LAUNCH = _CURRENT_LAUNCH, state
+    return previous
+
+
+def current_launch():
+    if _CURRENT_LAUNCH is None:
+        raise RuntimeError(
+            "this operation must be used inside a launch body (@launch.body)"
+        )
+    return _CURRENT_LAUNCH
+
+
+def open_launch_region(launch, tensors, counts, body):
+    """Emit air.launch with ``counts`` as its sizes and run ``body`` inside.
+
+    Block arguments are ids + sizes + operands; air.launch is 2-D, so the
+    operands start at index 4.
+    """
+    from air.dialects.air import launch as launch_region
+
+    @launch_region(sizes=counts, operands=[t.value for t in tensors])
+    def launch_body(*largs):
+        launch.opened = True
+        launch.leaves = [
+            Leaf(largs[axis], f"l{axis}") for axis in range(len(launch.ctx.grid))
+        ]
+        launch.coords = [IndexExpr({leaf: 1}, 0) for leaf in launch.leaves]
+        saved = [t.value for t in tensors]
+        for t, v in zip(tensors, largs[4:]):
+            t.value = v
+        try:
+            body()
+        finally:
+            for t, v in zip(tensors, saved):
+                t.value = v
+
+
+def infer_name(fallback, depth=2):
+    """Recover ``tile_m`` from the source line ``tile_m = air.symbol()``.
+
+    Cosmetic only: it affects how ``launch.search_space`` and error messages
+    read back, never what is emitted.
+    """
+    try:
+        frame = inspect.stack()[depth]
+        line = (frame.code_context or [""])[0]
+        match = re.match(r"\s*([A-Za-z_]\w*)\s*=", line)
+        if match:
+            return match.group(1)
+    except Exception:
+        pass
+    return fallback
 
 
 def infer_name(fallback, depth=2):
@@ -467,15 +550,30 @@ class SegmentContext:
     """
 
     def __init__(self, grid=None, name=None):
-        # A grid here is the *launch* iteration space: one segment instance per
-        # point, which is how the reference matmul tiles M and N. It cannot be
-        # the herd's job, because the L2 staging buffers are re-filled per point
-        # -- the outer tiling has to sit where the L3->L2 transfers are.
+        # A grid here is this segment's *own* iteration space -- air.segment's
+        # `sizes`, which the dialect prints as `unroll(...)`. air.launch,
+        # air.segment and air.herd each carry one and they are not the same
+        # thing: a launch point is a repetition of the whole segment, while a
+        # segment point is a spatial copy of the segment body, which air-to-aie
+        # lays out across columns or devices. Writing a grid here used to set
+        # the *launch's* sizes, which conflated the two and made air.segment's
+        # own iteration space unreachable.
         self.dims = parse_grid(grid) if grid is not None else ()
         if len(self.dims) > 2:
             raise NotImplementedError(
-                f"air.launch is 2-D, so a segment grid is 1-D or 2-D; got "
+                f"an air.segment iteration space is 1-D or 2-D; got "
                 f"{len(self.dims)}-D"
+            )
+        if self.dims:
+            raise NotImplementedError(
+                "air.segment(<grid>) is the segment's own iteration space -- "
+                "air.segment's `sizes`, which unrolls the segment body into one "
+                "spatial copy per point (see programming_examples/segment_unroll"
+                "). air.api does not emit that yet.\n\n"
+                "If you meant the outer tiling -- one segment instance per "
+                "point, L2 staging refilled each time -- that is the *launch's* "
+                "iteration space: write air.launch(<grid>) and take the "
+                "coordinates in the launch body."
             )
         self.grid = tuple(d.count for d in self.dims)
         self.tile_sizes = tuple(d.step for d in self.dims)
@@ -525,67 +623,82 @@ class SegmentContext:
         return decorator
 
     def _emit(self, fn):
-        global _CURRENT_SEGMENT
-
         trace = active_trace()
         n_expected = len(self.dims)
         if _positional_arity(fn) != n_expected:
             raise TypeError(
                 f"segment body takes {_positional_arity(fn)} coordinate "
-                f"argument(s) but the launch iteration space is "
+                f"argument(s) but the segment iteration space is "
                 f"{n_expected}-D"
                 + (
                     "; a segment with no grid is a single instance and its body "
-                    "takes no arguments"
+                    "takes no arguments. Outer tiling belongs on air.launch, "
+                    "whose coordinates arrive in the launch body"
                     if n_expected == 0
                     else ""
                 )
             )
 
-        from air.dialects.air import launch as launch_region
+        launch = current_launch()
+        if launch.opened:
+            # air.launch is already open -- either because it carries a grid, or
+            # because an earlier segment opened it.
+            self._emit_segment(fn, trace)
+        else:
+            # A gridless launch still has to exist for a segment to sit in:
+            # air-insert-launch-around-herd only wraps a *bare* herd, and skips
+            # one already inside a segment, so a segment with no launch above it
+            # compiles and silently computes zeros. One point, 2-D as air.launch
+            # requires.
+            open_launch_region(
+                launch, trace.tensors, [1, 1], lambda: self._emit_segment(fn, trace)
+            )
+
+    def _emit_segment(self, fn, trace):
+        """Emit air.segment inside the already-open air.launch."""
+        global _CURRENT_SEGMENT
+
         from air.dialects.air import segment as segment_region
         from air.dialects.memref import DeallocOp
 
         tensors = trace.tensors
         segment_self = self
+        launch = current_launch()
 
-        # air.launch is always 2-D; an absent or 1-D grid pads with 1. Its block
-        # arguments are sizes*2 + operands, so the operands start at index 4.
-        counts = list(self.grid) + [1] * (2 - len(self.grid))
+        # air.segment is IsolatedFromAbove, so a launch coordinate used in this
+        # body cannot simply be referenced -- it is threaded in as an operand
+        # ahead of the tensors, and rebound to the block argument inside.
+        outer_leaves = launch.leaves
+        operands = [leaf.value for leaf in outer_leaves] + [t.value for t in tensors]
+        sizes = list(self.grid) + [1] * (2 - len(self.grid)) if self.grid else []
 
-        @launch_region(sizes=counts, operands=[t.value for t in tensors])
-        def launch_body(*largs):
-            # The launch induction variables become segment operands, ahead of
-            # the tensors -- air.segment is IsolatedFromAbove, so a coordinate
-            # cannot simply be referenced from inside it.
-            ivs = list(largs[: len(segment_self.dims)])
-            outer = ivs + list(largs[4:])
+        @segment_region(name=self.name, operands=operands, sizes=sizes)
+        def segment_body(*args):
+            global _CURRENT_SEGMENT
 
-            # sizes=[] on the segment means its block arguments are exactly the
-            # operands.
-            @segment_region(name=segment_self.name, operands=outer)
-            def segment_body(*args):
-                global _CURRENT_SEGMENT
-
-                coords = [
-                    IndexExpr.leaf(v, f"s{axis}")
-                    for axis, v in enumerate(args[: len(ivs)])
-                ]
-                bound = args[len(ivs) :]
-                saved = [t.value for t in tensors]
-                for t, v in zip(tensors, bound):
+            # Block arguments are ids + sizes + operands, so a segment with an
+            # iteration space of its own offsets the operands by 2 * its rank.
+            n = len(sizes)
+            coords = [IndexExpr.leaf(v, f"u{axis}") for axis, v in enumerate(args[:n])]
+            bound = args[2 * n :]
+            saved_outer = [leaf.value for leaf in outer_leaves]
+            for leaf, v in zip(outer_leaves, bound[: len(outer_leaves)]):
+                leaf.value = v
+            saved = [t.value for t in tensors]
+            for t, v in zip(tensors, bound[len(outer_leaves) :]):
+                t.value = v
+            previous, _CURRENT_SEGMENT = _CURRENT_SEGMENT, segment_self
+            try:
+                fn(*coords)
+                for buf in segment_self._buffers:
+                    DeallocOp(buf.value)
+            finally:
+                segment_self._buffers.clear()
+                for t, v in zip(tensors, saved):
                     t.value = v
-                previous, _CURRENT_SEGMENT = _CURRENT_SEGMENT, segment_self
-                try:
-                    fn(*coords)
-                    # Freed here, inside the region the allocs were emitted into.
-                    for buf in segment_self._buffers:
-                        DeallocOp(buf.value)
-                finally:
-                    segment_self._buffers.clear()
-                    for t, v in zip(tensors, saved):
-                        t.value = v
-                    _CURRENT_SEGMENT = previous
+                for leaf, v in zip(outer_leaves, saved_outer):
+                    leaf.value = v
+                _CURRENT_SEGMENT = previous
 
 
 def segment(grid=None, name=None):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -589,16 +589,54 @@ def _():
     _staged(body)
 
 
-# A segment grid is the launch iteration space, and air.launch is 2-D.
+# air.launch, air.segment and air.herd each own an iteration space, and it is
+# written on the op that has it. A grid on air.segment is air.segment's own
+# `sizes` -- the unroll that copies the segment body across columns -- and is
+# not a way to spell the outer tiling. Saying so is the whole point: it used to
+# be silently redirected to the launch, which made air.segment's own iteration
+# space unreachable and taught the wrong model of the hierarchy.
+# CHECK-LABEL: TEST: segment_grid_is_not_the_launch_grid
+# CHECK: NotImplementedError: air.segment(<grid>) is the segment's own iteration space
+# CHECK: write air.launch(<grid>) and take the coordinates in the launch body
+@expect(NotImplementedError, "segment_grid_is_not_the_launch_grid")
+def _():
+    air.segment([range(0, 128, 64)])
+
+
 # CHECK-LABEL: TEST: segment_grid_too_deep
-# CHECK: NotImplementedError: air.launch is 2-D, so a segment grid is 1-D or 2-D
+# CHECK: NotImplementedError: an air.segment iteration space is 1-D or 2-D; got 3-D
 @expect(NotImplementedError, "segment_grid_too_deep")
 def _():
     air.segment(product(range(0, 128, 64), range(0, 128, 64), range(0, 128, 64)))
 
 
+# CHECK-LABEL: TEST: launch_grid_too_deep
+# CHECK: NotImplementedError: air.launch is 1-D or 2-D; got 3-D
+@expect(NotImplementedError, "launch_grid_too_deep")
+def _():
+    air.launch(product(range(0, 128, 64), range(0, 128, 64), range(0, 128, 64)))
+
+
+# CHECK-LABEL: TEST: launch_body_arity
+# The launch's coordinates arrive in the launch body, so its arity has to match
+# the grid it was given -- the same rule air.herd and air.segment follow.
+# CHECK: TypeError: launch body takes 0 coordinate argument(s) but the launch iteration space is 1-D
+@expect(TypeError, "launch_body_arity")
+def _():
+    air.tensor([64, 64], bf16)
+    air.tensor([64, 64], bf16)
+
+    with air.launch([range(0, 128, 64)], name="k") as launch:
+
+        @launch.body
+        def _():
+            pass
+
+    launch.mlir()
+
+
 # CHECK-LABEL: TEST: segment_body_takes_no_args
-# CHECK: TypeError: segment body takes 1 coordinate argument(s) but the launch iteration space is 0-D
+# CHECK: TypeError: segment body takes 1 coordinate argument(s) but the segment iteration space is 0-D
 @expect(TypeError, "segment_body_takes_no_args")
 def _():
     air.tensor([64, 64], bf16)

--- a/python/test/api/hierarchy.py
+++ b/python/test/api/hierarchy.py
@@ -1,0 +1,131 @@
+# ./python/test/api/hierarchy.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Each hierarchy op owns its own iteration space, and the DSL writes it there.
+
+``air.launch``, ``air.segment`` and ``air.herd`` all implement
+``air_HierarchyInterface`` and each carries a ``Variadic<Index>:$sizes``. They
+are symmetric in the dialect and they mean different things:
+
+  * a **launch** point replays everything inside it -- a segment's L2 staging is
+    refilled per point, which is where outer tiling belongs;
+  * a **segment** point is a spatial copy of the segment body, which
+    ``air-to-aie`` lays out across columns or devices (the dialect prints it as
+    ``unroll(...)``; see ``programming_examples/segment_unroll``);
+  * a **herd** point is a core.
+
+This file exists because the DSL once broke that symmetry: a grid written on
+``air.segment`` set the *launch's* sizes, and the segment's own sizes were
+hard-wired empty. Nothing caught it. The emitted IR was correct for every case
+in the tree -- the launch grid landed where it should -- so no behavioural test
+could fail, and the one thing that would have exposed it, air.api emitting a
+segment iteration space, was unreachable by construction.
+
+The guard therefore has to assert *where the grid lands*, not what the kernel
+computes.
+"""
+
+from air import api as air
+from air.api.types import i32
+
+M, N = 64, 64
+TILE = 32
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: launch_grid_lands_on_launch
+#
+# A 2x2 grid written on air.launch appears as air.launch's own sizes...
+# CHECK: air.launch (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2{{.*}}, %{{.*}}=%c2{{.*}})
+#
+# ...and the segment nested inside carries none of its own: no `unroll(...)`,
+# no `in (...)`, just its operands. This is the line that would have failed on
+# the conflated version, where the 2x2 was the segment's to give away.
+# CHECK: air.segment @seg args
+# CHECK-NOT: air.segment {{.*}}unroll
+@run
+def launch_grid_lands_on_launch():
+    A = air.tensor([M, N], i32)
+    B = air.tensor([M, N], i32)
+
+    with air.launch(
+        [range(0, M, TILE), range(0, N, TILE)], name="tiled", target="npu1"
+    ) as launch:
+
+        @launch.body
+        def _(si, sj):
+            row, col = si * TILE, sj * TILE
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    # The launch coordinates are usable here: air.segment is
+                    # IsolatedFromAbove, so the DSL threads them in as operands
+                    # rather than leaving a dangling reference.
+                    l2 = air.alloc([TILE, TILE], i32, scope=seg.private())
+                    air.ops.load(l2, A[row : row + TILE, col : col + TILE])
+                    air.ops.store(l2, B[row : row + TILE, col : col + TILE])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: herd_grid_lands_on_herd
+# A grid written on air.herd is air.herd's sizes, and reaches neither of the
+# other two: with no launch grid and no segment there is no air.launch at all,
+# which is the shape this kernel's hand-written predecessor had.
+# CHECK-NOT: air.launch
+# CHECK: air.herd @h tile (%{{.*}}, %{{.*}}) in (%{{.*}}=%c4{{.*}}, %{{.*}}=%c1{{.*}})
+@run
+def herd_grid_lands_on_herd():
+    A = air.tensor([M, N], i32)
+    B = air.tensor([M, N], i32)
+
+    with air.launch(name="bare", target="npu1") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(4)], name="h", shape=(4,)) as h:
+
+                @h.body
+                def _(tx):
+                    buf = air.alloc([TILE, N], i32, scope=h.private())
+                    air.ops.load(buf, A[0:TILE, 0:N])
+                    air.ops.store(buf, B[0:TILE, 0:N])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: gridless_launch_still_hosts_a_segment
+# A launch with no grid says nothing, so it emits nothing -- until a segment
+# needs somewhere to sit. air-insert-launch-around-herd only wraps a *bare*
+# herd and skips one already inside a segment, so a segment with no launch
+# above it compiles and silently computes zeros.
+# CHECK: air.launch (%{{.*}}, %{{.*}}) in (%{{.*}}=%c1{{.*}}, %{{.*}}=%c1{{.*}})
+# CHECK: air.segment @seg
+@run
+def gridless_launch_still_hosts_a_segment():
+    A = air.tensor([M, N], i32)
+    B = air.tensor([M, N], i32)
+
+    with air.launch(name="hosted", target="npu1") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    l2 = air.alloc([TILE, N], i32, scope=seg.private())
+                    air.ops.load(l2, A[0:TILE, 0:N])
+                    air.ops.store(l2, B[0:TILE, 0:N])
+
+    print(launch.mlir())

--- a/python/test/api/pack.py
+++ b/python/test/api/pack.py
@@ -34,17 +34,18 @@ def build():
     B = air.tensor([K, N], bf16)
     C = air.tensor([M, N], bf16)
 
-    with air.launch(name="matmul", target="npu1") as launch:
+    with air.launch(
+        [range(0, M, TILE_M * HERD_M), range(0, N, TILE_N * HERD_N)],
+        name="matmul",
+        target="npu1",
+    ) as launch:
 
         @launch.body
-        def _():
-            with air.segment(
-                [range(0, M, TILE_M * HERD_M), range(0, N, TILE_N * HERD_N)],
-                name="matmul_seg",
-            ) as seg:
+        def _(ss, st):
+            with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
-                def _(ss, st):
+                def _():
                     row, col = ss * TILE_M * HERD_M, st * TILE_N * HERD_N
 
                     l2_a = air.alloc(
@@ -165,14 +166,14 @@ def build_named_kernel():
     A = air.tensor([32, 32], bf16)
     C = air.tensor([32, 32], bf16)
 
-    with air.launch(name="named", target="npu1") as launch:
+    with air.launch([range(0, 32, 32)], name="named", target="npu1") as launch:
 
         @launch.body
-        def _():
-            with air.segment([range(0, 32, 32)], name="seg") as seg:
+        def _(si):
+            with air.segment(name="seg") as seg:
 
                 @seg.body
-                def _(si):
+                def _():
                     acc = air.alloc(mm.c(32, 32), bf16, scope=seg.shared())
                     l2 = air.alloc([32, 32], bf16, scope=seg.private())
                     air.ops.load(l2, A[0:32, 0:32])


### PR DESCRIPTION
## The bug

`air.launch`, `air.segment` and `air.herd` all implement `air_HierarchyInterface` and each carries its own `sizes` — [`AIR.td:231-241`](../blob/main/mlir/include/air/Dialect/AIR/AIR.td#L231-L241):

```tablegen
def air_SegmentOp : air_Op<"segment", [...]>,
   Arguments<(ins OptionalAttr<SymbolNameAttr>:$sym_name,
                  Variadic<air_AsyncToken>:$async_dependencies,
                  Variadic<Index>:$sizes,              // <-- its own grid
                  Variadic<AnyType>:$segment_operands)>
```

They are symmetric in the dialect and they mean different things:

| op | a point is |
|---|---|
| `air.launch` | a **temporal** replay of everything inside — a segment's L2 staging is refilled per point, so outer tiling belongs here |
| `air.segment` | a **spatial** copy of the segment body, which `air-to-aie` lays out across columns or devices (printed `unroll(...)`) |
| `air.herd` | a core |

air.api broke that symmetry. A grid written on `air.segment` set the **launch's** sizes, and the segment's own were hard-wired to `[]`:

```python
counts = list(self.grid) + [1] * (2 - len(self.grid))
@launch_region(sizes=counts, ...)                    # the "segment" grid -> LAUNCH sizes
    # sizes=[] on the segment means its block arguments are exactly the operands.
    @segment_region(name=..., operands=outer)        # segment grid: [] -- always
```

Two consequences. The API taught the wrong model — `air.segment([...])` reads as the segment's iteration space and was not. And `air.segment`'s own iteration space was **unreachable**, so neither `programming_examples/segment_unroll` nor `channel_examples/channel_3d_segment_unroll` can be written on air.api, though five CI lits exercise that feature through the raw bindings.

## The fix

`air.launch` takes the grid it always had in the dialect and opens its own region, with the arity rule `air.herd` and `air.segment` already follow — coordinates arrive in the launch body:

```python
# before                                    # after
with air.launch(name="matmul_bf16"):        with air.launch(
    @launch.body                                [range(0, m, seg_m), range(0, n, seg_n)],
    def _():                                    name="matmul_bf16"):
        with air.segment(                       @launch.body
            [range(0, m, seg_m),                def _(si, sj):
             range(0, n, seg_n)],                   with air.segment(name="matmul_seg"):
            name="matmul_seg"):                         @seg.body
            @seg.body                                   def _():
            def _(si, sj):
```

`air.segment` emits its own `sizes` and rejects the old spelling instead of silently redirecting it:

> `air.segment(<grid>)` is the segment's own iteration space — air.segment's `sizes`, which unrolls the segment body into one spatial copy per point (see `programming_examples/segment_unroll`). air.api does not emit that yet.
>
> If you meant the outer tiling — one segment instance per point, L2 staging refilled each time — that is the *launch's* iteration space: write `air.launch(<grid>)` and take the coordinates in the launch body.

Emitting a segment iteration space is still unimplemented — but it is now a **named gap** instead of an invisible one.

A launch with no grid still emits nothing until a segment needs somewhere to sit, which keeps a kernel that stages nothing at the plain `func` + `air.herd` shape its predecessor had (`relu`, `eltwise_add` and `axpy` all predate any `@launch`).

## No IR changes

**All 24 air.api examples are byte-identical to `origin/main`.** This is an API correction; nine call sites move the grid from `air.segment` to `air.launch`.

## Why no test caught it, and what does now

The defect mis-emitted nothing. CI exercises real multi-point launch grids on every PR — `2x2`, `1x2`, `2x1`, `128x1` — and they were always correct, so no behavioural test could fail. The only observable symptom was air.api emitting a segment iteration space, which the defect itself made impossible.

An expressiveness gap cannot be tested for, only asserted against. So `python/test/api/hierarchy.py` checks **where a grid lands**, not what the kernel computes:

```
# CHECK: air.launch (%{{.*}}, %{{.*}}) in (%{{.*}}=%c2{{.*}}, %{{.*}}=%c2{{.*}})
# CHECK: air.segment @seg args
# CHECK-NOT: air.segment {{.*}}unroll
```

That fails on the old code and passes on the new. Plus four negative tests: the redirect message, a 3-D segment grid, a 3-D launch grid, and launch-body arity.

## Verification, npu1 (Phoenix)

- 24/24 examples byte-identical to `origin/main`
- `lit --filter=api` 11/11, including the new guard
- npu1 lit sweep over every converted example: 29 pass, 1 fail — `matrix_vector_multiplication/bf16` at its `PROFILE` step with a missing `xrt/xrt_bo.h`; its three correctness runs pass and a build without these changes reproduces it identically (this box was configured without XRT, so lit passes `XILINX_XRT=XRT_DIR-NOTFOUND`)

Not run here: the `chess` and `ryzen_ai_npu2` lits.

#1866 touches two of the same files and will be rebased on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)