### PR TITLE
[docs] Acknowledge FastFlowLM for the designs these models reimplement

### DIFF
--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -705,6 +705,8 @@ def render_llm_sweep(recs, base_url=""):
 
 Steady-state decode throughput at increasing KV-cache depth.
 
+The models below are MLIR-AIR reimplementations, based on AMD NPU LLM designs originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 {head}
 {sep}
 {chr(10).join(rows)}

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -705,7 +705,8 @@ def render_llm_sweep(recs, base_url=""):
 
 Steady-state decode throughput at increasing KV-cache depth.
 
-The models below are MLIR-AIR reimplementations, based on AMD NPU LLM designs originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+The models below are MLIR-AIR reimplementations, based on AMD NPU LLM designs
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 {head}
 {sep}

--- a/programming_examples/generate_readme.py
+++ b/programming_examples/generate_readme.py
@@ -705,8 +705,9 @@ def render_llm_sweep(recs, base_url=""):
 
 Steady-state decode throughput at increasing KV-cache depth.
 
-The models below are MLIR-AIR reimplementations, based on AMD NPU LLM designs
-originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+The models below reimplement AMD NPU LLM designs originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team, using the higher-level
+abstractions of the MLIR-AIR dialect.
 
 {head}
 {sep}

--- a/programming_examples/llms/README.md
+++ b/programming_examples/llms/README.md
@@ -7,11 +7,11 @@ multi-launch ELFs and gates correctness against a Hugging Face bf16 reference.
 
 ## Acknowledgments
 
