### PR TITLE
[python] air.api: channel endpoints at launch scope, cascade channels, tensor views, and data_transfer_transpose/channel

### DIFF
--- a/programming_examples/data_transfer_transpose/channel/transpose.py
+++ b/programming_examples/data_transfer_transpose/channel/transpose.py
@@ -1,15 +1,51 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Transpose an [M, K] matrix through a channel, on air.api.
+
+    chan_in.put(A)                        # L3 -> channel, at launch scope
+    ...
+    chan_in.get(t)                        # channel -> L1, in the herd
+    chan_out.put(t.transpose(1, 0))       # L1 -> channel, axes swapped
+    ...
+    chan_out.get(B)                       # channel -> L3, at launch scope
+
+The third of the three transposes in this directory and the only one that uses
+channels. ``dma/transpose.py`` moves the tile with two ``ops.load``/``ops.store``
+transfers; this one hands it to a named channel instead, so the herd never names
+the L3 tensors at all -- a channel is a module-level symbol, not an operand, and
+that is the whole point of it.
+
+The transpose itself is identical to the DMA variant: a property of the access
+pattern the *put* walks, not a computation. ``t.transpose(1, 0)`` derives sizes
+[k, m] and strides [1, k] from the permutation, where the predecessor passed
+``sizes=[1, k, m], strides=[1, 1, k]`` to ``ChannelPut`` as literal lists. Same
+descriptor, minus the leading unit axis the DSL has no reason to write.
+
+**The puts and gets sit at launch scope, around the segment rather than inside
+it**, which is how the predecessor is written and is load-bearing: the put has
+to happen before the segment runs and the get after it, because they are the
+two ends of the stream the segment consumes and produces.
+
+The L1 buffer is ``[m, k]`` rather than the predecessor's flat ``[k * m]``. It
+holds the same bytes; the shape is now the shape of the thing in it, which is
+what lets the permutation be written at all.
+
+Both element types the Makefile exercises still work -- ``uint32`` and
+``float32``. Nothing here is arithmetic, so the unsigned type is carried by the
+transfers without being computed on, which is the one place air.api accepts one.
+
+``--target`` is new and defaults to detecting the installed part.
+"""
+
 import argparse
+
 import numpy as np
 
-np.random.seed(42)
+from air import api as air
+from air.api.types import dtype_of
+from air.backend.xrt_runner import XRTRunner
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp
-from air.backend.xrt_runner import XRTRunner, type_mapper
+np.random.seed(42)
 
 dtype_map = {
     "uint32": np.uint32,
@@ -18,48 +54,40 @@ dtype_map = {
 DEFAULT_DTYPE = "uint32"
 
 
-@module_builder
-def build_module(m, k, dtype):
-    xrt_dtype = type_mapper(dtype)
+def build_module(m, k, np_dtype):
+    dt = dtype_of(np_dtype)
 
-    memrefTyIn = MemRefType.get(shape=[m, k], element_type=xrt_dtype)
-    memrefTyOut = MemRefType.get(shape=[k, m], element_type=xrt_dtype)
+    chan_in = air.channel("ChanIn")
+    chan_out = air.channel("ChanOut")
 
-    Channel("ChanIn")
-    Channel("ChanOut")
+    A = air.tensor([m, k], dt)
+    B = air.tensor([k, m], dt)
 
-    # We will send an image worth of data in and out
-    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
-    def transpose(arg0, arg1):
-        @launch(operands=[arg0, arg1])
-        def launch_body(a, b):
-            # Put data into the channel
-            ChannelPut("ChanIn", a)
+    with air.launch(name="transpose") as launch:
 
-            @segment(name="seg")
-            def segment_body():
-                @herd(name="herd", sizes=[1, 1])
-                def herd_body(_tx, _ty, _sx, _sy):
-                    # We want to store our data in L1 memory
-                    mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
+        @launch.body
+        def _():
+            # Into the stream, before the segment that consumes it.
+            chan_in.put(A)
 
-                    # This is the type definition of the tensor
-                    tensor_type = MemRefType.get(
-                        shape=[k * m],  # Read as one large array
-                        element_type=xrt_dtype,
-                        memory_space=mem_space,
-                    )
+            with air.segment(name="seg") as seg:
 
-                    # We must allocate a buffer of tile size for the input/output
-                    tensor_in = AllocOp(tensor_type, [], [])
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="herd", shape=(1,)) as h:
 
-                    ChannelGet("ChanIn", tensor_in)
-                    ChannelPut("ChanOut", tensor_in, sizes=[1, k, m], strides=[1, 1, k])
+                        @h.body
+                        def _(tx):
+                            t = air.alloc([m, k], dt, scope=h.private())
+                            chan_in.get(t)
+                            # The whole example: the same tile, walked with its
+                            # axes swapped on the way out. A view, not a copy.
+                            chan_out.put(t.transpose(1, 0))
 
-                    DeallocOp(tensor_in)
+            # Out of the stream, after the segment that filled it.
+            chan_out.get(B)
 
-            # Write data back out to the channel
-            ChannelGet("ChanOut", b)
+    return launch
 
 
 if __name__ == "__main__":
@@ -105,11 +133,19 @@ if __name__ == "__main__":
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
     np_dtype = dtype_map[args.dtype]
-    mlir_module = build_module(args.m, args.k, np_dtype)
+    launch = build_module(args.m, args.k, np_dtype)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -140,6 +176,7 @@ if __name__ == "__main__":
         verbose=args.verbose,
         output_format=args.output_format,
         instance_name="transpose",
+        target_device=launch.target,
         runtime_loop_tiling_sizes=[4, 4],
     )
     exit(

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -245,20 +245,33 @@ class Channel:
 
     def _emit(self, obj, indices, dependency, direction):
         from ._trace import current_herd, current_launch, current_segment
+        from ._value import Tensor, TensorSlice
         from .ops import _check_dependency, _endpoint
 
         _check_dependency(dependency)
         self._declare()
-        endpoint = _endpoint(obj, f"channel.{direction}", "argument")
+
+        # Decide placement from the type alone, and resolve the endpoint only
+        # once the insertion point is final. `_endpoint` materialises a tensor
+        # slice's offset arithmetic where it is called, so resolving it here
+        # would emit an affine.apply outside the launch on the re-entry path
+        # below, and then a second one inside -- leaving the first orphaned at
+        # func scope.
+        tensor = (
+            obj.tensor
+            if isinstance(obj, TensorSlice)
+            else obj if isinstance(obj, Tensor) else None
+        )
+        what = "tensor slice" if isinstance(obj, TensorSlice) else "tensor"
 
         # Where an L3 endpoint may sit, from three measurements rather than
         # one; see the module docstring.
-        if endpoint.tensor is not None:
+        if tensor is not None:
             try:
                 current_launch()
             except RuntimeError:
                 raise RuntimeError(
-                    f"air.channel.{direction} on an L3 {endpoint.what} has to be "
+                    f"air.channel.{direction} on an L3 {what} has to be "
                     "inside an air.launch: reaching L3 needs a shim DMA "
                     "allocation, and outside a launch the compiler has none to "
                     f"link to (it fails with \"'air.channel.{direction}' op failed "
@@ -270,7 +283,7 @@ class Channel:
                 and current_segment(required=False) is None
             ):
                 raise RuntimeError(
-                    f"air.channel.{direction} on an L3 {endpoint.what} inside a "
+                    f"air.channel.{direction} on an L3 {what} inside a "
                     "herd body needs an air.segment around that herd: the shim "
                     "DMA allocation is the segment's, and without one aircc does "
                     "not diagnose it but crashes, in air-dependency, on a "
@@ -280,39 +293,35 @@ class Channel:
                     "fine with no segment at all."
                 )
 
-        idx = self._indices(indices, direction)
-
-        if direction == "get" and endpoint.tensor is not None:
+        if direction == "get" and tensor is not None:
             # Same rule ops.store applies: being written from the device is what
             # makes a tensor an output, which fixes the calling convention.
-            endpoint.tensor.is_output = True
+            tensor.is_output = True
 
         from air.dialects.air import ChannelGet, ChannelPut
 
         op = ChannelGet if direction == "get" else ChannelPut
 
-        def build(ep=endpoint):
-            offsets, sizes, strides = ep.pattern or ([], [], [])
+        def build():
+            # Resolved here, not above, so that both the endpoint's offset
+            # arithmetic and the bundle indices are emitted at whichever
+            # insertion point this op ends up at. Opening or re-entering the
+            # launch's region also rebinds each tensor to that region's block
+            # argument, so an endpoint captured outside would still name the
+            # function's, and air.channel.put would fail to verify with "using
+            # value defined outside the region".
+            endpoint = _endpoint(obj, f"channel.{direction}", "argument")
+            offsets, sizes, strides = endpoint.pattern or ([], [], [])
             return op(
                 self.name,
-                ep.value,
+                endpoint.value,
                 offsets=offsets,
                 sizes=sizes,
                 strides=strides,
-                indices=idx,
+                indices=self._indices(indices, direction),
             )
 
-        def build_rebound():
-            # Re-resolved because opening or re-entering the launch's region
-            # rebinds each tensor to that region's block argument: an endpoint
-            # captured outside still names the function's, and air.channel.put
-            # then fails to verify with "using value defined outside the
-            # region". Only on that path -- resolving twice would also
-            # re-materialise the offset arithmetic, and every channel op that is
-            # already inside the region must keep emitting exactly what it did.
-            return build(_endpoint(obj, f"channel.{direction}", "argument"))
-
-        if endpoint.tensor is None:
+        if tensor is None:
             return Token(build())
 
         # An L3 endpoint has to sit inside the launch, which is what brings the
@@ -329,8 +338,26 @@ class Channel:
             # Already inside the region; nothing will be rebound.
             return Token(build())
 
+        # Stepping back into the launch moves the op, and with it the offset
+        # arithmetic, inside an IsolatedFromAbove region. A constant travels;
+        # anything derived from a coordinate or a loop variable does not,
+        # because that value was created out here. Emitting it anyway produces
+        # "'affine.apply' op using value defined outside the region", which
+        # reads as a DSL bug rather than as the shape of the program.
+        if isinstance(obj, TensorSlice) and any(o.terms for o in obj.offsets):
+            raise RuntimeError(
+                f"air.channel.{direction} on an L3 tensor slice whose offset is "
+                "computed from a coordinate or loop variable cannot sit after "
+                "an air.segment at launch scope: the op has to move inside "
+                "air.launch to reach a shim DMA allocation, and the value the "
+                "offset is built from was created outside it. Either move this "
+                f"{direction} inside the segment, where the offset and the "
+                "transfer are in the same region, or put it before the segment, "
+                "which opens the launch around both."
+            )
+
         built = []
-        in_launch_body(lambda: built.append(build_rebound()))
+        in_launch_body(lambda: built.append(build()))
         return Token(built[0])
 
     # -- public ------------------------------------------------------------

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -71,9 +71,11 @@ def _as_dims(value, what):
 class Channel:
     """A named channel; ``put`` and ``get`` move data through it."""
 
-    __slots__ = ("name", "size", "broadcast_shape", "_declared")
+    __slots__ = ("name", "size", "broadcast_shape", "channel_type", "_declared")
 
-    def __init__(self, name, size=None, broadcast_shape=None, **unsupported):
+    def __init__(
+        self, name, size=None, broadcast_shape=None, channel_type=None, **unsupported
+    ):
         if not isinstance(name, str) or not name:
             raise TypeError(
                 "air.channel(name) takes the channel's symbol name, e.g. "
@@ -109,6 +111,25 @@ class Channel:
                     )
 
         self.name = name
+        # Only the cascade type is implemented, because it is the only one this
+        # package can gate: matrix_vector_multiplication/bf16_cascade runs it on
+        # npu1. The others each have their own lowering and verifier rules --
+        # see _UNSUPPORTED -- and adding them blind would be a channel that
+        # compiles as something other than what was asked for.
+        if channel_type is not None and channel_type != "npu_cascade":
+            raise NotImplementedError(
+                f"air.channel(channel_type={channel_type!r}) is not implemented; "
+                f"{_UNSUPPORTED['channel_type']}. Only 'npu_cascade' is "
+                "available, and the default (npu_dma_stream) is what you get by "
+                "leaving channel_type off."
+            )
+        if channel_type is not None and broadcast_shape is not None:
+            raise ValueError(
+                "air.channel takes broadcast_shape= or channel_type=, not both: "
+                "a cascade is a point-to-point link between neighbouring cores, "
+                "so there is nothing for a broadcast shape to describe."
+            )
+        self.channel_type = channel_type
         self._declared = False
 
     def __repr__(self):
@@ -130,6 +151,7 @@ class Channel:
             return
         from air.ir import InsertionPoint
         from air.dialects.air import Channel as ChannelOp
+        from air.dialects.air import channel as channel_decl
 
         from ._trace import active_trace
 
@@ -151,11 +173,17 @@ class Channel:
             # The enclosing func always follows, so there is a next sibling.
             ip = InsertionPoint(ops[last + 1])
         with ip:
-            ChannelOp(
-                self.name,
-                size=self.size,
-                broadcast_shape=self.broadcast_shape,
-            )
+            if self.channel_type is None:
+                ChannelOp(
+                    self.name,
+                    size=self.size,
+                    broadcast_shape=self.broadcast_shape,
+                )
+            else:
+                # The generated builder rather than the extension class: only
+                # it carries channel_type, and only the extension class carries
+                # broadcast_shape, which a typed channel is not allowed anyway.
+                channel_decl(self.name, size=self.size, channel_type=self.channel_type)
         self._declared = True
 
     def _indices(self, indices, direction):
@@ -216,26 +244,42 @@ class Channel:
         return out
 
     def _emit(self, obj, indices, dependency, direction):
-        from ._trace import current_segment
+        from ._trace import current_herd, current_launch, current_segment
         from .ops import _check_dependency, _endpoint
 
         _check_dependency(dependency)
         self._declare()
         endpoint = _endpoint(obj, f"channel.{direction}", "argument")
 
-        # An L3 endpoint needs the shim DMA allocation that only a segment
-        # brings; see the module docstring for the measurement.
-        if endpoint.tensor is not None and current_segment(required=False) is None:
-            raise RuntimeError(
-                f"air.channel.{direction} on an L3 {endpoint.what} has to be inside "
-                "an air.segment: reaching L3 needs a shim DMA allocation, "
-                "and outside a segment the compiler has none to link to (it "
-                f"fails with \"'air.channel.{direction}' op failed to link to any "
-                'shim dma allocation"). Wrap the body in '
-                "`with air.segment(...) as seg:` and move it there."
-            )
+        # Where an L3 endpoint may sit, from three measurements rather than
+        # one; see the module docstring.
+        if endpoint.tensor is not None:
+            try:
+                current_launch()
+            except RuntimeError:
+                raise RuntimeError(
+                    f"air.channel.{direction} on an L3 {endpoint.what} has to be "
+                    "inside an air.launch: reaching L3 needs a shim DMA "
+                    "allocation, and outside a launch the compiler has none to "
+                    f"link to (it fails with \"'air.channel.{direction}' op failed "
+                    'to link to any shim dma allocation"). Open one with '
+                    "`with air.launch(...) as launch:` and move it there."
+                ) from None
+            if (
+                current_herd(required=False) is not None
+                and current_segment(required=False) is None
+            ):
+                raise RuntimeError(
+                    f"air.channel.{direction} on an L3 {endpoint.what} inside a "
+                    "herd body needs an air.segment around that herd: the shim "
+                    "DMA allocation is the segment's, and without one aircc does "
+                    "not diagnose it but crashes, in air-dependency, on a "
+                    "dependencyGraph index assertion. Either wrap the herd in "
+                    "`with air.segment(...) as seg:`, or move this "
+                    f"{direction} out to launch scope, where an L3 endpoint is "
+                    "fine with no segment at all."
+                )
 
-        offsets, sizes, strides = endpoint.pattern or ([], [], [])
         idx = self._indices(indices, direction)
 
         if direction == "get" and endpoint.tensor is not None:
@@ -246,16 +290,48 @@ class Channel:
         from air.dialects.air import ChannelGet, ChannelPut
 
         op = ChannelGet if direction == "get" else ChannelPut
-        return Token(
-            op(
+
+        def build(ep=endpoint):
+            offsets, sizes, strides = ep.pattern or ([], [], [])
+            return op(
                 self.name,
-                endpoint.value,
+                ep.value,
                 offsets=offsets,
                 sizes=sizes,
                 strides=strides,
                 indices=idx,
             )
-        )
+
+        def build_rebound():
+            # Re-resolved because opening or re-entering the launch's region
+            # rebinds each tensor to that region's block argument: an endpoint
+            # captured outside still names the function's, and air.channel.put
+            # then fails to verify with "using value defined outside the
+            # region". Only on that path -- resolving twice would also
+            # re-materialise the offset arithmetic, and every channel op that is
+            # already inside the region must keep emitting exactly what it did.
+            return build(_endpoint(obj, f"channel.{direction}", "argument"))
+
+        if endpoint.tensor is None:
+            return Token(build())
+
+        # An L3 endpoint has to sit inside the launch, which is what brings the
+        # shim DMA allocation. In a gridless launch that region is opened
+        # lazily, so a put that runs *before* the first segment is what opens
+        # it, and a get that drains the result afterwards has to step back in --
+        # data_transfer_transpose/channel does both, around the segment rather
+        # than within it. Without this they land at func scope and the compiler
+        # reports "failed to link to any shim dma allocation".
+        from ._trace import in_launch_body
+
+        launch = current_launch()
+        if launch.opened and launch.reentry is None:
+            # Already inside the region; nothing will be rebound.
+            return Token(build())
+
+        built = []
+        in_launch_body(lambda: built.append(build_rebound()))
+        return Token(built[0])
 
     # -- public ------------------------------------------------------------
 
@@ -296,6 +372,12 @@ def _reject_unsupported(kwargs):
         raise NotImplementedError(f"air.api does not implement {key}=: {what}")
 
 
-def channel(name, size=None, broadcast_shape=None, **unsupported):
+def channel(name, size=None, broadcast_shape=None, channel_type=None, **unsupported):
     """Declare a named channel; ``put`` into it and ``get`` out of it."""
-    return Channel(name, size=size, broadcast_shape=broadcast_shape, **unsupported)
+    return Channel(
+        name,
+        size=size,
+        broadcast_shape=broadcast_shape,
+        channel_type=channel_type,
+        **unsupported,
+    )

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -177,8 +177,8 @@ def active_trace():
     return _ACTIVE_TRACE
 
 
-def current_herd():
-    if _CURRENT_HERD is None:
+def current_herd(required=True):
+    if _CURRENT_HERD is None and required:
         raise RuntimeError(
             "this operation must be used inside a herd body (@herd.body)"
         )
@@ -203,11 +203,19 @@ class LaunchState:
     at the plain `func` + `air.herd` shape its hand-written predecessors have.
     """
 
