### PR TITLE
[air-runner] Diagnose a stalled simulation instead of reporting a time

### DIFF
--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -438,6 +438,18 @@ public:
   void scheduleLaunch(runnerNode &launch, device &device_resource_node,
                       uint64_t &time) {
 
+    // Note whether anything reported an error while this launch ran, so the
+    // stall check at the end can stay quiet when a more specific diagnostic
+    // has already been given. Returning failure leaves the diagnostic for the
+    // default handler to print.
+    bool diagnosticEmitted = false;
+    mlir::ScopedDiagnosticHandler diagHandler(
+        launch.ctrl_g->hierarchyOp->getContext(), [&](mlir::Diagnostic &diag) {
+          if (diag.getSeverity() == mlir::DiagnosticSeverity::Error)
+            diagnosticEmitted = true;
+          return mlir::failure();
+        });
+
     auto start_v = launch.ctrl_g->start_vertex;
     // Reset launch graph
     launch.processed_vertices.clear();
@@ -498,6 +510,26 @@ public:
       if (time > 5000000000)
         running = false;
     }
+
+    // The loop stops as soon as no runner node can make progress. That is the
+    // normal end of a simulation, but it is also exactly what a stall looks
+    // like: an op that can never satisfy its dispatch condition -- a
+    // channel.get whose matching put count can never be reached, say -- simply
+    // stops being retried, and everything behind it is abandoned. The reported
+    // time is then a plausible-looking number for a run that never happened.
+    // Reaching the launch terminator is the check that the whole graph ran.
+    //
+    // Only diagnose it when nothing else already has: a run that stopped
+    // because a hierarchy could not be allocated has reported its own reason,
+    // and not reaching the terminator is the expected consequence.
+    auto terminator_v = launch.ctrl_g->terminator_vertex;
+    launch.runner_assertion(
+        launch.ctrl_g->g[terminator_v].is_started() || diagnosticEmitted,
+        "simulation stalled at " + std::to_string(time) +
+            " cycles without reaching the launch terminator. Some op could "
+            "never satisfy its dispatch condition; the most common cause is a "
+            "channel whose put and get disagree on how many spatial instances "
+            "they represent, so the pair can never be matched.");
   }
 
 private:

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -367,6 +367,15 @@ public:
     resource_hiers.clear();
   }
 
+  // Report a fatal modelling error and stop. Public so the driver can use the
+  // same reporting path for whole-simulation invariants.
+  void runner_assertion(bool cond, std::string msg = "") {
+    if (!cond) {
+      std::cerr << "Error: " + msg + "\n";
+      exit(EXIT_FAILURE);
+    }
+  }
+
 private:
   // Dependency graph helper functions.
   dependencyCanonicalizer canonicalizer;
@@ -1798,13 +1807,6 @@ private:
   }
 
   // Runner error assertion
