### PR TITLE
[python] air.api: reductions, and the two vector_examples converted

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_reduce_add/vector_reduce_add.py
+++ b/programming_examples/primitives/vector_examples/vector_reduce_add/vector_reduce_add.py
@@ -1,172 +1,94 @@
-# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Row-wise sum reduction, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview, collapse_shape
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    reduction,
-    extract,
-    CombiningKind,
-    broadcast,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.math import exp
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    out[m] = np.sum(a[m, :])
+
+The predecessor hand-rolled the row loop: an ``scf.for`` over the tile, two
+``memref.subview``s and two ``memref.collapse_shape``s per trip to turn a
+``[1, n]`` slice into a rank-1 ``memref<n>``, a ``vector.transfer_read`` with an
+explicit identity map and padding constant, ``vector.reduction``, and a scalar
+store. Here that is ``air.ops.reduce_add``: the emitter walks the rows, reads each
+one as a vector and reduces it, and the subviews and collapse_shapes are not
+needed at all -- air.api reads at an offset directly.
+
+A reduction is the DSL's only shape-changing operation, so it has to be the
+whole right-hand side. Its *operand* can still be an expression, which is how
+``ops.reduce_add(a[:] * b[:])`` would give a row-wise dot product; this example
+reduces a bare tile.
+
+The destination may keep the reduced axis (``[tile_m, 1]``, numpy's
+keepdims=True) or drop it (``[tile_m]``). This example drops it, so the L1 tile
+has the same rank as the ``[m]`` L3 output and the store is a plain transfer.
+The predecessor kept it in L1 and dropped it in the DMA instead, which is the
+same buffer either way.
+
+The whole row is read as one vector of extent n, exactly as the predecessor
+did. That is deliberate rather than incidental: stepping the row in
+vector-width chunks would need a loop-carried vector accumulator, which is the
+construct ``ops.dot`` documents as failing to legalize on AIE2. The cost is
+that n has to be a vector length the backend accepts -- 16 here, and 16 and
+32 are both known to work on npu1.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself through a hand-built AffineMap.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(m, n, tile_m, np_dtype_in):
-    a_size = [m, n]
-    out_size = [m]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert m % (tile_m * num_tiles) == 0
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3outputMemrefTy = MemRefType.get(out_size, xrt_dtype_in)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_m, n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1outputMemrefTy = MemRefType.get(
-        shape=[tile_m, 1],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
-    def vector_reduce_add(arg0, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg2],
+    assert m % (tile_m * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1outputMemrefTy, [], [])
 
-            for _l_ivx in range_(0, m, tile_m * num_tiles):
+    A = air.tensor([m, n], dt)
+    OUT = air.tensor([m], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_m),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="vector_reduce_add") as launch:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset, 0],
-                    src_sizes=[tile_m, n],
-                    src_strides=[n, 1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cTileN = ConstantOp(index_type, tile_m)
-                for j in range_(c0, cTileN, c1):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j, c0],
-                        [1, n],
-                        [1, 1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j, c0],
-                        [1, 1],
-                        [1, 1],
-                    )
-                    layout = StridedLayoutAttr.get(
-                        ShapedType.get_dynamic_size(),
-                        [
-                            1,
-                        ],
-                    )
-                    collapsed_type = MemRefType.get(
-                        (n,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapsed_type_2 = MemRefType.get(
-                        (1,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapse_dims = [[0, 1]]
-                    collapse_a = collapse_shape(
-                        collapsed_type, sub_a_vec, collapse_dims
-                    )
-                    collapse_c = collapse_shape(
-                        collapsed_type_2, sub_c_vec, collapse_dims
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([n], xrt_dtype_in),
-                        collapse_a,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c_red = reduction(xrt_dtype_in, CombiningKind.ADD, v_a)
-                    store(v_c_red, collapse_c, [c0])
-                    yield_([])
+        @launch.body
+        def _():
+            with air.herd(
+                [range(0, m, tile_m)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_m],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*: the herd's iteration space counts
+                    # tiles and h.tile_sizes carries the step.
+                    i0 = tx * tile_m
+                    a = air.alloc([tile_m, n], dt, scope=h.private())
+                    out = air.alloc([tile_m], dt, scope=h.private())
 
-                yield_([])
+                    air.ops.load(a, A[i0 : i0 + tile_m, :])
+                    out[:] = air.ops.reduce_add(a[:])
+                    air.ops.store(out, OUT[i0 : i0 + tile_m])
+
+    return launch
 
 
 if __name__ == "__main__":
-    # Default values.
     M = 65536
     N = 16
     TILE_M = 256
@@ -174,29 +96,17 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_reduce_add example",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-p",
-        "--print-module-only",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--m",
-        type=int,
-        default=M,
-        help="Input size (dimension M)",
-    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=M, help="Input size (dimension M)")
     parser.add_argument(
         "--n",
         type=int,
         default=N,
-        help="Input size (dimension N)",
+        help="Input size (dimension N), the axis reduced over. Read as a single "
+        "vector, so it must be a vector length the backend accepts.",
     )
     parser.add_argument("--tile-m", type=int, default=TILE_M, help="Tile size M")
     parser.add_argument(
@@ -215,15 +125,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.m,
-        args.n,
-        args.tile_m,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.m, args.n, args.tile_m, INPUT_DATATYPE)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -233,30 +146,28 @@ if __name__ == "__main__":
     )
 
     if args.compile_mode == "compile-and-run":
-
-        # Stochastically sample num_sample results, and pass to XRTRunner backend for verification.
+        # Stochastically sample num_sample results, and pass to XRTRunner
+        # backend for verification.
         num_samples = 100
         sampled_indices = np.vstack([np.random.randint(0, args.m, num_samples)])
 
-        # Compute reference results for sampled indices
         sampled_values = np.array(
             [np.sum(input_a[i]) for i in zip(*sampled_indices)],
             dtype=INPUT_DATATYPE,
         )
 
-        # Store as a dictionary
         sampled_data = {
             "shape": (args.m,),
             "indices": sampled_indices,
             "values": sampled_values,
         }
 
-        ###### Compile and test
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_reduce_add",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -269,13 +180,12 @@ if __name__ == "__main__":
         )
 
     elif args.compile_mode == "compile-only":
-        ###### Compile only
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)
-
         backend.unload()

--- a/programming_examples/primitives/vector_examples/vector_reduce_max/vector_reduce_max.py
+++ b/programming_examples/primitives/vector_examples/vector_reduce_max/vector_reduce_max.py
@@ -1,174 +1,94 @@
-# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Row-wise maximum reduction, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview, collapse_shape
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    reduction,
-    extract,
-    CombiningKind,
-    broadcast,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.math import exp
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    out[m] = np.max(a[m, :])
+
+The predecessor hand-rolled the row loop: an ``scf.for`` over the tile, two
+``memref.subview``s and two ``memref.collapse_shape``s per trip to turn a
+``[1, n]`` slice into a rank-1 ``memref<n>``, a ``vector.transfer_read`` with an
+explicit identity map and padding constant, ``vector.reduction``, and a scalar
+store. Here that is ``air.ops.reduce_max``: the emitter walks the rows, reads each
+one as a vector and reduces it, and the subviews and collapse_shapes are not
+needed at all -- air.api reads at an offset directly.
+
+A reduction is the DSL's only shape-changing operation, so it has to be the
+whole right-hand side. Its *operand* can still be an expression, which is how
+``ops.reduce_add(a[:] * b[:])`` would give a row-wise dot product; this example
+reduces a bare tile.
+
+The destination may keep the reduced axis (``[tile_m, 1]``, numpy's
+keepdims=True) or drop it (``[tile_m]``). This example drops it, so the L1 tile
+has the same rank as the ``[m]`` L3 output and the store is a plain transfer.
+The predecessor kept it in L1 and dropped it in the DMA instead, which is the
+same buffer either way.
+
+The whole row is read as one vector of extent n, exactly as the predecessor
+did. That is deliberate rather than incidental: stepping the row in
+vector-width chunks would need a loop-carried vector accumulator, which is the
+construct ``ops.dot`` documents as failing to legalize on AIE2. The cost is
+that n has to be a vector length the backend accepts -- 32 here, and 16 and
+32 are both known to work on npu1.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's. The predecessor asked for a [1, NUM_TILES] herd
+  and then wrote the outer loop itself through a hand-built AffineMap.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
 def build_module(m, n, tile_m, np_dtype_in):
-    a_size = [m, n]
-    out_size = [m]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert m % (tile_m * num_tiles) == 0
-    VECTOR_SIZE = 16
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3outputMemrefTy = MemRefType.get(out_size, xrt_dtype_in)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_m, n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1outputMemrefTy = MemRefType.get(
-        shape=[tile_m, 1],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
-    def vector_reduce_max(arg0, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg2],
+    assert m % (tile_m * NUM_TILES) == 0
+    dt = dtype_of(np_dtype_in)
+    if dt is None:
+        raise ValueError(
+            f"unsupported element type {np_dtype_in!r}; air.api knows "
+            f"float32, float16, bfloat16, int8/16/32 and uint8/16/32"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1outputMemrefTy, [], [])
 
-            for _l_ivx in range_(0, m, tile_m * num_tiles):
+    A = air.tensor([m, n], dt)
+    OUT = air.tensor([m], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_m),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="vector_reduce_max") as launch:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset, 0],
-                    src_sizes=[tile_m, n],
-                    src_strides=[n, 1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_m)
-                for j in range_(c0, cTileN, c1):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j, c0],
-                        [1, n],
-                        [1, 1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j, c0],
-                        [1, 1],
-                        [1, 1],
-                    )
-                    layout = StridedLayoutAttr.get(
-                        ShapedType.get_dynamic_size(),
-                        [
-                            1,
-                        ],
-                    )
-                    collapsed_type = MemRefType.get(
-                        (n,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapsed_type_2 = MemRefType.get(
-                        (1,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapse_dims = [[0, 1]]
-                    collapse_a = collapse_shape(
-                        collapsed_type, sub_a_vec, collapse_dims
-                    )
-                    collapse_c = collapse_shape(
-                        collapsed_type_2, sub_c_vec, collapse_dims
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([n], xrt_dtype_in),
-                        collapse_a,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    v_c_red = reduction(xrt_dtype_in, CombiningKind.MAXIMUMF, v_a)
-                    store(v_c_red, collapse_c, [c0])
-                    yield_([])
+        @launch.body
+        def _():
+            with air.herd(
+                [range(0, m, tile_m)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_m],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*: the herd's iteration space counts
+                    # tiles and h.tile_sizes carries the step.
+                    i0 = tx * tile_m
+                    a = air.alloc([tile_m, n], dt, scope=h.private())
+                    out = air.alloc([tile_m], dt, scope=h.private())
 
-                yield_([])
+                    air.ops.load(a, A[i0 : i0 + tile_m, :])
+                    out[:] = air.ops.reduce_max(a[:])
+                    air.ops.store(out, OUT[i0 : i0 + tile_m])
+
+    return launch
 
 
 if __name__ == "__main__":
-    # Default values.
     M = 65536
     N = 32
     TILE_M = 256
@@ -176,29 +96,17 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_reduce_max example",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-p",
-        "--print-module-only",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--m",
-        type=int,
-        default=M,
-        help="Input size (dimension M)",
-    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--m", type=int, default=M, help="Input size (dimension M)")
     parser.add_argument(
         "--n",
         type=int,
         default=N,
-        help="Input size (dimension N)",
+        help="Input size (dimension N), the axis reduced over. Read as a single "
+        "vector, so it must be a vector length the backend accepts.",
     )
     parser.add_argument("--tile-m", type=int, default=TILE_M, help="Tile size M")
     parser.add_argument(
@@ -217,15 +125,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.m,
-        args.n,
-        args.tile_m,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.m, args.n, args.tile_m, INPUT_DATATYPE)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -235,30 +146,28 @@ if __name__ == "__main__":
     )
 
     if args.compile_mode == "compile-and-run":
-
-        # Stochastically sample num_sample results, and pass to XRTRunner backend for verification.
+        # Stochastically sample num_sample results, and pass to XRTRunner
+        # backend for verification.
         num_samples = 100
         sampled_indices = np.vstack([np.random.randint(0, args.m, num_samples)])
 
-        # Compute reference results for sampled indices
         sampled_values = np.array(
             [np.max(input_a[i]) for i in zip(*sampled_indices)],
             dtype=INPUT_DATATYPE,
         )
 
-        # Store as a dictionary
         sampled_data = {
             "shape": (args.m,),
             "indices": sampled_indices,
             "values": sampled_values,
         }
 
-        ###### Compile and test
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_reduce_max",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -271,13 +180,12 @@ if __name__ == "__main__":
         )
 
     elif args.compile_mode == "compile-only":
-        ###### Compile only
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)
-
         backend.unload()

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -28,14 +28,16 @@ type, the arith table, the vector type and the padding constant) so they can be
 looked up per node rather than threaded down the walk.
 """
 
-from air.ir import AffineDimExpr, AffineMap, AffineMapAttr, VectorType
+from air.ir import AffineDimExpr, AffineMap, AffineMapAttr, IndexType, VectorType
 from air.dialects import arith
 from air.dialects import math as math_dialect
 from air.dialects.memref import load as memref_load, store as memref_store
 from air.dialects.scf import for_ as range_, yield_
 from air.dialects.vector import (
+    CombiningKind,
     broadcast,
     fma as vector_fma,
+    reduction,
     transfer_read,
     transfer_write,
 )
@@ -103,6 +105,12 @@ _INT_OPS = {
 # Named so the failure can say *why*, not just "not supported for dtype float".
 _BITWISE = ("and", "or", "xor")
 
+# vector.reduction combining kinds. maximumf mirrors the elementwise _FLOAT_OPS
+# choice of arith.maximumf over maxnumf; the signed integer form matches the
+# rest of air.api's integer dtypes, and unsigned never reaches here.
+_REDUCE_F = {"add": CombiningKind.ADD, "max": CombiningKind.MAXIMUMF}
+_REDUCE_I = {"add": CombiningKind.ADD, "max": CombiningKind.MAXSI}
+
 
 def _check_region(node, dst, dtype, expected=None):
     """Check every buffer leaf against the element type of *its* region.
@@ -166,6 +174,13 @@ def _regions_in(node, dtype, out):
 
 def emit_elementwise(dst, expr):
     """Emit ``dst[:] = expr`` as a loop nest over ``dst``'s shape."""
+    # A reduction is the one right-hand side whose shape is not the
+    # destination's, so it is dispatched before the elementwise shape check
+    # rather than being taught to it.
+    if expr.kind == "reduce":
+        _emit_reduce(dst, expr)
+        return
+
     # A bare scalar on the right-hand side is a fill (`acc[:] = 0.0`), which is
     # how an accumulator is zeroed before a K loop. It needs no leaves: the
     # destination supplies the shape.
@@ -257,6 +272,87 @@ class _Region:
             if vectorized
             else None
         )
+
+
+def _emit_reduce(dst, expr):
+    """Emit ``dst[:] = ops.reduce_*(src)`` -- one vector.reduction per row.
+
+    The destination keeps the operand's rank with the innermost dimension set
+    to 1 (numpy's ``keepdims=True``), so the loop nest walks the outer
+    dimensions and each trip reduces one whole innermost axis.
+
+    That axis is read as a *single* vector of its full extent rather than in
+    steps of the destination's vector width. This is what the hand-written
+    kernels do, and it is the reason there is no accumulator here: stepping
+    would need a loop-carried vector accumulator, which is exactly the
+    construct ``ops.dot`` documents as failing to legalize on AIE2 (LLVM
+    splits it into sub-512-bit pieces). The cost is that the reduced axis has
+    to be a vector length the backend accepts.
+    """
+    operand = expr.args[0]
+    dtype = dst.dtype
+    require_computable(dtype, "air.api.ops.reduce_add / reduce_max")
+    require_signless(dtype, "air.api.ops.reduce_add / reduce_max")
+
+    # The source shape is the destination's with the innermost extent taken
+    # from the operand's own leaves: that dimension is what gets collapsed, so
+    # it is the one thing the destination cannot tell us.
+    leaves = operand.leaves()
+    src_shape = leaves[0].shape
+    for leaf in leaves:
+        if leaf.shape != src_shape:
+            raise ValueError(
+                f"shape mismatch inside a reduction: operands have shapes "
+                f"{src_shape} and {leaf.shape}"
+            )
+        if leaf.dtype is not dtype:
+            raise ValueError(
+                f"dtype mismatch in elementwise assignment: destination is "
+                f"{dtype} but operand is {leaf.dtype}"
+            )
+        if leaf.value is None:
+            raise RuntimeError(
+                "buffer used before allocation; air.alloc() must be called "
+                "inside the herd body that uses it"
+            )
+
+    # Two destination spellings are accepted, matching numpy's keepdims:
+    #   [.., n] -> [.., 1]  keeps the reduced axis (keepdims=True)
+    #   [.., n] -> [..]     drops it (keepdims=False)
+    # Both occur in the kernels this replaces, and in the *same* kernel: the
+    # hand-written reduce_add allocates its L1 tile [tile_m, 1] but declares
+    # the L3 output [m], so whichever spelling the DSL refused would have
+    # forced the example to change shape somewhere.
+    kept = tuple(list(src_shape[:-1]) + [1])
+    dropped = tuple(src_shape[:-1])
+    keepdims = tuple(dst.shape) == kept
+    if not keepdims and tuple(dst.shape) != dropped:
+        raise ValueError(
+            f"shape mismatch in a reduction: reducing {src_shape} along its "
+            f"innermost axis gives {kept} (keeping the axis) or {dropped} "
+            f"(dropping it), but the destination is {tuple(dst.shape)}"
+        )
+
+    lanes = src_shape[-1]
+    rank = len(src_shape)
+    minor = AffineMapAttr.get(AffineMap.get(rank, 0, [AffineDimExpr.get(rank - 1)]))
+    regions = {d: _Region(d, lanes, True) for d in _regions_in(operand, dtype, [])}
+    kind = (_REDUCE_F if dtype.is_float else _REDUCE_I)[expr.op]
+
+    # Index-typed 0 for the collapsed axis: it is both where the whole
+    # row is read from and where the scalar result is stored.
+    zero = _result(arith.ConstantOp(IndexType.get(), 0))
+    bounds = [(0, extent, 1) for extent in src_shape[:-1]]
+
+    def body(ivs):
+        reads = {}
+        value = _eval(
+            operand, ivs + [zero], regions[dtype], regions, True, minor, reads
+        )
+        scalar = _result(reduction(dtype.mlir(), kind, value))
+        memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
+
+    _nest(bounds, body)
 
 
 def _emit_vector(dst, expr, width):

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -277,9 +277,9 @@ class _Region:
 def _emit_reduce(dst, expr):
     """Emit ``dst[:] = ops.reduce_*(src)`` -- one vector.reduction per row.
 
-    The destination keeps the operand's rank with the innermost dimension set
-    to 1 (numpy's ``keepdims=True``), so the loop nest walks the outer
-    dimensions and each trip reduces one whole innermost axis.
+    The destination is the operand with its innermost axis collapsed -- kept
+    as 1 or dropped, see the shape check below -- so the loop nest walks the
+    outer dimensions and each trip reduces one whole innermost axis.
 
     That axis is read as a *single* vector of its full extent rather than in
     steps of the destination's vector width. This is what the hand-written

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -369,6 +369,12 @@ class BufferExpr:
         #
         # "fma" is the second ternary kind. Unlike "select", whose first
         # argument is a predicate, all three of its arguments are value-typed.
+        #
+        # "reduce" is the only node whose *shape* differs from its operand's:
+        # it collapses the innermost dimension to 1. Everything else here is
+        # elementwise, which is why the emitter can check leaf shapes against
+        # the destination, and why a reduce has to be the whole right-hand
+        # side rather than nesting inside a larger expression.
         self.kind = kind
         self.op = op
         self.args = tuple(args)
@@ -581,6 +587,8 @@ class BufferExpr:
         if self.kind == "fma":
             a, b, c = self.args
             return f"fma({a!r}, {b!r}, {c!r})"
+        if self.kind == "reduce":
+            return f"reduce_{self.op}({self.args[0]!r})"
         symbol = _OP_SYMBOLS.get(self.op)
         if symbol is None:
             # No infix spelling (maximum/minimum and anything added later):

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -51,6 +51,8 @@ __all__ = [
     "not_equal",
     "select",
     "fma",
+    "reduce_add",
+    "reduce_max",
     "relu",
     "tanh",
     "sigmoid",
@@ -669,6 +671,65 @@ def fma(a, b, c):
             "is a scalar, which the emitter cannot shape"
         )
     return BufferExpr("fma", op="fma", args=(a, b, c))
+
+
+def _reduce(name, key, x):
+    if not isinstance(x, (Buffer, BufferExpr)):
+        raise TypeError(
+            f"air.api.ops.{name} expects a buffer slice, got {type(x).__name__}"
+        )
+    expr = BufferExpr.coerce(x)
+    if expr.kind == "compare":
+        raise TypeError(
+            f"air.api.ops.{name} got a comparison, which is a predicate (i1) "
+            "rather than a value. Pass it through air.api.ops.select first"
+        )
+    if expr.kind == "reduce":
+        raise NotImplementedError(
+            f"air.api.ops.{name} cannot reduce a reduction: the inner one has "
+            "already collapsed the innermost dimension to 1, so the outer one "
+            "would be a no-op over a single element. Reducing a second axis is "
+            "not supported -- store the first result and reduce that"
+        )
+    if not expr.leaves():
+        raise ValueError(
+            f"air.api.ops.{name} needs a buffer operand, got a scalar; there "
+            "is no shape to reduce over"
+        )
+    return BufferExpr("reduce", op=key, args=(expr,))
+
+
+def reduce_add(x):
+    """Sum along the innermost axis. Lowers to vector.reduction <add>.
+
+    The destination keeps the operand's rank with its innermost dimension set
+    to 1, which is numpy's ``keepdims=True`` and is what the hand-written
+    kernels allocate (``[tile_m, n]`` in, ``[tile_m, 1]`` out)::
+
+        acc = air.alloc([tile_m, 1], bf16, scope=h.private())
+        acc[:] = air.ops.reduce_add(a[:])
+
+    This is the only shape-changing operation in the expression language, so
+    it has to be the whole right-hand side -- it cannot appear inside a larger
+    expression, because the surrounding elementwise ops would be operating on
+    two different shapes. Its *operand* may be any elementwise expression,
+    which is what makes ``reduce_add(a[:] * b[:])`` a row-wise dot product.
+
+    The whole innermost axis is read as a single vector, matching the
+    predecessor kernels: there is no accumulation loop, and therefore no
+    loop-carried vector accumulator, which is the construct ``ops.dot``
+    documents as unlegalizable on AIE2. The cost is that the axis length has
+    to be a vector width the target accepts.
+    """
+    return _reduce("reduce_add", "add", x)
+
+
+def reduce_max(x):
+    """Maximum along the innermost axis. Lowers to vector.reduction <maximumf>
+    (float) or <maxsi> (signed integer). See :func:`reduce_add` for the shape
+    rule and why the reduction must be the whole right-hand side.
+    """
+    return _reduce("reduce_max", "max", x)
 
 
 def _unary(name, x):

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -20,13 +20,18 @@ Elementwise compute ops (``maximum``, ``minimum``, ``relu``, ``tanh``, and the
 ``sigmoid``/``silu``/``gelu`` compositions built on them) build lazy expression
 nodes instead, and return a :class:`~air.api._value.BufferExpr`.
 
+``reduce_add`` and ``reduce_max`` build such a node too, but it is the one whose
+shape differs from its operand's: it collapses the innermost axis. That is why a
+reduction has to be the whole right-hand side rather than nesting inside a
+larger expression.
+
 ``dot`` is a statement rather than an expression: it accumulates into a buffer
 and returns a Token, matching the signature the API proposal specified. On rank-6
 (micro-tiled) operands it becomes the blocked contraction the AIE2 matmul
 intrinsic wants; see ``air.api._pack``.
 
-The remaining compute ops from the wider API proposal (``reduce``, ``exp``,
-``stack``, ``dequant``, ``atomic_add``) are not implemented. They raise rather
+The remaining compute ops from the wider API proposal (``exp``, ``stack``,
+``dequant``, ``atomic_add``) are not implemented. They raise rather
 than returning a plausible-looking placeholder: a DSL that accepts an op it
 cannot lower produces a kernel that runs and is silently wrong. ``exp`` is on
 that list by choice rather than by oversight -- the activations here are composed
@@ -702,12 +707,24 @@ def _reduce(name, key, x):
 def reduce_add(x):
     """Sum along the innermost axis. Lowers to vector.reduction <add>.
 
-    The destination keeps the operand's rank with its innermost dimension set
-    to 1, which is numpy's ``keepdims=True`` and is what the hand-written
-    kernels allocate (``[tile_m, n]`` in, ``[tile_m, 1]`` out)::
+    The destination is the operand with its innermost axis collapsed, spelled
+    either way -- keeping the axis as 1 (numpy's ``keepdims=True``) or
+    dropping it::
 
-        acc = air.alloc([tile_m, 1], bf16, scope=h.private())
+        out = air.alloc([tile_m], bf16, scope=h.private())      # dropped
+        out[:] = air.ops.reduce_add(a[:])                       # a is [tile_m, n]
+
+        acc = air.alloc([tile_m, 1], bf16, scope=h.private())   # kept
         acc[:] = air.ops.reduce_add(a[:])
+
+    Both exist because the hand-written kernels use both at once: their L1
+    tile is ``[tile_m, 1]`` while their L3 output is ``[m]``.
+
+    Prefer dropping the axis unless something downstream wants it. ``ops.store``
+    squeezes *leading* unit dimensions but not trailing ones, so a kept-axis
+    ``[tile_m, 1]`` tile cannot be stored into a rank-1 ``[m]`` slice -- which
+    is the DMA those kernels write. Dropping it keeps the L1 tile the same rank
+    as the L3 output and sidesteps that entirely.
 
     This is the only shape-changing operation in the expression language, so
     it has to be the whole right-hand side -- it cannot appear inside a larger
@@ -726,8 +743,9 @@ def reduce_add(x):
 
 def reduce_max(x):
     """Maximum along the innermost axis. Lowers to vector.reduction <maximumf>
-    (float) or <maxsi> (signed integer). See :func:`reduce_add` for the shape
-    rule and why the reduction must be the whole right-hand side.
+    (float) or <maxsi> (signed integer). See :func:`reduce_add` for the two
+    destination spellings and why the reduction must be the whole right-hand
+    side.
     """
     return _reduce("reduce_max", "max", x)
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1598,6 +1598,33 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: reduce_of_a_scalar
+# Nothing supplies an axis to reduce over. Caught by the operand type check
+# rather than the leaf check -- a bare float never becomes a BufferExpr at all.
+# CHECK: TypeError: air.api.ops.reduce_add expects a buffer slice, got float
+@expect(TypeError, "reduce_of_a_scalar")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        a[:] = ops.reduce_add(2.0)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: reduce_of_a_comparison
+# A comparison is i1, a predicate rather than a value, so there is nothing
+# meaningful to sum or maximise.
+# CHECK: TypeError: air.api.ops.reduce_add got a comparison
+@expect(TypeError, "reduce_of_a_comparison")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], bf16, scope=h.private())
+        b = air.alloc([64], bf16, scope=h.private())
+        b[:] = ops.reduce_add(a[:] > 0.0)
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: fma_of_only_scalars
 # Nothing supplies a shape, so there is no loop to build.
 # CHECK: ValueError: air.api.ops.fma needs at least one buffer operand
