### PR TITLE
[python] air.api: refuse arithmetic on f16 instead of miscomputing it

### DIFF
--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -28,7 +28,7 @@ from air.dialects.memref import load as memref_load, store as memref_store
 from air.dialects.scf import for_ as range_, yield_
 from air.dialects.vector import broadcast, transfer_read, transfer_write
 
-from .types import require_signless
+from .types import require_computable, require_signless
 
 __all__ = ["emit_elementwise"]
 
@@ -105,6 +105,18 @@ def emit_elementwise(dst, expr):
                 "buffer used before allocation; air.alloc() must be called "
                 "inside the herd body that uses it"
             )
+
+    # A tile the core has no instructions for -- f16 -- follows the same rule
+    # as an unsigned one: it can be *copied* elementwise, because a copy emits a
+    # read and a write and no arith op, and the bits arrive unchanged. Measured
+    # on npu1: an f16 copy is exact on 2048 of 2048 elements, and an f16 add is
+    # wrong on 2048 of 2048. Only the second is refused.
+    if not dst.dtype.computes and expr.kind != "buffer":
+        require_computable(
+            dst.dtype,
+            "an elementwise operator or broadcast scalar (a plain copy, "
+            "dst[:] = src[:], is)",
+        )
 
     if dst.dtype.is_unsigned:
         # An unsigned tile can be *copied* elementwise but not computed on. The

--- a/python/air/api/_extern.py
+++ b/python/air/api/_extern.py
@@ -55,7 +55,7 @@ class ExternKernel:
                 'should link against, e.g. object="mv.o". It becomes the '
                 "link_with attribute on both the declaration and the herd."
             )
-        from .types import DType, require_signless
+        from .types import DType, require_computable, require_signless
 
         for s in scalars:
             if not isinstance(s, DType):
@@ -71,6 +71,7 @@ class ExternKernel:
             # be. Caught at the declaration rather than at the first call, which
             # is where the constant would actually be built.
             require_signless(s, "an air.extern scalar argument")
+            require_computable(s, "an air.extern scalar argument")
         self.name = name
         self.object = object
         self.scalars = list(scalars)

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -251,12 +251,13 @@ class Buffer:
         from air.dialects.linalg import fill
 
         from . import ops as _ops
-        from .types import require_signless
+        from .types import require_computable, require_signless
 
         # linalg.fill's value comes from an arith.constant, which has no signful
         # form; a packed buffer is an accumulator anyway, and ops.dot has
         # already refused an unsigned one.
         require_signless(self.dtype, "a fill of a micro-tiled buffer")
