### PR TITLE
[python] air.api: unsigned element types, and passthrough_kernel converted onto them

### DIFF
--- a/programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py
+++ b/programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py
@@ -1,86 +1,103 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Passthrough through a hand-written AIE kernel, on air.api.
+
+Same schedule as ``passthrough_channel`` -- L3 -> channel -> L1, back out
+L1 -> channel -> L3 -- with the core-side copy done by ``passThroughLine`` from
+``passThrough.cc`` instead of by the DSL:
+
+    air.channel @ChanIn                    declared at module scope
+    air.channel @ChanOut
+      air.segment
+        ChanIn.put(A)                      the whole [n] vector, once
+        herd                               link_with = "passThrough.cc.o"
+          for _ in air.sequential(subvectors)
+              ChanIn.get(tile_in)          one [n/subvectors] chunk per trip
+              passThroughLine(tile_in, tile_out, chunk)
+              ChanOut.put(tile_out)
+        ChanOut.get(B)
+
+The data is ``uint8``, and the tiles say so. That is what ``ui8`` is for here:
+``air.extern`` emits
+
+    func.func private @passThroughLine(memref<1024xui8, 2 : i32>,
+                                       memref<1024xui8, 2 : i32>, i32)
+
+which is the signature aircc links the object file against, and the object file
+was compiled from ``uint8_t *`` (``-DBIT_WIDTH=8`` in the Makefile). Declaring
+``i8`` would put a prototype in the IR that ``passThrough.cc`` does not define.
+
+Unsigned types in air.api are movable but not computable -- MLIR's arith and
+linalg ops take signless operands -- which costs this example nothing, since
+everything done to the data happens inside the external kernel.
+
+The put and get on the L3 side sit in the segment rather than beside it, as in
+``passthrough_channel``: reaching L3 needs a shim DMA allocation, and hoisting
+them out to function scope fails in air-to-aie with "failed to link to any shim
+dma allocation".
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32, ui8
 
 INOUT_DATATYPE = np.uint8
 
 
-@module_builder
 def build_module(vector_size, num_subvectors):
     assert vector_size % num_subvectors == 0
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    chunk = vector_size // num_subvectors
 
-    # Type and method of input/output
-    memrefTyInOut = T.memref(vector_size, xrt_dtype)
-    Channel("ChanIn")
-    Channel("ChanOut")
+    A = air.tensor([vector_size], ui8)
+    B = air.tensor([vector_size], ui8)
 
-    # The compute core splits input into subvectors for processing
-    lineWidthInBytes = vector_size // num_subvectors
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
 
