### PR TITLE
[python] air.api: refuse `and`/`or`/`not` on a buffer expression

### DIFF
--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -324,6 +324,32 @@ class BufferSlice:
         return f"BufferSlice({self.buffer!r}, sizes={self.sizes})"
 
 
+# How a binary node prints. The tree stores an internal key ("add"), not the
+# source spelling, so without this a repr shows `(Buffer add Buffer)` -- which
+# reads like a typo. Keys with no infix form fall back to a call spelling.
+# Entries are listed for every key the emitter knows, including the comparison
+# and bitwise ones, so the table does not need revisiting when those land.
+_OP_SYMBOLS = {
+    "add": "+",
+    "sub": "-",
+    "mul": "*",
+    "div": "/",
+    "and": "&",
+    "or": "|",
+    "xor": "^",
+    "lt": "<",
+    "le": "<=",
+    "gt": ">",
+    "ge": ">=",
+    "eq": "==",
+    "ne": "!=",
+}
+
+# Keys with no infix spelling print as the call the user actually wrote, so the
+# internal key never reaches a repr either way: ops.maximum, not "max".
+_OP_CALL_NAMES = {"max": "maximum", "min": "minimum"}
+
+
 class BufferExpr:
     """A lazy elementwise expression over buffers and scalars.
 
@@ -436,6 +462,21 @@ class BufferExpr:
     # instead; ops.select rejects the plain bool that `a[:] == b[:]` produces,
     # naming those, so the difference cannot pass silently.
 
+    def __bool__(self):
+        # NumPy's guard, for NumPy's reason. `and`, `or` and `not` are the one
+        # part of Python's operator surface a library cannot reach: there is no
+        # dunder for them, they coerce the operand through __bool__, and they
+        # short-circuit. Without this, `a[:] and b[:]` takes the default
+        # object truthiness (always True), returns b[:], and emits nothing --
+        # a kernel that silently computes half of what was written.
+        raise TypeError(
+            "cannot use a buffer expression as a truth value: `and`, `or` and "
+            "`not` would silently return one operand and emit no kernel code, "
+            "because Python does not allow them to be overloaded. Use the "
+            "elementwise operators `&`, `|`, `^` for logic, or "
+            "air.api.ops.select(cond, a, b) to choose between values."
+        )
+
     def leaves(self):
         """All buffer leaves, in traversal order."""
         if self.kind == "buffer":
@@ -455,4 +496,10 @@ class BufferExpr:
         if self.kind == "select":
             c, a, b = self.args
             return f"select({c!r}, {a!r}, {b!r})"
-        return f"({self.args[0]!r} {self.op} {self.args[1]!r})"
+        symbol = _OP_SYMBOLS.get(self.op)
+        if symbol is None:
+            # No infix spelling (maximum/minimum and anything added later):
+            # show it as the call it is rather than inventing an operator.
+            name = _OP_CALL_NAMES.get(self.op, self.op)
+            return f"{name}({self.args[0]!r}, {self.args[1]!r})"
+        return f"({self.args[0]!r} {symbol} {self.args[1]!r})"

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -469,12 +469,27 @@ class BufferExpr:
         # short-circuit. Without this, `a[:] and b[:]` takes the default
         # object truthiness (always True), returns b[:], and emits nothing --
         # a kernel that silently computes half of what was written.
+        #
+        # The redirection is built from what this build actually has rather
+        # than hardcoded. `&` and ops.select are landing in separate changes,
+        # and an error that names surface the caller does not have is worse
+        # than the silent bug it replaces -- while hedging every suggestion
+        # with "if available" would make the useful case vague. Asking is
+        # exact in both.
+        suggestions = []
+        if hasattr(type(self), "__and__"):
+            suggestions.append("the elementwise operators `&`, `|`, `^` for logic")
+        from . import ops
+
+        if hasattr(ops, "select"):
+            suggestions.append(
+                "air.api.ops.select(cond, a, b) to choose between values"
+            )
+        advice = f" Use {' or '.join(suggestions)}." if suggestions else ""
         raise TypeError(
             "cannot use a buffer expression as a truth value: `and`, `or` and "
             "`not` would silently return one operand and emit no kernel code, "
-            "because Python does not allow them to be overloaded. Use the "
-            "elementwise operators `&`, `|`, `^` for logic, or "
-            "air.api.ops.select(cond, a, b) to choose between values."
+            "because Python does not allow them to be overloaded." + advice
         )
 
     def leaves(self):

--- a/python/test/api/truthiness.py
+++ b/python/test/api/truthiness.py
@@ -110,3 +110,59 @@ def _show(x, y):
 
 
 trace(_show)
+
+
+# CHECK-LABEL: TEST: advice_names_only_surface_that_exists
+# The redirection is built from what the build has, not hardcoded. `&` and
+# ops.select arrive in separate changes, and an error naming surface the caller
+# does not have is worse than the bug it replaces -- while hedging every
+# suggestion with "if available" would make the useful case vague.
+#
+# All four states are *constructed* rather than observed. An earlier version
+# only printed the states the build happened to be in and skipped the rest,
+# which meant its coverage silently shrank as the surface landed: once
+# ops.select merged, two of the four lines stopped being produced at all and
+# the test failed for a reason that had nothing to do with the guard.
+# CHECK: neither: (no advice)
+# CHECK: & only: Use the elementwise operators `&`, `|`, `^` for logic.
+# CHECK: both: Use the elementwise operators `&`, `|`, `^` for logic or air.api.ops.select(cond, a, b) to choose between values.
+# CHECK: select only: Use air.api.ops.select(cond, a, b) to choose between values.
+print("\nTEST: advice_names_only_surface_that_exists")
+
+from air.api import ops as _ops
+from air.api._value import BufferExpr as _Expr
+
+
+def _advice():
+    try:
+        bool(_Expr("scalar", scalar=1))
+    except TypeError as e:
+        return str(e).split("overloaded.")[1].strip() or "(no advice)"
+
+
+_real_and = vars(_Expr).get("__and__")
+_real_select = getattr(_ops, "select", None)
+
+
+def _surface(has_and, has_select):
+    """Put the build into one of the four states, whichever it started in."""
+    if has_and:
+        _Expr.__and__ = _real_and or (lambda self, o: None)
+    elif "__and__" in vars(_Expr):
+        del _Expr.__and__
+    if has_select:
+        _ops.select = _real_select or (lambda *a: None)
+    elif hasattr(_ops, "select"):
+        del _ops.select
+
+
+for _label, _a, _s in (
+    ("neither", False, False),
+    ("& only", True, False),
+    ("both", True, True),
+    ("select only", False, True),
+):
+    _surface(_a, _s)
+    print(f"{_label}: {_advice()}")
+
+_surface(_real_and is not None, _real_select is not None)

--- a/python/test/api/truthiness.py
+++ b/python/test/api/truthiness.py
@@ -1,0 +1,112 @@
+# ./python/test/api/truthiness.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""A buffer expression has no truth value, and prints its operators.
+
+`and`, `or` and `not` are the one part of Python's operator surface a library
+cannot reach. There is no dunder for them: they coerce the operand through
+__bool__ and short-circuit, so `a[:] and b[:]` evaluates bool(a[:]) -- default
+object truthiness, always True -- and hands back b[:]. Nothing raises and no IR
+is emitted, so the kernel silently computes half of what was written.
+
+That is the same class of trap as `==` on a buffer expression, and the same
+answer NumPy reached: refuse the coercion and name the operator to use instead.
+
+The repr change is here for the same reason. A binary node stores an internal
+key, not the source spelling, so it used to print `(Buffer add Buffer)` -- and
+once the bitwise operators exist, `a[:] & b[:]` would print `(Buffer and
+Buffer)`, naming the very operator the guard above rejects.
+"""
+
+from air import api as air
+from air.api.types import f32
+
+
+def trace(body):
+    """Run ``body`` inside a herd, so allocation and scope rules are satisfied."""
+    a = air.tensor([64], f32)
+    out = air.tensor([64], f32)
+
+    with air.launch(name="t") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, 64, 64)], shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    x = air.alloc([64], f32, scope=h.private())
+                    y = air.alloc([64], f32, scope=h.private())
+                    body(x, y)
+                    air.ops.load(x, a[0:64])
+                    air.ops.store(x, out[0:64])
+
+    launch.build(target="npu1")
+
+
+def attempt(label, fn):
+    print("\nTEST:", label)
+    try:
+        fn()
+        print("ERROR: no exception raised")
+    except TypeError as e:
+        print(f"TypeError: {e}")
+
+
+# CHECK-LABEL: TEST: and_on_a_buffer_expression
+# CHECK: TypeError: cannot use a buffer expression as a truth value
+attempt(
+    "and_on_a_buffer_expression",
+    lambda: trace(lambda x, y: x[:] and y[:]),
+)
+
+
+# CHECK-LABEL: TEST: or_on_a_buffer_expression
+# CHECK: TypeError: cannot use a buffer expression as a truth value
+attempt(
+    "or_on_a_buffer_expression",
+    lambda: trace(lambda x, y: x[:] or y[:]),
+)
+
+
+# CHECK-LABEL: TEST: not_on_a_buffer_expression
+# CHECK: TypeError: cannot use a buffer expression as a truth value
+attempt(
+    "not_on_a_buffer_expression",
+    lambda: trace(lambda x, y: not x[:]),
+)
+
+
+# CHECK-LABEL: TEST: if_on_a_buffer_expression
+# The form a user is most likely to write by accident, and the one that used to
+# take the `if` branch unconditionally.
+# CHECK: TypeError: cannot use a buffer expression as a truth value
+def _if_branch(x, y):
+    if x[:]:
+        pass
+
+
+attempt("if_on_a_buffer_expression", lambda: trace(_if_branch))
+
+
+# CHECK-LABEL: TEST: repr_uses_operator_symbols
+# The internal key never reaches the user: `add` prints as `+`, and an operator
+# with no infix spelling prints as the call it is.
+# CHECK: (Buffer{{.*}} + Buffer{{.*}})
+# CHECK: (Buffer{{.*}} * 2.0)
+# CHECK: maximum(Buffer{{.*}}, 0.0)
+# CHECK-NOT: add
+print("\nTEST: repr_uses_operator_symbols")
+
+
+def _show(x, y):
+    print(repr(x[:] + y[:]))
+    print(repr(x[:] * 2.0))
+    print(repr(air.ops.maximum(x[:], 0.0)))
+
+
+trace(_show)