-    __slots__ = ("ctx", "opened", "coords", "leaves")
+    __slots__ = ("ctx", "opened", "coords", "leaves", "reentry")
 
     def __init__(self, ctx):
         self.ctx = ctx
         self.opened = False
+        # Where to put work traced *after* the region closed, for a gridless
+        # launch. Such a launch is opened lazily around the first thing that
+        # needs it, so everything after that -- a second segment, a channel get
+        # draining the result -- would otherwise be emitted at func scope, as a
+        # sibling of the launch instead of a child.
+        # (block, tensor block-argument values); None while the region is open,
+        # and for a launch with a grid, which stays open for the whole body.
+        self.reentry = None
         # This launch's coordinates, as expressions handed to the body, plus the
         # leaves behind them. A nested IsolatedFromAbove region rebinds each
         # leaf's .value to its own block argument.
@@ -236,6 +244,9 @@ def open_launch_region(launch, tensors, counts, body):
     operands start at index 4.
     """
     from air.dialects.air import launch as launch_region
+    from air.ir import InsertionPoint
+
+    closed = []
 
     @launch_region(sizes=counts, operands=[t.value for t in tensors])
     def launch_body(*largs):
@@ -247,11 +258,59 @@ def open_launch_region(launch, tensors, counts, body):
         saved = [t.value for t in tensors]
         for t, v in zip(tensors, largs[4:]):
             t.value = v
+        # Captured here, published only once this region closes: while it is
+        # open the ordinary insertion point is already right, and the block has
+        # no terminator to insert ahead of yet.
+        closed.append((InsertionPoint.current.block, list(largs[4:])))
         try:
             body()
         finally:
             for t, v in zip(tensors, saved):
                 t.value = v
+
+    if closed:
+        launch.reentry = closed[0]
+
+
+def in_launch_body(emit):
+    """Run ``emit()`` inside air.launch's region, opening or re-entering it.
+
+    Everything that has to live inside the launch goes through here: a segment,
+    and an L3 channel endpoint, which needs the shim DMA allocation the launch
+    brings. Three cases, and the third is the one that used to be missing:
+
+    * the launch carries a grid, so its region is open for the whole body and
+      the current insertion point is already right;
+    * it is gridless and nothing has needed it yet, so open it now, lazily --
+      which is what keeps a kernel that stages nothing at the plain ``func`` +
+      ``air.herd`` shape its hand-written predecessors have;
+    * it is gridless and was already opened *and closed* around something
+      earlier, so step back into its block, ahead of the terminator, with the
+      tensors rebound to its block arguments.
+    """
+    launch = current_launch()
+    if not launch.opened:
+        # One point, 2-D as air.launch requires.
+        open_launch_region(launch, active_trace().tensors, [1, 1], emit)
+        return
+    if launch.reentry is None:
+        emit()
+        return
+
+    from air.ir import InsertionPoint
+
+    block, arg_values = launch.reentry
+    terminator = block.operations[len(block.operations) - 1]
+    tensors = active_trace().tensors
+    saved = [t.value for t in tensors]
+    for t, v in zip(tensors, arg_values):
+        t.value = v
+    try:
+        with InsertionPoint(terminator):
+            emit()
+    finally:
+        for t, v in zip(tensors, saved):
+            t.value = v
 
 
 def infer_name(fallback, depth=2):
@@ -758,20 +817,11 @@ class SegmentContext:
                 )
             )
 
-        launch = current_launch()
-        if launch.opened:
-            # air.launch is already open -- either because it carries a grid, or
-            # because an earlier segment opened it.
-            self._emit_segment(fn, trace)
-        else:
-            # A gridless launch still has to exist for a segment to sit in:
-            # air-insert-launch-around-herd only wraps a *bare* herd, and skips
-            # one already inside a segment, so a segment with no launch above it
-            # compiles and silently computes zeros. One point, 2-D as air.launch
-            # requires.
-            open_launch_region(
-                launch, trace.tensors, [1, 1], lambda: self._emit_segment(fn, trace)
-            )
+        # A gridless launch still has to exist for a segment to sit in:
+        # air-insert-launch-around-herd only wraps a *bare* herd, and skips one
+        # already inside a segment, so a segment with no launch above it
+        # compiles and silently computes zeros.
+        in_launch_body(lambda: self._emit_segment(fn, trace))
 
     def _emit_segment(self, fn, trace):
         """Emit air.segment inside the already-open air.launch."""

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -246,7 +246,102 @@ def _as_int(offset, what):
     return int(value)
 
 
-class Tensor:
+class _StridedView:
+    """``reshape`` and ``transpose`` over an (offsets, sizes, strides) triple.
+
+    Shared by :class:`TensorSlice` and :class:`BufferSlice`, which differ only
+    in what they are a region *of*. Neither constructor moves anything: a view
+    re-describes the same elements at a different rank or in a different order,
+    so all three lists are rewritten together and the walk is unchanged.
+    """
+
+    __slots__ = ()
+
+    def _respan(self, offsets, sizes, strides, logical_sizes):
+        """Build another region of the same thing. Implemented by each slice."""
+        raise NotImplementedError
+
+    def reshape(self, *shape):
+        """This region's elements at a different rank, as a view.
+
+        Splitting an axis is how a tile is laid out in the blocks a matmul
+        instruction consumes: a [32, 32] region becomes [8, 4, 4, 8] and the
+        walk is unchanged, only re-described. Raises rather than copying when
+        no view exists -- see :func:`_reshape_pattern`.
+        """
+        if len(shape) == 1 and not isinstance(shape[0], int):
+            shape = tuple(shape[0])
+        offsets, sizes, strides = _reshape_pattern(
+            self.sizes, self.strides, self.offsets, shape
+        )
+        return self._respan([coerce_index(o) for o in offsets], sizes, strides, sizes)
+
+    def __getitem__(self, key):
+        """A sub-region of this region, subscripted like the original array.
+
+        A view is a region like any other, so it subscripts like one -- which is
+        what lets an offset be chosen *after* the walk has been re-described.
+        conv2d_14x14's L2 gather is the case: the pattern it needs is a
+        reshape and a transpose of the whole memtile buffer, and only then a
+        pick of one (row, block) out of it.
+        """
+        key = _normalize_key(key, len(self.sizes), "region")
+        offsets, sizes = [], []
+        for dim, (sub, extent) in enumerate(zip(key, self.sizes)):
+            offset, size = _resolve_subscript(sub, extent, dim)
+            offsets.append(offset)
+            sizes.append(size)
+        # Added to this region's own offsets, not scaled: an offset is an index
+        # along its axis, which the transfer multiplies by that axis's stride --
+        # the same convention Tensor.__getitem__ and Buffer.__getitem__ use, and
+        # the reason this view keeps the strides it already had.
+        combined = [
+            coerce_index(base + off) for base, off in zip(self.offsets, offsets)
+        ]
+        return self._respan(combined, sizes, list(self.strides), sizes)
+
+    def transpose(self, *axes):
+        """This region walked with its axes permuted.
+
+        Nothing moves: offsets, sizes and strides are permuted together, so the
+        descriptor visits the same elements in a different order. Takes a full
+        permutation, as numpy does.
+        """
+        if len(axes) == 1 and not isinstance(axes[0], int):
+            axes = tuple(axes[0])
+        axes = [int(a) for a in axes]
+        _check_axes(axes, len(self.sizes))
+        return self._respan(
+            _permute(self.offsets, axes),
+            _permute(self.sizes, axes),
+            _permute(self.strides, axes),
+            _permute(self.logical_sizes, axes),
+        )
+
+
+class _Reshapable:
+    """``reshape``/``transpose`` on the whole of a Tensor or a Buffer.
+
+    Both are the same two lines -- take the whole thing as a region, then view
+    it -- and the region type is the only difference, which ``_whole_view``
+    supplies.
+    """
+
+    __slots__ = ()
+
+    def _whole_view(self):
+        raise NotImplementedError
+
+    def reshape(self, *shape):
+        """The whole array at a different rank, as a view. See _StridedView."""
+        return self._whole_view().reshape(*shape)
+
+    def transpose(self, *axes):
+        """The whole array with its axes permuted. See _StridedView."""
+        return self._whole_view().transpose(*axes)
+
+
+class Tensor(_Reshapable):
     """A host-visible array in L3. Becomes a ``func.func`` argument."""
 
     def __init__(self, shape, dtype, name=None):
@@ -267,6 +362,19 @@ class Tensor:
             offsets.append(offset)
             sizes.append(size)
         return TensorSlice(self, offsets, sizes, list(self.strides))
+
+    def _whole_view(self):
+        """The whole tensor as a region, for reshape/transpose to work on.
+
+        Built directly rather than through __getitem__ so that a rank-N tensor
+        does not need a rank-N full subscript written out first.
+        """
+        return TensorSlice(
+            self,
+            [coerce_index(0) for _ in self.shape],
+            list(self.shape),
+            list(self.strides),
+        )
 
     def __setitem__(self, key, value):
         raise TypeError(
@@ -300,16 +408,28 @@ def _resolve_subscript(sub, extent, dim):
     return coerce_index(sub), 1
 
 
-class TensorSlice:
+class TensorSlice(_StridedView):
     """An access pattern into a :class:`Tensor`: offsets, static sizes, strides."""
 
-    __slots__ = ("tensor", "offsets", "sizes", "strides")
+    __slots__ = ("tensor", "offsets", "sizes", "strides", "logical_sizes", "is_view")
 
-    def __init__(self, tensor, offsets, sizes, strides):
+    def __init__(
+        self, tensor, offsets, sizes, strides, logical_sizes=None, is_view=False
+    ):
         self.tensor = tensor
         self.offsets = offsets
         self.sizes = sizes
         self.strides = strides
+        # Same two fields, and the same meaning, as on BufferSlice: the region's
+        # element shape, and whether reshape/transpose produced it -- which is
+        # what tells a transfer to check element counts instead of axes.
+        self.logical_sizes = list(sizes if logical_sizes is None else logical_sizes)
+        self.is_view = is_view
+
+    def _respan(self, offsets, sizes, strides, logical_sizes):
+        return TensorSlice(
+            self.tensor, offsets, sizes, strides, logical_sizes, is_view=True
+        )
 
     @property
     def dtype(self):
@@ -322,7 +442,7 @@ class TensorSlice:
         return f"TensorSlice({self.tensor.name}, sizes={self.sizes})"
 
 
-class Buffer:
+class Buffer(_Reshapable):
     """A tile allocated in a hardware scope: L1 (a core) or L2 (a memtile).
 
     A subscript designates a *region* of the buffer, and what that means depends