+        require_computable(self.dtype, "a fill of a micro-tiled buffer")
         if not isinstance(value, (int, float)) or isinstance(value, bool):
             raise NotImplementedError(
                 "only a scalar fill is supported on a micro-tiled buffer "

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -35,7 +35,7 @@ from ``tanh``, which has a checked lowering, so nothing has needed a vector
 """
 
 from ._value import Buffer, BufferExpr, BufferSlice, Tensor, TensorSlice, Token
-from .types import require_signless
+from .types import require_computable, require_signless
 
 __all__ = [
     "load",
@@ -736,6 +736,7 @@ def dot(a, b, acc=None, alpha=1.0, transpose_b=False, dependency=None, *, kernel
         # element type fails verification inside the op that was just emitted,
         # several frames from the call that caused it.
         require_signless(buf.dtype, f"air.api.ops.dot's {name} operand")
+        require_computable(buf.dtype, f"air.api.ops.dot's {name} operand")
 
     if alpha != 1.0:
         raise NotImplementedError(

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -28,9 +28,10 @@ __all__ = [
     "ui32",
     "dtype_of",
 ]
-# `require_signless` is deliberately absent from __all__: it is the guard the
-# emission paths call, not something a kernel author reaches for. All four
-# callers import it by name, which __all__ does not govern.
+# `require_signless` and `require_computable` are deliberately absent from
+# __all__: they are the guards the emission paths call, not something a kernel
+# author reaches for. All four callers import them by name, which __all__ does
+# not govern.
 
 
 class DType:
@@ -54,13 +55,31 @@ class DType:
     first example to vectorise an i32 elementwise body -- the previous value of
     8 was an extrapolation by element size and was wrong.
 
-    Widths for f16, i8 and i16 are still extrapolated that way and have not been
-    compiled; treat them as unverified. The unsigned widths are never reached at
-    all -- see ``is_unsigned``.
+    Widths for i8 and i16 are still extrapolated that way and have not been
+    compiled; treat them as unverified.
+
+    The *unsigned* widths are genuinely dead: an unsigned buffer is forced onto
+    the scalar path even for a plain copy, because ``vector.transfer_read``
+    takes a padding value and that padding value is an ``arith.constant``. See
+    ``is_unsigned``.
+
+    f16 is not like that, and it would be wrong to lump the two together.
+    Arithmetic on f16 is refused (see ``computes``) but a plain copy is still
+    allowed and still vectorises, so f16's width *is* used -- an ``f16`` tile
+    copy emits ``vector<16xf16>``. That 16 is measured rather than
+    extrapolated: an f16 copy at 16 lanes is exact on 2048 of 2048 elements on
+    npu1, which is unsurprising, since a copy moves bit patterns and never asks
+    the core to interpret them as floats.
     """
 
     def __init__(
-        self, name, np_dtype, default_vector_width, is_float, is_unsigned=False
+        self,
+        name,
+        np_dtype,
+        default_vector_width,
+        is_float,
+        is_unsigned=False,
+        computes=True,
     ):
         self.name = name
         self.np_dtype = np_dtype
@@ -77,6 +96,11 @@ class DType:
         # `require_signless`, which every emission path that builds an arith or
         # linalg op calls.
         self.is_unsigned = is_unsigned
+        # False when the AIE core has no instruction for this type, so a buffer
+        # of it can be declared, allocated and moved but not computed on. Same
+        # shape of restriction as `is_unsigned` above, enforced at the same four
+        # call sites -- see `require_computable`.
+        self.computes = computes
 
     @property
     def itemsize(self):
@@ -95,7 +119,14 @@ class DType:
 
 
 bf16 = DType("bf16", bfloat16, 16, is_float=True)
-f16 = DType("f16", np.float16, 16, is_float=True)
+# AIE2 and AIE2P have no fp16 instruction, scalar or vector -- bf16 is the
+# 16-bit float the hardware implements. Nothing in the toolchain refuses an f16
+# kernel, though: it compiles, runs, and returns the result of having read the
+# f16 bit patterns as bf16. Measured on npu1, `c[:] = a[:] + b[:]` over f16
+# buffers is wrong on 2048 of 2048 elements -- f16 512.5 is 0x6001, and 0x6001
+# read as bf16 is 1.0078125 x 2^65, which is what came back. Declared anyway so
+# the type can still describe f16 *data* being moved, which does work.
+f16 = DType("f16", np.float16, 16, is_float=True, computes=False)
 f32 = DType("f32", np.float32, 16, is_float=True)
 i8 = DType("i8", np.int8, 32, is_float=False)
 i16 = DType("i16", np.int16, 16, is_float=False)
@@ -157,4 +188,33 @@ def require_signless(dtype, what):
         f"passed to an air.extern kernel -- which is what the uint8 examples in "
         f"this tree do. To compute on it in the DSL, declare it "
         f"air.api.{dtype.name[1:]} instead and interpret the data yourself."
+    )
+
+
+def require_computable(dtype, what):
+    """Refuse ``what`` on an element type the AIE core cannot compute on.
+
+    The same shape of restriction as :func:`require_signless`, for a different
+    reason, and enforced at the same four call sites: a buffer of such a type
+    can be declared, allocated, moved with ``ops.load``/``store`` and
+    ``air.channel``, and handed to an ``air.extern`` kernel, but no arith or
+    linalg op may be built over it.
+
+    Today that is f16 alone. It matters because the failure it replaces is
+    silent: AIE2 has no fp16 instruction, and rather than refusing an f16
+    kernel the toolchain compiles one that reads the f16 bit patterns as bf16.
+    Nothing raises, nothing warns, and the numbers come back wrong -- which is
+    the failure mode this package exists to eliminate.
+    """
+    if dtype.computes:
+        return
+    raise NotImplementedError(
+        f"{what} is not supported for {dtype}: neither NPU generation has an "
+        f"fp16 instruction, scalar or vector, so there is nothing to lower it "
+        f"to. This is not caught downstream -- the backend reinterprets the "
+        f"f16 bits as bf16 and returns wrong numbers with no error at all, so "
+        f"it is refused here instead. Use air.api.bf16, which is the 16-bit "
+        f"float the hardware implements, or air.api.f32. An air.api.f16 buffer "
+        f"can still be declared and moved, so f16 *data* can be transferred "
+        f"and passed to an air.extern kernel."
     )

