### PR TITLE
[air-opt] Stop air-shrink-memref-sizes-by-access retyping subviews it did not shrink

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -5870,12 +5870,32 @@ struct UpdateSubViewOutputTypeAfterMemrefShrinkage
     : public OpRewritePattern<memref::SubViewOp> {
   using OpRewritePattern<memref::SubViewOp>::OpRewritePattern;
 
+  // Two memref types can spell the same layout differently: an identity
+  // layout and an explicit `strided<[1]>` describe the same walk over the
+  // same buffer. inferRankReducedResultType always produces the explicit
+  // form, so a plain `!=` reports a difference for a subview that shrinkage
+  // never touched -- and retyping it then invalidates any func.call into an
+  // extern kernel whose declaration is written in the identity form.
+  static bool layoutsAgree(MemRefType lhs, MemRefType rhs) {
+    if (lhs.getShape() != rhs.getShape() ||
+        lhs.getElementType() != rhs.getElementType() ||
+        lhs.getMemorySpace() != rhs.getMemorySpace())
+      return false;
+    SmallVector<int64_t> lhsStrides, rhsStrides;
+    int64_t lhsOffset = 0, rhsOffset = 0;
+    if (failed(lhs.getStridesAndOffset(lhsStrides, lhsOffset)) ||
+        failed(rhs.getStridesAndOffset(rhsStrides, rhsOffset)))
+      return false;
+    return lhsStrides == rhsStrides && lhsOffset == rhsOffset;
+  }
+
   LogicalResult matchAndRewrite(memref::SubViewOp op,
                                 PatternRewriter &rewriter) const override {
     MemRefType newResultType = memref::SubViewOp::inferRankReducedResultType(
         op.getType().getShape(), op.getSourceType(), op.getMixedOffsets(),
         op.getMixedSizes(), op.getMixedStrides());
-    if (newResultType != op.getType()) {
+    if (newResultType != op.getType() &&
+        !layoutsAgree(newResultType, op.getType())) {
       op.getResult().setType(newResultType);
       return success();
     } else

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/shrink_memref_sizes_by_access.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/shrink_memref_sizes_by_access.mlir
@@ -86,4 +86,45 @@ module {
     }
     return
   }
+
+  // A subview whose result type is already correct must be left alone.
+  //
+  // inferRankReducedResultType always spells the layout out --
+  // memref<8xbf16, strided<[1]>, 2> -- while the canonical form of the same
+  // walk is the identity layout, memref<8xbf16, 2>. Retyping on a bare `!=`
+  // therefore rewrites a subview that no shrinkage touched, and the func.call
+  // below, whose callee is an extern kernel declared with the identity form,
+  // stops verifying. Here the alloc is accessed in full by the channel.put,
+  // so nothing shrinks at all and there is nothing to update.
+  // CHECK-LABEL: func2
+  // CHECK: memref.subview %{{.*}}[0] [8] [1] : memref<32xbf16, 2 : i32> to memref<8xbf16, 2 : i32>
+  // CHECK: func.call @zero_bf16(%{{.*}}) : (memref<8xbf16, 2 : i32>) -> ()
+  air.channel @channel_2 [1, 1]
+  func.func private @zero_bf16(memref<8xbf16, 2 : i32>) attributes {link_with = "mv.o", llvm.emit_c_interface}
+  func.func @func2() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg0) in (%arg1=%c1) {
+      %1 = air.segment @segment_2 async {
+        %c1_0 = arith.constant 1 : index
+        %2 = air.herd @herd_2 async tile (%arg2, %arg3) in (%arg4=%c1_0, %arg5=%c1_0) attributes {link_with = "mv.o"} {
+          %c0 = arith.constant 0 : index
+          %c32 = arith.constant 32 : index
+          %c1_1 = arith.constant 1 : index
+          %async_token, %results = air.execute -> (memref<32xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<32xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<32xbf16, 2 : i32>
+          }
+          %subview = memref.subview %results[0] [8] [1] : memref<32xbf16, 2 : i32> to memref<8xbf16, 2 : i32>
+          %async_token_1 = air.execute [%async_token] {
+            func.call @zero_bf16(%subview) : (memref<8xbf16, 2 : i32>) -> ()
+          }
+          %3 = air.channel.put async [%async_token_1] @channel_2[%arg2, %arg3] (%results[%c0] [%c32] [%c1_1]) {id = 1 : i32} : (memref<32xbf16, 2 : i32>)
+          %async_token_2 = air.execute [%3] {
+            memref.dealloc %results : memref<32xbf16, 2 : i32>
+          }
+        }
+      }
+    }
+    return
+  }
 }