@@ -371,14 +491,6 @@ class Buffer:
             offsets.append(offset)
             sizes.append(size)
         return BufferSlice(self, offsets, sizes, list(self.strides))
-
-    def reshape(self, *shape):
-        """The whole tile at a different rank, as a view. See BufferSlice."""
-        return self._whole_view().reshape(*shape)
-
-    def transpose(self, *axes):
-        """The whole tile with its axes permuted. See BufferSlice."""
-        return self._whole_view().transpose(*axes)
 
     def _whole_view(self):
         """The whole buffer as a region, for reshape/transpose to work on.
@@ -433,7 +545,7 @@ class Buffer:
         return f"Buffer(shape={self.shape}, dtype={self.dtype}, space={self.space})"
 
 
-class BufferSlice:
+class BufferSlice(_StridedView):
     """An access pattern into a :class:`Buffer`, for use as a DMA endpoint."""
 
     __slots__ = ("buffer", "offsets", "sizes", "strides", "logical_sizes", "is_view")
@@ -467,46 +579,9 @@ class BufferSlice:
     def materialize_offsets(self):
         return [o.materialize() for o in self.offsets]
 
-    def reshape(self, *shape):
-        """This region's elements at a different rank, as a view.
-
-        Splitting an axis is how a tile is laid out in the blocks a matmul
-        instruction consumes: a [32, 32] region becomes [8, 4, 4, 8] and the
-        walk is unchanged, only re-described. Raises rather than copying when
-        no view exists -- see :func:`_reshape_pattern`.
-        """
-        if len(shape) == 1 and not isinstance(shape[0], int):
-            shape = tuple(shape[0])
-        offsets, sizes, strides = _reshape_pattern(
-            self.sizes, self.strides, self.offsets, shape
-        )
+    def _respan(self, offsets, sizes, strides, logical_sizes):
         return BufferSlice(
-            self.buffer,
-            [coerce_index(o) for o in offsets],
-            sizes,
-            strides,
-            logical_sizes=sizes,
-            is_view=True,
-        )
-
-    def transpose(self, *axes):
-        """This region walked with its axes permuted.
-
-        Nothing moves: offsets, sizes and strides are permuted together, so the
-        descriptor visits the same elements in a different order. Takes a full
-        permutation, as numpy does.
-        """
-        if len(axes) == 1 and not isinstance(axes[0], int):
-            axes = tuple(axes[0])
-        axes = [int(a) for a in axes]
-        _check_axes(axes, len(self.sizes))
-        return BufferSlice(
-            self.buffer,
-            _permute(self.offsets, axes),
-            _permute(self.sizes, axes),
-            _permute(self.strides, axes),
-            logical_sizes=_permute(self.logical_sizes, axes),
-            is_view=True,
+            self.buffer, offsets, sizes, strides, logical_sizes, is_view=True
         )
 
     def __repr__(self):

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -131,10 +131,11 @@ def _endpoint(obj, direction, role):
         return _Endpoint(
             obj.tensor.value,
             obj.dtype,
-            tuple(obj.sizes),
+            tuple(obj.logical_sizes),
             (obj.materialize_offsets(), list(obj.sizes), list(obj.strides)),
             tensor=obj.tensor,
             what="tensor slice",
+            is_view=obj.is_view,
         )
     if isinstance(obj, Tensor):
         # A whole tensor, which channel put/get take routinely --

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -282,3 +282,90 @@ def channel_pack():
                     air.ops.store(l2_b, Out)
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: l3_endpoint_after_a_segment_reenters_the_launch
+# A gridless launch opens its region lazily, so the segment is what opens it and
+# a get written afterwards is back out at trace scope. It has to step into the
+# region anyway, because reaching L3 needs the shim DMA allocation the launch
+# brings; without that it lands at func scope and aircc reports "failed to link
+# to any shim dma allocation".
+#
+# The endpoint is resolved inside that region rather than before choosing it.
+# Resolving early would materialise the slice's offset arithmetic out here and
+# then again inside, orphaning the first copy at func scope. With a constant
+# offset there is no arithmetic to orphan, which is why the pin is on the op's
+# position: the get is the last thing in the launch body, after air.segment.
+# CHECK: air.launch
+# CHECK: air.segment @seg
+# CHECK: air.channel.get @drain[] (%{{.*}}[32] [32] [1]) : (memref<64xi32>)
+@run
+def l3_endpoint_after_a_segment_reenters_the_launch():
+    A = air.tensor([64], i32)
+    B = air.tensor([64], i32)
+    feed = air.channel("feed")
+    drain = air.channel("drain")
+
+    with air.launch(name="reentry") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            buf = air.alloc([32], i32, scope=h.private())
+                            air.ops.load(buf, A[0:32])
+                            feed.put(buf)
+                            drain.put(buf)
+
+                    l2 = air.alloc([32], i32, scope=seg.private())
+                    feed.get(l2)
+
+            drain.get(B[32:64])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: a_computed_offset_cannot_follow_the_segment
+# Same position, but the offset is built from a loop variable that lives outside
+# the launch. Moving the op into the region cannot take that value with it --
+# air.launch is IsolatedFromAbove -- so this is refused by name rather than left
+# to fail as "'affine.apply' op using value defined outside the region", which
+# reads as a DSL bug instead of as the shape of the program.
+# CHECK: RuntimeError: air.channel.get on an L3 tensor slice whose offset is
+# CHECK-SAME: computed from a coordinate or loop variable
+@run
+def a_computed_offset_cannot_follow_the_segment():
+    B = air.tensor([64], i32)
+    drain = air.channel("drain2")
+
+    with air.launch(name="computed") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            buf = air.alloc([32], i32, scope=h.private())
+                            buf[:] = 0
+                            drain.put(buf)
+
+            for i in air.sequential(2):
+                drain.get(B[i * 32 : i * 32 + 32])
+
+    try:
+        launch.mlir()
+    except RuntimeError as e:
+        print(f"RuntimeError: {e}")
+    else:
+        print("ERROR: no exception raised")

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1109,12 +1109,25 @@ def _():
 
 
 # CHECK-LABEL: TEST: channel_type_unsupported
-# Accepting channel_type and ignoring it would compile a cascade request as a
-# DMA stream -- the silent-wrongness this package exists to avoid.
-# CHECK: NotImplementedError: air.api does not implement channel_type=
+# npu_cascade is implemented now, because it is the one type this package can
+# gate on hardware. The rest are still refused: accepting channel_type and
+# ignoring it would compile an mmio request as a DMA stream, which is the
+# silent-wrongness this package exists to avoid, and each of them has its own
+# lowering and verifier rules.
+# CHECK: NotImplementedError: air.channel(channel_type='npu_mmio') is not implemented
 @expect(NotImplementedError, "channel_type_unsupported")
 def _():
-    air.channel("C", channel_type="npu_cascade")
+    air.channel("C", channel_type="npu_mmio")
+
+
+# CHECK-LABEL: TEST: channel_type_with_broadcast
+# A cascade is a point-to-point link between neighbouring cores, so there is
+# nothing for a broadcast shape to describe and asking for both is a mistake
+# about what the channel is rather than a combination to resolve.
+# CHECK: ValueError: air.channel takes broadcast_shape= or channel_type=, not both
+@expect(ValueError, "channel_type_with_broadcast")
+def _():
+    air.channel("C", size=[2], broadcast_shape=[4], channel_type="npu_cascade")
 
 
 # CHECK-LABEL: TEST: channel_indices_without_size
@@ -1158,13 +1171,22 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: channel_l3_needs_segment
-# Reaching L3 needs a shim DMA allocation, which only a segment brings. Measured
-# on npu1: the same design with its put hoisted out of the segment fails in
-# air-to-aie with "failed to link to any shim dma allocation", so this raises at
-# the call site instead, naming the fix.
-# CHECK: RuntimeError: air.channel.put on an L3 tensor has to be inside an air.segment
-@expect(RuntimeError, "channel_l3_needs_segment")
+# CHECK-LABEL: TEST: channel_l3_in_a_herd_needs_segment
+# Where an L3 endpoint may sit is three separate facts, and this rule used to
+# state only one of them -- "it needs a segment" -- which was both too weak and
+# too strong. Measured:
+#
+#   * outside air.launch entirely: "failed to link to any shim dma allocation";
+#   * at launch scope with no segment: fine, and data_transfer_transpose/channel
+#     is written that way and passes on npu1;
+#   * inside a herd with no segment: aircc does not diagnose it, it *crashes*,
+#     on a dependencyGraph index assertion in air-dependency.
+#
+# This pins the third. Crashing the compiler is the worst of the three failure
+# modes to inherit, so it raises at the call site with both ways out.
+# CHECK: RuntimeError: air.channel.put on an L3 tensor inside a herd body needs an air.segment
+# CHECK-SAME: dependencyGraph index assertion
+@expect(RuntimeError, "channel_l3_in_a_herd_needs_segment")
 def _():
     ch = air.channel("C")
 

--- a/python/test/api/tensor_views.py
+++ b/python/test/api/tensor_views.py
@@ -1,0 +1,91 @@
+# ./python/test/api/tensor_views.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""An L3 tensor reshapes and transposes, the same way a buffer does.
+
+``reshape`` and ``transpose`` were buffer-only, which made the two ends of a
+transfer unequal for no reason anyone had decided: the L1 side of a 4-D scatter
+could be described as the shape the hardware walks and the L3 side could not.
+conv2d_14x14 is the case -- its input is declared ``[4, 802816]`` and read as
+``[4, 14, 64, 56]`` with strides ``[802816, 3584, 56, 1]``.
+
+Both now come from one implementation. ``_StridedView`` holds reshape and
+transpose over an (offsets, sizes, strides) triple and is mixed into both slice
+types; ``_Reshapable`` holds the two-line delegation from a whole Tensor or
+Buffer to a region of itself. The only thing either slice supplies is what kind
+of region to build.
+"""
+
+from air import api as air
+from air.api.types import i8
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: a_tensor_region_reshapes_into_the_walk_the_hardware_wants
+# [4, 802816] sliced to [4, 50176] and re-described as [4, 14, 64, 56]. The
+# strides are the giveaway that nothing moved: the outer axis keeps the tensor's
+# own 802816, and the three inner ones are the row-major strides of the slice.
+# This is conv2d_14x14's input scatter, which was previously inexpressible.
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[0, 0, 0, %{{.*}}] [4, 14, 64, 56] [802816, 3584, 56, 1])
+@run
+def a_tensor_region_reshapes_into_the_walk_the_hardware_wants():
+    A = air.tensor([4, 802816], i8)
+    OUT = air.tensor([200704], i8)
+
+    with air.launch(name="scatter") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    l2 = air.alloc([4, 14, 3584], i8, scope=seg.private())
+
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            for yp in air.sequential(16):
+                                y0 = yp * 50176
+                                air.ops.load(
+                                    l2, A[:, y0 : y0 + 50176].reshape(4, 14, 64, 56)
+                                )
+                            b = air.alloc([256], i8, scope=h.private())
+                            air.ops.store(b, OUT[0:256])
+
+    print(launch.build(target="npu1"))
+
+
+# CHECK-LABEL: TEST: a_tensor_transposes_like_a_buffer
+# transpose permutes offsets, sizes and strides together, so a [64, 32] tensor
+# read with its axes swapped is sizes [32, 64] and strides [1, 32] -- the same
+# descriptor data_transfer_transpose builds from the L1 side.
+# CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %{{.*}}[0, 0] [32, 64] [1, 32])
+@run
+def a_tensor_transposes_like_a_buffer():
+    A = air.tensor([64, 32], i8)
+    OUT = air.tensor([2048], i8)
+
+    with air.launch(name="t") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    b = air.alloc([32, 64], i8, scope=h.private())
+                    air.ops.load(b, A.transpose(1, 0))
+                    air.ops.store(b.reshape(2048), OUT[0:2048])
+
+    print(launch.build(target="npu1"))


