### PR TITLE
[programming_examples] air.api: the two data_transfer_transpose variants that do not use channels

### DIFF
--- a/programming_examples/data_transfer_transpose/dma/transpose.py
+++ b/programming_examples/data_transfer_transpose/dma/transpose.py
@@ -56,17 +56,20 @@ def build_module(m, k, np_dtype):
 
         @launch.body
         def _():
-            with air.segment(name="seg"):
-                with air.herd([range(1)], name="herd", shape=(1,)) as h:
+            with air.segment(name="seg") as seg:
 
-                    @h.body
-                    def _(tx):
-                        t = air.alloc([m, k], dt, scope=h.private())
-                        air.ops.load(t, A[:, :])
-                        # The whole example: the same tile, walked with its axes
-                        # swapped. A view, not a copy -- nothing moves until the
-                        # store's descriptor walks it.
-                        air.ops.store(t.transpose(1, 0), B[:, :])
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="herd", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            t = air.alloc([m, k], dt, scope=h.private())
+                            air.ops.load(t, A[:, :])
+                            # The whole example: the same tile, walked with its
+                            # axes swapped. A view, not a copy -- nothing moves
+                            # until the store's descriptor walks it.
+                            air.ops.store(t.transpose(1, 0), B[:, :])
 
     return launch
 