--- a/python/test/api/no_fp16.py
+++ b/python/test/api/no_fp16.py
@@ -1,0 +1,127 @@
+# ./python/test/api/no_fp16.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api refuses arithmetic on f16, because neither NPU can do it.
+
+AIE2 and AIE2P have no fp16 instruction, scalar or vector; bf16 is the 16-bit
+float the hardware implements. What made this worth a guard is not the gap but
+how the gap presented: nothing in the toolchain refused an f16 kernel. It
+compiled, it ran, and it returned the result of having read the f16 bit
+patterns as bf16 -- with no error, no warning, and no legalizer failure.
+
+Measured on npu1 before this guard existed:
+
+    c[:] = a[:] + b[:]   over f16 buffers   wrong on 2048 of 2048 elements
+    f16 512.5 is 0x6001, and 0x6001 read as bf16 is 1.0078125 x 2^65
+    the device returned                     3.718172e19
+
+That is the failure mode this package exists to remove, so f16 now behaves the
+way unsigned does: a buffer of it can be declared, allocated and *moved*, and
+only arithmetic is refused. Movement is not refused because movement works --
+an f16 DMA and an f16 elementwise copy are both exact on 2048 of 2048.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f16, f32
+
+
+def trace(body, dtype=f16):
+    src = air.tensor([64], dtype)
+    out = air.tensor([64], dtype)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, 64, 64)], shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], dtype, scope=h.private())
+                    c = air.alloc([64], dtype, scope=h.private())
+                    ops.load(a, src[0:64])
+                    body(c, a)
+                    ops.store(c, out[0:64])
+
+    return launch.build(target="npu1")
+
+
+def expect(label, fn):
+    print("\nTEST:", label)
+    try:
+        fn()
+        print("no exception")
+    except NotImplementedError as e:
+        print(f"NotImplementedError: {e}")
+
+
+# CHECK-LABEL: TEST: f16_add
+# The message has to say what the hardware cannot do and what to use instead;
+# "not supported" alone would send the reader looking for a missing feature in
+# air.api rather than a missing instruction in the core.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar (a plain copy, dst[:] = src[:], is) is not supported for air.api.f16: neither NPU generation has an fp16 instruction
+# CHECK-SAME: Use air.api.bf16
+expect("f16_add", lambda: trace(lambda c, a: c.__setitem__(slice(None), a[:] + a[:])))
+
+
+# CHECK-LABEL: TEST: f16_broadcast_scalar
+# A scalar operand is an arith.constant, so this is refused for the same reason
+# even though only one side is a buffer.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar
+expect(
+    "f16_broadcast_scalar",
+    lambda: trace(lambda c, a: c.__setitem__(slice(None), a[:] * 2.0)),
+)
+
+
+# CHECK-LABEL: TEST: f16_fill
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar
+expect("f16_fill", lambda: trace(lambda c, a: c.__setitem__(slice(None), 1.0)))
+
+
+# CHECK-LABEL: TEST: f16_named_op
+# ops.relu composes down to arith.maximumf, so the guard has to catch it at the
+# emitter rather than at each op's own front door.
+# CHECK: NotImplementedError: an elementwise operator or broadcast scalar
+expect(
+    "f16_named_op",
+    lambda: trace(lambda c, a: c.__setitem__(slice(None), ops.relu(a[:]))),
+)
+
+
+# CHECK-LABEL: TEST: f16_extern_scalar
+# An extern kernel's buffer arguments may be f16 -- moving the data is the
+# point -- but a scalar argument is materialised by arith.constant.
+# CHECK: NotImplementedError: an air.extern scalar argument is not supported for air.api.f16
+expect("f16_extern_scalar", lambda: air.extern("k", object="k.o", scalars=[f16]))
+
+
+# CHECK-LABEL: TEST: f16_copy_is_allowed
+# The other half of the rule, and the half that keeps the type useful: a plain
+# copy emits a read and a write and no arith op, so the bits arrive unchanged.
+# Refusing it would make f16 undeclarable rather than uncomputable.
+#
+# The copy also *vectorises*, which is why f16's default_vector_width is live
+# surface rather than dead: an unsigned buffer is forced onto the scalar path
+# even for a copy, and f16 is not. Pinned here so the two restrictions do not
+# get described as the same thing.
+# CHECK: memref<64xf16
+# CHECK: vector<16xf16>
+# CHECK-NOT: arith.addf
+print("\nTEST: f16_copy_is_allowed")
+print(trace(lambda c, a: c.__setitem__(slice(None), a[:])))
+
+
+# CHECK-LABEL: TEST: the_types_that_do_compute_are_untouched
+# The guard keys on one flag, so the risk is that it catches more than f16.
+# CHECK: bf16 arith.addf: yes
+# CHECK: f32 arith.addf: yes
+print("\nTEST: the_types_that_do_compute_are_untouched")
+for name, dt in (("bf16", bf16), ("f32", f32)):
+    ir = str(trace(lambda c, a: c.__setitem__(slice(None), a[:] + a[:]), dtype=dt))
+    print(f"{name} arith.addf: {'yes' if 'arith.addf' in ir else 'NO'}")


