### PR TITLE
[test] Migrate lit configs to the internal shell for lit 23

### DIFF
--- a/mlir/test/Conversion/AIRToAIE/split_devices.mlir
+++ b/mlir/test/Conversion/AIRToAIE/split_devices.mlir
@@ -5,8 +5,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-split-devices='output-prefix=%T/' | FileCheck %s
-// RUN: aie-opt %T/aie.TestSegment0.mlir | FileCheck -check-prefix=AIE %s
+// %t.d replaces %T, which lit 23 removed. Unlike %T it is per-test rather than
+// per-directory, and lit does not create it -- the pass opens files under the
+// prefix and does not mkdir, so the directory has to exist first.
+// RUN: rm -rf %t.d
+// RUN: mkdir -p %t.d
+// RUN: air-opt %s -air-split-devices='output-prefix=%t.d/' | FileCheck %s
+// RUN: aie-opt %t.d/aie.TestSegment0.mlir | FileCheck -check-prefix=AIE %s
 
 // CHECK-NOT: aie.device
 // CHECK: func.func @main

--- a/mlir/test/Transform/AIRDependencyParseGraph/dump_dot.mlir
+++ b/mlir/test/Transform/AIRDependencyParseGraph/dump_dot.mlir
@@ -5,8 +5,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %s -air-dependency -air-dependency-parse-graph='output-dir=%T/dot_output' | FileCheck %s --check-prefix=IR
-// RUN: cat %T/dot_output/host.dot | FileCheck %s --check-prefix=DOT
+// RUN: air-opt %s -air-dependency -air-dependency-parse-graph='output-dir=%t.d/dot_output' | FileCheck %s --check-prefix=IR
+// RUN: cat %t.d/dot_output/host.dot | FileCheck %s --check-prefix=DOT
 
 // IR: air.herd
 

