### PR TITLE
[python] air.api: the scalar_examples family, and the shift surface it needed

### DIFF
--- a/programming_examples/primitives/scalar_examples/scalar_invsqrt/scalar_invsqrt.py
+++ b/programming_examples/primitives/scalar_examples/scalar_invsqrt/scalar_invsqrt.py
@@ -1,114 +1,100 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Scalar inverse square root (1/sqrt(x)) primitive, on air.api.
+
+    c[:] = air.ops.rsqrt(a[:])        with vector=0
+
+One line of compute, and the ``vector=0`` beside it is the whole point of this
+example. It is what sends air.api's emitter down its scalar path: a plain
+``scf.for`` over the tile in steps of one, ``memref.load``, ``math.rsqrt`` on an
+f32 scalar, ``memref.store`` -- precisely what the raw-bindings predecessor
+wrote by hand.
+
+**npu2 only, and that is inherited, not new.** ``math.rsqrt`` on a plain f32 is
+an instruction on npu2 and is not one on npu1, where the AIE lowering instead
+calls ``getRsqrtBf16`` out of an object file -- a bf16 entry point, with nothing
+to offer an f32 scalar. The predecessor's lit is already
+``REQUIRES: ryzen_ai_npu2`` for that reason. What is new is that building for
+npu1 now says so, rather than producing a module that fails several passes later
+in the backend. ``vector_examples/vector_rsqrt --version 2`` is the same
+computation and refuses npu1 the same way; ``--version 1`` there is the route
+that works on npu1, in bf16 and against that object file.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's, and it distributes differently. The predecessor
+  wrote the outer loop itself and gave core ``ty`` the tiles at
+  ``_l_ivx + ty * tile_n`` -- an interleaved assignment, every other tile. The
+  DSL hands each core a contiguous run of tiles instead. Every tile is still
+  computed exactly once by exactly one core, and the tiles are independent, so
+  the result is unchanged.
+* The L1 buffers are allocated and freed together. The predecessor allocated
+  both outside its temporal loop and called ``DeallocOp`` on them *inside* it,
+  which frees each buffer once per trip -- 32 times, at the default size. Here
+  the pair is scoped to the loop body and balances.
+
+``--target`` is new and defaults to detecting the installed part, which is what
+the predecessor did implicitly by having no device flag at all. Naming it makes
+``-p`` reproducible, and gives the npu1 refusal above something to key off.
+"""
+
 import argparse
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.math import rsqrt
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api.types import f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def scalar_invsqrt(arg0, arg1):
-
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
+def build_module(n, tile_n, target="auto"):
+    assert n % (tile_n * NUM_TILES) == 0
+    resolved = air.resolve_target(target)
+    if resolved == "npu1":
+        raise ValueError(
+            "scalar f32 rsqrt is npu2-only: on npu1 math.rsqrt lowers to a call "
+            "into getRsqrtBf16, which takes bf16 and has no f32 scalar form. "
+            "The predecessor's lit was REQUIRES: ryzen_ai_npu2 for the same "
+            "reason. For npu1, see vector_examples/vector_rsqrt --version 1."
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+    dt = f32
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    A = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="scalar_invsqrt") as launch:
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cTileN = ConstantOp(index_type, tile_n)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    # vector=0 is the scalar path -- see the module docstring.
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=0)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=0)
 
-                # Scalar loop: compute 1.0 / sqrt(x) for each element
-                for j in range_(c0, cTileN, c1):
-                    # Load scalar value from input
-                    scalar_a = load(l1_a_data.result, [j])
-                    # Compute inverse square root: 1.0 / sqrt(a)
-                    scalar_c = rsqrt(scalar_a)
-                    # Store result
-                    store(scalar_c, l1_out_data.result, [j])
-                    yield_([])
+                    air.ops.load(a, A[i0 : i0 + tile_n])
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
+                    c[:] = air.ops.rsqrt(a[:])
 
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -146,13 +132,17 @@ if __name__ == "__main__":
         default="compile-and-run",
         help="Configure to whether to run after compile",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device) or npu2. This example is npu2-only -- see the module docstring",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.n,
-        args.tile_n,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.n, args.tile_n, args.target)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -189,6 +179,7 @@ if __name__ == "__main__":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -205,6 +196,7 @@ if __name__ == "__main__":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/scalar_examples/scalar_reciprocal/scalar_reciprocal.py
+++ b/programming_examples/primitives/scalar_examples/scalar_reciprocal/scalar_reciprocal.py
@@ -1,116 +1,91 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Scalar reciprocal (1/x) primitive, on air.api.
+
+    c[:] = 1.0 / a[:]        with vector=0
+
+One line of compute, and the ``vector=0`` beside it is the whole point of this
+example. It is what sends air.api's emitter down its scalar path: a plain
+``scf.for`` over the tile in steps of one, ``memref.load``, ``arith.divf`` on an
+f32 scalar, ``memref.store``. That is precisely what the raw-bindings
+predecessor wrote by hand, and it is what separates this example from
+``vector_examples/vector_reciprocal`` -- which is otherwise the same program at
+the same size with the same seed and the same tolerance, and differs in asking
+for a 16- or 32-lane vector instead.
+
+f32 is deliberate and inherited: the predecessor hardcoded ``np.float32`` and
+exposed no dtype flag. Its vector sibling documents why nothing else legalizes
+there; here the constraint is softer, since a scalar divide has no vector for
+the backend to reject, but no lit exercises another type and a conversion is not
+the place to widen the contract.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's, and it distributes differently. The predecessor
+  wrote the outer loop itself and gave core ``ty`` the tiles at
+  ``_l_ivx + ty * tile_n``, stepping by ``tile_n * NUM_TILES`` -- an interleaved
+  assignment, every other tile. The DSL hands each core a contiguous run of
+  tiles instead. Every tile is still computed exactly once by exactly one core,
+  and the tiles are independent, so the result is unchanged.
+* The L1 buffers are allocated and freed together. The predecessor allocated
+  both outside its temporal loop and called ``DeallocOp`` on them *inside* it,
+  which frees each buffer once per trip -- 32 times, at the default size. Here
+  the pair is scoped to the loop body and balances.
+
+``--target`` is new and defaults to detecting the installed part, which is what
+the predecessor did implicitly by having no device flag at all. Naming it makes
+``-p`` reproducible for a generation that is not the one plugged in.
+"""
+
 import argparse
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api.types import f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in):
-    a_size = [n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    index_type = IndexType.get()
+def build_module(n, tile_n):
+    assert n % (tile_n * NUM_TILES) == 0
+    dt = f32
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
+    A = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="scalar_reciprocal") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def scalar_reciprocal(arg0, arg1):
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1MemrefTy, [], [])
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    # vector=0 is the scalar path -- see the module docstring.
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=0)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=0)
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+                    air.ops.load(a, A[i0 : i0 + tile_n])
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    c[:] = 1.0 / a[:]
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cTileN = ConstantOp(index_type, tile_n)
-
-                # Constant 1.0 for reciprocal computation
-                one_const = arith.ConstantOp(xrt_dtype_in, 1.0)
-
-                # Scalar loop: compute 1.0 / x for each element
-                for j in range_(c0, cTileN, c1):
-                    # Load scalar value from input
-                    scalar_a = load(l1_a_data.result, [j])
-                    # Compute reciprocal: 1.0 / a
-                    scalar_c = arith.DivFOp(one_const, scalar_a)
-                    # Store result
-                    store(scalar_c, l1_out_data.result, [j])
-                    yield_([])
-
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
-
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -148,13 +123,17 @@ if __name__ == "__main__":
         default="compile-and-run",
         help="Configure to whether to run after compile",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.n,
