### PR TITLE
[python] air.api: the segment's own iteration space, and segment_unroll converted

### DIFF
--- a/programming_examples/segment_unroll/segment_unroll.py
+++ b/programming_examples/segment_unroll/segment_unroll.py
@@ -1,41 +1,54 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-"""
-Segment Unroll Example
+"""Segment unroll, on air.api.
 
-This example demonstrates the segment unroll feature in MLIR-AIR. A segment with
-a 'sizes' attribute is unrolled, creating multiple copies of the segment body,
-each with different segment indices. This allows for efficient parallelization
-across multiple segment instances.
+``air.launch``, ``air.segment`` and ``air.herd`` each carry their own iteration
+space, and this is the example for the middle one. A grid on ``air.segment``
+becomes its ``sizes``, printed as ``unroll(...)``, and it means something
+different from the other two:
 
-The kernel reads a vector, adds 10 to each element across multiple unrolled
-segments, and writes the result back. Each segment processes a portion of the
-input data using channels indexed by segment coordinates.
+* a **launch** point replays everything inside it -- temporal;
+* a **segment** point is a *spatial copy* of the segment body, which
+  ``air-to-aie`` lays out across columns, so N points is N physical herds at
+  once rather than one herd run N times;
+* a **herd** point is a core.
+
+Each copy is handed its own coordinate and uses it to pick its endpoint of a
+channel declared ``size=[SX, SY]``::
+
+    air.segment @segment_with_unroll unroll(%u0, %u1) in (%c2, %c1)
+      air.channel.put @ChanIn[%u0, %u1] ...
+      air.herd @compute_herd args(%arg=%u0, ...)      <- threaded in explicitly
+        air.channel.get @ChanIn[%u0, %u1] ...
+
+That third line is the one worth understanding: ``air.herd`` is
+``IsolatedFromAbove``, so the segment's coordinate cannot simply be referenced
+from inside the herd body. air.api threads it in as a herd operand, which is
+what the raw-bindings predecessor spelled by hand as ``operands=[seg_x, seg_y]``.
+
+The L3 endpoints sit **inside** the segment, where the predecessor had them
+beside it at launch scope. air.api has no scope between the two, and this is the
+better placement anyway: each copy moves its own chunk, indexed by its own
+coordinate, rather than a host-side Python loop stamping out one put per copy
+from outside. The offset is ``seg_x * CHUNK`` -- an ordinary expression on a
+coordinate.
 """
 
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects import arith
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
-# Configuration
 VECTOR_LEN = 64
-SEGMENT_SIZE_X = 2  # Segment unroll factor in X dimension
-SEGMENT_SIZE_Y = 1  # Segment unroll factor in Y dimension
+SEGMENT_SIZE_X = 2  # Segment unroll factor in X
+SEGMENT_SIZE_Y = 1  # Segment unroll factor in Y
 INOUT_DATATYPE = np.int32
 
-# Sanity checks: ensure vector length is evenly divisible by segment dimensions
-# This is required because VECTOR_LEN // SEGMENT_SIZE_X is used to size L1 memrefs
-# and compute host-side slice sizes. Non-divisible configurations would silently
-# truncate and/or mis-size buffers.
+# CHUNK sizes both the L1 tiles and each copy's slice of L3, so the vector has
+# to divide evenly across the copies.
 assert VECTOR_LEN % SEGMENT_SIZE_X == 0, (
     f"VECTOR_LEN ({VECTOR_LEN}) must be evenly divisible by "
     f"SEGMENT_SIZE_X ({SEGMENT_SIZE_X})"
@@ -45,99 +58,48 @@ assert VECTOR_LEN % (SEGMENT_SIZE_X * SEGMENT_SIZE_Y) == 0, (
     f"total segment count ({SEGMENT_SIZE_X * SEGMENT_SIZE_Y})"
 )
 
+CHUNK = VECTOR_LEN // SEGMENT_SIZE_X
 
-@module_builder
+
 def build_module():
-    """Build a kernel with segment unroll to demonstrate its lowering."""
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = T.memref(VECTOR_LEN, xrt_dtype)
+    """Build the segment-unroll kernel. Returns an ``air.api`` launch."""
+    A = air.tensor([VECTOR_LEN], i32)
+    B = air.tensor([VECTOR_LEN], i32)
 
-    # L1 memory space for tile data
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    image_type_l1 = MemRefType.get(
-        shape=[VECTOR_LEN // SEGMENT_SIZE_X],
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    # One endpoint per unrolled copy, which is why these are sized by the
+    # segment grid and not by the herd.
+    chan_in = air.channel("ChanIn", size=[SEGMENT_SIZE_X, SEGMENT_SIZE_Y])
+    chan_out = air.channel("ChanOut", size=[SEGMENT_SIZE_X, SEGMENT_SIZE_Y])
 
-    # Define channels for data movement with dimensions matching segment unroll
-    # Each unrolled segment instance needs its own channel endpoint
-    Channel("ChanIn", size=[SEGMENT_SIZE_X, SEGMENT_SIZE_Y])
-    Channel("ChanOut", size=[SEGMENT_SIZE_X, SEGMENT_SIZE_Y])
+    with air.launch(name="segment_unroll_test") as launch:
 
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def segment_unroll_test(input_buf, output_buf):
-        """Test function with segment unroll."""
+        @launch.body
+        def _():
+            with air.segment(
+                [range(SEGMENT_SIZE_X), range(SEGMENT_SIZE_Y)],
+                name="segment_with_unroll",
+            ) as seg:
 
-        @launch(operands=[input_buf, output_buf])
-        def launch_body(a, b):
-            # Put on each subchannel at launch level
-            # Each unrolled segment instance reads from its own subchannel
-            chunk_size = VECTOR_LEN // SEGMENT_SIZE_X
-            for sx in range(SEGMENT_SIZE_X):
-                for sy in range(SEGMENT_SIZE_Y):
-                    offset = sx * chunk_size
-                    # Use python indices to create the MLIR constants for channel indices
-                    sx_idx = arith.constant(T.index(), sx)
-                    sy_idx = arith.constant(T.index(), sy)
-                    offset_idx = arith.constant(T.index(), offset)
-                    size_idx = arith.constant(T.index(), chunk_size)
-                    stride_idx = arith.constant(T.index(), 1)
-                    # Put a portion of input to each subchannel
-                    ChannelPut(
-                        "ChanIn",
-                        a,
-                        indices=[sx_idx, sy_idx],
-                        offsets=[offset_idx],
-                        sizes=[size_idx],
-                        strides=[stride_idx],
-                    )
+                @seg.body
+                def _(seg_x, seg_y):
+                    # This copy's slice of the vector.
+                    off = seg_x * CHUNK
+                    chan_in.put(A[off : off + CHUNK], indices=[seg_x, seg_y])
 
-            # Segment with unroll - this creates SEGMENT_SIZE_X * SEGMENT_SIZE_Y
-            # copies of the segment body, each with different segment indices
-            @segment(name="segment_with_unroll", sizes=[SEGMENT_SIZE_X, SEGMENT_SIZE_Y])
-            def segment_body(seg_x, seg_y, seg_sx, seg_sy):
-                """Segment body that will be unrolled."""
+                    with air.herd([range(1)], name="compute_herd", shape=(1,)) as h:
 
-                # Pass segment unroll indices to herd via operands
-                @herd(name="compute_herd", sizes=[1, 1], operands=[seg_x, seg_y])
-                def herd_body(tx, ty, sx, sy, herd_seg_x, herd_seg_y):
-                    """Simple compute: add 10 to each element."""
-                    tile_in = AllocOp(image_type_l1, [], [])
-                    tile_out = AllocOp(image_type_l1, [], [])
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc([CHUNK], i32, scope=h.private())
+                            tile_out = air.alloc([CHUNK], i32, scope=h.private())
 
-                    # Use segment indices to select the correct channel endpoint
-                    ChannelGet("ChanIn", tile_in, indices=[herd_seg_x, herd_seg_y])
+                            chan_in.get(tile_in, indices=[seg_x, seg_y])
+                            tile_out[:] = tile_in[:] + 10
+                            chan_out.put(tile_out, indices=[seg_x, seg_y])
 
-                    for i in range_(VECTOR_LEN // SEGMENT_SIZE_X):
-                        val = load(tile_in, [i])
-                        val_plus_10 = arith.addi(val, arith.constant(xrt_dtype, 10))
-                        store(val_plus_10, tile_out, [i])
-                        yield_([])
+                    chan_out.get(B[off : off + CHUNK], indices=[seg_x, seg_y])
 
-                    ChannelPut("ChanOut", tile_out, indices=[herd_seg_x, herd_seg_y])
-
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
-
-            # Get on each subchannel at launch level (after producer @segment)
-            for sx in range(SEGMENT_SIZE_X):
-                for sy in range(SEGMENT_SIZE_Y):
-                    offset = sx * chunk_size
-                    sx_idx = arith.constant(T.index(), sx)
-                    sy_idx = arith.constant(T.index(), sy)
-                    offset_idx = arith.constant(T.index(), offset)
-                    size_idx = arith.constant(T.index(), chunk_size)
-                    stride_idx = arith.constant(T.index(), 1)
-                    # Get a portion of output from each subchannel
-                    ChannelGet(
-                        "ChanOut",
-                        b,
-                        indices=[sx_idx, sy_idx],
-                        offsets=[offset_idx],
-                        sizes=[size_idx],
-                        strides=[stride_idx],
-                    )
+    return launch
 
 
 if __name__ == "__main__":
@@ -165,17 +127,22 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    mlir_module = build_module().build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
 
-    # Prepare test data
-    # Input: [0, 1, 2, ..., 63]
-    # Expected output: [10, 11, 12, ..., 73]
+    # Input: [0, 1, ..., 63]; expected output: [10, 11, ..., 73]
     input_a = np.arange(VECTOR_LEN, dtype=INOUT_DATATYPE)
     output_b = input_a + 10
 

--- a/python/air/api/_compile.py
+++ b/python/air/api/_compile.py
@@ -146,7 +146,29 @@ class LaunchContext:
 
         self._module = module
         self._check_interface()
+        self._verify(module)
         return module
+
+    @staticmethod
+    def _verify(module):
+        """Fail here rather than emitting IR that only aircc will reject.
+
+        Nothing else in this package checks that what the tracer built is
+        *valid* MLIR, and printing does not check either: `str(module)` on an
+        invalid module prints happily, in the generic form, which is easy to
+        read past. That gap hid a real defect -- a segment coordinate referenced
+        inside an air.herd body, which is IsolatedFromAbove, emitted an
+        affine.apply over an SSA value from outside the region and said nothing
+        until an explicit verify(). A DSL whose whole premise is that misuse
+        raises should not hand back IR it has never checked.
+        """
+        try:
+            module.operation.verify()
+        except Exception as e:
+            raise RuntimeError(
+                f"air.api emitted invalid IR -- this is a bug in the DSL, not "
+                f"in the kernel:\n{e}"
+            ) from e
 
     def _run_body(self, state):
         """Run the launch body, opening air.launch first if this launch has a grid.

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -665,22 +665,18 @@ class SegmentContext:
                 f"an air.segment iteration space is 1-D or 2-D; got "
                 f"{len(self.dims)}-D"
             )
