### PR TITLE
[programming_examples] Drop the qwen decode's last 6 air.shim_col pins

### DIFF
--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -750,12 +750,7 @@ def build_module():
         # LOOPCLOSE build and the working host-toX one. spreadCollapsedPacketChannels
         # now partitions such a ring by producer, so each ring's arrival order is
         # fixed by the one producer feeding it.
-        _lut = channel_decl("ropeLUT", size=[1])  # host cos/sin LUT -> rope core
-        # Feed the LUT from a FREE shim column: the packetization above is triggered by
-        # shim col 1 being oversubscribed (ropeLUT + rmsIn + rmsW + layerOut + qDrain).
-        # Off col 1 the LUT feed stays circuit-switched, which cannot share the rope
-        # tile's packet S2MM at all.
-        _lut.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 0)
+        channel_decl("ropeLUT", size=[1])  # host cos/sin LUT -> rope core
         channel_decl(
             "gluDrain", size=[1]
         )  # glu out (down-X) -> shim (Step C; loopclose D)
@@ -775,41 +770,26 @@ def build_module():
             channel_decl("inKV_V", size=[NGRP])  # cache V [16,REGION_W] -> mem_7_1
             if KV_APPEND:
                 # reference-faithful on-chip KV-cache append (mirror fused_decode.py:762-775):
-                # rope's roped-K / raw-V leave on ONE dedicated rope MM2S as PACKET flows
-                # pinned to the attn shim col (7) -> DDR cache. Qwen has ONE col group
-                # (NGRP=1) so both K and V transit col 7 (Llama split cols 3/4).
+                # rope's roped-K / raw-V leave on ONE dedicated rope MM2S as PACKET
+                # flows -> DDR cache.
                 #
-                # Which rope MM2S they take is no longer stated. rope also emits ropeQ
-                # as a CIRCUIT flow (-> the col-6 q-broadcast memtile), and a physical
-                # output port cannot carry both a static circuit route and packet
-                # routes -- the packet BDs would be steered by the circuit connection
-                # instead of their packet dests. AIRToAIE separates them itself now
-                # (TileDMAAllocator::spreadCollapsedPacketChannels), reaching the same
-                # placement this used to name.
-                _apK = channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
-                _apK.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                    i32, ATTN_COL
-                )
-                _apV = channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
-                _apV.operation.attributes["air.shim_col"] = IntegerAttr.get(
-                    i32, ATTN_COL
-                )
+                # Neither the shim column nor the rope MM2S is stated. rope also emits
+                # ropeQ as a CIRCUIT flow (-> the col-6 q-broadcast memtile), and a
+                # physical output port cannot carry both a static circuit route and
+                # packet routes -- the packet BDs would be steered by the circuit
+                # connection instead of their packet dests. AIRToAIE separates them
+                # itself (TileDMAAllocator::spreadCollapsedPacketChannels), and steers
+                # the readbacks to their own shim tile, reaching the placement these
+                # used to name.
+                channel_decl("appendK", size=[1], channel_type="npu_dma_packet")
+                channel_decl("appendV", size=[1], channel_type="npu_dma_packet")
             channel_decl(
                 "toK", size=[N_ATTN_CU]
             )  # staging -> qk core (k block, reshaped)
             channel_decl(
                 "toV", size=[N_ATTN_CU]
             )  # staging -> kv core (v block, reshaped)
-            _ao = channel_decl(
-                "attnO", size=[N_ATTN_CU]
-            )  # kv o -> drain (o-proj X Step D2)
-            if DRAIN_ATTNO:
-                # Bisection path only (no on-chip oref consumer): send the o drain out a
-                # shim column away from col 7, which already carries appendK/appendV +
-                # inKV_K/inKV_V. Sharing col 7 makes two flows target the same shim
-                # dest -> "aie.masterset op targets same destination South: 2" at route
-                # time (this is why the earlier attn-alone bisect would not build).
-                _ao.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 6)
+            channel_decl("attnO", size=[N_ATTN_CU])  # kv o -> drain (o-proj X Step D2)
         else:
             channel_decl("qDrain", size=[1])  # bisection: rope q -> host
         if ATTN and ROPE_ECHO:
