### PR TITLE
[programming_examples] air.api: the five plain-DMA examples

### DIFF
--- a/programming_examples/matrix_scalar_add/multi_core_dma/multi_core_dma.py
+++ b/programming_examples/matrix_scalar_add/multi_core_dma/multi_core_dma.py
@@ -1,146 +1,100 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Add each tile's index to that tile, one core per tile, on air.api.
+
+The sibling ``single_core_dma`` walks every tile from one core with a loop nest.
+This one hands each tile to its own core: the loop *is* the herd, and the loop
+variables are herd coordinates rather than induction variables.
+
+    with air.herd([range(rows), range(cols)], name="xaddherd") as h:
+        def _(tx, ty):
+            air.ops.load(tile_in, A[tx*th : ..., ty*tw : ...])
+            tile_out[:] = tile_in[:] + (tx * cols + ty)
+            air.ops.store(tile_out, B[tx*th : ..., ty*tw : ...])
+
+That is the whole difference from the sibling, and it is the one air.api makes
+cheapest. In the raw-bindings version this replaces, turning a herd coordinate
+into an offset meant building an ``AffineMap`` per expression -- four of them,
+each a handful of ``AffineExpr.get_mul``/``get_add`` calls, plus an
+``affine_apply`` per use -- because a coordinate is an SSA value and cannot be
+multiplied with Python's ``*``. Here it can: ``tx`` is an index expression, so
+``tx * tile_height`` is a slice bound and ``tx * cols + ty`` broadcasts into the
+elementwise expression as an ``index_cast``. Roughly sixty lines of map
+construction become three.
+
+Unchanged otherwise, except that the per-tile add is written
+``tile_out[:] = tile_in[:] + n`` rather than a scalar loop nest over every
+(i, j). ``vector=0`` keeps the emitted loop scalar as the predecessor's was,
+whatever ``--tile-width`` is given: a <8 x i32> add is 256-bit and does not
+legalize on AIE2.
+"""
+
 import argparse
+import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.affine import apply as affine_apply
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
+
+DTYPE = {np.int32: i32}
 
 
-@module_builder
 def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
     assert image_height % tile_height == 0
     assert image_width % tile_width == 0
-    image_size = [image_height, image_width]
+    dt = DTYPE[np_dtype]
     tile_size = [tile_height, tile_width]
-    xrt_dtype = type_mapper(np_dtype)
+    rows = image_height // tile_height
+    cols = image_width // tile_width
 
-    memrefTyInOut = MemRefType.get(image_size, xrt_dtype)
+    A = air.tensor([image_height, image_width], dt)
+    B = air.tensor([image_height, image_width], dt)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+                @seg.body
+                def _():
+                    # shape= is pinned to the tile grid rather than left to the
+                    # default. air.api's default 2-D shape on npu1 is (1, 4) --
+                    # deliberately conservative, since a 2-D herd can run out of
+                    # shim DMA capacity before it runs out of columns -- and
+                    # letting it apply here would strip-mine the row axis back
+                    # into a temporal loop, giving 2 cores doing 2 tiles each
+                    # where the predecessor had 4 cores doing one apiece. One
+                    # core per tile is the entire point of this example.
+                    with air.herd(
+                        [range(rows), range(cols)],
+                        name="xaddherd",
+                        shape=(rows, cols),
+                    ) as h:
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We are hoping to map each tile to a different compute core.
-                @herd(
-                    name="xaddherd",
-                    sizes=[image_height // tile_height, image_width // tile_width],
-                    operands=[arg2, arg3],
-                )
-                def herd_body(tx, ty, _sx, _sy, a, b):
-                    scaled_index_map_height = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(tile_height),
+                        @h.body
+                        def _(tx, ty):
+                            tile_in = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
                             )
-                        ],
-                    )
-                    scaled_index_map_width = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(tile_width),
-                            )
-                        ],
-                    )
-                    create_tile_index_height = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(image_width // tile_width),
-                            )
-                        ],
-                    )
-                    create_tile_index = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineSymbolExpr.get(1),
-                            )
-                        ],
-                    )
-                    offset0 = affine_apply(scaled_index_map_height, [tx])
-                    offset1 = affine_apply(scaled_index_map_width, [ty])
-                    tile_index_height = affine_apply(create_tile_index_height, [tx])
-                    compute_tile_id = affine_apply(
-                        create_tile_index, [tile_index_height, ty]
-                    )
-
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=tile_size,
-                        element_type=T.i32(),
-                        memory_space=mem_space,
-                    )
-
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in = AllocOp(tile_type, [], [])
-                    tile_out = AllocOp(tile_type, [], [])
-
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    dma_memcpy_nd(
-                        tile_in,
-                        a,
-                        src_offsets=[offset0, offset1],
-                        src_sizes=tile_size,
-                        src_strides=[image_width, 1],
-                    )
-
-                    # Access every value in the tile
-                    for i in range_(tile_height):
-                        for j in range_(tile_width):
-                            # Load the input value from tile_in
-                            val_in = load(tile_in, [i, j])
-
-                            # Compute the output value
-                            val_out = arith.addi(
-                                val_in, arith.index_cast(xrt_dtype, compute_tile_id)
+                            tile_out = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
                             )
 
-                            # Store the output value in tile_out
-                            store(val_out, tile_out, [i, j])
-                            yield_([])
-                        yield_([])
+                            i0 = tx * tile_height
+                            j0 = ty * tile_width
+                            air.ops.load(
+                                tile_in,
+                                A[i0 : i0 + tile_height, j0 : j0 + tile_width],
+                            )
+                            tile_out[:] = tile_in[:] + (tx * cols + ty)
+                            air.ops.store(
+                                tile_out,
+                                B[i0 : i0 + tile_height, j0 : j0 + tile_width],
+                            )
 
-                    # Copy the output tile into the output
-                    dma_memcpy_nd(
-                        b,
-                        tile_out,
-                        dst_offsets=[offset0, offset1],
-                        dst_sizes=tile_size,
-                        dst_strides=[image_width, 1],
-                    )
-
-                    # Deallocate our L1 buffers
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
+    return launch
 
 
 if __name__ == "__main__":
@@ -153,7 +107,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the multi_core_dma example",
     )
     parser.add_argument(
         "-v",
@@ -188,16 +142,24 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.image_height,
         args.image_width,
         args.tile_height,
         args.tile_width,
         INOUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
+++ b/programming_examples/matrix_scalar_add/single_core_dma/single_core_dma.py
@@ -1,116 +1,100 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Add each tile's index to that tile, one core walking every tile, on air.api.
+
+The image is cut into tiles and a single core visits them in turn, adding the
+tile's row-major index to every element it holds:
+
+    for r in air.sequential(0, rows)
+      for c in air.sequential(0, cols)
+        air.ops.load(tile_in, A[r*th : ..., c*tw : ...])    L3 -> L1, strided
+        tile_out[:] = tile_in[:] + (r * cols + c)
+        air.ops.store(tile_out, B[r*th : ..., c*tw : ...])  L1 -> L3, strided
+
+This is the DMA counterpart of ``single_core_channel``, and the contrast is the
+reason both exist. The channel version puts one tile per trip from the segment
+and lets *arrival order* do the indexing, so the core never names a tile. Here
+the transfer is addressed, so the loop variables appear twice over: once as the
+L3 offset, and once as the value being added.
+
+Both uses go through the same machinery -- ``r`` and ``c`` are index
+expressions, so ``r * tile_height`` is a slice bound and ``r * cols + c``
+broadcasts into the elementwise expression as an ``index_cast``. The
+raw-bindings version this replaces spelled both by hand, with
+``arith.MulIOp``/``AddIOp`` for the offsets and an explicit ``arith.index_cast``
+for the addend.
+
+Unchanged otherwise, except that the per-tile add is written
+``tile_out[:] = tile_in[:] + n`` rather than a scalar loop nest over every
+(i, j). ``vector=0`` keeps the emitted loop scalar as the predecessor's was,
+whatever ``--tile-width`` is given: a <8 x i32> add is 256-bit and does not
+legalize on AIE2.
+"""
+
 import argparse
