### PR TITLE
[programming_examples] Drop the qwen decode's air.memtile_dma_channel_min floor

### DIFF
--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -1983,7 +1983,7 @@ def build_module():
                             ChannelGet("inKV_K", kb, indices=[idx(gi)])
                             ChannelGet("inKV_V", vb, indices=[idx(gi)])
                             for _lc, _cc in enumerate(_cus):
-                                _pk = ChannelPut(
+                                ChannelPut(
                                     "toK",
                                     kb,
                                     indices=[idx(_cc)],
@@ -1991,7 +1991,7 @@ def build_module():
                                     sizes=[idx(16), idx(16), idx(8)],
                                     strides=[idx(8), idx(_gw), idx(1)],
                                 )
-                                _pv = ChannelPut(
+                                ChannelPut(
                                     "toV",
                                     vb,
                                     indices=[idx(_cc)],
@@ -2004,18 +2004,6 @@ def build_module():
                                     sizes=[idx(2), idx(16), idx(8), idx(8)],
                                     strides=[idx(_gw * 8), idx(8), idx(_gw), idx(1)],
                                 )
-                                # Reserve mem_7_1 MM2S 0 for the q-broadcast (mem_6_1->qk)
-                                # + attn-o feedback (kv->mem_6_1) that transit col-7's
-                                # switchbox: KV on MM2S 0 collides with that transit and
-                                # deadlocks once attn actively couples qk<->kv. Mirror the
-                                # proven Llama _reblock_dec fix (col-3 there) -> steer toK/
-                                # toV onto memtile MM2S channels 1+.
-                                _pk.operation.attributes[
-                                    "air.memtile_dma_channel_min"
-                                ] = IntegerAttr.get(T.i32(), 1)
-                                _pv.operation.attributes[
-                                    "air.memtile_dma_channel_min"
-                                ] = IntegerAttr.get(T.i32(), 1)
                             DeallocOp(kb)
                             DeallocOp(vb)
                             yield_([])


### PR DESCRIPTION
Continues the derivable-pin retirement (after #1884 finished `air.shim_col`). The qwen engine's 4 live `air.memtile_dma_channel_min` instances are removed. The llama engine's 4 stay **for now** — not because they are legitimate, but because removing them exposes a defect in the memtile channel allocator that wants its own fix.

Both engines carried the same rationale: the KV staging memtile also carries a transiting q-broadcast, so KV on memtile MM2S 0 was said to collide with that transit and deadlock *"once attn actively couples qk<->kv"*. That is a **runtime** claim, so each arm was built and run on NPU2.

### qwen — removable

IR delta is exactly the 4 attributes on the `toK`/`toV` puts, nothing else. Without the floor, col 7 uses MM2S **0-3** instead of **1-3** — KV does take MM2S 0, precisely the condition the pin forbade — and nothing deadlocks:

| gate | result |
|---|---|
| `make verify` (top-k token-set vs HF bf16) | **PASS 2/2** |
| `make gen N_GEN=64` x3 | 25.23 / 25.28 / 25.12 tok/s, rc=0, no timeout or hang |

~256 decode tokens with qk↔kv coupled. The deadlock was described as deterministic once coupled; four clean runs falsify that for this design. Throughput matches the pinned baseline (mean 25.18 tok/s, same toolchain).

### llama — blocked on an allocator defect, not on a real constraint

Removing llama's floor is a hard compile failure in the pathfinder:

```
'aie.packet_flow' op packet flow source (5, 1) DMA0 could not be routed to
destination (1, 1) DMA2; the pathfinder produced an incomplete routing.
```

The whole-design delta between the two arms is four intra-column circuit flows out of the col-3 memtile shifting from MM2S 1-4 to 0-3. Packet flows are byte-identical. Perturbing just those four assignments in the emitted IR:

| col-3 memtile MM2S set | routes? |
|---|---|
| `{0,1,2,3}` — what the allocator picks unpinned | **fails** |
| `{1,2,3,4}` — what the pin forces | ok |
| `{4,1,2,3}` — move only the DMA0 flow | ok |
| `{0,3,4,5}` — DMA0 still used, others spread | ok |

So channel 0 is not special (`{0,3,4,5}` uses it and routes) and density is not fatal (`{1,2,3,4}` is contiguous and routes). Only the dense-from-zero block is unroutable — and that is exactly what the allocator produces:

```cpp
int avail = memtile_dma_channels - minCh;
chan = minCh + (num_allocs % avail);
```

`air.memtile_dma_channel_min` is a manual bias on the base of that round-robin. There is no routability awareness in `MemTileDMAAllocator` at all, whereas `TileDMAAllocator` and `ShimDMAAllocator` both gained a `spreadCollapsedPacketChannels` policy in #1862 / #1851. The memtile allocator is the one that never got it, and this pin is the hand-patch standing in for it.

### Follow-up: this is an mlir-aie bug, not an AIR cost-model gap

Chasing the A/B properly changes the conclusion. The raw IR diff between the two arms is **16 lines in 5439** — the four col-3 memtile flows and their four `dma_start`s shifting index. `packet_flow(7)` itself is byte-identical.

Sweeping all 15 four-channel subsets for that memtile gives a clean law: **fails iff channel 0 is used and channel 5 is free** (4 of 15 fail). Hardware would not care whether an unrelated channel is idle, which is the first sign this is not a real constraint.

It is not. Leaving col 3 on the "bad" `{0,1,2,3}` and instead perturbing an unrelated memtile three columns away makes the design route, confirmed on **aiecc's own router**, not just `aie-opt`:

| input | col 3 | col 6 | routing errors |
|---|---|---|---|
| baseline | `{0,1,2,3}` | `{0,1,2,3}` | 1 |
| col-6 perturbed | `{0,1,2,3}` unchanged | `{0,1,2,5}` | 0 |

So the col-3 pin encodes nothing about col 3. It is one arbitrary nudge among many that happen to make routing succeed. Cols 0, 6 and 7 all use the same dense `{0,1,2,3}` packing with no pin and no complaint.

The actual defect is in packet-flow materialisation. `Pathfinder::findPaths` **succeeds** — there is no "Unable to find a legal routing", so this is neither infeasibility nor an iteration-cap timeout. The failure is downstream in `AIECreatePathFindFlows.cpp`: for source `(5,1) DMA0`, every candidate connection at its own switchbox is rejected by the `findPathToDest` "reject false broadcast" filter, leaving `srcRouted == false`. The flow is a 3-way convergent gather — `(5,1)`, `(4,1)` and `(2,2)` sharing one `packetGroupId` into `(1,1) DMA2` — and convergent groups are the fragile case here; a 3-way convergent `@xnorm` merge previously became unroutable across an mlir-aie bump.

Consequences for this attribute:

- No `MemTileDMAAllocator` cost model should be written. AIR's mapping is legal; a policy tuned to dodge this would encode a router bug into the allocator and would be silently wrong the moment the router is fixed.
- Fix belongs in mlir-aie's convergent packet-group materialisation. Once it lands, llama's remaining 4 pins should delete with no AIR change at all.

`check-air-mlir` 513 passed, 0 failed. No compiler code changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