-        if self.dims:
-            raise NotImplementedError(
-                "air.segment(<grid>) is the segment's own iteration space -- "
-                "air.segment's `sizes`, which unrolls the segment body into one "
-                "spatial copy per point (see programming_examples/segment_unroll"
-                "). air.api does not emit that yet.\n\n"
-                "If you meant the outer tiling -- one segment instance per "
-                "point, L2 staging refilled each time -- that is the *launch's* "
-                "iteration space: write air.launch(<grid>) and take the "
-                "coordinates in the launch body."
-            )
         self.grid = tuple(d.count for d in self.dims)
         self.tile_sizes = tuple(d.step for d in self.dims)
         self.name = name or "segment_0"
         self._buffers = []
         self._registered = False
+        # This segment's own coordinates, as Leaf objects, bound while the body
+        # is traced. A nested herd needs them threaded in as operands, because
+        # air.herd is IsolatedFromAbove -- the same reason the segment itself
+        # takes the launch's coordinates as operands. Empty for a gridless
+        # segment, which is what keeps every existing example's operand list
+        # byte-identical.
+        self.leaves = []
 
     def __enter__(self):
         return self
@@ -778,8 +774,16 @@ class SegmentContext:
 
             # Block arguments are ids + sizes + operands, so a segment with an
             # iteration space of its own offsets the operands by 2 * its rank.