-    # Memref type definition used by the compute core and external function
-    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    tensor_type = MemRefType.get(
-        shape=[lineWidthInBytes],
-        element_type=xrt_dtype,
-        memory_space=mem_space,
+    # The line width the kernel loops over. Its type has to be declared: a
+    # Python int does not say whether the kernel wants i32 or index.
+    pass_through_line = air.extern(
+        "passThroughLine", object="passThrough.cc.o", scalars=[i32]
     )
 
-    # Function definition of the external function we will call
-    passThroughLine = external_func(
-        "passThroughLine", inputs=[tensor_type, tensor_type, T.i32()]
-    )
+    with air.launch(name="copy") as launch:
 
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            ChannelPut("ChanIn", a)
+                @seg.body
+                def _():
+                    chan_in.put(A)
 
-            @segment(name="seg")
-            def segment_body():
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
 
-                @herd(name="copyherd", sizes=[1, 1], link_with="passThrough.cc.o")
-                def herd_body(_tx, _ty, _sx, _sy):
+                        @h.body
+                        def _(tx):
+                            # Hoisted above the loop and reused across trips,
+                            # which is what the loop is for; the predecessor
+                            # allocated a fresh pair per trip.
+                            tile_in = air.alloc([chunk], ui8, scope=h.private())
+                            tile_out = air.alloc([chunk], ui8, scope=h.private())
 
-                    # Process each subvector individually
-                    for _i in range_(num_subvectors):
-                        tensor_in = AllocOp(tensor_type, [], [])
-                        tensor_out = AllocOp(tensor_type, [], [])
+                            for _i in air.sequential(0, num_subvectors):
+                                chan_in.get(tile_in)
+                                pass_through_line(tile_in, tile_out, chunk)
+                                chan_out.put(tile_out)
 
-                        ChannelGet("ChanIn", tensor_in)
+                    chan_out.get(B)
 
-                        call(
-                            passThroughLine,
-                            inputs=[tensor_in, tensor_out, lineWidthInBytes],
-                            input_types=[tensor_type, tensor_type, T.i32()],
-                        )
-
-                        ChannelPut("ChanOut", tensor_out)
-
-                        # Deallocate our L1 buffers
-                        DeallocOp(tensor_in)
-                        DeallocOp(tensor_out)
-                        yield_([])
-
-            ChannelGet("ChanOut", b)
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the passthrough_kernel example",
     )
     parser.add_argument(
         "-s",
@@ -113,10 +130,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.vector_size, args.subvector_size)
+    launch = build_module(args.vector_size, args.subvector_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -36,6 +36,16 @@ elementwise arithmetic on whole L1 tiles, an ``air.sequential`` loop, and
 ``NotImplementedError`` at the point of use. Nothing degrades quietly into a
 kernel that runs and returns wrong numbers.
 
+Element types are ``bf16 f16 f32``, ``i8 i16 i32`` and ``ui8 ui16 ui32``. The
+unsigned three are *movable but not computable*: MLIR spells signedness in the
+operation rather than the type, so the whole ``arith`` dialect -- and every
+named ``linalg`` contraction built out of it -- takes signless operands, and a
+``ui8`` one does not verify. An unsigned tile can therefore be allocated, moved
+by ``ops.load``/``ops.store`` and ``air.channel``, copied elementwise, and
+handed to an ``air.extern`` kernel, which is what a ``uint8`` example in this
+tree needs; arithmetic on one raises at the call site naming the signed type to
+declare instead.
+
 ``launch``, ``segment`` and ``herd`` are independent levels: a kernel that needs
 no staging writes a herd on its own, and one that does wraps it in a segment.
 Giving ``air.segment`` an iteration space makes it the *launch* grid, one segment
@@ -94,7 +104,7 @@ from ._trace import (
     wait,
 )
 from ._value import Buffer, BufferSlice, Tensor, TensorSlice, Token
-from .types import DType, bf16, f16, f32, i8, i16, i32
+from .types import DType, bf16, f16, f32, i8, i16, i32, ui8, ui16, ui32
 
 __all__ = [
     # operations
@@ -127,6 +137,9 @@ __all__ = [
     "i8",
     "i16",
     "i32",
+    "ui8",
+    "ui16",
+    "ui32",
     # objects surfaced for isinstance checks and typing
     "LaunchContext",
     "SegmentContext",

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -28,6 +28,8 @@ from air.dialects.memref import load as memref_load, store as memref_store
 from air.dialects.scf import for_ as range_, yield_
 from air.dialects.vector import broadcast, transfer_read, transfer_write
 
+from .types import require_signless
+
 __all__ = ["emit_elementwise"]
 
 _FLOAT_OPS = {
@@ -80,6 +82,23 @@ def emit_elementwise(dst, expr):
                 "buffer used before allocation; air.alloc() must be called "
                 "inside the herd body that uses it"
             )
+
+    if dst.dtype.is_unsigned:
+        # An unsigned tile can be *copied* elementwise but not computed on. The
+        # copy holds because it emits memref.load/store and no arith op at all,
+        # which is exactly the loop the hand-written uint8 examples spell out;
+        # anything else -- an operator, or a broadcast constant -- reaches an
+        # arith builder that rejects a signful operand. The vector path is not
+        # available even for the copy: vector.transfer_read takes a padding
+        # value, and that padding value is an arith.constant.
+        if expr.kind != "buffer":
+            require_signless(
+                dst.dtype,
+                "an elementwise operator or broadcast scalar (a plain copy, "
+                "dst[:] = src[:], is)",
+            )
+        _emit_scalar(dst, expr, _INT_OPS)
+        return
 
     shape = dst.shape
     # A rank-0 buffer is a single scalar -- the accumulator linalg.dot writes

--- a/python/air/api/_extern.py
+++ b/python/air/api/_extern.py
@@ -55,7 +55,7 @@ class ExternKernel:
                 'should link against, e.g. object="mv.o". It becomes the '
                 "link_with attribute on both the declaration and the herd."
             )
-        from .types import DType
+        from .types import DType, require_signless
 
         for s in scalars:
             if not isinstance(s, DType):
@@ -66,6 +66,11 @@ class ExternKernel:
                     "bf16 or f32, and buffer types are inferred from the buffers "
                     "themselves."
                 )
+            # A scalar argument is materialised by arith.constant, so it has to
+            # be signless even though the *buffer* arguments beside it need not
+            # be. Caught at the declaration rather than at the first call, which
+            # is where the constant would actually be built.
+            require_signless(s, "an air.extern scalar argument")
         self.name = name
         self.object = object
         self.scalars = list(scalars)

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -251,7 +251,12 @@ class Buffer:
         from air.dialects.linalg import fill
 
         from . import ops as _ops
+        from .types import require_signless
 
+        # linalg.fill's value comes from an arith.constant, which has no signful
+        # form; a packed buffer is an accumulator anyway, and ops.dot has
+        # already refused an unsigned one.
+        require_signless(self.dtype, "a fill of a micro-tiled buffer")
         if not isinstance(value, (int, float)) or isinstance(value, bool):
             raise NotImplementedError(
                 "only a scalar fill is supported on a micro-tiled buffer "

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -35,6 +35,7 @@ from ``tanh``, which has a checked lowering, so nothing has needed a vector
 """
 
 from ._value import Buffer, BufferExpr, BufferSlice, Tensor, TensorSlice, Token
+from .types import require_signless
 
 __all__ = [
     "load",
@@ -643,6 +644,11 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None, *, kernel
             )
         if buf.value is None:
             raise RuntimeError(f"air.api.ops.dot: {name} used before allocation")
+        # A named linalg contraction builds its region from arith ops --
+        # arith.extsi and arith.muli for an integer operand -- so an unsigned
+        # element type fails verification inside the op that was just emitted,
+        # several frames from the call that caused it.
+        require_signless(buf.dtype, f"air.api.ops.dot's {name} operand")
 
     if alpha != 1.0:
         raise NotImplementedError(

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -27,8 +27,10 @@ __all__ = [
     "ui16",
     "ui32",
     "dtype_of",
-    "require_signless",
 ]
+# `require_signless` is deliberately absent from __all__: it is the guard the
+# emission paths call, not something a kernel author reaches for. All four
+# callers import it by name, which __all__ does not govern.
 
 
 class DType:

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -15,7 +15,20 @@ runner can never disagree about how a numpy dtype maps onto the device.
 import numpy as np
 from ml_dtypes import bfloat16
 
-__all__ = ["DType", "bf16", "f16", "f32", "i8", "i16", "i32", "dtype_of"]
+__all__ = [
+    "DType",
+    "bf16",
+    "f16",
+    "f32",
+    "i8",
+    "i16",
+    "i32",
+    "ui8",
+    "ui16",
+    "ui32",
+    "dtype_of",
+    "require_signless",
+]
 
 
 class DType:
@@ -34,10 +47,13 @@ class DType:
     never exercised there.
 
     Widths for f16, i8, i16 and i32 are extrapolated by element size and have
-    not been compiled; treat them as unverified.
+    not been compiled; treat them as unverified. The unsigned widths are never
+    reached at all -- see ``is_unsigned``.
     """
 
-    def __init__(self, name, np_dtype, default_vector_width, is_float):
+    def __init__(
+        self, name, np_dtype, default_vector_width, is_float, is_unsigned=False
+    ):
         self.name = name
         self.np_dtype = np_dtype
         self.default_vector_width = default_vector_width
@@ -45,6 +61,14 @@ class DType:
         # for the ml_dtypes extension types, which would silently select the
         # integer arithmetic ops for a bf16 kernel.
         self.is_float = is_float
+        # MLIR's arith and linalg ops constrain their integer operands to be
+        # *signless* (`SignlessIntegerLike`), while `type_mapper` maps numpy's
+        # unsigned dtypes onto MLIR's signful `ui8`/`ui16`/`ui32`. So an
+        # unsigned buffer can be declared, allocated, moved and handed to an
+        # external kernel, but arithmetic on one does not verify -- see
+        # `require_signless`, which every emission path that builds an arith or
+        # linalg op calls.
+        self.is_unsigned = is_unsigned
 
     @property
     def itemsize(self):
@@ -69,7 +93,18 @@ i8 = DType("i8", np.int8, 32, is_float=False)
 i16 = DType("i16", np.int16, 16, is_float=False)
 i32 = DType("i32", np.int32, 8, is_float=False)
 
-_BY_NP = {d.np_dtype: d for d in (bf16, f16, f32, i8, i16, i32)}
+# Unsigned integers exist so that a kernel over `np.uint8` data can say so. The
+# alternative -- declaring i8 and passing uint8 arrays -- type-checks nowhere
+# and makes the emitted `func.func private @...` declaration disagree with the
+# C prototype the object file was compiled from. The vector widths mirror their
+# signed counterparts and are unreachable while arithmetic is refused; they are
+# stated rather than left at 0 so that relaxing the refusal does not silently
+# also change the width.
+ui8 = DType("ui8", np.uint8, 32, is_float=False, is_unsigned=True)
+ui16 = DType("ui16", np.uint16, 16, is_float=False, is_unsigned=True)
+ui32 = DType("ui32", np.uint32, 8, is_float=False, is_unsigned=True)
+
+_BY_NP = {d.np_dtype: d for d in (bf16, f16, f32, i8, i16, i32, ui8, ui16, ui32)}
 
 
 def dtype_of(np_dtype):
@@ -79,3 +114,30 @@ def dtype_of(np_dtype):
     (``np.dtype("float32")``); the table is keyed by the former.
     """
     return _BY_NP.get(np_dtype) or _BY_NP.get(getattr(np_dtype, "type", None))
+
+
+def require_signless(dtype, what):
+    """Refuse ``what`` on an unsigned element type, naming why it cannot work.
+
+    MLIR spells signedness in the *operation*, not the type: ``arith.divsi`` and
+    ``arith.divui`` both take signless operands. So the whole ``arith`` dialect
+    -- and every named ``linalg`` contraction, whose region is built from it --
+    is constrained to signless integers, and a ``ui8`` operand fails
+    verification rather than being reinterpreted.
+
+    This is not a limitation air.api could paper over by bitcasting to the
+    signed sibling: that would silently change what ``max``, ``div`` and a
+    widening contraction compute. Refuse, and name the signed type to declare
+    instead.
+    """
+    if not dtype.is_unsigned:
+        return
+    raise NotImplementedError(
+        f"{what} is not supported for {dtype}: MLIR's arith and linalg ops "
+        f"require signless integer operands, and an unsigned numpy dtype maps "
+        f"onto the signful MLIR type '{dtype.name}'. An unsigned buffer can be "
+        f"allocated, moved with air.api.ops.load/store and air.channel, and "
+        f"passed to an air.extern kernel -- which is what the uint8 examples in "
+        f"this tree do. To compute on it in the DSL, declare it "
+        f"air.api.{dtype.name[1:]} instead and interpret the data yourself."
+    )

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -16,7 +16,7 @@ from itertools import product
 
 from air import api as air
 from air.api import ops  # noqa: F401
-from air.api.types import bf16, f32
+from air.api.types import bf16, f32, i32, ui8
 
 
 def expect(exc_types, label):
@@ -1238,3 +1238,60 @@ def _():
         ch.put(buf[0:20, 0:8], pack=mm.b(20, 8, lead=()))
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: unsigned_elementwise_operator
+# An unsigned tile can be copied but not computed on: every arith op is
+# constrained to signless integer operands, so `a[:] + b[:]` on ui8 would build
+# an arith.addi that does not verify. Refused at the call site, naming i8.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar (a plain copy, dst[:] = src[:], is) is not supported for air.api.ui8
+# CHECK-SAME: declare it air.api.i8 instead
+@expect(NotImplementedError, "unsigned_elementwise_operator")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], ui8, scope=h.private())
+        b = air.alloc([64], ui8, scope=h.private())
+        a[:] = a[:] + b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: unsigned_fill
+# A fill is not a copy either: the broadcast scalar is an arith.constant, which
+# has no signful form -- `arith.constant 0 : ui8` fails with "integer return
+# type must be signless".
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar (a plain copy, dst[:] = src[:], is) is not supported for air.api.ui8
+@expect(NotImplementedError, "unsigned_fill")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], ui8, scope=h.private())
+        a[:] = 0
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: unsigned_dot
+# A named linalg contraction builds its region out of arith ops -- arith.extsi
+# then arith.muli for an integer operand -- so the verifier failure would land
+# inside the op rather than at this call.
+# CHECK: NotImplementedError: air.api.ops.dot's a operand is not supported for air.api.ui8
+@expect(NotImplementedError, "unsigned_dot")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], ui8, scope=h.private())
+        b = air.alloc([16, 16], ui8, scope=h.private())
+        acc = air.alloc([16, 16], i32, scope=h.private())
+        ops.dot(a, b, acc=acc)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: unsigned_extern_scalar
+# The *buffer* arguments of an extern kernel may be unsigned -- that is the
+# whole point of the type -- but a scalar argument is materialised by
+# arith.constant, so it may not be. Caught at the declaration rather than at the
+# first call, which is where the constant would actually be built.
+# CHECK: NotImplementedError: an air.extern scalar argument is not supported for air.api.ui8
+@expect(NotImplementedError, "unsigned_extern_scalar")
+def _():
+    air.extern("k", object="k.o", scalars=[ui8])

--- a/python/test/api/unsigned.py
+++ b/python/test/api/unsigned.py
@@ -1,0 +1,150 @@
+# ./python/test/api/unsigned.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Unsigned element types: movable, and not computable.
+
+MLIR spells signedness in the *operation* -- ``arith.divsi`` and ``arith.divui``
+both take signless operands -- so the whole ``arith`` dialect, and every named
+``linalg`` contraction whose region is built from it, rejects a ``ui8``. What
+that leaves is everything that only moves bytes: a memref of any element type,
+``air.dma_memcpy_nd``, ``air.channel``, and a ``func.call`` into a hand-written
+kernel.
+
+That is the whole surface a ``uint8`` kernel needs, and declaring ``i8`` instead
+would be an untruth in the one place it is load-bearing: the emitted
+``func.func private`` declaration is the signature aircc links the object file
+against.
+
+The refusals live in ``errors.py``; this file pins what does work.
+"""
+
+from air import api as air
+from air.api.types import i32, ui8, ui16, ui32
+
+N = 64
+CHUNK = 16
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: extern_kernel_over_ui8
+# The declaration aircc links against carries ui8, matching the uint8_t* the
+# object file was compiled from -- this is the reason the type exists.
+# CHECK: func.func private @passThroughLine(memref<16xui8, 2 : i32>, memref<16xui8, 2 : i32>, i32)
+# CHECK-SAME: link_with = "passThrough.cc.o"
+# CHECK: air.channel @In
+# CHECK: air.channel @Out
+# CHECK: func.func @k(%{{.*}}: memref<64xui8>, %{{.*}}: memref<64xui8>)
+# The L3 endpoints keep the tensor's element type through the channel...
+# CHECK: air.channel.put{{ *}}@In[] (%{{.*}}[] [] []) : (memref<64xui8>)
+# ...and the L1 tiles are ui8 too, allocated in memory space 2.
+# CHECK: %[[IN:.*]] = memref.alloc() : memref<16xui8, 2 : i32>
+# CHECK: %[[OUT:.*]] = memref.alloc() : memref<16xui8, 2 : i32>
+# CHECK: air.channel.get{{ *}}@In[] (%[[IN]][] [] []) : (memref<16xui8, 2 : i32>)
+# CHECK: func.call @passThroughLine(%[[IN]], %[[OUT]], %{{.*}})
+# CHECK: air.channel.put{{ *}}@Out[] (%[[OUT]][] [] []) : (memref<16xui8, 2 : i32>)
+# CHECK: air.channel.get{{ *}}@Out[] (%{{.*}}[] [] []) : (memref<64xui8>)
+@run
+def extern_kernel_over_ui8():
+    A = air.tensor([N], ui8)
+    B = air.tensor([N], ui8)
+    chan_in = air.channel("In")
+    chan_out = air.channel("Out")
+    line = air.extern("passThroughLine", object="passThrough.cc.o", scalars=[i32])
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    chan_in.put(A)
+
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc([CHUNK], ui8, scope=h.private())
+                            tile_out = air.alloc([CHUNK], ui8, scope=h.private())
+                            for _i in air.sequential(0, N // CHUNK):
+                                chan_in.get(tile_in)
+                                line(tile_in, tile_out, CHUNK)
+                                chan_out.put(tile_out)
+
+                    chan_out.get(B)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: elementwise_copy_is_scalar
+# A copy carries no operator, so it emits memref.load/store and no arith op at
+# all -- which is exactly the loop the hand-written uint8 examples spell out.
+# The vector path is unavailable even here: vector.transfer_read takes a padding
+# value, and that padding value is an arith.constant.
+# The CHECK-NEXTs are the assertion: the copy loop's body is those two ops and
+# nothing else, so neither a transfer_read nor its padding constant is there.
+# CHECK: air.herd @copy
+# CHECK: air.dma_memcpy_nd
+# CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+# CHECK-NEXT: %[[V:.*]] = memref.load %{{.*}} : memref<16xui8, 2 : i32>
+# CHECK-NEXT: memref.store %[[V]], %{{.*}} : memref<16xui8, 2 : i32>
+# CHECK-NEXT: }
+@run
+def elementwise_copy_is_scalar():
+    A = air.tensor([N], ui8)
+    B = air.tensor([N], ui8)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, CHUNK)], name="copy", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    src = air.alloc([CHUNK], ui8, scope=h.private())
+                    dst = air.alloc([CHUNK], ui8, scope=h.private())
+                    air.ops.load(src, A[tx : tx + CHUNK])
+                    dst[:] = src[:]
+                    air.ops.store(dst, B[tx : tx + CHUNK])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: wider_unsigned_widths
+# ui16 and ui32 travel the same path; the DMA's element count comes from the
+# shape and its stride from the memref, so the width only has to reach the type.
+# CHECK: func.func @k(%{{.*}}: memref<64xui16>, %{{.*}}: memref<64xui32>
+# CHECK: memref.alloc() : memref<16xui16, 2 : i32>
+# CHECK: memref.alloc() : memref<16xui32, 2 : i32>
+@run
+def wider_unsigned_widths():
+    A = air.tensor([N], ui16)
+    B = air.tensor([N], ui32)
+    C = air.tensor([N], ui32)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, CHUNK)], name="widths", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    narrow = air.alloc([CHUNK], ui16, scope=h.private())
+                    wide = air.alloc([CHUNK], ui32, scope=h.private())
+                    air.ops.load(narrow, A[tx : tx + CHUNK])
+                    air.ops.load(wide, B[tx : tx + CHUNK])
+                    air.ops.store(wide, C[tx : tx + CHUNK])
+
+    print(launch.mlir())


