### PR TITLE
[python] air.api: implement ops.dot(transpose_b=True)

### DIFF
--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -587,6 +587,23 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None, *, kernel
     One rule covers all four: ``a``'s last axis contracts against ``b``'s first,
     and ``acc`` keeps what is left of each.
 
+    ``transpose_b=True`` says B is stored ``[n, k]`` rather than ``[k, n]``, so
+    ``a``'s last axis contracts against b's last. It is emitted as a named
+    ``linalg.matmul`` carrying the transpose in its indexing maps -- not the
+    deprecated ``linalg.matmul_transpose_b``, and not a ``linalg.generic``.
+    Nothing downstream needs to know: ``air-to-aie`` matches no named
+    contraction, and both ``lower_linalg_to_func`` and
+    ``transform.air.herd_vectorize`` go through the ``LinalgOp`` interface,
+    which is indexing-map agnostic.
+
+    Two limits worth stating. It is verified through the scalar path -- lowered
+    by ``convert-linalg-to-loops`` and run on npu1 -- and *not* through the AIE2
+    matmul intrinsic, which wants micro-tiled operands whose layout the DMA pack
+    (``mm.b(...)``) already fixes. And under ``lower_linalg_to_func`` an external
+    kernel built for ``[k, n]`` links happily against an ``[n, k]`` operand and
+    computes silently wrong results, so pass ``kernel=`` to give the transposed
+    form its own symbol.
+
     ``kernel=`` is keyword-only, and sits after ``dependency`` so that every
     existing positional binding is unchanged: inserting it earlier would have
     silently rebound a positionally-passed ``dependency`` to it. It names the
@@ -660,30 +677,55 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None, *, kernel
             f"air.api.ops.dot(transpose_b=True) is meaningless for {signature}; "
             "it transposes a matrix operand"
         )
-    if transpose_b:
-        raise NotImplementedError(
-            "air.api.ops.dot(transpose_b=True) is not implemented yet; it needs "
-            "linalg.matmul_transpose_b"
-        )
-
-    # a's last axis contracts against b's first; acc keeps the rest of each.
-    k_a, k_b = a.shape[-1], b.shape[0]
+    # a's last axis contracts against b's first -- or against b's last, when B
+    # is stored transposed. acc keeps what is left of each.
+    k_a = a.shape[-1]
+    k_b = b.shape[-1] if transpose_b else b.shape[0]
     if k_a != k_b:
         raise ValueError(
             f"air.api.ops.dot shape mismatch for {signature}: a is {a.shape} and "
             f"b is {b.shape}; a's contracting dimension ({k_a}) must equal b's "
             f"({k_b})"
+            + (" -- with transpose_b=True, b is [n, k]" if transpose_b else "")
         )
-    expected = tuple(a.shape[:-1]) + tuple(b.shape[1:])
+    expected = tuple(a.shape[:-1]) + (
+        tuple(b.shape[:-1]) if transpose_b else tuple(b.shape[1:])
+    )
     if tuple(acc.shape) != expected:
         raise ValueError(
             f"air.api.ops.dot shape mismatch for {signature}: a . b is "
             f"{expected} but acc is {tuple(acc.shape)}"
         )
 
-    op = getattr(linalg, op_name)(a.value, b.value, outs=[acc.value])
+    if transpose_b:
+        # A named linalg.matmul carrying the transpose in its indexing maps,
+        # rather than the deprecated linalg.matmul_transpose_b. Downstream this
+        # is the same op: air-to-aie matches no named contraction, and both
+        # `lower_linalg_to_func` and transform.air.herd_vectorize go through the
+        # LinalgOp interface, which is indexing-map agnostic.
+        op = linalg.matmul(
+            a.value, b.value, outs=[acc.value], indexing_maps=_transpose_b_maps()
+        )
+    else:
+        op = getattr(linalg, op_name)(a.value, b.value, outs=[acc.value])
     _set_library_call(kernel)
     return Token(op)