-        args.tile_n,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.n, args.tile_n)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -191,6 +170,7 @@ if __name__ == "__main__":
         runner = XRTRunner(
             verbose=args.verbose,
             omit_while_true_loop=False,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -207,6 +187,7 @@ if __name__ == "__main__":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/primitives/scalar_examples/scalar_shift_saturate/scalar_shift_saturate.py
+++ b/programming_examples/primitives/scalar_examples/scalar_shift_saturate/scalar_shift_saturate.py
@@ -1,135 +1,119 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Scalar shift + saturate (fixed-point quantization) primitive, on air.api.
 
-"""Scalar Shift + Saturate Example
+    v = ops.minimum(ops.maximum(a[:] >> shift, -128), 127)
+    c[:] = ops.cast(ops.cast(v, i8), i32)                    with vector=0
 
-Computes element-wise fixed-point quantization on a 1D i32 input [N]:
-  output[i] = clip(input[i] >> shift_amount, -128, 127)
+    output[i] = clip(input[i] >> shift_amount, -128, 127)
 
-The scalar shrsi + maxsi + minsi + trunci chain is fused by the
-LowerScalarShiftClampTruncToSRS pattern (mlir-aie PR #2894) into
-a vectorized SRS (Shift-Round-Saturate) operation:
-  broadcast_scalar -> cast(isResAcc) -> srs(narrowed) -> ext_elem
+**The shape of this expression is the point of the example, not incidental to
+it.** The scalar ``shrsi + maxsi + minsi + trunci`` chain is what mlir-aie's
+``LowerScalarShiftClampTruncToSRS`` pattern (PR #2894) matches, fusing it into a
+vectorized SRS -- shift-round-saturate -- of the form
+``broadcast_scalar -> cast(isResAcc) -> srs(narrowed) -> ext_elem``. So this
+example exists to check that a *decomposed* chain still gets recognised, and the
+conversion has to emit the same five ops in the same order for it to keep
+testing that. It does: the emitted arith sequence is identical to the
+predecessor's, op for op.
 
-Input and output are both i32 memrefs. The trunci(i8) + extsi(i32)
-round-trip preserves the pattern match while keeping DMA types uniform.
+**Where the rounding comes from.** The kernel shifts with a bare ``shrsi`` and
+never rounds. The reference rounds -- ``(x + (1 << (shift - 1))) >> shift``.
+They agree because ``AIECoreToStandard`` sets rounding mode 9 (positive_inf) for
+integer SRS, so the rounding is supplied by the fused hardware instruction and
+not by the IR. That is exactly what makes this test load-bearing, and why it
+checks at ``rtol=0, atol=0``: if the pattern failed to match, the shift would
+happen without rounding and the answers would differ by one.
 
-Uses a 1x2 AIE herd with DMA transfers between L3 and L1 memory.
+The ``trunci(i8)`` then ``extsi(i32)`` round-trip is likewise deliberate. It is
+what completes the pattern, while leaving both DMA endpoints i32 so the L3
+buffers stay one type.
+
+**The narrowing cast.** ``air.api.ops.cast`` normally refuses i32 -> i8: on AIE
+a vectorised ``arith.trunci`` saturates where the scalar one wraps, so the same
+source would compute different things depending on the tile shape. That
+objection does not apply here and air.api can tell, structurally -- the operand
+is a clamp to constant bounds that fit i8, so no value the two paths disagree
+about can reach the cast. The clamp has to genuinely be in the expression tree;
+an unclamped narrow, or one clamped to bounds wider than the target, is still
+refused.
+
+Three differences from the predecessor, shared with the rest of this directory:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's, so each core gets a contiguous run of tiles where
+  the predecessor's hand-built AffineMap interleaved them. Every tile is still
+  computed exactly once by exactly one core, and the tiles are independent.
+* The L1 buffers are allocated and freed together. The predecessor allocated
+  both outside its temporal loop and called ``DeallocOp`` on them *inside* it,
+  freeing each buffer once per trip.
 """
 
 import argparse
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api.types import i8, i32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
+
+# The i8 saturation bounds. Named because they appear twice -- once in the
+# kernel and once in the reference -- and because ops.cast reads them back off
+# the expression tree to decide the narrowing cast is safe.
+I8_MIN, I8_MAX = -128, 127
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype, shift_amount=4):
-    xrt_dtype = type_mapper(np_dtype)
-    num_tiles = 2
-    assert n % (tile_n * num_tiles) == 0
-    index_type = IndexType.get()
-
-    # L3 MemRefTypes (i32 for both input and output)
-    l3memrefTy = MemRefType.get([n], xrt_dtype)
-
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    @FuncOp.from_py_func(l3memrefTy, l3memrefTy)
-    def scalar_shift_saturate(arg0, arg1):
-
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg1],
+def build_module(n, tile_n, shift_amount=4):
+    assert n % (tile_n * NUM_TILES) == 0
+    if not 1 <= shift_amount < 32:
+        raise ValueError(
+            f"shift_amount must be in [1, 32) for an i32 shift, got "
+            f"{shift_amount}. The reference rounds with 1 << (shift - 1), "
+            f"which needs at least 1"
         )