### PR DESCRIPTION
Adds `ui8`/`ui16`/`ui32` to `air.api` and converts
`programming_examples/passthrough/passthrough_kernel` onto it, replacing the
raw-bindings version.

**No new ops.** `air.api.ops.__all__` is byte-identical to `main`. The public
surface change is three element types and nothing else.

## Why the type has to exist

`passthrough_kernel` is `np.uint8` throughout. Without unsigned types the only
way to write it in the DSL is to declare `i8` and pass `uint8` arrays, which
makes the emitted declaration disagree with the C prototype the object file was
compiled from — and that declaration is what aircc links against:

```
func.func private @passThroughLine(memref<1024xui8, 2 : i32>, memref<1024xui8, 2 : i32>, i32)
  attributes {link_with = "passThrough.cc.o", llvm.emit_c_interface}
```

`passThrough.cc` defines `passThroughLine(uint8_t *, uint8_t *, int32_t)` under
`-DBIT_WIDTH=8`, which the Makefile sets.

## Unsigned is movable, not computable

MLIR spells signedness in the *operation*, not the type — `arith.divsi` and
`arith.divui` both take signless operands — so the whole `arith` dialect, and
every named `linalg` contraction whose region is built from it, rejects a
`ui8`. Probed rather than assumed:

```
error: 'arith.constant' op integer return type must be signless
 note: see current operation: %0 = "arith.constant"() <{value = 0 : ui8}> : () -> ui8

error: 'arith.extsi' op operand #0 must be signless-fixed-width-integer-like, but got 'ui8'
 note: see current operation: %0 = "arith.extsi"(%arg3) : (ui8) -> i32
```