### PR DESCRIPTION
Two commits: one converts an example and fixes what blocked it, one adds view
surface that has a test but no converted example yet. Split so the second can be
dropped if you would rather it waited.

## 1. L3 channel endpoints inside the launch, cascade channels, and `data_transfer_transpose/channel`

`data_transfer_transpose/channel` puts and gets at **launch** scope, around the
segment rather than within it — the put has to happen before the segment runs
and the get after it, because they are the two ends of the stream the segment
consumes and produces. air.api could not express that, for two reasons.

**The guard claimed more than its evidence.** It required an L3 endpoint to be
inside an `air.segment`, from a single measurement: a put and get hoisted to
function scope, *outside `air.launch` entirely*. That shows a launch is needed,
not a segment. All three positions, now measured:

| where | result |
|---|---|
| outside `air.launch` | `failed to link to any shim dma allocation` |
| launch scope, no segment | **fine** — this example is written that way and passes on npu1 |
| inside a herd, no segment | aircc does not diagnose it, it **crashes**, on a `dependencyGraph` index assertion |

The rule is now "inside a launch, and inside a segment too if you are inside a
herd", with a message per case. The third is the one worth having — inheriting a
compiler crash is worse than inheriting a diagnostic.

**A gridless launch opens lazily, around the first thing that needs it.** Only a
segment triggered that, so a put traced before the segment landed at func scope,
and a get traced after it landed there too — outside the launch, which is
exactly the first failure above. `in_launch_body` now handles all three
positions in one place, used by segments and L3 channel endpoints alike. It also
fixes a second segment in one launch, which had the same cause and produced a
segment that was a *sibling* of the launch rather than a child — an op-count
check could not see that, since the counts were right and only the nesting was
wrong.

