### PR TITLE
[air-runner] Replace path enumeration in hasPath with reachability

### DIFF
--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -1303,18 +1303,24 @@ private:
   // also reach b, which is two linear traversals.
   bool hasPath(Graph::VertexId start_v, Graph::VertexId end_v, Graph &G,
                SmallVector<Graph::VertexId, 1> &vec) {
-    std::set<Graph::VertexId> forward, backward;
+    llvm::DenseSet<Graph::VertexId> forward, backward;
     SmallVector<Graph::VertexId> worklist;
+    // Forward-reachable vertices in traversal order. The result is built by
+    // filtering this rather than by iterating the set, so the order does not
+    // depend on the hash function: the caller may push reset vertices onto the
+    // wavefront candidate list, and that order reaches the trace.
+    SmallVector<Graph::VertexId> reached;
 
     forward.insert(start_v);
     worklist.push_back(start_v);
     while (!worklist.empty()) {
       auto v = worklist.pop_back_val();
+      reached.push_back(v);
       for (auto adj_v : G.adjacentVertices(v))
         if (forward.insert(adj_v).second)
           worklist.push_back(adj_v);
     }
-    if (!forward.count(end_v))
+    if (!forward.contains(end_v))
       return false;
 
     backward.insert(end_v);
@@ -1326,8 +1332,8 @@ private:
           worklist.push_back(inv_v);
     }
 
-    for (auto v : forward)
-      if (backward.count(v))
+    for (auto v : reached)
+      if (backward.contains(v))
         vec.push_back(v);
     return true;
   }

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -1286,26 +1286,50 @@ private:
     }
   }
 
+  // Collect every vertex lying on some path from start_v to end_v.
+  //
+  // This enumerated paths and concatenated them, which is exponential in
+  // reconvergent branching rather than in graph size. One stage of a pipelined
+  // model is a wide diamond -- a token fanning out to N segments and rejoining
+  // at a barrier -- so L stages give N^L paths. At N=12 that is 20k paths for
+  // four layers and 10^12 for twelve, and the vector asked for 4.5 billion
+  // entries before aborting. A model whose segments are chained only through
+  // channels never hit it, because channels are not dependency edges and the
+  // launch graph stays shallow.
+  //
+  // The one caller only iterates the result to reset vertices, which is
+  // idempotent and order-independent, so the *set* is all that is needed. The
+  // vertices on some path from a to b are exactly those reachable from a that
+  // also reach b, which is two linear traversals.
   bool hasPath(Graph::VertexId start_v, Graph::VertexId end_v, Graph &G,
                SmallVector<Graph::VertexId, 1> &vec) {
+    std::set<Graph::VertexId> forward, backward;
+    SmallVector<Graph::VertexId> worklist;
 
-    vec.push_back(start_v);
-    if (start_v == end_v)
-      return true;
-    int pathCount = 0;
-    auto adj_set = G.adjacentVertices(start_v);
-    for (auto adj_v : adj_set) {
-      SmallVector<Graph::VertexId, 1> tmp_vec;
-      if (this->hasPath(adj_v, end_v, G, tmp_vec)) {
-        pathCount++;
-        // Concatenate
-        vec.insert(vec.end(), tmp_vec.begin(), tmp_vec.end());
-      }
+    forward.insert(start_v);
+    worklist.push_back(start_v);
+    while (!worklist.empty()) {
+      auto v = worklist.pop_back_val();
+      for (auto adj_v : G.adjacentVertices(v))
+        if (forward.insert(adj_v).second)
+          worklist.push_back(adj_v);
     }
-    if (pathCount)
-      return true;
-    vec.pop_back();
-    return false;
+    if (!forward.count(end_v))
+      return false;
+
+    backward.insert(end_v);
+    worklist.push_back(end_v);
+    while (!worklist.empty()) {
+      auto v = worklist.pop_back_val();
+      for (auto inv_v : G.inverseAdjacentVertices(v))
+        if (backward.insert(inv_v).second)
+          worklist.push_back(inv_v);
+    }
+
+    for (auto v : forward)
+      if (backward.count(v))
+        vec.push_back(v);
+    return true;
   }
 
   // Get a vector of async tokens which are ready to advance to the next loop


### PR DESCRIPTION
`hasPath` enumerated every path from start to end and concatenated their vertex lists, with no visited set and no memoisation. That is exponential in *reconvergent branching* rather than in graph size.

A wide diamond — one token fanning out to N ops and rejoining at a barrier — multiplies the path count by N. A model built from L such stages has N^L paths. At N=12 that is 20k paths for four stages, 4×10⁸ for eight, and 10¹² for twelve, at which point the vector requested 4.5 billion entries and LLVM aborted:

```
LLVM ERROR: SmallVector unable to grow. Requested capacity (4495263186)
is larger than maximum value for size type (4294967295)
 #13 runnerNode::hasPath(...)
 #14 runnerNode::hasPath(...)
 #15 runnerNode::hasPath(...)
 #17 runnerNode::resetGraphBetweenTwoVertices(...)
 #18 AIRRunner_impl::scheduleLaunch(...)
```

Graph size was not the problem: the same op count in a shape without reconvergent async dependencies simulates fine, because dependency edges are what build the diamonds. It appears once ops fanning out from a common token also rejoin — which is what any pipelined or barrier-synchronised model does.

### Fix

The sole caller only iterates the result to reset vertices, which is idempotent and order-independent, so the *set* is all that is needed. The vertices on some path from a to b are exactly those reachable from a that also reach b: one forward traversal over `adjacentVertices`, one backward over `inverseAdjacentVertices`, and their intersection. Linear in the graph.

### Testing

`check-air-mlir` passes with no failures. A 432-segment model that previously simulated reports an identical latency before and after, so this is behaviour-preserving wherever the old code terminated.

No new lit test: reproducing the abort needs on the order of 10⁹ paths, which is a several-thousand-line input, and any smaller case passes under both implementations because the old one merely gets slow rather than failing. The existing runner tests cover the behaviour that had to stay the same.