The second is from `linalg.matmul` over `ui8` memrefs: the failure lands
*inside* the op that was just emitted, several frames from the call that caused
it. So `require_signless` guards the four sites that build an arith or linalg
op — `_emit.emit_elementwise`, `ops.dot`, `_value._packed_fill`, and
`air.extern`'s `scalars=` — and names the signed type to declare instead. It is
not exported from `air.api`; `hasattr(air.api, "require_signless")` is `False`.

Bitcasting to the signed sibling was the quiet alternative and is wrong: it
changes what `max`, `div` and a widening contraction compute.

What remains is everything that only moves bytes — allocation,
`ops.load`/`ops.store`, `air.channel`, and a `func.call` into a hand-written
kernel — which is the whole surface a uint8 kernel needs. An elementwise
**copy** is also allowed and is forced onto the scalar path: it emits
`memref.load`/`store` and no arith op, which is exactly the loop the
hand-written uint8 examples spell out. The vector path is unavailable even
there, because `vector.transfer_read` takes a padding value and that padding
value is an `arith.constant`.

This asymmetry is the part worth pushing on in review: `ui8` is a type that
roughly half the ops reject. It is there because of the MLIR constraint above,
not because the work was left unfinished.

## Replacement gate for the example

| Axis | Predecessor | Conversion | |
|---|---|---|---|
| CLI (both files parsed with `ast`) | `-s/--vector_size` 4096, `--subvector_size` 4, `-v`, `-p`, `--output-format {xclbin,elf}` | all identical | **gain** — adds `--target auto`; nothing dropped, no default or choice list changed |
| Element type | `type_mapper(np.uint8)` → `ui8` | `air.api.ui8` → `ui8` | equal |
| Herd / tile | `sizes=[1,1]`, `[1024]` L1 | same | equal |
| Tolerance | `run_test(...)` with neither argument → `rtol=1e-3, atol=1e-8` | identical call | equal (no dtype added, nothing to re-gate) |
| Correctness scope | all 4096 elements | same | equal |
| Test invocations | 5 `make … run` lines across 5 lits | 5 across 5 | equal |
| `REQUIRES` | unchanged | unchanged | equal |
| Makefile | untouched | untouched | equal |
| Perf harness | none | none | equal — see below |
| `build_module` returns | `air.ir.Module` | `LaunchContext` | loud; no Python importer exists (scan below) |