**`channel_type="npu_cascade"`** is accepted now. Only that one: it is the type
this package can gate, and the others each have their own lowering and verifier
rules, so accepting them blind would compile a channel as something other than
what was asked for. Cascade + `broadcast_shape` together is refused — a cascade
is point-to-point.

Gated: 19 lits pass on npu1 across data_transfer_transpose, matrix_scalar_add,
passthrough and channel_examples. The new example's lit passes for both element
types and is not vacuous — dropping the transpose fails it on 2027 of 2048
elements.

## 2. `reshape`/`transpose` on an L3 tensor

Buffer-only until now, which made the two ends of a transfer unequal for no
reason anyone had decided: the L1 side of a strided scatter could be described
as the shape the hardware walks and the L3 side could not.

Both ends now come from one implementation rather than two copies.
`_StridedView` holds reshape/transpose over an `(offsets, sizes, strides)`
triple and is mixed into both slice types, which supply only a `_respan` hook;
`_Reshapable` holds the delegation from a whole Tensor or Buffer to a region of
itself. `BufferSlice` loses 40 lines of duplicated body. `TensorSlice` gains
`logical_sizes` and `is_view`, which it needed anyway — without them a transfer
would not relax its axis check for a reshaped tensor the way it already does for
a reshaped buffer. Views are subscriptable too, since an offset often has to be
chosen after the walk is re-described.

**This one has no converted example behind it, and that is stated in the commit
message.** It was written for `conv2d_14x14`, whose rank-6 L2 gather it
expresses exactly — reshape to `[4,4,2,8,98,8]` then swap two axes gives
`[1,1,2,98,8,8]` / `[50176,12544,6272,8,784,1]`, byte-for-byte upstream's
`[<2,6272>,<98,8>,<8,784>,<8,1>]` wrap. That conversion is **not** included: it
builds and emits the right descriptors but computes wrong results on npu1 (4.7M
mismatches, close-but-wrong values) while the predecessor passes, and I have not
found the cause.

## Gating

* All other `air.api` examples emit byte-identical IR throughout both commits.
* `python/test/api/` 27/27, with `tensor_views.py` control-tested against the
  unmixed `_value.py`.
* Rebased onto `81f63174` and the hardware gate re-run after the rebase.