-  void runner_assertion(bool cond, std::string msg = "") {
-    if (!cond) {
-      std::cerr << "Error: " + msg + "\n";
-      exit(EXIT_FAILURE);
-    }
-  }
-
   // Get a vector of first elements from a vector of tuples
   std::vector<Graph::VertexId> getVectorOfFirstFromVectorOfTuples(
       std::vector<

--- a/mlir/test/Util/Runner/stalled_simulation.mlir
+++ b/mlir/test/Util/Runner/stalled_simulation.mlir
@@ -1,0 +1,62 @@
+//===- stalled_simulation.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// A channel whose put and get disagree on how many spatial instances they
+// represent: the put sits in a 4x1 herd, so it dispatches four, while the
+// single get at segment level expects one and the channel declares no
+// broadcast_shape to reconcile them. This violates the static balance
+// condition, and the pairing test in executeOp(ChannelGetOp) can never hold.
+//
+// The get is therefore never retired and every op behind it is abandoned.
+// The scheduling loop stops as soon as no runner node can make progress,
+// which is indistinguishable from a normal finish unless the launch
+// terminator is checked -- so before this was checked, a stalled run reported
+// a plausible latency and exited 0. The failure mode was a wrong number
+// rather than an error, which is the expensive kind.
+//
+// Runs that stop because a hierarchy could not be allocated already report
+// their own reason and are expected not to reach the terminator; those must
+// stay quiet here, which is what Util/Runner/bad_launch covers.
+
+// RUN: not air-runner %s -f test -m %S/arch.json 2>&1 | FileCheck %s
+
+// CHECK: Error: simulation stalled
+// CHECK-SAME: without reaching the launch terminator
+
+module {
+  air.channel @unbalanced [1, 1]
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %launch = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) attributes {id = 1 : i32} {
+      %seg = air.segment async attributes {id = 10 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+        %c4_s = arith.constant 4 : index
+        %herd = air.herd @m async tile (%tx, %ty) in (%tsx=%c4_s, %tsy=%c1_s) attributes {id = 100 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %tl, %bl = air.execute -> (memref<64xbf16, 2>) {
+            %a2 = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %a2 : memref<64xbf16, 2>
+          }
+          %p = air.channel.put async [%tl] @unbalanced[] (%bl[] [] []) {id = 21 : i32} : (memref<64xbf16, 2>)
+        }
+        %tok, %buf = air.execute -> (memref<64xbf16, 1>) {
+          %a = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %a : memref<64xbf16, 1>
+        }
+        %rx = air.channel.get async [%tok] @unbalanced[] (%buf[] [] []) {id = 20 : i32} : (memref<64xbf16, 1>)
+        // Downstream work, so the stall is on the terminator's dependency
+        // path rather than a dangling token the terminator never waited for.
+        %sink = air.herd @sink async [%rx] tile (%sx, %sy) in (%ssx=%c1_s, %ssy=%c1_s) attributes {id = 101 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %st, %sb = air.execute -> (memref<64xbf16, 2>) {
+            %sa = memref.alloc() : memref<64xbf16, 2>
+            air.execute_terminator %sa : memref<64xbf16, 2>
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -2,22 +2,54 @@
 // SPDX-License-Identifier: MIT
 //
 // REQUIRES: xrt
+// XFAIL: *
 // RUN: mkdir -p test_airrunner
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile run | FileCheck %s
-// Updated post-#1659: ping-pong restored for K-tiled L1 fills dispatched via
-// mutually-exclusive affine.if broadcast branches (only one branch fires per
-// outer iter, so multi-fill of the same alloc is safe).
-// Updated with the air.api port of matrix_multiplication/bf16: 423.808 ->
-// 423.824us, +0.016us on a 16-iteration estimate, i.e. about one cycle per
-// iteration. The port stages L2 flat -- each buffer is exactly the L3 region it
-// holds -- where the predecessor used a [herd_m, herd_n, tile_m, tile_n] grid.
-// For A the two are byte-identical, for B and C they differ, and this is that
-// difference as the simulator models it.
+// RUN: make -f %S/Makefile run 2>&1 | FileCheck %s
 //
-// Checked before touching the number, at this test's own configuration: the
-// output is bit-identical on npu1 (mean_rel_L1=4.011e-03, rel_err max=9.627e+02,
-// abs_err max=1.953e-03 for both), and the lowered design has identical
-// resource counts -- 16 aie.core, 196 aie.dma_bd, 424 aie.use_lock, 60 flows.
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 423.824us
+// This design does not currently simulate to completion, so the test is
+// expected to fail: air-runner reports the stall and exits non-zero, and no
+// latency line is printed.
+//
+// Marked XFAIL rather than rewritten to assert the stall, so the signal points
+// the right way. An expectation that matches the error would go green now and
+// red the day someone fixes it. As an XFAIL it turns into an XPASS instead,
+// which is the prompt to drop this marker and pin the real latency.
+//
+// It used to expect a line reading
+//   "Latency (single-iteration mode, estimated for 16 iterations): 423.824us".
+// That number was the point at which the simulation gave up. air-runner runs
+// until no runner node can make progress, which is also what an unsatisfiable
+// dispatch condition looks like, so a stalled run and a finished one used to
+// print the same thing. The run stalls at 26489 cycles and the test uses
+// single-iteration mode over 16 iterations: 26489 * 16 = 423824 ns, exactly
+// the figure above. It was the stall point, not a latency.
+//
+// What actually happens, on the 4x4 configuration this test uses: all sixteen
+// herds terminate, but the C write-back over @channel_10 completes one get out
+// of sixteen, no segment or launch terminator is ever reached, and the four
+// L3->L2 input channels are left with a put dispatched and no matching get.
+// So the number was "time to finish compute, with the output drain missing" --
+// an underestimate, which is why it looked plausible for so long.
+//
+// Notes for whoever picks this up:
+//   - It is not a scale problem. herd 1x1 stalls at 8057 cycles, 2x2 at 14201,
+//     4x4 at 26489. The 1x1 configuration is the smallest repro.
+//   - It is not the ping-pong transform. Dropping air-label-scf-for-to-ping-pong
+//     and air-ping-pong-transform from the pipeline still stalls, at 6362.
+//   - It is not simulation granularity. "herd" stalls identically to "core".
+//   - Nothing is ready-but-blocked at the stall: every unstarted op still has an
+//     incomplete predecessor, so this is an unsatisfiable dependency state
+//     rather than resource starvation.
+//   - test/airrunner/matmul, which builds its IR through the transform dialect
+//     instead of parsing the air.api example, reaches both terminators and is
+//     unaffected.
+//
+// Whether the generated IR is at fault or air-runner cannot model it is still
+// open. Restore a latency expectation once it simulates to completion; do not
+// just re-pin whatever number the runner prints.
+
+// Deliberately matches the line without its value: the old number was the
+// stall point, and the real one is not yet known.
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations):


### PR DESCRIPTION
The scheduling loop stops as soon as no runner node can make progress. That is the normal end of a simulation, but it is also exactly what a stall looks like: an op that can never satisfy its dispatch condition — a `channel.get` whose matching put count is unreachable, say — simply stops being retried, and every op behind it is abandoned. The runner then printed whatever time it had reached and exited 0.

That is the expensive failure mode, because the output says nothing is wrong. A model that lost most of its work to an unsatisfiable pairing reported `0.025us` against a true `10.5us`, and the only way to notice was to count events in the trace and find the work missing.

### Fix

Check that the launch terminator was actually reached, and report a stall if not.

Runs that stop because a hierarchy could not be allocated have already given a more specific reason and are expected not to terminate, so a `ScopedDiagnosticHandler` notes whether anything was reported and keeps this quiet when something was — which is what `Util/Runner/bad_launch` asserts.

`runner_assertion` moves to the public section so the driver reports through the same path.

### Scope

This is a backstop, not a deadlock detector. It catches stalls on the terminator's dependency path, which is where they matter, but an abandoned op whose token nothing consumes still passes unnoticed.

### Testing

`check-air-mlir`: 511 passed, 7 xfail, no failures. The new test builds a put/get spatial-factor mismatch that can never pair, places it on the terminator's dependency path, and checks for the diagnostic. It reports a plausible latency and exits 0 without this change.