--- a/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
+++ b/programming_examples/decode_ffn_swiglu/matvec_int4_swiglu_rms.py
@@ -40,7 +40,6 @@ from air.ir import (
     AffineMapAttr,
     AffineSymbolExpr,
     BF16Type,
-    BoolAttr,
     F32Type,
     IntegerAttr,
     IntegerType,
@@ -133,10 +132,11 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
         l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
         l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
 
-        # Allocate the partial buffer as a 32-lane (CASCADE_WIDTH-style) buffer
-        # and pass a subview-cast to the M_TILE-shaped kernel — matches the
-        # matvec_int4_packed_add layout so air-shrink-memref-sizes-by-access
-        # rewrites the kernel signature consistently across all stitched calls.
+        # The partial buffer is declared 32 lanes wide to match the
+        # matvec_int4_packed_add layout, and a subview-cast is passed to the
+        # M_TILE-shaped kernel. There is no cascade here, so nothing reads past
+        # lane M_TILE and air-shrink-memref-sizes-by-access shrinks the buffer
+        # back down to M_TILE, folding the subview away.
         CASCADE_WIDTH = 32
         packed_l2 = MemRefType.get([tile_bytes], i8_ty, memory_space=l2_ms)
         packed_l1 = MemRefType.get([tile_bytes], i8_ty, memory_space=l1_ms)
@@ -373,9 +373,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8):
                         )
                         for outer in for_(M_div):
                             l1_partial_op = AllocOp(partial_full_ty, [], [])
-                            l1_partial_op.attributes["air.shrinkage"] = BoolAttr.get(
-                                False
-                            )
                             l1_partial_slice_strided = subview(
                                 l1_partial_op.result, [0], [M_TILE], [1]
                             )