+
+
+def _transpose_b_maps():
+    """Indexing maps for ``acc[m, n] += a[m, k] * b[n, k]``.
+
+    Raw ``AffineMap``s, not ``AffineMapAttr``s: the linalg wrapper's type hint
+    says otherwise but it wraps them itself, and pre-wrapping raises.
+    """
+    from air.ir import AffineDimExpr, AffineMap
+
+    m, n, k = (AffineDimExpr.get(i) for i in range(3))
+    return [
+        AffineMap.get(3, 0, [m, k]),
+        AffineMap.get(3, 0, [n, k]),
+        AffineMap.get(3, 0, [m, n]),
+    ]
 
 
 def _set_library_call(kernel):

--- a/python/test/api/dot.py
+++ b/python/test/api/dot.py
@@ -166,3 +166,48 @@ def dot_rank_dispatch():
                     air.ops.store(c, out[0:T, 0:T])
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: dot_transpose_b
+# transpose_b=True says B is stored [n, k] rather than [k, n]. That is still a
+# named linalg.matmul -- the transpose rides in the indexing maps, so nothing
+# downstream has to recognise a second op. Pinning the maps here is the point:
+# B's map must be (n, k), and dropping the transpose would silently give the
+# default (k, n) and a matmul against the wrong operand layout.
+# CHECK-DAG: #[[MA:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+# CHECK-DAG: #[[MB:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+# CHECK-DAG: #[[MC:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+# CHECK: linalg.matmul indexing_maps = [#[[MA]], #[[MB]], #[[MC]]] ins(%{{.*}}, %{{.*}} : memref<32x64xbf16, 2 : i32>, memref<32x64xbf16, 2 : i32>) outs(%{{.*}} : memref<32x32xf32, 2 : i32>)
+#
+# The untransposed spelling is unchanged -- no indexing_maps at all.
+# CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : memref<32x64xbf16, 2 : i32>, memref<64x32xbf16, 2 : i32>) outs(%{{.*}} : memref<32x32xf32, 2 : i32>)
+@run
+def dot_transpose_b():
+    K, T = 64, 32
+    a = air.tensor([T, K], bf16)
+    bt = air.tensor([T, K], bf16)  # B stored transposed: [n, k]
+    bn = air.tensor([K, T], bf16)  # and the ordinary [k, n]
+    out = air.tensor([T, T], f32)
+
+    with air.launch(name="tb") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, 1, 1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    ab = air.alloc([T, K], bf16, scope=h.private())
+                    tb = air.alloc([T, K], bf16, scope=h.private())
+                    nb = air.alloc([K, T], bf16, scope=h.private())
+                    air.ops.load(ab, a[0:T, 0:K])
+                    air.ops.load(tb, bt[0:T, 0:K])
+                    air.ops.load(nb, bn[0:K, 0:T])
+
+                    c = air.alloc([T, T], f32, scope=h.private(), vector=0)
+                    c[:] = 0.0
+                    air.ops.dot(ab, tb, acc=c, transpose_b=True)
+                    air.ops.dot(ab, nb, acc=c)
+                    air.ops.store(c, out[0:T, 0:T])
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -276,6 +276,37 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: dot_transpose_b_wrong_axis
+# With transpose_b=True, B is [n, k] -- so the contracting axis is its *last*,
+# and passing an ordinary [k, n] operand is caught rather than contracted along
+# the wrong axis. The message says which convention is in force, because the
+# two spellings differ only in a keyword.
+# CHECK: ValueError: air.api.ops.dot shape mismatch for (m, k) @ (k, n) -> (m, n)
+# CHECK: with transpose_b=True, b is [n, k]
+@expect(ValueError, "dot_transpose_b_wrong_axis")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 64], bf16, scope=h.private())
+        b = air.alloc([64, 32], bf16, scope=h.private())  # [k, n], not [n, k]
+        acc = air.alloc([32, 32], f32, scope=h.private())
+        ops.dot(a, b, acc=acc, transpose_b=True)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dot_transpose_b_acc_shape
+# CHECK: ValueError: air.api.ops.dot shape mismatch for (m, k) @ (k, n) -> (m, n): a . b is (32, 16) but acc is (32, 32)
+@expect(ValueError, "dot_transpose_b_acc_shape")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([32, 64], bf16, scope=h.private())
+        b = air.alloc([16, 64], bf16, scope=h.private())  # n = 16
+        acc = air.alloc([32, 32], f32, scope=h.private())
+        ops.dot(a, b, acc=acc, transpose_b=True)
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: dot_shape_mismatch
 # CHECK: ValueError: air.api.ops.dot shape mismatch
 @expect(ValueError, "dot_shape_mismatch")


