### PR TITLE
[programming_examples] air.api: sine_cosine and softmax via air.extern

### DIFF
--- a/programming_examples/sine_cosine/sine_cosine.py
+++ b/programming_examples/sine_cosine/sine_cosine.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 """Elementwise sine or cosine via a hand-written AIE kernel, on air.api.
 
-    sinf = air.extern("sinf_bf16_24_8", object="sine_cosine.o")
-    cosf = air.extern("cosf_bf16_24_8", object="sine_cosine.o")
+    kernel = air.extern(
+        "sinf_bf16_24_8" if mode == "sin" else "cosf_bf16_24_8",
+        object="sine_cosine.o",
+    )
     ...
     air.ops.load(a, A[i0 : i0 + tile_n])
-    (sinf if mode == "sin" else cosf)(a, out)
+    kernel(a, out)
     air.ops.store(out, C[i0 : i0 + tile_n])
 
 Nothing is computed in the DSL here -- the whole kernel body is one call into
@@ -20,6 +22,13 @@ Both symbols live in one object file, and only one of them is called per build
 -- ``--mode`` picks at trace time, so the other is never declared. A herd links
 against a single object, which is the constraint ``air.extern`` enforces; two
 kernels from the *same* object are fine.
+
+Note how much of this example's interface the object file pins.
+``sinf_bf16_24_8`` instantiates ``sinf_cosf_poly_bf16<24, 8, true>``: both the
+element type and the 24-element extent are compiled into the object rather than
+read from the memref it is handed, so a kernel called with any other tile size
+would read and write 24 elements regardless. ``--tile-n`` and the dtype are
+therefore checked below rather than accepted and silently miscomputed.
 
 Unchanged from the predecessor except that the herd is [herd_n, 1] rather than
 [1, herd_n] -- a 1-D air.api herd is laid out along x, the orientation that
@@ -45,8 +54,30 @@ from air.backend.xrt_runner import XRTRunner
 np.random.seed(42)
 
 
+KERNEL_TILE_N = 24  # the 24 in sinf_cosf_poly_bf16<24, 8, ...>
+
+
 def build_module(n, tile_n, herd_n, mode, np_dtype_in):
     assert n % (tile_n * herd_n) == 0
+    # Checked, not assumed. The object file exports exactly two symbols, and
+    # each one bakes in the element type and the extent -- neither is read from
+    # the memref at the call. Getting either wrong links and runs, and computes
+    # the wrong answer, so refuse here where the cause can still be named.
+    if mode not in ("sin", "cos"):
+        raise ValueError(f"mode must be 'sin' or 'cos', got {mode!r}")
+    if np_dtype_in is not bfloat16:
+        raise ValueError(
+            f"sine_cosine.o exports only bf16 kernels (sinf_bf16_24_8 / "
+            f"cosf_bf16_24_8), so np_dtype_in must be ml_dtypes.bfloat16, "
+            f"got {np_dtype_in!r}"
+        )
+    if tile_n != KERNEL_TILE_N:
+        raise ValueError(
+            f"tile_n must be {KERNEL_TILE_N}: the extent is a template "
+            f"argument of sinf_cosf_poly_bf16<{KERNEL_TILE_N}, 8, ...>, "
+            f"compiled into sine_cosine.o, not taken from the memref. "
+            f"got tile_n={tile_n}"
+        )
     dt = bf16
 
     A = air.tensor([n], dt)
@@ -108,7 +139,14 @@ if __name__ == "__main__":
         default=N,
         help="Total number of elements",
     )
-    parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
+    parser.add_argument(
+        "--tile-n",
+        type=int,
+        default=TILE_N,
+        help=f"Tile size. Pinned to {KERNEL_TILE_N} by sine_cosine.o, which "
+        f"compiles the extent in as a template argument; other values are "
+        f"rejected rather than silently miscomputed",
+    )
     parser.add_argument(
         "--herd-n",
         type=int,

--- a/programming_examples/sine_cosine/sine_cosine.py
+++ b/programming_examples/sine_cosine/sine_cosine.py
@@ -1,136 +1,83 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from math import cos, sin, sqrt, exp
+"""Elementwise sine or cosine via a hand-written AIE kernel, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
-from ml_dtypes import bfloat16
+    sinf = air.extern("sinf_bf16_24_8", object="sine_cosine.o")
+    cosf = air.extern("cosf_bf16_24_8", object="sine_cosine.o")
+    ...
+    air.ops.load(a, A[i0 : i0 + tile_n])
+    (sinf if mode == "sin" else cosf)(a, out)
+    air.ops.store(out, C[i0 : i0 + tile_n])
+
+Nothing is computed in the DSL here -- the whole kernel body is one call into
+``sine_cosine.o``. That is the point: ``air.extern`` emits the private
+``func.func`` declaration, stamps ``link_with`` on both the declaration and the
+herd, and builds the ``func.call``, which the raw-bindings version this replaces
+spelled out as a ``FuncOp`` per symbol plus two attribute assignments plus a
+``CallOp``.
+
+Both symbols live in one object file, and only one of them is called per build
+-- ``--mode`` picks at trace time, so the other is never declared. A herd links
+against a single object, which is the constraint ``air.extern`` enforces; two
+kernels from the *same* object are fine.
+
+Unchanged from the predecessor except that the herd is [herd_n, 1] rather than
+[1, herd_n] -- a 1-D air.api herd is laid out along x, the orientation that
+places on both generations -- and the tile grid is strip-mined onto those cores
+by the DSL rather than by a hand-written outer loop with an AffineMap for the
+offset.
+"""
+
+import argparse
+from math import cos, sin
 
 import numpy as np
+from ml_dtypes import bfloat16
 
+from air import api as air
+from air.api import bf16
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+# Load-bearing: the inputs below are drawn from np.random, and the tolerance is
+# loose enough (rtol=1e0 against a bf16 sine) that an unseeded draw fails
+# intermittently rather than never.
 np.random.seed(42)
 
-range_ = for_
 
-
-@module_builder
-def build_module(n, tile_n, herd_n, sin_or_cos, np_dtype_in):
+def build_module(n, tile_n, herd_n, mode, np_dtype_in):
     assert n % (tile_n * herd_n) == 0
-    if sin_or_cos == "sin":
-        isSine = True
-        isCosine = False
-    elif sin_or_cos == "cos":
-        isSine = False
-        isCosine = True
-    else:
-        raise AssertionError
-    a_size = [n]
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
+    dt = bf16
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
+    # Declared per build, not both: --mode selects one, and the unused symbol is
+    # never emitted. Both come from the same object file, which is what lets a
+    # single herd link against them.
+    kernel = air.extern(
+        "sinf_bf16_24_8" if mode == "sin" else "cosf_bf16_24_8",
+        object="sine_cosine.o",
     )
 
-    # Function declaration
-    sinf_func = FuncOp(
-        "sinf_bf16_24_8",
-        ([l1MemrefTy, l1MemrefTy], []),
-        visibility="private",
-    )
-    cosf_func = FuncOp(
-        "cosf_bf16_24_8",
-        ([l1MemrefTy, l1MemrefTy], []),
-        visibility="private",
-    )
-    for func in [sinf_func, cosf_func]:
-        func.attributes["link_with"] = StringAttr.get("sine_cosine.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name="sine_cosine") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def sine_cosine(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, herd_n],
-            operands=[arg0, arg1],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            with air.herd([range(0, n, tile_n)], name="herd_0", shape=(herd_n,)) as h:
 
-            for t in range_(0, n, tile_n * herd_n):
+                @h.body
+                def _(tx):
+                    # tx counts tiles, not elements.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private())
+                    out = air.alloc([tile_n], dt, scope=h.private())
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [t, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    kernel(a, out)
+                    air.ops.store(out, C[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-
-                if isSine:
-                    sinf_call = CallOp(
-                        sinf_func,
-                        [l1_a_data, l1_out_data],
-                    )
-                elif isCosine:
-                    cosf_call = CallOp(
-                        cosf_func,
-                        [l1_a_data, l1_out_data],
-                    )
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
-
-                yield_([])
-
-        herd_body.attributes["link_with"] = StringAttr.get("sine_cosine.o")
+    return launch
 
 
 if __name__ == "__main__":
@@ -143,7 +90,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the sine_cosine example",
     )
     parser.add_argument(
         "-v",
@@ -191,16 +138,24 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         args.herd_n,
         args.mode,
         INPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -225,6 +180,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="sine_cosine",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -242,6 +198,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/softmax/softmax.py
+++ b/programming_examples/softmax/softmax.py
@@ -1,117 +1,76 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from math import cos, sin, sqrt, exp
+"""Per-tile softmax via a hand-written AIE kernel, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
-from ml_dtypes import bfloat16
+    softmax = air.extern("softmax_bf16", object="softmax.o", scalars=[i32])
+    ...
+    air.ops.load(a, A[i0 : i0 + tile_n])
+    softmax(a, tile_n - 1, out)
+    air.ops.store(out, C[i0 : i0 + tile_n])
+
+Each core runs the reduction over its own [tile_n] tile, so the softmax is
+per-tile rather than over the whole vector -- which is what the reference in
+``__main__`` computes too, tile by tile.
+
+The DSL computes nothing here; the kernel body is one call into ``softmax.o``.
+``air.extern`` emits the private ``func.func`` declaration, stamps ``link_with``
+on both it and the herd, and builds the ``func.call``.
+
+Note where the scalar sits. ``softmax_bf16`` takes ``(memref, i32, memref)`` --
+the length argument is *between* the two buffers, not appended after them.
+``air.extern`` walks the call's arguments in order and takes the next entry from
+``scalars=`` each time it meets a non-buffer, so the declaration comes out with
+the operands in the order the C symbol expects; ``scalars=[i32]`` only says what
+type that one non-buffer argument has, not where it goes.
+
+Unchanged from the raw-bindings version this replaces except that the herd is
+[herd_n, 1] rather than [1, herd_n] -- a 1-D air.api herd is laid out along x,
+the orientation that places on both generations -- and the tile grid is
+strip-mined onto those cores by the DSL rather than by a hand-written outer loop
+with an AffineMap for the offset.
+"""
+
+import argparse
+from math import exp
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import bf16, i32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
 
-
-@module_builder
 def build_module(n, tile_n, herd_n, np_dtype_in):
     assert n % (tile_n * herd_n) == 0
-    a_size = [n]
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
+    dt = bf16
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    softmax = air.extern("softmax_bf16", object="softmax.o", scalars=[i32])
 
-    # Function declaration
-    softmax_func = FuncOp(
-        "softmax_bf16",
-        ([l1MemrefTy, T.i32(), l1MemrefTy], []),
-        visibility="private",
-    )
-    for func in [softmax_func]:
-        func.attributes["link_with"] = StringAttr.get("softmax.o")
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name="softmax") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def softmax(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, herd_n],
-            operands=[arg0, arg1],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+        @launch.body
+        def _():
+            with air.herd([range(0, n, tile_n)], name="herd_0", shape=(herd_n,)) as h:
 
-            for t in range_(0, n, tile_n * herd_n):
+                @h.body
+                def _(tx):
+                    # tx counts tiles, not elements.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private())
+                    out = air.alloc([tile_n], dt, scope=h.private())
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [t, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    softmax(a, tile_n - 1, out)
+                    air.ops.store(out, C[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                const_pos = ConstantOp(IntegerAttr.get(T.i32(), tile_n - 1), None)
-                softmax_call = CallOp(
-                    softmax_func,
-                    [l1_a_data, const_pos, l1_out_data],
-                )
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
-
-                yield_([])
-
-        herd_body.attributes["link_with"] = StringAttr.get("softmax.o")
+    return launch
 
 
 if __name__ == "__main__":
@@ -123,7 +82,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the softmax example",
     )
     parser.add_argument(
         "-v",
@@ -164,15 +123,23 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         args.herd_n,
         INPUT_DATATYPE,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -199,6 +166,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="softmax",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -216,6 +184,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/softmax/softmax.py
+++ b/programming_examples/softmax/softmax.py
@@ -23,6 +23,12 @@ the length argument is *between* the two buffers, not appended after them.
 the operands in the order the C symbol expects; ``scalars=[i32]`` only says what
 type that one non-buffer argument has, not where it goes.
 
+The scalar is the *only* part of the shape the kernel reads at runtime. The
+element type and the tile extent are compiled into ``softmax.o``:
+``softmax_bf16`` opens with ``zero_vectorized<bfloat16, 1, 256, 16>(out)``,
+which clears 256 elements whatever the memref says. Both are therefore checked
+below rather than accepted and silently miscomputed.
+
 Unchanged from the raw-bindings version this replaces except that the herd is
 [herd_n, 1] rather than [1, herd_n] -- a 1-D air.api herd is laid out along x,
 the orientation that places on both generations -- and the tile grid is
@@ -44,8 +50,28 @@ from air.backend.xrt_runner import XRTRunner
 np.random.seed(42)
 
 
+KERNEL_TILE_N = 256  # the 256 in zero_vectorized<bfloat16, 1, 256, 16>
+
+
 def build_module(n, tile_n, herd_n, np_dtype_in):
     assert n % (tile_n * herd_n) == 0
+    # Checked, not assumed. softmax.o exports one symbol, and it bakes in both
+    # the element type and the extent -- `softmax_bf16` opens by calling
+    # zero_vectorized<bfloat16, 1, 256, 16>(out), which clears 256 elements
+    # whatever the memref says. A smaller tile is written past its end; a larger
+    # one is left partly dirty. Both link and run.
+    if np_dtype_in is not bfloat16:
+        raise ValueError(
+            f"softmax.o exports only a bf16 kernel (softmax_bf16), so "
+            f"np_dtype_in must be ml_dtypes.bfloat16, got {np_dtype_in!r}"
+        )
+    if tile_n != KERNEL_TILE_N:
+        raise ValueError(
+            f"tile_n must be {KERNEL_TILE_N}: the extent is a template "
+            f"argument of the zero_vectorized call inside softmax_bf16, "
+            f"compiled into softmax.o, not taken from the memref. "
+            f"got tile_n={tile_n}"
+        )
     dt = bf16
 
     A = air.tensor([n], dt)
@@ -100,7 +126,14 @@ if __name__ == "__main__":
         default=N,
         help="Total number of elements",
     )
-    parser.add_argument("--tile-n", type=int, default=TILE_N, help="Tile size")
+    parser.add_argument(
+        "--tile-n",
+        type=int,
+        default=TILE_N,
+        help=f"Tile size. Pinned to {KERNEL_TILE_N} by softmax.o, which "
+        f"compiles the extent in as a template argument; other values are "
+        f"rejected rather than silently miscomputed",
+    )
     parser.add_argument(
         "--herd-n",
         type=int,


### PR DESCRIPTION
Converts the two extern-kernel examples that have npu1 lit coverage, replacing
the raw-bindings versions. **No DSL code changes.**

Neither computes anything in the DSL: the kernel body is one call into a
hand-written object file. `air.extern` emits the private `func.func`
declaration, stamps `link_with` on both it and the herd, and builds the
`func.call` — which the predecessors spelled out as a `FuncOp` per symbol, two
attribute assignments, and a `CallOp`. The emitted declaration and call are
byte-identical to the predecessors', including softmax's operand order.

Between them they extend proven `air.extern` usage in two directions:

* **`sine_cosine` declares one of *two* symbols from a single object file**,
  chosen by `--mode` at trace time, so the unused one is never emitted. The
  predecessor declared both unconditionally, leaving a dead declaration in every
  build. A herd links against one object; two kernels from the same object are
  fine.
* **`softmax`'s C symbol is `(memref, i32, memref)`** — the length argument sits
  *between* the two buffers. `air.extern` walks the call's arguments in order
  and takes the next entry from `scalars=` at each non-buffer position, so
  `scalars=` says what type the non-buffer argument has, not where it goes.
  Previously only scalar-last was exercised.

Both herds become `[herd_n, 1]` rather than `[1, herd_n]`; a 1-D `air.api` herd
is laid out along x, the orientation that places on both generations. The tile
grid is strip-mined onto those cores by the DSL rather than by a hand-written
outer loop with an `AffineMap` for the offset.

## The `sine_cosine` seed, measured rather than assumed

`sine_cosine` regains `np.random.seed(42)`, which I dropped while converting.
The predecessor carries it too, and it is load-bearing there: inputs come from
`np.random.randn` and the check is relative-only (`rtol=1e0, atol=1e-8`), so any
draw containing bf16's nearest value to −π/2 — where `cos` is 0.000484 — fails
whatever the implementation.

A seed can hide a real numerical difference by pinning the test to one input
set, so this was checked rather than argued. Both versions were compiled once
and run over the **same** 20 draws (seeds 0..19) at the lit's config
(`--mode cos --n 192 --herd-n 4`), comparing **raw device output**, not just
pass/fail:

```
seed  bitwise A==B  A pass  B pass  A bad  B bad   max|A-B|
   9          True   False   False      1      1          0
  15          True   False   False      1      1          0
  16          True   False   False      1      1          0
   (the other 17 seeds: True / True / True / 0 / 0 / 0)

bitwise identical: 20/20
arm A (predecessor) passed: 17/20
arm B (conversion)  passed: 17/20
```

The same three seeds fail in both arms, one bad element each, `max|A-B| = 0` on
every seed: the two designs produce **byte-identical device output** despite
assigning tiles to cores differently (predecessor herd `(1,4)` with
`scf.for 0 to 192 step 96`, offset `arg8 + arg3*24`; conversion herd `(4,1)`
with `scf.for 0 to 2 step 1`, offset `arg2*48 + arg8*24` — same coverage of all
8 tiles, different assignment).

Predicting failure from `min|cos(x)| < 1e-3` alone, with no hardware involved,
reproduces the observed set exactly:

```
predicted set: [9, 15, 16]  observed set: [9, 15, 16]  exact match: True
```

So the seed restores the predecessor's behaviour rather than masking a
difference in the conversion, and the ~15% flake rate it suppresses is
inherited. A small `atol` alongside `rtol=1e0` would make the test robust rather
than merely pinned, but that is a pre-existing weakness and is left alone here.

## Verification

7 lits. The 2 runnable on this box pass **from a wiped output directory**:

```
$ rm -rf build/test/sine_cosine build/test/softmax
$ lit -sv build/programming_examples --filter 'sine_cosine|softmax'
Testing Time: 2.45s
  Unsupported:   5 (1.31%)
  Passed     :   2 (0.52%)
```

The other 5 need a chess licence (2) or npu2 (3). `softmax` compiles for npu2 in
both formats the npu2 lits ask for, against a real `aie2p` kernel object:

```
=== npu2 / xclbin ===  -rw-rw-r-- 34234 air.xclbin  OK
=== npu2 / elf ===     -rw-rw-r-- 91072 air.elf     OK
```

`sine_cosine` has no npu2 path to check: its Makefile has no `AIE_TARGET`
support and its lits are npu1-only.

`black --check`: both files unchanged.

**No perf A/B has been run.** Neither example has a `profile` target or a
`test.cpp` harness, and the npu2 arm is unavailable on this box.

### Two pre-existing warts noticed, deliberately not fixed here

* These lits run `make clean` **without** `PEANO_INSTALL_DIR`, so the Makefile
  selects `BUILD_DIR := build_chess` and cleans the wrong directory —
  `build_peano` is never cleaned between runs. Affects every peano lit with this
  Makefile shape and predates this branch; it is why the run above wipes the
  output dirs explicitly.
* `softmax`'s `make print` target passes `--arch $(AIE_TARGET)`, which neither
  the predecessor nor this conversion accepts. Dormant — no lit uses `print`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