--- a/programming_examples/data_transfer_transpose/dma/transpose.py
+++ b/programming_examples/data_transfer_transpose/dma/transpose.py
@@ -1,15 +1,43 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Transpose an [M, K] matrix on the way out of L1, on air.api.
+
+    air.ops.load(t, A[:, :])
+    air.ops.store(t.transpose(1, 0), B[:, :])
+
+There is no compute here at all. The transpose is a property of the *access
+pattern* the second DMA walks: the tile is read back with its two axes swapped,
+so the descriptor carries sizes [k, m] and strides [1, k] where the buffer's own
+are [m, k] and [k, 1]. The hand-written predecessor spelled that by passing
+``src_sizes=[1, k, m], src_strides=[1, 1, k]`` to ``dma_memcpy_nd`` as literal
+lists; ``transpose`` derives the identical descriptor from the permutation,
+which is the same thing said in terms of what it means rather than what it
+computes to.
+
+``transpose`` takes a full permutation, numpy-style, rather than being a bare
+``.T``: on an nd machine reversing every axis is rarely what is meant, and
+naming the permutation is what makes a rank-3 or rank-4 version of this readable
+instead of a puzzle.
+
+The L1 tile is ``[m, k]`` rather than the predecessor's flat ``[m * k]``. It
+holds the same bytes and the same transfers move them; the shape is now the
+shape of the thing in it, which is what lets the permutation be written at all.
+
+Both element types the Makefile exercises still work -- ``uint32`` via
+``run_int`` and ``float32`` via ``run_float``. Nothing here is arithmetic, so
+the unsigned type is carried by the transfer without being computed on, which is
+the one place air.api accepts one.
+"""
+
 import argparse
+
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt_runner import XRTRunner
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp
-from air.backend.xrt_runner import XRTRunner, type_mapper
+np.random.seed(42)
 
 dtype_map = {
     "uint32": np.uint32,
@@ -18,60 +46,35 @@ dtype_map = {
 DEFAULT_DTYPE = "uint32"
 
 
-@module_builder
-def build_module(m, k, dtype):
-    xrt_dtype = type_mapper(dtype)
+def build_module(m, k, np_dtype):
+    dt = dtype_of(np_dtype)
 
-    memrefTyIn = MemRefType.get(shape=[m, k], element_type=xrt_dtype)
-    memrefTyOut = MemRefType.get(shape=[k, m], element_type=xrt_dtype)
+    A = air.tensor([m, k], dt)
+    B = air.tensor([k, m], dt)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
-    def transpose(arg0, arg1):
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
-                @herd(name="herd", sizes=[1, 1], operands=[arg2, arg3])
-                def herd_body(_tx, _ty, _sx, _sy, a, b):
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+    with air.launch(name="transpose") as launch:
 
-                    # This is the type definition of the tensor
-                    tensor_type = MemRefType.get(
-                        shape=[m * k],  # Read as one large array
-                        element_type=xrt_dtype,
-                        memory_space=mem_space,
-                    )
+        @launch.body
+        def _():
+            with air.segment(name="seg"):
+                with air.herd([range(1)], name="herd", shape=(1,)) as h:
 
-                    # We must allocate a buffer of tile size for the input/output
-                    tensor_in = AllocOp(tensor_type, [], [])
+                    @h.body
+                    def _(tx):
+                        t = air.alloc([m, k], dt, scope=h.private())
+                        air.ops.load(t, A[:, :])
+                        # The whole example: the same tile, walked with its axes
+                        # swapped. A view, not a copy -- nothing moves until the
+                        # store's descriptor walks it.
+                        air.ops.store(t.transpose(1, 0), B[:, :])
 
-                    dma_memcpy_nd(
-                        tensor_in,
-                        a,
-                    )
-
-                    dma_memcpy_nd(
-                        b,
-                        tensor_in,
-                        src_sizes=[1, k, m],
-                        src_strides=[1, 1, k],
-                    )
-
-                    # Deallocate our L1 buffer
-                    DeallocOp(tensor_in)
-
-                    # We must allocate a buffer of tile size for the input/output
-                    tensor_in = AllocOp(tensor_type, [], [])
-
-                    DeallocOp(tensor_in)
+    return launch
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the matrix_scalar_add/single_core_channel example",
+        description="Builds, runs, and tests the data_transfer_transpose/dma example",
     )
 
     parser.add_argument(
@@ -109,13 +112,20 @@ if __name__ == "__main__":
         choices=["xclbin", "elf"],
         default="xclbin",
         dest="output_format",
-        help="Output format for the compiled binary (default: xclbin)",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
 
     args = parser.parse_args()
 
     np_dtype = dtype_map[args.dtype]
-    mlir_module = build_module(args.m, args.k, np_dtype)
+    launch = build_module(args.m, args.k, np_dtype)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -146,6 +156,7 @@ if __name__ == "__main__":
         verbose=args.verbose,
         output_format=args.output_format,
         instance_name="transpose",
+        target_device=launch.target,
         runtime_loop_tiling_sizes=[4, 4],
     )
     exit(

--- a/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
+++ b/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
@@ -60,19 +60,22 @@ def build_module(m, k):
 
         @launch.body
         def _():
-            with air.segment(name="seg"):
-                with air.herd(
-                    [range(1)], name="herd", shape=(1,), link_with=EXTERN_OBJECT
-                ) as h:
+            with air.segment(name="seg") as seg:
 
-                    @h.body
-                    def _(tx):
-                        l1_in = air.alloc([m * k], bf16, scope=h.private())
-                        l1_out = air.alloc([m * k], bf16, scope=h.private())
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(1)], name="herd", shape=(1,), link_with=EXTERN_OBJECT
+                    ) as h:
 
-                        air.ops.load(l1_in, A)
-                        transpose_bf16(l1_in, l1_out)
-                        air.ops.store(l1_out, B)
+                        @h.body
+                        def _(tx):
+                            l1_in = air.alloc([m * k], bf16, scope=h.private())
+                            l1_out = air.alloc([m * k], bf16, scope=h.private())
+
+                            air.ops.load(l1_in, A)
+                            transpose_bf16(l1_in, l1_out)
+                            air.ops.store(l1_out, B)
 
     return launch
 

--- a/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
+++ b/programming_examples/data_transfer_transpose/dma_bf16/transpose_bf16.py
@@ -1,77 +1,80 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""bf16 matrix transpose using an external kernel, on air.api.
 
-"""bf16 matrix transpose using an external kernel.
+    transpose_bf16 = air.extern("transpose_bf16", link_with="transpose.o")
+    ...
+    air.ops.load(l1_in, A)
+    transpose_bf16(l1_in, l1_out)
+    air.ops.store(l1_out, B)
 
