### PR TITLE
[python] air.api: comparisons and ops.select, and vector_select converted

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_select/vector_select.py
+++ b/programming_examples/primitives/vector_examples/vector_select/vector_select.py
@@ -1,170 +1,105 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Elementwise select primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp, cmpf, select, CmpFPredicate
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = air.ops.select(a[:] >= b[:], a[:], b[:])
+
+One line of compute. The predecessor built the same expression as a hand-rolled
+vector loop -- an ``scf.for`` over the tile in steps of VECTOR_SIZE, three
+``memref.subview``s per trip, two ``vector.transfer_read``s with an explicit
+identity permutation map and a padding constant, ``arith.cmpf`` with
+``CmpFPredicate.OGE``, ``arith.select``, and a ``transfer_write``. Here the
+emitter builds that loop, and the subviews are not needed at all: air.api reads
+at an offset directly.
+
+The emitted arithmetic is unchanged: ``arith.cmpf oge`` producing a
+``vector<VECTOR_SIZExi1>`` predicate, feeding ``arith.select``.
+
+A comparison is the first thing in air.api's expression language whose result
+type is *not* the element type, which is why ``select`` is a function rather
+than an operator: the i1 a comparison yields has exactly one legal consumer.
+The ordering comparisons are operators (``<``, ``<=``, ``>``, ``>=``) and map to
+the *ordered* float predicates -- ``oge``, not ``uge``, so the result is false
+when either operand is NaN, matching C and matching what the predecessor named.
+Equality is ``ops.equal`` / ``ops.not_equal`` rather than ``==`` / ``!=``,
+because overloading ``__eq__`` would make every expression unhashable and would
+change what ``expr == expr`` means for ordinary Python.
+
+Note what this kernel computes: ``select(a >= b, a, b)`` is ``max(a, b)``, and
+the reference in ``__main__`` is written as ``max()``. ``ops.maximum`` would
+lower it to a single ``arith.maximumf``. Both spellings are kept because
+``vector_max`` and this example exist to be compared -- writing this one as a
+maximum would erase the distinction the pair is for.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    b_size = a_size
-    out_size = a_size
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_select(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_b,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="vector_select") as launch:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_b_vec = subview(
-                        l1_b_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j],
-                        [VECTOR_SIZE],
-                        [1],
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    # Compare: a >= b (ordered greater-or-equal)
-                    cmp_result = cmpf(CmpFPredicate.OGE, v_a, v_b)
-                    # Select: when cmp is true (a >= b), pick a; otherwise pick b
-                    v_c = select(cmp_result, v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                yield_([])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
+
+                    # cmpf + select on purpose, not ops.maximum -- vector_max is
+                    # the single-op half of this pair. See the module docstring.
+                    c[:] = air.ops.select(a[:] >= b[:], a[:], b[:])
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -224,6 +159,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -231,12 +173,13 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n,
         args.tile_n,
         INPUT_DATATYPE,
         args.vector_size,
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -274,6 +217,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="vector_select",
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -292,6 +236,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             bf16_emulation=bf16_emulation,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -50,6 +50,29 @@ _FLOAT_UNARY_OPS = {
     "tanh": math_dialect.tanh,
 }
 
+# Comparison predicates. The float side uses the *ordered* forms: ordered means
+# false when either operand is NaN, which is C's `>=` and what the hand-written
+# vector_select kernel named (CmpFPredicate.OGE). The integer side uses the
+# signed forms -- air.api's integer dtypes are signless-or-signed, and an
+# unsigned buffer never reaches here (see require_signless below).
+_CMP_F = {
+    "lt": arith.CmpFPredicate.OLT,
+    "le": arith.CmpFPredicate.OLE,
+    "gt": arith.CmpFPredicate.OGT,
+    "ge": arith.CmpFPredicate.OGE,
+    "eq": arith.CmpFPredicate.OEQ,
+    "ne": arith.CmpFPredicate.ONE,
+}
+
+_CMP_I = {
+    "lt": arith.CmpIPredicate.slt,
+    "le": arith.CmpIPredicate.sle,
+    "gt": arith.CmpIPredicate.sgt,
+    "ge": arith.CmpIPredicate.sge,
+    "eq": arith.CmpIPredicate.eq,
+    "ne": arith.CmpIPredicate.ne,
+}
+
 _INT_OPS = {
     "add": arith.AddIOp,
     "sub": arith.SubIOp,
@@ -148,7 +171,15 @@ def _emit_vector(dst, expr, ops, width):
 
     def body(ivs):
         value = _eval(
-            expr, ivs, ops, ety, vectorized=True, vec_ty=vec_ty, minor=minor, pad=zero
+            expr,
+            ivs,
+            ops,
+            ety,
+            vectorized=True,
+            vec_ty=vec_ty,
+            minor=minor,
+            pad=zero,
+            reads={},
         )
         transfer_write(None, value, dst.value, ivs, minor, [True])
 
@@ -160,7 +191,7 @@ def _emit_scalar(dst, expr, ops):
     bounds = [(0, extent, 1) for extent in dst.shape]
 
     def body(ivs):
-        value = _eval(expr, ivs, ops, ety, vectorized=False)
+        value = _eval(expr, ivs, ops, ety, vectorized=False, reads={})
         memref_store(value, dst.value, ivs)
 
     _nest(bounds, body)
@@ -184,13 +215,29 @@ def _result(v):
     return v.result if hasattr(v, "result") else v
 
 
-def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
+def _eval(
+    node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None, reads=None
+):
     if node.kind == "buffer":
+        # One read per buffer per loop body, not one per mention. A buffer that
+        # appears more than once in the tree -- `select(a >= b, a, b)` names
+        # both twice, and gelu names x four times -- is the same value at every
+        # mention: nothing writes to L1 between them inside a single iteration.
+        # Without this the emitter issues a redundant transfer_read for each
+        # extra mention, which is what the hand-written kernels avoid by binding
+        # the read to a local once.
+        key = id(node.buffer)
+        if reads is not None and key in reads:
+            return reads[key]
         if vectorized:
-            return _result(
+            value = _result(
                 transfer_read(vec_ty, node.buffer.value, ivs, minor, pad, [True])
             )
-        return _result(memref_load(node.buffer.value, ivs))
+        else:
+            value = _result(memref_load(node.buffer.value, ivs))
+        if reads is not None:
+            reads[key] = value
+        return value
 
     if node.kind == "scalar":
         value = node.scalar
@@ -241,7 +288,37 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
                 f"{'integer' if ops is _INT_OPS else 'float'} buffers"
             )
         return _result(
-            fn(_eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad))
+            fn(
+                _eval(
+                    node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads
+                )
+            )
+        )
+
+    if node.kind == "compare":
+        # Yields i1 (vector<Wxi1> when vectorised), not the element type. Only
+        # a "select" node consumes this, which ops.select enforces at trace
+        # time -- nothing else in _eval can receive one.
+        table = _CMP_I if ops is _INT_OPS else _CMP_F
+        predicate = table.get(node.op)
+        if predicate is None:
+            raise NotImplementedError(
+                f"comparison '{node.op}' is not supported for dtype "
+                f"{'integer' if ops is _INT_OPS else 'float'}"
+            )
+        lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
+        rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
+        build = arith.cmpi if ops is _INT_OPS else arith.cmpf
+        return _result(build(predicate, lhs, rhs))
+
+    if node.kind == "select":
+        cond, a, b = node.args
+        return _result(
+            arith.select(
+                _eval(cond, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
+                _eval(a, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
+                _eval(b, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
+            )
         )
 
     if node.kind == "binary":
@@ -251,8 +328,8 @@ def _eval(node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None):
                 f"elementwise operator '{node.op}' is not supported for dtype "
                 f"{'float' if ops is _FLOAT_OPS else 'integer'}"
             )
-        lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad)
-        rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad)
+        lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
+        rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
         return _result(op(lhs, rhs))
 
     raise AssertionError(f"unknown expression node kind {node.kind!r}")

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -334,7 +334,10 @@ class BufferExpr:
     __slots__ = ("kind", "op", "args", "buffer", "scalar")
 
     def __init__(self, kind, op=None, args=(), buffer=None, scalar=None):
-        self.kind = kind  # "buffer" | "scalar" | "unary" | "binary"
+        # "buffer" | "scalar" | "unary" | "binary" evaluate to the element
+        # type; "compare" evaluates to i1 and only ops.select consumes it;
+        # "select" takes (compare, value, value) back to the element type.
+        self.kind = kind
         self.op = op
         self.args = tuple(args)
         self.buffer = buffer
@@ -405,6 +408,34 @@ class BufferExpr:
     def __neg__(self):
         return BufferExpr("scalar", scalar=0) - self
 
+    # Comparisons build a *predicate* node, not a value node. Its result type is
+    # i1 (vector<Wxi1> when vectorised), not the element type every other node
+    # yields, so the only thing that can consume one is air.api.ops.select --
+    # which is why there is no operator spelling for select itself.
+    def _compare(self, other, op, reverse=False):
+        other = BufferExpr.coerce(other)
+        args = (other, self) if reverse else (self, other)
+        return BufferExpr("compare", op=op, args=args)
+
+    def __lt__(self, o):
+        return self._compare(o, "lt")
+
+    def __le__(self, o):
+        return self._compare(o, "le")
+
+    def __gt__(self, o):
+        return self._compare(o, "gt")
+
+    def __ge__(self, o):
+        return self._compare(o, "ge")
+
+    # __eq__ and __ne__ are deliberately NOT overloaded. Defining __eq__ sets
+    # __hash__ to None, making every expression unhashable, and it changes what
+    # `expr == expr` means for ordinary Python code that has nothing to do with
+    # kernels. Equality comparisons are spelled air.api.ops.equal / not_equal
+    # instead; ops.select rejects the plain bool that `a[:] == b[:]` produces,
+    # naming those, so the difference cannot pass silently.
+
     def leaves(self):
         """All buffer leaves, in traversal order."""
         if self.kind == "buffer":
@@ -421,4 +452,7 @@ class BufferExpr:
             return repr(self.scalar)
         if self.kind == "unary":
             return f"{self.op}({self.args[0]!r})"
+        if self.kind == "select":
+            c, a, b = self.args
+            return f"select({c!r}, {a!r}, {b!r})"
         return f"({self.args[0]!r} {self.op} {self.args[1]!r})"

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -377,6 +377,93 @@ def relu(x):
     return maximum(expr, 0.0 if leaves[0].dtype.is_float else 0)
 
 
+# ---------------------------------------------------------------------------
+# Comparison and select
+# ---------------------------------------------------------------------------
+
+# Float comparisons are the *ordered* predicates (OGE, not UGE): ordered means
+# the result is false when either operand is NaN, which is what C's `>=` does
+# and what the hand-written vector_select kernel asked for by name.
+_COMPARISONS = {"lt", "le", "gt", "ge", "eq", "ne"}
+
+
+def _comparison(name, key, a, b):
+    for operand, pos in ((a, "first"), (b, "second")):
+        if isinstance(operand, bool) or not isinstance(
+            operand, (Buffer, BufferExpr, int, float)
+        ):
+            raise TypeError(
+                f"air.api.ops.{name} expects a buffer slice or a numeric scalar "
+                f"as its {pos} argument, got {type(operand).__name__}"
+            )
+    a, b = BufferExpr.coerce(a), BufferExpr.coerce(b)
+    if not a.leaves() and not b.leaves():
+        raise ValueError(
+            f"air.api.ops.{name} needs at least one buffer operand; both "
+            "arguments are scalars, which the emitter cannot shape"
+        )
+    return BufferExpr("compare", op=key, args=(a, b))
+
+
+def equal(a, b):
+    """Elementwise ==. Lowers to arith.cmpf OEQ (float) / arith.cmpi eq (int).
+
+    Spelled as a function rather than ``==`` on purpose -- see the note on
+    ``BufferExpr.__eq__`` in ``_value.py``. The ordering comparisons (``<``,
+    ``<=``, ``>``, ``>=``) *are* available as operators.
+    """
+    return _comparison("equal", "eq", a, b)
+
+
+def not_equal(a, b):
+    """Elementwise !=. Lowers to arith.cmpf ONE (float) / arith.cmpi ne (int)."""
+    return _comparison("not_equal", "ne", a, b)
+
+
+def select(cond, a, b):
+    """Elementwise ``cond ? a : b``. Lowers to arith.select.
+
+    ``cond`` must be a comparison -- ``x[:] >= y[:]``, or ``ops.equal(x, y)`` --
+    because that is the only thing in this expression language whose result type
+    is i1. The predicate is emitted as an arith.cmpf/cmpi feeding an
+    arith.select, which is the pair the hand-written kernel spells out.
+
+    Note that ``select(a >= b, a, b)`` is ``maximum(a, b)`` and lowers to two
+    ops where ``ops.maximum`` lowers to one. Both spellings exist because the
+    vector_select and vector_max examples exist to compare them; prefer
+    ``ops.maximum`` unless the point is the select itself.
+    """
+    if isinstance(cond, bool):
+        raise TypeError(
+            "air.api.ops.select got a plain bool as its condition. `==` and "
+            "`!=` on buffer expressions are Python identity comparisons, not "
+            "elementwise ones, and evaluate to a bool before select ever sees "
+            "them -- use air.api.ops.equal / not_equal for those, or one of "
+            "the ordering operators <, <=, >, >= which do build a predicate"
+        )
+    if not isinstance(cond, BufferExpr) or cond.kind != "compare":
+        raise TypeError(
+            "air.api.ops.select expects a comparison as its condition (for "
+            f"example x[:] >= y[:], or ops.equal(x[:], y[:])), got "
+            f"{type(cond).__name__}"
+        )
+    for operand, pos in ((a, "second"), (b, "third")):
+        if isinstance(operand, bool) or not isinstance(
+            operand, (Buffer, BufferExpr, int, float)
+        ):
+            raise TypeError(
+                f"air.api.ops.select expects a buffer slice or a numeric scalar "
+                f"as its {pos} argument, got {type(operand).__name__}"
+            )
+    a, b = BufferExpr.coerce(a), BufferExpr.coerce(b)
+    if not a.leaves() and not b.leaves() and not cond.leaves():
+        raise ValueError(
+            "air.api.ops.select needs at least one buffer operand; every "
+            "argument is a scalar, which the emitter cannot shape"
+        )
+    return BufferExpr("select", op="select", args=(cond, a, b))
+
+
 def _unary(name, x):
     if not isinstance(x, (Buffer, BufferExpr)):
         raise TypeError(

--- a/python/test/api/cmp_select.py
+++ b/python/test/api/cmp_select.py
@@ -1,4 +1,4 @@
-# ./python/test/api/select.py -*- Python -*-
+# ./python/test/api/cmp_select.py -*- Python -*-
 
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
@@ -6,6 +6,15 @@
 # RUN: %PYTHON %s | FileCheck %s
 
 """air.api lowers comparisons and select.
+
+Named cmp_select.py, not select.py: lit puts the test's own directory on
+sys.path, and `select` is a stdlib module. On a Python built with select as a
+shared extension rather than statically -- which is what GitHub's hosted
+runners ship -- a file named select.py here wins the import, so `subprocess`
+(reached via numpy -> platform) picks up this file instead. It then imports
+air.api.types while air.api.types is still importing numpy, and every test in
+this directory dies on a circular import. Do not name a test after a stdlib
+module.
 
 A comparison is the first expression node whose result type is *not* the element
 type -- it yields i1, or vector<Wxi1> when vectorised. That is why it gets its

--- a/python/test/api/cmp_select.py
+++ b/python/test/api/cmp_select.py
@@ -149,17 +149,23 @@ def select_composes_inside_a_larger_tree():
     )
 
 
-# CHECK-LABEL: TEST: scalar_fallback_keeps_the_predicate
-# A tile that is not a multiple of the vector width falls back to a scalar
-# memref.load/store loop. The comparison survives it as a scalar i1 -- there is
-# no vector type anywhere -- which is what makes select usable on the narrow
-# tiles the vector path cannot take.
+# The emitter vectorises only when
+#     bool(shape) and width > 0 and shape[-1] % width == 0
+# so there are *two* independent ways to land on the scalar loop. Both are
+# pinned, because a test that exercises one while claiming the other is worse
+# than no test: it reads as coverage.
+
+
+# CHECK-LABEL: TEST: scalar_fallback_no_vector_width
+# Route 1: the caller asked for no vectorisation at all (width == 0). The
+# comparison survives as a scalar i1 -- no vector type anywhere -- which is what
+# makes select usable on the narrow tiles the vector path cannot take.
 # CHECK-NOT: vector.transfer_read
 # CHECK: arith.cmpf oge, {{.*}} : f32
 # CHECK: arith.select
 # CHECK: memref.store
 @run
-def scalar_fallback_keeps_the_predicate():
+def scalar_fallback_no_vector_width():
     print(
         build(
             f32,
@@ -167,6 +173,27 @@ def scalar_fallback_keeps_the_predicate():
             N=192,
             tile=24,
             vector=0,
+            herd_shape=(2,),
+        ).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: scalar_fallback_tile_not_a_multiple
+# Route 2: a non-zero width that does not divide the tile -- 24 % 16 = 8. This
+# is the remainder condition, and it is the one a user hits by accident.
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.cmpf oge, {{.*}} : f32
+# CHECK: arith.select
+# CHECK: memref.store
+@run
+def scalar_fallback_tile_not_a_multiple():
+    print(
+        build(
+            f32,
+            lambda a, b: air.ops.select(a[:] >= b[:], a[:], b[:]),
+            N=192,
+            tile=24,
+            vector=16,
             herd_shape=(2,),
         ).mlir()
     )

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1328,3 +1328,58 @@ def _():
 @expect(NotImplementedError, "unsigned_extern_scalar")
 def _():
     air.extern("k", object="k.o", scalars=[ui8])
+
+
+# CHECK-LABEL: TEST: select_on_a_bool
+# The trap this message exists for. `==` and `!=` are NOT overloaded on buffer
+# expressions -- overloading __eq__ would make every expression unhashable and
+# would change what `expr == expr` means for ordinary Python -- so `a[:] ==
+# b[:]` is an identity comparison that evaluates to a plain bool long before
+# select is called. Refusing it by name is the only way that difference does not
+# pass silently as `select(False, ...)`.
+# CHECK: TypeError: air.api.ops.select got a plain bool as its condition.
+@expect(TypeError, "select_on_a_bool")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        b = air.alloc([64], f32, scope=h.private())
+        ops.select(a[:] == b[:], a[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: select_on_a_value
+# A value expression is not a predicate. Its result type is the element type,
+# not i1, so arith.select would fail to verify well downstream of the mistake.
+# CHECK: TypeError: air.api.ops.select expects a comparison as its condition
+@expect(TypeError, "select_on_a_value")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        b = air.alloc([64], f32, scope=h.private())
+        ops.select(a[:] + b[:], a[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: comparison_of_two_scalars
+# A comparison between two scalars has no shape for the emitter to give it, and
+# it is a Python-level constant the caller should have folded themselves.
+# CHECK: ValueError: air.api.ops.equal needs at least one buffer operand
+@expect(ValueError, "comparison_of_two_scalars")
+def _():
+    ops.equal(1.0, 2.0)
+
+
+# CHECK-LABEL: TEST: unsigned_select
+# Comparisons and select go through arith like every other operator, so an
+# unsigned buffer is refused for the same reason it is refused for `+`:
+# arith.cmpi takes signless operands.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar (a plain copy, dst[:] = src[:], is) is not supported for air.api.ui8
+@expect(NotImplementedError, "unsigned_select")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], ui8, scope=h.private())
+        a[:] = ops.select(a[:] >= 1, a[:], 1)
+
+    _trace(body)

--- a/python/test/api/naming.py
+++ b/python/test/api/naming.py
@@ -1,0 +1,39 @@
+# ./python/test/api/naming.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""No test file may be named after a stdlib module.
+
+lit puts the test's own directory on sys.path, so a test named e.g. select.py
+can win the import of the stdlib module of that name. Whether it *does* depends
+on how the running Python was built: `select` is statically built in on many
+distro Pythons, so the clash is invisible there, but GitHub's hosted runners
+ship it as a shared extension in lib-dynload and the path-based finder consults
+sys.path first.
+
+When that happens the damage is not local. numpy imports platform, which imports
+subprocess, which imports select -- so the test file gets executed in the middle
+of numpy's own import, tries to import air.api.types while air.api.types is
+still importing numpy, and dies on a circular import. Every test in the
+directory fails, not just the misnamed one.
+
+This is cheap to check and expensive to debug, so it is checked.
+"""
+
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+offenders = sorted(
+    p.name
+    for p in HERE.glob("*.py")
+    if p.stem in sys.stdlib_module_names and p.stem != "naming"
+)
+
+print("stdlib-shadowing test files:", offenders if offenders else "none")
+
+# CHECK: stdlib-shadowing test files: none

--- a/python/test/api/select.py
+++ b/python/test/api/select.py
@@ -1,0 +1,163 @@
+# ./python/test/api/select.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers comparisons and select.
+
+A comparison is the first expression node whose result type is *not* the element
+type -- it yields i1, or vector<Wxi1> when vectorised. That is why it gets its
+own node kind and why nothing but `ops.select` can consume one: every other node
+in the tree feeds an arith builder that infers its result type from operand 0.
+
+Float comparisons use the ordered predicates (OGE, not UGE), which is what the
+hand-written vector_select kernel named and what C's `>=` means: false when
+either operand is NaN.
+"""
+
+from air import api as air
+from air.api.types import bf16, f32, i32
+
+
+def build(dtype, body, N=65536, tile=1024, vector=16, herd_shape=(2,)):
+    a = air.tensor([N], dtype)
+    b = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="sel") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, tile)], shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    col = tx * tile
+                    a_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    b_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(a_buf, a[col : col + tile])
+                    air.ops.load(b_buf, b[col : col + tile])
+                    o_buf[:] = body(a_buf, b_buf)
+                    air.ops.store(o_buf, out[col : col + tile])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: select_ge_float
+# The vector_select kernel's expression: cmpf OGE feeding a select, both on
+# vector<16xf32>, with the predicate result typed vector<16xi1>.
+# CHECK: vector.transfer_read {{.*}} vector<16xf32>
+# CHECK: vector.transfer_read {{.*}} vector<16xf32>
+# CHECK: arith.cmpf oge, {{.*}} : vector<16xf32>
+# CHECK: arith.select {{.*}} vector<16xi1>, vector<16xf32>
+# CHECK: vector.transfer_write {{.*}} vector<16xf32>
+@run
+def select_ge_float():
+    print(build(f32, lambda a, b: air.ops.select(a[:] >= b[:], a[:], b[:])).mlir())
+
+
+# CHECK-LABEL: TEST: ordering_operators_are_ordered_predicates
+# All four ordering operators, and each maps to the *ordered* float predicate.
+# CHECK-DAG: arith.cmpf olt
+# CHECK-DAG: arith.cmpf ole
+# CHECK-DAG: arith.cmpf ogt
+# CHECK-DAG: arith.cmpf oge
+@run
+def ordering_operators_are_ordered_predicates():
+    def body(a, b):
+        return (
+            air.ops.select(a[:] < b[:], a[:], b[:])
+            + air.ops.select(a[:] <= b[:], a[:], b[:])
+            + air.ops.select(a[:] > b[:], a[:], b[:])
+            + air.ops.select(a[:] >= b[:], a[:], b[:])
+        )
+
+    print(build(f32, body).mlir())
+
+
+# CHECK-LABEL: TEST: equal_and_not_equal_are_functions
+# `==` on a buffer expression is Python identity, so equality is spelled as a
+# function. Both map to the ordered float predicates.
+# CHECK-DAG: arith.cmpf oeq
+# CHECK-DAG: arith.cmpf one
+@run
+def equal_and_not_equal_are_functions():
+    def body(a, b):
+        return air.ops.select(air.ops.equal(a[:], b[:]), a[:], b[:]) + air.ops.select(
+            air.ops.not_equal(a[:], b[:]), a[:], b[:]
+        )
+
+    print(build(f32, body).mlir())
+
+
+# CHECK-LABEL: TEST: select_integer_uses_signed_cmpi
+# Integer buffers take arith.cmpi with the *signed* predicates -- an unsigned
+# dtype never reaches the emitter's arith path at all (see unsigned.py).
+# CHECK: arith.cmpi sgt, {{.*}} : vector<16xi32>
+# CHECK: arith.select {{.*}} vector<16xi1>, vector<16xi32>
+@run
+def select_integer_uses_signed_cmpi():
+    print(build(i32, lambda a, b: air.ops.select(a[:] > b[:], a[:], b[:])).mlir())
+
+
+# CHECK-LABEL: TEST: select_against_a_scalar_broadcasts
+# A scalar arm broadcasts to the vector width, same as any other scalar in an
+# elementwise tree -- this is relu spelled the long way round.
+# CHECK: arith.constant 0.0{{.*}} : f32
+# CHECK: vector.broadcast {{.*}} : f32 to vector<16xf32>
+# CHECK: arith.cmpf ogt, {{.*}} : vector<16xf32>
+# CHECK: arith.select
+@run
+def select_against_a_scalar_broadcasts():
+    print(build(f32, lambda a, b: air.ops.select(a[:] > 0.0, a[:], 0.0)).mlir())
+
+
+# CHECK-LABEL: TEST: select_composes_inside_a_larger_tree
+# A select is an ordinary value node: it can be an operand of the arithmetic
+# operators, and the whole tree still lowers as one loop with one transfer_write.
+# CHECK: arith.cmpf oge
+# CHECK: arith.select
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: arith.addf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_write
+# CHECK-NOT: vector.transfer_write
+@run
+def select_composes_inside_a_larger_tree():
+    print(
+        build(
+            bf16,
+            lambda a, b: 2.0 * air.ops.select(a[:] >= b[:], a[:], b[:]) + b[:],
+        ).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: scalar_fallback_keeps_the_predicate
+# A tile that is not a multiple of the vector width falls back to a scalar
+# memref.load/store loop. The comparison survives it as a scalar i1 -- there is
+# no vector type anywhere -- which is what makes select usable on the narrow
+# tiles the vector path cannot take.
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.cmpf oge, {{.*}} : f32
+# CHECK: arith.select
+# CHECK: memref.store
+@run
+def scalar_fallback_keeps_the_predicate():
+    print(
+        build(
+            f32,
+            lambda a, b: air.ops.select(a[:] >= b[:], a[:], b[:]),
+            N=192,
+            tile=24,
+            vector=0,
+            herd_shape=(2,),
+        ).mlir()
+    )


### PR DESCRIPTION
Adds the first expression node in `air.api` whose result type is **not** the
element type, and converts the example that needs it. 6 files, +525/−164.

A comparison yields `i1` — `vector<Wxi1>` when vectorised — where every other
node in the expression tree yields the element type and feeds an arith builder
that infers its result from operand 0. So comparisons get their own node kind
and exactly one legal consumer:

```python
c[:] = air.ops.select(a[:] >= b[:], a[:], b[:])
```

## Surface

* **`<`, `<=`, `>`, `>=`** on a buffer expression build a predicate node. Float
  comparisons use the *ordered* predicates (`oge`, not `uge`): false when either
  operand is NaN, which is C's `>=` and what the hand-written kernel named as
  `CmpFPredicate.OGE`. Integer comparisons use the signed predicates.
* **`ops.equal` / `ops.not_equal` rather than `==` / `!=`.** Defining `__eq__`
  would set `__hash__` to `None` and make every expression unhashable, and would
  change what `expr == expr` means for ordinary Python. The cost of *not*
  overloading it is that `a[:] == b[:]` silently evaluates to a bool — so
  `ops.select` rejects a plain bool by name and points at `ops.equal`. That is
  the one thing here that could have failed quietly, so it fails loudly and is
  pinned by a test.
* **`ops.select(cond, a, b)`** → `arith.select`. A non-comparison condition is
  rejected at trace time, which is the only place the i1-vs-element-type
  mismatch can be reported against the user's own line rather than deep in
  verification.

## One read per buffer per loop body, not one per mention

`select(a >= b, a, b)` names each buffer twice and `gelu` names `x` four times;
the emitter was issuing a redundant `vector.transfer_read` for every extra
mention, so `vector_select` came out with 4 reads against the predecessor's 2. A
per-body cache keyed on the buffer fixes it — **gelu 5 reads → 1, silu 2 → 1**,
and vector_select 4 → 2, which is what brings the conversion to op-for-op parity.

**Be clear what that is worth.** The npu2 artifacts for gelu, silu and sigmoid
are the *same size* before and after (20055 / 19287 / 18778 bytes), so the aircc
pipeline was already CSE-ing those reads. This is an IR-quality change that
earns the parity claim below — not a measured speedup, and I am not claiming one.

## vector_select is op-for-op identical to its predecessor

| op | pred | conv |
|---|---:|---:|
| `arith.cmpf` (oge, `vector<16xbf16>`) | 1 | 1 |
| `arith.select` (`vector<16xi1>`, `vector<16xbf16>`) | 1 | 1 |
| `vector.transfer_read` | 2 | 2 |
| `vector.transfer_write` | 1 | 1 |
| `memref.subview` | 3 | **0** |
| `arith.constant` | 10 | 9 |

`select(a >= b, a, b)` is `max(a, b)`, and `ops.maximum` would lower it to a
single `arith.maximumf`. Both spellings are kept deliberately: `vector_max` and
`vector_select` exist to be compared, so writing this one as a maximum would
erase the distinction the pair is for — the same call already made for
`vector_muladd` vs `vector_fma`.

## Verification

* `python/test/api/select.py` — 8 FileCheck cases: predicate types, all four
  ordering operators, `equal`/`not_equal`, signed `cmpi` for integers, scalar
  broadcast, composition inside a larger tree, and the scalar fallback.
* `python/test/api/errors.py` — 4 negative cases, including the `==` trap.
* **Full api suite 15/15** after the emitter change (14 pre-existing + select).
* npu1 lits, from wiped output directories:

```
PASS: primitives/vector_examples/vector_select/run_makefile_peano.lit
PASS: primitives/vector_examples/vector_select/run_makefile_peano_bf16_emulation.lit
PASS: relu/run_makefile_peano.lit
PASS: leaky_relu/run_makefile_peano.lit
```

`relu` and `leaky_relu` are there as read-cache regression cover, not as scope.

* The 3 npu2-gated `vector_select` configs compile (vec16 elf 18416, vec32
  xclbin 10506, vec32 elf 18224), as do gelu/silu/sigmoid on npu2 — those three
  are the examples the read cache changes most and are npu2-only, so they cannot
  be run on this box.

**No perf A/B has been run.**

### Reviewer note on blast radius

Unlike the preceding conversion PRs, this one touches shared DSL code. The read
cache changes the emitted IR of **every** `air.api` example, not just the one
converted here — that is why gelu/silu/sigmoid are covered above despite being
out of scope, and why the artifact-size comparison is included rather than
asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
