### PR TITLE
[air-runner] Model fixed link latency separately from occupancy

### DIFF
--- a/mlir/include/air/Util/Dependency.h
+++ b/mlir/include/air/Util/Dependency.h
@@ -168,6 +168,15 @@ struct dependencyNodeEntry {
   std::vector<dependencyGraph *> nextDependencyGraphs;
   uint64_t start_time;
   uint64_t end_time;
+  // Time at which the event releases the hardware resources it reserved. For a
+  // data movement event this is the end of the link's *occupancy*
+  // (bytes/bandwidth), which can be earlier than end_time when the link model
+  // also carries a fixed time-of-flight latency. Ports model link bandwidth,
+  // not flight time, so holding them for the latency term would cap link
+  // throughput at 1/(occupancy + latency). When no latency is modelled this
+  // equals end_time and the early-release path is inert.
+  uint64_t release_time;
+  bool resources_released;
   std::vector<std::pair<uint64_t, uint64_t>> start_end_time_log;
   // Token count is used to synchronize operations which consumes/produces
   // multiple async tokens.
@@ -175,6 +184,9 @@ struct dependencyNodeEntry {
 
   bool is_started() { return (start_time != 0) && (end_time != 0); }
   bool is_done(uint64_t t) { return t >= end_time; }
+  // True when this event models a link whose occupancy ends before its data
+  // lands, i.e. the early resource release is meaningful for it.
+  bool has_link_latency() { return release_time && release_time < end_time; }
 
   dependencyNodeEntry(std::string asyncEventName = "",
                       std::string asyncEventType = "", std::string color = "",
@@ -186,7 +198,8 @@ struct dependencyNodeEntry {
       : asyncEventName(asyncEventName), asyncEventType(asyncEventType),
         color(color), shape(shape), detailed_description(detailed_description),
         operationId(operationId), op(op), start_time(start_time),
-        end_time(end_time), token_count(token_count) {}
+        end_time(end_time), release_time(end_time), resources_released(false),
+        token_count(token_count) {}
 };
 
 // Dependency graph object

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -166,11 +166,19 @@ public:
     s << "},\n";
   }
 
-  // Model each event's latency
-  uint64_t modelOp(device &d, dependencyNodeEntry &c) {
+  // Model each event's latency.
+  // Returns the event's *occupancy*: how long it holds the resources it
+  // reserved. For data movement events, any fixed link time-of-flight is
+  // reported separately through `link_latency` (in cycles) rather than folded
+  // into the return value, because flight time delays when data lands without
+  // occupying the link. Callers add the two to obtain the completion time.
+  uint64_t modelOp(device &d, dependencyNodeEntry &c,
+                   uint64_t *link_latency = nullptr) {
     auto type = c.asyncEventType;
     auto name = c.asyncEventName;
     uint64_t execution_time = 1;
+    if (link_latency)
+      *link_latency = 0;
 
     if (type == "wait_all") {
       execution_time = 1;
@@ -190,6 +198,8 @@ public:
         execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, srcTy);
       else
         execution_time = getTransferCost(d, c.op, srcSpace, dstSpace, dstTy);
+      if (link_latency)
+        *link_latency = getTransferLatency(d, srcSpace, dstSpace);
     } else if (type == "channel" &&
                (name.find("ChannelGetOp") != std::string::npos)) {
       auto getOp = mlir::dyn_cast_if_present<xilinx::air::ChannelGetOp>(c.op);
@@ -215,6 +225,8 @@ public:
       else
         execution_time =
             getTransferCost(d, c.op, srcSpace, dstSpace, dstVolumn, dstTy);
+      if (link_latency)
+        *link_latency = getTransferLatency(d, srcSpace, dstSpace);
     } else if (type == "execute" && name != "ExecuteTerminatorOp") {
       if (!isa<air::ExecuteOp>(c.op))
         c.op->emitOpError("has mismatching event type").attachNote()
@@ -271,6 +283,10 @@ public:
             c.wavefront, i);
       }
     }
+    // Free links whose occupancy has ended but whose payload is still in
+    // flight, so the next transfer can claim them.
+    c.releaseCompletedLinkOccupancy(time);
+
     // Update wavefront
     for (auto it = c.wavefront.begin(); it != c.wavefront.end(); ++it) {
       if (G[std::get<0>(*it)].is_started() &&
@@ -351,9 +367,15 @@ public:
                           canonicalizer.getIteratorFromPosition(
                               c.ctrl_g->position, c.ctrl_g->hierarchyOp));
 
+        uint64_t link_latency = 0;
+        uint64_t occupancy =
+            modelOp(device_resource_node, G[next_vertex], &link_latency);
         G[next_vertex].start_time = time;
-        G[next_vertex].end_time =
-            time + modelOp(device_resource_node, G[next_vertex]);
+        // Resources are held for the occupancy only; the event completes once
+        // the payload has also traversed the link.
+        G[next_vertex].release_time = time + occupancy;
+        G[next_vertex].end_time = time + occupancy + link_latency;
+        G[next_vertex].resources_released = false;
         // emit trace event begin
         auto runner_id = getIdAttr(c.ctrl_g->hierarchyOp);
         auto tid = std::get<2>(c.wavefront.back());
@@ -460,6 +482,8 @@ public:
     bool running = true;
     launch.ctrl_g->g[start_v].start_time = 1;
     launch.ctrl_g->g[start_v].end_time = 1;
+    launch.ctrl_g->g[start_v].release_time = 1;
+    launch.ctrl_g->g[start_v].resources_released = false;
     launch.pushStartToWavefront(start_v);
     // Consume devices upon launch
     // TODO: multi-device modelling
@@ -677,6 +701,15 @@ private:
       op->emitOpError("data rate not found in JSON model");
     double seconds = bytes / bps;
     return (uint64_t)ceil(seconds * cps);
+  }
+
+  // Fixed time-of-flight, in cycles, of the link between two memory spaces.
+  // Independent of payload size, and not part of the link's occupancy.
+  uint64_t getTransferLatency(device &d, unsigned srcSpace, unsigned dstSpace) {
+    auto it = d.interfaces.find({srcSpace, dstSpace});
+    if (it == d.interfaces.end() || !it->second)
+      return 0;
+    return (uint64_t)std::llround(it->second->latency);
   }
 
   uint64_t getTransferVolumn(air::ChannelInterface op) {

--- a/mlir/lib/Util/Runner/Resource.cpp
+++ b/mlir/lib/Util/Runner/Resource.cpp
@@ -54,6 +54,11 @@ protected:
 class port : public resource {
 public:
   double data_rate;
+  // Fixed time-of-flight of this link, in cycles. Independent of payload size;
+  // it delays when data lands but does not occupy the link, so it is accounted
+  // separately from data_rate. Defaults to zero, which reproduces the
+  // bandwidth-only cost model.
+  double latency = 0;
   std::map<std::string, port> connected_ports;
 
   port() {}
@@ -68,25 +73,30 @@ public:
   port(port *base) {
     name = base->name;
     data_rate = base->data_rate;
+    latency = base->latency;
     this->reset_reservation();
     // TODO: Copy port Connections as well
     // May be challenging due to hierarchy --
     // need to copy while copying regions/tiles etc.
   }
 
-  port(resource *parent, unsigned src, unsigned dst, double data_rate) {
+  port(resource *parent, unsigned src, unsigned dst, double data_rate,
+       double latency = 0) {
     this->set_name("L" + std::to_string(src) + "_to_" + "L" +
                    std::to_string(dst));
     this->set_data_rate(data_rate);
+    this->set_latency(latency);
     this->set_parent(parent);
     this->reset_reservation();
   }
 
   port(resource *parent, std::string ms_n_dir,
-       std::optional<double> bytes_per_second, unsigned idx) {
+       std::optional<double> bytes_per_second, unsigned idx,
+       std::optional<double> latency = std::nullopt) {
     if (bytes_per_second) {
       this->set_name(ms_n_dir + "_" + std::to_string(idx));
       this->set_data_rate(*bytes_per_second);
+      this->set_latency(latency ? *latency : 0);
       this->set_parent(parent);
       this->reset_reservation();
     }
@@ -99,6 +109,8 @@ public:
   void set_data_rate(long bytes_per_cycle) {
     this->data_rate = bytes_per_cycle;
   }
+
+  void set_latency(double cycles) { this->latency = cycles; }
 
 private:
 }; // port

--- a/mlir/lib/Util/Runner/ResourceHierarchy.cpp
+++ b/mlir/lib/Util/Runner/ResourceHierarchy.cpp
@@ -68,7 +68,9 @@ public:
           for (unsigned i = 0; i < *inbound_port_count; i++) {
             auto bytes_per_second =
                 inboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L1_inbound", bytes_per_second, i);
+            auto latency = inboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L1_inbound", bytes_per_second, i, latency);
             inbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("inbound", inbound_port_vec));
@@ -83,7 +85,9 @@ public:
           for (unsigned i = 0; i < *outbound_port_count; i++) {
             auto bytes_per_second =
                 outboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L1_outbound", bytes_per_second, i);
+            auto latency = outboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L1_outbound", bytes_per_second, i, latency);
             outbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("outbound", outbound_port_vec));
@@ -178,7 +182,9 @@ public:
           for (unsigned i = 0; i < *inbound_port_count; i++) {
             auto bytes_per_second =
                 inboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L2_inbound", bytes_per_second, i);
+            auto latency = inboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L2_inbound", bytes_per_second, i, latency);
             inbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("inbound", inbound_port_vec));
@@ -193,7 +199,9 @@ public:
           for (unsigned i = 0; i < *outbound_port_count; i++) {
             auto bytes_per_second =
                 outboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L2_outbound", bytes_per_second, i);
+            auto latency = outboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L2_outbound", bytes_per_second, i, latency);
             outbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("outbound", outbound_port_vec));
@@ -274,7 +282,12 @@ public:
         double b_s = this->getDataRateFromMemorySpace(s, "outbound");
         double b_d = this->getDataRateFromMemorySpace(d, "inbound");
         double b = std::min(b_s, b_d);
-        port *new_port = new port(this, s, d, b);
+        // Bandwidth is the bottleneck of the two ends, but time-of-flight is
+        // paid at both: data serialises out of the source and back in at the
+        // destination, so the two latencies add.
+        double l = this->getLatencyFromMemorySpace(s, "outbound") +
+                   this->getLatencyFromMemorySpace(d, "inbound");
+        port *new_port = new port(this, s, d, b, l);
         this->interfaces.insert({{s, d}, new_port});
       }
     }
@@ -322,7 +335,9 @@ public:
           for (unsigned i = 0; i < *inbound_port_count; i++) {
             auto bytes_per_second =
                 inboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L3_inbound", bytes_per_second, i);
+            auto latency = inboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L3_inbound", bytes_per_second, i, latency);
             inbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("inbound", inbound_port_vec));
@@ -337,7 +352,9 @@ public:
           for (unsigned i = 0; i < *outbound_port_count; i++) {
             auto bytes_per_second =
                 outboundPortsObject->getNumber("bytes_per_second");
-            port *new_port = new port(this, "L3_outbound", bytes_per_second, i);
+            auto latency = outboundPortsObject->getNumber("latency");
+            port *new_port =
+                new port(this, "L3_outbound", bytes_per_second, i, latency);
             outbound_port_vec.push_back(new_port);
           }
           this->ports.insert(std::make_pair("outbound", outbound_port_vec));
@@ -367,37 +384,40 @@ public:
     this->set_ports(portsObject);
   }
 
-  double getDataRateFromMemorySpace(unsigned memory_space,
-                                    std::string port_direction) {
+  // Get the representative port serving a memory space in a given direction,
+  // or nullptr if the model does not describe one.
+  port *getPortFromMemorySpace(unsigned memory_space,
+                               std::string port_direction) {
     auto ms = symbolizeMemorySpace(memory_space);
     if (!ms)
-      return 0;
+      return nullptr;
     if (*ms == air::MemorySpace::L3) {
       if (this->ports.count(port_direction))
-        return this->ports[port_direction][0]->data_rate;
-      else
-        return 0;
+        return this->ports[port_direction][0];
+      return nullptr;
     } else if (*ms == air::MemorySpace::L2) {
-      if (this->dus.size()) {
-        if (this->dus[0]->ports.count(port_direction))
-          return this->dus[0]->ports[port_direction][0]->data_rate;
-        else
-          return 0;
-      } else
-        return 0;
+      if (this->dus.size() && this->dus[0]->ports.count(port_direction))
+        return this->dus[0]->ports[port_direction][0];
+      return nullptr;
     } else if (*ms == air::MemorySpace::L1) {
-      if (this->dus.size()) {
-        if (this->dus[0]->tiles.size()) {
-          if (this->dus[0]->tiles[0]->ports.count(port_direction))
-            return this->dus[0]->tiles[0]->ports[port_direction][0]->data_rate;
-          else
-            return 0;
-        } else
-          return 0;
-      } else
-        return 0;
-    } else
-      return 0;
+      if (this->dus.size() && this->dus[0]->tiles.size() &&
+          this->dus[0]->tiles[0]->ports.count(port_direction))
+        return this->dus[0]->tiles[0]->ports[port_direction][0];
+      return nullptr;
+    }
+    return nullptr;
+  }
+
+  double getDataRateFromMemorySpace(unsigned memory_space,
+                                    std::string port_direction) {
+    auto *p = this->getPortFromMemorySpace(memory_space, port_direction);
+    return p ? p->data_rate : 0;
+  }
+
+  double getLatencyFromMemorySpace(unsigned memory_space,
+                                   std::string port_direction) {
+    auto *p = this->getPortFromMemorySpace(memory_space, port_direction);
+    return p ? p->latency : 0;
   }
 
   device(std::string name = "", resource *parent = nullptr,

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -150,8 +150,12 @@ public:
   // Free link resources whose occupancy has ended but whose payload is still
   // in flight. Ports model link bandwidth, not time-of-flight, so holding them
   // until the data lands would cap link throughput at 1/(occupancy + latency)
-  // and stop a deep pipeline from filling. Inert unless the arch model gives
-  // the link a latency, in which case release_time == end_time.
+  // and stop a deep pipeline from filling.
+  //
+  // Only an arch model that gives the link a latency reaches this: that is
+  // what makes release_time < end_time, which is what has_link_latency()
+  // tests. Without one the two are equal, there is no window in which the
+  // ports are free but the payload has not landed, and this is inert.
   void releaseCompletedLinkOccupancy(uint64_t time) {
     Graph &G = this->ctrl_g->g;
     for (auto &entry : this->wavefront) {

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -137,7 +137,37 @@ public:
       auto command_node = this->ctrl_g->g[std::get<0>(*it)];
       if (command_node.is_started() && (command_node.end_time)) {
         next_times.push_back(command_node.end_time);
+        // A link whose occupancy ends before its payload lands frees its ports
+        // at release_time, so the simulator has to stop there too.
+        if (command_node.has_link_latency() &&
+            !command_node.resources_released) {
+          next_times.push_back(command_node.release_time);
+        }
       }
+    }
+  }
+
+  // Free link resources whose occupancy has ended but whose payload is still
+  // in flight. Ports model link bandwidth, not time-of-flight, so holding them
+  // until the data lands would cap link throughput at 1/(occupancy + latency)
+  // and stop a deep pipeline from filling. Inert unless the arch model gives
+  // the link a latency, in which case release_time == end_time.
+  void releaseCompletedLinkOccupancy(uint64_t time) {
+    Graph &G = this->ctrl_g->g;
+    for (auto &entry : this->wavefront) {
+      auto &node = G[std::get<0>(entry)];
+      if (!node.has_link_latency() || node.resources_released)
+        continue;
+      if (!node.is_started() || time < node.release_time)
+        continue;
+      // Driven from the get, which owns the pairing of both ends' ports. Only
+      // ports are released here; resource hierarchies reserved by segments and
+      // herds are released by their terminators instead.
+      auto getOp = dyn_cast_if_present<air::ChannelGetOp>(node.op);
+      if (!getOp)
+        continue;
+      this->releaseChannelPortsForGet(getOp);
+      node.resources_released = true;
     }
   }
 
@@ -1015,6 +1045,8 @@ private:
     // Start sub-runner node by pushing start node into its wavefront
     sub_runner_node->ctrl_g->g[sub_start_v].start_time = time;
     sub_runner_node->ctrl_g->g[sub_start_v].end_time = time;
+    sub_runner_node->ctrl_g->g[sub_start_v].release_time = time;
+    sub_runner_node->ctrl_g->g[sub_start_v].resources_released = false;
     this->runner_assertion(!sub_runner_node->wavefront.size(),
                            "sub runner node " + air::to_string(op) +
                                " is busy");
@@ -1161,7 +1193,11 @@ private:
       this->runner_assertion(false, "unknown channel.put op");
   }
 
-  void executeOp(air::ChannelGetOp op, Graph::VertexId it) {
+  // Release the ports held by a channel's matched put/get pairs. A put's
+  // outbound port and its get's inbound port are freed together, capped by
+  // whichever side has fewer reservations outstanding, so a get can never free
+  // more puts than have actually been dispatched to it.
+  void releaseChannelPortsForGet(air::ChannelGetOp op) {
 
     // Get launch runner node
     auto launch_runner = this;
@@ -1169,14 +1205,8 @@ private:
       launch_runner = launch_runner->parent;
     }
 
-    // Get op progress
-    auto put_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(
-        this->getChannelInstanceKey(op), "put");
-    auto get_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(
-        this->getChannelInstanceKey(op), "get");
     unsigned bcast_factor =
         launch_runner->getBCastSizeFromChannelDeclaration(op.getOperation());
-    unsigned total_count = this->tokenSpatialFactorForResource(op);
 
     // Calculate how many src and dst ports to deallocate
     std::pair<std::string, std::string> put_key =
@@ -1227,6 +1257,35 @@ private:
         get_deallocate_count++;
       }
     }
