### PR TITLE
[programming_examples] air.api: four vector_examples primitives

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_add/vector_add.py
+++ b/programming_examples/primitives/vector_examples/vector_add/vector_add.py
@@ -1,167 +1,89 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Vector add primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] + b[:]
+
+One line of compute, over a [n] vector cut into [tile_n] tiles and spread across
+``NUM_TILES`` cores. It is the smallest member of the vector_examples family,
+and the family is a showcase: each sibling differs from this one only in the
+operator on that line.
+
+That is the whole argument for writing these on air.api. The raw-bindings
+version this replaces spelled the vectorised loop by hand -- an ``scf.for`` over
+the tile in steps of VECTOR_SIZE, three ``memref.subview``s per trip to carve
+out the current lane group, three ``vector.transfer_read``s with an explicit
+identity permutation map and a padding constant, the ``arith`` op, and a
+``transfer_write`` -- roughly forty lines in which exactly one token, ``AddFOp``,
+said what the kernel computes. Here the emitter builds that loop, and the
+subviews are not needed at all: air.api reads at an offset directly.
+
+The strip-mine is also the DSL's. The predecessor asked for a [1, NUM_TILES]
+herd and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+through a hand-built AffineMap. Here the herd's iteration space is the whole
+tile grid and air.api strip-mines it onto ``NUM_TILES`` cores, so a core that
+gets more than one tile loops over them without the kernel saying so.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* ``vector=`` is threaded from ``--vector-size`` down to the allocation, so the
+  emitter's loop uses the width the lits ask for rather than the dtype default.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import bf16, f32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    b_size = a_size
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = bf16 if np_dtype_in is bfloat16 else f32
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="vector_add") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_add(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_b,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_b_vec = subview(
-                        l1_b_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c = arith.AddFOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+                    c[:] = a[:] + b[:]
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -173,7 +95,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_add example",
     )
     parser.add_argument(
         "-v",
@@ -221,6 +143,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -228,12 +157,13 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
         args.vector_size,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/primitives/vector_examples/vector_add/vector_add.py
+++ b/programming_examples/primitives/vector_examples/vector_add/vector_add.py
@@ -203,6 +203,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_add",
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -221,6 +222,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_max/vector_max.py
+++ b/programming_examples/primitives/vector_examples/vector_max/vector_max.py
@@ -1,167 +1,74 @@
-# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Vector elementwise maximum primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp, MaximumFOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = ops.maximum(a[:], b[:])
+
+A member of the vector_examples family; see ``vector_add`` for what the DSL is
+doing here and why the raw-bindings version this replaces was forty lines of
+hand-rolled ``memref.subview`` plus ``vector.transfer_read``/``transfer_write``
+to say one thing. ``ops.maximum`` emits ``arith.maximumf``, which is exactly what the
+predecessor built by hand -- not ``maxnumf``, whose scalar f32 form the
+LLVM 24 bump regressed.
+
+The herd is [NUM_TILES, 1] rather than the predecessor's [1, NUM_TILES] -- a 1-D
+air.api herd is laid out along x, the orientation that places on both
+generations -- and the tile grid is strip-mined onto those cores by the DSL
+rather than by a hand-written outer loop.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import bf16, f32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    b_size = a_size
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = bf16 if np_dtype_in is bfloat16 else f32
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="vector_max") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_max(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_b,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_b_vec = subview(
-                        l1_b_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c = MaximumFOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+                    c[:] = air.ops.maximum(a[:], b[:])
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -221,6 +128,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -228,12 +142,13 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
         args.vector_size,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/primitives/vector_examples/vector_max/vector_max.py
+++ b/programming_examples/primitives/vector_examples/vector_max/vector_max.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 """Vector elementwise maximum primitive, on air.api.
 
@@ -186,6 +186,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_max",
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -204,6 +205,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
+++ b/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
@@ -195,6 +195,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_mul",
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -213,6 +214,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
+++ b/programming_examples/primitives/vector_examples/vector_mul/vector_mul.py
@@ -1,172 +1,81 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Vector multiply primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] * b[:]
+
+A member of the vector_examples family; see ``vector_add`` for what the DSL is
+doing here and why the raw-bindings version this replaces was forty lines of
+hand-rolled ``memref.subview`` plus ``vector.transfer_read``/``transfer_write``
+to say one thing. Only the operator differs, and the vector width is selected by
+``--arch`` rather than given directly -- see below.
+
+The herd is [NUM_TILES, 1] rather than the predecessor's [1, NUM_TILES] -- a 1-D
+air.api herd is laid out along x, the orientation that places on both
+generations -- and the tile grid is strip-mined onto those cores by the DSL
+rather than by a hand-written outer loop.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import bf16, f32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
+# The predecessor selects its vector width from the target architecture rather
+# than taking it directly. Note this only picks a width -- it does not pin the
+# device, which stays `auto` via --target, so a module built here still runs on
+# whichever generation is installed.
+ARCH_VECTOR_SIZES = {"aie2": 16, "aie2p": 64}
+
+
 def build_module(n, tile_n, np_dtype_in, arch="aie2"):
-    a_size = [n]
-    b_size = a_size
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    # Architecture-specific vector size
-    arch_vector_sizes = {
-        "aie2": 16,
-        "aie2p": 64,
-    }
-    VECTOR_SIZE = arch_vector_sizes.get(arch, 16)  # default to 16 if unknown
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    vector_size = ARCH_VECTOR_SIZES.get(arch, 16)
+    dt = bf16 if np_dtype_in is bfloat16 else f32
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="vector_mul") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_mul(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_b,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_b_vec = subview(
-                        l1_b_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c = arith.MulFOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+                    c[:] = a[:] * b[:]
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -177,7 +86,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_mul example",
     )
     parser.add_argument(
         "-v",
@@ -201,7 +110,7 @@ if __name__ == "__main__":
         type=str,
         choices=["aie2", "aie2p"],
         default="aie2",
-        help="Target AIE architecture (aie2 or aie2p)",
+        help="Target AIE architecture (aie2 or aie2p); selects the vector width",
     )
     parser.add_argument(
         "--compile-mode",
@@ -226,6 +135,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -233,12 +149,13 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
         args.arch,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
+++ b/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
@@ -186,6 +186,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_sub",
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -204,6 +205,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
+++ b/programming_examples/primitives/vector_examples/vector_sub/vector_sub.py
@@ -1,167 +1,72 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Vector subtract primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] - b[:]
+
+A member of the vector_examples family; see ``vector_add`` for what the DSL is
+doing here and why the raw-bindings version this replaces was forty lines of
+hand-rolled ``memref.subview`` plus ``vector.transfer_read``/``transfer_write``
+to say one thing. Only the operator differs.
+
+The herd is [NUM_TILES, 1] rather than the predecessor's [1, NUM_TILES] -- a 1-D
+air.api herd is laid out along x, the orientation that places on both
+generations -- and the tile grid is strip-mined onto those cores by the DSL
+rather than by a hand-written outer loop.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import bf16, f32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    b_size = a_size
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = bf16 if np_dtype_in is bfloat16 else f32
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="vector_sub") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_sub(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_b,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_b_vec = subview(
-                        l1_b_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c = arith.SubFOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+                    c[:] = a[:] - b[:]
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -173,7 +78,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_sub example",
     )
     parser.add_argument(
         "-v",
@@ -221,6 +126,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -228,12 +140,13 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
         args.vector_size,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)


### PR DESCRIPTION
Converts `vector_add`, `vector_sub`, `vector_mul` and `vector_max` onto `air.api`, replacing the raw-bindings versions. Each is now one line of compute:

```python
c[:] = a[:] + b[:]                  # vector_add
c[:] = a[:] - b[:]                  # vector_sub
c[:] = a[:] * b[:]                  # vector_mul
c[:] = air.ops.maximum(a[:], b[:])  # vector_max
```

**No DSL code changes** — example conversions only. 618 lines deleted, 293 added.

### Why these four are the clearest case yet for the DSL

Each predecessor spelled its vectorised loop by hand: an `scf.for` over the tile in steps of `VECTOR_SIZE`, three `memref.subview`s per trip to carve out the current lane group, three `vector.transfer_read`s with an explicit identity permutation map and a padding constant, the `arith` op, and a `transfer_write`. Roughly forty lines in which exactly one token said what the kernel computes. The emitter builds that loop — and the subviews are not needed at all, because `air.api` reads at an offset directly.

The strip-mine is the DSL's now too. Each predecessor asked for a `[1, NUM_TILES]` herd and then wrote the outer loop itself, computing the L3 offset through a hand-built `AffineMap`. Here the herd's iteration space is the whole tile grid and `air.api` strip-mines it onto `NUM_TILES` cores.

### Behavioural differences, stated rather than buried

- **Tile distribution changes from interleaved to blocked.** The predecessor's core `ty` took tiles `ty, ty+2, ty+4, …`; each core now takes a contiguous run. Coverage is identical — every 1024-element tile of the 65536-element vector, exactly once — and the tiles are independent, so the result is unchanged.
- **The herd becomes `[NUM_TILES, 1]` rather than `[1, NUM_TILES]`.** A 1-D `air.api` herd is laid out along x, which is the orientation that places on both generations.
- `vector_mul` keeps its `--arch` flag. It selects the vector width (`aie2` → 16, `aie2p` → 64) and, despite the name, does **not** pin the device: `--target` stays `auto`, so the module still runs on whichever generation is installed.

### Verification

19 lits across the four. **8 are runnable on the npu1 box used here, and all 8 pass** — including both `--bf16-emulation` configs, which build the f32 variant rather than bf16:

```
-- Testing: 19 of 383 tests, 16 workers --
  Unsupported:  11 (2.87%)
  Passed     :   8 (2.09%)
```

The 11 unsupported are all `ryzen_ai_npu2`. They are covered by compile sweeps instead: all four examples compile for `npu2_4col` in **both** `xclbin` and `elf` form, at the exact vector widths those lits ask for — `vector<32xbf16>` for add/sub/max (`VECTOR_SIZE=32`) and `vector<64xbf16>` for mul (`AIE_TARGET=aie2p`).

Not measured: no perf A/B — the box used here is npu1, and these examples have no `profile` target or `--perf-iters`.

### Note for whoever picks up the rest of this family

The remaining `vector_examples` are deliberately not in this PR. `vector_div` and `vector_reciprocal` are *entirely* npu2-gated (zero lits runnable on npu1) and bf16 vector divide is a known non-legalizing case, so they want an npu2 box rather than a compile-only claim from here. `vector_fma` needs an fma surface, `vector_muladd` is the chained mul→add f32 legalization trap, `vector_broadcast_scalar` needs `collapse_shape`, and the rest need `exp`, `rsqrt`, `select`, bitwise ops, int↔float casts or reductions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)