-Transposes an [M, K] bf16 matrix to [K, M] using a C++ kernel compiled
-with Peano. The kernel performs scalar element-by-element transpose.
+**Why this one has a kernel and its sibling does not.** ``dma/transpose.py``
+transposes by walking the tile with its axes swapped -- a DMA descriptor with
+sizes [k, m] and strides [1, k] -- and needs no compute at all. That route is
+closed here: on AIE the innermost DMA stride must be 1 for data narrower than
+32 bits, so a bf16 transpose cannot be expressed as an access pattern. The
+matrix is DMAed into L1 contiguously instead and a scalar C++ kernel does the
+transpose in place of the descriptor.
 
-DMA stride-based transpose is not possible for sub-32-bit types on AIE
-because the inner-most DMA stride must be 1 for <32b data widths.
-Instead, we DMA the matrix into L1 contiguously and let the kernel
-perform the transpose.
+So the two variants are not duplicates. They are the two halves of one fact
+about the hardware, and the element type is what selects between them.
+
+Everything here is flat: the L3 tensors are ``[m * k]`` and ``[k * m]`` and the
+L1 tiles are ``[m * k]``, because the kernel takes raw buffers and computes the
+indices itself from its ``DIM_M``/``DIM_N`` defines. That is the predecessor's
+shape too, kept rather than tidied -- the flatness is part of the contract with
+transpose.cc, not an artifact.
+
+``air.extern`` carries ``link_with="transpose.o"``, which stamps the attribute
+on both the declaration and the herd; the Makefile compiles transpose.cc to
+exactly that name in the build directory.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-np.random.seed(42)
-
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api.types import bf16
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+np.random.seed(42)
 
 INOUT_DATATYPE = bfloat16
 
+# The object the Makefile compiles transpose.cc into, in the build directory.
+EXTERN_OBJECT = "transpose.o"
 
-@module_builder
+
 def build_module(m, k):
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    # The kernel is compiled with -DDIM_M/-DDIM_N, so it knows the shape; the
+    # buffers it is handed are flat.
+    transpose_bf16 = air.extern("transpose_bf16", link_with=EXTERN_OBJECT)
 
-    memrefTyIn = MemRefType.get(shape=[m * k], element_type=xrt_dtype)
-    memrefTyOut = MemRefType.get(shape=[k * m], element_type=xrt_dtype)
+    A = air.tensor([m * k], bf16)
+    B = air.tensor([k * m], bf16)
 
-    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1_type = MemRefType.get(
-        shape=[m * k],
-        element_type=xrt_dtype,
-        memory_space=mem_space,
-    )
+    with air.launch(name="transpose") as launch:
 
-    transpose_func = external_func("transpose_bf16", inputs=[l1_type, l1_type])
+        @launch.body
+        def _():
+            with air.segment(name="seg"):
+                with air.herd(
+                    [range(1)], name="herd", shape=(1,), link_with=EXTERN_OBJECT
+                ) as h:
 
-    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
-    def transpose(arg0, arg1):
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            @segment(name="seg", operands=[a, b])
-            def segment_body(arg2, arg3):
-                @herd(
-                    name="herd",
-                    sizes=[1, 1],
-                    operands=[arg2, arg3],
-                    link_with="transpose.o",
-                )
-                def herd_body(_tx, _ty, _sx, _sy, a, b):
-                    l1_in = AllocOp(l1_type, [], [])
-                    l1_out = AllocOp(l1_type, [], [])
+                    @h.body
+                    def _(tx):
+                        l1_in = air.alloc([m * k], bf16, scope=h.private())
+                        l1_out = air.alloc([m * k], bf16, scope=h.private())
 
-                    dma_memcpy_nd(l1_in, a)
+                        air.ops.load(l1_in, A)
+                        transpose_bf16(l1_in, l1_out)
+                        air.ops.store(l1_out, B)
 