+  }
+
+  void executeOp(air::ChannelGetOp op, Graph::VertexId it) {
+
+    // Get launch runner node
+    auto launch_runner = this;
+    while ((launch_runner->runner_node_type != "launch")) {
+      launch_runner = launch_runner->parent;
+    }
+
+    // Get op progress
+    auto put_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(
+        this->getChannelInstanceKey(op), "put");
+    auto get_processed = launch_runner->getAlreadyDispatchedForDynamicDispatch(
+        this->getChannelInstanceKey(op), "get");
+    unsigned bcast_factor =
+        launch_runner->getBCastSizeFromChannelDeclaration(op.getOperation());
+    unsigned total_count = this->tokenSpatialFactorForResource(op);
+
+    // Release the ports of matched put/get pairs. This may already have
+    // happened at the link's occupancy boundary if the link models a
+    // time-of-flight; in that case nothing is left reserved and this is a
+    // no-op.
+    this->releaseChannelPortsForGet(op);
+
+    std::pair<std::string, std::string> put_key =
+        std::make_pair(this->getChannelInstanceKey(op), "put");
+    std::pair<std::string, std::string> get_key =
+        std::make_pair(this->getChannelInstanceKey(op), "get");
 
     // If data movement is complete, clear put and get progresses
     if ((put_processed * bcast_factor == total_count) &&
@@ -1278,6 +1337,8 @@ private:
           std::make_pair(G[v].start_time, G[v].end_time));
       G[v].start_time = 0;
       G[v].end_time = 0;
+      G[v].release_time = 0;
+      G[v].resources_released = false;
     }
 
     // Push adj. vertices to latent wavefront candidates