+import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
+
+DTYPE = {np.int32: i32}
 
 
-@module_builder
 def build_module(image_height, image_width, tile_height, tile_width, np_dtype):
     assert image_height % tile_height == 0
     assert image_width % tile_width == 0
-    image_size = [image_height, image_width]
+    dt = DTYPE[np_dtype]
     tile_size = [tile_height, tile_width]
-    xrt_dtype = type_mapper(np_dtype)
+    rows = image_height // tile_height
+    cols = image_width // tile_width
 
-    memrefTyInOut = MemRefType.get(image_size, xrt_dtype)
+    A = air.tensor([image_height, image_width], dt)
+    B = air.tensor([image_height, image_width], dt)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="xaddherd", shape=(1,)) as h:
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We just need one compute core, so we ask for a 1x1 herd
-                @herd(name="xaddherd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(_tx, _ty, _sx, _sy, a, b):
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=tile_size,
-                        element_type=T.i32(),
-                        memory_space=mem_space,
-                    )
-
-                    # Loop over columns and rows of tiles
-                    for tile_index0 in range_(image_height // tile_height):
-                        for tile_index1 in range_(image_width // tile_width):
-
-                            # We must allocate a buffer of tile size for the input/output
-                            tile_in = AllocOp(tile_type, [], [])
-                            tile_out = AllocOp(tile_type, [], [])
-
-                            # Convert the type of the tile size variable to the Index type
-                            tile_size0 = arith.ConstantOp.create_index(tile_height)
-                            tile_size1 = arith.ConstantOp.create_index(tile_width)
-
-                            # Calculate the offset into the channel data, which is based on our loop vars
-                            offset0 = arith.MulIOp(tile_size0, tile_index0)
-                            offset1 = arith.MulIOp(tile_size1, tile_index1)
-                            tile_num = arith.MulIOp(
-                                tile_index0,
-                                arith.ConstantOp.create_index(
-                                    image_width // tile_width
-                                ),
+                        @h.body
+                        def _(tx):
+                            # Hoisted above the loop and reused across trips;
+                            # the predecessor allocated a fresh pair per tile.
+                            tile_in = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
                             )
-                            tile_num = arith.AddIOp(tile_num.results[0], tile_index1)
-
-                            # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                            dma_memcpy_nd(
-                                tile_in,
-                                a,
-                                src_offsets=[offset0, offset1],
-                                src_sizes=tile_size,
-                                src_strides=[image_width, 1],
+                            tile_out = air.alloc(
+                                tile_size, dt, scope=h.private(), vector=0
                             )
 
-                            # Access every value in the tile
-                            for i in range_(tile_height):
-                                for j in range_(tile_width):
-                                    # Load the input value from tile_in
-                                    val_in = load(tile_in, [i, j])
-
-                                    # Compute the output value
-                                    val_out = arith.addi(
-                                        val_in, arith.index_cast(xrt_dtype, tile_num)
+                            for r in air.sequential(0, rows):
+                                for c in air.sequential(0, cols):
+                                    i0 = r * tile_height
+                                    j0 = c * tile_width
+                                    air.ops.load(
+                                        tile_in,
+                                        A[
+                                            i0 : i0 + tile_height,
+                                            j0 : j0 + tile_width,
+                                        ],
+                                    )
+                                    tile_out[:] = tile_in[:] + (r * cols + c)
+                                    air.ops.store(
+                                        tile_out,
+                                        B[
+                                            i0 : i0 + tile_height,
+                                            j0 : j0 + tile_width,
+                                        ],
                                     )
 
-                                    # Store the output value in tile_out
-                                    store(val_out, tile_out, [i, j])
-                                    yield_([])
-                                yield_([])
-
-                            # Copy the output tile into the output
-                            dma_memcpy_nd(
-                                b,
-                                tile_out,
-                                dst_offsets=[offset0, offset1],
-                                dst_sizes=tile_size,
-                                dst_strides=[image_width, 1],
-                            )
-
-                            # Deallocate our L1 buffers
-                            DeallocOp(tile_in)
-                            DeallocOp(tile_out)
-
-                            yield_([])
-                        yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -123,7 +107,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the single_core_dma example",
     )
     parser.add_argument(
         "-v",
@@ -158,16 +142,24 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.image_height,
         args.image_width,
         args.tile_height,
         args.tile_width,
         INOUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
+++ b/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
@@ -1,97 +1,91 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Passthrough a vector one chunk at a time, over plain DMA, on air.api.
+
+The sibling ``passthrough_channel`` streams the same vector through a channel
+pair. This one does it with transfers instead:
+
+    for i in air.sequential(0, n, chunk)
+        air.ops.load(tile_in, A[i : i + chunk])     L3 -> L1
+        tile_out[:] = tile_in[:]
+        air.ops.store(tile_out, B[i : i + chunk])   L1 -> L3
+
+which is the difference worth having both for. A channel is a stream, so one put
+of the whole vector can feed many gets of a chunk each and neither end names an
+offset. A transfer is addressed, so the offset is spelled out per trip and the
+shapes must agree -- and the loop variable is what supplies it.
+
+The six element types the predecessor accepted are all still here, including the
+two unsigned ones. ``uint8`` is the default and the one three of the four lits
+run, so it is the case that has to keep working: an unsigned tile is *movable
+but not computable* in air.api, and this kernel only ever moves and copies it,
+which is exactly the line the DSL draws. Declaring ``i8`` for ``uint8`` data
+instead -- as ``passthrough_channel`` still does -- would make the emitted
+memref element type disagree with the array the runner is handed.
+
+Unchanged from the raw-bindings version this replaces, except for two things:
+
+* The chunk buffers are hoisted above the loop and reused across trips, which is
+  what the loop is for; the predecessor allocated a fresh pair per trip.
+* The copy is written ``tile_out[:] = tile_in[:]`` rather than a scalar loop over
+  every element. For the four signless types that vectorises; for ``uint8`` and
+  ``uint16`` the emitter stays scalar, because a vector copy needs a padding
+  value and that padding value is an ``arith.constant``, which will not take an
+  unsigned type. So the unsigned configs emit the same scalar loop the
+  predecessor did, and the signless ones are strictly faster.
+"""
+
 import argparse
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import bf16, f32, i8, i16, ui8, ui16
 
-dtype_map = {
-    "uint8": np.uint8,
-    "int8": np.int8,
-    "int16": np.int16,
-    "uint16": np.uint16,
-    "float32": np.float32,
-    "bfloat16": bfloat16,
+# numpy dtype -> air.api element type. The unsigned entries are the point of the
+# table: `type_mapper` maps np.uint8 onto MLIR's signful `ui8`, so declaring i8
+# here would emit a kernel whose signature disagrees with its inputs.
+DTYPE = {
+    "uint8": (np.uint8, ui8),
+    "int8": (np.int8, i8),
+    "int16": (np.int16, i16),
+    "uint16": (np.uint16, ui16),
+    "float32": (np.float32, f32),
+    "bfloat16": (bfloat16, bf16),
 }
 DEFAULT_DTYPE = "uint8"
 
 
-@module_builder
-def build_module(vector_size, num_subvectors, np_dtype):
+def build_module(vector_size, num_subvectors, dt):
     assert vector_size % num_subvectors == 0
-    xrt_dtype = type_mapper(np_dtype)
+    chunk = vector_size // num_subvectors
 
-    # Type and method of input/output
-    memrefTyInOut = T.memref(vector_size, xrt_dtype)
+    A = air.tensor([vector_size], dt)
+    B = air.tensor([vector_size], dt)
 
-    # The compute core splits input into subvectors for processing
-    lineWidthInBytes = vector_size // num_subvectors
+    with air.launch(name="copy") as launch:
 
-    # Memref type definition used by the compute core and external function
-    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    tensor_type = MemRefType.get(
-        shape=[lineWidthInBytes],
-        element_type=xrt_dtype,
-        memory_space=mem_space,
-    )
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
 
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc([chunk], dt, scope=h.private())
+                            tile_out = air.alloc([chunk], dt, scope=h.private())
 
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+                            for i in air.sequential(0, num_subvectors * chunk, chunk):
+                                air.ops.load(tile_in, A[i : i + chunk])
+                                tile_out[:] = tile_in[:]
+                                air.ops.store(tile_out, B[i : i + chunk])
 
-                @herd(name="copyherd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(_tx, _ty, _sx, _sy, c, d):
-
-                    # Process each subvector individually
-                    for i in range_(
-                        0, num_subvectors * lineWidthInBytes, lineWidthInBytes
-                    ):
-                        # We must allocate a buffer of image size for the input/output
-                        tensor_in = AllocOp(tensor_type, [], [])
-                        tensor_out = AllocOp(tensor_type, [], [])
-
-                        # Place the input image (a) into the L1 memory region
-                        dma_memcpy_nd(
-                            tensor_in,
-                            c,
-                            src_offsets=[i],
-                            src_sizes=[lineWidthInBytes],
-                            src_strides=[1],
-                        )
-
-                        for j in range_(lineWidthInBytes):
-                            # Load the input value
-                            val = load(tensor_in, [j])
-
-                            # Store the output value
-                            store(val, tensor_out, [j])
-                            yield_([])
-
-                        dma_memcpy_nd(
-                            d,
-                            tensor_out,
-                            dst_offsets=[i],
-                            dst_sizes=[lineWidthInBytes],
-                            dst_strides=[1],
-                        )
-
-                        # Deallocate our L1 buffers
-                        DeallocOp(tensor_in)
-                        DeallocOp(tensor_out)
-                        yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -134,13 +128,21 @@ if __name__ == "__main__":
         "-t",
         "--dtype",
         default=DEFAULT_DTYPE,
-        choices=dtype_map.keys(),
+        choices=DTYPE.keys(),
         help="The data type to use (default: uint8)",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
     args = parser.parse_args()
 
-    np_dtype = dtype_map[args.dtype]
-    mlir_module = build_module(args.vector_size, args.subvector_size, np_dtype)
+    np_dtype, dt = DTYPE[args.dtype]
+    launch = build_module(args.vector_size, args.subvector_size, dt)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
+++ b/programming_examples/passthrough/passthrough_dma/passthrough_dma.py
@@ -45,8 +45,9 @@ from air import api as air
 from air.api import bf16, f32, i8, i16, ui8, ui16
 
 # numpy dtype -> air.api element type. The unsigned entries are the point of the
-# table: `type_mapper` maps np.uint8 onto MLIR's signful `ui8`, so declaring i8
-# here would emit a kernel whose signature disagrees with its inputs.
+# table: air.api maps np.uint8 onto MLIR's unsigned `ui8`, not the signless `i8`,
+# so declaring i8 here would emit a kernel whose argument type disagrees with the
+# np.uint8 array handed to XRTRunner below.
 DTYPE = {
     "uint8": (np.uint8, ui8),
     "int8": (np.int8, i8),

--- a/programming_examples/segment_alloc/segment_alloc.py
+++ b/programming_examples/segment_alloc/segment_alloc.py
@@ -1,16 +1,41 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A tile staged through L2 on its way to a core, on air.api.
+
+The sibling ``shim_dma_2d`` moves the same 8x16 tile straight from L3 into L1.
+This one puts a memtile in between, which is what ``air.segment`` is for:
+
+    l2 = air.alloc(TILE_SIZE, i32, scope=seg.private())   a memtile buffer
+      air.ops.load(l2, A[0:8, 0:16])                      L3 -> L2, strided
+      air.ops.load(tile_in, l2)                           L2 -> L1, contiguous
+      tile_out[:] = tile_in[:]
+      air.ops.store(tile_out, B[0:8, 0:16])               L1 -> L3, strided
+
+``seg.private()`` is the whole point of the example: it allocates in memory
+space 1, and the herd nested in the segment body carries that buffer in as an
+operand automatically. ``air.herd`` is ``IsolatedFromAbove``, so in the
+raw-bindings version this replaces, the L2 buffer had to be listed in
+``operands=[...]`` by hand and picked back up as a body parameter. Here the
+tracer knows which buffers are live in the enclosing segment and threads them
+itself.
+
+The strided L3 read is unchanged: the image is 16x32 and the tile 8x16, so the
+tile is not contiguous, and the transfer carries sizes [8, 16] strides [32, 1].
+Only the top-left tile is touched; the rest of B stays zero.
+
+Unchanged from the raw-bindings version except that the copy is written
+``tile_out[:] = tile_in[:]`` rather than a scalar loop nest over every (i, j).
+The tile's innermost dimension is 16, so that vectorises to a ``<16 x i32>``
+(512-bit) read and write.
+"""
+
 import argparse
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -26,91 +51,34 @@ assert IMAGE_WIDTH % TILE_WIDTH == 0
 INOUT_DATATYPE = np.int32
 
 
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, xrt_dtype)
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
-                # We want to store our data in L1 memory
-                mem_space_l2 = IntegerAttr.get(T.i32(), MemorySpace.L2)
+                @seg.body
+                def _():
+                    # L2: a memtile buffer, passed into the herd for us.
+                    l2_tile = air.alloc(TILE_SIZE, i32, scope=seg.private())
 
-                # This is the type definition of the tile
-                tile_type_l2 = MemRefType.get(
-                    shape=TILE_SIZE,
-                    element_type=xrt_dtype,
-                    memory_space=mem_space_l2,
-                )
+                    with air.herd([range(1)], name="copyherd", shape=(1,)) as h:
 
-                # We must allocate a buffer of tile size for the input/output
-                tile_in_l2 = AllocOp(tile_type_l2, [], [])
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc(TILE_SIZE, i32, scope=h.private())
+                            tile_out = air.alloc(TILE_SIZE, i32, scope=h.private())
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We just need one compute core, so we ask for a 1x1 herd
-                @herd(name="copyherd", sizes=[1, 1], operands=[arg2, arg3, tile_in_l2])
-                def herd_body(tx, ty, sx, sy, a, b, my_l2_tile):
+                            air.ops.load(l2_tile, A[0:TILE_HEIGHT, 0:TILE_WIDTH])
+                            air.ops.load(tile_in, l2_tile)
+                            tile_out[:] = tile_in[:]
+                            air.ops.store(tile_out, B[0:TILE_HEIGHT, 0:TILE_WIDTH])
 
-                    # We want to store our data in L1 memory
-                    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-
-                    # This is the type definition of the tile
-                    tile_type_l1 = MemRefType.get(
-                        shape=TILE_SIZE,
-                        element_type=xrt_dtype,
-                        memory_space=mem_space_l1,
-                    )
-
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in_l1 = AllocOp(tile_type_l1, [], [])
-                    tile_out_l1 = AllocOp(tile_type_l1, [], [])
-
-                    dma_memcpy_nd(
-                        my_l2_tile,
-                        a,
-                        src_offsets=[0, 0],
-                        src_sizes=TILE_SIZE,
-                        src_strides=[IMAGE_WIDTH, 1],
-                    )
-
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    dma_memcpy_nd(
-                        tile_in_l1,
-                        my_l2_tile,
-                    )
-
-                    # Access every value in the tile
-                    for i in range_(TILE_HEIGHT):
-                        for j in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val = load(tile_in_l1, [i, j])
-
-                            # Store the output value in tile_out
-                            store(val, tile_out_l1, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    # Copy the output tile into the output
-                    dma_memcpy_nd(
-                        b,
-                        tile_out_l1,
-                        dst_offsets=[0, 0],
-                        dst_sizes=TILE_SIZE,
-                        dst_strides=[IMAGE_WIDTH, 1],
-                    )
-
-                    # Deallocate our L1 buffers
-                    DeallocOp(tile_in_l1)
-                    DeallocOp(tile_out_l1)
+    return launch
 
 
 if __name__ == "__main__":
@@ -136,10 +104,17 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    mlir_module = build_module().build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/shim_dma_2d/run.py
+++ b/programming_examples/shim_dma_2d/run.py
@@ -29,9 +29,16 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module()
+    mlir_module = build_module().build(target=args.target)
 
     input_a = np.arange(np.prod(IMAGE_SIZE), dtype=INOUT_DATATYPE).reshape(IMAGE_SIZE)
     output_b = np.zeros(shape=IMAGE_SIZE, dtype=INOUT_DATATYPE)

--- a/programming_examples/shim_dma_2d/shim_dma_2d.py
+++ b/programming_examples/shim_dma_2d/shim_dma_2d.py
@@ -1,13 +1,36 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""One tile through L1 with a strided shim DMA, on air.api.
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
+The smallest program that shows a *2-D* shim transfer. The image is 16x32 and
+the tile is 8x16, so the tile is not contiguous in L3: reading it means a DMA
+with sizes [8, 16] and strides [32, 1], which is what the shim's buffer
+descriptor is for. Everything else -- one core, a copy, and the tile written
+back to the same corner -- is deliberately trivial, so the transfer is the only
+thing under test.
 
-range_ = for_
+    air.ops.load(tile_in, A[0:8, 0:16])      L3 -> L1, strided
+    tile_out[:] = tile_in[:]
+    air.ops.store(tile_out, B[0:8, 0:16])    L1 -> L3, strided
+
+Only the top-left tile is touched; the rest of B stays zero, and all three
+harnesses in this directory check exactly that.
+
+Unchanged from the raw-bindings version this replaces, except that the copy is
+written ``tile_out[:] = tile_in[:]`` rather than a scalar loop nest over every
+(i, j). The tile's innermost dimension is 16, so that vectorises to a
+``<16 x i32>`` (512-bit) read and write, where the predecessor moved one element
+per iteration.
+
+``build_module`` returns the launch rather than a module, matching the other
+converted examples; ``.build(target=...)`` produces the module. ``run.py`` and
+``test.py`` import the shape constants below, so they stay module-level.
+"""
+
+import argparse
+
+from air import api as air
+from air.api import i32
 
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 16
@@ -21,74 +44,44 @@ assert IMAGE_HEIGHT % TILE_HEIGHT == 0
 assert IMAGE_WIDTH % TILE_WIDTH == 0
 
 
-@module_builder
 def build_module():
-    memrefTyInOut = MemRefType.get(IMAGE_SIZE, T.i32())
+    A = air.tensor(IMAGE_SIZE, i32)
+    B = air.tensor(IMAGE_SIZE, i32)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyInOut, memrefTyInOut)
-    def copy(arg0, arg1):
+    with air.launch(name="copy") as launch:
 
-        # The arguments are the input and output
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-            # The arguments are still the input and the output
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="xaddherd", shape=(1,)) as h:
 
-                # The herd sizes correspond to the dimensions of the contiguous block of cores we are hoping to get.
-                # We just need one compute core, so we ask for a 1x1 herd
-                @herd(name="xaddherd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(_tx, _ty, _sx, _sy, a, b):
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+                        @h.body
+                        def _(tx):
+                            tile_in = air.alloc(TILE_SIZE, i32, scope=h.private())
+                            tile_out = air.alloc(TILE_SIZE, i32, scope=h.private())
 
-                    # This is the type definition of the tile
-                    tile_type = MemRefType.get(
-                        shape=TILE_SIZE,
-                        element_type=T.i32(),
-                        memory_space=mem_space,
-                    )
+                            air.ops.load(tile_in, A[0:TILE_HEIGHT, 0:TILE_WIDTH])
+                            tile_out[:] = tile_in[:]
+                            air.ops.store(tile_out, B[0:TILE_HEIGHT, 0:TILE_WIDTH])
 
-                    # We must allocate a buffer of tile size for the input/output
-                    tile_in = AllocOp(tile_type, [], [])
-                    tile_out = AllocOp(tile_type, [], [])
-
-                    # Copy a tile from the input image (a) into the L1 memory region (tile_in)
-                    dma_memcpy_nd(
-                        tile_in,
-                        a,
-                        src_offsets=[0, 0],
-                        src_sizes=TILE_SIZE,
-                        src_strides=[IMAGE_WIDTH, 1],
-                    )
-
-                    # Access every value in the tile
-                    for i in range_(TILE_HEIGHT):
-                        for j in range_(TILE_WIDTH):
-                            # Load the input value from tile_in
-                            val = load(tile_in, [i, j])
-
-                            # Store the output value in tile_out
-                            store(val, tile_out, [i, j])
-                            yield_([])
-                        yield_([])
-
-                    # Copy the output tile into the output
-                    dma_memcpy_nd(
-                        b,
-                        tile_out,
-                        dst_offsets=[0, 0],
-                        dst_sizes=TILE_SIZE,
-                        dst_strides=[IMAGE_WIDTH, 1],
-                    )
-
-                    # Deallocate our L1 buffers
-                    DeallocOp(tile_in)
-                    DeallocOp(tile_out)
+    return launch
 
 
 if __name__ == "__main__":
-    module = build_module()
-    print(module)
+    parser = argparse.ArgumentParser(
+        prog="shim_dma_2d.py",
+        description="Prints the AIR module for the shim_dma_2d example",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    args = parser.parse_args()
+
+    print(build_module().build(target=args.target))


### PR DESCRIPTION
Converts the DMA counterparts of examples already on `air.api`, replacing the raw-bindings versions:

| example | what it shows |
|---|---|
| `shim_dma_2d` | a strided 2-D shim transfer |
| `passthrough/passthrough_dma` | chunked passthrough, 6 element types |
| `segment_alloc` | L2 staging via `seg.private()` |
| `matrix_scalar_add/single_core_dma` | one core walking every tile |
| `matrix_scalar_add/multi_core_dma` | one core per tile |

**No DSL code changes** — these are example conversions only, so the emitted IR of the already-converted examples is untouched.

Three of the five are siblings of converted channel examples, and the pairs are worth reading together: a channel is a stream, so one put can feed many gets and neither end names an offset, while a transfer is addressed and the loop variable supplies the offset explicitly. `multi_core_dma` is where `air.api` pays off most — turning a herd coordinate into an L3 offset needed four hand-built `AffineMap`s and an `affine_apply` per use, because a coordinate is an SSA value; here `tx` is an index expression and `tx * tile_height` is just a slice bound.

`passthrough_dma` keeps all six element types, including `uint8` and `uint16`, now declared as such rather than as their signed siblings. An unsigned tile is movable but not computable in `air.api`, and this kernel only moves and copies one; the emitter keeps those two configs on the scalar path, since a vector copy needs a padding value and that is an `arith.constant`.

### The one behavioural trap worth flagging in review

`multi_core_dma` pins `shape=(rows, cols)` on its herd. `air.api`'s default 2-D herd shape on npu1 is `(1, 4)` — deliberately conservative, since a 2-D herd can exhaust shim DMA capacity before it exhausts columns — and letting it apply here strip-mines the row axis into a temporal `scf.for`, giving **2 cores doing 2 tiles each where the predecessor had 4 doing one apiece**. The output is still correct, so this is only visible by diffing the emitted herd sizes against the predecessor. One core per tile is the point of this example against its `single_core` sibling, hence the explicit shape.

`shim_dma_2d`'s `build_module` now returns the launch rather than a module, matching the other conversions; `run.py` calls `.build(target=...)`. Its module-level shape constants stay, because `run.py` and `test.py` both `import *` from it.

### Verification

17 lits across the five. **6 are runnable on the npu1 box used here, and all 6 pass:**

```
-- Testing: 17 of 383 tests, 16 workers --
Total Discovered Tests: 383
  Excluded   : 366 (95.56%)
  Unsupported:  11 (2.87%)
  Passed     :   6 (1.57%)
```

The 11 unsupported are not silently skipped: 6 need a chess licence (not installed here) and 5 are `ryzen_ai_npu2`. Both groups were covered by compile sweeps instead — all five examples compile for `npu2_4col`, and the four with `OUTPUT_FORMAT=elf` lits also compile via `--output-format elf`.

`passthrough_dma` advertises 6 dtypes while its lits exercise only 2, so all six were compile-swept on npu1:

```
uint8: COMPILE OK (8358 bytes)
int8: COMPILE OK (8486 bytes)
int16: COMPILE OK (8342 bytes)
uint16: COMPILE OK (8342 bytes)
float32: COMPILE OK (8342 bytes)
bfloat16: COMPILE OK (8342 bytes)
```

The four signless types now vectorise where the predecessor ran scalar; `uint8`/`uint16` stay scalar, matching the predecessor exactly.

Not measured: no perf A/B was run on npu2 — the box used here is npu1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)