+            # That rank is the *padded* one -- air.segment's sizes are 2-D like
+            # air.launch's -- but the body only ever sees as many coordinates as
+            # it declared, so a 1-D grid yields one. This is the same split the
+            # launch makes; keeping them symmetric is the point of #1868.
             n = len(sizes)
-            coords = [IndexExpr.leaf(v, f"u{axis}") for axis, v in enumerate(args[:n])]
+            declared = len(segment_self.dims)
+            segment_self.leaves = [
+                Leaf(v, f"u{axis}") for axis, v in enumerate(args[:declared])
+            ]
+            coords = [IndexExpr({leaf: 1}, 0) for leaf in segment_self.leaves]
             bound = args[2 * n :]
             saved_outer = [leaf.value for leaf in outer_leaves]
             for leaf, v in zip(outer_leaves, bound[: len(outer_leaves)]):
@@ -936,7 +940,18 @@ class HerdContext:
         # has run it.
         enclosing = current_segment(required=False)
         staged = list(enclosing._buffers) if enclosing is not None else []
-        operands = [t.value for t in tensors] + [b.value for b in staged]
+        # An unrolled segment's own coordinates, threaded in for the same reason
+        # the L2 buffers are: air.herd is IsolatedFromAbove, so a body that
+        # indexes a channel by segment coordinate cannot simply reference it.
+        # Empty unless the segment carries a grid, which is what keeps this
+        # inert for every kernel that does not use one -- an unused herd operand
+        # is not free, it survives air-dependency as an async edge.
+        outer = list(enclosing.leaves) if enclosing is not None else []
+        operands = (
+            [leaf.value for leaf in outer]
+            + [t.value for t in tensors]
+            + [b.value for b in staged]
+        )
         # air.herd is always 2-D. A 1-D grid is laid out along x -- [P, 1], the
         # orientation the hand-written eltwise_add kernel uses for its 8-core
         # npu2 config. [1, P] does not place.
