### PR TITLE
[programming_examples] name the launch grid for the launch, not the segment

### DIFF
--- a/programming_examples/matrix_multiplication/bf16/run.py
+++ b/programming_examples/matrix_multiplication/bf16/run.py
@@ -90,10 +90,14 @@ def build_module(
     dt_in, dt_out = DTYPE[np_dtype_in], DTYPE[np_dtype_out]
     mm = air.micro_tile(*MMUL_MKN[arch])
 
-    # One segment covers herd_m x herd_n output tiles; the launch grid covers
-    # the rest of M and N. The outer tiling has to sit here rather than in the
-    # herd because the L2 staging buffers are refilled per launch point.
-    seg_m, seg_n = tile_m * herd_m, tile_n * herd_n
+    # The extent of one L2 staging tile: a segment covers herd_m x herd_n
+    # output tiles, and l2_a/l2_b/l2_c below are sized from it. The launch steps
+    # by exactly that, one L2 tile per point, so the outer tiling sits on the
+    # launch rather than the herd -- the staging buffers are refilled per point.
+    # Named for what it dimensions, not for the hierarchy level that consumes
+    # it: air.launch, air.segment and air.herd each own a separate iteration
+    # space, and a launch point is not a synonym for a segment.
+    l2_m, l2_n = tile_m * herd_m, tile_n * herd_n
 
     A = air.tensor([m, k], dt_in)
     B = air.tensor([k, n], dt_in)
@@ -105,16 +109,16 @@ def build_module(
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
     with air.launch(
-        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_bf16"
+        [range(0, m, l2_m), range(0, n, l2_n)], name="matmul_bf16"
     ) as launch:
 
         @launch.body
-        def _(si, sj):
+        def _(li, lj):
             with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
                 def _():
-                    row, col = si * seg_m, sj * seg_n
+                    row, col = li * l2_m, lj * l2_n
 
                     # L2 staging is flat: each buffer is exactly the region of
                     # L3 it holds, so filling and draining it are plain
@@ -122,9 +126,9 @@ def build_module(
                     # sub-region out. For A this is also byte-identical to the
                     # predecessor's [herd_m, 1, tile_m, tile_k_l2] -- row-major
                     # [a, 1, b, c] and [a*b, c] are the same buffer.
-                    l2_a = air.alloc([seg_m, tile_k_l2], dt_in, scope=seg.private())
-                    l2_b = air.alloc([tile_k_l2, seg_n], dt_in, scope=seg.private())
-                    l2_c = air.alloc([seg_m, seg_n], dt_out, scope=seg.private())
+                    l2_a = air.alloc([l2_m, tile_k_l2], dt_in, scope=seg.private())
+                    l2_b = air.alloc([tile_k_l2, l2_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([l2_m, l2_n], dt_out, scope=seg.private())
                     # The accumulator outlives each entry into the compute herd,
                     # because the k2 reduction is at segment scope, so it is
                     # allocated here and carries one slab per core.
@@ -145,8 +149,8 @@ def build_module(
                             acc[:] = 0.0
 
                     for k2 in air.sequential(0, k, tile_k_l2):
-                        air.ops.load(l2_a, A[row : row + seg_m, k2 : k2 + tile_k_l2])
-                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + seg_n])
+                        air.ops.load(l2_a, A[row : row + l2_m, k2 : k2 + tile_k_l2])
+                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + l2_n])
 
                         with air.herd(
                             [range(herd_m), range(herd_n)],
@@ -195,7 +199,7 @@ def build_module(
                                 ],
                             )
 
-                    air.ops.store(l2_c, C[row : row + seg_m, col : col + seg_n])
+                    air.ops.store(l2_c, C[row : row + l2_m, col : col + l2_n])
 
     return launch
 

--- a/programming_examples/matrix_multiplication/i16/run.py
+++ b/programming_examples/matrix_multiplication/i16/run.py
@@ -86,10 +86,14 @@ def build_module(
     dt_in, dt_out = DTYPE[np_dtype_in], DTYPE[np_dtype_out]
     mm = air.micro_tile(*MMUL_MKN[arch])
 
-    # One segment covers herd_m x herd_n output tiles; the launch grid covers
-    # the rest of M and N. The outer tiling has to sit here rather than in the
-    # herd because the L2 staging buffers are refilled per launch point.
-    seg_m, seg_n = tile_m * herd_m, tile_n * herd_n
+    # The extent of one L2 staging tile: a segment covers herd_m x herd_n
+    # output tiles, and l2_a/l2_b/l2_c below are sized from it. The launch steps
+    # by exactly that, one L2 tile per point, so the outer tiling sits on the
+    # launch rather than the herd -- the staging buffers are refilled per point.
+    # Named for what it dimensions, not for the hierarchy level that consumes
+    # it: air.launch, air.segment and air.herd each own a separate iteration
+    # space, and a launch point is not a synonym for a segment.
+    l2_m, l2_n = tile_m * herd_m, tile_n * herd_n
 
     A = air.tensor([m, k], dt_in)
     B = air.tensor([k, n], dt_in)
@@ -101,16 +105,16 @@ def build_module(
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
     with air.launch(
-        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_i16"
+        [range(0, m, l2_m), range(0, n, l2_n)], name="matmul_i16"
     ) as launch:
 
         @launch.body
-        def _(si, sj):
+        def _(li, lj):
             with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
                 def _():
-                    row, col = si * seg_m, sj * seg_n
+                    row, col = li * l2_m, lj * l2_n
 
                     # L2 staging is flat: each buffer is exactly the region of
                     # L3 it holds, so filling and draining it are plain
@@ -118,9 +122,9 @@ def build_module(
                     # sub-region out. For A this is also byte-identical to the
                     # predecessor's [herd_m, 1, tile_m, tile_k_l2] -- row-major
                     # [a, 1, b, c] and [a*b, c] are the same buffer.
-                    l2_a = air.alloc([seg_m, tile_k_l2], dt_in, scope=seg.private())
-                    l2_b = air.alloc([tile_k_l2, seg_n], dt_in, scope=seg.private())
-                    l2_c = air.alloc([seg_m, seg_n], dt_out, scope=seg.private())
+                    l2_a = air.alloc([l2_m, tile_k_l2], dt_in, scope=seg.private())
+                    l2_b = air.alloc([tile_k_l2, l2_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([l2_m, l2_n], dt_out, scope=seg.private())
                     # The accumulator outlives each entry into the compute herd,
                     # because the k2 reduction is at segment scope, so it is
                     # allocated here and carries one slab per core.
@@ -141,8 +145,8 @@ def build_module(
                             acc[:] = 0
 
                     for k2 in air.sequential(0, k, tile_k_l2):
-                        air.ops.load(l2_a, A[row : row + seg_m, k2 : k2 + tile_k_l2])
-                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + seg_n])
+                        air.ops.load(l2_a, A[row : row + l2_m, k2 : k2 + tile_k_l2])
+                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + l2_n])
 
                         with air.herd(
                             [range(herd_m), range(herd_n)],
@@ -191,7 +195,7 @@ def build_module(
                                 ],
                             )
 
-                    air.ops.store(l2_c, C[row : row + seg_m, col : col + seg_n])
+                    air.ops.store(l2_c, C[row : row + l2_m, col : col + l2_n])
 
     return launch
 

--- a/programming_examples/matrix_multiplication/i8/run.py
+++ b/programming_examples/matrix_multiplication/i8/run.py
@@ -88,10 +88,14 @@ def build_module(
     dt_in, dt_out = DTYPE[np_dtype_in], DTYPE[np_dtype_out]
     mm = air.micro_tile(*MMUL_MKN[arch])
 
-    # One segment covers herd_m x herd_n output tiles; the launch grid covers
-    # the rest of M and N. The outer tiling has to sit here rather than in the
-    # herd because the L2 staging buffers are refilled per launch point.
-    seg_m, seg_n = tile_m * herd_m, tile_n * herd_n
+    # The extent of one L2 staging tile: a segment covers herd_m x herd_n
+    # output tiles, and l2_a/l2_b/l2_c below are sized from it. The launch steps
+    # by exactly that, one L2 tile per point, so the outer tiling sits on the
+    # launch rather than the herd -- the staging buffers are refilled per point.
+    # Named for what it dimensions, not for the hierarchy level that consumes
+    # it: air.launch, air.segment and air.herd each own a separate iteration
+    # space, and a launch point is not a synonym for a segment.
+    l2_m, l2_n = tile_m * herd_m, tile_n * herd_n
 
     A = air.tensor([m, k], dt_in)
     B = air.tensor([k, n], dt_in)
@@ -102,17 +106,15 @@ def build_module(
     # the micro-tile, so the module is architecture-specific before the herd is
     # even sized, and letting the two disagree would build for one generation
     # while shaped for the other.
-    with air.launch(
-        [range(0, m, seg_m), range(0, n, seg_n)], name="matmul_i8"
-    ) as launch:
+    with air.launch([range(0, m, l2_m), range(0, n, l2_n)], name="matmul_i8") as launch:
 
         @launch.body
-        def _(si, sj):
+        def _(li, lj):
             with air.segment(name="matmul_seg") as seg:
 
                 @seg.body
                 def _():
-                    row, col = si * seg_m, sj * seg_n
+                    row, col = li * l2_m, lj * l2_n
 
                     # L2 staging is flat: each buffer is exactly the region of
                     # L3 it holds, so filling and draining it are plain
@@ -120,9 +122,9 @@ def build_module(
                     # sub-region out. For A this is also byte-identical to the
                     # predecessor's [herd_m, 1, tile_m, tile_k_l2] -- row-major
                     # [a, 1, b, c] and [a*b, c] are the same buffer.
-                    l2_a = air.alloc([seg_m, tile_k_l2], dt_in, scope=seg.private())
-                    l2_b = air.alloc([tile_k_l2, seg_n], dt_in, scope=seg.private())
-                    l2_c = air.alloc([seg_m, seg_n], dt_out, scope=seg.private())
+                    l2_a = air.alloc([l2_m, tile_k_l2], dt_in, scope=seg.private())
+                    l2_b = air.alloc([tile_k_l2, l2_n], dt_in, scope=seg.private())
+                    l2_c = air.alloc([l2_m, l2_n], dt_out, scope=seg.private())
                     # The accumulator outlives each entry into the compute herd,
                     # because the k2 reduction is at segment scope, so it is
                     # allocated here and carries one slab per core.
@@ -143,8 +145,8 @@ def build_module(
                             acc[:] = 0
 
                     for k2 in air.sequential(0, k, tile_k_l2):
-                        air.ops.load(l2_a, A[row : row + seg_m, k2 : k2 + tile_k_l2])
-                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + seg_n])
+                        air.ops.load(l2_a, A[row : row + l2_m, k2 : k2 + tile_k_l2])
+                        air.ops.load(l2_b, B[k2 : k2 + tile_k_l2, col : col + l2_n])
 
                         with air.herd(
                             [range(herd_m), range(herd_n)],
@@ -193,7 +195,7 @@ def build_module(
                                 ],
                             )
 
-                    air.ops.store(l2_c, C[row : row + seg_m, col : col + seg_n])
+                    air.ops.store(l2_c, C[row : row + l2_m, col : col + l2_n])
 
     return launch
 

--- a/programming_examples/matrix_vector_multiplication/bf16/matvec.py
+++ b/programming_examples/matrix_vector_multiplication/bf16/matvec.py
@@ -95,8 +95,11 @@ def build_module(
 
     dt_in, dt_out = DTYPE[np_dtype_in], DTYPE[np_dtype_out]
 
-    # Each launch instance owns herd_m * tile_m output rows.
-    seg_m = tile_m * herd_m
+    # The extent of one L2 staging tile, which the launch steps by: each launch
+    # point owns herd_m * tile_m output rows. Named for what it dimensions
+    # rather than for the hierarchy level that consumes it -- air.launch,
+    # air.segment and air.herd each own a separate iteration space.
+    l2_m = tile_m * herd_m
 
     # The kernel and the fill live in the same object file and are linked into
     # the herd by air.extern. The three leading i32s are rows, K and the row
@@ -116,23 +119,23 @@ def build_module(
     B = air.tensor([k], dt_in)
     C = air.tensor([m], dt_out)
 
-    with air.launch([range(0, m, seg_m)], name="matvec_bf16") as launch:
+    with air.launch([range(0, m, l2_m)], name="matvec_bf16") as launch:
 
         @launch.body
-        def _(si):
+        def _(li):
             with air.segment(name="matvec_bf16_0") as seg:
 
                 @seg.body
                 def _():
-                    row = si * seg_m
+                    row = li * l2_m
 
                     # L3 -> L2: the A panel for this chunk, and the C panel it
                     # will drain into. Flat, so each is exactly the L3 region it
                     # holds; a core takes its own window with tx * tile_m.
-                    l2_a = air.alloc([seg_m, k], dt_in, scope=seg.private())
-                    l2_c = air.alloc([seg_m], dt_out, scope=seg.private())
+                    l2_a = air.alloc([l2_m, k], dt_in, scope=seg.private())
+                    l2_c = air.alloc([l2_m], dt_out, scope=seg.private())
 
-                    air.ops.load(l2_a, A[row : row + seg_m, :])
+                    air.ops.load(l2_a, A[row : row + l2_m, :])
 
                     # shape=(herd_m,) rather than letting air.api pick: an
                     # herd_m wider than the part has columns should fail in the
@@ -161,7 +164,7 @@ def build_module(
 
                             air.ops.store(l1_c, l2_c[base : base + tile_m])
 
-                    air.ops.store(l2_c, C[row : row + seg_m])
+                    air.ops.store(l2_c, C[row : row + l2_m])
 
     return launch.build(target=target)
 

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -70,7 +70,7 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
 
         @launch.body
         def _(lj):
-            with air.segment(name="vecmat_i8_0") as seg:
+            with air.segment(name="vecmat_bf16_0") as seg:
 
                 @seg.body
                 def _():

--- a/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/bf16/single_core/single_core.py
@@ -69,12 +69,12 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
     with air.launch([range(0, n, tile_n)], name="vecmat_bf16") as launch:
 
         @launch.body
-        def _(sj):
+        def _(lj):
             with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
                 def _():
-                    col = sj * tile_n
+                    col = lj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())
                     l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())

--- a/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/block_quantized_i8/single_core/single_core.py
@@ -116,12 +116,12 @@ def build_module(k, n, bs, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with=
     with air.launch([range(0, n, tile_n)], name="vecmat_i8") as launch:
 
         @launch.body
-        def _(sj):
+        def _(lj):
             with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
                 def _():
-                    col = sj * tile_n
+                    col = lj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())
                     l2_a_s = air.alloc([k // bs], dt_out, scope=seg.private())

--- a/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
+++ b/programming_examples/vector_matrix_multiplication/i8/single_core/single_core.py
@@ -102,12 +102,12 @@ def build_module(k, n, tile_k, tile_n, np_dtype_in, np_dtype_out, link_with="vm.
     with air.launch([range(0, n, tile_n)], name="vecmat_i8") as launch:
 
         @launch.body
-        def _(sj):
+        def _(lj):
             with air.segment(name="vecmat_i8_0") as seg:
 
                 @seg.body
                 def _():
-                    col = sj * tile_n
+                    col = lj * tile_n
 
                     l2_a = air.alloc([k], dt_in, scope=seg.private())
                     l2_b = air.alloc([k, tile_n], dt_in, scope=seg.private())


### PR DESCRIPTION
#1868 established that `air.launch`, `air.segment` and `air.herd` each implement
`air_HierarchyInterface` and each own a separate `sizes`. The examples that
motivated that fix still carried the old conflated model in their **variable
names** — which is the form most likely to teach it to the next reader.

This is a rename plus comments. No behaviour change, gated on emitted IR.

## The audit

All 7 converted examples that give `air.launch` an iteration space:

| file | launch step | launch coord |
|---|---|---|
| `matrix_multiplication/bf16/run.py` | `seg_m, seg_n` → `l2_m, l2_n` | `si, sj` → `li, lj` |
| `matrix_multiplication/i16/run.py` | `seg_m, seg_n` → `l2_m, l2_n` | `si, sj` → `li, lj` |
| `matrix_multiplication/i8/run.py` | `seg_m, seg_n` → `l2_m, l2_n` | `si, sj` → `li, lj` |
| `matrix_vector_multiplication/bf16/matvec.py` | `seg_m` → `l2_m` | `si` → `li` |
| `vector_matrix_multiplication/bf16/single_core` | `tile_n` (already fine) | `sj` → `lj` |
| `vector_matrix_multiplication/block_quantized_i8/single_core` | `tile_n` (already fine) | `sj` → `lj` |
| `vector_matrix_multiplication/i8/single_core` | `tile_n` (already fine) | `sj` → `lj` |

Two distinct defects, worth separating because they are not equally wrong.

**`si`/`sj`, 7 files — plainly wrong.** These are `air.launch`'s own induction
variables. The `s` reads as segment; they index the launch grid and nothing
else. No defence.

**`seg_m`/`seg_n`, 4 files — defensible at one site, misleading at the other.**
The value is `tile_m * herd_m`, and at

```python
l2_a = air.alloc([seg_m, tile_k_l2], dt_in, scope=seg.private())
```

it genuinely does dimension the segment's L2 tile. But at

```python
air.launch([range(0, m, seg_m), range(0, n, seg_n)], name="matmul_bf16")
```

it reads as "the launch iterates over segments" — exactly the conflation #1868
removed from the API. `air.segment` has its own iteration space (`unroll(...)`,
one spatial copy per point); a launch point is not a synonym for a segment.

`l2_m` names what the value *dimensions* rather than the hierarchy level that
consumes it, and matches the `tile_k_l2` and `l2_a`/`l2_b`/`l2_c` already in
those files. The comment at each definition site now states which level owns
what, so the distinction survives the next edit.

## No contract change

Neither name was ever a CLI flag — `--tile-m`, `--tile-n` and `--herd-m` are —
nor a function parameter. `seg_m`/`seg_n` are derived locals and `si`/`sj` are
body parameters of a nested closure.

This matters most for `matvec`, whose `build_module` is imported by 9 files
under `llms/` that **PR CI does not run** (they are nightly-only; this is the
path that broke in #1849). Its signature is untouched:

```python
def build_module(m, k, tile_m, m_input, herd_m, np_dtype_in, np_dtype_out,
                 link_with="mv.o", target="auto"):
```

```
$ grep -rn "from matvec import\|import matvec\b" --include=*.py .
programming_examples/llms/llama32_3b/llama32_3b_decode.py:114
programming_examples/llms/qwen3_4b/qwen3_4b_decode.py:151
programming_examples/llms/qwen25_1_5b/qwen25_1_5b_decode.py:124
programming_examples/llms/qwen25_0_5b/qwen25_0_5b_decode.py:124
programming_examples/llms/shared/builders/rms_qkv_bias_rope_multi.py:632
programming_examples/llms/shared/builders/rms_qkv_qknorm_rope_multi.py:705
programming_examples/llms/shared/builders/rms_gemv_rope_multi.py:406
programming_examples/llms/shared/builders/lm_head_gemv_multi.py:58
programming_examples/llms/qwen25_3b/qwen25_3b_decode.py:142
```

All nine call it positionally; none referenced a renamed local.

## Gate: emitted IR is byte-identical

A local-variable rename must not move a byte of IR, so that is what was checked
rather than inspection. All 7 examples re-emitted with `-p`, before and after,
and again after `black`:

```
$ diff -r /tmp/nm_before /tmp/nm_after
$ echo $?
0
```

```
$ git log --oneline origin/main..HEAD
<commit> [programming_examples] name the launch grid for the launch, not the segment

$ git diff --stat origin/main...HEAD
 .../matrix_multiplication/bf16/run.py              | 30 +++++++++++---------
 .../matrix_multiplication/i16/run.py               | 30 +++++++++++---------
 .../matrix_multiplication/i8/run.py                | 32 ++++++++++++----------
 .../matrix_vector_multiplication/bf16/matvec.py    | 21 ++++++++------
 .../bf16/single_core/single_core.py                |  4 +--
 .../block_quantized_i8/single_core/single_core.py  |  4 +--
 .../i8/single_core/single_core.py                  |  4 +--
 7 files changed, 69 insertions(+), 56 deletions(-)
```

`black --check`: 7 files unchanged. No `.lit` or `Makefile` touched, so the test
surface is untouched too.

Independent of #1871 (disjoint files, both branched from `main`).
