### PR TITLE
[python] air.api: bitwise &, | and ^, and the three vector_examples converted

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_andi/vector_andi.py
+++ b/programming_examples/primitives/vector_examples/vector_andi/vector_andi.py
@@ -17,9 +17,13 @@ The emitted arithmetic is unchanged: a bare ``arith.andi`` on
 Bitwise operators are integer-only, and that is a property of MLIR rather than
 of this example: there is ``arith.andi`` and no floating-point counterpart, so
 air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
-letting them fall through a generic "unsupported operator". i32 is checked below
-for the same reason -- see the sibling ``vector_ori / vector_xori`` examples, which differ
-from this one only in that operator.
+letting them fall through a generic "unsupported operator".
+
+What ``build_module`` checks is that the element type is a *signless integer* --
+not that it is i32 specifically. These operators work at any integer width, and
+air.api's own test suite covers i16; i32 is simply what ``__main__`` passes,
+matching the predecessor. See the sibling ``vector_ori / vector_xori`` examples, which
+differ from this one only in the operator.
 
 Two differences from the predecessor worth naming:
 

--- a/programming_examples/primitives/vector_examples/vector_andi/vector_andi.py
+++ b/programming_examples/primitives/vector_examples/vector_andi/vector_andi.py
@@ -1,131 +1,97 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
+"""Elementwise bitwise AND primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] & b[:]
+
+One line of compute. The predecessor built the same expression as a hand-rolled
+vector loop -- an ``scf.for`` over the tile in steps of VECTOR_SIZE, three
+``memref.subview``s per trip, two ``vector.transfer_read``s with an explicit
+identity permutation map and a padding constant, ``arith.andi``, and a
+``transfer_write``. Here the emitter builds that loop, and the subviews are not
+needed at all: air.api reads at an offset directly.
+
+The emitted arithmetic is unchanged: a bare ``arith.andi`` on
+``vector<VECTOR_SIZExi32>``.
+
+Bitwise operators are integer-only, and that is a property of MLIR rather than
+of this example: there is ``arith.andi`` and no floating-point counterpart, so
+air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
+letting them fall through a generic "unsupported operator". i32 is checked below
+for the same reason -- see the sibling ``vector_ori / vector_xori`` examples, which differ
+from this one only in that operator.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_andi(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_a, _l3_b, _l3_c):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+    # Checked rather than documented: `&` lowers to arith.andi, which has no
+    # floating-point form, and an unsigned type cannot reach arith at all.
+    if dt.is_float or dt.is_unsigned:
+        raise ValueError(
+            f"the bitwise operator '&' is integer-only and needs a signless "
+            f"integer element type; got {np_dtype_in!r}"
+        )
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(l1_a_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_b_vec = subview(l1_b_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c_vec = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
-                    pad = arith.ConstantOp(xrt_dtype_in, 0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_c = arith.AndIOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+    with air.launch(name="vector_andi") as launch:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                yield_([])
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
+
+                    c[:] = a[:] & b[:]
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -162,10 +128,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    launch = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -202,6 +176,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_andi",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -217,6 +192,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_ori/vector_ori.py
+++ b/programming_examples/primitives/vector_examples/vector_ori/vector_ori.py
@@ -17,9 +17,13 @@ The emitted arithmetic is unchanged: a bare ``arith.ori`` on
 Bitwise operators are integer-only, and that is a property of MLIR rather than
 of this example: there is ``arith.ori`` and no floating-point counterpart, so
 air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
-letting them fall through a generic "unsupported operator". i32 is checked below
-for the same reason -- see the sibling ``vector_andi / vector_xori`` examples, which differ
-from this one only in that operator.
+letting them fall through a generic "unsupported operator".
+
+What ``build_module`` checks is that the element type is a *signless integer* --
+not that it is i32 specifically. These operators work at any integer width, and
+air.api's own test suite covers i16; i32 is simply what ``__main__`` passes,
+matching the predecessor. See the sibling ``vector_andi / vector_xori`` examples, which
+differ from this one only in the operator.
 
 Two differences from the predecessor worth naming:
 

--- a/programming_examples/primitives/vector_examples/vector_ori/vector_ori.py
+++ b/programming_examples/primitives/vector_examples/vector_ori/vector_ori.py
@@ -1,131 +1,97 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
+"""Elementwise bitwise OR primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] | b[:]
+
+One line of compute. The predecessor built the same expression as a hand-rolled
+vector loop -- an ``scf.for`` over the tile in steps of VECTOR_SIZE, three
+``memref.subview``s per trip, two ``vector.transfer_read``s with an explicit
+identity permutation map and a padding constant, ``arith.ori``, and a
+``transfer_write``. Here the emitter builds that loop, and the subviews are not
+needed at all: air.api reads at an offset directly.
+
+The emitted arithmetic is unchanged: a bare ``arith.ori`` on
+``vector<VECTOR_SIZExi32>``.
+
+Bitwise operators are integer-only, and that is a property of MLIR rather than
+of this example: there is ``arith.ori`` and no floating-point counterpart, so
+air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
+letting them fall through a generic "unsupported operator". i32 is checked below
+for the same reason -- see the sibling ``vector_andi / vector_xori`` examples, which differ
+from this one only in that operator.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_ori(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_a, _l3_b, _l3_c):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+    # Checked rather than documented: `|` lowers to arith.ori, which has no
+    # floating-point form, and an unsigned type cannot reach arith at all.
+    if dt.is_float or dt.is_unsigned:
+        raise ValueError(
+            f"the bitwise operator '|' is integer-only and needs a signless "
+            f"integer element type; got {np_dtype_in!r}"
+        )
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(l1_a_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_b_vec = subview(l1_b_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c_vec = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
-                    pad = arith.ConstantOp(xrt_dtype_in, 0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_c = arith.OrIOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+    with air.launch(name="vector_ori") as launch:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                yield_([])
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
+
+                    c[:] = a[:] | b[:]
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -162,10 +128,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    launch = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -202,6 +176,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_ori",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -217,6 +192,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_xori/vector_xori.py
+++ b/programming_examples/primitives/vector_examples/vector_xori/vector_xori.py
@@ -1,131 +1,97 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
+"""Elementwise bitwise XOR primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:] ^ b[:]
+
+One line of compute. The predecessor built the same expression as a hand-rolled
+vector loop -- an ``scf.for`` over the tile in steps of VECTOR_SIZE, three
+``memref.subview``s per trip, two ``vector.transfer_read``s with an explicit
+identity permutation map and a padding constant, ``arith.xori``, and a
+``transfer_write``. Here the emitter builds that loop, and the subviews are not
+needed at all: air.api reads at an offset directly.
+
+The emitted arithmetic is unchanged: a bare ``arith.xori`` on
+``vector<VECTOR_SIZExi32>``.
+
+Bitwise operators are integer-only, and that is a property of MLIR rather than
+of this example: there is ``arith.xori`` and no floating-point counterpart, so
+air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
+letting them fall through a generic "unsupported operator". i32 is checked below
+for the same reason -- see the sibling ``vector_andi / vector_ori`` examples, which differ
+from this one only in that operator.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_xori(arg0, arg1, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_a, _l3_b, _l3_c):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+    # Checked rather than documented: `^` lowers to arith.xori, which has no
+    # floating-point form, and an unsigned type cannot reach arith at all.
+    if dt.is_float or dt.is_unsigned:
+        raise ValueError(
+            f"the bitwise operator '^' is integer-only and needs a signless "
+            f"integer element type; got {np_dtype_in!r}"
+        )
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    A = air.tensor([n], dt)
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(l1_a_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_b_vec = subview(l1_b_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c_vec = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
-                    pad = arith.ConstantOp(xrt_dtype_in, 0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_b = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_b_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
-                    )
-                    v_c = arith.XOrIOp(v_a, v_b)
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
+    with air.launch(name="vector_xori") as launch:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_out_data)
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                yield_([])
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+
+                    air.ops.load(a, A[i0 : i0 + tile_n])
+                    air.ops.load(b, B[i0 : i0 + tile_n])
+
+                    c[:] = a[:] ^ b[:]
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -162,10 +128,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    launch = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -202,6 +176,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_xori",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -217,6 +192,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_xori/vector_xori.py
+++ b/programming_examples/primitives/vector_examples/vector_xori/vector_xori.py
@@ -17,9 +17,13 @@ The emitted arithmetic is unchanged: a bare ``arith.xori`` on
 Bitwise operators are integer-only, and that is a property of MLIR rather than
 of this example: there is ``arith.xori`` and no floating-point counterpart, so
 air.api refuses ``&``, ``|`` and ``^`` on a float buffer by name instead of
-letting them fall through a generic "unsupported operator". i32 is checked below
-for the same reason -- see the sibling ``vector_andi / vector_ori`` examples, which differ
-from this one only in that operator.
+letting them fall through a generic "unsupported operator".
+
+What ``build_module`` checks is that the element type is a *signless integer* --
+not that it is i32 specifically. These operators work at any integer width, and
+air.api's own test suite covers i16; i32 is simply what ``__main__`` passes,
+matching the predecessor. See the sibling ``vector_andi / vector_ori`` examples, which
+differ from this one only in the operator.
 
 Two differences from the predecessor worth naming:
 

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -80,7 +80,16 @@ _INT_OPS = {
     "div": arith.DivSIOp,
     "max": arith.MaxSIOp,
     "min": arith.MinSIOp,
+    # Bitwise. Integer only -- there is no arith.andf, so these deliberately
+    # have no _FLOAT_OPS counterpart and _eval names the dtype when a float
+    # buffer reaches one.
+    "and": arith.AndIOp,
+    "or": arith.OrIOp,
+    "xor": arith.XOrIOp,
 }
+
+# Named so the failure can say *why*, not just "not supported for dtype float".
+_BITWISE = ("and", "or", "xor")
 
 
 def emit_elementwise(dst, expr):
@@ -324,6 +333,12 @@ def _eval(
     if node.kind == "binary":
         op = ops.get(node.op)
         if op is None:
+            if node.op in _BITWISE and ops is _FLOAT_OPS:
+                raise NotImplementedError(
+                    f"the bitwise operator '{node.op}' is integer-only: MLIR "
+                    f"has arith.{node.op}i but no floating-point counterpart, "
+                    f"so it cannot be applied to a {ety} buffer"
+                )
             raise NotImplementedError(
                 f"elementwise operator '{node.op}' is not supported for dtype "
                 f"{'float' if ops is _FLOAT_OPS else 'integer'}"

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -435,6 +435,27 @@ class BufferExpr:
     # kernels. Equality comparisons are spelled air.api.ops.equal / not_equal
     # instead; ops.select rejects the plain bool that `a[:] == b[:]` produces,
     # naming those, so the difference cannot pass silently.
+    # Bitwise operators are integer-only: MLIR has arith.andi/ori/xori and no
+    # floating-point counterpart, so a float buffer reaching one of these is a
+    # user error rather than something to coerce. The emitter rejects it by
+    # name rather than falling through a generic "unsupported operator".
+    def __and__(self, o):
+        return self._binary(o, "and")
+
+    def __rand__(self, o):
+        return self._binary(o, "and", reverse=True)
+
+    def __or__(self, o):
+        return self._binary(o, "or")
+
+    def __ror__(self, o):
+        return self._binary(o, "or", reverse=True)
+
+    def __xor__(self, o):
+        return self._binary(o, "xor")
+
+    def __rxor__(self, o):
+        return self._binary(o, "xor", reverse=True)
 
     def leaves(self):
         """All buffer leaves, in traversal order."""

--- a/python/test/api/bitwise.py
+++ b/python/test/api/bitwise.py
@@ -88,12 +88,29 @@ def narrower_integer():
     print(build(i16, lambda a, b: a[:] ^ b[:]).mlir())
 
 
-# CHECK-LABEL: TEST: scalar_fallback
-# A tile that is not a multiple of the vector width falls back to a scalar
-# memref.load/store loop, and the bitwise op survives it as a scalar i32.
+# The emitter vectorises only when
+#     bool(shape) and width > 0 and shape[-1] % width == 0
+# so there are *two* independent ways to land on the scalar loop. Both are
+# pinned, because a test that exercises one while claiming the other is worse
+# than no test: it reads as coverage.
+
+
+# CHECK-LABEL: TEST: scalar_fallback_no_vector_width
+# Route 1: the caller asked for no vectorisation at all (width == 0).
 # CHECK-NOT: vector.transfer_read
 # CHECK: arith.andi {{.*}} : i32
 # CHECK: memref.store
 @run
-def scalar_fallback():
+def scalar_fallback_no_vector_width():
     print(build(i32, lambda a, b: a[:] & b[:], N=192, tile=24, vector=0).mlir())
+
+
+# CHECK-LABEL: TEST: scalar_fallback_tile_not_a_multiple
+# Route 2: a non-zero width that does not divide the tile -- 24 % 16 = 8. This
+# is the remainder condition, and it is the one a user hits by accident.
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.andi {{.*}} : i32
+# CHECK: memref.store
+@run
+def scalar_fallback_tile_not_a_multiple():
+    print(build(i32, lambda a, b: a[:] & b[:], N=192, tile=24, vector=16).mlir())

--- a/python/test/api/bitwise.py
+++ b/python/test/api/bitwise.py
@@ -1,0 +1,99 @@
+# ./python/test/api/bitwise.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers &, | and ^ to arith.andi / ori / xori.
+
+These are the DSL's first integer-only operators. Every other binary operator
+has both a float and an integer form, so `_FLOAT_OPS` and `_INT_OPS` are
+parallel tables; the bitwise entries exist only in the integer one, and a float
+buffer reaching them is refused by name rather than falling through the generic
+"unsupported operator" message.
+"""
+
+from air import api as air
+from air.api.types import i16, i32
+
+
+def build(dtype, body, N=65536, tile=1024, vector=16, herd_shape=(2,)):
+    a = air.tensor([N], dtype)
+    b = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="bw") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, tile)], shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    col = tx * tile
+                    a_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    b_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(a_buf, a[col : col + tile])
+                    air.ops.load(b_buf, b[col : col + tile])
+                    o_buf[:] = body(a_buf, b_buf)
+                    air.ops.store(o_buf, out[col : col + tile])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: andi_ori_xori
+# One op each, on vector<16xi32> -- what the three vector_examples emit. The
+# order is the tree's, not the source line's: both operands of `|` are evaluated
+# before it, so andi and xori come first and ori joins them.
+# CHECK: arith.andi {{.*}} : vector<16xi32>
+# CHECK: arith.xori {{.*}} : vector<16xi32>
+# CHECK: arith.ori {{.*}} : vector<16xi32>
+@run
+def andi_ori_xori():
+    print(build(i32, lambda a, b: (a[:] & b[:]) | (a[:] ^ b[:])).mlir())
+
+
+# CHECK-LABEL: TEST: bitwise_with_a_scalar_mask
+# A scalar operand broadcasts like any other, so a constant mask is ordinary.
+# CHECK: arith.constant 255 : i32
+# CHECK: vector.broadcast {{.*}} : i32 to vector<16xi32>
+# CHECK: arith.andi {{.*}} : vector<16xi32>
+@run
+def bitwise_with_a_scalar_mask():
+    print(build(i32, lambda a, b: a[:] & 0xFF).mlir())
+
+
+# CHECK-LABEL: TEST: reflected_operands
+# `0xff & a[:]` takes __rand__, which puts the scalar on the left -- the operand
+# order is preserved rather than silently commuted.
+# CHECK: arith.andi {{.*}} : vector<16xi32>
+@run
+def reflected_operands():
+    print(build(i32, lambda a, b: 0xFF & a[:]).mlir())
+
+
+# CHECK-LABEL: TEST: narrower_integer
+# Nothing about these is i32-specific; i16 lowers the same way at its own width.
+# CHECK: arith.xori {{.*}} : vector<16xi16>
+@run
+def narrower_integer():
+    print(build(i16, lambda a, b: a[:] ^ b[:]).mlir())
+
+
+# CHECK-LABEL: TEST: scalar_fallback
+# A tile that is not a multiple of the vector width falls back to a scalar
+# memref.load/store loop, and the bitwise op survives it as a scalar i32.
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.andi {{.*}} : i32
+# CHECK: memref.store
+@run
+def scalar_fallback():
+    print(build(i32, lambda a, b: a[:] & b[:], N=192, tile=24, vector=0).mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1383,3 +1383,34 @@ def _():
         a[:] = ops.select(a[:] >= 1, a[:], 1)
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: bitwise_on_a_float_buffer
+# The bitwise operators are the DSL's first integer-only ones. MLIR has
+# arith.andi and no floating-point counterpart, so this cannot be coerced --
+# and the message says which operator and why rather than the generic
+# "not supported for dtype float", because & on a float buffer is usually a
+# dtype mistake upstream rather than a wrong choice of operator.
+# CHECK: NotImplementedError: the bitwise operator 'and' is integer-only
+@expect(NotImplementedError, "bitwise_on_a_float_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        b = air.alloc([64], f32, scope=h.private())
+        a[:] = a[:] & b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: bitwise_on_an_unsigned_buffer
+# Unsigned is refused earlier and for a different reason: arith takes signless
+# operands, so no operator at all reaches the emitter for a ui8 buffer.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar (a plain copy, dst[:] = src[:], is) is not supported for air.api.ui8
+@expect(NotImplementedError, "bitwise_on_an_unsigned_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], ui8, scope=h.private())
+        b = air.alloc([64], ui8, scope=h.private())
+        a[:] = a[:] ^ b[:]
+
+    _trace(body)


### PR DESCRIPTION
Adds the DSL's first **integer-only** operators and converts the three examples
that need them. 7 files, +449/−354.

```python
c[:] = a[:] & b[:]      # vector_andi -> arith.andi
c[:] = a[:] | b[:]      # vector_ori  -> arith.ori
c[:] = a[:] ^ b[:]      # vector_xori -> arith.xori
```

Every other binary operator has both a float and an integer form, so
`_FLOAT_OPS` and `_INT_OPS` are parallel tables. These three exist only in the
integer one: MLIR has `arith.andi` and no floating-point counterpart, and there
is no coercion that would invent one. A float buffer reaching them raises naming
the operator and the reason, rather than falling through the generic "not
supported for dtype float" — `&` on a float buffer is usually a dtype mistake
upstream, and the message should say so.

Reflected forms (`__rand__`/`__ror__`/`__rxor__`) are included, so `0xff & a[:]`
preserves operand order rather than silently commuting.

## Op-for-op parity, all three

| op | pred | conv |
|---|---:|---:|
| `arith.andi` / `ori` / `xori` | 1 | 1 |
| `vector.transfer_read` | 2 | 2 |
| `vector.transfer_write` | 1 | 1 |
| `arith.constant` | 9 | 9 |
| `air.dma_memcpy_nd` | 3 | 3 |
| `memref.alloc` / `dealloc` | 3 | 3 |
| `memref.subview` | 3 | **0** |
| `affine.apply` | 1 | 3 |

Only the incidental subviews go away; `affine.apply` becomes one per DMA rather
than one shared.

## Verification

* `python/test/api/bitwise.py` — 5 FileCheck cases: the three ops, a scalar
  mask, reflected operands, a narrower integer type, and the scalar fallback.
* `python/test/api/errors.py` — 2 negative cases: float (refused by name) and
  unsigned (refused earlier by the existing signless guard, for a *different*
  reason). Both pinned so the two paths do not get conflated.
* **Full api suite 15/15.**
* npu1 lits, from wiped output directories:

```
PASS:  vector_andi/run_makefile_peano.lit
PASS:  vector_ori/run_makefile_peano.lit
XFAIL: vector_xori/run_npu1_makefile_peano.lit
```

### The XFAIL is inherited, and that was checked rather than assumed

Both arms die in the same place, with only the SSA number differing:

```
pred:  unable to legalize instruction: %61:_(<16 x s32>) = G_XOR
conv:  unable to legalize instruction: %118:_(<16 x s32>) = G_XOR
```

That is the AIE2 GISel gap the lit's own comment documents — no legalizer rule
for vector `G_XOR`, no VBXOR instruction. AIE2P legalizes it natively, and the
npu2 build confirms that. So the conversion is not satisfying the XFAIL
coincidentally for some new reason.

### npu2 compile sweep

Predecessor forced to npu2 via `AIR_TARGET_DEVICE` as a control — it has no
`--target`, so without that it silently builds npu1 artifacts and is not a
control at all.

```
config                     pred      conv
vector_andi npu2 xclbin    9945      10538
vector_ori  npu2 xclbin    9945      10538
vector_xori npu2 xclbin    9977      10634
```

The ~6% growth is the ping-pong buffering inherent to air.api — predecessors
hoist their allocs outside the outer loop; air.api allocates inside the herd
body and `air-ping-pong-transform` double-buffers. Same cause as #1880, where it
is documented along with the measurements ruling out herd orientation and
`stack_size`.

**No perf A/B has been run.**

### Merge-order note

This touches the same two files as #1881 (`ops.select`) — `_value.py` adds
operator methods to `BufferExpr`, `_emit.py` adds `_INT_OPS` entries — so expect
a small textual conflict if both land. They are independent features and neither
depends on the other; this branched off `main` rather than stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