@@ -956,9 +971,13 @@ class HerdContext:
             # herd's block arguments, in the order they were passed as operands.
             saved = [t.value for t in tensors]
             saved_staged = [b.value for b in staged]
-            for t, v in zip(tensors, inner[: len(tensors)]):
+            saved_outer = [leaf.value for leaf in outer]
+            n_outer = len(outer)
+            for leaf, v in zip(outer, inner[:n_outer]):
+                leaf.value = v
+            for t, v in zip(tensors, inner[n_outer : n_outer + len(tensors)]):
                 t.value = v
-            for b, v in zip(staged, inner[len(tensors) :]):
+            for b, v in zip(staged, inner[n_outer + len(tensors) :]):
                 b.value = v
             previous, _CURRENT_HERD = _CURRENT_HERD, herd_self
 
@@ -996,6 +1015,8 @@ class HerdContext:
                     t.value = v
                 for b, v in zip(staged, saved_staged):
                     b.value = v
+                for leaf, v in zip(outer, saved_outer):
+                    leaf.value = v
                 _CURRENT_HERD = previous
 
         # aircc compiles the object named here alongside the herd's cores.

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -104,13 +104,22 @@ i32 = DType("i32", np.int32, 16, is_float=False)
 # Unsigned integers exist so that a kernel over `np.uint8` data can say so. The
 # alternative -- declaring i8 and passing uint8 arrays -- type-checks nowhere
 # and makes the emitted `func.func private @...` declaration disagree with the
-# C prototype the object file was compiled from. The vector widths mirror their
-# signed counterparts and are unreachable while arithmetic is refused; they are
-# stated rather than left at 0 so that relaxing the refusal does not silently
-# also change the width.
-ui8 = DType("ui8", np.uint8, 32, is_float=False, is_unsigned=True)
-ui16 = DType("ui16", np.uint16, 16, is_float=False, is_unsigned=True)
-ui32 = DType("ui32", np.uint32, 8, is_float=False, is_unsigned=True)
+# C prototype the object file was compiled from.
+#
+# The vector width is *taken from* the signed counterpart rather than repeated,
+# so the two cannot drift. They were repeated as literals when these types
+# landed, and i32's 8 -> 16 correction in this PR immediately left ui32 holding
+# the width now known not to legalize -- which is the silent divergence that
+# stating them was meant to prevent. Unreachable while arithmetic on unsigned is
+# refused, and stated anyway so that relaxing that refusal does not also quietly
+# change the width.
+ui8 = DType("ui8", np.uint8, i8.default_vector_width, is_float=False, is_unsigned=True)
+ui16 = DType(
+    "ui16", np.uint16, i16.default_vector_width, is_float=False, is_unsigned=True
+)
+ui32 = DType(
+    "ui32", np.uint32, i32.default_vector_width, is_float=False, is_unsigned=True
+)
 
 _BY_NP = {d.np_dtype: d for d in (bf16, f16, f32, i8, i16, i32, ui8, ui16, ui32)}
 

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -48,9 +48,15 @@ class DType:
     its npu1 config actually runs scalar (VECTOR_SIZE=0), so that advice is
     never exercised there.
 