Three structural differences, all shared with the already-converted
`passthrough_channel`: the two L3-side channel endpoints move from launch scope
into the segment (air.api has no scope between the two — reaching L3 needs a
shim DMA allocation, and hoisting them to function scope fails in `air-to-aie`
with "failed to link to any shim dma allocation"); the L1 tile pair is
allocated once and reused across trips rather than per trip; and `air.launch`
carries a 1x1 grid rather than an empty one.

## Verification

```
$ git log --oneline origin/main..HEAD
d7e3ca01 [programming_examples] passthrough_kernel on air.api
77109f99 [python] air.api: unsigned element types ui8, ui16 and ui32

$ git diff --stat origin/main...HEAD
 .../passthrough_kernel/passthrough_kernel.py       | 137 +++++++++++--------
 python/air/api/__init__.py                         |  15 ++-
 python/air/api/_emit.py                            |  19 +++
 python/air/api/_extern.py                          |   7 +-
 python/air/api/_value.py                           |   5 +
 python/air/api/ops.py                              |   6 +
 python/air/api/types.py                            |  70 +++++++++-
 python/test/api/errors.py                          |  59 +++++++-
 python/test/api/unsigned.py                        | 150 +++++++++++++++++++++
 9 files changed, 405 insertions(+), 63 deletions(-)
```