-        def herd_body(_tx, _ty, _sx, _sy, _l3_in, _l3_out):
-            l1_in = AllocOp(l1MemrefTy, [], [])
-            l1_out = AllocOp(l1MemrefTy, [], [])
+    dt = i32
 
-            for _l_ivx in range_(0, n, tile_n * num_tiles):
+    A = air.tensor([n], dt)
+    C = air.tensor([n], dt)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_n),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+    with air.launch(name="scalar_shift_saturate") as launch:
 
-                dma_memcpy_nd(
-                    l1_in,
-                    _l3_in,
-                    src_offsets=[offset],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
+        @launch.body
+        def _():
+            # The iteration space is every tile; shape= pins the core count to
+            # what the predecessor asked for, and the DSL strip-mines the rest
+            # into a loop on each core.
+            with air.herd(
+                [range(0, n, tile_n)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cTileN = ConstantOp(index_type, tile_n)
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not an element offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_n
+                    # vector=0 is the scalar path, which is what the SRS pattern
+                    # this example exercises matches against.
+                    a = air.alloc([tile_n], dt, scope=h.private(), vector=0)
+                    c = air.alloc([tile_n], dt, scope=h.private(), vector=0)
 
-                # Constants for shift + signed saturation clamp
-                shift_const = arith.ConstantOp(
-                    xrt_dtype, IntegerAttr.get(xrt_dtype, shift_amount)
-                )
-                min_const = arith.ConstantOp(
-                    xrt_dtype, IntegerAttr.get(xrt_dtype, -128)
-                )
-                max_const = arith.ConstantOp(xrt_dtype, IntegerAttr.get(xrt_dtype, 127))
+                    air.ops.load(a, A[i0 : i0 + tile_n])
 
-                # Scalar loop: shift right, clamp to [-128, 127], truncate to i8
-                for j in range_(c0, cTileN, c1):
-                    scalar_val = load(l1_in.result, [j])
+                    # shrsi, then maxsi, then minsi, then trunci/extsi. The
+                    # order is the pattern's; see the module docstring.
+                    clamped = air.ops.minimum(
+                        air.ops.maximum(a[:] >> shift_amount, I8_MIN), I8_MAX
+                    )
+                    c[:] = air.ops.cast(air.ops.cast(clamped, i8), i32)
 
-                    # Arithmetic right shift
-                    shifted = arith.shrsi(scalar_val, shift_const)
-                    # Signed saturation clamp
-                    clamped_lo = arith.maxsi(shifted, min_const)
-                    clamped_hi = arith.minsi(clamped_lo, max_const)
-                    # Truncate to i8 (triggers SRS pattern from PR #2894)
-                    truncated = arith.trunci(T.i8(), clamped_hi)
-                    # Extend back to i32 for uniform output type
-                    extended = arith.extsi(xrt_dtype, truncated)
+                    air.ops.store(c, C[i0 : i0 + tile_n])
 
-                    store(extended, l1_out.result, [j])
-                    yield_([])
-
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out,
-                    dst_offsets=[offset],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-
-                DeallocOp(l1_in)
-                DeallocOp(l1_out)
-
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -166,10 +150,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.shift_amount)
+    launch = build_module(args.n, args.tile_n, args.shift_amount)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -178,7 +170,7 @@ if __name__ == "__main__":
     # Use a range where shifted values span the i8 output range:
     # With shift=4, input range [-2048, 2047] produces shifted values in [-128, 127].
     # Extend slightly beyond to also exercise saturation clamping.
-    max_val = (127 << args.shift_amount) + (1 << args.shift_amount)
+    max_val = (I8_MAX << args.shift_amount) + (1 << args.shift_amount)
     input_a = np.random.randint(-max_val, max_val, args.n, dtype=INPUT_DATATYPE)
 
     if args.compile_mode == "compile-and-run":
@@ -190,7 +182,7 @@ if __name__ == "__main__":
         # which rounds toward positive infinity at the midpoint.
         def ref_shift_saturate(x, shift):
             shifted = (x + (1 << (shift - 1))) >> shift
-            return np.clip(shifted, -128, 127).astype(np.int8).astype(np.int32)
+            return np.clip(shifted, I8_MIN, I8_MAX).astype(np.int8).astype(np.int32)
 
         sampled_values = np.array(
             [
@@ -210,6 +202,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="scalar_shift_saturate",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -227,6 +220,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -102,10 +102,17 @@ _INT_OPS = {
     "and": arith.AndIOp,
     "or": arith.OrIOp,
     "xor": arith.XOrIOp,
+    # Shifts, likewise integer-only. The right shift is *arithmetic*
+    # (arith.shrsi, sign-replicating) rather than logical, because air.api's
+    # integer dtypes are signed and Python's own `>>` on a negative int is
+    # arithmetic too -- x >> n == floor(x / 2**n) for both.
+    "shl": arith.ShLIOp,
+    "shr": arith.ShRSIOp,
 }
 
 # Named so the failure can say *why*, not just "not supported for dtype float".
 _BITWISE = ("and", "or", "xor")
+_SHIFT = ("shl", "shr")
 
 # vector.reduction combining kinds. maximumf mirrors the elementwise _FLOAT_OPS
 # choice of arith.maximumf over maxnumf; the signed integer form matches the
@@ -446,11 +453,15 @@ def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
         # The operand is evaluated in *its* region -- a different element type,
         # a different arith table, and a different vector type -- and only the
         # conversion itself lands in this one.
-        from .ops import _conversion_op
+        from .ops import _clamped_into, _conversion_op
 
         source = node.args[0].element_dtype()
         operand = recur(node.args[0], regions[source])
-        build = _conversion_op(source, region.dtype)
+        # The same structural check ``cast`` used to accept this node. Asking
+        # again here keeps the rule in one place rather than trusting a flag
+        # threaded down from the call site.
+        narrowing_ok = _clamped_into(node.args[0], region.dtype)
+        build = _conversion_op(source, region.dtype, narrowing_ok=narrowing_ok)
         return _result(build(vec_ty if vectorized else ety, operand))
 
     if node.kind == "scalar":
@@ -571,6 +582,14 @@ def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
                     f"the bitwise operator '{node.op}' is integer-only: MLIR "
                     f"has arith.{node.op}i but no floating-point counterpart, "
                     f"so it cannot be applied to a {ety} buffer"
+                )
+            if node.op in _SHIFT and ops is _FLOAT_OPS:
+                spelling = "<<" if node.op == "shl" else ">>"
+                raise NotImplementedError(
+                    f"the shift operator '{spelling}' is integer-only: MLIR "
+                    f"has arith.shli/shrsi and no floating-point counterpart, "
+                    f"so it cannot be applied to a {ety} buffer. Scaling a "
+                    f"float by a power of two is a multiply"
                 )
             raise NotImplementedError(
                 f"elementwise operator '{node.op}' is not supported for dtype "

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -539,6 +539,44 @@ _OP_SYMBOLS = {
 _OP_CALL_NAMES = {"max": "maximum", "min": "minimum"}
 
 
+def _check_shift_amount(amount, value, op):
+    """Reject a constant shift count that MLIR would turn into poison.
+
+    ``>>`` matches Python on the part people actually reason about -- it is
+    arithmetic, so a negative value floors rather than filling with zeros --
+    but it does *not* match Python on the shift count, and the difference is
+    silent. Python's ints are arbitrary precision: ``x >> 100`` is 0 or -1, and
+    ``x >> -1`` raises. MLIR inherits LLVM's rule instead, where a shift of the
+    operand's own width or more, or by a negative amount, is **poison**, and
+    poison is not an error -- it is a value the optimiser may assume never
+    happens, which is how it turns into a wrong answer several passes later
+    rather than a diagnostic.
+
+    So a constant out-of-range count is refused here, at the call site, which
+    is the closest this can get to Python's own ValueError. A count that is not
+    a compile-time constant cannot be checked and is documented rather than
+    guarded -- see the shift operators on ``BufferExpr``.
+    """
+    if amount.kind != "scalar" or not isinstance(amount.scalar, (int, bool)):
+        return  # runtime amount: nothing to check, see the docstring
+    count = int(amount.scalar)
+    dtype = value.element_dtype()
+    spelling = "<<" if op == "shl" else ">>"
+    if count < 0:
+        raise ValueError(
+            f"negative shift count {count} in '{spelling}': Python raises here "
+            f"and MLIR would make it poison, which is silent. Shift by a "
+            f"non-negative amount, or use the opposite operator"
+        )
+    if dtype is not None and count >= dtype.itemsize * 8:
+        raise ValueError(
+            f"shift count {count} is not less than the width of {dtype} "
+            f"({dtype.itemsize * 8} bits) in '{spelling}': Python would give "
+            f"{'0 or -1' if op == 'shr' else 'a wider integer'} but MLIR makes "
+            f"it poison, which is silent. Shift by less than the width"
+        )
+
+
 class BufferExpr:
     """A lazy elementwise expression over buffers and scalars.
 
@@ -641,6 +679,8 @@ class BufferExpr:
     def _binary(self, other, op, reverse=False):
         other = BufferExpr.coerce(other)
         args = (other, self) if reverse else (self, other)
+        if op in ("shl", "shr"):
+            _check_shift_amount(args[1], args[0], op)
         return BufferExpr("binary", op=op, args=args)
 
     def __add__(self, o):
@@ -718,6 +758,33 @@ class BufferExpr:
 
     def __rxor__(self, o):
         return self._binary(o, "xor", reverse=True)
+
+    # Shifts are integer-only for the same reason and rejected the same way.
+    #
+    # `>>` is arithmetic (arith.shrsi). There is no signedness choice to make
+    # here, rather than a convention being picked: arith requires signless
+    # operands, so an unsigned buffer is refused before it reaches any operator
+    # at all, and every buffer that can reach a shift is signed. Arithmetic is
+    # also what Python does -- `-8 >> 1` is -4 in both, not a huge positive.
+    #
+    # The shift *count* is where the resemblance to Python stops. Python's ints
+    # are arbitrary precision, so `x >> 100` is 0 and `x << 100` just gets
+    # wider; MLIR makes a count of the width or more poison, and `<<` wraps.
+    # A constant count out of range is refused by _check_shift_amount above. A
+    # count computed at runtime -- `1 << a[:]`, or a shift read from a buffer --
+    # cannot be checked, and is the one place where an out-of-range value still
+    # reaches the backend as poison.
+    def __lshift__(self, o):
+        return self._binary(o, "shl")
+
+    def __rlshift__(self, o):
+        return self._binary(o, "shl", reverse=True)
+
+    def __rshift__(self, o):
+        return self._binary(o, "shr")
+
+    def __rrshift__(self, o):
+        return self._binary(o, "shr", reverse=True)
 
     def __bool__(self):
         # NumPy's guard, for NumPy's reason. `and`, `or` and `not` are the one

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -556,10 +556,23 @@ def _check_shift_amount(amount, value, op):
     is the closest this can get to Python's own ValueError. A count that is not
     a compile-time constant cannot be checked and is documented rather than
     guarded -- see the shift operators on ``BufferExpr``.
+
+    "Constant" has to include an IndexExpr that folds to one. Index arithmetic
+    over herd coordinates is ordinary in a kernel body, and ``tx - tx + 32``
+    reaches the emitter as a literal ``arith.constant 32`` -- indistinguishable,
+    by the time it gets there, from having been written as ``32``. Reading it
+    back has to go through ``as_const()``: IndexExpr does not implement equality
+    or int conversion against a Python int, so an isinstance test alone sees
+    every index expression as "runtime" and lets the folded ones through.
     """
-    if amount.kind != "scalar" or not isinstance(amount.scalar, (int, bool)):
+    if amount.kind != "scalar":
+        return  # not a scalar operand at all: nothing to check
+    count = amount.scalar
+    if hasattr(count, "as_const"):
+        count = count.as_const()  # None when it is genuinely runtime
+    if not isinstance(count, (int, bool)):
         return  # runtime amount: nothing to check, see the docstring
-    count = int(amount.scalar)
+    count = int(count)
     dtype = value.element_dtype()
     spelling = "<<" if op == "shl" else ">>"
     if count < 0:

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -432,15 +432,74 @@ def cast(x, dtype):
         return expr
     require_signless(source, "air.api.ops.cast")
     require_signless(dtype, "air.api.ops.cast")
-    _conversion_op(source, dtype)  # raises here, at the call site, not at emit
+    if not _clamped_into(expr, dtype):
+        # raises here, at the call site, not at emit
+        _conversion_op(source, dtype)
     return BufferExpr("cast", args=(expr,), dtype=dtype)
 
 
-def _conversion_op(source, target):
+def _int_range(dtype):
+    """The inclusive [lo, hi] a signed integer dtype can represent."""
+    bits = dtype.itemsize * 8
+    return -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
+
+
+def _const_operand(node):
+    """The Python value of a scalar leaf, or ``None`` if it is not one."""
+    if node.kind == "scalar" and isinstance(node.scalar, (int, bool)):
+        return int(node.scalar)
+    return None
+
+
+def _clamped_into(expr, target):
+    """True if *expr* is a clamp whose bounds provably fit *target*.
+
+    This is the one narrowing int -> int cast that is allowed, and it is
+    allowed because the objection to the rest does not apply to it. That
+    objection -- see ``_conversion_op`` -- is that arith.trunci wraps on the
+    emitter's scalar path and saturates on its vector path, so the same source
+    would compute different things depending on the tile shape. The two
+    disagree only on values the target cannot hold. When the operand is
+    ``minimum(maximum(x, lo), hi)`` with constant lo and hi inside the target's
+    range, no such value can reach the cast, both paths agree, and the result
+    is a property of the program again.
+
+    That is a structural check, not a promise from the caller: the clamp has to
+    be *there*, in the expression tree, with constant bounds. ``_conversion_op``
+    ends by saying in-range values agree and nothing can check it -- this is
+    the case where something can.
+
+    Deliberately narrow. Either order of the pair is accepted, since clamping
+    is commutative here, but a runtime bound, a bound read from a buffer, or a
+    clamp one operation further away all fall through to the refusal.
+    """
+    if target.is_float:
+        return False
+    if not (expr.kind == "binary" and expr.op in ("min", "max")):
+        return False
+    inner = expr.args[0] if expr.args[0].kind == "binary" else None
+    outer_bound = _const_operand(expr.args[1]) if len(expr.args) == 2 else None
+    if inner is None or outer_bound is None:
+        return False
+    if not (inner.op in ("min", "max") and inner.op != expr.op):
+        return False
+    inner_bound = _const_operand(inner.args[1]) if len(inner.args) == 2 else None
+    if inner_bound is None:
+        return False
+    hi = outer_bound if expr.op == "min" else inner_bound
+    lo = inner_bound if expr.op == "min" else outer_bound
+    t_lo, t_hi = _int_range(target)
+    return lo >= t_lo and hi <= t_hi and lo <= hi
+
+
+def _conversion_op(source, target, narrowing_ok=False):
     """The arith op converting ``source`` to ``target``, or a refusal.
 
     Shared by ``cast`` (so a bad pair is rejected where the user wrote it) and
     by the emitter (so it does not need a second copy of the rules).
+
+    ``narrowing_ok`` is set only for the int -> int narrowing that
+    ``_clamped_into`` has proven safe; see the comment on the refusal below.
     """
     from air.dialects import arith
 
@@ -470,7 +529,10 @@ def _conversion_op(source, target):
     # takes depends on whether the tile is a multiple of the vector width,
     # which is not something the author of the cast is thinking about, so the
     # same source would compute two different things depending on the tile
-    # size. In-range values agree, but nothing here can check that.
+    # size. In-range values agree, and _clamped_into is the one case where
+    # that can be established from the expression tree rather than assumed.
+    if narrowing_ok:
+        return arith.TruncIOp
     raise NotImplementedError(
         f"air.api.ops.cast will not narrow {source} to {target}: on AIE the "
         f"vectorised arith.trunci saturates while the scalar one wraps, and "

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -16,7 +16,7 @@ from itertools import product
 
 from air import api as air
 from air.api import ops  # noqa: F401
-from air.api.types import bf16, f16, f32, i16, i32, ui8
+from air.api.types import bf16, f16, f32, i8, i16, i32, ui8
 
 
 def expect(exc_types, label):
@@ -1416,6 +1416,88 @@ def _():
         a = air.alloc([16, 16], i32, scope=h.private())
         c = air.alloc([16, 16], i16, scope=h.private())
         c[:] = ops.cast(a[:], i16)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_narrowing_int_clamped_to_wider_bounds
+# The clamped exception is about the bounds, not the presence of a clamp. These
+# bounds do not fit i8, so values the two trunci paths disagree about can still
+# reach the cast and the refusal stands.
+# CHECK: NotImplementedError: air.api.ops.cast will not narrow air.api.i32 to air.api.i8
+@expect(NotImplementedError, "cast_narrowing_int_clamped_to_wider_bounds")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], i32, scope=h.private())
+        c = air.alloc([16, 16], i8, scope=h.private())
+        c[:] = ops.cast(ops.minimum(ops.maximum(a[:], -200), 127), i8)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: cast_narrowing_int_clamped_on_one_side
+# A single-sided clamp leaves the other side unbounded, so it proves nothing.
+# CHECK: NotImplementedError: air.api.ops.cast will not narrow air.api.i32 to air.api.i8
+@expect(NotImplementedError, "cast_narrowing_int_clamped_on_one_side")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([16, 16], i32, scope=h.private())
+        c = air.alloc([16, 16], i8, scope=h.private())
+        c[:] = ops.cast(ops.minimum(a[:], 127), i8)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: shift_on_a_float_buffer
+# Integer-only for the same reason as the bitwise operators, and named the same
+# way. The message also says what to write instead, because scaling a float by a
+# power of two is a thing people reach for << to express.
+# CHECK: NotImplementedError: the shift operator '>>' is integer-only
+@expect(NotImplementedError, "shift_on_a_float_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], f32, scope=h.private())
+        a[:] = a[:] >> 2
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: shift_by_a_negative_count
+# Python raises ValueError here. MLIR would make it poison instead, which is
+# silent and survives into the backend as a wrong answer rather than a
+# diagnostic, so this is refused where it is written.
+# CHECK: ValueError: negative shift count -1 in '>>'
+@expect(ValueError, "shift_by_a_negative_count")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], i32, scope=h.private())
+        a[:] = a[:] >> -1
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: shift_by_the_operand_width
+# The boundary, not an arbitrary large number: 32 is the first count an i32
+# cannot take. Python would give 0 or -1; LLVM says poison.
+# CHECK: ValueError: shift count 32 is not less than the width of air.api.i32
+@expect(ValueError, "shift_by_the_operand_width")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], i32, scope=h.private())
+        a[:] = a[:] >> 32
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: shift_width_is_per_dtype
+# i8 runs out eight times sooner, so the check reads the operand's own width
+# rather than assuming 32.
+# CHECK: ValueError: shift count 8 is not less than the width of air.api.i8
+@expect(ValueError, "shift_width_is_per_dtype")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], i8, scope=h.private())
+        a[:] = a[:] << 8
 
     _trace(body)
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1489,6 +1489,24 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: shift_by_a_folded_index_expression
+# "Constant" has to mean "folds to a constant", not "was typed as an int
+# literal". Index arithmetic over herd coordinates is ordinary in a kernel
+# body, and `tx - tx + 32` reaches the emitter as a literal arith.constant 32 --
+# by then indistinguishable from having been written as 32, and just as much
+# poison. Reading it back needs as_const(): IndexExpr implements neither
+# equality nor int conversion against a Python int, so an isinstance test alone
+# classifies every index expression as runtime and lets the folded ones past.
+# CHECK: ValueError: shift count 32 is not less than the width of air.api.i32
+@expect(ValueError, "shift_by_a_folded_index_expression")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], i32, scope=h.private())
+        a[:] = a[:] >> (tx - tx + 32)
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: shift_width_is_per_dtype
 # i8 runs out eight times sooner, so the check reads the operand's own width
 # rather than assuming 32.