### PR DESCRIPTION
`and`, `or` and `not` are the one part of Python's operator surface a library
cannot reach. There is no dunder for them: they coerce the operand through
`__bool__` and short-circuit. `BufferExpr` defined neither `__bool__` nor
`__len__`, so they took default object truthiness — always `True`:

```
a[:] and b[:]  ->  Buffer(...)   the 2nd operand. No error, no IR.
a[:] or b[:]   ->  Buffer(...)   the 1st operand.
not a[:]       ->  False
if a[:]:                         always taken
```

So `c[:] = a[:] and b[:]` compiled, ran, and copied `b` — a kernel that silently
computes half of what was written.

This is the same class as `==` on a buffer expression, and worse: `==` at least
yields an obviously wrong `bool`, where this yields a plausible-looking
`BufferExpr` that has quietly dropped an operand. Fixed the way NumPy fixes it —
`__bool__` raises, naming what to use instead.

## Also: the internal op key no longer reaches a repr

The tree stores `"add"`, not `"+"`, so a binary node printed as
`(Buffer add Buffer)` — which reads like a typo. It would read far worse once
the bitwise operators land, where `a[:] & b[:]` would print
`(Buffer and Buffer)`, naming the very operator this guard rejects.

Infix keys now print their symbol, and keys with no infix form print the call
the user actually wrote:

```
(Buffer(...) + Buffer(...))
(Buffer(...) * 2.0)
maximum(Buffer(...), 0.0)        <- ops.maximum, not the internal "max"
```

The symbol table lists the comparison and bitwise keys too, so it will not need
revisiting when those land.

## Verified

* `python/test/api/truthiness.py` — `and` / `or` / `not` / `if`, plus the repr
  forms.
* **Full api suite 15/15.**
* **No internal code depends on truthiness of a `BufferExpr`** — every
  `if <name>:` in `python/air/api/` tests a list, a bool, a match object or a
  string. Checked rather than assumed, then confirmed on hardware: 7 air.api
  example lits pass from wiped output directories (axpy, eltwise_add,
  eltwise_add_with_l2, leaky_relu, relu, vector_add ×2), 0 failures.

## Scope

Deliberately `BufferExpr` only, not `Buffer`. `a[:] and b[:]` is caught; bare
`a and b` on the unsubscripted buffers is not. `if buf:` and `if buf is not
None` are plausible things to write about a `Buffer`, so the risk/benefit there
is worse. Easy to extend later if it proves needed.

## Merge order

**Please land after #1881 and #1882.** The error message tells the user to use
`&` / `|` / `^` and `air.api.ops.select` — `&` arrives with #1882 and
`ops.select` with #1881. Merged ahead of them, the message would send someone to
surface that does not exist yet, which is worse than the silent bug it replaces.

The bug itself is pre-existing on `main` and independent of both, which is why
this is its own PR rather than folded into either. The three touch `_value.py`
in different regions (both others insert after `__neg__`; this adds `__bool__`
before `leaves()` and a table above the class), so a clean merge is likely
regardless of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
