### PR TITLE
[python] air.api: thread the launch's coordinates into a nested herd

### DIFF
--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1015,13 +1015,26 @@ class HerdContext:
         # The herd is the first thing that knows how many of a shared buffer's
         # leading dimensions are cores, so it is where their L1 charge is gated.
         _charge_shared_l1(enclosing, len(self.grid), self.name)
-        # An unrolled segment's own coordinates, threaded in for the same reason
-        # the L2 buffers are: air.herd is IsolatedFromAbove, so a body that
-        # indexes a channel by segment coordinate cannot simply reference it.
-        # Empty unless the segment carries a grid, which is what keeps this
-        # inert for every kernel that does not use one -- an unused herd operand
-        # is not free, it survives air-dependency as an async edge.
-        outer = list(enclosing.leaves) if enclosing is not None else []
+        # Every coordinate in scope, threaded in for the same reason the L2
+        # buffers are: air.herd is IsolatedFromAbove, so a body that offsets a
+        # transfer by an enclosing coordinate cannot simply reference it.
+        #
+        # Both the launch's and the enclosing segment's, and in that order --
+        # outermost first, matching how air.segment already receives the
+        # launch's. Passing only the segment's used to be enough by accident:
+        # the launch's coordinates were reachable from segment scope, so an
+        # example whose outer tiling stayed there worked, and one that carried
+        # a launch coordinate *into* the herd emitted an affine.apply on a value
+        # defined outside the region and failed verification.
+        #
+        # Every live one is passed, referenced or not, which is the policy
+        # already applied to tensors and to L2 buffers: the tracer cannot know
+        # what the body will touch until it has run it. That is not free -- an
+        # unused herd operand survives air-dependency as an async edge -- but a
+        # coordinate is one index, and correctness for the kernels that need it
+        # is worth the edge for the kernels that do not.
+        outer = list(current_launch().leaves)
+        outer += list(enclosing.leaves) if enclosing is not None else []
         operands = (
             [leaf.value for leaf in outer]
             + [t.value for t in tensors]

--- a/python/test/api/hierarchy.py
+++ b/python/test/api/hierarchy.py
@@ -129,3 +129,51 @@ def gridless_launch_still_hosts_a_segment():
                     air.ops.store(l2, B[0:TILE, 0:N])
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: a_launch_coordinate_reaches_into_the_herd
+# The same symmetry, one level further down. air.launch, air.segment and
+# air.herd are each IsolatedFromAbove, so a coordinate does not simply fall
+# through: it has to be passed as an operand at every boundary it crosses.
+#
+# The launch's coordinate was passed to the segment and stopped there, so a herd
+# body that offset a transfer by it emitted an affine.apply on a value defined
+# outside the region and the module failed verification. It went unnoticed
+# because outer tiling normally stays at segment scope, where the L2 staging is,
+# and only a kernel with no staging pushes it all the way in.
+#
+# The launch coordinate arrives as the herd's first argument, ahead of the
+# tensors, and the offset is computed from it *inside* the herd.
+# CHECK: air.launch (%[[LI:.*]], %{{.*}}) in (%{{.*}}=%c2{{.*}}
+# CHECK: air.segment @seg args(%[[SI:[^=]*]]=%[[LI]]
+# CHECK: air.herd @herd_0 tile (%[[TX:[^,]*]], %{{.*}}) in ({{.*}}) args(%[[HI:[^=]*]]=%[[SI]]
+# CHECK: affine.apply {{.*}}[%[[HI]], %[[TX]]]
+@run
+def a_launch_coordinate_reaches_into_the_herd():
+    A = air.tensor([M, N], i32)
+    B = air.tensor([M, N], i32)
+
+    with air.launch([range(0, M, TILE)], name="crossing", target="npu1") as launch:
+
+        @launch.body
+        def _(li):
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    base = li * TILE
+
+                    with air.herd([range(2)], name="herd_0", shape=(2,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            # Both coordinates in one expression: this is the
+                            # line that could not be written before.
+                            row = base + tx * (TILE // 2)
+                            buf = air.alloc(
+                                [TILE // 2, N], i32, scope=h.private(), vector=0
+                            )
+                            air.ops.load(buf, A[row : row + TILE // 2, 0:N])
+                            air.ops.store(buf, B[row : row + TILE // 2, 0:N])
+
+    print(launch.mlir())


### PR DESCRIPTION
`air.launch`, `air.segment` and `air.herd` are each `IsolatedFromAbove`, so a
coordinate does not fall through: it has to be passed as an operand at every
boundary it crosses. `air.segment` already received the launch's, but the herd
was given only the **segment's own** grid coordinates. A herd body that offset a
transfer by a launch coordinate emitted

```
error: 'affine.apply' op using value defined outside the region
       required by region isolation constraints
```

and the module failed verification.

It went unnoticed because outer tiling normally stays at segment scope, where the
L2 staging it refills lives. Only a kernel with **no** staging — one whose herd
DMAs straight from L3, which is how `mnist_fc/broadcast_bias_add` is written —
pushes the coordinate all the way in.

The fix passes both, outermost first. Every live one, referenced or not, which is
the policy already applied to tensors and to L2 buffers: the tracer cannot know
what the body will touch until it has run it.

## What the extra operand costs: nothing at runtime

Six of the 45 `air.api` examples gain one `index` operand on their herd — matmul
i16/i8, matvec bf16, and all three vecmat. Their op hierarchies and op histograms
are unchanged; the diffs are the operand list and SSA renumbering and nothing
else:

```
< air.herd @herd_0 tile (...) args(%arg18=%arg11, ...) : memref<288xi8>, ...
> air.herd @herd_0 tile (...) args(%arg18=%arg10, ...) : index, memref<288xi8>, ...
```

The comment on that line used to warn that an unused herd operand is not free
because it survives `air-dependency` as an async edge, so this was worth
measuring rather than asserting. I built `vector_matrix_multiplication/i8` both
ways and compared what actually reaches the device:

| artifact | result |
|---|---|
| `air.insts.bin` | **byte-identical** (420 bytes) |
| core ELF | **byte-identical** |
| optimised core LLVM IR | identical apart from the build path in its `ModuleID` comment |

The operand is consumed by `air-to-aie` and never reaches a core.

## Gating

* `python/test/api/` 24/24.
* **All six affected examples pass on npu1 hardware.**
* New `a_launch_coordinate_reaches_into_the_herd` in `hierarchy.py` pins the
  operand chain from launch to segment to herd, and the `affine.apply` that
  consumes it. Control-tested: without the fix it does not merely fail its
  CHECKs, it raises.

One caveat stated plainly: `matrix_vector_multiplication/bf16`'s lit does fail,
but on its **profiling** step, which cannot find XRT's headers on my box. It
fails identically on unmodified `main`. That lit's three correctness
configurations were run directly instead and all three PASS.

## Not included

`mnist_fc/broadcast_bias_add` is the example that motivated this. Converting it
needs both this fix and the buffer-to-buffer broadcast in #1904, so it is the
batch after both land rather than a stacked branch here.