### PR TITLE
[python] air.api: broadcast an operand axis of extent 1, and vector_broadcast_scalar

### DIFF
--- a/programming_examples/primitives/vector_examples/vector_broadcast_scalar/vector_broadcast_scalar.py
+++ b/programming_examples/primitives/vector_examples/vector_broadcast_scalar/vector_broadcast_scalar.py
@@ -1,181 +1,98 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from ml_dtypes import bfloat16
+"""Broadcast one scalar per row across a whole row, on air.api.
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview, collapse_shape
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    reduction,
-    extract,
-    CombiningKind,
-    broadcast,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.math import exp
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+    c[:] = a[:]
+
+with ``a`` shaped ``[tile_m, 1]`` and ``c`` shaped ``[tile_m, n]``. That is the
+entire kernel. The right-hand side is a plain copy and the shapes are what make
+it a broadcast: numpy's rule, right-aligned, an operand axis either matches the
+destination's or is 1 and gets stretched.
+
+The predecessor said the same thing as a per-row ``scf.for`` containing two
+``memref.subview``s, two ``memref.collapse_shape``s with an explicit dynamic
+``StridedLayoutAttr``, a ``memref.load`` and a ``vector.broadcast``, plus a
+``vector.transfer_write``. The emitted arithmetic is unchanged -- when the
+broadcast axis is the *innermost* one there is no contiguous run to read, so the
+emitter loads the single element and splats it, which is exactly the
+``memref.load`` + ``vector.broadcast`` pair above.
+
+The subviews and collapse_shapes were only ever there to get a rank-1 view the
+vector ops would accept; indexing a rank-2 buffer at ``[j, 0]`` needs neither.
+
+Two differences from the predecessor worth naming, both shared with the
+``average_pool`` conversion this example is the mirror image of:
+
+* The herd is [NUM_TILES, 1] rather than [1, NUM_TILES]. A 1-D air.api herd is
+  laid out along x, which is the orientation that places on both generations.
+* The strip-mine is the DSL's, so each core gets a contiguous run of tiles where
+  the predecessor's hand-built AffineMap interleaved them. Every tile is still
+  written exactly once by exactly one core, and the rows are independent.
+
+``--target`` is new and defaults to detecting the installed part, which is what
+the predecessor did implicitly by having no device flag at all.
+"""
+
+import argparse
 
 import numpy as np
+from ml_dtypes import bfloat16
 
+from air import api as air
+from air.api.types import bf16
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
+
+# The rows checked against the reference are drawn at random, so the seed is
+# what makes a failure reproducible: without it a mismatch reports row indices
+# that the next run will not look at.
 np.random.seed(42)
 
-range_ = for_
+NUM_TILES = 2
 
 
-@module_builder
-def build_module(m, n, tile_m, np_dtype_in):
-    a_size = [m]
-    out_size = [m, n]
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    num_tiles = 2
-    assert m % (tile_m * num_tiles) == 0
-    VECTOR_SIZE = 16
-    index_type = IndexType.get()
+def build_module(m, n, tile_m):
+    assert m % (tile_m * NUM_TILES) == 0
 
-    # L3 MemRefTypes
-    l3memrefTy = MemRefType.get(a_size, xrt_dtype_in)
-    l3outputMemrefTy = MemRefType.get(out_size, xrt_dtype_in)
+    A = air.tensor([m], bf16)
+    C = air.tensor([m, n], bf16)
 
-    # L1 MemRefTypes
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_m, 1],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-    l1outputMemrefTy = MemRefType.get(
-        shape=[tile_m, n],
-        element_type=xrt_dtype_in,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
+    with air.launch(name="vector_broadcast_scalar") as launch:
 
-    @FuncOp.from_py_func(l3memrefTy, l3outputMemrefTy)
-    def vector_broadcast_scalar(arg0, arg2):
-        @herd(
-            name="herd_0",
-            sizes=[1, num_tiles],
-            operands=[arg0, arg2],
-        )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_a,
-            _l3_c,
-        ):
-            l1_a_data = AllocOp(l1MemrefTy, [], [])
-            l1_out_data = AllocOp(l1outputMemrefTy, [], [])
+        @launch.body
+        def _():
+            # The iteration space is every tile of rows; shape= pins the core
+            # count to what the predecessor asked for, and the DSL strip-mines
+            # the rest into a loop on each core.
+            with air.herd(
+                [range(0, m, tile_m)], name="herd_0", shape=(NUM_TILES,)
+            ) as h:
 
