### PR TITLE
[python] air.api: squeeze trailing unit axes in transfers, and convert average_pool

### DIFF
--- a/programming_examples/average_pool/average_pool.py
+++ b/programming_examples/average_pool/average_pool.py
@@ -1,184 +1,100 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Average pool over the rows of an [M, N] array, on air.api.
 
-"""Vectorized AveragePool Example
+    c[:] = air.ops.reduce_add(a[:] * (1.0 / n))
 
-Implements 1D average pooling on a 2D input [M, N]:
-  output[i] = mean(input[i, :]) for each row i
+One line of compute. ``ops.reduce_add`` collapses the innermost dimension, so an
+``[tile_m, n]`` tile reduces to an ``[tile_m, 1]`` buffer -- a column of row
+averages -- which is what the predecessor built by hand out of a per-row
+``scf.for`` containing two ``memref.subview``s, two ``memref.collapse_shape``s
+with an explicit dynamic ``StridedLayoutAttr``, a ``vector.transfer_read`` with
+an identity permutation map and a padding constant, a ``vector.broadcast``, an
+``arith.mulf`` and a ``vector.reduction``.
 
-Each row of N elements is scaled by 1/N (vectorized multiply) and then
-reduced to a single scalar using vector.reduction with ADD.
+The emitted arithmetic is unchanged: broadcast 1/n to a vector, multiply, then
+``vector.reduction <add>``.
 
-Uses a 1x2 AIE herd with DMA transfers between L3 and L1 memory.
+**The scale happens before the reduction, and that is load-bearing.** Writing it
+the other way round -- reduce, then scale the result -- is one scalar bf16
+multiply per row instead of one vector multiply per row, and the predecessor
+carries a comment saying a scalar bf16 multiply "can produce corrupted output on
+AIE2". Putting the multiply inside the reduce keeps it on the vector, matching
+both the predecessor's IR and its reference, which also scales each element
+before summing. In bf16 those two orders do not agree to the last bit even in
+exact arithmetic, so this is not only about the AIE2 hazard.
+
+The ``[tile_m, 1]`` shape of the output tile is what a reduction produces, while
+the L3 array it belongs in is ``[m]``. ``ops.store`` accepts the pair: it
+already ignored a *leading* unit axis, which is how a per-core L2 staging tile
+is spelled, and now ignores a trailing one for the symmetric reason. Both
+describe the same tile_m contiguous elements.
+
+Two differences from the predecessor worth naming:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's, so each core gets a contiguous run of tiles where
+  the predecessor's hand-built AffineMap interleaved them. Every tile is still
+  computed exactly once by exactly one core, and the rows are independent.
+
+``--target`` is new and defaults to detecting the installed part, which is what
+the predecessor did implicitly by having no device flag at all.
 """
 
 import argparse
