### PR TITLE
[python] air.api: ops.fma, and the vector_fma example converted

### DIFF
--- a/programming_examples/axpy/axpy.py
+++ b/programming_examples/axpy/axpy.py
@@ -7,18 +7,14 @@ Computes out = alpha * x + y over a 1-D [N] vector.
 
 The DSL emits the herd, the L1 allocations, the affine tile offsets, the DMAs,
 and the vectorised compute loop; what it hands to the backend is an ordinary AIR
-module. `alpha * x_buf[:] + y_buf[:]` is a lazy expression tree that is lowered
-once, as a single vectorised loop, when it is assigned into out_buf.
+module. The right-hand side is a lazy expression tree that is lowered once, as a
+single loop, when it is assigned into out_buf.
 
-Two differences from the raw-bindings implementation this replaces, both
-deliberate:
-
-  - It emits arith.mulf + arith.addf where the predecessor hand-built a
-    vector.fma.
-  - The predecessor pinned a 2-core herd and cycled tiles across it. Here the
-    logical tile grid (N // tile_n) is strip-mined onto whatever the target
-    provides -- 4 cores on npu1, 8 on npu2 -- with each core owning a
-    contiguous block of tiles.
+One difference from the raw-bindings implementation this replaces, deliberate:
+the predecessor pinned a 2-core herd and cycled tiles across it, while here the
+logical tile grid (N // tile_n) is strip-mined onto whatever the target provides
+-- 4 cores on npu1, 8 on npu2 -- with each core owning a contiguous block of
+tiles.
 
 f32 runs scalar, and that is not a tuning choice. A *chained* f32
 multiply-then-add on 512-bit vectors does not legalize in the AIE2 backend:
@@ -30,6 +26,14 @@ own is fine -- f32 vector add, sub, mul and div all compile at 16 lanes, and so
 does `2.0 * x[:]` by itself -- so it is specifically the mul feeding an add.
 bf16 has no such problem and vectorises the whole expression. (bf16 *divide*
 does not legalize, but axpy does not divide.) Hence VECTOR_BY_DTYPE below.
+
+The fused form does not rescue f32 either, which is why the spelling below is
+conditional rather than simply `air.ops.fma` everywhere. A native f32
+`vector.fma` is explicitly marked illegal by the aievec conversion, and there
+is no scalar fma instruction on AIE2 at all -- so on the scalar path there is
+nothing to fuse into, and `alpha * x + y` remains the only expressible form.
+Vectorised bf16 takes the fused route and rounds once, which is what the
+hand-written predecessor did.
 """
 
 import argparse
@@ -101,7 +105,20 @@ def build_axpy(n, tile_n, alpha, dtype=bf16, herd_shape=None, vector=None):
                     air.ops.load(x_buf, x[window])
                     air.ops.load(y_buf, y[window])
 
-                    out_buf[:] = alpha * x_buf[:] + y_buf[:]
+                    # Fused when the emitter will vectorise, two ops when it
+                    # will not. The condition is exactly the emitter's own
+                    # test for taking the vector path, because ops.fma has no
+                    # scalar form to fall back to -- see the module docstring.
+                    # `vector` is None for "use the dtype's default", so the
+                    # width has to be resolved the same way air.alloc resolves
+                    # it; testing `vector` itself would read bf16's None as 0
+                    # and quietly take the unfused path on the one dtype that
+                    # can fuse.
+                    width = dtype.default_vector_width if vector is None else vector
+                    if width and tn % width == 0:
+                        out_buf[:] = air.ops.fma(alpha, x_buf[:], y_buf[:])
+                    else:
+                        out_buf[:] = alpha * x_buf[:] + y_buf[:]
 
                     air.ops.store(out_buf, out[window])
 

--- a/programming_examples/primitives/vector_examples/vector_fma/vector_fma.py
+++ b/programming_examples/primitives/vector_examples/vector_fma/vector_fma.py
@@ -1,137 +1,127 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Fused multiply-add primitive, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp, fma
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    out[:] = air.ops.fma(alpha, b[:], c[:])
+
+This is the fused half of a matched pair with ``vector_muladd``, which computes
+the same value as ``alpha * b[:] + c[:]``. The two exist to be compared, so the
+distinction has to survive the conversion: this one emits a single
+``vector.fma`` and rounds once, and muladd emits ``arith.mulf`` +
+``arith.addf`` and rounds twice. Writing ``alpha * b[:] + c[:]`` here would
+quietly turn this example into a duplicate of its sibling, which is why
+``air.api.ops.fma`` exists rather than the emitter pattern-matching the pair.
+
+The predecessor hand-rolled the vector loop: an ``scf.for`` over the tile in
+steps of VECTOR_SIZE, three ``memref.subview``s per trip, two
+``vector.transfer_read``s with an explicit identity permutation map and a
+padding constant, a ``vector.broadcast`` of alpha, ``vector.fma``, and a
+``transfer_write``. Here the emitter builds that loop and the subviews are not
+needed at all -- air.api reads at an offset directly -- while the arithmetic is
+unchanged.
+
+Two hardware constraints shape the configuration below. Both were measured by
+compiling, and both are enforced up front rather than left to fail deep in the
+backend:
+
+* **There is no scalar fma on AIE2.** ``math.fma`` reaches the backend and
+  fails to legalize (``unable to legalize instruction: (s16) = G_FMA``) on
+  npu1 and npu2, bf16 and f32, with and without emulation. So VECTOR_SIZE=0 is
+  not a valid configuration here, and neither is a tile that is not a multiple
+  of the vector width -- either would route the emitter into a scalar fallback
+  that cannot compile. This is the same trap ``math.tanh`` sprang on the
+  activations conversion, so it is refused rather than discovered.
+* **f32 needs bf16 emulation.** ``vector.fma`` on ``vector<16xf32>`` is
+  explicitly marked illegal by the aievec conversion. That is exactly the
+  configuration ``--bf16-emulation`` sets up, which is why this example's f32
+  mode is the emulated one and there is no native f32 mode. The predecessor
+  had the same shape for the same reason.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself, computing ``_l_ivx + _ty * tile_n``
+  through a hand-built AffineMap. Here the herd's iteration space is the whole
+  tile grid and air.api strip-mines it onto NUM_TILES cores.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(n, tile_n, np_dtype_in, alpha=2.0, vector_size=16):
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get([n], xrt_dtype_in)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    vecTy = VectorType.get([VECTOR_SIZE], xrt_dtype_in)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy, l3memrefTy)
-    def vector_fma(arg0, arg1, arg2):
-        # arg0 = b, arg1 = c, arg2 = output
-        # Computes: output = alpha * b + c (via vector.fma)
-
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1, arg2],
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_b,
-            _l3_c,
-            _l3_out,
-        ):
-            l1_b_data = AllocOp(l1MemrefTy, [], [])
-            l1_c_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+    # Refused here rather than at the vector.fma builder so that the message
+    # names the flag the user set. There is no scalar fma instruction on AIE2,
+    # so unlike every other primitive in this directory, the emitter's scalar
+    # fallback is a build failure rather than a slow but correct kernel.
+    if vector_size <= 0:
+        raise ValueError(
+            "vector_fma needs a positive --vector-size: AIE2 has no scalar fma "
+            "instruction, so the scalar fallback does not compile. Use "
+            "vector_muladd for a scalar-capable multiply-add"
+        )
+    if tile_n % vector_size:
+        raise ValueError(
+            f"tile size {tile_n} must be a multiple of the vector size "
+            f"{vector_size}: a partial tile would route the emitter onto its "
+            f"scalar path, which has no fma instruction to lower to"
+        )
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    B = air.tensor([n], dt)
+    C = air.tensor([n], dt)
+    OUT = air.tensor([n], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="vector_fma") as launch:
 
-                dma_memcpy_nd(
-                    l1_b_data,
-                    _l3_b,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_c_data,
-                    _l3_c,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                c0 = ConstantOp(index_type, 0)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    b = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
+                    out = air.alloc([tile_n], dt, scope=h.private(), vector=vector_size)
 
-                # Broadcast scalar alpha to vector
-                a_const = arith.ConstantOp(xrt_dtype_in, alpha)
-                v_a = BroadcastOp(vecTy, a_const)
+                    air.ops.load(b, B[i0 : i0 + tile_n])
+                    air.ops.load(c, C[i0 : i0 + tile_n])
 
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_b = subview(l1_b_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_c = subview(l1_c_data.result, [j], [VECTOR_SIZE], [1])
-                    sub_out = subview(l1_out_data.result, [j], [VECTOR_SIZE], [1])
+                    # One op on purpose, not two -- vector_muladd is the
+                    # unfused half of this pair. See the module docstring.
+                    out[:] = air.ops.fma(alpha, b[:], c[:])
 
-                    v_b = transfer_read(vecTy, sub_b, [c0], identity_map, cst0, [True])
-                    v_c = transfer_read(vecTy, sub_c, [c0], identity_map, cst0, [True])
+                    air.ops.store(out, OUT[i0 : i0 + tile_n])
 
-                    # alpha * b + c via vector.fma
-                    v_result = fma(v_a, v_b, v_c)
-                    transfer_write(None, v_result, sub_out, [c0], identity_map, [True])
-                    yield_([])
-
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out_data,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_c_data)
-                DeallocOp(l1_out_data)
-
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -177,7 +167,16 @@ if __name__ == "__main__":
         dest="bf16_emulation",
         default=False,
         action="store_true",
-        help="Use f32 input data type and emulate f32 vector arithmetic using bf16 operations.",
+        help="Use f32 input data type and emulate f32 vector arithmetic using "
+        "bf16 operations. This is the only way to run this example on f32: a "
+        "native f32 vector.fma is illegal in the aievec conversion.",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
 
     args = parser.parse_args()
@@ -186,9 +185,10 @@ if __name__ == "__main__":
         INPUT_DATATYPE = np.float32
     bf16_emulation = args.bf16_emulation
 
-    mlir_module = build_module(
+    launch = build_module(
         args.n, args.tile_n, INPUT_DATATYPE, args.alpha, args.vector_size
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -214,6 +214,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_fma",
+            target_device=launch.target,
             bf16_emulation=bf16_emulation,
             runtime_loop_tiling_sizes=[4, 4],
         )
@@ -232,6 +233,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             bf16_emulation=bf16_emulation,
             runtime_loop_tiling_sizes=[4, 4],
         )

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -462,10 +462,7 @@ def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
                 "that is (air.alloc(..., vector=W) with shape[-1] % W == 0), "
                 "or write a * b + c, which has a scalar form and rounds twice"
             )
-        a, b, c = (
-            _eval(arg, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
-            for arg in node.args
-        )
+        a, b, c = (recur(arg) for arg in node.args)
         return _result(vector_fma(a, b, c))
 
     if node.kind == "binary":

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -33,7 +33,12 @@ from air.dialects import arith
 from air.dialects import math as math_dialect
 from air.dialects.memref import load as memref_load, store as memref_store
 from air.dialects.scf import for_ as range_, yield_
-from air.dialects.vector import broadcast, transfer_read, transfer_write
+from air.dialects.vector import (
+    broadcast,
+    fma as vector_fma,
+    transfer_read,
+    transfer_write,
+)
 
 from .types import require_computable, require_signless
 
@@ -418,6 +423,50 @@ def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
     if node.kind == "select":
         cond, a, b = node.args
         return _result(arith.select(recur(cond), recur(a), recur(b)))
+
+    if node.kind == "fma":
+        # a * b + c as one operation, so the product is not rounded before it
+        # is added. Two separate arith ops round twice; the hand-written
+        # vector_fma and axpy kernels both spell vector.fma for that reason.
+        #
+        # There is no integer counterpart and none is needed: integer multiply
+        # and add are exact, so `a * b + c` already computes what an integer
+        # fma would, and MLIR has no arith.fmai to lower to.
+        if ops is _INT_OPS:
+            raise NotImplementedError(
+                "air.api.ops.fma is float-only: fusing the multiply and the "
+                "add exists to avoid the intermediate *rounding*, and integer "
+                "multiply-add has none to avoid. MLIR has no integer fma op "
+                f"to lower to, so on a {ety} buffer write a * b + c instead, "
+                "which computes the same thing"
+            )
+        # The scalar spelling would be math.fma, and it is refused rather than
+        # emitted because it does not compile: AIE2 has no scalar fma
+        # instruction, and `G_FMA` reaches the backend unlegalized. Measured on
+        # npu1 and npu2, bf16 and f32, with and without bf16 emulation -- all
+        # five fail with "unable to legalize instruction: (s16) = G_FMA".
+        #
+        # Emitting it anyway would repeat the math.tanh trap, where the
+        # emitter's usual correctness-first fallback -- drop to a scalar loop
+        # when the innermost dimension is not a multiple of the vector width --
+        # is the *unsafe* direction, turning a working kernel into a build
+        # failure whose error names an LLVM virtual register. Unlike tanh, this
+        # is caught here, where the tile shape that caused it can be named.
+        if not vectorized:
+            raise NotImplementedError(
+                "air.api.ops.fma has no scalar form on AIE2: there is no "
+                "scalar fma instruction, so math.fma reaches the backend and "
+                "fails to legalize. The emitter is on its scalar path here "
+                "because the destination's innermost dimension is not a "
+                "multiple of its vector width -- give the buffer a tile shape "
+                "that is (air.alloc(..., vector=W) with shape[-1] % W == 0), "
+                "or write a * b + c, which has a scalar form and rounds twice"
+            )
+        a, b, c = (
+            _eval(arg, ivs, ops, ety, vectorized, vec_ty, minor, pad, reads)
+            for arg in node.args
+        )
+        return _result(vector_fma(a, b, c))
 
     if node.kind == "binary":
         op = ops.get(node.op)

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -361,11 +361,14 @@ class BufferExpr:
     __slots__ = ("kind", "op", "args", "buffer", "scalar", "dtype")
 
     def __init__(self, kind, op=None, args=(), buffer=None, scalar=None, dtype=None):
-        # "buffer" | "scalar" | "unary" | "binary" evaluate to the element
-        # type; "compare" evaluates to i1 and only ops.select consumes it;
-        # "select" takes (compare, value, value) back to the element type;
+        # "buffer" | "scalar" | "unary" | "binary" | "fma" evaluate to the
+        # element type; "compare" evaluates to i1 and only ops.select consumes
+        # it; "select" takes (compare, value, value) back to the element type;
         # "cast" evaluates to a *different* element type from its operand,
         # which is the only node for which that is true.
+        #
+        # "fma" is the second ternary kind. Unlike "select", whose first
+        # argument is a predicate, all three of its arguments are value-typed.
         self.kind = kind
         self.op = op
         self.args = tuple(args)
@@ -573,6 +576,11 @@ class BufferExpr:
         if self.kind == "select":
             c, a, b = self.args
             return f"select({c!r}, {a!r}, {b!r})"
+        # The other ternary kind, and like select it needs its own branch: the
+        # tail below is binary and indexes exactly two args.
+        if self.kind == "fma":
+            a, b, c = self.args
+            return f"fma({a!r}, {b!r}, {c!r})"
         symbol = _OP_SYMBOLS.get(self.op)
         if symbol is None:
             # No infix spelling (maximum/minimum and anything added later):

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -44,6 +44,13 @@ __all__ = [
     "cast",
     "maximum",
     "minimum",
+    # equal/not_equal/select were added with the comparison operators and were
+    # never listed here, so `from air.api.ops import *` silently omitted them.
+    # Corrected while adding fma rather than left as a trap for the next entry.
+    "equal",
+    "not_equal",
+    "select",
+    "fma",
     "relu",
     "tanh",
     "sigmoid",
@@ -603,6 +610,65 @@ def select(cond, a, b):
             "argument is a scalar, which the emitter cannot shape"
         )
     return BufferExpr("select", op="select", args=(cond, a, b))
+
+
+def fma(a, b, c):
+    """Elementwise ``a * b + c`` as one operation. Lowers to vector.fma.
+    Float only, and **vectorised only** -- see the constraints below.
+
+    This is not a shorthand for ``a * b + c``: it is a different computation.
+    Writing the product and the sum as two arith ops rounds twice, once when
+    ``a * b`` is stored into an intermediate of the buffer's element type and
+    again after the add. An fma rounds once, carrying the full-width product
+    into the addition. On bf16, whose 8-bit significand loses the low half of
+    nearly every product, that is a difference you can see in the output
+    rather than a last-ulp curiosity.
+
+    Two constraints, both measured rather than assumed, and both narrower than
+    they first appear:
+
+    * **There is no scalar form.** AIE2 has no scalar fma instruction, so
+      math.fma reaches the backend and fails to legalize -- on npu1 and npu2,
+      bf16 and f32, with and without bf16 emulation. The emitter refuses its
+      own scalar fallback here rather than emitting one that cannot compile.
+    * **f32 needs bf16 emulation.** ``vector.fma`` on ``vector<16xf32>`` is
+      *explicitly marked illegal* by the aievec conversion, so a native f32
+      kernel fails with "failed to legalize operation 'vector.fma'". Under
+      ``bf16_emulation=True`` it lowers through bf16 and compiles.
+
+    So this does **not** rescue f32 from the limitation the axpy conversion
+    documents -- a chained f32 multiply-then-add does not legalize either
+    (``<16 x s32> = G_FMUL``), and f32 has no vectorised route to a
+    multiply-add by any spelling. What ops.fma buys is the single rounding on
+    bf16, which is what the hand-written vector_fma kernel was written for.
+
+    The third argument is the addend, matching C's ``fma(x, y, z)`` and MLIR's
+    operand order; there is no operator spelling because Python has none.
+    """
+    for operand, pos in ((a, "first"), (b, "second"), (c, "third")):
+        if not isinstance(operand, (Buffer, BufferExpr, int, float)):
+            raise TypeError(
+                f"air.api.ops.fma expects a buffer slice or a numeric scalar "
+                f"as its {pos} argument, got {type(operand).__name__}"
+            )
+        # A comparison is the one BufferExpr whose result is i1 rather than the
+        # element type. Only ops.select can consume one; feeding it to an fma
+        # would build an arith op over a predicate and fail deep in the MLIR
+        # verifier, naming an SSA value rather than the argument at fault.
+        if isinstance(operand, BufferExpr) and operand.kind == "compare":
+            raise TypeError(
+                f"air.api.ops.fma got a comparison as its {pos} argument. A "
+                "comparison is a predicate (i1), not a value, so it cannot be "
+                "multiplied or added -- pass it through air.api.ops.select "
+                "first to choose between two values"
+            )
+    a, b, c = BufferExpr.coerce(a), BufferExpr.coerce(b), BufferExpr.coerce(c)
+    if not a.leaves() and not b.leaves() and not c.leaves():
+        raise ValueError(
+            "air.api.ops.fma needs at least one buffer operand; every argument "
+            "is a scalar, which the emitter cannot shape"
+        )
+    return BufferExpr("fma", op="fma", args=(a, b, c))
 
 
 def _unary(name, x):

--- a/python/test/api/axpy.py
+++ b/python/test/api/axpy.py
@@ -69,6 +69,13 @@ def run(f):
 # CHECK: vector.transfer_write {{.*}} vector<16xbf16>
 # CHECK: air.dma_memcpy_nd
 # CHECK: memref.dealloc
+#
+# Note this is no longer op-for-op what programming_examples/axpy emits: that
+# example now spells the vectorised bf16 case air.ops.fma, which rounds once
+# instead of twice. What is pinned here is the DSL property the file is about
+# -- that a nested tree of operators lowers as one loop -- and `alpha * x + y`
+# is still exactly what axpy emits on its scalar paths. See api/fma.py for the
+# fused form.
 @run
 def axpy_vectorized():
     print(build(65536, 1024, 2.0, herd_shape=(4,)).mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1546,3 +1546,78 @@ def _():
         c[:] = ops.cast(ops.select(a[:] > 0.0, 1, 2), i32)
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: fma_on_an_integer_buffer
+# fma exists to avoid the intermediate rounding, and integer multiply-add has
+# none to avoid -- so this is not a gap to be filled later, and the message
+# says so and names the spelling that does work rather than implying that
+# an arith.fmai might arrive one day.
+# CHECK: NotImplementedError: air.api.ops.fma is float-only
+@expect(NotImplementedError, "fma_on_an_integer_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], i32, scope=h.private())
+        b = air.alloc([64], i32, scope=h.private())
+        a[:] = ops.fma(2, a[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: fma_has_no_scalar_form
+# The emitter's usual fallback -- drop to a scalar loop when the innermost
+# dimension is not a multiple of the vector width -- is the *unsafe* direction
+# here, exactly as it is for math.tanh: AIE2 has no scalar fma instruction, so
+# math.fma reaches the backend and fails to legalize. Unlike tanh, which is
+# emitted anyway and fails hours later with an LLVM virtual register in the
+# message, this is refused at the point where the tile shape can be named.
+# CHECK: NotImplementedError: air.api.ops.fma has no scalar form on AIE2
+@expect(NotImplementedError, "fma_has_no_scalar_form")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([60], bf16, scope=h.private(), vector=16)
+        b = air.alloc([60], bf16, scope=h.private(), vector=16)
+        a[:] = ops.fma(2.0, a[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: fma_of_a_comparison
+# A comparison is i1, not a value, so it can be selected between but not
+# multiplied. Caught at the call site: letting it through would build an
+# arith op over a predicate and fail in the MLIR verifier, which names an SSA
+# value rather than the argument at fault.
+# CHECK: TypeError: air.api.ops.fma got a comparison as its second argument
+@expect(TypeError, "fma_of_a_comparison")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        b = air.alloc([64], bf16, scope=h.private())
+        a[:] = ops.fma(2.0, a[:] > b[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: fma_of_only_scalars
+# Nothing supplies a shape, so there is no loop to build.
+# CHECK: ValueError: air.api.ops.fma needs at least one buffer operand
+@expect(ValueError, "fma_of_only_scalars")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        a[:] = ops.fma(2.0, 3.0, 4.0)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: fma_of_a_tensor_slice
+# An L3 tensor slice names a DMA region, not a value. The message names the
+# argument position, which matters more for a ternary op than a binary one.
+# CHECK: TypeError: air.api.ops.fma expects a buffer slice or a numeric scalar as its third argument
+@expect(TypeError, "fma_of_a_tensor_slice")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        a[:] = ops.fma(2.0, a[:], A[0:64, 0])
+
+    _trace(body)

--- a/python/test/api/fma.py
+++ b/python/test/api/fma.py
@@ -1,0 +1,151 @@
+# ./python/test/api/fma.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers ops.fma to a single vector.fma.
+
+The point of this op is that it is *not* a spelling of ``a * b + c``. Two arith
+ops round the product before adding it; one vector.fma does not. So most of
+what these tests pin is a negative -- no arith.mulf, no arith.addf -- because
+that is the property a future emitter change could silently lose while every
+numerical test still passed within tolerance.
+
+The matched pair is deliberate: vector_muladd emits the two-op form and
+vector_fma the fused one, and the last test here holds them side by side so
+that the difference is pinned rather than described in a comment.
+"""
+
+from air import api as air
+from air.api.types import bf16, f32, i32
+
+
+def build(body, dtype=bf16, N=65536, tile=1024, vector=16, herd_shape=(2,)):
+    b = air.tensor([N], dtype)
+    c = air.tensor([N], dtype)
+    out = air.tensor([N], dtype)
+
+    with air.launch(name="fma") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, N, tile), shape=herd_shape) as h:
+
+                @h.body
+                def _(tx):
+                    (tn,) = h.tile_sizes
+                    col = tx * tn
+                    b_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    c_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc([tn], dtype, scope=h.private(), vector=vector)
+                    air.ops.load(b_buf, b[col : col + tn])
+                    air.ops.load(c_buf, c[col : col + tn])
+                    o_buf[:] = body(b_buf, c_buf)
+                    air.ops.store(o_buf, out[col : col + tn])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: fma_is_a_single_op
+# alpha * b + c with the multiply fused into the add. The two CHECK-NOTs are
+# the whole test: an emitter that expanded this back into a mul and an add
+# would still produce numerically close output and would still pass every
+# tolerance-based check in the tree.
+# CHECK-NOT: arith.mulf
+# CHECK-NOT: arith.addf
+# CHECK: vector.broadcast {{.*}} : bf16 to vector<16xbf16>
+# CHECK: vector.fma {{.*}} : vector<16xbf16>
+@run
+def fma_is_a_single_op():
+    print(build(lambda b, c: air.ops.fma(2.0, b[:], c[:])).mlir())
+
+
+# CHECK-LABEL: TEST: fma_of_three_buffer_operands
+# No broadcast when nothing is a scalar: three transfer_reads feed one fma.
+# CHECK: vector.transfer_read
+# CHECK: vector.transfer_read
+# CHECK: vector.fma {{.*}} : vector<16xbf16>
+@run
+def fma_of_three_buffer_operands():
+    print(build(lambda b, c: air.ops.fma(b[:], c[:], b[:])).mlir())
+
+
+# CHECK-LABEL: TEST: fma_reads_a_repeated_buffer_once
+# b appears twice above and again here. The emitter's per-iteration read cache
+# is keyed on the buffer, so a buffer named more than once in one tree is read
+# once -- two reads for the two distinct buffers, not three for the three
+# mentions. Pinned because the fma node was the first ternary node whose
+# arguments are all value-typed, and a fresh traversal would be easy to write
+# without threading the cache through.
+# CHECK-COUNT-2: vector.transfer_read
+# CHECK-NOT: vector.transfer_read
+# CHECK: vector.fma
+@run
+def fma_reads_a_repeated_buffer_once():
+    print(build(lambda b, c: air.ops.fma(b[:], b[:], c[:])).mlir())
+
+
+# CHECK-LABEL: TEST: fma_composes_with_the_operators
+# An fma node is value-typed, so it nests inside an ordinary expression tree
+# and the whole thing still lowers as one loop. Here the fma feeds a multiply.
+# CHECK: vector.fma {{.*}} : vector<16xbf16>
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: vector.transfer_write
+@run
+def fma_composes_with_the_operators():
+    print(build(lambda b, c: air.ops.fma(2.0, b[:], c[:]) * 3.0).mlir())
+
+
+# CHECK-LABEL: TEST: fma_nests_inside_itself
+# fma(a, b, fma(...)) -- the addend is itself an fma, which is the shape a
+# polynomial evaluated by Horner's rule takes.
+# CHECK-COUNT-2: vector.fma {{.*}} : vector<16xbf16>
+@run
+def fma_nests_inside_itself():
+    print(
+        build(lambda b, c: air.ops.fma(2.0, b[:], air.ops.fma(3.0, c[:], b[:]))).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: fma_at_vector_width_32
+# The npu2 lits run VECTOR_SIZE=32. Both widths compile; this pins that the
+# width reaches the fma rather than only the transfer_read.
+# CHECK: vector.fma {{.*}} : vector<32xbf16>
+@run
+def fma_at_vector_width_32():
+    print(build(lambda b, c: air.ops.fma(2.0, b[:], c[:]), vector=32).mlir())
+
+
+# CHECK-LABEL: TEST: f32_fma_is_emitted_but_needs_bf16_emulation
+# The emitter has no reason to refuse f32 -- vector.fma over f32 is valid MLIR
+# and is what --bf16-emulation consumes. What rejects it is the aievec
+# conversion, which marks a native f32 vector.fma explicitly illegal ("failed
+# to legalize operation 'vector.fma'"). That is a backend decision the DSL
+# cannot see, and the error names the op, so it is left to the backend and
+# pinned here instead of guessed at.
+# CHECK: vector.fma {{.*}} : vector<16xf32>
+@run
+def f32_fma_is_emitted_but_needs_bf16_emulation():
+    print(build(lambda b, c: air.ops.fma(2.0, b[:], c[:]), dtype=f32).mlir())
+
+
+# CHECK-LABEL: TEST: the_unfused_pair_still_emits_two_ops
+# The other half of the matched pair, in the same file so the two cannot drift
+# apart unnoticed. vector_muladd depends on `alpha * b[:] + c[:]` continuing to
+# emit a separate mul and add; if some future rewrite fused them, that example
+# would become a duplicate of vector_fma and the comparison both exist for
+# would quietly stop being a comparison.
+# CHECK-NOT: vector.fma
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: arith.addf {{.*}} : vector<16xbf16>
+@run
+def the_unfused_pair_still_emits_two_ops():
+    print(build(lambda b, c: 2.0 * b[:] + c[:]).mlir())

--- a/python/test/api/fma.py
+++ b/python/test/api/fma.py
@@ -19,7 +19,7 @@ that the difference is pinned rather than described in a comment.
 """
 
 from air import api as air
-from air.api.types import bf16, f32, i32
+from air.api.types import bf16, f32
 
 
 def build(body, dtype=bf16, N=65536, tile=1024, vector=16, herd_shape=(2,)):


### PR DESCRIPTION
Adds a fused multiply-add to the DSL and moves
`programming_examples/primitives/vector_examples/vector_fma` onto it.

## Why the DSL needed a fused spelling

`vector_fma` and `vector_muladd` are a matched pair: both compute
`alpha * b + c`, and they exist so the fused and unfused forms can be
compared. Converting `vector_fma` as `alpha * b[:] + c[:]` would have made it
byte-for-byte identical to its sibling and silently deleted the comparison —
`vector_muladd`'s own docstring already says "vector_fma is the fused half of
this pair". So this is a case where the example needed new surface rather than
a workaround. `python/test/api/fma.py` holds both forms side by side so the
distinction is pinned rather than described in a comment.

`ops.fma` is a new ternary node kind — the second after `select`, and the
first whose arguments are all value-typed — lowering to `vector.fma`.

## Constraints, all measured by compiling

Two of the three turned out narrower than expected, and one contradicted what
I first wrote in the docstring.

* **There is no scalar fma on AIE2.** `math.fma` reaches the backend and fails
  to legalize (`unable to legalize instruction: (s16) = G_FMA`) on npu1 and
  npu2, bf16 and f32, with and without bf16 emulation — five for five. The
  emitter therefore refuses its own scalar fallback instead of emitting an op
  that cannot build. That fallback is normally the safe direction; for fma, as
  for `math.tanh` before it, it is the unsafe one. Unlike tanh this is caught
  where the offending tile shape can be named.
* **A native f32 `vector.fma` is explicitly marked illegal** by the aievec
  conversion. So this does *not* rescue f32 from the chained-multiply-add
  limitation the axpy conversion documents — f32 has no vectorised
  multiply-add by any spelling. It works only under `bf16_emulation=True`,
  which is exactly the mode the predecessor's fifth lit already exercised.
* **Integer fma is refused permanently, not pending.** Integer multiply-add is
  exact, so there is no intermediate rounding to avoid and no `arith.fmai` to
  lower to. The message says so rather than implying one might arrive.

## axpy

Updated in the same commit because it is where the gap was recorded: its
docstring listed "emits arith.mulf + arith.addf where the predecessor
hand-built a vector.fma" as a deliberate difference, which is no longer
necessary for vectorised bf16. The spelling is conditional on the emitter's
own vectorisation test, since the scalar and f32 paths still have nothing to
fuse into.

Also adds `equal`/`not_equal`/`select` to `ops.__all__`, which were omitted
when the comparison operators landed.

## Verification

* `vector_fma`'s two `ryzen_ai` lits pass on npu1 hardware, including the
  bf16-emulation one; the three npu2-only configurations compile clean.
* `axpy` passes on npu1, and `vector_muladd` still passes as a control.
* All 18 `python/test/api` suites green.
* The IR tests were checked against two mutations — expanding the fma back
  into a mul and an add, and disabling the per-buffer read cache — and both
  are caught, so the CHECK-NOTs are not vacuous.
* Byte-identity sweep over every air.api example on npu1 and npu2: 92
  identical, 2 differ, 2 new. The two that differ are axpy, and the diff is
  exactly the intended four-line substitution.

## Prior art

Checked against the obvious neighbours, since a fused elementwise MAC is a
recurring API question. NumPy has no `fma` (proposed in 2013, rejected as
scope creep), PyTorch has no `torch.fma` (`addcmul` is defined by allocation
behaviour rather than rounding), and TensorFlow leaves it to XLA. All three
rest on the premise that a downstream compiler will fuse `a*b+c` anyway,
which is false here — measured, `arith.mulf` feeding `arith.addf` stays two
ops through the whole pipeline. Triton, the nearest neighbour
architecturally, has exactly this split: `tl.dot(a, b, acc=...)` for the
contraction and a separate elementwise `tl.fma(x, y, z)`, which is the layout
air.api already had and this completes.