-    Widths for f16, i8, i16 and i32 are extrapolated by element size and have
-    not been compiled; treat them as unverified. The unsigned widths are never
-    reached at all -- see ``is_unsigned``.
+    i32 is 32-bit like f32 and behaves the same way: 8 lanes (256-bit) fails in
+    the AIE backend with "unable to legalize instruction: <8 x s32> G_ADD", so
+    it also defaults to 16. Measured on npu1 by segment_unroll, which was the
+    first example to vectorise an i32 elementwise body -- the previous value of
+    8 was an extrapolation by element size and was wrong.
+
+    Widths for f16, i8 and i16 are still extrapolated that way and have not been
+    compiled; treat them as unverified. The unsigned widths are never reached at
+    all -- see ``is_unsigned``.
     """
 
     def __init__(
@@ -93,7 +99,7 @@ f16 = DType("f16", np.float16, 16, is_float=True)
 f32 = DType("f32", np.float32, 16, is_float=True)
 i8 = DType("i8", np.int8, 32, is_float=False)
 i16 = DType("i16", np.int16, 16, is_float=False)
-i32 = DType("i32", np.int32, 8, is_float=False)
+i32 = DType("i32", np.int32, 16, is_float=False)
 
 # Unsigned integers exist so that a kernel over `np.uint8` data can say so. The
 # alternative -- declaring i8 and passing uint8 arrays -- type-checks nowhere

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -689,18 +689,51 @@ def _():
     _staged(body)
 
 
-# air.launch, air.segment and air.herd each own an iteration space, and it is
-# written on the op that has it. A grid on air.segment is air.segment's own
-# `sizes` -- the unroll that copies the segment body across columns -- and is
-# not a way to spell the outer tiling. Saying so is the whole point: it used to
-# be silently redirected to the launch, which made air.segment's own iteration
-# space unreachable and taught the wrong model of the hierarchy.
-# CHECK-LABEL: TEST: segment_grid_is_not_the_launch_grid
-# CHECK: NotImplementedError: air.segment(<grid>) is the segment's own iteration space
-# CHECK: write air.launch(<grid>) and take the coordinates in the launch body
-@expect(NotImplementedError, "segment_grid_is_not_the_launch_grid")
+# The segment's iteration space is now emitted rather than refused, so the
+# positive cases live in hierarchy.py. What stays here is its arity rule, which
+# is the same one air.launch and air.herd follow: a body sees exactly as many
+# coordinates as the grid it was given, and a gridless segment sees none. The
+# message has to keep pointing at air.launch for the outer tiling, because
+# reaching for air.segment to spell that is the original conflation.
+# CHECK-LABEL: TEST: segment_body_arity
+# CHECK: TypeError: segment body takes 0 coordinate argument(s) but the segment iteration space is 1-D
+@expect(TypeError, "segment_body_arity")
 def _():
-    air.segment([range(0, 128, 64)])
+    A = air.tensor([128], bf16)
+    B = air.tensor([128], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment([range(2)], name="seg") as seg:
+
+                @seg.body
+                def _():
+                    pass
+
+    launch.mlir()
+
+
+# CHECK-LABEL: TEST: gridless_segment_body_arity
+# CHECK: TypeError: segment body takes 1 coordinate argument(s) but the segment iteration space is 0-D
+# CHECK-SAME: Outer tiling belongs on air.launch
+@expect(TypeError, "gridless_segment_body_arity")
+def _():
+    A = air.tensor([128], bf16)
+    B = air.tensor([128], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _(u0):
+                    pass
+
+    launch.mlir()
 
 
 # CHECK-LABEL: TEST: segment_grid_too_deep


### PR DESCRIPTION
#1868 established that `air.launch`, `air.segment` and `air.herd` each carry a
separate `sizes`, but left air.segment's unreachable — `air.segment(<grid>)`
raised. This emits it, and converts the example it exists for.

A segment point is not a launch point. It is a **spatial copy** of the segment
body, which `air-to-aie` lays out across columns, so N points is N physical
herds running at once rather than one herd run N times. The dialect prints it
`unroll(...)`.

## Two bugs the raise was hiding

The emission path was already there from #1868, so I expected deleting the raise
to be most of the work. It wasn't:

**Coordinate arity used the padded rank.** `air.segment`'s sizes are 2-D like
`air.launch`'s, so `n = len(sizes)` is always 2, and a 1-D grid handed two
coordinates to a one-argument body. The body now sees exactly what it declared —
what `air.launch` already did.

**The segment's coordinates could not reach the herd.** `air.herd` is
`IsolatedFromAbove`, so a body indexing a channel by segment coordinate failed
with `'affine.apply' op using value defined outside the region`. They are now
threaded in as herd operands, which is what the predecessor spelled by hand as
`operands=[seg_x, seg_y]`.

```mlir
air.segment @segment_with_unroll unroll(%arg8, %arg9) in (%arg10=%c2, %arg11=%c1_1) args(...)
  air.channel.put @ChanIn[%1, %2] (%arg12[%0] [32] [1]) : (memref<64xi32>)
  air.herd @compute_herd tile (...) args(%arg18=%arg8, %arg19=%arg9, %arg20=%arg12, %arg21=%arg13)
                                        : index, index, memref<64xi32>, memref<64xi32>
    air.channel.get @ChanIn[%6, %7] (%alloc[] [] []) : (memref<32xi32, 2 : i32>)
```

**The threading is deliberately not general.** Passing every enclosing
coordinate into every herd would add unused operands to all 26 converted
examples, and an unused herd operand is not free — it survives `air-dependency`
as an async edge. So it is scoped to segment coordinates and is empty unless the
segment carries a grid.

## i32 default vector width: 8 → 16

`segment_unroll` is the first example to vectorise an i32 elementwise body, and
8 lanes (256-bit) dies in the AIE backend:

```
LLVM ERROR: unable to legalize instruction: %16:_(<8 x s32>) = G_ADD %13:_, %14:_ (in function: core_2_2)
aiecc: 'llvm-aie/bin/llc' failed: Aborted (core dumped)
```

Same failure f32 already had documented at that width — i32 is 32-bit too. The
old value was an extrapolation by element size that had never been compiled, and
`types.py` said as much. f16/i8/i16 remain extrapolated and still unverified.

## No new ops

`air.api.ops.__all__` and `air.api.__all__` are both byte-identical to `main`.
`air.segment(<grid>)` was already the entry point; it raised, and now it emits.

## Verification

```
$ lit -v build/programming_examples --filter segment_unroll
UNSUPPORTED: ... segment_unroll/run_makefile_chess.lit (1 of 5)
UNSUPPORTED: ... segment_unroll/run_makefile_peano_elf.lit (2 of 5)
UNSUPPORTED: ... channel_examples/channel_3d_segment_unroll/run_makefile_peano.lit (3 of 5)
UNSUPPORTED: ... channel_examples/channel_3d_segment_unroll/run_makefile_peano_elf.lit (4 of 5)
PASS: AIR_PROGRAMMING_EXAMPLES :: segment_unroll/run_makefile_peano.lit (5 of 5)
```

`run_makefile_chess` needs a chess licence (this box has none) and
`run_makefile_peano_elf` is `ryzen_ai_npu2` — both CI. The two
`channel_3d_segment_unroll` entries are a different example, still blocked on
`channel_type="npu_cascade"`; this PR does not touch it.

Regression guard — every converted example re-emitted against this branch and
against `main`:

```
$ diff -r /tmp/g_b /tmp/g_a -x '*segment_unroll*'
$ echo $?
0
```

```
$ lit build/python/test/ --filter=api
  Passed : 14 (100% of non-excluded)
```

The `errors.py` case asserting `air.segment(<grid>)` raises is now wrong by
construction; it is replaced by the two arity rules, keeping the message that
points outer tiling at `air.launch`.

## What the example gains, and what changed under it

The L3 endpoints move from launch scope into the segment — air.api has no scope
between the two, and it is the better placement: each copy moves its own chunk
indexed by its own coordinate, rather than a host-side Python loop stamping out
one put per copy from outside. Its scalar add also vectorises, so the emitted
core differs from the predecessor's by more than the schedule. CLI is a superset
(`--target` added, nothing dropped, checked by parsing both files with `ast`).
Same 3 lits, same `REQUIRES`, no Makefile change.