Per-commit file lists:

```
$ git show --name-status HEAD~1        # the DSL change
M	python/air/api/__init__.py
M	python/air/api/_emit.py
M	python/air/api/_extern.py
M	python/air/api/_value.py
M	python/air/api/ops.py
M	python/air/api/types.py
M	python/test/api/errors.py
A	python/test/api/unsigned.py

$ git show --name-status HEAD          # the conversion
M	programming_examples/passthrough/passthrough_kernel/passthrough_kernel.py
```

Which hardware each gate admits:

```
$ grep -H 'REQUIRES:' programming_examples/passthrough/passthrough_kernel/*.lit
run_npu1_makefile_chess.lit:// REQUIRES: ryzen_ai_npu1, valid_xchess_license
run_npu2_makefile_chess.lit:// REQUIRES: ryzen_ai_npu2, valid_xchess_license
run_npu2_makefile_peano_elf.lit:// REQUIRES: ryzen_ai_npu2, peano
run_npu1_makefile_peano.lit:// REQUIRES: ryzen_ai_npu1, peano
run_npu2_makefile_peano.lit:// REQUIRES: ryzen_ai_npu2, peano
```

### Hardware, npu1 (this is an npu1 Phoenix host)

```
$ lit -v --show-unsupported build/programming_examples --filter passthrough_kernel
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: passthrough/passthrough_kernel/run_npu2_makefile_peano_elf.lit (1 of 5)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: passthrough/passthrough_kernel/run_npu2_makefile_chess.lit (2 of 5)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: passthrough/passthrough_kernel/run_npu1_makefile_chess.lit (3 of 5)
UNSUPPORTED: AIR_PROGRAMMING_EXAMPLES :: passthrough/passthrough_kernel/run_npu2_makefile_peano.lit (4 of 5)
PASS: AIR_PROGRAMMING_EXAMPLES :: passthrough/passthrough_kernel/run_npu1_makefile_peano.lit (5 of 5)
```

