### PR TITLE
[air-runner] Fix dangling parent pointers across segment runner nodes

### DIFF
--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -104,12 +104,19 @@ public:
     launchGraph.runner_node = this;
     launchGraph.runner_node->channel_token_counts_ptr =
         &(launchGraph.runner_node->channel_token_counts);
+    // Each herd runner node stores a raw pointer to its parent segment runner
+    // node, so the segment vector must not reallocate while herds are being
+    // attached to it -- otherwise every herd created before a later push_back
+    // is left pointing at freed storage, and its tile pool comes back empty.
+    this->sub_runner_nodes.reserve(launchGraph.subgraphs.size());
     for (auto &segmentGraph : launchGraph.subgraphs) {
       // Create segment runner node
       this->sub_runner_nodes.push_back(runnerNode(
           this, &segmentGraph, "segment", this->dep_ctx, this->sim_granularity,
           &(launchGraph.runner_node->channel_token_counts)));
       auto current_segment_node = &(this->sub_runner_nodes.back());
+      current_segment_node->sub_runner_nodes.reserve(
+          segmentGraph.subgraphs.size());
       for (auto &herdGraph : segmentGraph.subgraphs) {
         // Create herd runner node
         current_segment_node->sub_runner_nodes.push_back(
@@ -542,8 +549,11 @@ private:
                                     std::vector<resource *> &reserved_resources,
                                     unsigned usage_count) {
     // A previously emitted error should have captured this
-    this->runner_assertion(usage_count <= resource_pool.size(),
-                           "failed to reserve resources");
+    this->runner_assertion(
+        usage_count <= resource_pool.size(),
+        "failed to reserve resources for " + this->runner_node_type +
+            " runner node: need " + std::to_string(usage_count) + ", " +
+            std::to_string(resource_pool.size()) + " available");
     for (unsigned i = 0; i < usage_count; i++) {
       resource_pool[i]->isReserved = true;
       reserved_resources.push_back(resource_pool[i]);

--- a/mlir/test/Util/Runner/multi_segment_herds.mlir
+++ b/mlir/test/Util/Runner/multi_segment_herds.mlir
@@ -1,0 +1,66 @@
+//===- multi_segment_herds.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Two air.segments, each containing an air.herd, chained by a channel.
+//
+// Regression test for the segment runner nodes being built into a std::vector
+// while each herd stores a raw pointer to its parent segment: pushing the
+// second segment reallocated that vector and left the first segment's herds
+// pointing at freed storage, so their tile pool came back empty and the run
+// aborted with "failed to reserve resources". A single segment with herds, or
+// several segments without them, both happened to avoid the reallocation.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: "name": "HerdOp(ma)[1, 1]",
+// CHECK: "name": "HerdOp(mb)[1, 1]",
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  air.channel @c2c [1, 1]
+  air.channel @onchip_a [1, 1]
+  air.channel @onchip_b [1, 1]
+  func.func @test(%arg0: memref<64xbf16>) {
+    %c1 = arith.constant 1 : index
+    %launch = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) args(%larg=%arg0) : memref<64xbf16> attributes {id = 1 : i32} {
+      %seg_a = air.segment async attributes {id = 10 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_a = arith.constant 1 : index
+        %tok_a, %buf_a = air.execute -> (memref<64xbf16, 1>) {
+          %al_a = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %al_a : memref<64xbf16, 1>
+        }
+        %fw_a = air.channel.put async [%tok_a] @onchip_a[] (%buf_a[] [] []) {id = 20 : i32} : (memref<64xbf16, 1>)
+        %herd_a = air.herd @ma async [%fw_a] tile (%tax, %tay) in (%tasx=%c1_a, %tasy=%c1_a) attributes {id = 100 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %tl_a, %bl_a = air.execute -> (memref<64xbf16, 2>) {
+            %a2 = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %a2 : memref<64xbf16, 2>
+          }
+          %g_a = air.channel.get async [%tl_a] @onchip_a[] (%bl_a[] [] []) {id = 21 : i32} : (memref<64xbf16, 2>)
+          %p_a = air.channel.put async [%g_a] @c2c[] (%bl_a[] [] []) {id = 22 : i32} : (memref<64xbf16, 2>)
+        }
+      }
+      %seg_b = air.segment async attributes {id = 11 : i32, x_loc = 1 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_b = arith.constant 1 : index
+        %tok_b, %buf_b = air.execute -> (memref<64xbf16, 1>) {
+          %al_b = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %al_b : memref<64xbf16, 1>
+        }
+        %rx_b = air.channel.get async [%tok_b] @c2c[] (%buf_b[] [] []) {id = 30 : i32} : (memref<64xbf16, 1>)
+        %fw_b = air.channel.put async [%rx_b] @onchip_b[] (%buf_b[] [] []) {id = 31 : i32} : (memref<64xbf16, 1>)
+        %herd_b = air.herd @mb async [%fw_b] tile (%tbx, %tby) in (%tbsx=%c1_b, %tbsy=%c1_b) attributes {id = 101 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %tl_b, %bl_b = air.execute -> (memref<64xbf16, 2>) {
+            %b2 = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %b2 : memref<64xbf16, 2>
+          }
+          %g_b = air.channel.get async [%tl_b] @onchip_b[] (%bl_b[] [] []) {id = 32 : i32} : (memref<64xbf16, 2>)
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Fixes a use-after-free that makes any launch with more than one segment-containing-a-herd unsimulatable.

## The bug

`initRunnerNodesFromLaunchGraph` builds the segment runner nodes into a `std::vector` while handing `&sub_runner_nodes.back()` to each herd as its `parent`:

```cpp
for (auto &segmentGraph : launchGraph.subgraphs) {
  this->sub_runner_nodes.push_back(runnerNode(...));      // may reallocate
  auto current_segment_node = &(this->sub_runner_nodes.back());
  for (auto &herdGraph : segmentGraph.subgraphs)
    current_segment_node->sub_runner_nodes.push_back(
        runnerNode(current_segment_node, ...));           // stores that pointer
}
```

Pushing the second segment reallocates the vector, so every herd created before it points at freed storage. `getTilesPoolFromParent()` reads through the stale pointer, comes back with an empty tile pool, and the run aborts:

```
Error: failed to reserve resources
```

A single segment with herds, or several segments without them, both happen to avoid the reallocation — which is why no existing test covers it. The combination is what breaks, and it is the natural shape for any pipelined multi-segment model.

## The fix

Reserve both vectors up front so the addresses handed out stay valid.

The assertion also now reports what was needed against what was available. The bare `"failed to reserve resources"` gave no indication of which pool was empty, which made this considerably harder to track down than it needed to be.

## Testing

`mlir/test/Util/Runner/multi_segment_herds.mlir` — two segments, one herd each, chained by a channel. Verified to fail on the unfixed runner and pass with the fix.

Full `mlir/test` suite: 510 passed, 7 expectedly failed, 0 failures. `git clang-format origin/main` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)