### PR DESCRIPTION
`transpose_b=True` says B is stored `[n, k]` rather than `[k, n]`, so `a`'s last axis contracts against b's last. It previously raised:

> not implemented yet; it needs `linalg.matmul_transpose_b`

That was stale. `linalg.matmul` takes `indexing_maps` directly from the Python bindings, so the transpose rides in the maps on a **named** op:

```mlir
#map  = affine_map<(d0, d1, d2) -> (d0, d2)>
#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>     // B as [n, k]
#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
linalg.matmul indexing_maps = [#map, #map1, #map2] ins(...) outs(...)
```

No deprecated op, no `linalg.generic`, no pipeline change.

## Why not generate-then-specialize

The other candidate was emitting a generic and recovering the named op with `--linalg-specialize-generic-ops`. Measured against this LLVM by round-tripping each named op through `--linalg-generalize-named-ops --linalg-specialize-generic-ops`:

| op | specializes back? |
|---|---|
| `linalg.matmul` | yes |
| `linalg.batch_matmul` | yes |
| `linalg.fill`, `linalg.copy` | yes |
| `linalg.dot` | **no** |
| `linalg.vecmat` | **no** |
| `linalg.matvec` | **no** |

Same on tensor semantics, so it is coverage rather than a memref restriction. That route would have discarded three of the four contractions `ops.dot` dispatches to, in order to re-derive by pattern match what the tracer already knows from the operand ranks. The named-op table stays.

## Nothing downstream needs to change

- `air-to-aie` matches **no** named contraction op (zero hits for `MatmulOp`/`VecmatOp`/`MatvecOp`/`DotOp` in `mlir/lib`, `mlir/include`)
- `lower_linalg_to_func` matches the interface — `fnName = linalgOp.getLibraryCallName()`
- `transform.air.herd_vectorize` is maps-agnostic by construction: `MatchAnyOpTypeTag()` + `linalg::hasVectorizationImpl` + `linalg::vectorize`

Checked by A/B against the untransposed matmul: both produce structurally identical `vector.contract`s, the transposed one with `vector<32x16xf32>` for B.

## Verified on npu1 (Phoenix)

Two arms computing the **same** `C = A @ B` against the same reference; the transposed arm is handed `Bᵀ` and must undo it through the map.

```
CONTROL     B stored [K,N], transpose_b=False   PASS!   exit 0
TRANSPOSED  B stored [N,K], transpose_b=True    PASS!   exit 0
```

The test discriminates rather than passing by luck:

```
elements differing between A@B and A@B.T : 1016 / 1024
max abs difference                        : 161
=> a map that ignored the transpose would mismatch
```

And the transpose survives into the core program — B read at `[n, k]`, A at `[m, k]`:

```mlir
scf.for %arg0 ... scf.for %arg1 ... scf.for %arg2 {
  %0 = memref.load %buf2[%arg0, %arg2]   // A[m, k]
  %1 = memref.load %buf1[%arg1, %arg2]   // B[n, k]
  %2 = memref.load %buf0[%arg0, %arg1]   // acc[m, n]
```

## Two limits, stated in the docstring

- **This is the scalar path** — `convert-linalg-to-loops`, 32×32×32, no external kernel and no transform script. The AIE2 matmul intrinsic is **not** exercised; it wants micro-tiled operands whose layout the DMA pack (`mm.b(...)`) already fixes, which is where a transposed B would more naturally be expressed. An earlier probe could not settle this either way — the untransposed control failed `convert-vector-to-aievec` identically, so the shapes were simply wrong for that path.
- **Under `lower_linalg_to_func`**, an external kernel built for `[k, n]` links happily against an `[n, k]` operand and computes silently wrong results, so the transposed form should be given its own symbol with `kernel=`.

There is also **no consumer in-tree** today — grepping for `transpose_b`/`matmul_transpose` finds only nvgpu, a DMA-transpose example, and air.api's own error strings. This is surface, measured rather than assumed.

## Regression

- All 24 air.api examples **byte-identical to main**
- `lit --filter=api` 11/11 — three maps pinned in `dot.py`, two shape rules in `errors.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)