-            for _l_ivx in range_(0, m, tile_m * num_tiles):
+                @h.body
+                def _(tx):
+                    # tx is a tile *index*, not a row offset: the herd's
+                    # iteration space counts tiles, and h.tile_sizes carries the
+                    # step. Multiply to get the window into L3.
+                    i0 = tx * tile_m
+                    # One value per row. The trailing 1 is the axis that gets
+                    # stretched, and ops.load ignores it against the rank-1 L3
+                    # region -- both describe the same tile_m contiguous
+                    # elements.
+                    a = air.alloc([tile_m, 1], bf16, scope=h.private())
+                    # A whole row per value, so the vector width is the row
+                    # width -- the predecessor's vector<Nxbf16>.
+                    c = air.alloc([tile_m, n], bf16, scope=h.private(), vector=n)
 
-                offset_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_m),
-                            ),
-                        )
-                    ],
-                )
-                offset = affine_apply(offset_map, [_l_ivx, _ty])
+                    air.ops.load(a, A[i0 : i0 + tile_m])
 
-                dma_memcpy_nd(
-                    l1_a_data,
-                    _l3_a,
-                    src_offsets=[
-                        offset,
-                    ],
-                    src_sizes=[tile_m],
-                    src_strides=[1],
-                )
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_m)
-                for j in range_(c0, cTileN, c1):
-                    sub_a_vec = subview(
-                        l1_a_data.result,
-                        [j, c0],
-                        [1, 1],
-                        [1, 1],
-                    )
-                    sub_c_vec = subview(
-                        l1_out_data.result,
-                        [j, c0],
-                        [1, n],
-                        [1, 1],
-                    )
-                    layout = StridedLayoutAttr.get(
-                        ShapedType.get_dynamic_size(),
-                        [
-                            1,
-                        ],
-                    )
-                    collapsed_type = MemRefType.get(
-                        (1,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapsed_type_2 = MemRefType.get(
-                        (n,),
-                        xrt_dtype_in,
-                        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-                        layout=layout,
-                    )
-                    collapse_dims = [[0, 1]]
-                    collapse_a = collapse_shape(
-                        collapsed_type, sub_a_vec, collapse_dims
-                    )
-                    collapse_c = collapse_shape(
-                        collapsed_type_2, sub_c_vec, collapse_dims
-                    )
-                    cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    scalar = load(collapse_a, [c0])
-                    # v_a = transfer_read(
-                    #     VectorType.get([n], xrt_dtype_in),
-                    #     collapse_a,
-                    #     [c0],
-                    #     AffineMapAttr.get(AffineMap.get_identity(1)),
-                    #     cst0,
-                    #     [True],
-                    # )
+                    # The whole example. [tile_m, 1] against [tile_m, n]: the
+                    # trailing axis is stretched, and because it is the
+                    # innermost one the read is a scalar load and a splat.
+                    c[:] = a[:]
 
-                    v_c_broadcast = broadcast(VectorType.get([n], xrt_dtype_in), scalar)
-                    # store(v_c_broadcast, collapse_c, [c0])
+                    air.ops.store(c, C[i0 : i0 + tile_m, :])
 
-                    transfer_write(
-                        None,
-                        v_c_broadcast,
-                        collapse_c,
-                        [c0],
-                        AffineMapAttr.get(AffineMap.get_identity(1)),
-                        [True],
-                    )
-                    yield_([])
-
-                dma_memcpy_nd(
-                    _l3_c,
-                    l1_out_data,
-                    dst_offsets=[offset, 0],
-                    dst_sizes=[tile_m, n],
-                    dst_strides=[n, 1],
-                )
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_out_data)
-
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -187,7 +104,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        description="Builds, runs, and tests the vector_broadcast_scalar example",
     )
     parser.add_argument(
         "-v",
@@ -228,15 +145,18 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.m,
-        args.n,
-        args.tile_m,
-        INPUT_DATATYPE,
-    )
+    launch = build_module(args.m, args.n, args.tile_m)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -245,7 +165,8 @@ if __name__ == "__main__":
 
     if args.compile_mode == "compile-and-run":
 
-        # Stochastically sample num_sample results, and pass to XRTRunner backend for verification.
+        # Stochastically sample num_sample results, and pass to XRTRunner backend
+        # for verification.
         num_samples = 100
         sampled_indices = np.vstack([np.random.randint(0, args.m, num_samples)])
 
@@ -268,6 +189,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             instance_name="vector_broadcast_scalar",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -284,6 +206,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -121,6 +121,61 @@ _REDUCE_F = {"add": CombiningKind.ADD, "max": CombiningKind.MAXIMUMF}
 _REDUCE_I = {"add": CombiningKind.ADD, "max": CombiningKind.MAXSI}
 
 
