### PR TITLE
[ci] Windows: constrain nanobind to the pin the repo already carries

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -54,7 +54,12 @@ jobs:
       - name: Install Python packages
         run: |
           python -m pip install --upgrade pip
-          pip install lit PyYAML numpy nanobind
+          # -c, not a pin spelled out here: utils/requirements_dev.txt already
+          # pins nanobind, and a second copy of the version is a second thing to
+          # drift. A constraints file only bounds packages that are actually
+          # being installed, so the cmake/ninja entries in it are inert (both
+          # come from setup-cpp above).
+          pip install lit PyYAML numpy nanobind -c utils/requirements_dev.txt
 
       - name: Ccache for C++ compilation
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
The Windows build has been failing at CMake configure since nanobind 3.0.0 shipped:

```
CMake Error at mlir/lib/cmake/mlir/MLIRDetectPythonEnv.cmake:84 (find_package):
  Could not find a configuration file for package "nanobind" that is
  compatible with requested version "2.9".

  The following configuration files were considered but not accepted:
    .../site-packages/nanobind/cmake/nanobind-config.cmake, version: 3.0.0
```

### This is not caused by any recent PR

- **`main` fails it**: the `push` run on `c9e93f31` is red with the identical error.
- The merge-queue run for #1875 failed the same way.
- It is a **configure-time** failure, and the PRs it is currently blocking (#1876) touch only Python example files.
- Every other check is green, including all 8 Windows wheel jobs — those install from the pinned requirements.

### Root cause

[`utils/requirements_dev.txt`](utils/requirements_dev.txt) already pins nanobind, and states the reason:

```
# Pinned, not a floor: nanobind ABI-couples to the MLIR distro wheel.
nanobind==2.12.0
```

`buildAndTestWindows.yml` was the one place that bypassed it:

```yaml
pip install lit PyYAML numpy nanobind      # unpinned
```

so it picked up 3.0.0 the day it was published. The Linux jobs go through the requirements file and are unaffected. That is why this broke on a day nobody touched the build.

### Why a constraints file rather than repeating the version

Spelling `nanobind==2.12.0` into the workflow would fix today's breakage but leave two copies of the version to drift apart — which is exactly how this happened. `-c` keeps one source of truth. It only bounds packages that are actually being installed, so the `cmake` / `ninja` / `pybind11` / `psutil` entries in that file are inert here (cmake and ninja already come from `setup-cpp` earlier in the job).

If reviewers would rather see the blunt one-token version pin instead, say so and I'll swap it — the behaviour today is identical.

### Verification

I cannot run Windows CI from my box, so this is verified by dry run plus YAML parse; the real check is CI on this PR.

```
$ pip install --dry-run --ignore-installed lit PyYAML numpy nanobind -c utils/requirements_dev.txt
Collecting nanobind
  Downloading nanobind-2.12.0-py3-none-any.whl.metadata (1.8 kB)
Would install PyYAML-6.0.3 lit-18.1.8 nanobind-2.12.0 numpy-2.5.2
```

nanobind resolves to 2.12.0 rather than 3.0.0, cmake and ninja are not pulled in, and there are no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)