### PR TITLE
[python] air.api: raise when a segment or herd body is never registered

### DIFF
--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -695,10 +695,14 @@ class SegmentContext:
         # replacing it here would bury the real error.
         if exc_type is None and not self._registered:
             raise RuntimeError(
-                f"{self._what} was opened but its body was never registered; "
-                f"decorate one with @<name>.body inside the `with` block. "
-                f"Without it nothing is emitted for this scope and the ops "
-                f"inside it are traced into the enclosing one"
+                f"{self._what} was opened but its body was never registered, so "
+                "nothing was emitted for this scope and the ops inside it were "
+                "traced into the enclosing one. The body is a function decorated "
+                "inside the `with`, which means the scope needs a name to "
+                f"decorate:\n\n    with {self._what}(...) as scope:\n"
+                "        @scope.body\n        def _():\n            ...\n\n"
+                "`as scope` is easy to leave off, and without it there is no "
+                "variable to hang the decorator on."
             )
         return False
 
@@ -943,10 +947,14 @@ class HerdContext:
         # replacing it here would bury the real error.
         if exc_type is None and not self._registered:
             raise RuntimeError(
-                f"{self._what} was opened but its body was never registered; "
-                f"decorate one with @<name>.body inside the `with` block. "
-                f"Without it nothing is emitted for this scope and the ops "
-                f"inside it are traced into the enclosing one"
+                f"{self._what} was opened but its body was never registered, so "
+                "nothing was emitted for this scope and the ops inside it were "
+                "traced into the enclosing one. The body is a function decorated "
+                "inside the `with`, which means the scope needs a name to "
+                f"decorate:\n\n    with {self._what}(...) as scope:\n"
+                "        @scope.body\n        def _():\n            ...\n\n"
+                "`as scope` is easy to leave off, and without it there is no "
+                "variable to hang the decorator on."
             )
         return False
 

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -649,6 +649,8 @@ class SegmentContext:
     reason every hand-written staging example in the tree nests the two.
     """
 
+    _what = "air.segment"
+
     def __init__(self, grid=None, name=None):
         # A grid here is this segment's *own* iteration space -- air.segment's
         # `sizes`, which the dialect prints as `unroll(...)`. air.launch,
@@ -680,7 +682,24 @@ class SegmentContext:
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_val, tb):
+        # A body that was never registered is the one way to leave this block
+        # having emitted nothing at all -- the `with` is pure bookkeeping and
+        # every op comes from the decorator. Silently emitting nothing is the
+        # worst available outcome: the enclosing ops vanish, the kernel still
+        # builds, and on a small grid it still runs and still passes, so
+        # neither a hardware test nor an op-count diff notices.
+        #
+        # Not raised while another exception is propagating: the body itself
+        # failing is far more interesting than the body being absent, and
+        # replacing it here would bury the real error.
+        if exc_type is None and not self._registered:
+            raise RuntimeError(
+                f"{self._what} was opened but its body was never registered; "
+                f"decorate one with @<name>.body inside the `with` block. "
+                f"Without it nothing is emitted for this scope and the ops "
+                f"inside it are traced into the enclosing one"
+            )
         return False
 
     def private(self):
@@ -821,6 +840,8 @@ def _needs(obj, kernel):
 class HerdContext:
     """A herd of compute cores over a (possibly strip-mined) tile grid."""
 
+    _what = "air.herd"
+
     def __init__(self, iterable, name=None, shape=None, target=None, link_with=None):
         self.dims = parse_grid(iterable)
         if len(self.dims) > 2:
@@ -909,7 +930,24 @@ class HerdContext:
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_val, tb):
+        # A body that was never registered is the one way to leave this block
+        # having emitted nothing at all -- the `with` is pure bookkeeping and
+        # every op comes from the decorator. Silently emitting nothing is the
+        # worst available outcome: the enclosing ops vanish, the kernel still
+        # builds, and on a small grid it still runs and still passes, so
+        # neither a hardware test nor an op-count diff notices.
+        #
+        # Not raised while another exception is propagating: the body itself
+        # failing is far more interesting than the body being absent, and
+        # replacing it here would bury the real error.
+        if exc_type is None and not self._registered:
+            raise RuntimeError(
+                f"{self._what} was opened but its body was never registered; "
+                f"decorate one with @<name>.body inside the `with` block. "
+                f"Without it nothing is emitted for this scope and the ops "
+                f"inside it are traced into the enclosing one"
+            )
         return False
 
     def private(self):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1836,3 +1836,81 @@ def _():
 @expect(TypeError, "herd_link_with_is_empty")
 def _():
     air.herd(range(0, 128, 64), link_with="")
+
+
+# CHECK-LABEL: TEST: segment_body_never_registered
+# `with air.segment(...)` is pure bookkeeping -- every op comes from the body
+# decorator -- so omitting it emits nothing at all for that scope and traces the
+# herd straight into the launch. That is the worst available failure: the IR is
+# structurally different, still builds, and on a small grid still runs and still
+# passes, so neither a hardware test nor an op-count diff catches it. It did
+# reach review once, in the data_transfer_transpose conversion.
+# CHECK: RuntimeError: air.segment was opened but its body was never registered
+@expect(RuntimeError, "segment_body_never_registered")
+def _():
+    A = air.tensor([64], bf16)
+    C = air.tensor([64], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="s") as seg:
+                with air.herd(range(0, 64, 64), shape=(1,)) as h:
+
+                    @h.body
+                    def _(tx):
+                        t = air.alloc([64], bf16, scope=h.private())
+                        ops.load(t, A[:])
+                        ops.store(t, C[:])
+
+    launch.mlir()
+
+
+# CHECK-LABEL: TEST: herd_body_never_registered
+# The same hole, and it is a real one rather than a theoretical twin: a lone
+# body-less herd happens to trip "kernel writes no output", but that check is
+# satisfied by any *other* herd that stores. Two herds with the second one's
+# body forgotten built cleanly and dropped it silently.
+# CHECK: RuntimeError: air.herd was opened but its body was never registered
+@expect(RuntimeError, "herd_body_never_registered")
+def _():
+    A = air.tensor([64], bf16)
+    C = air.tensor([64], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, 64, 64), name="h1", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    t = air.alloc([64], bf16, scope=h.private())
+                    ops.load(t, A[:])
+                    ops.store(t, C[:])
+
+            with air.herd(range(0, 64, 64), name="h2", shape=(1,)):
+                pass
+
+    launch.mlir()
+
+
+# CHECK-LABEL: TEST: a_failing_body_is_not_masked
+# The guard must stay quiet while another exception is propagating. A body that
+# raised is far more interesting than a body that is absent, and reporting the
+# absence here would bury the real error -- which, at that point, is the only
+# reason the body never registered.
+# CHECK: ValueError: the body's own problem
+@expect(ValueError, "a_failing_body_is_not_masked")
+def _():
+    air.tensor([64], bf16)
+
+    with air.launch(name="k") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="s"):
+                raise ValueError("the body's own problem")
+
+    launch.mlir()


### PR DESCRIPTION
`with air.segment(...)` and `with air.herd(...)` are pure bookkeeping — `__enter__` and `__exit__` are no-ops and every op comes from the `body` decorator. Omitting the decorator therefore emits **nothing** for that scope, and the ops inside it are traced into the enclosing one.

That is the worst available failure mode: the IR is structurally different, it still builds, and on a small grid it still runs and still passes — so neither a hardware test nor an op-count diff notices.

It reached review once already, in #1900. A missing `@seg.body` dropped both the segment *and* the launch, leaving a bare `air.herd` where the predecessor had `air.launch` → `air.segment` → `air.herd`. The npu1 lit passed on both element types anyway, and the IR diff I ran compared only the `air.dma_memcpy_nd` lines — which were correct the whole time.

## Where the holes actually are — measured, not assumed

| context | body omitted | verdict |
|---|---|---|
| `air.launch` | `RuntimeError: launch has no body` | genuinely guarded |
| `air.herd` | `RuntimeError: kernel writes no output` | **incidental** |
| `air.segment` | builds fine, segment vanishes | unguarded |

The `herd` row looked safe, so I tested it rather than trusting it. That error is the *no-output* check, not a missing-body check, and any **other** herd that stores satisfies it:

```python
with air.herd(..., name="h1") as h:
    @h.body
    def _(tx): ...   # stores
with air.herd(..., name="h2"):
    pass             # body forgotten
```

builds cleanly and drops `h2` silently. So both holes are real; only `launch` is genuinely covered.

## The fix

```python
def __exit__(self, exc_type, exc_val, tb):
    if exc_type is None and not self._registered:
        raise RuntimeError(f"{self._what} was opened but its body was never registered; ...")
    return False
```

on `SegmentContext` and `HerdContext`.

**Why `__exit__` rather than a `build()`-time check:** the error fires at the `with` statement that caused it. Deferring would need global "entered but unregistered" state and would report far from the cause — which is exactly the weakness of launch's existing message.

**`exc_type is None` is load-bearing.** If the body itself raised, `__exit__` must stay quiet: a body that failed is more interesting than a body that is absent, and at that point the failure is the *only* reason it never registered. Pinned as `a_failing_body_is_not_masked`.

This mirrors the guard already present for registering a body **twice** — same invariant, other end.

`air.launch` is deliberately left alone: it already errors with a good message, and moving its check to `__exit__` would change which error existing users see, for no benefit. The asymmetry is commented rather than refactored away.

## Gates

- `python/test/api` **24/24**, with three new tests: one per hole, plus the not-masked case.
- **All 45 buildable air.api examples still build**, and their `-p` output is **byte-identical** to the unguarded baseline — no correct program is affected.
- Nothing in the tree relied on a body-less context: I scanned every converted example, and the only apparent hit was inside a docstring.

118 lines, of which 78 are tests. No behaviour change for correct code.