### PR TITLE
[air-runner] Fix silently truncated simulation of multi-instance segments

### DIFF
--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -521,6 +521,11 @@ private:
     if (num_rows && num_cols) {
       usage_count *= llvm::divideCeil(*num_rows, du_size_x);
       usage_count *= llvm::divideCeil(*num_cols, du_size_y);
+      // All instances of a segment's iteration space are co-resident for the
+      // lifetime of the segment, so their resource demands sum rather than
+      // alias. Without this a 2x1 segment is billed one DU and fits an arch
+      // that cannot hold it.
+      usage_count *= this->canonicalizer.getTripCountInHierarchyOp(op);
       return usage_count;
     } else {
       op->emitOpError("Segment has no placed AIE cores");
@@ -802,8 +807,7 @@ private:
 
     // Check how many evnets need to be dispatched in this op
     unsigned total =
-        this->tokenSpatialFactorForResource<air::HierarchyInterface>(
-            Op.getOperation(), {});
+        this->tokenSpatialFactorForResource(Op.getOperation());
     this->allocateEventToResources(chan_interface, reserved_resources,
                                    "outbound", dispatched);
 
@@ -836,8 +840,7 @@ private:
     unsigned dispatched = 0;
     // Check how many evnets need to be dispatched in this op
     unsigned total =
-        this->tokenSpatialFactorForResource<air::HierarchyInterface>(
-            Op.getOperation(), {});
+        this->tokenSpatialFactorForResource(Op.getOperation());
     this->allocateEventToResources(chan_interface, reserved_resources,
                                    "inbound", dispatched);
 
@@ -967,8 +970,7 @@ private:
 
     // Check how many events in total
     unsigned total =
-        this->tokenSpatialFactorForResource<air::HierarchyInterface>(
-            putOp.getOperation(), {});
+        this->tokenSpatialFactorForResource(putOp.getOperation());
     unsigned already_dispatched = this->getAlreadyDispatchedForDynamicDispatch(
         putOp.getChanName().str(), "put");
 
@@ -1144,7 +1146,7 @@ private:
     std::pair<std::string, std::string> key =
         std::make_pair(op.getChanName().str(), "put");
     unsigned total_count =
-        this->tokenSpatialFactorForResource<air::HierarchyInterface>(op, {});
+        this->tokenSpatialFactorForResource(op);
     if (launch_runner->channel_ops_in_progress.count(key)) {
       unsigned processed = launch_runner->channel_ops_in_progress[key].first;
       if (processed == total_count) {
@@ -1170,7 +1172,7 @@ private:
     unsigned bcast_factor =
         launch_runner->getBCastSizeFromChannelDeclaration(op.getOperation());
     unsigned total_count =
-        this->tokenSpatialFactorForResource<air::HierarchyInterface>(op, {});
+        this->tokenSpatialFactorForResource(op);
 
     // Calculate how many src and dst ports to deallocate
     std::pair<std::string, std::string> put_key =
@@ -1613,14 +1615,28 @@ private:
     return output;
   }
 
-  // Get batch-dispatched count up until type
-  template <typename T>
-  unsigned tokenSpatialFactorForResource(Operation *op,
-                                         std::vector<unsigned> position) {
+  // The number of concurrent instances of an op: the product of every
+  // enclosing spatial factor -- herd and segment iteration spaces, and
+  // scf.parallel trip counts. air.launch is excluded, because the runner
+  // simulates launch iterations separately.
+  //
+  // The walk must not stop at the innermost enclosing hierarchy. Stopping
+  // there leaves a channel op inside a herd blind to the segment iteration
+  // space enclosing that herd, while its matching op at segment level still
+  // sees it. The put then dispatches N instances and its get expects one, so
+  // the pairing test in executeOp(ChannelGetOp) can never hold, the get never
+  // retires, and the herd is left hanging with its body unexecuted -- a
+  // silently truncated simulation that still exits 0.
+  //
+  // A hierarchy with no iteration space contributes a factor of one, so this
+  // is a no-op for IR that does not use one.
+  unsigned tokenSpatialFactorForResource(Operation *op) {
     unsigned output = 1;
     auto parent = op;
-    while ((!isa<T>(parent)) && !(isa<func::FuncOp>(parent))) {
+    while (parent && !isa<func::FuncOp>(parent)) {
       parent = parent->getParentOp();
+      if (!parent)
+        break;
       if (auto scf_par = dyn_cast_if_present<scf::ParallelOp>(parent)) {
         for (unsigned i = 0; i < scf_par.getNumLoops(); i++) {
           auto lbCstOp = scf_par.getLowerBound()[i]

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -806,8 +806,7 @@ private:
     unsigned dispatched = 0;
 
     // Check how many evnets need to be dispatched in this op
-    unsigned total =
-        this->tokenSpatialFactorForResource(Op.getOperation());
+    unsigned total = this->tokenSpatialFactorForResource(Op.getOperation());
     this->allocateEventToResources(chan_interface, reserved_resources,
                                    "outbound", dispatched);
 
@@ -839,8 +838,7 @@ private:
         dyn_cast_if_present<air::ChannelInterface>(Op.getOperation());
     unsigned dispatched = 0;
     // Check how many evnets need to be dispatched in this op
-    unsigned total =
-        this->tokenSpatialFactorForResource(Op.getOperation());
+    unsigned total = this->tokenSpatialFactorForResource(Op.getOperation());
     this->allocateEventToResources(chan_interface, reserved_resources,
                                    "inbound", dispatched);
 
@@ -969,8 +967,7 @@ private:
     }
 
     // Check how many events in total
-    unsigned total =
-        this->tokenSpatialFactorForResource(putOp.getOperation());
+    unsigned total = this->tokenSpatialFactorForResource(putOp.getOperation());
     unsigned already_dispatched = this->getAlreadyDispatchedForDynamicDispatch(
         putOp.getChanName().str(), "put");
 
@@ -1145,8 +1142,7 @@ private:
     // Check if this op has been completely dispatched
     std::pair<std::string, std::string> key =
         std::make_pair(op.getChanName().str(), "put");
-    unsigned total_count =
-        this->tokenSpatialFactorForResource(op);
+    unsigned total_count = this->tokenSpatialFactorForResource(op);
     if (launch_runner->channel_ops_in_progress.count(key)) {
       unsigned processed = launch_runner->channel_ops_in_progress[key].first;
       if (processed == total_count) {
@@ -1171,8 +1167,7 @@ private:
         op.getChanName().str(), "get");
     unsigned bcast_factor =
         launch_runner->getBCastSizeFromChannelDeclaration(op.getOperation());
-    unsigned total_count =
-        this->tokenSpatialFactorForResource(op);
+    unsigned total_count = this->tokenSpatialFactorForResource(op);
 
     // Calculate how many src and dst ports to deallocate
     std::pair<std::string, std::string> put_key =

--- a/mlir/test/Util/Runner/bad_launch/bad_segment_iteration_space.mlir
+++ b/mlir/test/Util/Runner/bad_launch/bad_segment_iteration_space.mlir
@@ -1,0 +1,38 @@
+//===- bad_segment_iteration_space.mlir -------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json 2>&1 | FileCheck %s
+
+// Check that a segment's iteration space is counted when allocating DUs.
+//
+// One instance of this segment costs a single DU, and the arch has three, so
+// the segment fits if the iteration space is ignored. All four instances are
+// co-resident for the segment's lifetime, so their demands sum: four DUs
+// against three available. Before getResourceCost accounted for the trip
+// count this ran to completion and reported a plausible latency.
+
+// CHECK: error: 'air.segment' op isn't allocated with enough resources to run
+// CHECK-NOT: "name": "LaunchTerminator",
+
+module {
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+      %c4 = arith.constant 4 : index
+      %1 = air.segment async unroll(%l) in (%ls=%c4) attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %async_token, %results = air.execute -> (memref<64xbf16, 1>) {
+          %alloc = memref.alloc() : memref<64xbf16, 1>
+          air.execute_terminator %alloc : memref<64xbf16, 1>
+        }
+        %async_token_0 = air.execute [%async_token] {
+          memref.dealloc %results : memref<64xbf16, 1>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/segment_iteration_space.mlir
+++ b/mlir/test/Util/Runner/segment_iteration_space.mlir
@@ -1,0 +1,66 @@
+//===- segment_iteration_space.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// An air.segment with an iteration space, containing a herd fed by a channel.
+//
+// Regression test for two defects that made a multi-instance segment simulate
+// as a plausible but wrong number rather than fail:
+//
+//  1. tokenSpatialFactorForResource stopped its walk at the innermost
+//     enclosing hierarchy, so the channel.get inside the herd never saw the
+//     segment's iteration space while the matching channel.put at segment
+//     level did. The put dispatched two instances and the get expected one,
+//     the pairing test in executeOp(ChannelGetOp) could never hold, the get
+//     never retired, and the herd was left hanging with its body unexecuted.
+//     The run still exited 0, reporting 0.025us instead of 10.5us -- the
+//     @nn custom op simply never appeared in the trace.
+//
+//  2. getResourceCost(air::SegmentOp) ignored the iteration space, so a 2x1
+//     segment was billed a single DU and fit an arch that cannot hold it.
+//
+// Both instances are co-resident, so the pair costs the same wall clock as
+// one (10480 for @nn plus channel and bookkeeping overhead) but twice the
+// DUs.
+
+// RUN: air-runner %s -f test -m %S/custom_op/arch.json | FileCheck %s
+
+// The herd must run its body to completion: the custom op appears, and both
+// terminators are reached.
+// CHECK: "name": "air.custom",
+// CHECK: "name": "HerdTerminator",
+// CHECK: "name": "SegmentTerminator",
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  air.channel @onchip [1, 1]
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %launch = air.launch async (%lx, %ly) in (%lsx=%c1, %lsy=%c1) attributes {id = 1 : i32} {
+      %c2_l = arith.constant 2 : index
+      %seg = air.segment async unroll(%l) in (%ls=%c2_l) attributes {id = 10 : i32, x_loc = 0 : i64, x_size = 4 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+        %tok, %buf = air.execute -> (memref<64xi8, 1>) {
+          %a = memref.alloc() : memref<64xi8, 1>
+          air.execute_terminator %a : memref<64xi8, 1>
+        }
+        %fw = air.channel.put async [%tok] @onchip[] (%buf[] [] []) {id = 20 : i32} : (memref<64xi8, 1>)
+        %herd = air.herd @m async [%fw] tile (%tx, %ty) in (%tsx=%c1_s, %tsy=%c1_s) attributes {id = 100 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %tl, %bl = air.execute -> (memref<64xi8, 2>) {
+            %a2 = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %a2 : memref<64xi8, 2>
+          }
+          %g = air.channel.get async [%tl] @onchip[] (%bl[] [] []) {id = 21 : i32} : (memref<64xi8, 2>)
+          %x = air.execute [%g] {
+            air.custom @nn operands (%bl) : memref<64xi8, 2>
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/segment_iteration_space.mlir
+++ b/mlir/test/Util/Runner/segment_iteration_space.mlir
@@ -21,6 +21,9 @@
 //
 //  2. getResourceCost(air::SegmentOp) ignored the iteration space, so a 2x1
 //     segment was billed a single DU and fit an arch that cannot hold it.
+//     That half is checked by bad_launch/bad_segment_iteration_space.mlir,
+//     which needs an arch too small for the instances; here the arch is big
+//     enough and only the first defect is in play.
 //
 // Both instances are co-resident, so the pair costs the same wall clock as
 // one (10480 for @nn plus channel and bookkeeping overhead) but twice the


### PR DESCRIPTION
An `air.segment` with an iteration space greater than one, containing a herd fed by a channel, dropped the herd's entire body. The run exited 0 with no diagnostic and reported `0.025us` where the correct answer was `10.5us` — the custom op never appeared in the trace and neither terminator was reached.

### Cause

`tokenSpatialFactorForResource` stopped its parent walk at the innermost enclosing hierarchy. A `channel.get` inside a herd therefore saw only the herd, never the segment iteration space enclosing it, while the matching `channel.put` at segment level *did* see it. The put dispatched N instances against a get expecting one, so the completion test in `executeOp(ChannelGetOp)` —

```
put_processed * bcast == total_count && get_processed == total_count
```

— could never hold. The get never retired and the herd hung with its body unexecuted.

### Fix

Walk all the way out instead, multiplying every enclosing spatial factor. `air.launch` stays excluded, as before, because launch iterations are simulated separately. A hierarchy with no iteration space contributes a factor of one, so nothing changes for IR that does not use one — which is every existing test.

The template parameter only ever terminated this walk and was always instantiated with `air::HierarchyInterface`, so it and the unused `position` argument are dropped rather than left to mislead.

Separately, `getResourceCost(air::SegmentOp)` ignored the iteration space entirely, so a 2x1 segment was billed a single DU and fit an arch that cannot hold it. All instances are co-resident for the lifetime of the segment, so their demands sum; multiply by the trip count. A 2x1 segment on a one-DU arch now reports *"isn't allocated with enough resources to run"* instead of a plausible number.

### Why it survived

The construct is well supported elsewhere in the compiler — `air-to-aie` unrolls a 2x1 segment across devices, with tests for metadata ordering, packet flow ids and `scf.if` interaction. None of those is a runner test.

### Testing

`check-air-mlir`: 511 passed, 7 xfail, no failures. The new test fails against the unfixed runner and passes against the fixed one (verified both ways on this branch).