### PR TITLE
[python] air.api: ops.cast, and the two int<->float conversion examples

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_fptosi/vector_fptosi.py
+++ b/programming_examples/primitives/vector_examples/vector_fptosi/vector_fptosi.py
@@ -1,122 +1,124 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
+"""Elementwise f32 -> i32 conversion primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = air.api.ops.cast(a[:], air.api.i32)
+
+The predecessor built this as a hand-rolled vector loop -- an ``scf.for`` over
+the tile in steps of VECTOR_SIZE, two ``memref.subview``s per trip, a
+``vector.transfer_read`` with an explicit identity permutation map and a padding
+constant, ``arith.fptosi``, and a ``transfer_write``. Here the emitter builds
+that loop, and the subviews are not needed at all: air.api reads at an offset.
+
+The emitted arithmetic is unchanged: a bare ``arith.fptosi`` from
+``vector<VECTOR_SIZExf32>`` to ``vector<VECTOR_SIZExi32>``.
+
+**This is the first example where the two L1 tiles have different element
+types.** Every air.api expression until now was written in one type, and the
+emitter carried a single element type, arith table and vector type down the
+whole tree. ``ops.cast`` is the node where those change: everything below it is
+read and computed in the source type, and only the conversion lands in the
+destination's. That distinction is visible, and load-bearing:
+``cast(a[:] * 2.0, i32)`` doubles in f32 and converts once, while
+``cast(a[:], i32) * 2`` converts first and doubles in i32.
+
+Which ``arith`` op a cast becomes follows from the two types, and each was run
+on npu1 against an exact numpy reference before being allowed -- vectorised and
+scalar, because compiling is a weaker claim than computing. Two results of that
+sweep are worth knowing:
+
+* ``fptosi`` and ``sitofp`` between f32 and i32, the pair this example uses,
+  are **exact on both routes**, so the scalar fallback is safe here. That is not
+  automatic: ``ops.tanh`` has no working scalar form at all, and its example has
+  to refuse both routes into the fallback up front.
+* Converting *to* a narrower float rounds toward negative infinity rather than
+  to nearest, so a bf16 destination differs from numpy by up to one ULP. That
+  is a property of the hardware and not of this op -- a plain
+  ``c[:] = a[:] + b[:]`` on bf16 buffers differs the same way.
+
+``ops.cast`` refuses narrowing between two integer types, which is why there is
+no ``vector_trunci`` sibling: measured on npu1, the vectorised ``arith.trunci``
+saturates while the scalar one wraps, and which one the emitter picks depends on
+the tile size.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, np_dtype_out, vector_size=16):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    # Both element types are honoured rather than advertised and ignored: the
+    # signature takes two, so passing np.int8 for the output has to either work
+    # or say why not. `ops.cast` itself rejects the pairs that do not compute,
+    # so there is no second copy of that rule here.
+    #
+    # Note that air.api.f16 is not usable on AIE2 whichever way it is reached:
+    # the backend reads f16 data as bf16, so even a plain `c[:] = a[:] + b[:]`
+    # on f16 buffers returns garbage. That is a property of the element type,
+    # not of the conversion.
+    types = []
+    for np_dtype in (np_dtype_in, np_dtype_out):
+        dt = dtype_of(np_dtype)
+        if dt is None:
+            raise ValueError(
+                f"unsupported element type {np_dtype!r}; air.api knows "
+                f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
+            )
+        types.append(dt)
+    dt_in, dt_out = types
 
-    l3memrefInTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3memrefOutTy = MemRefType.get(a_size, xrt_dtype_out)
-    l1MemrefInTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1MemrefOutTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_out,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    A = air.tensor([n], dt_in)
+    C = air.tensor([n], dt_out)
 
-    @FuncOp.from_py_func(l3memrefInTy, l3memrefOutTy)
-    def vector_fptosi(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
-        )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_a, _l3_c):
-            l1_a_data = AllocOp(l1MemrefInTy, [], [])
-            l1_out_data = AllocOp(l1MemrefOutTy, [], [])
+    with air.launch(name="vector_fptosi") as launch:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(l1_a_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c_vec = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
-                    pad = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc(
+                        [tile_n], dt_in, scope=h.private(), vector=vector_size
                     )
-                    v_c = arith.FPToSIOp(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_out), v_a
+                    c = air.alloc(
+                        [tile_n], dt_out, scope=h.private(), vector=vector_size
                     )
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                    air.ops.load(a, A[i0 : i0 + tile_n])
 
-                yield_([])
+                    c[:] = air.ops.cast(a[:], dt_out)
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -154,12 +156,20 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n, args.tile_n, INPUT_DATATYPE, OUTPUT_DATATYPE, args.vector_size
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -190,6 +200,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_fptosi",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -205,6 +216,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         backend.compile(mlir_module)

--- a/programming_examples/primitives/vector_examples/vector_sitofp/vector_sitofp.py
+++ b/programming_examples/primitives/vector_examples/vector_sitofp/vector_sitofp.py
@@ -1,122 +1,124 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
+"""Elementwise i32 -> f32 conversion primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = air.api.ops.cast(a[:], air.api.f32)
+
+The predecessor built this as a hand-rolled vector loop -- an ``scf.for`` over
+the tile in steps of VECTOR_SIZE, two ``memref.subview``s per trip, a
+``vector.transfer_read`` with an explicit identity permutation map and a padding
+constant, ``arith.sitofp``, and a ``transfer_write``. Here the emitter builds
+that loop, and the subviews are not needed at all: air.api reads at an offset.
+
+The emitted arithmetic is unchanged: a bare ``arith.sitofp`` from
+``vector<VECTOR_SIZExi32>`` to ``vector<VECTOR_SIZExf32>``.
+
+**This is the first example where the two L1 tiles have different element
+types.** Every air.api expression until now was written in one type, and the
+emitter carried a single element type, arith table and vector type down the
+whole tree. ``ops.cast`` is the node where those change: everything below it is
+read and computed in the source type, and only the conversion lands in the
+destination's. That distinction is visible, and load-bearing:
+``cast(a[:] * 2.0, i32)`` doubles in f32 and converts once, while
+``cast(a[:], i32) * 2`` converts first and doubles in i32.
+
+Which ``arith`` op a cast becomes follows from the two types, and each was run
+on npu1 against an exact numpy reference before being allowed -- vectorised and
+scalar, because compiling is a weaker claim than computing. Two results of that
+sweep are worth knowing:
+
+* ``fptosi`` and ``sitofp`` between f32 and i32, the pair this example uses,
+  are **exact on both routes**, so the scalar fallback is safe here. That is not
+  automatic: ``ops.tanh`` has no working scalar form at all, and its example has
+  to refuse both routes into the fallback up front.
+* Converting *to* a narrower float rounds toward negative infinity rather than
+  to nearest, so a bf16 destination differs from numpy by up to one ULP. That
+  is a property of the hardware and not of this op -- a plain
+  ``c[:] = a[:] + b[:]`` on bf16 buffers differs the same way.
+
+``ops.cast`` refuses narrowing between two integer types, which is why there is
+no ``vector_trunci`` sibling: measured on npu1, the vectorised ``arith.trunci``
+saturates while the scalar one wraps, and which one the emitter picks depends on
+the tile size.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, np_dtype_out, vector_size=16):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
+    assert n % (tile_n * NUM_TILES) == 0
+    # Both element types are honoured rather than advertised and ignored: the
+    # signature takes two, so passing np.int8 for the output has to either work
+    # or say why not. `ops.cast` itself rejects the pairs that do not compute,
+    # so there is no second copy of that rule here.
+    #
+    # Note that air.api.f16 is not usable on AIE2 whichever way it is reached:
+    # the backend reads f16 data as bf16, so even a plain `c[:] = a[:] + b[:]`
+    # on f16 buffers returns garbage. That is a property of the element type,
+    # not of the conversion.
+    types = []
+    for np_dtype in (np_dtype_in, np_dtype_out):
+        dt = dtype_of(np_dtype)
+        if dt is None:
+            raise ValueError(
+                f"unsupported element type {np_dtype!r}; air.api knows "
+                f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
+            )
+        types.append(dt)
+    dt_in, dt_out = types
 