### PR DESCRIPTION
Neither NPU generation has an fp16 instruction, scalar or vector — bf16 is the
16-bit float AIE2 and AIE2P implement. What made this worth a guard is not the
gap but how the gap presented: **nothing in the toolchain refused an f16
kernel**. It compiled, it ran, no legalizer complained, and it returned the
result of having read the f16 bit patterns as bf16.

Measured on npu1 before this change:

```
c[:] = a[:] + b[:]  over f16 buffers   wrong on 2048 of 2048 elements
f16 512.5 is 0x6001; 0x6001 read as bf16 is 1.0078125 x 2^65
the device returned                    3.718172e19
```

A silently wrong kernel with no error is the failure mode this package exists to
remove.

## Movable, not computable

The split is measured rather than assumed:

```
f16   dma  :    0/2048 differ   EXACT
f16   copy :    0/2048 differ   EXACT
f16   add  : 2048/2048 differ
```

A copy emits a read and a write and no arith op, so the bits arrive unchanged.
So f16 now behaves the way unsigned already does — declarable, allocatable and
movable, with only arithmetic refused. Refusing movement too would make f16
undeclarable rather than uncomputable, and a kernel that moves f16 data and
hands it to an `air.extern` kernel is a real thing to want.

`require_computable` mirrors `require_signless` and is called from the same four
sites that build an arith or linalg op: the elementwise emitter, `ops.dot`, the
micro-tiled fill, and `air.extern`'s scalar arguments. The message names the
hardware reason and the type to use instead — "not supported" alone would send
the reader looking for a missing feature in air.api rather than a missing
instruction in the core.

## Verification

- 17/17 api lits, including a new `python/test/api/no_fp16.py` that pins the
  refusals, the still-allowed copy, and that bf16/f32 are untouched.
- No example is affected: nothing under `programming_examples/` declares f16.
- The emitted IR of all 86 air.api example modules (npu1 and npu2) is
  byte-identical to main.

## Related, not fixed here

The same sweep found that **bf16 arithmetic rounds toward −∞ rather than to
nearest-even** — `add`, `sub` and `mul` all match a floor model on 2048/2048
elements. That is a separate defect with a separate cause
(`set.ctrl.reg(i32 6, i32 0)` emitted by mlir-aie's `AIECoreToStandard.cpp`),
and it is not addressed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)