The three npu2 gates need an npu2 host — **CI, or the parallel npu2 session**.
`run_npu1_makefile_chess` needs `valid_xchess_license`; `LM_LICENSE_FILE` and
`XILINXD_LICENSE_FILE` are both empty on this box, so **no machine reachable
from here can run it** — CI only.

### No perf A/B, and why

Neither arm survives a second dispatch, so there is nothing to time. Measured
symmetrically on npu1:

```
RESULT arm=old n_perf_iters=0: rc=0 latency=None      (PASS!)
RESULT arm=old n_perf_iters=2: AirBackendError: NPU kernel run did not complete: ert_cmd_state.ERT_CMD_STATE_TIMEOUT
RESULT arm=new n_perf_iters=0: rc=0 latency=None      (PASS!)
RESULT arm=new n_perf_iters=2: AirBackendError: NPU kernel run did not complete: ert_cmd_state.ERT_CMD_STATE_TIMEOUT
```

That is why the predecessor has neither a `--perf-iters` flag nor a `profile`
target. Inherited, not introduced. Whether npu2 behaves the same is being
checked on an npu2 host; if it does not, the A/B can be run there.

### Compile sweep, both arms

`{new, old} × {npu1, npu2} × xclbin` plus `npu2 × elf` — 6/6 `COMPILE OK`.