+def _broadcast_offset(shape, dst_shape):
+    """numpy's broadcast rule, one-sided: can ``shape`` be read as ``dst_shape``?
+
+    Returns how many destination axes the operand does not have -- the amount
+    the two shapes are offset by once right-aligned -- or None if they do not
+    broadcast. Right-aligned each operand axis must either match the
+    destination's or be 1, and leading axes the operand does not have at all
+    are the ``1`` case written by omission.
+
+    One-sided because the destination of an air.api assignment is a buffer that
+    already exists: numpy would broadcast both sides against each other and
+    allocate the result, and here the result's shape is given, which is numpy's
+    own rule for an explicit ``out=``.
+    """
+    offset = len(dst_shape) - len(shape)
+    if offset < 0:
+        return None
+    for extent, target in zip(shape, dst_shape[offset:]):
+        if extent != target and extent != 1:
+            return None
+    return offset
+
+
+def _is_broadcast(shape, dst_shape):
+    """Does reading ``shape`` as ``dst_shape`` actually stretch anything?"""
+    return tuple(shape) != tuple(dst_shape)
+
+
+def _zero_index_if(needed):
+    """An index-typed 0 for the pinned axes of a broadcast, or None.
+
+    Conditional so that a kernel with no broadcast in it emits no constant, and
+    therefore the same IR it emitted before broadcasting existed.
+    """
+    return _result(arith.ConstantOp(IndexType.get(), 0)) if needed else None
+
+
+def _leaf_index(shape, dst_shape, ivs, zero):
+    """The indices to read a leaf of ``shape`` at, inside a nest over ``dst_shape``.
+
+    An axis that matches the destination's is walked with the destination's own
+    induction variable; an axis of extent 1 against a wider destination is
+    pinned at 0, which is what makes the read a broadcast. Axes the operand does
+    not have contribute no index at all.
+
+    When the shapes are equal this returns ``ivs`` unchanged, which is what
+    keeps every existing kernel's IR byte-identical.
+    """
+    offset = _broadcast_offset(shape, dst_shape)
+    return [
+        ivs[i + offset] if extent == dst_shape[i + offset] else zero
+        for i, extent in enumerate(shape)
+    ]
+
+
 def _check_region(node, dst, dtype, expected=None):
     """Check every buffer leaf against the element type of *its* region.
 
@@ -144,10 +199,12 @@ def _check_region(node, dst, dtype, expected=None):
         return
     if node.kind == "buffer":
         leaf = node.buffer
-        if leaf.shape != dst.shape:
+        if _broadcast_offset(leaf.shape, dst.shape) is None:
             raise ValueError(
                 f"shape mismatch in elementwise assignment: destination has "
-                f"shape {dst.shape} but operand has shape {leaf.shape}"
+                f"shape {dst.shape} but operand has shape {leaf.shape}, which "
+                f"does not broadcast to it. Right-aligned, every operand axis "
+                f"must either match the destination's or be 1"
             )
         if leaf.dtype is not dtype:
             raise ValueError(
@@ -312,7 +369,11 @@ def _emit_reduce(dst, expr):
         if leaf.shape != src_shape:
             raise ValueError(
                 f"shape mismatch inside a reduction: operands have shapes "
-                f"{src_shape} and {leaf.shape}"
+                f"{src_shape} and {leaf.shape}. Unlike a plain elementwise "
+                f"assignment, a reduction does not broadcast its operands: the "
+                f"innermost extent is the thing being collapsed, so an operand "
+                f"of extent 1 there would change what the reduction means "
+                f"rather than being stretched to fit"
             )
         if leaf.dtype is not dtype:
             raise ValueError(
@@ -343,8 +404,7 @@ def _emit_reduce(dst, expr):
         )
 
     lanes = src_shape[-1]
-    rank = len(src_shape)
-    minor = AffineMapAttr.get(AffineMap.get(rank, 0, [AffineDimExpr.get(rank - 1)]))
+    minor = _minor(len(src_shape))
     regions = {d: _Region(d, lanes, True) for d in _regions_in(operand, dtype, [])}
     kind = (_REDUCE_F if dtype.is_float else _REDUCE_I)[expr.op]
 
@@ -353,22 +413,33 @@ def _emit_reduce(dst, expr):
     zero = _result(arith.ConstantOp(IndexType.get(), 0))
     bounds = [(0, extent, 1) for extent in src_shape[:-1]]
 
+    # Every leaf here has the operand's shape -- the check above insists on it,
+    # since a reduction's extent is what is being collapsed -- so the read is
+    # always the plain one and broadcasting does not arise.
+    def load(buf, at, region):
+        return _result(
+            transfer_read(region.vec_ty, buf.value, at, minor, region.pad, [True])
+        )
+
     def body(ivs):
         reads = {}
-        value = _eval(
-            operand, ivs + [zero], regions[dtype], regions, True, minor, reads
-        )
+        value = _eval(operand, ivs + [zero], regions[dtype], regions, True, load, reads)
         scalar = _result(reduction(dtype.mlir(), kind, value))
         memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
 
     _nest(bounds, body)
 
 
+def _minor(rank):
+    """A minor-identity permutation map: read a rank-N memref's innermost dim."""
+    return AffineMapAttr.get(AffineMap.get(rank, 0, [AffineDimExpr.get(rank - 1)]))
+
+
 def _emit_vector(dst, expr, width):
     shape = dst.shape
     rank = len(shape)
     # Read a rank-1 vector out of a rank-N memref along the innermost dim.