--- a/python/test/api/shift.py
+++ b/python/test/api/shift.py
@@ -1,0 +1,143 @@
+# ./python/test/api/shift.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers << and >> to arith.shli / shrsi.
+
+Integer-only, like the bitwise operators beside them and for the same reason:
+there is no floating-point counterpart in arith, so a float buffer reaching one
+is refused by name rather than falling through the generic message.
+
+`>>` is *arithmetic* (arith.shrsi, sign-replicating) rather than logical. That
+matches Python, where `>>` on a negative int floors instead of filling with
+zeros, and it matches air.api's integer dtypes, which are signed.
+
+The last two tests pin the shift-clamp-truncate chain that
+primitives/scalar_examples/scalar_shift_saturate is built on. The order of
+those five ops is what mlir-aie's LowerScalarShiftClampTruncToSRS pattern
+matches, so it is pinned here rather than left to the example's hardware lit --
+which only runs on npu2.
+"""
+
+from air import api as air
+from air.api.types import f32, i8, i16, i32
+
+
+def build(dtype, body, N=65536, tile=1024, vector=16, out_dtype=None):
+    out_dtype = out_dtype or dtype
+    a = air.tensor([N], dtype)
+    out = air.tensor([N], out_dtype)
+
+    with air.launch(name="sh") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(0, N, tile)], shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    col = tx * tile
+                    a_buf = air.alloc([tile], dtype, scope=h.private(), vector=vector)
+                    o_buf = air.alloc(
+                        [tile], out_dtype, scope=h.private(), vector=vector
+                    )
+                    air.ops.load(a_buf, a[col : col + tile])
+                    o_buf[:] = body(a_buf)
+                    air.ops.store(o_buf, out[col : col + tile])
+
+    return launch
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def clamp(x, lo, hi):
+    return air.ops.minimum(air.ops.maximum(x, lo), hi)
+
+
+# CHECK-LABEL: TEST: shl_and_shr
+# CHECK: arith.shli {{.*}} : vector<16xi32>
+# CHECK: arith.shrsi {{.*}} : vector<16xi32>
+@run
+def shl_and_shr():
+    print(build(i32, lambda a: (a[:] << 2) >> 1).mlir())
+
+
+# CHECK-LABEL: TEST: reflected_operands
+# `1 << a[:]` takes __rlshift__, which puts the scalar on the left. A variable
+# shift *amount* is as legal as a variable shift *operand* -- and is the one
+# case the shift-count check cannot cover, since there is no constant to look
+# at. An out-of-range value here still reaches the backend as poison; a
+# constant one is refused at the call site (see errors.py).
+# CHECK: vector.broadcast {{.*}} : i32 to vector<16xi32>
+# CHECK: arith.shli {{.*}} : vector<16xi32>
+@run
+def reflected_operands():
+    print(build(i32, lambda a: 1 << a[:]).mlir())
+
+
+# CHECK-LABEL: TEST: narrower_integer
+# CHECK: arith.shrsi {{.*}} : vector<16xi16>
+@run
+def narrower_integer():
+    print(build(i16, lambda a: a[:] >> 3).mlir())
+
+
+# CHECK-LABEL: TEST: scalar_fallback
+# vector=0 is the path scalar_shift_saturate uses, and the path the SRS pattern
+# matches against.
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.shrsi {{.*}} : i32
+# CHECK: memref.store
+@run
+def scalar_fallback():
+    print(build(i32, lambda a: a[:] >> 4, N=192, tile=24, vector=0).mlir())
+
+
+# CHECK-LABEL: TEST: srs_chain
+# The five ops scalar_shift_saturate emits, in the order the mlir-aie pattern
+# expects: shift, clamp low, clamp high, narrow, widen back.
+# CHECK: arith.shrsi {{.*}} : i32
+# CHECK: arith.maxsi {{.*}} : i32
+# CHECK: arith.minsi {{.*}} : i32
+# CHECK: arith.trunci {{.*}} : i32 to i8
+# CHECK: arith.extsi {{.*}} : i8 to i32
+@run
+def srs_chain():
+    print(
+        build(
+            i32,
+            lambda a: air.ops.cast(air.ops.cast(clamp(a[:] >> 4, -128, 127), i8), i32),
+            N=192,
+            tile=24,
+            vector=0,
+        ).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: clamped_narrowing_is_order_insensitive
+# max-then-min above; min-then-max here. Clamping is commutative, so both are
+# accepted -- the rule is about the bounds, not the spelling.
+# CHECK: arith.trunci {{.*}} : i32 to i8
+@run
+def clamped_narrowing_is_order_insensitive():
+    print(
+        build(
+            i32,
+            lambda a: air.ops.cast(
+                air.ops.cast(
+                    air.ops.maximum(air.ops.minimum(a[:] >> 4, 127), -128), i8
+                ),
+                i32,
+            ),
+            N=192,
+            tile=24,
+            vector=0,
+        ).mlir()
+    )


### PR DESCRIPTION
Converts all three of `programming_examples/primitives/scalar_examples` onto `air.api`, and adds the two pieces of surface the third one needed.

Each of these examples is one line of compute next to a `vector=0`, and that `vector=0` is what they are *for*: it sends the emitter down its scalar path, which is the same `scf.for` over the tile in steps of one, `memref.load`, one arith/math op, `memref.store` that the raw-bindings predecessors wrote by hand. The emitted compute is unchanged in all three.

| example | compute | lit |
|---|---|---|
| `scalar_reciprocal` | `c[:] = 1.0 / a[:]` | `ryzen_ai` — **passes on npu1 hardware** |
| `scalar_invsqrt` | `c[:] = ops.rsqrt(a[:])` | `ryzen_ai_npu2` |
| `scalar_shift_saturate` | `ops.cast(ops.cast(clamp(a[:] >> n, -128, 127), i8), i32)` | `ryzen_ai_npu2` |

The first two need no new surface — `ops.rsqrt` and the scalar path both landed in #1890.

## New surface

**`<<` and `>>`.** New `_INT_OPS` entries (`arith.shli` / `arith.shrsi`) and the matching dunders, integer-only and refused by name on a float buffer exactly as the bitwise operators beside them are.

`>>` is arithmetic, and there is no signedness choice being made here rather than a convention being picked: `arith` requires signless operands, so an unsigned buffer is refused before it reaches *any* operator, and every buffer that can reach a shift is signed. That is also what Python does — `-8 >> 1` is `-4` in both.

The shift *count* is where the resemblance to Python stops, silently, so it is checked:

| | Python | MLIR |
|---|---|---|
| `x >> 100` (i32) | `0` / `-1` | poison |
| `x << 40` (i32) | widens | poison |
| `x >> -1` | `ValueError` | poison |

Poison is not an error — it is a value the optimiser may assume never occurs, so it surfaces as a wrong answer several passes later rather than as a diagnostic. A **constant** count out of range is now refused where it is written, which is the closest this gets to Python's own `ValueError`; the boundaries are per-dtype (i32 allows 31, refuses 32; i8 allows 7, refuses 8). A count computed at runtime — `1 << a[:]` — has no constant to inspect, still reaches the backend as poison if out of range, and is documented rather than guarded.

**A narrowing int → int cast, when the operand is provably in range.** `ops.cast` has refused i32 → i8 since #1885 on measured evidence: the vectorised `arith.trunci` saturates while the scalar one wraps, and the emitter picks between them by tile shape, so the same source would compute two different things depending on a tile size. That refusal ends by noting in-range values agree and nothing can check it.

`_clamped_into` is the case where something can. When the operand is `min(max(x, lo), hi)` with **constant** bounds inside the target's range, no value the two paths disagree about can reach the cast, both agree, and the result is a property of the program again. Either clamp order is accepted, since clamping is commutative. Everything else still raises — an unclamped narrow, a clamp to bounds wider than the target, and a single-sided clamp are each pinned as still-refused in `errors.py`.

This is a structural check on the expression tree, not a promise from the caller. The clamp has to be there.

## Why `scalar_shift_saturate` needs the op order preserved

It exists to check that mlir-aie's `LowerScalarShiftClampTruncToSRS` pattern (mlir-aie #2894) still matches a *decomposed* `shrsi + maxsi + minsi + trunci + extsi` chain and fuses it into a hardware SRS. So the conversion has to emit those five ops in that order or the example stops testing anything.

The kernel never rounds; the reference does (`(x + (1 << (shift-1))) >> shift`). They agree only because `AIECoreToStandard` sets rounding mode 9 (positive_inf) for integer SRS, so the rounding comes from the fused instruction and not from the IR. That is why this test checks at `rtol=0, atol=0`, and why a missed pattern match would show up as an off-by-one rather than as a build failure.

## Gates

- `scalar_reciprocal`'s lit **passes on npu1 hardware**, and passes non-vacuously: corrupting the reference to `2.0/x` fails with `actual` exactly half of `expected`, on both the predecessor and the conversion.
- The two npu2-only examples cannot run on a Phoenix box, so they are gated by compilation — and for `scalar_shift_saturate` that is gated hard: the generated **core LLVM IR is byte-identical** to the predecessor's, with the same three `@llvm.aie2p.I256.v32.acc32.srs` calls. The pattern demonstrably fires and the numerics cannot differ. The arith chain matches op for op at the air level too.
- **Blast radius: `-p` output for all 45 buildable `air.api` examples is byte-identical before and after.** Re-measured after the shift-count check landed in `_binary`, which is on the path of every operator.
- `python/test/api` 24/24, including a new `shift.py` pinning the operators, the scalar path, and the SRS chain order — worth a PR-gated test of its own, since the example that depends on it only runs on npu2.

## Differences from the predecessors, shared by all three

* The herd is `[NUM_TILES, 1]` rather than `[1, NUM_TILES]`. A 1-D `air.api` herd is laid out along x, the orientation that places on both generations.
* The strip-mine is the DSL's, so each core gets a contiguous run of tiles where the predecessors' hand-built `AffineMap` interleaved them. Every tile is still computed exactly once by exactly one core, and the tiles are independent.
* The L1 buffers now allocate and free together. **The predecessors allocated both outside the temporal loop and called `DeallocOp` on them inside it**, freeing each buffer once per trip — 32 times at the default size.

`scalar_invsqrt` additionally refuses npu1 with a message instead of building a module that dies later in the backend: `math.rsqrt` on a plain f32 is an instruction on npu2, and on npu1 lowers to a call into `getRsqrtBf16`, which has no f32 scalar form. Its lit was already `REQUIRES: ryzen_ai_npu2` for that reason.

## Note

After conversion these are close to their `vector_examples` siblings with one flag changed — same size, same seed, same tolerance. They are kept separate because they are separately tracked examples with their own lits, but the duplication is now visible in a way it was not before.