-    l3memrefInTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3memrefOutTy = MemRefType.get(a_size, xrt_dtype_out)
-    l1MemrefInTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1MemrefOutTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_out,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    A = air.tensor([n], dt_in)
+    C = air.tensor([n], dt_out)
 
-    @FuncOp.from_py_func(l3memrefInTy, l3memrefOutTy)
-    def vector_sitofp(arg0, arg1):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
-        )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_a, _l3_c):
-            l1_a_data = AllocOp(l1MemrefInTy, [], [])
-            l1_out_data = AllocOp(l1MemrefOutTy, [], [])
+    with air.launch(name="vector_sitofp") as launch:
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_a_vec = subview(l1_a_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c_vec = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
-                    pad = arith.ConstantOp(xrt_dtype_in, 0)
-                    v_a = transfer_read(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_in),
-                        sub_a_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        pad,
-                        [True],
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    a = air.alloc(
+                        [tile_n], dt_in, scope=h.private(), vector=vector_size
                     )
-                    v_c = arith.SIToFPOp(
-                        VectorType.get([VECTOR_SIZE], xrt_dtype_out), v_a
+                    c = air.alloc(
+                        [tile_n], dt_out, scope=h.private(), vector=vector_size
                     )
-                    transfer_write(
-                        None,
-                        v_c,
-                        sub_c_vec,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                    air.ops.load(a, A[i0 : i0 + tile_n])
 
-                yield_([])
+                    c[:] = air.ops.cast(a[:], dt_out)
+
+                    air.ops.store(c, C[i0 : i0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -154,12 +156,20 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n, args.tile_n, INPUT_DATATYPE, OUTPUT_DATATYPE, args.vector_size
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -187,6 +197,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_sitofp",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -202,6 +213,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         backend.compile(mlir_module)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -19,6 +19,13 @@ elementwise body is the documented cause of NPU timeouts on tiles this size.
 When the innermost dimension is not a multiple of the vector width the emitter
 falls back to a scalar ``memref.load``/``store`` loop rather than failing --
 correctness first, with the width left to the caller to fix for speed.
+
+One expression can hold more than one element type, because ``ops.cast``
+converts between them. Everything below a cast node is read and computed in the
+source type and only the conversion itself lands in the destination's; a
+``_Region`` groups the four things that differ between the two (the MLIR element
+type, the arith table, the vector type and the padding constant) so they can be
+looked up per node rather than threaded down the walk.
 """
 
 from air.ir import AffineDimExpr, AffineMap, AffineMapAttr, VectorType
@@ -92,28 +99,72 @@ _INT_OPS = {
 _BITWISE = ("and", "or", "xor")
 
 
-def emit_elementwise(dst, expr):
-    """Emit ``dst[:] = expr`` as a loop nest over ``dst``'s shape."""
-    leaves = expr.leaves()
-    # A bare scalar on the right-hand side is a fill (`acc[:] = 0.0`), which is
-    # how an accumulator is zeroed before a K loop. It needs no leaves: the
-    # destination supplies the shape.
-    for leaf in leaves:
+def _check_region(node, dst, dtype, expected=None):
+    """Check every buffer leaf against the element type of *its* region.
+
+    Without a cast in the tree there is one region and this is the loop that
+    used to live in ``emit_elementwise``, with its two messages unchanged. A
+    cast starts a new region: below it the expected type is the cast's source,
+    so leaves there are checked against that instead of against ``dst`` -- and
+    ``expected`` renames the type in the message accordingly, because "the
+    destination is f32" is untrue of an assignment whose destination is i32 and
+    whose cast happens to convert from f32.
+
+    Shape is checked against the destination in either region: a cast changes
+    the element type and nothing else.
+    """
+    expected = expected or f"destination is {dtype}"
+    if node.kind == "cast":
+        source = node.args[0].element_dtype()
+        _check_region(
+            node.args[0], dst, source, expected=f"the cast converts from {source}"
+        )
+        return
+    if node.kind == "buffer":
+        leaf = node.buffer
         if leaf.shape != dst.shape:
             raise ValueError(
                 f"shape mismatch in elementwise assignment: destination has "
                 f"shape {dst.shape} but operand has shape {leaf.shape}"
             )
-        if leaf.dtype is not dst.dtype:
+        if leaf.dtype is not dtype:
             raise ValueError(
-                f"dtype mismatch in elementwise assignment: destination is "
-                f"{dst.dtype} but operand is {leaf.dtype}"
+                f"dtype mismatch in elementwise assignment: {expected} but "
+                f"operand is {leaf.dtype}"
             )
         if leaf.value is None:
             raise RuntimeError(
                 "buffer used before allocation; air.alloc() must be called "
                 "inside the herd body that uses it"
             )
+        return
+    for arg in node.args:
+        _check_region(arg, dst, dtype, expected)
+
+
+def _regions_in(node, dtype, out):
+    """Element types appearing in ``node``, outermost first.
+
+    Order is deliberate and not incidental: it fixes the order the padding
+    constants are emitted in, so an expression with no cast in it produces
+    byte-identical IR to the version of this emitter that knew only one type.
+    """
+    if dtype is not None and dtype not in out:
+        out.append(dtype)
+    if node.kind == "cast":
+        _regions_in(node.args[0], node.args[0].element_dtype(), out)
+        return out
+    for arg in node.args:
+        _regions_in(arg, dtype, out)
+    return out
+
+
+def emit_elementwise(dst, expr):
+    """Emit ``dst[:] = expr`` as a loop nest over ``dst``'s shape."""
+    # A bare scalar on the right-hand side is a fill (`acc[:] = 0.0`), which is
+    # how an accumulator is zeroed before a K loop. It needs no leaves: the
+    # destination supplies the shape.
+    _check_region(expr, dst, dst.dtype)
 
     if dst.dtype.is_unsigned:
         # An unsigned tile can be *copied* elementwise but not computed on. The
@@ -129,7 +180,7 @@ def emit_elementwise(dst, expr):
                 "an elementwise operator or broadcast scalar (a plain copy, "
                 "dst[:] = src[:], is)",
             )
-        _emit_scalar(dst, expr, _INT_OPS)
+        _emit_scalar(dst, expr)
         return
 
     shape = dst.shape
@@ -139,11 +190,10 @@ def emit_elementwise(dst, expr):
     width = dst.vector_width
     vectorized = bool(shape) and width > 0 and shape[-1] % width == 0
 
-    ops = _FLOAT_OPS if dst.dtype.is_float else _INT_OPS
     if vectorized:
-        _emit_vector(dst, expr, ops, width)
+        _emit_vector(dst, expr, width)
     else:
-        _emit_scalar(dst, expr, ops)
+        _emit_scalar(dst, expr)
 
 
 # ---------------------------------------------------------------------------
@@ -166,41 +216,59 @@ def _nest(bounds, body):
     rec(0, [])
 
 
-def _emit_vector(dst, expr, ops, width):
+class _Region:
+    """Everything the emitter needs to work in one element type.
+
+    Before ``ops.cast`` there was exactly one of these per assignment and its
+    four fields were four separate arguments threaded down ``_eval``. A cast
+    makes an expression hold more than one element type at once, so they are
+    grouped and looked up per node instead.
+
+    The padding constant is built once here rather than per read, which is what
+    keeps it hoisted above the loop nest exactly as before.
+    """
+
+    __slots__ = ("dtype", "ops", "ety", "vec_ty", "pad")
+
+    def __init__(self, dtype, width, vectorized):
+        self.dtype = dtype
+        self.ety = dtype.mlir()
+        self.ops = _FLOAT_OPS if dtype.is_float else _INT_OPS
+        self.vec_ty = VectorType.get([width], self.ety) if vectorized else None
+        self.pad = (
+            arith.ConstantOp(self.ety, 0.0 if dtype.is_float else 0)
+            if vectorized
+            else None
+        )
+
+
+def _emit_vector(dst, expr, width):
     shape = dst.shape
     rank = len(shape)
-    ety = dst.dtype.mlir()
-    vec_ty = VectorType.get([width], ety)
     # Read a rank-1 vector out of a rank-N memref along the innermost dim.
     minor = AffineMapAttr.get(AffineMap.get(rank, 0, [AffineDimExpr.get(rank - 1)]))
-    zero = arith.ConstantOp(ety, 0.0 if dst.dtype.is_float else 0)
+    # One lane count for the whole nest, taken from the destination. A cast does
+    # not change how many elements a trip covers, only how wide each one is, so
+    # the source is read at the destination's lane count and not at its own
+    # dtype's default.
+    regions = {d: _Region(d, width, True) for d in _regions_in(expr, dst.dtype, [])}
 
     bounds = [(0, extent, 1) for extent in shape[:-1]]
     bounds.append((0, shape[-1], width))
 
     def body(ivs):
-        value = _eval(
-            expr,
-            ivs,
-            ops,
-            ety,
-            vectorized=True,
-            vec_ty=vec_ty,
-            minor=minor,
-            pad=zero,
-            reads={},
-        )
+        value = _eval(expr, ivs, regions[dst.dtype], regions, True, minor, {})
         transfer_write(None, value, dst.value, ivs, minor, [True])
 
     _nest(bounds, body)
 
 
-def _emit_scalar(dst, expr, ops):
-    ety = dst.dtype.mlir()
+def _emit_scalar(dst, expr):
+    regions = {d: _Region(d, 0, False) for d in _regions_in(expr, dst.dtype, [])}
     bounds = [(0, extent, 1) for extent in dst.shape]
 
     def body(ivs):
-        value = _eval(expr, ivs, ops, ety, vectorized=False, reads={})
+        value = _eval(expr, ivs, regions[dst.dtype], regions, False, None, {})
         memref_store(value, dst.value, ivs)
 
     _nest(bounds, body)
@@ -224,9 +292,13 @@ def _result(v):
     return v.result if hasattr(v, "result") else v
 
 
-def _eval(
-    node, ivs, ops, ety, vectorized, vec_ty=None, minor=None, pad=None, reads=None
-):
+def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
+    ops, ety = region.ops, region.ety
+    vec_ty, pad = region.vec_ty, region.pad
+
+    def recur(child, into=region):
+        return _eval(child, ivs, into, regions, vectorized, minor, reads)
+
     if node.kind == "buffer":
         # One read per buffer per loop body, not one per mention. A buffer that
         # appears more than once in the tree -- `select(a >= b, a, b)` names
@@ -235,6 +307,13 @@ def _eval(
         # Without this the emitter issues a redundant transfer_read for each
         # extra mention, which is what the hand-written kernels avoid by binding
         # the read to a local once.
+        #
+        # The key is the buffer alone, with no region in it, and that is safe
+        # rather than lucky: a buffer has one element type, `_check_region`
+        # requires every leaf to match the type of the region it sits in, and a
+        # cast is the only thing that starts a new region. So a given buffer is
+        # reachable from exactly one region and its cached value can only ever
+        # have been read at that region's vector type.
         key = id(node.buffer)
         if reads is not None and key in reads:
             return reads[key]
@@ -247,6 +326,17 @@ def _eval(
         if reads is not None:
             reads[key] = value
         return value
+
+    if node.kind == "cast":
+        # The operand is evaluated in *its* region -- a different element type,
+        # a different arith table, and a different vector type -- and only the
+        # conversion itself lands in this one.
+        from .ops import _conversion_op
+
+        source = node.args[0].element_dtype()
+        operand = recur(node.args[0], regions[source])
+        build = _conversion_op(source, region.dtype)
+        return _result(build(vec_ty if vectorized else ety, operand))
 
     if node.kind == "scalar":
         value = node.scalar
@@ -296,18 +386,13 @@ def _eval(
                 f"elementwise operator '{node.op}' is not supported for "
                 f"{'integer' if ops is _INT_OPS else 'float'} buffers"
             )
-        return _result(
-            fn(
-                _eval(
-                    node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads
-                )
-            )
-        )
+        return _result(fn(recur(node.args[0])))
 
     if node.kind == "compare":
         # Yields i1 (vector<Wxi1> when vectorised), not the element type. Only
         # a "select" node consumes this, which ops.select enforces at trace
-        # time -- nothing else in _eval can receive one.
+        # time -- nothing else in _eval can receive one. Its *operands* are
+        # ordinary values in this region, so they recur normally.
         table = _CMP_I if ops is _INT_OPS else _CMP_F
         predicate = table.get(node.op)
         if predicate is None:
@@ -315,20 +400,12 @@ def _eval(
                 f"comparison '{node.op}' is not supported for dtype "
                 f"{'integer' if ops is _INT_OPS else 'float'}"
             )
-        lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
-        rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
         build = arith.cmpi if ops is _INT_OPS else arith.cmpf
-        return _result(build(predicate, lhs, rhs))
+        return _result(build(predicate, recur(node.args[0]), recur(node.args[1])))
 
     if node.kind == "select":
         cond, a, b = node.args
-        return _result(
-            arith.select(
-                _eval(cond, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
-                _eval(a, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
-                _eval(b, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads),
-            )
-        )
+        return _result(arith.select(recur(cond), recur(a), recur(b)))
 
     if node.kind == "binary":
         op = ops.get(node.op)
@@ -343,8 +420,6 @@ def _eval(
                 f"elementwise operator '{node.op}' is not supported for dtype "
                 f"{'float' if ops is _FLOAT_OPS else 'integer'}"
             )
-        lhs = _eval(node.args[0], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
-        rhs = _eval(node.args[1], ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
-        return _result(op(lhs, rhs))
+        return _result(op(recur(node.args[0]), recur(node.args[1])))
 
     raise AssertionError(f"unknown expression node kind {node.kind!r}")

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -331,21 +331,59 @@ class BufferExpr:
     once and emits a single vectorised loop.
     """
 
-    __slots__ = ("kind", "op", "args", "buffer", "scalar")
+    __slots__ = ("kind", "op", "args", "buffer", "scalar", "dtype")
 
-    def __init__(self, kind, op=None, args=(), buffer=None, scalar=None):
+    def __init__(self, kind, op=None, args=(), buffer=None, scalar=None, dtype=None):
         # "buffer" | "scalar" | "unary" | "binary" evaluate to the element
         # type; "compare" evaluates to i1 and only ops.select consumes it;
-        # "select" takes (compare, value, value) back to the element type.
+        # "select" takes (compare, value, value) back to the element type;
+        # "cast" evaluates to a *different* element type from its operand,
+        # which is the only node for which that is true.
         self.kind = kind
         self.op = op
         self.args = tuple(args)
         self.buffer = buffer
         self.scalar = scalar
+        # Set on a "cast" node only: the element type its operand is converted
+        # *to*. Every other node adopts the type of the region it sits in, which
+        # is what ``element_dtype`` below reports.
+        self.dtype = dtype
 
     @staticmethod
     def leaf(buffer):
         return BufferExpr("buffer", buffer=buffer)
+
+    def element_dtype(self):
+        """The element type this subtree evaluates to, or ``None`` if unknown.
+
+        ``None`` means "no buffer decided it" -- a subtree of nothing but
+        scalars, as in the fill ``acc[:] = 0.0``. Such a subtree adopts whatever
+        type surrounds it, so the caller supplies one rather than reading it
+        here.
+
+        A ``cast`` node is where the answer stops depending on its operand: it
+        reports its own target type and does not recurse. That is what makes an
+        expression able to hold more than one element type at once -- everything
+        below a cast is evaluated in the source type, everything above it in the
+        target type.
+        """
+        if self.kind == "buffer":
+            return self.buffer.dtype
+        if self.kind == "cast":
+            return self.dtype
+        if self.kind == "scalar":
+            return None
+        if self.kind == "select":
+            # Skip the predicate: a select evaluates to the type of the two
+            # values it chooses between, and asking the comparison would report
+            # the type of *its* operands. Those agree today, because one region
+            # covers the whole tree -- but only by construction, not by rule.
+            return self.args[1].element_dtype() or self.args[2].element_dtype()
+        for arg in self.args:
+            found = arg.element_dtype()
+            if found is not None:
+                return found
+        return None
 
     @staticmethod
     def coerce(value):
@@ -471,6 +509,8 @@ class BufferExpr:
             return repr(self.buffer)
         if self.kind == "scalar":
             return repr(self.scalar)
+        if self.kind == "cast":
+            return f"cast({self.args[0]!r}, {self.dtype!r})"
         if self.kind == "unary":
             return f"{self.op}({self.args[0]!r})"
         if self.kind == "select":

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -41,6 +41,7 @@ __all__ = [
     "load",
     "store",
     "copy",
+    "cast",
     "maximum",
     "minimum",
     "relu",
@@ -353,6 +354,133 @@ def _elementwise(name, key, a, b):
     return BufferExpr("binary", op=key, args=(a, b))
 
 
+def cast(x, dtype):
+    """Convert an elementwise expression to another element type.
+
+        l1_out[:] = air.api.ops.cast(l1_in[:], air.api.i32)
+
+    This is the one node whose operand has a different element type from its
+    result, so everything below it is read, and computed on, in the source type:
+    ``cast(a[:] * 2.0, i32)`` doubles in f32 and converts once, while
+    ``cast(a[:], i32) * 2`` converts first and doubles in i32.
+
+    Which ``arith`` op it becomes follows from the two types -- ``sitofp``,
+    ``fptosi``, ``extf``, ``truncf`` or ``extsi``. Every one of those was run on
+    npu1 hardware against an exact numpy reference before being allowed here,
+    vectorised and scalar, because compiling is not the same claim as computing:
+    of the pairs probed, four compiled cleanly and returned wrong values.
+
+    Two results of that sweep are worth knowing before using this:
+
+    * **A float result is rounded toward negative infinity, not to nearest.**
+      Converting to bf16 differs from numpy's round-half-to-even by up to one
+      ULP (2^-7 relative). That is not a property of this op -- a plain
+      ``c[:] = a[:] + b[:]`` on bf16 buffers differs from numpy the same way --
+      but an exact comparison against a numpy reference will fail on roughly
+      half of all inputs, so compare with a tolerance.
+    * **Narrowing between integer types is refused**, not supported-with-caveats.
+      See ``_conversion_op`` below for the measurement.
+    """
+    from .types import DType
+
+    if not isinstance(dtype, DType):
+        raise TypeError(
+            f"air.api.ops.cast needs an air.api element type as its second "
+            f"argument (air.api.i32, air.api.f32, ...), got {dtype!r}"
+        )
+    expr = BufferExpr.coerce(x)
+    if expr.kind == "compare":
+        # A comparison evaluates to i1, not to an element type, so there is
+        # nothing to convert *from* -- and a conversion op applied to a
+        # vector<Wxi1> would be a verifier failure well downstream of the
+        # mistake. Say what to do instead.
+        raise TypeError(
+            "air.api.ops.cast got a comparison, which is a predicate rather "
+            "than a value: it evaluates to i1, not to an element type. Turn it "
+            "into values first with air.api.ops.select(cond, a, b), or write "
+            "the comparison against already-converted operands"
+        )
+    source = expr.element_dtype()
+    if source is None:
+        # Two different situations produce no source type, and they need
+        # different messages because they need different fixes.
+        if expr.leaves():
+            # `cast(ops.select(a[:] > 0, 1, 2), i32)`. There *are* buffers, but
+            # only in the predicate: ops.select allows that, and the values it
+            # chooses between are both scalars, so the expression takes its
+            # element type from whatever surrounds it. There is nothing to
+            # convert from, and it cannot simply be adopted into the target
+            # type either -- the predicate's own operands would then have to
+            # be i32 as well, which is not what was written.
+            raise TypeError(
+                "air.api.ops.cast cannot convert this expression: its buffers "
+                "appear only in a comparison, and the values it evaluates to "
+                "are all scalars, so it has no element type of its own to "
+                "convert from. Cast the operands instead -- for example "
+                "ops.select(a[:] > 0, ops.cast(x[:], t), ops.cast(y[:], t))"
+            )
+        # `cast(1.0, i32)` -- no buffer at all, so the constant would simply be
+        # built in the target type anyway. Write the constant you meant.
+        raise TypeError(
+            "air.api.ops.cast needs an expression containing at least one "
+            f"buffer; {x!r} is a bare scalar, which is already built in "
+            "whatever element type surrounds it"
+        )
+    if source is dtype:
+        # Converting to the type it already has. numpy's astype does this too,
+        # and it must not fall through to a builder: arith rejects a same-type
+        # extf with "operand type and result type are cast incompatible".
+        return expr
+    require_signless(source, "air.api.ops.cast")
+    require_signless(dtype, "air.api.ops.cast")
+    _conversion_op(source, dtype)  # raises here, at the call site, not at emit
+    return BufferExpr("cast", args=(expr,), dtype=dtype)
+
+
+def _conversion_op(source, target):
+    """The arith op converting ``source`` to ``target``, or a refusal.
+
+    Shared by ``cast`` (so a bad pair is rejected where the user wrote it) and
+    by the emitter (so it does not need a second copy of the rules).
+    """
+    from air.dialects import arith
+
+    if source.is_float and target.is_float:
+        if target.itemsize > source.itemsize:
+            return arith.ExtFOp
+        if target.itemsize < source.itemsize:
+            return arith.TruncFOp
+        # bf16 and f16 are both 2 bytes, so neither extf nor truncf applies:
+        # they have different exponent widths and MLIR has no direct op.
+        raise NotImplementedError(
+            f"air.api.ops.cast cannot convert {source} to {target} directly: "
+            f"they are the same width, so it is neither a widening nor a "
+            f"narrowing, and arith has no op for it. Convert through "
+            f"air.api.f32 in two steps"
+        )
+    if source.is_float:
+        return arith.FPToSIOp
+    if target.is_float:
+        return arith.SIToFPOp
+    if target.itemsize > source.itemsize:
+        return arith.ExtSIOp
+    # Narrowing int -> int. Refused on evidence rather than on principle:
+    # measured on npu1, arith.trunci wraps on the scalar path (matching both
+    # MLIR's own semantics and numpy) and *saturates* on the vector path --
+    # i32 933033 came back as 32767 rather than 15529. Which path the emitter
+    # takes depends on whether the tile is a multiple of the vector width,
+    # which is not something the author of the cast is thinking about, so the
+    # same source would compute two different things depending on the tile
+    # size. In-range values agree, but nothing here can check that.
+    raise NotImplementedError(
+        f"air.api.ops.cast will not narrow {source} to {target}: on AIE the "
+        f"vectorised arith.trunci saturates while the scalar one wraps, and "
+        f"the emitter picks between them based on the tile size, so the result "
+        f"would depend on a tile shape rather than on the program. Mask "
+        f"explicitly if wrapping is what you want"
+    )
+
+
 def maximum(a, b):
     """Elementwise max. Lowers to arith.maximumf (float) / arith.maxsi (int)."""
     return _elementwise("maximum", "max", a, b)
@@ -371,10 +499,23 @@ def relu(x):
     a Python float fails with "expected floating point type".
     """
     expr = BufferExpr.coerce(x)
-    leaves = expr.leaves()
-    if not leaves:
-        raise ValueError("air.api.ops.relu needs a buffer operand, got a scalar")
-    return maximum(expr, 0.0 if leaves[0].dtype.is_float else 0)
+    # The expression's own element type, not the first buffer under it. Those
+    # agree everywhere except across a cast, where `relu(cast(a[:], i32))` has
+    # an f32 leaf and an i32 result -- and it is the result that decides which
+    # zero to build.
+    dtype = expr.element_dtype()
+    if dtype is None:
+        # No value type of its own. That is a bare scalar, which relu cannot
+        # shape -- or an expression whose buffers sit only in a predicate, as
+        # in `relu(ops.select(a[:] > 0, 1, 2))`, which ops.select allows and
+        # which the emitter shapes from those buffers. Fall back to a leaf,
+        # which is the type the surrounding region will be built in anyway,
+        # since every leaf in a region is required to match it.
+        leaves = expr.leaves()
+        if not leaves:
+            raise ValueError("air.api.ops.relu needs a buffer operand, got a scalar")
+        dtype = leaves[0].dtype
+    return maximum(expr, 0.0 if dtype.is_float else 0)
 
 
 # ---------------------------------------------------------------------------

--- a/python/test/api/cast.py
+++ b/python/test/api/cast.py
@@ -1,0 +1,184 @@
+# ./python/test/api/cast.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers air.ops.cast to the arith conversion ops.
+
+A cast is the first node whose operand has a different element type from its
+result, so it is the first thing that makes one assignment hold two element
+types at once. Everything below it is read and computed in the source type;
+only the conversion lands in the destination's. The two orderings below --
+``cast(a[:] * 2.0, i32)`` against ``cast(a[:], i32) * 2`` -- are the whole
+point of that rule, and they must emit different arithmetic.
+
+The pairs checked here are the ones that were run on npu1 hardware against an
+exact numpy reference: every conversion this file emits is one that computes.
+"""
+
+from air import api as air
+from air.api.types import bf16, f32, i16, i32
+
+
+def build(body, dt_in, dt_out, N=256, tile=128, vector=None):
+    src = air.tensor([N], dt_in)
+    out = air.tensor([N], dt_out)
+
+    with air.launch(name="cast") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, tile)], shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    (tn,) = h.tile_sizes
+                    col = tx * tn
+                    a = air.alloc([tn], dt_in, scope=h.private(), vector=vector)
+                    c = air.alloc([tn], dt_out, scope=h.private(), vector=vector)
+                    air.ops.load(a, src[col : col + tn])
+                    c[:] = body(a)
+                    air.ops.store(c, out[col : col + tn])
+
+    print(launch.build(target="npu1"))
+
+
+# CHECK-LABEL: TEST: f32_to_i32
+# A float source and an integer destination: arith.fptosi, on the vector type,
+# with the read still at the destination's lane count.
+# CHECK: vector.transfer_read {{.*}} vector<16xf32>
+# CHECK: arith.fptosi %{{.*}} : vector<16xf32> to vector<16xi32>
+# CHECK: vector.transfer_write {{.*}} vector<16xi32>
+print("\nTEST: f32_to_i32")
+build(lambda a: air.ops.cast(a[:], i32), f32, i32)
+
+
+# CHECK-LABEL: TEST: i32_to_f32
+# CHECK: arith.sitofp %{{.*}} : vector<16xi32> to vector<16xf32>
+print("\nTEST: i32_to_f32")
+build(lambda a: air.ops.cast(a[:], f32), i32, f32)
+
+
+# CHECK-LABEL: TEST: widening_float_is_extf
+# CHECK: arith.extf %{{.*}} : vector<16xbf16> to vector<16xf32>
+print("\nTEST: widening_float_is_extf")
+build(lambda a: air.ops.cast(a[:], f32), bf16, f32, vector=16)
+
+
+# CHECK-LABEL: TEST: narrowing_float_is_truncf
+# CHECK: arith.truncf %{{.*}} : vector<16xf32> to vector<16xbf16>
+print("\nTEST: narrowing_float_is_truncf")
+build(lambda a: air.ops.cast(a[:], bf16), f32, bf16, vector=16)
+
+
+# CHECK-LABEL: TEST: widening_int_is_extsi
+# CHECK: arith.extsi %{{.*}} : vector<16xi16> to vector<16xi32>
+print("\nTEST: widening_int_is_extsi")
+build(lambda a: air.ops.cast(a[:], i32), i16, i32)
+
+
+# CHECK-LABEL: TEST: compute_below_the_cast_stays_in_the_source_type
+# `cast(a[:] * 2.0, i32)` doubles in f32 -- an f32 constant, broadcast, and an
+# arith.mulf on vector<16xf32> -- and converts once, at the end.
+# CHECK: arith.constant 2.000000e+00 : f32
+# CHECK: arith.mulf {{.*}} : vector<16xf32>
+# CHECK: arith.fptosi %{{.*}} : vector<16xf32> to vector<16xi32>
+print("\nTEST: compute_below_the_cast_stays_in_the_source_type")
+build(lambda a: air.ops.cast(a[:] * 2.0, i32), f32, i32)
+
+
+# CHECK-LABEL: TEST: compute_above_the_cast_is_in_the_target_type
+# The same two operations in the other order: convert first, then add in i32.
+# The constant is `3 : i32` rather than `3.0 : f32`, which is what proves the
+# scalar took its type from the region it sits in rather than from the source
+# buffer of the assignment.
+# CHECK: arith.fptosi %{{.*}} : vector<16xf32> to vector<16xi32>
+# CHECK: arith.constant 3 : i32
+# CHECK: arith.addi {{.*}} : vector<16xi32>
+print("\nTEST: compute_above_the_cast_is_in_the_target_type")
+build(lambda a: air.ops.cast(a[:], i32) + 3, f32, i32)
+
+
+# CHECK-LABEL: TEST: scalar_fallback_no_vector_width
+# One of the two independent routes to the scalar loop: the caller turned
+# vectorisation off. memref.load, a scalar arith.fptosi, memref.store.
+# CHECK-NOT: vector.transfer_read
+# CHECK: memref.load
+# CHECK: arith.fptosi %{{.*}} : f32 to i32
+# CHECK: memref.store
+print("\nTEST: scalar_fallback_no_vector_width")
+build(lambda a: air.ops.cast(a[:], i32), f32, i32, vector=0)
+
+
+# CHECK-LABEL: TEST: scalar_fallback_tile_not_a_multiple
+# The other route, and the one that matters for a cast: nothing in the source
+# mentions a width, and the emitter picks the scalar loop because 100 is not a
+# multiple of 16. A cast must mean the same thing on both routes -- which is
+# exactly why narrowing between integer types is refused, since there it does
+# not (the vector form saturates and the scalar form wraps).
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.fptosi %{{.*}} : f32 to i32
+print("\nTEST: scalar_fallback_tile_not_a_multiple")
+build(lambda a: air.ops.cast(a[:], i32), f32, i32, N=200, tile=100)
+
+
+# CHECK-LABEL: TEST: cast_to_the_same_type_emits_nothing
+# numpy's astype is a no-op when the type already matches, and so is this. It
+# must not reach a builder: arith rejects a same-type extf with "operand type
+# and result type are cast incompatible".
+# CHECK-NOT: arith.extf
+# CHECK-NOT: arith.truncf
+# CHECK-NOT: arith.fptosi
+# CHECK-NOT: arith.sitofp
+# CHECK: vector.transfer_write
+print("\nTEST: cast_to_the_same_type_emits_nothing")
+build(lambda a: air.ops.cast(a[:], f32), f32, f32)
+
+
+# CHECK-LABEL: TEST: ops_relu_over_a_cast_zeroes_in_the_target_type
+# ops.relu picks its zero constant from the expression's element type. Those
+# agree everywhere except across a cast, where the buffer under it is f32 and
+# the result is i32 -- so the zero must be `0 : i32`, and arith.maxsi rather
+# than arith.maximumf must do the clamping.
+# CHECK: arith.fptosi %{{.*}} : vector<16xf32> to vector<16xi32>
+# CHECK: arith.constant 0 : i32
+# CHECK: arith.maxsi {{.*}} : vector<16xi32>
+# CHECK-NOT: arith.maximumf
+print("\nTEST: ops_relu_over_a_cast_zeroes_in_the_target_type")
+build(lambda a: air.ops.relu(air.ops.cast(a[:], i32)), f32, i32)
+
+
+# CHECK-LABEL: TEST: repr_names_the_target_type
+# A cast node prints as the call the user wrote, naming the type it converts
+# to. Without this it would fall through to the binary form and print as
+# `(Buffer None Buffer)`, since a cast carries no operator key.
+# CHECK: cast(Buffer(shape=(128,), dtype=air.api.f32, space=L1), air.api.i32)
+print("\nTEST: repr_names_the_target_type")
+
+_shown = []
+
+
+def _show_then_cast(a):
+    expr = air.ops.cast(a[:], i32)
+    _shown.append(repr(expr))
+    return expr
+
+
+build(_show_then_cast, f32, i32)
+print(_shown[0])
+
+
+# CHECK-LABEL: TEST: relu_over_a_predicate_only_select
+# The companion to the refusal in errors.py, and a regression guard. ops.relu
+# asks the expression for its element type to decide whether to build 0.0 or
+# 0; an expression whose buffers sit only in a predicate has no element type of
+# its own, and relu must fall back to a leaf rather than reject it -- this
+# lowers fine, and rejecting it would be a regression against a form ops.select
+# explicitly permits.
+# CHECK: arith.cmpf
+# CHECK: arith.select
+# CHECK: arith.maximumf
+print("\nTEST: relu_over_a_predicate_only_select")
+build(lambda a: air.ops.relu(air.ops.select(a[:] > 0.0, 1.0, 2.0)), f32, f32)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -16,7 +16,7 @@ from itertools import product
 
 from air import api as air
 from air.api import ops  # noqa: F401
-from air.api.types import bf16, f32, i32, ui8
+from air.api.types import bf16, f16, f32, i16, i32, ui8
 
 
 def expect(exc_types, label):
@@ -1412,5 +1412,137 @@ def _():
         a = air.alloc([64], ui8, scope=h.private())
         b = air.alloc([64], ui8, scope=h.private())
         a[:] = a[:] ^ b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_narrowing_int
+# Refused on evidence, not on principle: measured on npu1, the vectorised
+# arith.trunci saturates while the scalar one wraps, and the emitter chooses
+# between them from the tile size. Accepting this would make the same source
+# compute two different things depending on a tile shape.
+# CHECK: NotImplementedError: air.api.ops.cast will not narrow air.api.i32 to air.api.i16
+@expect(NotImplementedError, "cast_narrowing_int")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], i32, scope=h.private())
+        c = air.alloc([16, 16], i16, scope=h.private())
+        c[:] = ops.cast(a[:], i16)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_same_width_float
+# bf16 and f16 are both two bytes, so the conversion is neither a widening nor
+# a narrowing and arith has no op for it.
+# CHECK: NotImplementedError: air.api.ops.cast cannot convert air.api.bf16 to air.api.f16 directly
+@expect(NotImplementedError, "cast_same_width_float")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], bf16, scope=h.private())
+        c = air.alloc([16, 16], f16, scope=h.private())
+        c[:] = ops.cast(a[:], f16)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_unsigned
+# A conversion is an arith op like any other, so the signless rule that governs
+# the operators governs it too.
+# CHECK: NotImplementedError: air.api.ops.cast is not supported for air.api.ui8
+@expect(NotImplementedError, "cast_unsigned")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], ui8, scope=h.private())
+        c = air.alloc([16, 16], i32, scope=h.private())
+        c[:] = ops.cast(a[:], i32)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_of_a_bare_scalar
+# There is no buffer under it, so there is no source type to convert from --
+# and the constant would have been built in the target type anyway.
+# CHECK: TypeError: air.api.ops.cast needs an expression containing at least one buffer
+@expect(TypeError, "cast_of_a_bare_scalar")
+def _():
+    ops.cast(1.0, i32)
+
+
+# CHECK-LABEL: TEST: cast_to_a_non_dtype
+# The second argument is an element type, not a string or a numpy dtype. Named
+# here rather than left to fail later inside the emitter.
+# CHECK: TypeError: air.api.ops.cast needs an air.api element type as its second argument
+@expect(TypeError, "cast_to_a_non_dtype")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], f32, scope=h.private())
+        ops.cast(a[:], "i32")
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dtype_mismatch_without_a_cast_still_raises
+# ops.cast is the *only* way to change element type in an expression; a bare
+# mismatch is still the error it always was, rather than an implicit
+# conversion. The message names the region's type, which without a cast in the
+# tree is the destination's.
+# CHECK: ValueError: dtype mismatch in elementwise assignment: destination is air.api.i32 but operand is air.api.f32
+@expect(ValueError, "dtype_mismatch_without_a_cast_still_raises")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], f32, scope=h.private())
+        c = air.alloc([16, 16], i32, scope=h.private())
+        c[:] = a[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: dtype_mismatch_below_a_cast
+# The leaves under a cast are checked against the cast's *source* type, not
+# against the destination of the assignment. Here the cast converts from f32,
+# so an i32 buffer sitting beside it in the same region is the mismatch.
+# CHECK: ValueError: dtype mismatch in elementwise assignment: the cast converts from air.api.f32 but operand is air.api.i32
+@expect(ValueError, "dtype_mismatch_below_a_cast")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], f32, scope=h.private())
+        b = air.alloc([16, 16], i32, scope=h.private())
+        c = air.alloc([16, 16], i32, scope=h.private())
+        c[:] = ops.cast(a[:] + b[:], i32)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_of_a_comparison
+# A comparison evaluates to i1, not to an element type, so there is nothing to
+# convert from -- and a conversion op applied to a vector<Wxi1> would fail the
+# verifier well downstream of the mistake. This is the one interaction between
+# ops.select and ops.cast that needs naming.
+# CHECK: TypeError: air.api.ops.cast got a comparison, which is a predicate rather than a value
+@expect(TypeError, "cast_of_a_comparison")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        b = air.alloc([64], f32, scope=h.private())
+        c = air.alloc([64], i32, scope=h.private())
+        c[:] = ops.cast(a[:] > b[:], i32)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_of_a_predicate_only_expression
+# ops.select allows every buffer to sit in the *predicate*, choosing between
+# two scalars -- so the expression has buffers but no element type of its own,
+# and takes one from whatever surrounds it. That is a different situation from
+# a bare scalar and gets a different message, because the fix is different:
+# cast the operands rather than the select.
+# CHECK: TypeError: air.api.ops.cast cannot convert this expression: its buffers appear only in a comparison
+@expect(TypeError, "cast_of_a_predicate_only_expression")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        c = air.alloc([64], i32, scope=h.private())
+        c[:] = ops.cast(ops.select(a[:] > 0.0, 1, 2), i32)
 
     _trace(body)


### PR DESCRIPTION
Adds `air.api.ops.cast(expr, dtype)` and converts
`primitives/vector_examples/vector_fptosi` and `vector_sitofp` onto it,
deleting their raw-bindings implementations.

A cast is the first node whose operand has a different element type from its
result, so it is the first thing that makes one assignment hold two element
types at once. Everything below it is read and computed in the source type and
only the conversion lands in the destination's, which is observable:
`cast(a[:] * 2.0, i32)` doubles in f32 and converts once, while
`cast(a[:], i32) * 2` converts first and doubles in i32.

The emitter used to carry one element type, one arith table, one vector type
and one padding constant as four arguments threaded down `_eval`. They are now
grouped into a `_Region` and looked up per node.

## Which conversions are allowed, and why

Each pair was run on npu1 hardware against an **exact** numpy reference,
vectorised and scalar, because compiling is a weaker claim than computing — of
the pairs probed, four compiled cleanly and returned wrong values.

| pair | verdict |
|---|---|
| f32↔i32, bf16→f32, i16→i32, bf16→i32 | exact on both routes |
| f32→bf16, i32→bf16 | 1 ULP: AIE rounds toward −∞, numpy to nearest-even |
| i32→i16 | **refused** |

`i32→i16` is refused because the vectorised `arith.trunci` **saturates**
(933033 → 32767) while the scalar one **wraps** (→ 15529), and the emitter picks
between those two paths from the tile size. Accepting it would make the same
source compute two different things depending on a tile shape. The float
rounding is uniform across both routes, so it is documented rather than refused
— and it is not specific to this op, since a plain `c[:] = a[:] + b[:]` on bf16
buffers differs from numpy the same way.

`ops.relu` picked its zero constant from the first buffer leaf, which is the
type *below* a cast rather than the expression's own. It survived by accident
(`0.0` coerces to `0` for an integer region); it now asks the expression, and a
test pins it.

## Verification

- 17/17 api lits; new `python/test/api/cast.py` plus 7 negative cases in
  `errors.py`.
- Both example lits PASS on npu1 hardware. A mutation test confirms they are not
  vacuous: corrupting the golden reference by +1 makes them fail with
  `expected=-577385, actual=-577386`.
- npu2 xclbin and elf compile; the **scalar route runs clean on hardware** for
  both examples, which is the claim the docstrings make.
- The emitted IR of all 86 air.api example modules (npu1 and npu2, 265 KB) is
  **byte-identical to main** — that is what makes the `_eval` refactor safe, and
  the api lits alone would not have caught an ordering change.
- Regression sweep of all 45 directories containing an air.api example:
  58 PASS / 1 FAIL, the failure being matvec's `PROFILE` step, which fails
  identically on unmodified main (this build has no XRT for the C++ harness).

**No perf A/B was run** — no npu2 box in this session and neither example has a
profile target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)