-    minor = AffineMapAttr.get(AffineMap.get(rank, 0, [AffineDimExpr.get(rank - 1)]))
+    minor = _minor(rank)
     # One lane count for the whole nest, taken from the destination. A cast does
     # not change how many elements a trip covers, only how wide each one is, so
     # the source is read at the destination's lane count and not at its own
@@ -378,19 +449,55 @@ def _emit_vector(dst, expr, width):
     bounds = [(0, extent, 1) for extent in shape[:-1]]
     bounds.append((0, shape[-1], width))
 
+    # Hoisted above the nest, like the padding constants, so a broadcast costs
+    # one constant for the whole kernel rather than one per trip.
+    zero = _zero_index_if(
+        any(_is_broadcast(leaf.shape, shape) for leaf in expr.leaves())
+    )
+
+    def load(buf, ivs, region):
+        index = _leaf_index(buf.shape, shape, ivs, zero)
+        if buf.shape and buf.shape[-1] == shape[-1]:
+            # The operand has the destination's innermost extent, so the vector
+            # read is the ordinary one -- at the operand's own rank, which is
+            # the destination's unless leading axes were broadcast away.
+            return _result(
+                transfer_read(
+                    region.vec_ty,
+                    buf.value,
+                    index,
+                    _minor(len(buf.shape)),
+                    region.pad,
+                    [True],
+                )
+            )
+        # The innermost axis is the broadcast one, so there is no run of
+        # contiguous elements to read: take the single element the whole vector
+        # is made of and splat it. This is what the hand-written
+        # vector_broadcast_scalar kernel spells as memref.load + vector.broadcast.
+        return _result(broadcast(region.vec_ty, _result(memref_load(buf.value, index))))
+
     def body(ivs):
-        value = _eval(expr, ivs, regions[dst.dtype], regions, True, minor, {})
+        value = _eval(expr, ivs, regions[dst.dtype], regions, True, load, {})
         transfer_write(None, value, dst.value, ivs, minor, [True])
 
     _nest(bounds, body)
 
 
 def _emit_scalar(dst, expr):
+    shape = dst.shape
     regions = {d: _Region(d, 0, False) for d in _regions_in(expr, dst.dtype, [])}
-    bounds = [(0, extent, 1) for extent in dst.shape]
+    bounds = [(0, extent, 1) for extent in shape]
+
+    zero = _zero_index_if(
+        any(_is_broadcast(leaf.shape, shape) for leaf in expr.leaves())
+    )
+
+    def load(buf, ivs, region):
+        return _result(memref_load(buf.value, _leaf_index(buf.shape, shape, ivs, zero)))
 
     def body(ivs):
-        value = _eval(expr, ivs, regions[dst.dtype], regions, False, None, {})
+        value = _eval(expr, ivs, regions[dst.dtype], regions, False, load, {})
         memref_store(value, dst.value, ivs)
 
     _nest(bounds, body)
@@ -414,12 +521,12 @@ def _result(v):
     return v.result if hasattr(v, "result") else v
 
 
-def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
+def _eval(node, ivs, region, regions, vectorized, load, reads=None):
     ops, ety = region.ops, region.ety
     vec_ty, pad = region.vec_ty, region.pad
 
     def recur(child, into=region):
-        return _eval(child, ivs, into, regions, vectorized, minor, reads)
+        return _eval(child, ivs, into, regions, vectorized, load, reads)
 
     if node.kind == "buffer":
         # One read per buffer per loop body, not one per mention. A buffer that
@@ -439,12 +546,7 @@ def _eval(node, ivs, region, regions, vectorized, minor, reads=None):
         key = id(node.buffer)
         if reads is not None and key in reads:
             return reads[key]
-        if vectorized:
-            value = _result(
-                transfer_read(vec_ty, node.buffer.value, ivs, minor, pad, [True])
-            )
-        else:
-            value = _result(memref_load(node.buffer.value, ivs))
+        value = load(node.buffer, ivs, region)
         if reads is not None:
             reads[key] = value
         return value

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -144,15 +144,27 @@ def _broadcast_offset(shape, dst_shape):
     return offset
 
 