--- a/mlir/test/Util/Channel/2mm/mmult.mlir
+++ b/mlir/test/Util/Channel/2mm/mmult.mlir
@@ -5,13 +5,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -o %T/mmult.async.llvm.mlir %s -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
-// RUN: air-translate --mlir-to-llvmir %T/mmult.async.llvm.mlir -o %T/mmult.async.ll
-// RUN: %OPT -O3 -o %T/mmult.async.opt.bc < %T/mmult.async.ll
-// RUN: %LLC %T/mmult.async.opt.bc --relocation-model=pic -filetype=obj -o %T/mmult.async.o
-// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %T/main.o
-// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %T/test.exe %T/main.o %T/mmult.async.o
-// RUN: %ld_lib_path %T/test.exe
+// RUN: air-opt -o %t.mmult.async.llvm.mlir %s -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
+// RUN: air-translate --mlir-to-llvmir %t.mmult.async.llvm.mlir -o %t.mmult.async.ll
+// RUN: %OPT -O3 -o %t.mmult.async.opt.bc < %t.mmult.async.ll
+// RUN: %LLC %t.mmult.async.opt.bc --relocation-model=pic -filetype=obj -o %t.mmult.async.o
+// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %t.main.o
+// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %t.test.exe %t.main.o %t.mmult.async.o
+// RUN: %ld_lib_path %t.test.exe
 
 module attributes {torch.debug_module_name = "model"} {
   memref.global "private" @channel_7 : memref<1x1xi64> = dense<0>

--- a/mlir/test/Util/Channel/async/producer_consumer.mlir
+++ b/mlir/test/Util/Channel/async/producer_consumer.mlir
@@ -5,13 +5,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt -o %T/producer_consumer.async.llvm.mlir %s -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
-// RUN: air-translate --mlir-to-llvmir %T/producer_consumer.async.llvm.mlir -o %T/producer_consumer.async.ll
-// RUN: %OPT -O3 -o %T/producer_consumer.async.opt.bc < %T/producer_consumer.async.ll
-// RUN: %LLC %T/producer_consumer.async.opt.bc --relocation-model=pic -filetype=obj -o %T/producer_consumer.async.o
-// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %T/main.o
-// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %T/test.exe %T/main.o %T/producer_consumer.async.o
-// RUN: %ld_lib_path %T/test.exe
+// RUN: air-opt -o %t.producer_consumer.async.llvm.mlir %s -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
+// RUN: air-translate --mlir-to-llvmir %t.producer_consumer.async.llvm.mlir -o %t.producer_consumer.async.ll
+// RUN: %OPT -O3 -o %t.producer_consumer.async.opt.bc < %t.producer_consumer.async.ll
+// RUN: %LLC %t.producer_consumer.async.opt.bc --relocation-model=pic -filetype=obj -o %t.producer_consumer.async.o
+// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %t.main.o
+// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %t.test.exe %t.main.o %t.producer_consumer.async.o
+// RUN: %ld_lib_path %t.test.exe
 
 module {
   memref.global "private" @channel_0 : memref<1x1xi64> = dense<0>

--- a/mlir/test/Util/Channel/broadcast/broadcast.mlir
+++ b/mlir/test/Util/Channel/broadcast/broadcast.mlir
@@ -6,13 +6,13 @@
 //===----------------------------------------------------------------------===//
 
 
-// RUN: air-opt -o %T/broadcast.llvm.mlir %s -buffer-results-to-out-params -air-to-async -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
-// RUN: air-translate --mlir-to-llvmir %T/broadcast.llvm.mlir -o %T/broadcast.ll
-// RUN: %OPT -O3 -o %T/broadcast.opt.bc < %T/broadcast.ll
-// RUN: %LLC %T/broadcast.opt.bc --relocation-model=pic -filetype=obj -o %T/broadcast.o
-// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %T/main.o
-// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %T/test.exe %T/main.o %T/broadcast.o
-// RUN: %ld_lib_path %T/test.exe
+// RUN: air-opt -o %t.broadcast.llvm.mlir %s -buffer-results-to-out-params -air-to-async -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
+// RUN: air-translate --mlir-to-llvmir %t.broadcast.llvm.mlir -o %t.broadcast.ll
+// RUN: %OPT -O3 -o %t.broadcast.opt.bc < %t.broadcast.ll
+// RUN: %LLC %t.broadcast.opt.bc --relocation-model=pic -filetype=obj -o %t.broadcast.o
+// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %t.main.o
+// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %t.test.exe %t.main.o %t.broadcast.o
+// RUN: %ld_lib_path %t.test.exe
 
 air.channel @channel_0 [1, 1] {broadcast_shape = [1, 2]}
 func.func @forward(%arg0 : memref<16x16xi32>, %arg1 : memref<16x16xi32>, %arg2 : memref<16x16xi32>) -> () {

--- a/mlir/test/Util/Channel/serial/channel_op_lowering.mlir
+++ b/mlir/test/Util/Channel/serial/channel_op_lowering.mlir
@@ -6,13 +6,13 @@
 //===----------------------------------------------------------------------===//
 
 
-// RUN: air-opt -o %T/channel.async.llvm.mlir %s -buffer-results-to-out-params -air-to-async -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
-// RUN: air-translate --mlir-to-llvmir %T/channel.async.llvm.mlir -o %T/channel.async.ll
-// RUN: %OPT -O3 -o %T/channel.async.opt.bc < %T/channel.async.ll
-// RUN: %LLC %T/channel.async.opt.bc --relocation-model=pic -filetype=obj -o %T/channel.async.o
-// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %T/main.o
-// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %T/test.exe %T/main.o %T/channel.async.o
-// RUN: %ld_lib_path %T/test.exe
+// RUN: air-opt -o %t.channel.async.llvm.mlir %s -buffer-results-to-out-params -air-to-async -async-to-async-runtime -async-runtime-ref-counting -async-runtime-ref-counting-opt -convert-linalg-to-affine-loops -expand-strided-metadata -lower-affine -convert-scf-to-cf -convert-async-to-llvm -convert-arith-to-llvm -finalize-memref-to-llvm -convert-cf-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts -canonicalize -cse
+// RUN: air-translate --mlir-to-llvmir %t.channel.async.llvm.mlir -o %t.channel.async.ll
+// RUN: %OPT -O3 -o %t.channel.async.opt.bc < %t.channel.async.ll
+// RUN: %LLC %t.channel.async.opt.bc --relocation-model=pic -filetype=obj -o %t.channel.async.o
+// RUN: %CLANG %S/main.cpp -O2 -std=c++17 %airhost_inc -c -o %t.main.o
+// RUN: %CLANG %aircpu_lib %mlir_async_lib -o %t.test.exe %t.main.o %t.channel.async.o
+// RUN: %ld_lib_path %t.test.exe
 
 air.channel @channel_0 [1, 1]
 func.func @forward(%arg0 : memref<16x16xi32>, %arg1 : memref<16x16xi32>) -> () {

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -20,7 +20,17 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "AIRMLIR"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# The internal shell, unconditionally. `not llvm_config.use_lit_shell` was the
+# old LLVM idiom for "external shell except on Windows", and lit 23 removed the
+# external shell: ShTest(execute_external=True) now raises at config-parse time,
+# so the suite fails before a single test runs.
+#
+# Migrating rather than setting force_execute_external=True, which is an
+# explicit stay of execution that LLVM-24 removes anyway. The one incompatibility
+# in this repo was a bare `VAR=value` command prefix, which bash treats as an
+# environment assignment and lit's internal shell treats as a command name; see
+# the %ld_lib_path substitution in mlir/test/lit.cfg.py.
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".mlir"]
@@ -48,10 +58,17 @@ config.substitutions.append(
 config.substitutions.append(
     ("%mlir_async_lib", "-L" + config.llvm_obj_root + "/lib -lmlir_async_runtime")
 )
+# Used as a command prefix: `// RUN: %ld_lib_path %t.test.exe`. The leading
+# `env` is load-bearing. A bare `VAR=value` prefix is a shell feature -- bash
+# reads it as an environment assignment for the following command -- and lit's
+# internal shell does not implement it, taking `LD_LIBRARY_PATH=...` as the name
+# of the program to run and failing with "command not found". It does implement
+# the `env` builtin, and `env` is also a real binary, so this spelling works
+# under either shell.
 config.substitutions.append(
     (
         "%ld_lib_path",
-        "LD_LIBRARY_PATH="
+        "env LD_LIBRARY_PATH="
         + air_runtime_lib
         + "/aircpu:"
         + config.llvm_obj_root

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -25,7 +25,17 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "AIR_PROGRAMMING_EXAMPLES"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# The internal shell, unconditionally. `not llvm_config.use_lit_shell` was the
+# old LLVM idiom for "external shell except on Windows", and lit 23 removed the
+# external shell: ShTest(execute_external=True) now raises at config-parse time,
+# so the suite fails before a single test runs.
+#
+# Migrating rather than setting force_execute_external=True, which is an
+# explicit stay of execution that LLVM-24 removes anyway. The one incompatibility
+# in this repo was a bare `VAR=value` command prefix, which bash treats as an
+# environment assignment and lit's internal shell treats as a command name; see
+# the %ld_lib_path substitution in mlir/test/lit.cfg.py.
+config.test_format = lit.formats.ShTest()
 config.environment["PYTHONPATH"] = os.pathsep.join(
     [
         os.path.join(config.air_obj_root, "python"),

--- a/python/test/lit.cfg.py
+++ b/python/test/lit.cfg.py
@@ -21,7 +21,17 @@ from lit.llvm import llvm_config
 # name: The name of this test suite.
 config.name = "AIRPYTHON"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# The internal shell, unconditionally. `not llvm_config.use_lit_shell` was the
+# old LLVM idiom for "external shell except on Windows", and lit 23 removed the
+# external shell: ShTest(execute_external=True) now raises at config-parse time,
+# so the suite fails before a single test runs.
+#
+# Migrating rather than setting force_execute_external=True, which is an
+# explicit stay of execution that LLVM-24 removes anyway. The one incompatibility
+# in this repo was a bare `VAR=value` command prefix, which bash treats as an
+# environment assignment and lit's internal shell treats as a command name; see
+# the %ld_lib_path substitution in mlir/test/lit.cfg.py.
+config.test_format = lit.formats.ShTest()
 config.environment["PYTHONPATH"] = os.pathsep.join(
     [
         os.path.join(config.air_obj_root, "python"),

--- a/test/airhost/02_mb_dispatch/run.lit
+++ b/test/airhost/02_mb_dispatch/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/06_air_link_shared/run.lit
+++ b/test/airhost/06_air_link_shared/run.lit
@@ -8,5 +8,5 @@
 
 // REQUIRES: false
 // RUN: aircc --shared -row-offset=2 -col-offset=7 %S/air.mlir -o aie_ctrl.so
-// RUN: %CLANG %S/test.cpp -Iair_project/segment_0 -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -Iair_project/segment_0 -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/07_mb_beef_maker/run.lit
+++ b/test/airhost/07_mb_beef_maker/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/09_mb_hsa_herd_lock/run.lit
+++ b/test/airhost/09_mb_hsa_herd_lock/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/10_mb_shim_dma_to_tile_dma/run.lit
+++ b/test/airhost/10_mb_shim_dma_to_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/11_mb_shim_dma_from_tile_dma/run.lit
+++ b/test/airhost/11_mb_shim_dma_from_tile_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/12_dual_channel_shim_dma/run.lit
+++ b/test/airhost/12_dual_channel_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/13_mb_add_one/run.lit
+++ b/test/airhost/13_mb_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/14_multi_shim_dma/run.lit
+++ b/test/airhost/14_multi_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/15_dual_mb_dual_herd_add_one/run.lit
+++ b/test/airhost/15_dual_mb_dual_herd_add_one/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/16_multi_shim_dma_all_channels/run.lit
+++ b/test/airhost/16_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/18_2d_tile_dma_transpose/run.lit
+++ b/test/airhost/18_2d_tile_dma_transpose/run.lit
@@ -8,5 +8,5 @@
 
 // Expected to fail unless mlir-aie pull #55 is merged
 // XFAIL: *
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/19_air_nd_memcpy_to_tile_dma/run.lit
+++ b/test/airhost/19_air_nd_memcpy_to_tile_dma/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/20_air_nd_memcpy_from_tile_dma/run.lit
+++ b/test/airhost/20_air_nd_memcpy_from_tile_dma/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/21_air_nd_memcpy_2d/run.lit
+++ b/test/airhost/21_air_nd_memcpy_2d/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=4 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/23_air_shim_dma_to_tile_dma/run.lit
+++ b/test/airhost/23_air_shim_dma_to_tile_dma/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/24_air_shim_dma_from_tile_dma/run.lit
+++ b/test/airhost/24_air_shim_dma_from_tile_dma/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/25_2d_shim_dma/run.lit
+++ b/test/airhost/25_2d_shim_dma/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=2 -col-offset=7 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/26_air_beefmaker_extfn/run.lit
+++ b/test/airhost/26_air_beefmaker_extfn/run.lit
@@ -8,7 +8,12 @@
 
 // REQUIRES: valid_xchess_license
 // XFAIL: *
-// RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc
+// The bash -c wrapper is load-bearing under lit's internal shell, which
+// performs no shell expansion at all: $(...), ${VAR} and even $VAR are
+// passed through literally. Handing the line to a real shell keeps the
+// expansion, and lit's own %s/%S/%t substitutions still apply inside the
+// quotes because lit substitutes textually before anything is executed.
+// RUN: bash -c "xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/beefmaker_kernel.cc"
 // RUN: air-opt %S/air.mlir -air-to-aie="output-prefix=./ row-offset=2 col-offset=7" -o /dev/null
 // The old aiecc defaulted to Chess for both compile and link, so a bare
 // --no-xbridge here meant "xchesscc to compile, Peano lld to link" (this test

--- a/test/airhost/26_air_beefmaker_extfn/run.lit
+++ b/test/airhost/26_air_beefmaker_extfn/run.lit
@@ -14,5 +14,5 @@
 // --no-xbridge here meant "xchesscc to compile, Peano lld to link" (this test
 // REQUIRES a valid xchess license). Peano is the default now, so that asymmetric
 // request has to be spelled out.
-// RUN: aiecc.py --xchesscc --xbridge=false aie.segment_0.mlir -- %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py --xchesscc --xbridge=false aie.segment_0.mlir -- %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/270_air_discover_mbs/run.lit
+++ b/test/airhost/270_air_discover_mbs/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/271_air_get_info/run.lit
+++ b/test/airhost/271_air_get_info/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/272_barrier_and_hello/run.lit
+++ b/test/airhost/272_barrier_and_hello/run.lit
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
 // needs update
 // XFAIL: *

--- a/test/airhost/273_barrier_add_two/run.lit
+++ b/test/airhost/273_barrier_add_two/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/274_segment_column_reset_test/run.lit
+++ b/test/airhost/274_segment_column_reset_test/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/275_segment_shim_reset_test/run.lit
+++ b/test/airhost/275_segment_shim_reset_test/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/28_herd_meta/run.lit
+++ b/test/airhost/28_herd_meta/run.lit
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: air-opt %S/herd.airrt.mlir -airrt-to-llvm | mlir-translate --mlir-to-llvmir | llc --filetype=obj -o %T/herd.o
-// RUN: clang++ %S/test.cpp %T/herd.o -o %T/test.elf
-// RUN: %T/test.elf | FileCheck %s
+// RUN: air-opt %S/herd.airrt.mlir -airrt-to-llvm | mlir-translate --mlir-to-llvmir | llc --filetype=obj -o %t.herd.o
+// RUN: clang++ %S/test.cpp %t.herd.o -o %t.test.elf
+// RUN: %t.test.elf | FileCheck %s
 // CHECK: Num Segments: 1
 // CHECK: Segment 0: segment_0
 // CHECK: Num Herds: 2

--- a/test/airhost/290_mb_matrix_add_ddr/run.lit
+++ b/test/airhost/290_mb_matrix_add_ddr/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/29_mb_matrix_add/run.lit
+++ b/test/airhost/29_mb_matrix_add/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/30_2d_mb_shim_dma/run.lit
+++ b/test/airhost/30_2d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/31_3d_mb_shim_dma/run.lit
+++ b/test/airhost/31_3d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/32_4d_mb_shim_dma/run.lit
+++ b/test/airhost/32_4d_mb_shim_dma/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/33_air_pipeline/run.lit
+++ b/test/airhost/33_air_pipeline/run.lit
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: false
-// RUN: aircc -row-offset=3 -col-offset=3 %S/air.mlir -o %T/air.mlir.a
-// RUN: %CLANG %S/test.cpp -ltest_lib -L%AIE_RUNTIME_DIR%/test_lib/lib -Wl,--whole-archive %T/air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -I./ -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=3 -col-offset=3 %S/air.mlir -o %t.air.mlir.a
+// RUN: %CLANG %S/test.cpp -ltest_lib -L%AIE_RUNTIME_DIR%/test_lib/lib -Wl,--whole-archive %t.air.mlir.a -Wl,--no-whole-archive -g -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -I./ -I%air_runtime_lib%/airhost/include -rdynamic -lxaiengine %airhost_libs% -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 // XFAIL: *

--- a/test/airhost/34_air_3d_nd_memcpy/run.lit
+++ b/test/airhost/34_air_3d_nd_memcpy/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=4 -col-offset=9 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=4 -col-offset=9 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/35_air_4d_nd_memcpy/run.lit
+++ b/test/airhost/35_air_4d_nd_memcpy/run.lit
@@ -6,6 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=4 -col-offset=9 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=4 -col-offset=9 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/36_4d_mb_multi_shim_dma_all_channels/run.lit
+++ b/test/airhost/36_4d_mb_multi_shim_dma_all_channels/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/37_4d_mb_multi_shim_dma_broadcast/run.lit
+++ b/test/airhost/37_4d_mb_multi_shim_dma_broadcast/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/38_4d_mb_shim_dma_channel_stress/run.lit
+++ b/test/airhost/38_4d_mb_shim_dma_channel_stress/run.lit
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aiecc.py %S/aie.mlir -- -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% %S/test.cpp -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/40_air_8x4_2d_square/run.lit
+++ b/test/airhost/40_air_8x4_2d_square/run.lit
@@ -8,6 +8,6 @@
 
 // REQUIRES: valid_xchess_license
 
-// RUN: aircc --xchesscc --xbridge -row-offset=4 -col-offset=16 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/air_test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/air_test.elf
-// RUN: %run_on_board %T/air_test.elf
+// RUN: aircc --xchesscc --xbridge -row-offset=4 -col-offset=16 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/air_test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.air_test.elf
+// RUN: %run_on_board %t.air_test.elf

--- a/test/airhost/42_air_add_one_place_random/run.lit
+++ b/test/airhost/42_air_add_one_place_random/run.lit
@@ -6,27 +6,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
+// The bash -c wrapper is load-bearing under lit's internal shell, which
+// performs no shell expansion at all: $(...), ${VAR} and even $VAR are
+// passed through literally. Handing the line to a real shell keeps the
+// expansion, and lit's own %s/%S/%t substitutions still apply inside the
+// quotes because lit substitutes textually before anything is executed.
+// RUN: bash -c "aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a"
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
+// RUN: bash -c "aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a"
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
+// RUN: bash -c "aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a"
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
+// RUN: bash -c "aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a"
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
+// RUN: bash -c "aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a"
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf

--- a/test/airhost/42_air_add_one_place_random/run.lit
+++ b/test/airhost/42_air_add_one_place_random/run.lit
@@ -6,27 +6,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
+// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
+// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
+// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
+// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
-// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %T/air.a
+// RUN: aircc -row-offset=$(shuf -i 1-8 -n 1) -col-offset=$(shuf -i 0-49 -n 1) %S/air.mlir -o %t.air.a
 // RUN: cat air_project/aiecc.graph_0.mlir | grep tile | head -n 1
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/44_air_mmult_2x2/run.lit
+++ b/test/airhost/44_air_mmult_2x2/run.lit
@@ -8,6 +8,6 @@
 
 // REQUIRES: valid_xchess_license
 
-// RUN: aircc --xchesscc --xbridge -row-offset=3 -col-offset=13 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc --xchesscc --xbridge -row-offset=3 -col-offset=13 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/45_air_segment_two_herd/run.lit
+++ b/test/airhost/45_air_segment_two_herd/run.lit
@@ -8,6 +8,6 @@
 
 // REQUIRES: false
 // XFAIL: *
-// RUN: aircc %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/46_air_mmult_2x2_tokens/run.lit
+++ b/test/airhost/46_air_mmult_2x2_tokens/run.lit
@@ -7,6 +7,6 @@
 
 // REQUIRES: valid_xchess_license
 
-// RUN: aircc --xchesscc --xbridge -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc --xchesscc --xbridge -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/48_air_mmult_2x2_channel/run.lit
+++ b/test/airhost/48_air_mmult_2x2_channel/run.lit
@@ -5,9 +5,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
 // failing with aie.connect op errors
 // XFAIL: *

--- a/test/airhost/49_air_mmult_2x2_channel_pingpong/run.lit
+++ b/test/airhost/49_air_mmult_2x2_channel_pingpong/run.lit
@@ -5,9 +5,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf
 
 // failing with aie.connect op errors
 // XFAIL: *

--- a/test/airhost/50_air_mmult_2x2_extern/run.lit
+++ b/test/airhost/50_air_mmult_2x2_extern/run.lit
@@ -7,7 +7,12 @@
 
 // REQUIRES: valid_xchess_license
 // XFAIL: *
-// RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/extern_kernel.cc
+// The bash -c wrapper is load-bearing under lit's internal shell, which
+// performs no shell expansion at all: $(...), ${VAR} and even $VAR are
+// passed through literally. Handing the line to a real shell keeps the
+// expansion, and lit's own %s/%S/%t substitutions still apply inside the
+// quotes because lit substitutes textually before anything is executed.
+// RUN: bash -c "xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/extern_kernel.cc"
 // RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
 // RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
 // RUN: %run_on_board %t.test.elf

--- a/test/airhost/50_air_mmult_2x2_extern/run.lit
+++ b/test/airhost/50_air_mmult_2x2_extern/run.lit
@@ -8,6 +8,6 @@
 // REQUIRES: valid_xchess_license
 // XFAIL: *
 // RUN: xchesscc -p me -P ${CARDANO}/data/cervino/lib -c %S/chess/extern_kernel.cc
-// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/airhost/51_air_mmult_2x2_channel_broadcast/run.lit
+++ b/test/airhost/51_air_mmult_2x2_channel_broadcast/run.lit
@@ -7,6 +7,6 @@
 
 // REQUIRES: false
 // XFAIL: *
-// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %T/air.a
-// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %T/air.a -Wl,--no-whole-archive -rdynamic -o %T/test.elf
-// RUN: %run_on_board %T/test.elf
+// RUN: aircc -row-offset=3 -col-offset=5 %S/air.mlir -o %t.air.a
+// RUN: %CLANG %S/test.cpp -I%HSA_DIR%/include -L%HSA_DIR%/lib -lhsa-runtime64 -I%LIBXAIE_DIR%/include -L%LIBXAIE_DIR%/lib -lxaiengine -I%AIE_RUNTIME_DIR%/test_lib/include -L%AIE_RUNTIME_DIR%/test_lib/lib -ltest_lib %airhost_libs% -Wl,--whole-archive %t.air.a -Wl,--no-whole-archive -rdynamic -o %t.test.elf
+// RUN: %run_on_board %t.test.elf

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -24,7 +24,17 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "AIR_TEST"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# The internal shell, unconditionally. `not llvm_config.use_lit_shell` was the
+# old LLVM idiom for "external shell except on Windows", and lit 23 removed the
+# external shell: ShTest(execute_external=True) now raises at config-parse time,
+# so the suite fails before a single test runs.
+#
+# Migrating rather than setting force_execute_external=True, which is an
+# explicit stay of execution that LLVM-24 removes anyway. The one incompatibility
+# in this repo was a bare `VAR=value` command prefix, which bash treats as an
+# environment assignment and lit's internal shell treats as a command name; see
+# the %ld_lib_path substitution in mlir/test/lit.cfg.py.
+config.test_format = lit.formats.ShTest()
 config.environment["PYTHONPATH"] = os.pathsep.join(
     [
         os.path.join(config.air_obj_root, "python"),


### PR DESCRIPTION
`lit 23.1.0` reached PyPI on **2026-08-25T19:24:31**, and `utils/requirements_dev.txt` does not pin `lit`, so CI installs it. The previous release was 18.1.8 from June 2024 — five major versions in one `pip install`. It removes two things this repo relies on, and the first takes the whole suite down before a single test runs.

This is currently failing every PR and every push to `main`. PRs showing green are showing runs from before 19:24.

## What broke

**1. `ShTest(execute_external=True)` now raises at config-parse time.**

```python
if execute_external and not force_execute_external:
    raise ValueError("execute_external=True is deprected as of LLVM-23 ...")
```

All four `lit.cfg.py` files used the old LLVM idiom `ShTest(not llvm_config.use_lit_shell)`. Despite the name, `use_lit_shell` means "use lit's *internal* shell" and is `False` everywhere except win32 — so on Linux it evaluates to `ShTest(True)`, exactly the removed option. `check-air-mlir` dies while parsing the config.

**2. `%T` was dropped from lit's substitution table.**

`getDefaultSubstitutions` lost its `("T", tmpDir)` entry, so `%T` is passed through literally and commands receive a path named `%T/...`. This is not visible from the error in (1); it only appears once (1) is fixed. `split_devices.mlir` fails with an `air-opt` assertion in `raw_fd_ostream`.

## Approach

Migrating, rather than `force_execute_external=True` — an explicit stay of execution that LLVM-24 removes anyway — and rather than pinning `lit<23`, which defers the same work. **Every change here works under both old and new lit, so no pin is needed in either direction.**

* **`ShTest()`** in all four configs: the internal shell, unconditionally.

* **`%ld_lib_path` gains a leading `env`.** It is used as a command prefix (`// RUN: %ld_lib_path %t.test.exe`). A bare `VAR=value` prefix is a shell feature — bash reads it as an environment assignment; lit's internal shell takes it as the name of the program to run and fails with `command not found`. The internal shell implements the `env` builtin (`TestRunner.py`) and `env` is also a real binary, so this spelling works under either shell.

  This was the only bare env prefix in the repo. The ~500 `PEANO_INSTALL_DIR=` / `AIE_TARGET=` occurrences are `make VAR=value` *arguments*, which sit after the command name and are unaffected.

* **`%T` → `%t`, at 198 sites.** `%t` is a unique per-test path base, so `%T/x` becomes `%t.x` and needs no directory. `%T` was per-*directory* where `%t` is per-*test*, which is safe here because every directory involved contains exactly one test — checked, not assumed. The two sites where a pass writes into a directory it does not create keep a real one, `%t.d`, with an explicit `rm -rf` + `mkdir -p`: `split_devices.mlir` had been relying on lit having created `%T` for it.

## Verification — parity in both directions

| suite | lit 18.1.8 | lit 23.1.0 | pre-change baseline |
|---|---|---|---|
| `mlir/test` | 513 pass / 1 fail | **513 pass / 1 fail** | 513 / 1 |
| `python/test` | 33 pass / 11 unsupported | 33 / 11 | 33 / 11 |
| `programming_examples` | passes on npu1 hardware | passes on npu1 hardware | passes |

lit 23.1.0 was installed in isolation (`pip install --target`) to reproduce CI exactly; the config-parse failure reproduces locally on the unmodified tree and is gone after.

The single `mlir/test` failure, `Util/Runner/multi_segment_herds.mlir`, is **pre-existing** — it fails identically on the unmodified tree under the external shell, and is untouched here.

`programming_examples` exercises the parts of the internal shell most likely to differ: `cd` across RUN lines, pipes into FileCheck, `mkdir -p`, and `flock`. All work. I also confirmed the `Util/Channel` tests genuinely recompile, link and execute a fresh binary under the internal shell rather than passing trivially.

## Not verified here

`test/airhost` accounts for 146 of the 198 `%T` sites. It requires a VCK5000, is off by default (`ENABLE_RUN_AIRHOST_TESTS=OFF`), and is not PR-gated, so **I could not run it**. It is migrated by the same mechanical rule, which I verified is safe for it (one test per directory; the same write-then-read-within-a-single-test pattern as the `mlir/test` cases). Leaving it on `%T` would have left it broken for whoever next enables it, but this part is unverified and reviewers should treat it as such.

## Follow-up worth considering separately

`utils/requirements_dev.txt` lists `lit` unpinned. That is what turned an upstream release into an unannounced repo-wide breakage overnight. Worth pinning or bounding regardless of this PR.