-from ml_dtypes import bfloat16
-
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, store, subview, collapse_shape
-from air.dialects.vector import (
-    transfer_read,
-    reduction,
-    CombiningKind,
-    broadcast,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
 
 import numpy as np
+from ml_dtypes import bfloat16
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import bf16
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
-def build_module(m, n, tile_m, np_dtype_in):
-    a_size = [m, n]
-    out_size = [m]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
+def build_module(m, n, tile_m):
     assert n > 0, "Pool width N must be positive"
-    assert m % (tile_m * num_tiles) == 0
-    index_type = IndexType.get()
+    assert m % (tile_m * NUM_TILES) == 0
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3outputMemrefTy = MemRefType.get(out_size, xrt_dtype_in)
+    A = air.tensor([m, n], bf16)
+    C = air.tensor([m], bf16)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_m, n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1outputMemrefTy = MemRefType.get(
-        shape=[tile_m, 1],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="average_pool") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
-    def average_pool(arg0, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1outputMemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile of rows; shape= pins the core
+            # count to what the predecessor asked for, and the DSL strip-mines
+            # the rest into a loop on each core.
+            with air.herd(
+                [range(0, m, tile_m)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, m, tile_m * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not a row offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_m
+                    # The reduction runs across a whole row, so the vector width
+                    # is the pool width -- the predecessor's vector<Nxbf16>.
+                    a = air.alloc([tile_m, n], bf16, scope=h.private(), vector=n)
+                    # One value per row, and scalar: the reduction writes a
+                    # single element per row, as the predecessor's store does.
+                    c = air.alloc([tile_m, 1], bf16, scope=h.private(), vector=0)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_m),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_m, :])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[offset, 0],
-                    src_sizes=[tile_m, n],
-                    src_strides=[n, 1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cTileN = ConstantOp(index_type, tile_m)
-                inv_n = arith.ConstantOp(xrt_dtype_in, 1.0 / n)
-                for j in range_(c0, cTileN, c1):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j, c0],
-                        [1, n],
-                        [1, 1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j, c0],
-                        [1, 1],
-                        [1, 1],
-                    )
-                    layout = StridedLayoutAttr.get(
-                        ShapedType.get_dynamic_size(),
-                        [
-                            1,
-                        ],
-                    )
-                    collapsed_type = MemRefType.get(
-                        (n,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapsed_type_2 = MemRefType.get(
-                        (1,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapse_dims = [[0, 1]]
-                    collapse_a = collapse_shape(
-                        collapsed_type, sub_a_vec, collapse_dims
-                    )
-                    collapse_c = collapse_shape(
-                        collapsed_type_2, sub_c_vec, collapse_dims
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    v_a = transfer_read(
-                        VectorType.get([n], xrt_dtype_in),
-                        collapse_a,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        cst0,
-                        [True],
-                    )
-                    # Multiply by 1/N before reduction to avoid scalar bf16
-                    # multiply which can produce corrupted output on AIE2.
-                    v_inv_n = broadcast(VectorType.get([n], xrt_dtype_in), inv_n)
-                    v_scaled = arith.mulf(v_a, v_inv_n)
-                    v_avg = reduction(xrt_dtype_in, CombiningKind.ADD, v_scaled)
-                    store(v_avg, collapse_c, [c0])
-                    yield_([])
+                    # Scale inside the reduce, not after it -- see the module
+                    # docstring. This keeps the multiply on the vector.
+                    c[:] = air.ops.reduce_add(a[:] * (1.0 / n))
 
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[
-                        offset,
-                    ],
-                    dst_sizes=[tile_m],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
+                    air.ops.store(c, C[i0 : i0 + tile_m])
 
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -229,15 +145,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.m,
-        args.n,
-        args.tile_m,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.m, args.n, args.tile_m)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -251,7 +170,9 @@ if __name__ == "__main__":
         num_samples = 100
         sampled_indices = np.vstack([np.random.randint(0, args.m, num_samples)])
 
-        # AveragePool reference: sum of (each element * 1/N) per row
+        # AveragePool reference: sum of (each element * 1/N) per row. The scale
+        # is applied per element rather than to the sum, matching the kernel --
+        # see the module docstring.
         inv_n_bf16 = INPUT_DATATYPE(1.0 / args.n)
         sampled_values = np.array(
             [np.sum(input_a[i] * inv_n_bf16) for i in zip(*sampled_indices)],
@@ -269,6 +190,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="average_pool",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -285,6 +207,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/average_pool/average_pool.py
+++ b/programming_examples/average_pool/average_pool.py
@@ -52,6 +52,13 @@ from air.api.types import bf16
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 
+# The rows checked against the reference are drawn at random, so the seed is
+# what makes a failure reproducible: without it a mismatch reports row indices
+# that the next run will not look at. Set at import, before any draw, which is
+# where the predecessor and the rest of this directory set it -- so the sampled
+# indices are not merely stable but the same ones the predecessor checked.
+np.random.seed(42)
+
 NUM_TILES = 2
 
 

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -163,17 +163,28 @@ def _endpoint(obj, direction, role):
     )
 
 
-def _squeeze_leading_units(sizes, rank):
-    """Drop leading unit dimensions until ``sizes`` has rank ``rank``.
+def _squeeze_units(sizes, rank):
+    """Drop outer unit dimensions until ``sizes`` has rank ``rank``.
 
-    A staged L2 tile is indexed per core, so the natural access pattern carries
-    a leading 1 -- ``staged[tx, j:j+m, :]`` is ``[1, m, k]`` into an ``[m, k]``
-    L1 buffer, exactly as the hand-written matvec kernel writes it. Only leading
-    ones are dropped, so a genuine shape mismatch still fails.
+    Leading ones come from staging: an L2 tile is indexed per core, so the
+    natural access pattern carries one -- ``staged[tx, j:j+m, :]`` is
+    ``[1, m, k]`` into an ``[m, k]`` L1 buffer, exactly as the hand-written
+    matvec kernel writes it.
+
+    Trailing ones come from reducing. ``ops.reduce_add`` collapses the innermost
+    dimension to 1, so the result of reducing an ``[m, n]`` tile is an ``[m, 1]``
+    buffer -- a column of m values -- and the L3 array it belongs in is ``[m]``.
+    Both spellings describe the same m contiguous elements.
+
+    Only *unit* dimensions are dropped, and only from the ends, so a genuine
+    mismatch still fails: nothing here can turn ``[m, n]`` into ``[n, m]``, or
+    excuse a differing extent.
     """
     sizes = list(sizes)
     while len(sizes) > rank and sizes[0] == 1:
         sizes.pop(0)
+    while len(sizes) > rank and sizes[-1] == 1:
+        sizes.pop()
     return tuple(sizes)
 
 
@@ -185,14 +196,15 @@ def _elements(sizes):
 
 
 def _check_pair(dst, src, direction):
-    """Shapes and dtypes must agree, up to leading unit dimensions.
+    """Shapes and dtypes must agree, up to outer unit dimensions.
 
     When either end is a reshaped or transposed view the axis-by-axis check is
     dropped and the element count is checked instead. That is not a weakening
     to taste: re-describing a walk is exactly what those two constructors do, so
     a view's rank and axis order are deliberately not the other end's, and the
     only things both ends still have to agree on are how many elements move and
-    of what type. Unviewed transfers keep the strict check.
+    of what type. Unviewed transfers keep the strict check, which tolerates a
+    leading or trailing unit axis -- see ``_squeeze_units``.
     """
     d, s = tuple(dst.sizes), tuple(src.sizes)
     if dst.is_view or src.is_view:
@@ -204,7 +216,7 @@ def _check_pair(dst, src, direction):
             )
     elif d != s:
         rank = min(len(d), len(s))
-        if _squeeze_leading_units(d, rank) != _squeeze_leading_units(s, rank):
+        if _squeeze_units(d, rank) != _squeeze_units(s, rank):
             raise ValueError(
                 f"transfer shape mismatch in air.api.ops.{direction}: the "
                 f"destination {dst.what} is {d} but the source {src.what} is {s}"

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -812,9 +812,24 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: trailing_squeeze_does_not_excuse_a_real_extent
+# A trailing unit dimension is squeezed so a reduction's [m, 1] tile can reach
+# a rank-1 [m] slice. That is about *unit* axes only: a trailing axis with a
+# real extent still has to match, or the transfer would silently move a
+# different number of elements.
+# CHECK: ValueError: transfer shape mismatch in air.api.ops.store
+@expect(ValueError, "trailing_squeeze_does_not_excuse_a_real_extent")
+def _():
+    def body(h, tx, ty, A, B, C):
+        o = air.alloc([16, 4], bf16, scope=h.private())
+        ops.store(o, C[0:16, 0:1])
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: staged_transfer_shape_mismatch
-# Only *leading* unit dimensions are squeezed, so a genuine mismatch still
-# fails rather than being reshaped into something plausible.
+# Only *unit* dimensions are squeezed, and only from the ends, so a genuine
+# mismatch still fails rather than being reshaped into something plausible.
 # CHECK: ValueError: transfer shape mismatch in air.api.ops.load
 @expect(ValueError, "staged_transfer_shape_mismatch")
 def _():

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -83,12 +83,10 @@ def reduce_max_uses_maxsi_on_integers():
 # Destination [tm, 1] rather than [tm]: the reduced axis is kept, numpy's
 # keepdims=True, and the scalar is stored at index 0 of it.
 #
-# Note the L3 output here is [M, 1], not [M]. ops.store squeezes *leading*
-# unit dimensions but not trailing ones, so a [tm, 1] L1 tile cannot currently
-# be stored into a rank-1 [m] slice -- which is exactly what the hand-written
-# reduce kernel does in its DMA. That is why the converted examples drop the
-# axis instead: it keeps the L1 tile the same rank as the L3 output. Both
-# spellings of the reduction work; only this pairing of the two is unsupported.
+# The L3 output here is [M, 1], matching the L1 tile rank for rank. Storing the
+# same [tm, 1] tile into a rank-1 [m] slice also works now -- see
+# keepdims_stores_into_a_rank_1_output below -- since ops.store squeezes a
+# trailing unit dimension as well as a leading one.
 # CHECK: memref.alloc() : memref<256x1xbf16, 2 : i32>
 # CHECK: vector.reduction <add>
 # CHECK: memref.store {{.*}}memref<256x1xbf16, 2 : i32>
@@ -113,6 +111,40 @@ def keepdims_stores_at_the_collapsed_index():
                     air.ops.load(a, A[row : row + tm, :])
                     o[:] = air.ops.reduce_add(a[:])
                     air.ops.store(o, OUT[row : row + tm, :])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: keepdims_stores_into_a_rank_1_output
+# The pairing average_pool needs: a [tm, 1] L1 tile -- the shape a reduction
+# produces -- stored into a rank-1 [m] L3 slice, which is the shape the array
+# of row averages actually has. ops.store squeezes the trailing unit dimension,
+# for the same reason it squeezes a leading one on a staged L2 tile: both
+# spellings describe the same tm contiguous elements.
+# CHECK: memref.alloc() : memref<256x1xbf16, 2 : i32>
+# CHECK: vector.reduction <add>
+# CHECK: air.dma_memcpy_nd ({{.*}}[256] [1], {{.*}}memref<256x1xbf16, 2 : i32>)
+@run
+def keepdims_stores_into_a_rank_1_output():
+    M, N, tile = 65536, 16, 256
+    A = air.tensor([M, N], bf16)
+    OUT = air.tensor([M], bf16)
+
+    with air.launch(name="red") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, M, tile), shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    (tm,) = h.tile_sizes
+                    row = tx * tm
+                    a = air.alloc([tm, N], bf16, scope=h.private())
+                    o = air.alloc([tm, 1], bf16, scope=h.private())
+                    air.ops.load(a, A[row : row + tm, :])
+                    o[:] = air.ops.reduce_add(a[:])
+                    air.ops.store(o, OUT[row : row + tm])
 
     print(launch.mlir())
 


### PR DESCRIPTION
`ops.store` already ignored a *leading* unit axis, because a per-core L2 staging tile is spelled `staged[tx, j:j+m, :]` and lands in an `[m, k]` L1 buffer. This does the same for a trailing one, for the symmetric reason: `ops.reduce_add` collapses the innermost dimension, so reducing an `[m, n]` tile gives an `[m, 1]` buffer — a column of m values — and the L3 array it belongs in is `[m]`. Both spellings describe the same m contiguous elements.

Only *unit* axes are dropped, and only from the ends. Nothing here can turn `[m, n]` into `[n, m]` or excuse a differing extent: a trailing axis of 4 against a trailing axis of 1 still fails, and is pinned as such in `errors.py`.

## The example

This was the only thing standing between `average_pool` and air.api. The compute needed no new surface:

```python
c[:] = air.ops.reduce_add(a[:] * (1.0 / n))
```

One line, against a per-row `scf.for` containing two `memref.subview`s, two `memref.collapse_shape`s with an explicit dynamic `StridedLayoutAttr`, a `vector.transfer_read` with an identity permutation map and a padding constant, a `vector.broadcast`, an `arith.mulf` and a `vector.reduction`. Op counts are identical to the predecessor's.

**The scale goes inside the reduce, and that is load-bearing.** Reducing first and scaling the result is one *scalar* bf16 multiply per row, and the predecessor carries a comment that a scalar bf16 multiply "can produce corrupted output on AIE2". Keeping the multiply inside puts it on the vector, matching the predecessor's IR and its reference — which also scales per element before summing, an order that differs from scale-after-sum in bf16 regardless of the AIE2 hazard.

## A comment that was documenting the limitation

`python/test/api/reduce.py` carried this:

> Note the L3 output here is [M, 1], not [M]. ops.store squeezes *leading* unit dimensions but not trailing ones, so a [tm, 1] L1 tile cannot currently be stored into a rank-1 [m] slice -- which is exactly what the hand-written reduce kernel does in its DMA. That is why the converted examples drop the axis instead.

That is now false, so it is replaced by a test exercising the pairing rather than a comment explaining the workaround.

## Gates

- **`average_pool` passes on npu1 hardware**, and non-vacuously: doubling the reference fails, and so does a 20% perturbation, which is just outside its `rtol=1e-1`.
  - Worth recording: a `+5.0` perturbation *passes*. That is the control being too weak rather than the test being loose — the row averages run to ~1e6, so +5.0 is far inside a 10% tolerance. The proportional controls are the meaningful ones.
- Op-count A/B against the predecessor: identical.
- `python/test/api` 23/23.
- **Blast radius: `-p` output for all 45 buildable air.api examples is byte-identical**, measured against a baseline rebuilt from current `origin/main`'s DSL after rebasing past #1892.

## Differences from the predecessor

* The herd is `[NUM_TILES, 1]` rather than `[1, NUM_TILES]`. A 1-D air.api herd is laid out along x, the orientation that places on both generations.
* The strip-mine is the DSL's, so each core gets a contiguous run of tiles where the predecessor's hand-built `AffineMap` interleaved them. Every tile is still computed exactly once by exactly one core, and the rows are independent.
* `--target` is new and defaults to detecting the installed part, which is what the predecessor did implicitly by having no device flag at all.

## Note on ordering

Rebased onto `main` past #1892, which touched the same `_check_pair` function; the code merged cleanly and only the docstring needed reconciling, so it now describes both the view case (#1892) and the unit-axis case (this PR).