--- a/mlir/test/Util/Runner/link_latency/arch.json
+++ b/mlir/test/Util/Runner/link_latency/arch.json
@@ -1,72 +1,78 @@
 {
-    "clock": 1000000000,
-    "cores": 1,
-    "datatypes": [
-        {
-        "bytes": 1,
-        "name": "i8"
+  "clock": 1000000000,
+  "cores": 1,
+  "datatypes": [
+    {
+      "bytes": 1,
+      "name": "i8"
+    }
+  ],
+  "devicename": "testdevice",
+  "kernels": {
+    "linalg.copy": {
+      "datatypes": {
+        "i8": {
+          "ops_per_core_per_cycle": 32,
+          "efficiency": 1
         }
+      },
+      "name": "linalg.copy"
+    }
+  },
+  "dus": {
+    "count": [
+      1,
+      1
     ],
-    "devicename": "testdevice",
-    "kernels": {
-        "linalg.copy": {
-            "datatypes": {
-                "i8": {
-                    "ops_per_core_per_cycle": 32,
-                    "efficiency": 1
-                }
-            },
-            "name": "linalg.copy"
-        }
+    "memory": {
+      "memory_space": "L2",
+      "bytes": 524288
     },
-    "dus": {
-        "count": [1, 1],
-        "memory": {
-            "memory_space": "L2",
-            "bytes": 524288
-        },
-        "ports": {
-            "outbound": {
-                "count": 1,
-                "bytes_per_second": 1000000000,
-                "latency": 300
-            },
-            "inbound": {
-                "count": 1,
-                "bytes_per_second": 1000000000,
-                "latency": 300
-            }
-        },
-        "tiles": {
-            "count": [1, 1],
-            "memory": {
-                "memory_space": "L1",
-                "bytes": 65536
-            },
-            "ports": {
-                "outbound": {
-                    "count": 1,
-                    "bytes_per_second": 1000000000,
-                    "latency": 200
-                },
-                "inbound": {
-                    "count": 1,
-                    "bytes_per_second": 1000000000,
-                    "latency": 200
-                }
-            }
-        }
+    "ports": {
+      "outbound": {
+        "count": 1,
+        "bytes_per_second": 1000000000,
+        "latency": 300
+      },
+      "inbound": {
+        "count": 1,
+        "bytes_per_second": 1000000000,
+        "latency": 300
+      }
     },
-    "noc": {
+    "tiles": {
+      "count": [
+        1,
+        1
+      ],
+      "memory": {
+        "memory_space": "L1",
+        "bytes": 65536
+      },
+      "ports": {
         "outbound": {
-            "count": 1,
-            "bytes_per_second": 1000000000,
-            "latency": 0
+          "count": 1,
+          "bytes_per_second": 1000000000,
+          "latency": 200
         },
         "inbound": {
-            "count": 1,
-            "bytes_per_second": 1000000000,
-            "latency": 0
+          "count": 1,
+          "bytes_per_second": 1000000000,
+          "latency": 200
         }
+      }
+    }
+  },
+  "noc": {
+    "outbound": {
+      "count": 1,
+      "bytes_per_second": 1000000000,
+      "latency": 0
+    },
+    "inbound": {
+      "count": 1,
+      "bytes_per_second": 1000000000,
+      "latency": 0
     }
   }
+}

--- a/mlir/test/Util/Runner/link_latency/arch.json
+++ b/mlir/test/Util/Runner/link_latency/arch.json
@@ -1,0 +1,72 @@
+{
+    "clock": 1000000000,
+    "cores": 1,
+    "datatypes": [
+        {
+        "bytes": 1,
+        "name": "i8"
+        }
+    ],
+    "devicename": "testdevice",
+    "kernels": {
+        "linalg.copy": {
+            "datatypes": {
+                "i8": {
+                    "ops_per_core_per_cycle": 32,
+                    "efficiency": 1
+                }
+            },
+            "name": "linalg.copy"
+        }
+    },
+    "dus": {
+        "count": [1, 1],
+        "memory": {
+            "memory_space": "L2",
+            "bytes": 524288
+        },
+        "ports": {
+            "outbound": {
+                "count": 1,
+                "bytes_per_second": 1000000000,
+                "latency": 300
+            },
+            "inbound": {
+                "count": 1,
+                "bytes_per_second": 1000000000,
+                "latency": 300
+            }
+        },
+        "tiles": {
+            "count": [1, 1],
+            "memory": {
+                "memory_space": "L1",
+                "bytes": 65536
+            },
+            "ports": {
+                "outbound": {
+                    "count": 1,
+                    "bytes_per_second": 1000000000,
+                    "latency": 200
+                },
+                "inbound": {
+                    "count": 1,
+                    "bytes_per_second": 1000000000,
+                    "latency": 200
+                }
+            }
+        }
+    },
+    "noc": {
+        "outbound": {
+            "count": 1,
+            "bytes_per_second": 1000000000,
+            "latency": 0
+        },
+        "inbound": {
+            "count": 1,
+            "bytes_per_second": 1000000000,
+            "latency": 0
+        }
+    }
+  }

--- a/mlir/test/Util/Runner/link_latency/channel_latency.mlir
+++ b/mlir/test/Util/Runner/link_latency/channel_latency.mlir
@@ -1,0 +1,56 @@
+//===- channel_latency.mlir -------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// A single L2->L1 channel transfer over a link that carries a fixed
+// time-of-flight in addition to its bandwidth cost.
+//
+// arch.json gives the L2 outbound port 300 cycles of latency and the L1
+// inbound port 200, so the L2->L1 interface latency is 300 + 200 = 500 cycles.
+// Both ports run at 1 byte/cycle, so a memref<64xi8> occupies the link for 64
+// cycles. The get therefore completes 64 + 500 = 564 cycles after it starts.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "B",
+// CHECK: "ts": 0.0[[#%d,TIME0:]],
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "E",
+// CHECK: "ts": 0.[[#TIME0 + 564]],
+
+module {
+  air.channel @channel_0 [1, 1]
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %async_token, %results = air.execute -> (memref<64xi8, 1>) {
+          %alloc = memref.alloc() : memref<64xi8, 1>
+          air.execute_terminator %alloc : memref<64xi8, 1>
+        }
+        %2 = air.channel.put async [%async_token]  @channel_0[] (%results[] [] []) {id = 3 : i32} : (memref<64xi8, 1>)
+        %3 = air.herd @herd_0 async tile (%arg4, %arg5) in (%arg6=%c1_0, %arg7=%c1_0) attributes {id = 4 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %async_token_1, %results_2 = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %4 = air.channel.get async [%async_token_1]  @channel_0[] (%results_2[] [] []) {id = 5 : i32} : (memref<64xi8, 2>)
+          %async_token_3 = air.execute [%4] {
+            memref.dealloc %results_2 : memref<64xi8, 2>
+          }
+        }
+        %async_token_4 = air.execute [%2] {
+          memref.dealloc %results : memref<64xi8, 1>
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/link_latency/link_reuse.mlir
+++ b/mlir/test/Util/Runner/link_latency/link_reuse.mlir
@@ -1,0 +1,85 @@
+//===- link_reuse.mlir ------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Two independent transfers contending for a single L1 inbound port, over a
+// link that carries a fixed time-of-flight.
+//
+// This is the regression test for separating link occupancy from link latency.
+// A port models bandwidth, not flight time, so it must be released once the
+// payload has been clocked out (64 cycles here) rather than when the payload
+// lands (64 + 500). The second transfer therefore starts at +64 and the pair
+// completes in 64 + 64 + 500 = 628 cycles, not 2 * (64 + 500) = 1128.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// The first get starts, and the second claims the freed port one occupancy later.
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "B",
+// CHECK: "ts": 0.0[[#%d,TIME0:]],
+// CHECK: "name": "ChannelGetOp@channel_1(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "B",
+// CHECK: "ts": 0.0[[#TIME0 + 64]],
+
+// Both land 500 cycles after their own occupancy ends.
+// CHECK: "name": "ChannelGetOp@channel_0(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "E",
+// CHECK: "ts": 0.[[#TIME0 + 564]],
+// CHECK: "name": "ChannelGetOp@channel_1(L1<--L2)",
+// CHECK-NEXT: "cat": "layer",
+// CHECK-NEXT: "ph": "E",
+// CHECK: "ts": 0.[[#TIME0 + 628]],
+
+module {
+  air.channel @channel_0 [1, 1]
+  air.channel @channel_1 [1, 1]
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg0, %arg1) in (%arg2=%c1, %arg3=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment async  attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %async_token, %results = air.execute -> (memref<64xi8, 1>) {
+          %alloc = memref.alloc() : memref<64xi8, 1>
+          air.execute_terminator %alloc : memref<64xi8, 1>
+        }
+        %async_token_0, %results_0 = air.execute -> (memref<64xi8, 1>) {
+          %alloc = memref.alloc() : memref<64xi8, 1>
+          air.execute_terminator %alloc : memref<64xi8, 1>
+        }
+        %2 = air.channel.put async [%async_token]  @channel_0[] (%results[] [] []) {id = 3 : i32} : (memref<64xi8, 1>)
+        %3 = air.channel.put async [%async_token_0]  @channel_1[] (%results_0[] [] []) {id = 4 : i32} : (memref<64xi8, 1>)
+        %4 = air.herd @herd_0 async tile (%arg4, %arg5) in (%arg6=%c1_0, %arg7=%c1_0) attributes {id = 5 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %async_token_1, %results_2 = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %async_token_2, %results_3 = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %5 = air.channel.get async [%async_token_1]  @channel_0[] (%results_2[] [] []) {id = 6 : i32} : (memref<64xi8, 2>)
+          %6 = air.channel.get async [%async_token_2]  @channel_1[] (%results_3[] [] []) {id = 7 : i32} : (memref<64xi8, 2>)
+          %async_token_3 = air.execute [%5] {
+            memref.dealloc %results_2 : memref<64xi8, 2>
+          }
+          %async_token_4 = air.execute [%6] {
+            memref.dealloc %results_3 : memref<64xi8, 2>
+          }
+        }
+        %async_token_5 = air.execute [%2] {
+          memref.dealloc %results : memref<64xi8, 1>
+        }
+        %async_token_6 = air.execute [%3] {
+          memref.dealloc %results_0 : memref<64xi8, 1>
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
A link has two costs: how long it is busy carrying a payload, and how long the payload is in flight. The runner only had the first — `getTransferCost` is bytes over bandwidth — so an interconnect whose cost is dominated by time-of-flight rather than throughput could not be expressed at all.

### Why it can't just be added to the existing cost

Resources are reserved in `pushToWavefront` and freed at `end_time`, so occupancy is exactly `modelOp`'s return value. Adding flight time there holds the link for the whole duration and caps its throughput at `1/(occupancy + latency)`. A deep pipeline then cannot fill — the opposite of how a high-latency link actually behaves.

### Approach

Give each event two timestamps:

```
release_time = start + occupancy       ports freed here   (bytes / bandwidth)
end_time     = release_time + latency  data arrives here  (time of flight)
```

`end_time` keeps its meaning, so `is_done`, dependency fulfilment and the trace are unchanged, and consumers still wait for the data. Only the *port release* moves earlier. `getTimeStampsFromWavefront` also has to offer `release_time` as a wake-up point, or the simulator sleeps straight past it.

Latency is declared per memory-space interface in the arch JSON, reusing the existing `interfaces` map, and is additive across the pair: src outbound + dst inbound.

### Backward compatibility

With no `latency` in the JSON, `release_time == end_time` and `has_link_latency()` is false, so the early-release path is unreachable — which is the case for every existing arch model.

Only the get side of a channel is costed, so the latency goes there. `air.dma_memcpy_nd` reserves no ports, so for DMA the split is inert and latency simply extends `end_time`.

### Testing

Two new tests. `channel_latency` checks a single transfer completes at `occupancy + latency`. `link_reuse` is the one that matters: two transfers contending for one port over a 500-cycle link finish in `64 + 64 + 500`, not `2 × (64 + 500)` — the second claims the port one *occupancy* after the first, not one flight time.

`check-air-mlir`: 512 passed, 7 xfail, no failures.