@@ -1606,6 +1633,21 @@ def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([64], bf16, scope=h.private())
         a[:] = ops.fma(2.0, 3.0, 4.0)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: reduce_of_a_reduce
+# The inner reduction has already collapsed the innermost axis to 1, so the
+# outer one would reduce a single element. Reducing a second axis is a
+# different feature, and the message says so rather than silently no-opping.
+# CHECK: NotImplementedError: air.api.ops.reduce_add cannot reduce a reduction
+@expect(NotImplementedError, "reduce_of_a_reduce")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], bf16, scope=h.private())
+        b = air.alloc([64], bf16, scope=h.private())
+        b[:] = ops.reduce_add(ops.reduce_add(a[:]))
 
     _trace(body)
 
@@ -1619,5 +1661,34 @@ def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([64], bf16, scope=h.private())
         a[:] = ops.fma(2.0, a[:], A[0:64, 0])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: reduce_into_the_wrong_shape
+# The destination must be the operand with its innermost axis collapsed --
+# either kept as 1 or dropped. Anything else is named with both alternatives,
+# because which one the caller wanted is not inferable.
+# CHECK: ValueError: shape mismatch in a reduction
+@expect(ValueError, "reduce_into_the_wrong_shape")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], bf16, scope=h.private())
+        b = air.alloc([64, 16], bf16, scope=h.private())
+        b[:] = ops.reduce_add(a[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: reduce_on_an_unsigned_buffer
+# Same rule as every other arith-building path: vector.reduction's combining
+# kinds are signed, and a ui8 operand does not verify.
+# CHECK: NotImplementedError: air.api.ops.reduce_add / reduce_max is not supported for air.api.ui8
+@expect(NotImplementedError, "reduce_on_an_unsigned_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], ui8, scope=h.private())
+        b = air.alloc([64], ui8, scope=h.private())
+        b[:] = ops.reduce_add(a[:])
 
     _trace(body)

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -1,0 +1,140 @@
+# ./python/test/api/reduce.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers ops.reduce_add / reduce_max to vector.reduction.
+
+A reduction is the DSL's only shape-changing node -- every other node is
+elementwise, so the emitter checks leaf shapes against the destination. What
+these pin is mostly that consequence: which axis is collapsed, that both
+keepdims spellings work, and that the row is read as a *single* vector with no
+accumulator, since a loop-carried vector accumulator is the construct AIE2
+cannot legalize.
+"""
+
+from air import api as air
+from air.api.types import bf16, i32
+
+
+def build(body, dtype=bf16, M=65536, N=16, tile=256, out_shape=None):
+    A = air.tensor([M, N], dtype)
+    OUT = air.tensor([M], dtype)
+
+    with air.launch(name="red") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, M, tile), shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    (tm,) = h.tile_sizes
+                    row = tx * tm
+                    a = air.alloc([tm, N], dtype, scope=h.private())
+                    o = air.alloc(out_shape or [tm], dtype, scope=h.private())
+                    air.ops.load(a, A[row : row + tm, :])
+                    o[:] = body(a)
+                    air.ops.store(o, OUT[row : row + tm])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: reduce_add_is_one_vector_read_and_one_reduction
+# The row is read whole -- vector<16xbf16> for an N of 16 -- and reduced in one
+# op. No scf.for over the row, and so no loop-carried vector accumulator: that
+# is the construct ops.dot documents as unlegalizable on AIE2, and reading the
+# full extent is how the hand-written kernel avoids it too.
+# CHECK: vector.transfer_read {{.*}} vector<16xbf16>
+# CHECK: vector.reduction <add>, {{.*}} : vector<16xbf16> into bf16
+# CHECK: memref.store
+@run
+def reduce_add_is_one_vector_read_and_one_reduction():
+    print(build(lambda a: air.ops.reduce_add(a[:])).mlir())
+
+
+# CHECK-LABEL: TEST: reduce_max_uses_maximumf_on_floats
+# maximumf, not maxnumf -- the same choice the elementwise ops.maximum makes,
+# and the form known to legalize on AIE2.
+# CHECK: vector.reduction <maximumf>, {{.*}} : vector<16xbf16> into bf16
+@run
+def reduce_max_uses_maximumf_on_floats():
+    print(build(lambda a: air.ops.reduce_max(a[:])).mlir())
+
+
+# CHECK-LABEL: TEST: reduce_max_uses_maxsi_on_integers
+# The signed integer form: air.api's integer dtypes are signed, and an unsigned
+# buffer is refused before it reaches here.
+# CHECK: vector.reduction <maxsi>, {{.*}} : vector<16xi32> into i32
+@run
+def reduce_max_uses_maxsi_on_integers():
+    print(build(lambda a: air.ops.reduce_max(a[:]), dtype=i32).mlir())
+
+
+# CHECK-LABEL: TEST: keepdims_stores_at_the_collapsed_index
+# Destination [tm, 1] rather than [tm]: the reduced axis is kept, numpy's
+# keepdims=True, and the scalar is stored at index 0 of it.
+#
+# Note the L3 output here is [M, 1], not [M]. ops.store squeezes *leading*
+# unit dimensions but not trailing ones, so a [tm, 1] L1 tile cannot currently
+# be stored into a rank-1 [m] slice -- which is exactly what the hand-written
+# reduce kernel does in its DMA. That is why the converted examples drop the
+# axis instead: it keeps the L1 tile the same rank as the L3 output. Both
+# spellings of the reduction work; only this pairing of the two is unsupported.
+# CHECK: memref.alloc() : memref<256x1xbf16, 2 : i32>
+# CHECK: vector.reduction <add>
+# CHECK: memref.store {{.*}}memref<256x1xbf16, 2 : i32>
+@run
+def keepdims_stores_at_the_collapsed_index():
+    M, N, tile = 65536, 16, 256
+    A = air.tensor([M, N], bf16)
+    OUT = air.tensor([M, 1], bf16)
+
+    with air.launch(name="red") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, M, tile), shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    (tm,) = h.tile_sizes
+                    row = tx * tm
+                    a = air.alloc([tm, N], bf16, scope=h.private())
+                    o = air.alloc([tm, 1], bf16, scope=h.private())
+                    air.ops.load(a, A[row : row + tm, :])
+                    o[:] = air.ops.reduce_add(a[:])
+                    air.ops.store(o, OUT[row : row + tm, :])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: reduce_over_an_expression_is_a_row_dot_product
+# The operand of a reduction may be any elementwise expression, so a row-wise
+# dot product needs no extra surface: the multiply happens on the vector,
+# before the reduction collapses it.
+# CHECK: arith.mulf {{.*}} : vector<16xbf16>
+# CHECK: vector.reduction <add>, {{.*}} : vector<16xbf16> into bf16
+@run
+def reduce_over_an_expression_is_a_row_dot_product():
+    print(build(lambda a: air.ops.reduce_add(a[:] * a[:])).mlir())
+
+
+# CHECK-LABEL: TEST: a_wider_axis_widens_the_vector_not_the_loop
+# N=32 is what vector_reduce_max defaults to. The reduced extent sets the
+# vector length directly, so a wider axis stays one read and one reduction
+# rather than becoming a loop.
+# CHECK: vector.transfer_read {{.*}} vector<32xbf16>
+# CHECK: vector.reduction <add>, {{.*}} : vector<32xbf16> into bf16
+# CHECK-NOT: vector.reduction
+@run
+def a_wider_axis_widens_the_vector_not_the_loop():
+    print(build(lambda a: air.ops.reduce_add(a[:]), N=32).mlir())


### PR DESCRIPTION
Adds `ops.reduce_add` and `ops.reduce_max`, and moves
`programming_examples/primitives/vector_examples/vector_reduce_{add,max}` onto
them.

## The first shape-changing node

Every other node in the expression language is elementwise, which is what lets
the emitter check each leaf's shape against the destination. A reduction
collapses the innermost axis, so it is dispatched *before* that check rather
than being taught to it, and it has to be the whole right-hand side — an
elementwise op surrounding it would be operating on two different shapes.

Its *operand* may still be any elementwise expression, so a row-wise dot
product needs no extra surface:

```python
out[:] = air.ops.reduce_add(a[:] * b[:])
```

## No accumulator, deliberately

The reduced axis is read as a single vector of its full extent rather than
stepped in vector-width chunks. That is what the hand-written kernels do, and
the reason matters: stepping would need a loop-carried vector accumulator,
which is exactly the construct `ops.dot`'s docstring already documents as
unlegalizable on AIE2 (LLVM splits it into sub-512-bit pieces). The cost is
that the reduced extent has to be a vector length the backend accepts — 16 and
32 are both exercised here, being what the two examples default to.

## Both keepdims spellings

`[.., n] -> [.., 1]` and `[.., n] -> [..]` are both accepted, because the
predecessor uses both **at once**: its L1 tile is `[tile_m, 1]` while its L3
output is `[m]`. Whichever the DSL refused would have forced the example to
change shape somewhere.

The converted examples drop the axis, which keeps the L1 tile the same rank as
the L3 output. Worth stating plainly: `ops.store` squeezes *leading* unit
dimensions but not trailing ones, so a kept-axis `[tile_m, 1]` tile cannot
currently be stored into a rank-1 `[m]` slice — the DMA the predecessor writes.
`api/reduce.py` pins both spellings and records that limitation at the point
where someone would meet it. Fixing it is a trailing-unit squeeze in
`_check_pair`, a separate change.

## Kinds

`maximumf` on floats — matching the elementwise `ops.maximum`, and the form
known to legalize on AIE2 — and `maxsi` on integers.

## Verification

* **npu1 hardware**: all three `ryzen_ai` lits across the two examples pass,
  matching the baseline measured *before* any change. `vector_add` and
  `vector_max` still pass as controls.
* Both examples compile clean for npu2.
* 21/21 `python/test/api` suites; `black` clean.
* The new IR tests were checked against three mutations — collapsing
  `reduce_max`'s kind onto `add`, fixing the vector length instead of taking it
  from the reduced axis, and dropping the destination-shape check — and all
  three are caught, so the CHECKs are not vacuous.

## A note on scoping

These two examples were previously assessed as *not* a single-feature batch, on
the grounds that they also need `collapse_shape` and `exp`. Neither holds:
`exp` is a dead import with zero call sites in both files, and
`collapse_shape`/`subview` are only how the raw code manufactures a rank-1 row
— air.api reads at an offset directly and needs neither. The assessment had
been made from the import lines rather than the call sites.