-Some of the LLM implementations in this directory are MLIR-AIR
-reimplementations, based on AMD NPU LLM designs originally developed by the
-[FastFlowLM](https://fastflowlm.com/) team
-([github.com/ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)). We thank the
-FastFlowLM team for their original work on these implementations.
+Some of the LLM implementations in this directory reimplement AMD NPU LLM
+designs originally developed by the [FastFlowLM](https://fastflowlm.com/) team
+([github.com/ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)), using the
+higher-level abstractions of the MLIR-AIR dialect. We thank the FastFlowLM team
+for their original work on these implementations.
 
 The remaining models were developed directly in MLIR-AIR.
 

--- a/programming_examples/llms/README.md
+++ b/programming_examples/llms/README.md
@@ -5,6 +5,16 @@ to the AMD NPU2 (AIE2P / Strix) in bf16 via MLIR-AIR. Each model is a
 self-contained example that composes registry-validated leaf kernels into fused
 multi-launch ELFs and gates correctness against a Hugging Face bf16 reference.
 
+## Acknowledgments
+
+Some of the LLM implementations in this directory are MLIR-AIR
+reimplementations, based on AMD NPU LLM designs originally developed by the
+[FastFlowLM](https://fastflowlm.com/) team
+([github.com/ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)). We thank the
+FastFlowLM team for their original work on these implementations.
+
+The remaining models were developed directly in MLIR-AIR.
+
 ## Supported models
 
 | Model | HF checkpoint | Layers | emb / head_dim / hidden | Attention | Family delta | Status |

--- a/programming_examples/llms/gemma3_4b_q4nx/README.md
+++ b/programming_examples/llms/gemma3_4b_q4nx/README.md
@@ -1,8 +1,8 @@
 # GEMMA3-4B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 Gemma3-4B (text) in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:

--- a/programming_examples/llms/gemma3_4b_q4nx/README.md
+++ b/programming_examples/llms/gemma3_4b_q4nx/README.md
@@ -1,5 +1,7 @@
 # GEMMA3-4B Q4NX prefill + decode on AMD NPU2
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 Gemma3-4B (text) in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:
 

--- a/programming_examples/llms/gemma3_4b_q4nx/README.md
+++ b/programming_examples/llms/gemma3_4b_q4nx/README.md
@@ -1,6 +1,8 @@
 # GEMMA3-4B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 Gemma3-4B (text) in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:

--- a/programming_examples/llms/llama31_8b_q4nx/README.md
+++ b/programming_examples/llms/llama31_8b_q4nx/README.md
@@ -1,5 +1,7 @@
 # LLAMA-3.1-8B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 A full **prefill + decode** MLIR-AIR inference for Llama-3.1-8B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2
 (AIE2P). The decoder layer runs **entirely on the AIE array** — attention

--- a/programming_examples/llms/llama31_8b_q4nx/README.md
+++ b/programming_examples/llms/llama31_8b_q4nx/README.md
@@ -1,6 +1,8 @@
 # LLAMA-3.1-8B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.1-8B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2

--- a/programming_examples/llms/llama31_8b_q4nx/README.md
+++ b/programming_examples/llms/llama31_8b_q4nx/README.md
@@ -1,8 +1,8 @@
 # LLAMA-3.1-8B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.1-8B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -1,8 +1,8 @@
 # LLAMA-3.2-1B Q4NX chatbot on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-1B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`), exposed as an

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -1,5 +1,7 @@
 # LLAMA-3.2-1B Q4NX chatbot on AMD NPU2
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-1B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`), exposed as an
 interactive chatbot on NPU2 (AIE2P):

--- a/programming_examples/llms/llama32_1b_q4nx/README.md
+++ b/programming_examples/llms/llama32_1b_q4nx/README.md
@@ -1,6 +1,8 @@
 # LLAMA-3.2-1B Q4NX chatbot on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-1B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`), exposed as an

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -1,5 +1,7 @@
 # LLAMA-3.2-3B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-3B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2
 (AIE2P). The decoder layer runs **entirely on the AIE array** — attention

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -1,8 +1,8 @@
 # LLAMA-3.2-3B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-3B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2

--- a/programming_examples/llms/llama32_3b_q4nx/README.md
+++ b/programming_examples/llms/llama32_3b_q4nx/README.md
@@ -1,6 +1,8 @@
 # LLAMA-3.2-3B Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 A full **prefill + decode** MLIR-AIR inference for Llama-3.2-3B using **Q4NX**
 weights (per-block 4-bit affine quantization, `w = q*scale + min`) on NPU2

--- a/programming_examples/llms/phi4_mini_q4nx/README.md
+++ b/programming_examples/llms/phi4_mini_q4nx/README.md
@@ -1,8 +1,8 @@
 # PHI-4-MINI Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 A full **prefill + decode** MLIR-AIR inference for `microsoft/Phi-4-mini-instruct` using
 **Q4NX** weights (per-block 4-bit affine quantization, `w = q*scale + min`) on

--- a/programming_examples/llms/phi4_mini_q4nx/README.md
+++ b/programming_examples/llms/phi4_mini_q4nx/README.md
@@ -1,6 +1,8 @@
 # PHI-4-MINI Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 A full **prefill + decode** MLIR-AIR inference for `microsoft/Phi-4-mini-instruct` using
 **Q4NX** weights (per-block 4-bit affine quantization, `w = q*scale + min`) on

--- a/programming_examples/llms/phi4_mini_q4nx/README.md
+++ b/programming_examples/llms/phi4_mini_q4nx/README.md
@@ -1,5 +1,7 @@
 # PHI-4-MINI Q4NX Inference on AMD NPU2 (MLIR-AIR)
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 A full **prefill + decode** MLIR-AIR inference for `microsoft/Phi-4-mini-instruct` using
 **Q4NX** weights (per-block 4-bit affine quantization, `w = q*scale + min`) on
 NPU2 (AIE2P). The decoder layer runs **entirely on the AIE array** — attention

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -1,5 +1,7 @@
 # Qwen2.5-3B Q4_0 Prefill on AMD NPU2 (MLIR-AIR)
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 Structural port of [`../llama32_1b_q4nx/`](../llama32_1b_q4nx/) to Qwen2.5-3B:
 4-bit weights, host dequant at load, then the whole transformer block —
 RMSNorm, Q/K/V GEMM, QKV bias, RoPE, causal GQA flash attention, O projection,

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -1,8 +1,8 @@
 # Qwen2.5-3B Q4_0 Prefill on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 Structural port of [`../llama32_1b_q4nx/`](../llama32_1b_q4nx/) to Qwen2.5-3B:
 4-bit weights, host dequant at load, then the whole transformer block —

--- a/programming_examples/llms/qwen25_3b_q4/README.md
+++ b/programming_examples/llms/qwen25_3b_q4/README.md
@@ -1,6 +1,8 @@
 # Qwen2.5-3B Q4_0 Prefill on AMD NPU2 (MLIR-AIR)
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 Structural port of [`../llama32_1b_q4nx/`](../llama32_1b_q4nx/) to Qwen2.5-3B:
 4-bit weights, host dequant at load, then the whole transformer block —

--- a/programming_examples/llms/qwen25_7b_q4nx/README.md
+++ b/programming_examples/llms/qwen25_7b_q4nx/README.md
@@ -1,8 +1,8 @@
 # QWEN2.5-7B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 Qwen2.5-7B-Instruct in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:

--- a/programming_examples/llms/qwen25_7b_q4nx/README.md
+++ b/programming_examples/llms/qwen25_7b_q4nx/README.md
@@ -1,5 +1,7 @@
 # QWEN2.5-7B Q4NX prefill + decode on AMD NPU2
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 Qwen2.5-7B-Instruct in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:
 

--- a/programming_examples/llms/qwen25_7b_q4nx/README.md
+++ b/programming_examples/llms/qwen25_7b_q4nx/README.md
@@ -1,6 +1,8 @@
 # QWEN2.5-7B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 Qwen2.5-7B-Instruct in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on
 the NPU:

--- a/programming_examples/llms/qwen3_8b_q4nx/README.md
+++ b/programming_examples/llms/qwen3_8b_q4nx/README.md
@@ -1,6 +1,8 @@
 # QWEN3-8B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation is an MLIR-AIR reimplementation, based on the corresponding
+AMD NPU LLM design originally developed by the
+[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
 
 Qwen3-8B in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on the NPU:
 

--- a/programming_examples/llms/qwen3_8b_q4nx/README.md
+++ b/programming_examples/llms/qwen3_8b_q4nx/README.md
@@ -1,8 +1,8 @@
 # QWEN3-8B Q4NX prefill + decode on AMD NPU2
 
-This implementation is an MLIR-AIR reimplementation, based on the corresponding
-AMD NPU LLM design originally developed by the
-[FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+This implementation reimplements the corresponding AMD NPU LLM design,
+originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM)
+team, using the higher-level abstractions of the MLIR-AIR dialect.
 
 Qwen3-8B in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on the NPU:
 

--- a/programming_examples/llms/qwen3_8b_q4nx/README.md
+++ b/programming_examples/llms/qwen3_8b_q4nx/README.md
@@ -1,5 +1,7 @@
 # QWEN3-8B Q4NX prefill + decode on AMD NPU2
 
+This implementation is an MLIR-AIR reimplementation, based on the corresponding AMD NPU LLM design originally developed by the [FastFlowLM](https://github.com/ROCm/FastFlowLM) team.
+
 Qwen3-8B in MLIR-AIR, reproducing FastFlowLM's mechanism end to end on the NPU:
 
 - **prefill** — a batched pass over the padded context: RMSNorm, Q/K/V GEMMs,


### PR DESCRIPTION
Eight of the LLM examples here reimplement AMD NPU LLM designs originally
developed by the [FastFlowLM](https://fastflowlm.com/) team
([github.com/ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)), using the
higher-level abstractions of the MLIR-AIR dialect: `llama32_1b_q4nx`,
`llama32_3b_q4nx`, `gemma3_4b_q4nx`, `phi4_mini_q4nx`, `llama31_8b_q4nx`,
`qwen3_8b_q4nx`, `qwen25_3b_q4` and `qwen25_7b_q4nx`.

This adds the acknowledgment, with links, in three places: the nightly benchmark
page, `programming_examples/llms/README.md`, and each of those models' own README.

> Some of the LLM implementations in this directory reimplement AMD NPU LLM
> designs originally developed by the [FastFlowLM](https://fastflowlm.com/) team
> ([github.com/ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)), using the
> higher-level abstractions of the MLIR-AIR dialect. We thank the FastFlowLM team
> for their original work on these implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