--- a/programming_examples/llms/llama32_1b_int4/multi_launch_builder/o_gemv_ffn_int4_fused.py
+++ b/programming_examples/llms/llama32_1b_int4/multi_launch_builder/o_gemv_ffn_int4_fused.py
@@ -57,7 +57,6 @@ from air.ir import (
     AffineMapAttr,
     AffineSymbolExpr,
     BF16Type,
-    BoolAttr,
     F32Type,
     InsertionPoint,
     IntegerAttr,
@@ -515,9 +514,6 @@ def build_module(
                                     l1_partial_full_la = AllocOp(
                                         partial_full_ty, [], []
                                     )
-                                    l1_partial_full_la.attributes["air.shrinkage"] = (
-                                        BoolAttr.get(False)
-                                    )
                                     l1_partial_strided_la = subview(
                                         l1_partial_full_la.result, [0], [M_TILE], [1]
                                     )
@@ -525,9 +521,6 @@ def build_module(
                                         D_la_l1, l1_partial_strided_la
                                     )
                                     l1_d_full_la = AllocOp(partial_full_ty, [], [])
-                                    l1_d_full_la.attributes["air.shrinkage"] = (
-                                        BoolAttr.get(False)
-                                    )
                                     l1_d_strided_la = subview(
                                         l1_d_full_la.result, [0], [M_TILE], [1]
                                     )
@@ -789,7 +782,6 @@ def build_module(
                         # ---- Hot int4 GEMV loop (ORIGINAL structure with
                         #      ping-pong on packed_l1 via per-iter alloc) ----
                         l1_partial_op = AllocOp(partial_full_ty, [], [])
-                        l1_partial_op.attributes["air.shrinkage"] = BoolAttr.get(False)
                         l1_partial_strided = subview(
                             l1_partial_op.result, [0], [M_TILE], [1]
                         )
@@ -997,15 +989,11 @@ def build_module(
 
                         for outer in for_(M_ld_div):
                             l1_partial_full = AllocOp(partial_full_ty, [], [])
-                            l1_partial_full.attributes["air.shrinkage"] = BoolAttr.get(
-                                False
-                            )
                             l1_partial_strided = subview(
                                 l1_partial_full.result, [0], [M_TILE], [1]
                             )
                             l1_partial = memref_cast(D_la_l1, l1_partial_strided)
                             l1_d_full = AllocOp(partial_full_ty, [], [])
-                            l1_d_full.attributes["air.shrinkage"] = BoolAttr.get(False)
                             l1_d_strided = subview(l1_d_full.result, [0], [M_TILE], [1])
                             l1_d = memref_cast(D_la_l1, l1_d_strided)
 

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_2tile_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_2tile_add.py
@@ -24,7 +24,6 @@ from ml_dtypes import bfloat16
 
 from air.ir import (
     BF16Type,
-    BoolAttr,
     IntegerAttr,
     MemRefType,
     StringAttr,
@@ -172,7 +171,6 @@ def build_module(M, K, m=8, k=512, n_cores=8):
                             # matvec/zero kernels only touch the first
                             # `m` lanes (rest is unused padding).
                             l1_part_op = AllocOp(partial_l1, [], [])
-                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
                             l1_part = l1_part_op.result
                             l1_part_slice_strided = subview(
                                 l1_part,
@@ -221,7 +219,6 @@ def build_module(M, K, m=8, k=512, n_cores=8):
 
                         for outer in for_(M_div_m_per_core):
                             l1_part_op = AllocOp(partial_l1, [], [])
-                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
                             l1_d_op = AllocOp(D_l1, [], [])
                             l1_part = l1_part_op.result
                             l1_d = l1_d_op.result

--- a/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
+++ b/programming_examples/matrix_vector_multiplication/int4_awq/matvec_int4_packed_add.py
@@ -28,7 +28,6 @@ from air.ir import (
     AffineMap,
     AffineSymbolExpr,
     BF16Type,
-    BoolAttr,
     IntegerAttr,
     IntegerType,
     MemRefType,
@@ -213,7 +212,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
                     def matvec_herd(tx, ty, _sx, _sy):
                         for _outer in for_(M_div_m_per_core):
                             l1_part_op = AllocOp(partial_l1, [], [])
-                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
                             l1_part = l1_part_op.result
                             l1_part_slice_strided = subview(l1_part, [0], [M_TILE], [1])
                             l1_part_slice = memref_cast(
@@ -255,7 +253,6 @@ def build_module(M, K, GS=128, M_TILE=8, K_CHUNK=2048, N_CORES=8, M_PER_LAUNCH=N
 
                         for outer in for_(M_div_m_per_core):
                             l1_part_op = AllocOp(partial_l1, [], [])
-                            l1_part_op.attributes["air.shrinkage"] = BoolAttr.get(False)
                             l1_d_op = AllocOp(D_l1, [], [])
                             ChannelGet("partial_cas", l1_part_op, indices=[tx])
                             l1_part_slice_strided = subview(


### PR DESCRIPTION
`UpdateSubViewOutputTypeAfterMemrefShrinkage` exists to repair a `memref.subview`'s result type after the alloc under it shrinks. It decides there is repair work to do by comparing the written type against `inferRankReducedResultType` with a bare `!=`. Those two disagree for subviews nothing has touched: the inferred form always spells the layout out, `memref<8xbf16, strided<[1]>, 2>`, while the canonical form of the same walk is the identity layout, `memref<8xbf16, 2>`. The pattern rewrites a correct subview into an equivalent-but-differently-spelled one, and the extern AIE kernel underneath it — whose declaration is written in the identity form — stops verifying:

```
'func.call' op operand type mismatch: expected operand type
'memref<8xbf16, 2 : i32>', but provided 'memref<8xbf16, strided<[1]>, 2 : i32>'
```

This fires with no shrinkage anywhere in the function. On the `matvec_2tile_add` IR the alloc stays 32 lanes either way; all the pass does is churn the subview and its two calls.

The fix compares strides and offset instead of type identity, and leaves the subview alone when they agree. On that same IR the pass output then differs from the previous behaviour on exactly the three subview/`func.call` lines that were being churned, and nothing else.

A plausible-looking alternative — refusing to shrink when a subview feeds an op the rewrite cannot follow — is wrong, and I tried it first: `loop_fusion.mlir` depends on shrinking an alloc whose subview feeds a `func.call`, which the pass already handles by rewriting the callee declaration.

## Second commit: the workarounds this removes

Four examples carried a hand-written `air.shrinkage = false` to escape that verifier failure. None is load-bearing now.

Two do not change at all — `matvec_2tile_add` and `matvec_int4_packed_add` keep their 32-lane buffer either way, because the cascade put reads all 32 lanes, so the alloc was never a shrink candidate. Compiled to ELF at the shipped npu2 configs with and without the attribute; the generated `aie.mlir` differs only in the attribute line:

| A/B | lines differing |
|---|---|
| `matvec_2tile_add` M=K=2048, herd-cols 8 | 2 |
| `matvec_int4_packed_add` M=K=2048 | 2 |
| `llms/.../o_gemv_ffn_int4_multi.py -p` | 4 |
| `llms/shared/builders/o_gemv_ffn_multi.py -p` | 4 |

The last two are the stitched multi-launch consumers that `import build_module` from those files. They run only in `nightlyPerfBenchmark`, **not** in PR CI, so they were A/B'd by hand rather than left to the nightly.

Two do change, as intended. `matvec_int4_swiglu_rms` has no cascade, so nothing reads past lane `M_TILE` and the buffer now shrinks 32 → 8 with the subview folded away; its comment claimed the 32-lane width kept the kernel signature consistent, which the shrink already handles, so the comment is corrected rather than the width. `o_gemv_ffn_int4_fused` shrinks 19 such buffers the same way.

`matrix_multiplication/bf16_in_{bf16,fp32}_out` keep their attribute. Theirs is the separate bug their own comments name: the footprint analysis sizes an alloc from DMA access bounds alone, so a chunked drain would shrink the C accumulator below what the matmul `func.call` writes.

## Testing

- New case in `shrink_memref_sizes_by_access.mlir`; it fails against the previous behaviour.
- `check-air-mlir` 524/524, `check-air-python` 39/39.
- npu1 programming-examples sweep, XFAIL/deadlock dirs excluded: 88 passed. The one failure, `matrix_vector_multiplication/bf16`, is its `profile` step dying on an unset `XILINX_XRT` in my local lit config — unreachable from a pass change.

**Not run on hardware:** every one of the four touched examples is npu2-only, and I only have npu1. For the two that compile to identical IR that is a complete argument; for `matvec_int4_swiglu_rms` and `o_gemv_ffn_int4_fused` it is not — those are verified to compile to ELF and no further. Worth an npu2 run before merge.