-                    call(
-                        transpose_func,
-                        inputs=[l1_in, l1_out],
-                        input_types=[l1_type, l1_type],
-                    )
-
-                    dma_memcpy_nd(b, l1_out)
-
-                    DeallocOp(l1_in)
-                    DeallocOp(l1_out)
+    return launch
 
 
 if __name__ == "__main__":
@@ -100,9 +103,17 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module(args.m, args.k)
+    launch = build_module(args.m, args.k)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -115,6 +126,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             output_format=args.output_format,
             instance_name="transpose",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -128,6 +140,7 @@ if __name__ == "__main__":
         backend = XRTBackend(
             verbose=args.verbose,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)


### PR DESCRIPTION
Converts `data_transfer_transpose/dma` and `data_transfer_transpose/dma_bf16` onto air.api. **No new DSL surface** — both use what #1892 and #1890 already landed, and no file under `python/air/api/` is touched.

## dma — the example the transpose view was built for

There is no compute in it at all. The transpose is a property of the *access pattern* the second DMA walks:

```python
air.ops.load(t, A[:, :])
air.ops.store(t.transpose(1, 0), B[:, :])
```

against a tile whose own sizes/strides are `[m, k]` / `[k, 1]`, that emits a descriptor with sizes `[k, m]` and strides `[1, k]`. The predecessor spelled the same thing by passing literal lists to `dma_memcpy_nd`:

| | sizes | strides |
|---|---|---|
| predecessor | `[1, k, m]` | `[1, 1, k]` |
| this | `[k, m]` | `[1, k]` |

Identical modulo the leading unit axis `ops.store` already squeezes. `transpose` takes a full permutation, numpy-style, rather than a bare `.T` — on an nd machine reversing every axis is rarely what is meant, and naming the permutation is what would make a rank-3 or rank-4 version of this readable.

The L1 tile is `[m, k]` rather than the predecessor's flat `[m * k]`. Same bytes, same transfers; the shape is now the shape of the thing in it, which is what lets the permutation be written at all.

## dma_bf16 — why this one needs a kernel and its sibling does not

That route is closed for bf16: **on AIE the innermost DMA stride must be 1 for data narrower than 32 bits**, so a bf16 transpose cannot be expressed as an access pattern. The matrix is DMAed into L1 contiguously and a scalar C++ kernel does the transpose in place of the descriptor — `air.extern("transpose_bf16", link_with="transpose.o")`.

So the two variants are not duplicates. They are the two halves of one fact about the hardware, and the element type selects between them. Both docstrings now say so, which the predecessors only said in one of the two.

Its buffers stay flat (`[m * k]`), because the kernel computes indices from its own `DIM_M`/`DIM_N` defines — the flatness is the contract with `transpose.cc`, not an artifact to tidy.

## channel is deliberately left alone

It is the third variant in this directory and it uses `air.channel` put/get, which air.api does not implement. Converting the other two does not strand it — it is untouched and still passes on hardware.

## Gates

**dma** — its peano lit passes on npu1 hardware, and exercises *both* element types the Makefile ships: `run_int` (uint32) and `run_float` (float32) are two separate FileCheck invocations in the same lit.

Non-vacuous: perturbing the expected matrix by 1 fails with **2028 mismatches out of 2048**, so the whole matrix is checked rather than sampled.

The chess lit is UNSUPPORTED here (no xchess license) and the elf lit is npu2-only.

**dma_bf16** — `REQUIRES: ryzen_ai_npu2`, and this was developed on a Phoenix box, so it is gated by compiling for npu2 with its aie2p kernel object built and linked exactly as the Makefile does (`compile-kernel`, then copied into `air_project/`). The predecessor was compiled the same way as a control; both produce an xclbin.

Its emitted IR matches the predecessor's op for op — same `func.func private` declaration, same `air.herd` with `link_with = "transpose.o"`, same two `air.dma_memcpy_nd` and the `func.call` between them. The only delta is the `llvm.emit_c_interface` attribute that `air.extern` stamps on every declaration it makes.

`python/test/api` 23/23. No blast-radius sweep was needed since no DSL file is touched.