-def _is_broadcast(shape, dst_shape):
-    """Does reading ``shape`` as ``dst_shape`` actually stretch anything?"""
-    return tuple(shape) != tuple(dst_shape)
+def _pins_an_axis(shape, dst_shape):
+    """Does reading ``shape`` as ``dst_shape`` pin one of its axes to 0?
+
+    Deliberately narrower than "is this a broadcast". An operand short of
+    *leading* axes -- a [16] bias against an [8, 16] tile -- is stretched
+    without any axis it actually has being pinned, because a missing axis
+    contributes no index at all. Only an axis that exists and is 1 against a
+    wider destination needs the constant.
+
+    The condition is the negation of the one in ``_leaf_index``, and is written
+    that way on purpose: the two must agree, or a constant is emitted that
+    nothing uses, or -- worse -- used before it is emitted.
+    """
+    offset = _broadcast_offset(shape, dst_shape)
+    return any(extent != dst_shape[i + offset] for i, extent in enumerate(shape))
 
 
 def _zero_index_if(needed):
     """An index-typed 0 for the pinned axes of a broadcast, or None.
 
-    Conditional so that a kernel with no broadcast in it emits no constant, and
+    Conditional so that a kernel that pins nothing emits no constant, and
     therefore the same IR it emitted before broadcasting existed.
     """
     return _result(arith.ConstantOp(IndexType.get(), 0)) if needed else None
@@ -452,7 +464,7 @@ def _emit_vector(dst, expr, width):
     # Hoisted above the nest, like the padding constants, so a broadcast costs
     # one constant for the whole kernel rather than one per trip.
     zero = _zero_index_if(
-        any(_is_broadcast(leaf.shape, shape) for leaf in expr.leaves())
+        any(_pins_an_axis(leaf.shape, shape) for leaf in expr.leaves())
     )
 
     def load(buf, ivs, region):
@@ -490,7 +502,7 @@ def _emit_scalar(dst, expr):
     bounds = [(0, extent, 1) for extent in shape]
 
     zero = _zero_index_if(
-        any(_is_broadcast(leaf.shape, shape) for leaf in expr.leaves())
+        any(_pins_an_axis(leaf.shape, shape) for leaf in expr.leaves())
     )
 
     def load(buf, ivs, region):

--- a/python/test/api/broadcast.py
+++ b/python/test/api/broadcast.py
@@ -95,7 +95,17 @@ def innermost_axis_is_a_scalar_load_and_a_splat():
 # read with an ordinary transfer_read -- but from a rank-1 memref, indexed by
 # the *inner* induction variable alone. That is the bias vector in
 # broadcast_bias_add, which the predecessor reached via a subview.
-# CHECK: scf.for %[[I:.*]] = %c0{{.*}} to %c8
+#
+# An operand short of *leading* axes is stretched without any axis it actually
+# has being pinned -- a missing axis contributes no index at all -- so this case
+# must emit no pinned-zero constant either. Same shape of check as
+# no_broadcast_emits_no_pinned_index below: the padding value is immediately
+# followed by the loop bounds.
+# CHECK: %[[PAD:.*]] = arith.constant 0.0{{.*}} : bf16
+# CHECK-NEXT: arith.constant 0 : index
+# CHECK-NEXT: arith.constant 8 : index
+# CHECK-NEXT: arith.constant 1 : index
+# CHECK-NEXT: scf.for %[[I:.*]] = %c0{{.*}} to %c8
 # CHECK: scf.for %[[J:.*]] = %c0{{.*}} to %c16
 # CHECK-DAG: vector.transfer_read %{{[a-z_0-9]+}}[%[[I]], %[[J]]]{{.*}}memref<8x16xbf16, 2 : i32>, vector<16xbf16>
 # CHECK-DAG: vector.transfer_read %{{[a-z_0-9]+}}[%[[J]]]{{.*}}memref<16xbf16, 2 : i32>, vector<16xbf16>