### Regression guard

Re-emitted every previously converted air.api example against this branch and
against `origin/main`, and diffed:

```
$ diff -rq /tmp/ir_before /tmp/ir_after --exclude='*passthrough_kernel*'
EXIT=0          # 22 examples, byte-identical
```

```
$ lit build/python/test/
Total Discovered Tests: 35
  Unsupported:  8 (22.86%)
  Passed     : 27 (77.14%)
```

Includes the new `api/unsigned.py` (3 IR cases: the extern-kernel program, the
scalar-path copy, and ui16/ui32 widths) and 4 new negative cases in
`api/errors.py` (elementwise operator, fill, `ops.dot`, `air.extern` scalar).

### Consumer scan

Run before designing the replacement and re-run after — dotted-path import,
path reference, and module basename, per the lesson from #1849:

```
$ grep -rn "from passthrough_kernel import\|import passthrough_kernel\b" --include=*.py .
(no hits)
$ grep -rln "passthrough/passthrough_kernel\b" . | grep -E '\.(py|lit|md|yml)$|Makefile'
programming_examples/generate_readme.py
```

`generate_readme.py` lists this example as `datatypes: u8`; regenerating
produces no diff. No Python importer, so the `build_module` return-type change
reaches nothing.

## Adjacent finding, deliberately not in this PR

`passthrough_channel` (#1852) declares `i8` while feeding `np.uint8` arrays —
the same untruth this PR removes, and `generate_readme.py` still lists it as
`u8`. It is now a two-line fix, but it would also move its
`tile_out[:] = tile_in[:]` from the vector path back to the scalar loop its own
predecessor emitted, which is a perf change on a merged example and needs its
own A/B. Left for a follow-up rather than folded in here.