@@ -829,11 +809,9 @@ def build_module():
         if OREF_2HOP:
             channel_decl("oref2", size=[1], channel_type="npu_dma_packet")
         if OREF_HOSTSRC:
-            _oi = channel_decl("orefIn", size=[1])
-            _oi.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 0)
+            channel_decl("orefIn", size=[1])
         if OREF_DRAIN:
-            _od = channel_decl("orefDrain", size=[1])
-            _od.operation.attributes["air.shim_col"] = IntegerAttr.get(i32, 6)
+            channel_decl("orefDrain", size=[1])
         if OREF_VIA_RMS:
             # attn-o gather memtile -> rms core. This must not share a channel
             # with the shim-sourced rmsIn/rmsW, and AIRToAIE now derives that.


### PR DESCRIPTION
Finishes the `air.shim_col` retirement started in #1803 and continued in #1819. After this, **no in-tree design sets `air.shim_col`** — the attribute survives only as a validated compiler override.

#1803 dropped 38 pins and kept 3 per design that measurably changed placement. #1819 derived those away for llama / 3b / gemma but explicitly left qwen alone ("its pins are in a separate file and are untouched"). This picks up that thread.

### Only 3 of the 6 were live

`attnO`, `orefIn` and `orefDrain` sit behind `DRAIN_ATTNO` / `OREF_HOSTSRC` / `OREF_DRAIN`, which are off by default and exercised by no lit or CI test. Removing their pins changes the emitted production IR by **0 lines** — the diff against the pinned build is exactly the 3 live attribute strings and nothing else.

### Placement, pins on -> off

| flow | pins on | pins off |
|---|---|---|
| `appendK` | 7_0 S2MM 0 | 2_0 S2MM 0 |
| `appendV` | 7_0 S2MM 1 | 3_0 S2MM 0 |
| `ropeLUT` | 0_0 MM2S 0 | 1_0 MM2S 0 |
| `rmsIn` | 1_0 MM2S 0 | 1_0 MM2S 1 |
| `rmsW` | 1_0 MM2S 1 | 1_0 MM2S 0 |

`appendK`/`appendV` are exactly what #1819's `spreadShimLTO` was built for: it lands them on distinct shim tiles rather than collapsing them onto one, which is the property the pin was protecting.

`ropeLUT` sharing `rmsW`'s MM2S looks like the regression the removed comment warned about, and is not. That comment claimed the pin kept the LUT feed circuit-switched. In fact `ropeLUT` is `npu_dma_packet` in **both** arms, packetized at `air-dma-to-channel` (pass_013) independently of the pin. Both it and `rmsW` are host-sourced packet flows, so sharing one shim MM2S is ordinary packet multiplexing — not the two-independent-producers-on-one-BD-chain hazard that motivated the pins originally.

### Gates (NPU2)

- `make verify` (top-k token-set vs HF bf16): **PASS 2/2**, identical to pins-on.
- Decode throughput, 3 reps each, **same toolchain both arms**:

  | arm | reps | mean |
  |---|---|---|
  | pins on | 25.12 / 25.19 / 25.22 | 25.18 tok/s |
  | pins off | 25.28 / 25.16 / 25.32 | 25.25 tok/s |

  Overlapping ranges; no measurable change.
- `check-air-mlir`: 513 passed, 0 failed.

The pins-on control was **rebuilt** rather than compared against the on-disk binary. That one predates the current toolchain (133 KB xclbin vs 108 KB today), so it is not a valid A/B arm.

### The reader stays

`air.shim_col` keeps its reader and its 5 lit tests (`shim_column_pin{,_s2mm,_invalid,_multiplex,_dedicated}.mlir`). #1862 kept `air.tile_dma_channel`'s reader on the same basis: the designs stop depending on the override, the override stays validated. No compiler code changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