--- a/python/test/api/broadcast.py
+++ b/python/test/api/broadcast.py
@@ -1,0 +1,166 @@
+# ./python/test/api/broadcast.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api stretches an operand axis of extent 1 to the destination's.
+
+numpy's rule, right-aligned and one-sided: the destination already exists, so
+each operand broadcasts *to* it rather than the two being broadcast against
+each other. That is numpy's own rule for an explicit ``out=``.
+
+Which code comes out depends on *which* axis is stretched, and that is the
+substance of this file:
+
+* an outer axis stretched leaves the innermost one intact, so the read is the
+  ordinary ``vector.transfer_read`` -- just at the operand's own rank, pinned at
+  0 on the stretched axes;
+* the *innermost* axis stretched has no contiguous run to read at all, so the
+  emitter loads the one element and splats it with ``vector.broadcast``.
+
+The second is what ``vector_broadcast_scalar`` needs and the first is what
+``mnist_fc/broadcast_bias_add`` needs; both were hand-written before, out of
+subviews and collapse_shapes, and both are two lines here.
+"""
+
+from air import api as air
+from air.api.types import bf16
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def build(shapes, body, dtype=bf16, vector=None):
+    """A herd whose body allocates one buffer per entry in ``shapes``.
+
+    ``shapes[0]`` is the destination; the rest are operands, and ``body`` is
+    handed them in order. Nothing is DMAed *in* -- the point is the compute
+    loop, and an unread buffer still gets an alloc for it to index -- but the
+    destination is stored out, because a kernel that writes no tensor is
+    refused before it reaches the emitter.
+    """
+    out_shape = shapes[0]
+    OUT = air.tensor(out_shape, dtype)
+    whole = tuple(slice(None) for _ in out_shape)
+
+    with air.launch(name="bc") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    bufs = [
+                        air.alloc(
+                            s,
+                            dtype,
+                            scope=h.private(),
+                            **({} if vector is None else {"vector": vector}),
+                        )
+                        for s in shapes
+                    ]
+                    dst, operands = bufs[0], bufs[1:]
+                    dst[:] = body(*operands)
+                    air.ops.store(dst, OUT[whole])
+
+    print(launch.build(target="npu1"))
+
+
+# CHECK-LABEL: TEST: innermost_axis_is_a_scalar_load_and_a_splat
+# [8, 1] into [8, 16]: the stretched axis is the contiguous one, so there is no
+# run of elements to read. One memref.load at column 0 -- note the pinned %c0 --
+# and one vector.broadcast, which is exactly what the hand-written
+# vector_broadcast_scalar kernel spells.
+# CHECK: %[[Z:.*]] = arith.constant 0 : index
+# CHECK: scf.for %[[I:.*]] =
+# CHECK: scf.for
+# CHECK: %[[S:.*]] = memref.load %{{.*}}[%[[I]], %[[Z]]] : memref<8x1xbf16, 2 : i32>
+# CHECK: %[[V:.*]] = vector.broadcast %[[S]] : bf16 to vector<16xbf16>
+# CHECK: vector.transfer_write %[[V]]
+# CHECK-NOT: memref.subview
+# CHECK-NOT: memref.collapse_shape
+@run
+def innermost_axis_is_a_scalar_load_and_a_splat():
+    build([[8, 16], [8, 1]], lambda a: a[:], vector=16)
+
+
+# CHECK-LABEL: TEST: a_missing_leading_axis_reads_at_its_own_rank
+# [16] added to [8, 16]: the innermost extent already matches, so the operand is
+# read with an ordinary transfer_read -- but from a rank-1 memref, indexed by
+# the *inner* induction variable alone. That is the bias vector in
+# broadcast_bias_add, which the predecessor reached via a subview.
+# CHECK: scf.for %[[I:.*]] = %c0{{.*}} to %c8
+# CHECK: scf.for %[[J:.*]] = %c0{{.*}} to %c16
+# CHECK-DAG: vector.transfer_read %{{[a-z_0-9]+}}[%[[I]], %[[J]]]{{.*}}memref<8x16xbf16, 2 : i32>, vector<16xbf16>
+# CHECK-DAG: vector.transfer_read %{{[a-z_0-9]+}}[%[[J]]]{{.*}}memref<16xbf16, 2 : i32>, vector<16xbf16>
+# CHECK: arith.addf
+# CHECK-NOT: memref.subview
+@run
+def a_missing_leading_axis_reads_at_its_own_rank():
+    build([[8, 16], [8, 16], [16]], lambda a, bias: a[:] + bias[:], vector=16)
+
+
+# CHECK-LABEL: TEST: an_explicit_leading_one_is_the_same_as_omitting_it
+# [1, 16] and [16] broadcast into [8, 16] identically -- the first axis is
+# pinned at 0 rather than dropped, so the read is rank-2, but it is still one
+# transfer_read of the whole row and no subview.
+# CHECK: %[[Z:.*]] = arith.constant 0 : index
+# CHECK: scf.for %{{.*}} = %c0{{.*}} to %c8
+# CHECK: scf.for %[[J:.*]] = %c0{{.*}} to %c16
+# CHECK: vector.transfer_read %{{[a-z_0-9]+}}[%[[Z]], %[[J]]]{{.*}}memref<1x16xbf16, 2 : i32>, vector<16xbf16>
+@run
+def an_explicit_leading_one_is_the_same_as_omitting_it():
+    build([[8, 16], [1, 16]], lambda a: a[:], vector=16)
+
+
+# CHECK-LABEL: TEST: a_middle_axis_can_be_stretched_too
+# [4, 1, 16] into [4, 8, 16]: nothing special about the ends. The middle index
+# is the pinned 0 and the other two are the destination's own variables.
+# CHECK: %[[Z:.*]] = arith.constant 0 : index
+# CHECK: scf.for %[[I:.*]] = %c0{{.*}} to %c4
+# CHECK: scf.for %{{.*}} = %c0{{.*}} to %c8
+# CHECK: scf.for %[[K:.*]] = %c0{{.*}} to %c16
+# CHECK: vector.transfer_read %{{[a-z_0-9]+}}[%[[I]], %[[Z]], %[[K]]]{{.*}}memref<4x1x16xbf16, 2 : i32>
+@run
+def a_middle_axis_can_be_stretched_too():
+    build([[4, 8, 16], [4, 1, 16]], lambda a: a[:], vector=16)
+
+
+# CHECK-LABEL: TEST: the_scalar_path_broadcasts_the_same_way
+# vector=0 sends the emitter down the memref.load/store path, where a broadcast
+# is nothing but which index goes in which position. Both operands are loaded
+# scalar; the stretched one at the pinned 0.
+# CHECK: %[[Z:.*]] = arith.constant 0 : index
+# CHECK: scf.for %[[I:.*]] = %c0{{.*}} to %c8
+# CHECK: scf.for %[[J:.*]] = %c0{{.*}} to %c4
+# CHECK-DAG: memref.load %{{.*}}[%[[I]], %[[J]]] : memref<8x4xbf16, 2 : i32>
+# CHECK-DAG: memref.load %{{.*}}[%[[I]], %[[Z]]] : memref<8x1xbf16, 2 : i32>
+# CHECK: arith.mulf
+# CHECK: memref.store
+@run
+def the_scalar_path_broadcasts_the_same_way():
+    build([[8, 4], [8, 4], [8, 1]], lambda a, s: a[:] * s[:], vector=0)
+
+
+# CHECK-LABEL: TEST: no_broadcast_emits_no_pinned_index
+# The regression pin for the whole feature: when every operand already has the
+# destination's shape, nothing is stretched and the emitter must produce exactly
+# the IR it produced before broadcasting existed -- in particular no leftover
+# index constant hoisted above the nest. The only constants here are the loop
+# bounds and the transfer_read padding value.
+# CHECK: memref.alloc
+# CHECK: memref.alloc
+# CHECK: %[[PAD:.*]] = arith.constant 0.0{{.*}} : bf16
+# CHECK-NEXT: %[[LB:.*]] = arith.constant 0 : index
+# CHECK-NEXT: arith.constant 8 : index
+# CHECK-NEXT: arith.constant 1 : index
+# CHECK-NEXT: scf.for
+@run
+def no_broadcast_emits_no_pinned_index():
+    build([[8, 16], [8, 16]], lambda a: a[:], vector=16)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1914,3 +1914,67 @@ def _():
                 raise ValueError("the body's own problem")
 
     launch.mlir()
+
+
+# CHECK-LABEL: TEST: broadcast_needs_an_extent_of_one
+# Broadcasting stretches an axis of extent 1 and nothing else. A [64, 32]
+# operand against a [64, 64] destination is not "half of each row", it is a
+# mistake, and numpy refuses it for the same reason.
+# CHECK: ValueError: shape mismatch in elementwise assignment
+# CHECK-SAME: does not broadcast to it
+@expect(ValueError, "broadcast_needs_an_extent_of_one")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 64], bf16, scope=h.private())
+        b = air.alloc([64, 32], bf16, scope=h.private())
+        a[:] = a[:] + b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: an_operand_cannot_be_wider_than_the_destination
+# The rule is one-sided: operands broadcast *to* the destination, which already
+# exists. Stretching the other way would mean writing 16 values into 1, and
+# numpy's `out=` refuses this too rather than picking one of them.
+# CHECK: ValueError: shape mismatch in elementwise assignment
+# CHECK-SAME: does not broadcast to it
+@expect(ValueError, "an_operand_cannot_be_wider_than_the_destination")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 1], bf16, scope=h.private())
+        b = air.alloc([64, 16], bf16, scope=h.private())
+        a[:] = b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: an_operand_cannot_have_more_axes_than_the_destination
+# Right-aligning a rank-2 operand against a rank-1 destination leaves an axis
+# with nowhere to go. Only the *operand* may be short of axes.
+# CHECK: ValueError: shape mismatch in elementwise assignment
+# CHECK-SAME: does not broadcast to it
+@expect(ValueError, "an_operand_cannot_have_more_axes_than_the_destination")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        b = air.alloc([4, 64], bf16, scope=h.private())
+        a[:] = b[:]
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: a_reduction_does_not_broadcast_its_operands
+# Everywhere else an extent of 1 is stretched, but the innermost extent of a
+# reduction is the thing being collapsed: stretching it would decide how many
+# terms the sum has, which is the reduction's meaning rather than a fit.
+# CHECK: ValueError: shape mismatch inside a reduction
+# CHECK-SAME: does not broadcast its operands
+@expect(ValueError, "a_reduction_does_not_broadcast_its_operands")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], bf16, scope=h.private())
+        s = air.alloc([64, 1], bf16, scope=h.private())
+        out = air.alloc([64], bf16, scope=h.private())
+        out[:] = ops.reduce_add(a[:] * s[:])
+
+    _trace(body)


### PR DESCRIPTION
`air.api` had no buffer-to-buffer broadcast. Only a Python scalar could be
stretched across a tile — `_check_region` demanded that every operand leaf have
exactly the destination's shape — so the one kernel in the tree whose whole point
is a broadcast had to be written by hand.

## The rule

numpy's, right-aligned and **one-sided**: each operand broadcasts *to* the
destination rather than the two being broadcast against each other, because the
destination of an `air.api` assignment is a buffer that already exists. That is
numpy's own rule for an explicit `out=`. Every operand axis must match the
destination's or be 1; leading axes the operand does not have are the 1 case
written by omission.

## Which code comes out depends on which axis is stretched

* An **outer** axis leaves the innermost one intact, so the read is the ordinary
  `vector.transfer_read` — at the *operand's* own rank, pinned at 0 on the
  stretched axes.
* The **innermost** axis has no contiguous run to read at all, so the emitter
  takes the single element with `memref.load` and splats it with
  `vector.broadcast`.

The second is what `vector_broadcast_scalar` needs; the first is the bias vector
in `mnist_fc/broadcast_bias_add`, which is **not** converted here — see below.

`_eval`'s `minor` parameter becomes a `load` callable, because how a leaf is read
is now a property of the leaf rather than of the nest.

A reduction still refuses to broadcast, and now says why: its innermost extent is
the thing being collapsed, so stretching it would decide how many terms the sum
has rather than making an operand fit.

## The example

`vector_broadcast_scalar` becomes

```python
c[:] = a[:]
```

with a `[tile_m, 1]` source and a `[tile_m, n]` destination. The predecessor said
it with two `memref.subview`s, two `memref.collapse_shape`s carrying an explicit
dynamic `StridedLayoutAttr`, a `memref.load` and a `vector.broadcast`. The
subviews existed only to get a rank-1 view the vector ops would accept, and
indexing a rank-2 buffer at `[j, 0]` needs neither. The emitted `memref.load` /
`vector.broadcast` / `vector.transfer_write` is unchanged, and so is the op
hierarchy — one `air.herd`, no segment.

## Gating

* `python/test/api/` 25/25, including a new `broadcast.py` covering the innermost
  axis, a missing leading axis, an explicit leading 1, a middle axis, the scalar
  path, and four new refusals in `errors.py`.
* **All 45 pre-existing `air.api` examples emit byte-identical IR.** When nothing
  is stretched, `_leaf_index` returns the destination's own induction variables
  unchanged and no pinned-zero constant is emitted at all. `no_broadcast_emits_no_pinned_index`
  pins that, and it is control-tested: forcing the constant on makes exactly that
  test fail.
* `run_makefile_peano.lit` **PASSes on npu1 hardware**, and the gate is not
  vacuous — perturbing the kernel by `+ 1.0` fails it with diff exactly 1.0.
* npu2 xclbin and elf both compile clean. npu1/elf fails, but the backend refuses
  that combination for the predecessor identically, which is why the elf lit is
  `REQUIRES: ryzen_ai_npu2`.

## Not converted: `mnist_fc/broadcast_bias_add`

It needs only the outer-axis half of this feature, but converting it ran into a
separate gap: **`air.api` cannot use a launch coordinate inside a herd body.**
`_trace.py:978` threads a *segment's* own grid coordinates into the herd but not
the *launch's*, so the coordinate crosses the `IsolatedFromAbove` boundary and the
module fails verification with `'affine.apply' op using value defined outside the
region`.

The fix is one line — also threading `current_launch().leaves` — and it works, but
it changes IR for 6 of the 45 examples (matmul i16/i8, matvec bf16, all three
vecmat), because an unused herd operand is not free: it survives `air-dependency`
as an async edge, which is why that line was gated in the first place. That is its
own change with its own hardware gating, so this PR reports the gap rather than
part-converting the example.