### PR TITLE
[programming_examples] air.api: shared_l1_multi_herd and mnist_fc/broadcast_bias_add

### DIFF
--- a/mlir/lib/Transform/AIRSplitLaunchForPadding.cpp
+++ b/mlir/lib/Transform/AIRSplitLaunchForPadding.cpp
@@ -63,8 +63,35 @@ static unsigned traceFuncArgIdx(Value memref) {
 // through arith.index_cast chains, which the canonicalizer no longer folds
 // away after llvm/llvm-project#189042 (it used to incorrectly drop
 // index → iN → index round-trips even when iN is narrower than index).
+// True when `expr` is a linear combination: sums of dims, symbols and
+// constants, each scaled only by a constant. Everything else -- mod, floordiv,
+// ceildiv, or a product of two non-constants -- is rejected.
+static bool isLinearCombination(AffineExpr expr) {
+  switch (expr.getKind()) {
+  case AffineExprKind::Constant:
+  case AffineExprKind::DimId:
+  case AffineExprKind::SymbolId:
+    return true;
+  case AffineExprKind::Add: {
+    auto bin = cast<AffineBinaryOpExpr>(expr);
+    return isLinearCombination(bin.getLHS()) &&
+           isLinearCombination(bin.getRHS());
+  }
+  case AffineExprKind::Mul: {
+    auto bin = cast<AffineBinaryOpExpr>(expr);
+    if (!isa<AffineConstantExpr>(bin.getLHS()) &&
+        !isa<AffineConstantExpr>(bin.getRHS()))
+      return false;
+    return isLinearCombination(bin.getLHS()) &&
+           isLinearCombination(bin.getRHS());
+  }
+  default:
+    return false;
+  }
+}
+
 // The coefficient `v` is multiplied by inside an affine.apply, or 0 if the
-// expression is not linear in `v`.
+// map's expression is not a linear combination of its inputs.
 //
 // An offset written as a chain of arith ops keeps the multiplier as its own
 // op, which the arith::MulIOp case below reads directly. Built through an
@@ -72,11 +99,20 @@ static unsigned traceFuncArgIdx(Value memref) {
 // what folding a whole offset computation into one op produces -- the same
 // multiplier is a coefficient inside the map, and there is no muli to find.
 // Recover it by evaluating the map's difference between v=1 and v=0, with
-// every other input pinned to 0: for an affine expression that is exactly the
-// coefficient.
+// every other input pinned to 0: for a linear combination that difference is
+// exactly the coefficient.
+//
+// The linearity check is not a formality. That difference is well-defined for
+// any expression, and for a semi-affine one it is not a multiplier: `s0 mod 8`
+// gives 1 - 0 = 1, and since inferTileSize keeps the *smallest* candidate a
+// spurious 1 would beat every real tile size and mis-split the padding
+// silently. Refusing to answer makes the pass report that it could not infer
+// the tile sizes, which is the safe outcome.
 static int64_t affineCoefficient(affine::AffineApplyOp applyOp, Value v) {
   AffineMap map = applyOp.getAffineMap();
   if (map.getNumResults() != 1)
+    return 0;
+  if (!isLinearCombination(map.getResult(0)))
     return 0;
 
   auto positionOf = [&](Value operand) -> std::optional<unsigned> {

--- a/mlir/lib/Transform/AIRSplitLaunchForPadding.cpp
+++ b/mlir/lib/Transform/AIRSplitLaunchForPadding.cpp
@@ -9,6 +9,7 @@
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Util/Util.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -62,6 +63,54 @@ static unsigned traceFuncArgIdx(Value memref) {
 // through arith.index_cast chains, which the canonicalizer no longer folds
 // away after llvm/llvm-project#189042 (it used to incorrectly drop
 // index → iN → index round-trips even when iN is narrower than index).
+// The coefficient `v` is multiplied by inside an affine.apply, or 0 if the
+// expression is not linear in `v`.
+//
+// An offset written as a chain of arith ops keeps the multiplier as its own
+// op, which the arith::MulIOp case below reads directly. Built through an
+// affine map instead -- `(s0 * 128 + s1 * 32)[block_idx, tile_idx]`, which is
+// what folding a whole offset computation into one op produces -- the same
+// multiplier is a coefficient inside the map, and there is no muli to find.
+// Recover it by evaluating the map's difference between v=1 and v=0, with
+// every other input pinned to 0: for an affine expression that is exactly the
+// coefficient.
+static int64_t affineCoefficient(affine::AffineApplyOp applyOp, Value v) {
+  AffineMap map = applyOp.getAffineMap();
+  if (map.getNumResults() != 1)
+    return 0;
+
+  auto positionOf = [&](Value operand) -> std::optional<unsigned> {
+    for (auto [i, o] : llvm::enumerate(applyOp.getOperands()))
+      if (o == operand)
+        return i;
+    return std::nullopt;
+  };
+  auto pos = positionOf(v);
+  if (!pos)
+    return 0;
+
+  auto *ctx = applyOp.getContext();
+  auto evaluateWith = [&](int64_t valueOfV) -> std::optional<int64_t> {
+    SmallVector<AffineExpr> dims, syms;
+    for (unsigned i = 0; i < map.getNumDims(); i++)
+      dims.push_back(getAffineConstantExpr(i == *pos ? valueOfV : 0, ctx));
+    for (unsigned i = 0; i < map.getNumSymbols(); i++)
+      syms.push_back(getAffineConstantExpr(
+          map.getNumDims() + i == *pos ? valueOfV : 0, ctx));
+    AffineExpr folded = simplifyAffineExpr(
+        map.getResult(0).replaceDimsAndSymbols(dims, syms), 0, 0);
+    if (auto constant = dyn_cast<AffineConstantExpr>(folded))
+      return constant.getValue();
+    return std::nullopt;
+  };
+
+  auto atOne = evaluateWith(1);
+  auto atZero = evaluateWith(0);
+  if (!atOne || !atZero)
+    return 0;
+  return *atOne - *atZero;
+}
+
 static void collectTileSizeCandidates(Value blockIdx,
                                       SmallVectorImpl<int64_t> &candidates) {
   SmallVector<Value> worklist{blockIdx};
@@ -75,6 +124,10 @@ static void collectTileSizeCandidates(Value blockIdx,
         if (auto constVal = getConstantIntValue(other))
           if (*constVal > 0)
             candidates.push_back(*constVal);
+      } else if (auto applyOp = dyn_cast<affine::AffineApplyOp>(user)) {
+        if (int64_t coefficient = affineCoefficient(applyOp, v))
+          if (coefficient > 0)
+            candidates.push_back(coefficient);
       } else if (isa<arith::IndexCastOp, arith::IndexCastUIOp>(user)) {
         Value result = user->getResult(0);
         if (visited.insert(result).second)
@@ -84,31 +137,37 @@ static void collectTileSizeCandidates(Value blockIdx,
   }
 }
 
-// Infer tile size from arith.muli of a launch block index. Also follows the
-// ID through air.segment hierarchy. When multiple multipliers exist, picks
-// the smallest (tile offset, not output stride).
+// Infer tile size from a launch block index's multiplier. Also follows the ID
+// down the air hierarchy. When multiple multipliers exist, picks the smallest
+// (tile offset, not output stride).
+static void collectThroughHierarchy(Value id,
+                                    SmallVectorImpl<int64_t> &candidates) {
+  collectTileSizeCandidates(id, candidates);
+  // Recursive, not one level: air.launch, air.segment and air.herd are each
+  // IsolatedFromAbove, so a kernel that stages through L2 threads the block
+  // index down two hops before it is ever multiplied, and stopping at the
+  // segment finds nothing at all.
+  for (auto &use : id.getUses()) {
+    auto hier = dyn_cast<HierarchyInterface>(use.getOwner());
+    if (!hier)
+      continue;
+    auto operands = hier.getKernelOperands();
+    auto bodyArgs = hier.getKernelArguments();
+    for (unsigned i = 0; i < operands.size(); ++i)
+      if (operands[i] == id) {
+        collectThroughHierarchy(bodyArgs[i], candidates);
+        break;
+      }
+  }
+}
+
 static int64_t inferTileSize(LaunchOp launchOp, unsigned dimIdx) {
   auto ids = launchOp.getIds();
   if (dimIdx >= ids.size())
     return 0;
-  Value blockIdx = ids[dimIdx];
 
   SmallVector<int64_t> candidates;
-  collectTileSizeCandidates(blockIdx, candidates);
-
-  // Follow through segment hierarchy.
-  for (auto &use : blockIdx.getUses()) {
-    if (auto hier = dyn_cast<HierarchyInterface>(use.getOwner())) {
-      auto operands = hier.getKernelOperands();
-      auto bodyArgs = hier.getKernelArguments();
-      for (unsigned i = 0; i < operands.size(); ++i) {
-        if (operands[i] == blockIdx) {
-          collectTileSizeCandidates(bodyArgs[i], candidates);
-          break;
-        }
-      }
-    }
-  }
+  collectThroughHierarchy(ids[dimIdx], candidates);
 
   if (candidates.empty())
     return 0;

--- a/mlir/test/Transform/AIRSplitLaunchForPadding/split_launch_for_padding_affine_offsets.mlir
+++ b/mlir/test/Transform/AIRSplitLaunchForPadding/split_launch_for_padding_affine_offsets.mlir
@@ -1,0 +1,51 @@
+//===- split_launch_for_padding_affine_offsets.mlir -------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-split-launch-for-padding | FileCheck %s
+
+// The tile size is inferred from the launch block index's multiplier. The
+// sibling tests spell that multiplier as its own arith.muli at segment scope;
+// here the whole offset is one affine.apply per axis, and the block index
+// reaches it two hops down -- through air.segment and then air.herd, both
+// IsolatedFromAbove -- which is the shape a folded offset computation
+// produces. The multiplier is then a coefficient inside the map rather than an
+// op of its own.
+//
+// M=100, N=100 padded to 128x128; tileM = 32 (s0 coefficient of #map),
+// tileN = 64 (s0 coefficient of #map1). mRem = 100 % 32 = 4,
+// nRem = 100 % 64 = 36, so both axes are split and all four partitions exist.
+
+// CHECK-LABEL: func.func @affine_offsets
+// CHECK: air.segment @seg_interior
+// CHECK: air.segment @seg_m_boundary
+// CHECK: air.segment @seg_n_boundary
+// CHECK: air.segment @seg_corner
+// CHECK-NOT: air.actual_sizes
+
+#map = affine_map<()[s0, s1] -> (s0 * 32 + s1 * 32)>
+#map1 = affine_map<()[s0, s1] -> (s0 * 64 + s1 * 32)>
+module {
+  func.func @affine_offsets(%arg0: memref<128x128xf32>, %arg2: memref<128x128xf32>) {
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    air.launch (%arg3, %arg4) in (%arg5=%c4, %arg6=%c2) args(%arg7=%arg0, %arg9=%arg2) : memref<128x128xf32>, memref<128x128xf32> attributes {air.actual_sizes = array<i64: 100, 100, 1>} {
+      air.segment @seg args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg14=%arg9) : index, index, memref<128x128xf32>, memref<128x128xf32> {
+        %c1 = arith.constant 1 : index
+        %c2_0 = arith.constant 2 : index
+        air.herd @herd_0 tile (%arg15, %arg16) in (%arg17=%c1, %arg18=%c2_0) args(%arg19=%arg10, %arg20=%arg11, %arg21=%arg12, %arg23=%arg14) : index, index, memref<128x128xf32>, memref<128x128xf32> {
+          %alloc = memref.alloc() : memref<32x32xf32, 2 : i32>
+          %0 = affine.apply #map()[%arg19, %arg15]
+          %1 = affine.apply #map1()[%arg20, %arg16]
+          air.dma_memcpy_nd (%alloc[] [] [], %arg21[%0, %1] [32, 32] [128, 1]) : (memref<32x32xf32, 2 : i32>, memref<128x128xf32>)
+          air.dma_memcpy_nd (%arg23[%0, %1] [32, 32] [128, 1], %alloc[] [] []) : (memref<128x128xf32>, memref<32x32xf32, 2 : i32>)
+          memref.dealloc %alloc : memref<32x32xf32, 2 : i32>
+        }
+      }
+    }
+    return
+  }
+}

--- a/programming_examples/mnist_fc/broadcast_bias_add/run.py
+++ b/programming_examples/mnist_fc/broadcast_bias_add/run.py
@@ -2,233 +2,113 @@
 #
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-#
-# Broadcast bias add: C[row,col] = A[row,col] + bias[col]
-# Adds a row vector (ne0-aligned) to every row of a matrix.
-# All data is f32.
-#
-# GGML layout: [ne0, ne1] where ne0 is contiguous.
-# GGML op: x+y: [ne0, ne1] + [ne0, 1] -> [ne0, ne1]
-# In numpy row-major: matrix is (ne1, ne0), bias is (ne0,).
-# The bias is along the contiguous (column) dimension, broadcast along rows.
-#
-# MNIST context: ops #2 and #5 in the GGML MNIST-FC pipeline.
-# Op #2: [500,500] + [500,1] -> [500,500], bias has ne0=500 elements.
+"""Broadcast bias add, on air.api: ``C[row, col] = A[row, col] + bias[col]``.
+
+Ops #2 and #5 of the GGML MNIST-FC pipeline. GGML's layout is ``[ne0, ne1]``
+with ``ne0`` contiguous, so in numpy row-major the matrix is ``(ne1, ne0)`` and
+the bias is ``(ne0,)`` -- one value per column, reused down every row. All f32.
+
+The whole kernel is one line:
+
+    out[:] = a[:] + bias[:]        [tile_m, tile_n] + [tile_n]
+
+which is numpy's broadcast rule, right-aligned: ``bias`` is short of an axis, so
+it is stretched along the one it does not have. The predecessor wrote the same
+thing as a doubly-nested loop that, for every 16-wide strip of every row,
+re-took a ``memref.subview`` of the bias and re-read it with a
+``vector.transfer_read`` -- the bias load is loop-invariant but was spelled
+inside both loops.
+
+Two things this does *not* change, because they are the example's contract:
+
+* ``M`` and ``N`` are padded up to a whole number of tiles, and when padding
+  happens the module carries ``air.actual_sizes`` on ``air.launch`` so the
+  runtime knows the real extent. ``launch.build()`` hands back the module, so
+  that attribute is set exactly where the predecessor set it.
+* ``--vector-size`` still selects the width, through ``air.alloc(vector=...)``.
+  16 is the default and the only width f32 has: 8 lanes does not legalize on
+  either generation.
+"""
 
 import argparse
 import math
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview, load
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api.types import f32
 from air.backend.xrt import XRTBackend
-from air.extras import types as extrasT
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
 
-
-@module_builder
 def build_module(m, n, tile_m, tile_n, herd_m, herd_n, vector_size=16):
-    """Build broadcast bias add module.
+    """Build the broadcast bias add launch.
 
-    m = ne1 (rows, padded), n = ne0 (cols, contiguous, padded).
-    Bias has length n (ne0). C[row,col] = A[row,col] + bias[col].
+    ``m`` = ne1 (rows, padded), ``n`` = ne0 (cols, contiguous, padded). The bias
+    has length ``n`` and is indexed by column.
     """
     assert m % (tile_m * herd_m) == 0
     assert n % (tile_n * herd_n) == 0
     assert tile_n % vector_size == 0
 
-    xrt_dtype = type_mapper(np.float32)
-    index_type = IndexType.get()
-    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
+    A = air.tensor([m, n], f32)
+    BIAS = air.tensor([n], f32)
+    OUT = air.tensor([m, n], f32)
 
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get([m, n], xrt_dtype)
-    # Bias has length n (ne0, contiguous dimension)
-    memrefTyBias = MemRefType.get([n], xrt_dtype)
-    memrefTyOut = MemRefType.get([m, n], xrt_dtype)
+    grid = [range(m // tile_m // herd_m), range(n // tile_n // herd_n)]
 
-    # L1 MemRefTypes
-    l1TileTy = MemRefType.get(
-        shape=[tile_m, tile_n], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-    # Bias tile: tile_n elements (one per column in the tile)
-    l1BiasTy = MemRefType.get(
-        shape=[tile_n], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
+    with air.launch(grid, name="broadcast_bias_add") as launch:
 
-    vecTy = VectorType.get([vector_size], xrt_dtype)
-    # Rank-reduced 1D subview type
-    l1SubviewTy = MemRefType.get(
-        [vector_size],
-        xrt_dtype,
-        layout=StridedLayoutAttr.get(ShapedType.get_dynamic_size(), [1]),
-        memory_space=l1_mem_space,
-    )
+        @launch.body
+        def _(lx, ly):
+            with air.segment(name="bias_add_seg") as seg:
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyBias, memrefTyOut)
-    def broadcast_bias_add(arg_a, arg_bias, arg_out):
-        launch_size = [m // tile_m // herd_m, n // tile_n // herd_n]
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_m), range(herd_n)],
+                        name="herd_0",
+                        shape=(herd_m, herd_n),
+                    ) as h:
 
-        @launch(operands=[arg_a, arg_bias, arg_out], sizes=launch_size)
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_a, l3_bias, l3_out
-        ):
+                        @h.body
+                        def _(tx, ty):
+                            # Where this core's tile starts. The launch point
+                            # picks the block of tiles; the tile coordinate
+                            # picks one inside it.
+                            m0 = lx * (tile_m * herd_m) + tx * tile_m
+                            n0 = ly * (tile_n * herd_n) + ty * tile_n
 
-            @segment(
-                name="bias_add_seg",
-                operands=[launch_ivx, launch_ivy, l3_a, l3_bias, l3_out],
-            )
-            def segment_body(launch_ivx_s, launch_ivy_s, l3_a_s, l3_bias_s, l3_out_s):
-                c_tile_m_herd_m = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_m * herd_m), None
-                )
-                c_tile_n_herd_n = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_n * herd_n), None
-                )
-                launch_offset_m = arith.MulIOp(launch_ivx_s, c_tile_m_herd_m)
-                launch_offset_n = arith.MulIOp(launch_ivy_s, c_tile_n_herd_n)
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_m, herd_n],
-                    operands=[
-                        launch_offset_m,
-                        launch_offset_n,
-                        l3_a_s,
-                        l3_bias_s,
-                        l3_out_s,
-                    ],
-                )
-                def herd_body(
-                    tx, ty, _sx, _sy, _loff_m, _loff_n, _l3_a, _l3_bias, _l3_out
-                ):
-                    l1_tile_in = AllocOp(l1TileTy, [], [])
-                    l1_tile_out = AllocOp(l1TileTy, [], [])
-                    l1_bias = AllocOp(l1BiasTy, [], [])
-
-                    m_offset_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(1),
-                                    AffineConstantExpr.get(tile_m),
-                                ),
+                            # Allocated in the predecessor's order -- tile in,
+                            # tile out, bias -- so the aie.buffer numbering
+                            # comes out the same and the two designs can be
+                            # compared as generated code, not just as results.
+                            a = air.alloc(
+                                [tile_m, tile_n],
+                                f32,
+                                scope=h.private(),
+                                vector=vector_size,
                             )
-                        ],
-                    )
-                    n_offset_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(1),
-                                    AffineConstantExpr.get(tile_n),
-                                ),
+                            out = air.alloc(
+                                [tile_m, tile_n],
+                                f32,
+                                scope=h.private(),
+                                vector=vector_size,
                             )
-                        ],
-                    )
-                    m_offset = affine_apply(m_offset_map, [_loff_m, tx])
-                    n_offset = affine_apply(n_offset_map, [_loff_n, ty])
-
-                    # DMA bias slice: bias[n_offset : n_offset + tile_n]
-                    # Bias is along ne0 (columns, contiguous dimension).
-                    dma_memcpy_nd(
-                        l1_bias,
-                        _l3_bias,
-                        src_offsets=[n_offset],
-                        src_sizes=[tile_n],
-                        src_strides=[1],
-                    )
-
-                    # DMA matrix tile
-                    dma_memcpy_nd(
-                        l1_tile_in,
-                        _l3_a,
-                        src_offsets=[m_offset, n_offset],
-                        src_sizes=[tile_m, tile_n],
-                        src_strides=[n, 1],
-                    )
-
-                    # Compute: C[row,col] = A[row,col] + bias[col]
-                    # Bias is along columns; load as vector, add to each row.
-                    c0 = ConstantOp(index_type, 0)
-                    c1 = ConstantOp(index_type, 1)
-                    c_vec_size = ConstantOp(index_type, vector_size)
-                    c_tile_m_cst = ConstantOp(index_type, tile_m)
-                    c_tile_n_cst = ConstantOp(index_type, tile_n)
-                    cst0 = arith.ConstantOp(xrt_dtype, 0.0)
-                    identity_map_1d = AffineMapAttr.get(AffineMap.get_identity(1))
-
-                    for i in range_(c0, c_tile_m_cst, c1):
-                        for j in range_(c0, c_tile_n_cst, c_vec_size):
-                            # Load bias vector (same for every row)
-                            sub_bias = subview(
-                                l1_bias.result,
-                                [j],
-                                [vector_size],
-                                [1],
-                            )
-                            v_bias = transfer_read(
-                                vecTy,
-                                sub_bias,
-                                [c0],
-                                identity_map_1d,
-                                cst0,
-                                [True],
+                            bias = air.alloc(
+                                [tile_n], f32, scope=h.private(), vector=vector_size
                             )
 
-                            sub_in = subview(
-                                l1_tile_in.result,
-                                [i, j],
-                                [1, vector_size],
-                                [1, 1],
-                                result_type=l1SubviewTy,
-                            )
-                            sub_out = subview(
-                                l1_tile_out.result,
-                                [i, j],
-                                [1, vector_size],
-                                [1, 1],
-                                result_type=l1SubviewTy,
-                            )
-                            v_in = transfer_read(
-                                vecTy, sub_in, [c0], identity_map_1d, cst0, [True]
-                            )
-                            v_out = arith.AddFOp(v_in, v_bias)
-                            transfer_write(
-                                None, v_out, sub_out, [c0], identity_map_1d, [True]
-                            )
-                            yield_([])
-                        yield_([])
+                            air.ops.load(a, A[m0 : m0 + tile_m, n0 : n0 + tile_n])
+                            air.ops.load(bias, BIAS[n0 : n0 + tile_n])
 
-                    # DMA output tile back to L3
-                    dma_memcpy_nd(
-                        _l3_out,
-                        l1_tile_out,
-                        dst_offsets=[m_offset, n_offset],
-                        dst_sizes=[tile_m, tile_n],
-                        dst_strides=[n, 1],
-                    )
+                            out[:] = a[:] + bias[:]
 
-                    DeallocOp(l1_tile_in)
-                    DeallocOp(l1_tile_out)
-                    DeallocOp(l1_bias)
+                            air.ops.store(out, OUT[m0 : m0 + tile_m, n0 : n0 + tile_n])
+
+    return launch
 
 
 if __name__ == "__main__":
@@ -262,6 +142,13 @@ if __name__ == "__main__":
         dest="compile_mode",
         default="compile-and-run",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -282,13 +169,16 @@ if __name__ == "__main__":
         print(f"M_padded={M_padded}, N_padded={N_padded}")
         print(f"TILE_M={TILE_M}, TILE_N={TILE_N}, HERD_M={HERD_M}, HERD_N={HERD_N}")
 
-    mlir_module = build_module(
+    launch = build_module(
         M_padded, N_padded, TILE_M, TILE_N, HERD_M, HERD_N, VECTOR_SIZE
     )
+    mlir_module = launch.build(target=args.target)
 
     # Add actual_sizes attribute for device-side padding
     needs_padding = (M_actual != M_padded) or (N_actual != N_padded)
     if needs_padding:
+        from air.ir import DenseI64ArrayAttr
+
         with mlir_module.context:
             for op in mlir_module.body.operations:
                 for inner_op in op.body.blocks[0].operations:
@@ -360,6 +250,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format="elf" if needs_padding else "xclbin",
             instance_name="broadcast_bias_add",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         exit(
@@ -376,6 +267,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format="elf" if needs_padding else "xclbin",
+            target_device=launch.target,
             runtime_loop_tiling_sizes=[4, 4],
         )
         module_function = backend.compile(mlir_module)

--- a/programming_examples/shared_l1_multi_herd/run.py
+++ b/programming_examples/shared_l1_multi_herd/run.py
@@ -1,70 +1,134 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Two herds passing a tile through a shared L1 buffer, on air.api.
 
-"""AIR Shared L1 Buffer Dataflow Example (multi-herd producer/consumer)
+The AIE array lets neighbouring tiles address the same L1 memory, so a herd can
+hand a tile to another herd without going back out to a memtile. What makes a
+buffer shared is where it is allocated: not in a herd body, where it lives and
+dies with one entry, but in the segment, with the segment's lifetime.
 
-This script demonstrates data flowing between TWO air herds via a shared L1
-buffer. The AIE architecture features shared L1 buffer across neighboring AIE
-tiles. For the single-herd (intra-herd, core-to-core) counterpart, see
-programming_examples/shared_l1_single_herd.
+    shared = air.alloc([m, n], bf16, scope=seg.shared())   L1, segment lifetime
 
-A shared L1 buffer is represented via a memref with memory_space=2, that is
-allocated outside of both herds, but used by both herds via their args list.
+      herd_producer     shared[:] = a[:] + 1.0             writes it
+      herd_consumer     c[:] = shared[:] + 2.0             reads it back
 
-Dataflow:
-  1. herd_producer: Reads input from external → local L1 buffer A
-                    Computes A + 1 → shared L1 buffer B
-  2. herd_consumer: Reads from shared L1 buffer B
-                    Computes B + 2 → local L1 buffer C
-                    Writes output from C → external
+    output = input + 3
 
-Final result: output = input + 3
+``seg.shared()`` is the whole of it. Both herds are nested in the segment body,
+and each carries the buffer in as an operand automatically -- ``air.herd`` is
+``IsolatedFromAbove``, so the raw-bindings version this replaces had to list it
+in ``operands=[shared_l1_buffer.result]`` on both herds and pick it back up as a
+body parameter on both. Nothing marks the buffer as shared beyond being
+allocated where it is; ``seg.private()`` next to it would be a memtile instead.
+
+For the intra-herd, core-to-core counterpart see ``shared_l1_single_herd``.
+
+Two differences from the predecessor worth naming:
+
+* Each ``+ 1.0`` and ``+ 2.0`` is one line rather than a doubly-nested loop over
+  16-element strips, each strip built from a ``memref.subview``, a
+  ``memref.collapse_shape`` to erase the leading unit dimension, a
+  ``vector.transfer_read``, a ``vector.BroadcastOp`` for the constant and a
+  ``vector.transfer_write``. The DSL picks the vector width; 64 bf16 across the
+  minor axis vectorises to 16 lanes, the same width the predecessor spelled out.
+* The launch grid is written ``air.launch([range(m // 64), range(n // 64)])``
+  and the tile origin falls out of the coordinates, rather than two hand-built
+  ``AffineMap``s applied to the launch ivs and threaded through every transfer.
+  At the shipped 64x64 that grid is 1x1; 128x128, 256x64 and 64x256 were run on
+  npu1 as well, because the predecessor accepted them and no lit covers them.
 """
 
 import argparse
+
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import bf16
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-import air
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import memref, vector, arith, scf
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp
-from air.backend.xrt_runner import XRTRunner
-from ml_dtypes import bfloat16
-
-# Constants for buffer sizes
-L1_BUFFER_SIZE_M = 64
-L1_BUFFER_SIZE_N = 64
-L2_BUFFER_SIZE_M = L1_BUFFER_SIZE_M
-L2_BUFFER_SIZE_N = L1_BUFFER_SIZE_N
-# Number of elements processed in a single vector operation
-VECTOR_SIZE = 16
-
-range_ = for_
+# The tile both herds work on, and the shape of every L1 and L2 buffer here.
+TILE_M = 64
+TILE_N = 64
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="AIR Shared L1 Buffer Example")
+def build_module(m, n):
+    assert m % TILE_M == 0, f"m={m} is not a multiple of the {TILE_M}-row tile"
+    assert n % TILE_N == 0, f"n={n} is not a multiple of the {TILE_N}-column tile"
+
+    A = air.tensor([m, n], bf16)
+    C = air.tensor([m, n], bf16)
+
+    to_producer = air.channel("InputToProducer")
+    from_consumer = air.channel("ConsumerToOutput")
+
+    # The tile grid goes on the launch, where the predecessor put it. A launch
+    # point is a replay of everything inside -- the L2 and shared L1 buffers
+    # below are refilled at each one -- and it is the only one of the three
+    # iteration spaces here that is 2-D on hardware: a *segment* grid is a
+    # spatial copy of the body across columns, and air-to-aie refuses a
+    # row-wise one with "AIE only supports column-wise device slicing".
+    with air.launch([range(m // TILE_M), range(n // TILE_N)], name="func1") as launch:
+
+        @launch.body
+        def _(ix, iy):
+            with air.segment(name="segment_0") as seg:
+
+                @seg.body
+                def _():
+                    r0, c0 = ix * TILE_M, iy * TILE_N
+
+                    l2_in = air.alloc([TILE_M, TILE_N], bf16, scope=seg.private())
+                    l2_out = air.alloc([TILE_M, TILE_N], bf16, scope=seg.private())
+
+                    # L1, allocated here rather than in a herd body, so it
+                    # outlives each herd and both can reach it.
+                    shared = air.alloc([TILE_M, TILE_N], bf16, scope=seg.shared())
+
+                    air.ops.load(l2_in, A[r0 : r0 + TILE_M, c0 : c0 + TILE_N])
+                    to_producer.put(l2_in)
+
+                    with air.herd([range(1)], name="herd_producer", shape=(1,)) as hp:
+
+                        @hp.body
+                        def _(tx):
+                            a = air.alloc([TILE_M, TILE_N], bf16, scope=hp.private())
+                            to_producer.get(a)
+                            shared[:] = a[:] + 1.0
+
+                    with air.herd([range(1)], name="herd_consumer", shape=(1,)) as hc:
+
+                        @hc.body
+                        def _(tx):
+                            c = air.alloc([TILE_M, TILE_N], bf16, scope=hc.private())
+                            c[:] = shared[:] + 2.0
+                            from_consumer.put(c)
+
+                    from_consumer.get(l2_out)
+                    air.ops.store(l2_out, C[r0 : r0 + TILE_M, c0 : c0 + TILE_N])
+
+    return launch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Builds, runs, and tests the shared L1 multi-herd example",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument(
-        "--m-size",
-        type=int,
-        default=64,
-        help="Number of rows (M dimension)",
+        "-p",
+        "--print-ir",
+        action="store_true",
+        help="Print MLIR IR and exit",
     )
     parser.add_argument(
-        "--n-size",
-        type=int,
-        default=64,
-        help="Number of columns (N dimension)",
+        "--m-size", type=int, default=TILE_M, help="Number of rows (M dimension)"
     )
     parser.add_argument(
-        "-p", "--print-ir", action="store_true", help="Print MLIR IR and exit"
+        "--n-size", type=int, default=TILE_N, help="Number of columns (N dimension)"
     )
     parser.add_argument(
         "--output-format",
@@ -74,344 +138,34 @@ def parse_args():
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+
     args = parser.parse_args()
-    return args
 
-
-@module_builder
-def build_module(M_SIZE, N_SIZE):
-    """
-    Build the AIR dataflow module demonstrating shared L1 buffer communication.
-
-    The key feature is that a shared L1 buffer (memory_space=2) is allocated
-    at the segment level (outside both herds) and passed to both herds via
-    their operands list.
-
-    Returns:
-        The constructed MLIR module.
-    """
-    index_type = IndexType.get()
-    bf16 = air.ir.Type.parse("bf16")
-
-    # Memory types
-    # L3 memory (external/DDR)
-    memrefMxN = MemRefType.get((M_SIZE, N_SIZE), bf16)
-    # L2 memory (memory_space=1)
-    memrefL2 = MemRefType.get(
-        (L2_BUFFER_SIZE_M, L2_BUFFER_SIZE_N), bf16, memory_space=Attribute.parse("1")
-    )
-    # L1 memory (memory_space=2) - used for both local and shared buffers
-    memrefL1 = MemRefType.get(
-        (L1_BUFFER_SIZE_M, L1_BUFFER_SIZE_N), bf16, memory_space=Attribute.parse("2")
-    )
-
-    # AIR channels for external data movement
-    # Input: L2 to herd_producer
-    channel("InputToProducer", size=[1, 1])
-    # Output: herd_consumer to L2
-    channel("ConsumerToOutput", size=[1, 1])
-
-    @FuncOp.from_py_func(memrefMxN, memrefMxN)
-    def func1(arg0, arg1):
-        """
-        Top-level function demonstrating shared L1 buffer dataflow.
-
-        Args:
-            arg0: Input memory reference (L3)
-            arg1: Output memory reference (L3)
-
-        Returns:
-            None. Operates via side effects on MLIR memory references.
-        """
-        launch_x_size = ConstantOp(index_type, M_SIZE // L1_BUFFER_SIZE_M)
-        launch_y_size = ConstantOp(index_type, N_SIZE // L1_BUFFER_SIZE_N)
-
-        @launch(operands=[arg0, arg1], sizes=[launch_x_size, launch_y_size])
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_in, l3_out
-        ):
-            @segment(operands=[launch_ivx, launch_ivy, l3_in, l3_out])
-            def segment_body(lau_ivx, lau_ivy, seg_in, seg_out):
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-                cM = ConstantOp(index_type, M_SIZE)
-                cN = ConstantOp(index_type, N_SIZE)
-
-                # Allocate L2 buffers for input and output staging
-                l2_in = AllocOp(memrefL2, [], [])
-                l2_out = AllocOp(memrefL2, [], [])
-
-                # ============================================================
-                # KEY FEATURE: Shared L1 buffer allocated at SEGMENT level
-                # This buffer will be passed to BOTH herds and represents
-                # the shared L1 memory between neighboring AIE tiles.
-                # ============================================================
-                shared_l1_buffer = AllocOp(memrefL1, [], [])
-
-                # Compute offsets based on launch indices
-                mul_m_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(L1_BUFFER_SIZE_M),
-                        )
-                    ],
-                )
-                mul_n_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(L1_BUFFER_SIZE_N),
-                        )
-                    ],
-                )
-                offset_m = affine_apply(mul_m_map, [lau_ivx])
-                offset_n = affine_apply(mul_n_map, [lau_ivy])
-
-                # Stage 1: DMA from L3 to L2
-                dma_memcpy_nd(
-                    l2_in.result,
-                    seg_in,
-                    dst_offsets=[c0, c0],
-                    dst_sizes=[cML1, cNL1],
-                    dst_strides=[cNL1, c1],
-                    src_offsets=[offset_m, offset_n],
-                    src_sizes=[cML1, cNL1],
-                    src_strides=[cN, c1],
-                )
-
-                # Stage 2: Send L2 buffer to herd_producer via channel
-                ChannelPut(
-                    "InputToProducer",
-                    l2_in.result,
-                    indices=[c0, c0],
-                    offsets=[c0, c0],
-                    sizes=[cML1, cNL1],
-                    strides=[cNL1, c1],
-                )
-
-                # ============================================================
-                # HERD_PRODUCER:
-                # - Receives input data from channel → local L1 buffer A
-                # - Computes A + 1 → writes to SHARED L1 buffer
-                # ============================================================
-                @herd(
-                    name="herd_producer",
-                    sizes=[c1, c1],
-                    operands=[shared_l1_buffer.result],  # Pass shared buffer
-                )
-                def herd_producer_body(
-                    hx,
-                    hy,
-                    hx_size,
-                    hy_size,
-                    shared_buf,  # Shared L1 buffer received as argument
-                ):
-                    # Allocate LOCAL L1 buffer A (inside this herd)
-                    local_buf_a = AllocOp(memrefL1, [], [])
-
-                    # Receive input data from channel into local buffer A
-                    ChannelGet("InputToProducer", local_buf_a.result, indices=[hx, hy])
-
-                    # Compute: shared_buf = local_buf_a + 1
-                    c0 = ConstantOp(index_type, 0)
-                    c1_idx = ConstantOp(index_type, 1)
-                    c16 = ConstantOp(index_type, VECTOR_SIZE)
-                    cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                    cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-
-                    # Add 1 to each element and write to shared buffer
-                    cst_one = arith.ConstantOp(bf16, 1.0)
-                    for i in range_(c0, cML1, c1_idx):
-                        for j in range_(c0, cNL1, c16):
-                            sub_a = memref.subview(
-                                local_buf_a.result, [i, j], [1, VECTOR_SIZE], [1, 1]
-                            )
-                            sub_shared = memref.subview(
-                                shared_buf, [i, j], [1, VECTOR_SIZE], [1, 1]
-                            )
-                            layout = StridedLayoutAttr.get(
-                                ShapedType.get_dynamic_size(), [1]
-                            )
-                            collapsed_type = MemRefType.get(
-                                (VECTOR_SIZE,),
-                                bf16,
-                                memory_space=Attribute.parse("2"),
-                                layout=layout,
-                            )
-                            collapse_a = memref.collapse_shape(
-                                collapsed_type, sub_a, [[0, 1]]
-                            )
-                            collapse_shared = memref.collapse_shape(
-                                collapsed_type, sub_shared, [[0, 1]]
-                            )
-                            cst0 = arith.ConstantOp(bf16, 0.0)
-                            v_a = vector.transfer_read(
-                                VectorType.get([VECTOR_SIZE], bf16),
-                                collapse_a,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                cst0,
-                                [True],
-                            )
-                            # Create vector of 1.0
-                            v_one = vector.BroadcastOp(
-                                VectorType.get([VECTOR_SIZE], bf16), cst_one
-                            )
-                            # Compute A + 1
-                            v_result = arith.AddFOp(v_a, v_one)
-                            # Write to shared buffer
-                            vector.transfer_write(
-                                None,
-                                v_result,
-                                collapse_shared,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                [True],
-                            )
-                            yield_([])
-                        yield_([])
-
-                # ============================================================
-                # HERD_CONSUMER:
-                # - Reads from SHARED L1 buffer (produced by herd_producer)
-                # - Computes shared_buf + 2 → writes to local L1 buffer C
-                # - Sends output from local buffer C to channel
-                # ============================================================
-                @herd(
-                    name="herd_consumer",
-                    sizes=[c1, c1],
-                    operands=[shared_l1_buffer.result],  # Pass same shared buffer
-                )
-                def herd_consumer_body(
-                    hx,
-                    hy,
-                    hx_size,
-                    hy_size,
-                    shared_buf,  # Same shared L1 buffer received as argument
-                ):
-                    # Allocate LOCAL L1 buffer C (inside this herd)
-                    local_buf_c = AllocOp(memrefL1, [], [])
-
-                    # Compute: local_buf_c = shared_buf + 2
-                    c0 = ConstantOp(index_type, 0)
-                    c1_idx = ConstantOp(index_type, 1)
-                    c16 = ConstantOp(index_type, VECTOR_SIZE)
-                    cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                    cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-
-                    # Add 2 to each element from shared buffer, write to local C
-                    cst_two = arith.ConstantOp(bf16, 2.0)
-                    for i in range_(c0, cML1, c1_idx):
-                        for j in range_(c0, cNL1, c16):
-                            sub_shared = memref.subview(
-                                shared_buf, [i, j], [1, VECTOR_SIZE], [1, 1]
-                            )
-                            sub_c = memref.subview(
-                                local_buf_c.result, [i, j], [1, VECTOR_SIZE], [1, 1]
-                            )
-                            layout = StridedLayoutAttr.get(
-                                ShapedType.get_dynamic_size(), [1]
-                            )
-                            collapsed_type = MemRefType.get(
-                                (VECTOR_SIZE,),
-                                bf16,
-                                memory_space=Attribute.parse("2"),
-                                layout=layout,
-                            )
-                            collapse_shared = memref.collapse_shape(
-                                collapsed_type, sub_shared, [[0, 1]]
-                            )
-                            collapse_c = memref.collapse_shape(
-                                collapsed_type, sub_c, [[0, 1]]
-                            )
-                            cst0 = arith.ConstantOp(bf16, 0.0)
-                            # Read from shared buffer
-                            v_shared = vector.transfer_read(
-                                VectorType.get([VECTOR_SIZE], bf16),
-                                collapse_shared,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                cst0,
-                                [True],
-                            )
-                            # Create vector of 2.0
-                            v_two = vector.BroadcastOp(
-                                VectorType.get([VECTOR_SIZE], bf16), cst_two
-                            )
-                            # Compute shared + 2
-                            v_result = arith.AddFOp(v_shared, v_two)
-                            # Write to local buffer C
-                            vector.transfer_write(
-                                None,
-                                v_result,
-                                collapse_c,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                [True],
-                            )
-                            yield_([])
-                        yield_([])
-
-                    # Send output from local buffer C to channel
-                    ChannelPut("ConsumerToOutput", local_buf_c.result, indices=[hx, hy])
-
-                # Stage: Receive output from herd_consumer via channel
-                ChannelGet(
-                    "ConsumerToOutput",
-                    l2_out.result,
-                    indices=[c0, c0],
-                    offsets=[c0, c0],
-                    sizes=[cML1, cNL1],
-                    strides=[cNL1, c1],
-                )
-
-                # Stage: DMA from L2 to L3 (output)
-                dma_memcpy_nd(
-                    seg_out,
-                    l2_out.result,
-                    dst_offsets=[offset_m, offset_n],
-                    dst_sizes=[cML1, cNL1],
-                    dst_strides=[cN, c1],
-                    src_offsets=[c0, c0],
-                    src_sizes=[cML1, cNL1],
-                    src_strides=[cNL1, c1],
-                )
-
-
-def main():
-    """Main entry point for running the AIR Shared L1 Buffer example."""
-    args = parse_args()
-    M_SIZE = args.m_size
-    N_SIZE = args.n_size
-
-    # Build the MLIR module
-    mlir_module = build_module(M_SIZE, N_SIZE)
-
+    launch = build_module(args.m_size, args.n_size)
+    mlir_module = launch.build(target=args.target)
     if args.print_ir:
-        # Print the MLIR IR and exit
-        print(str(mlir_module))
-        return
+        print(mlir_module)
+        exit(0)
 
-    # Prepare input and expected output data
-    # Final result: output = input + 1 (producer) + 2 (consumer) = input + 3
-    A = np.random.rand(M_SIZE, N_SIZE).astype(bfloat16)
+    # output = input + 1 (producer) + 2 (consumer)
+    A = np.random.rand(args.m_size, args.n_size).astype(bfloat16)
     C = (A + 3.0).astype(bfloat16)
 
-    # Run the module using XRTRunner
     runner = XRTRunner(
         omit_while_true_loop=False,
-        verbose=False,
+        verbose=args.verbose,
         runtime_loop_tiling_sizes=[1, 1],
         output_format=args.output_format,
         instance_name="func1",
-        debug_ir=True,
+        target_device=launch.target,
+        report_precision=True,
     )
     exit(
         runner.run_test(
@@ -421,7 +175,3 @@ def main():
             rtol=1e-2,
         )
     )
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Two examples onto `air.api`, and the compiler fix the second one needed.

## `shared_l1_multi_herd`

Two herds hand a tile to each other through an L1 buffer neither of them allocates. What makes it shared is *where* it lives: `seg.shared()` gives it the segment's lifetime instead of one entry into a herd body, and both nested herds carry it in as an operand automatically. The predecessor listed it in `operands=[shared_l1_buffer.result]` on both herds and picked it back up as a body parameter on both — the same fact stated three times.

The compute is `shared[:] = a[:] + 1.0` and `c[:] = shared[:] + 2.0`. Each replaces a doubly-nested loop over 16-element strips, where every strip was a `memref.subview`, a `memref.collapse_shape` to erase the leading unit dimension, a `vector.transfer_read`, a `vector.BroadcastOp` for the constant and a `vector.transfer_write`. The emitted vectors are the same `vector<16xbf16>`.

**The tile grid stays on `air.launch`, where the predecessor had it.** Putting it on the segment instead looks equivalent and is not: a segment grid is a spatial copy of the body across columns, and air-to-aie rejects a row-wise one with *"AIE only supports column-wise device slicing"*. The shipped 1x1 configuration hides this, since the lit only runs the default 64x64 — it surfaced only when the predecessor was run at 128x128, where it passes.

Gated on npu1: the lit passes, and because that single configuration exercises neither grid axis, 128x128, 256x64 and 64x256 were run by hand as well. All PASS, `mean_rel_L1` 1.8e-03 against the predecessor's inherited `rtol=1e-2`.

## `mnist_fc/broadcast_bias_add`

`C[row, col] = A[row, col] + bias[col]`, ops #2 and #5 of the GGML MNIST-FC pipeline, becomes one line:

```python
out[:] = a[:] + bias[:]        # [tile_m, tile_n] + [tile_n]
```

numpy's rule, right-aligned: `bias` is short an axis, so it is stretched along the one it does not have. The predecessor wrote this as a doubly-nested loop that, for every 16-wide strip of every row, re-took a `memref.subview` of the bias and re-read it with a `vector.transfer_read` — the bias load is loop-invariant but was spelled inside both loops.

Padding behaviour is untouched, because it is the example's contract: `M`/`N` are still rounded up to whole tiles, `air.actual_sizes` still goes on `air.launch` when they move, and `--vector-size` still selects the width (through `air.alloc(vector=...)`).

## `air-split-launch-for-padding`: infer through `affine.apply` and the full hierarchy

The pass reads the tile size off the launch block index's multiplier, and recognised exactly one spelling: an `arith.muli`, on the index itself or one hop down inside `air.segment`. air.api folds the whole offset computation into a single `affine.apply` per axis — no `muli` to find — and threads the block index down *two* hops, since `air.launch`, `air.segment` and `air.herd` are each `IsolatedFromAbove`. Either way `inferTileSize` returned 0 and the pass gave up with

```
air-split-launch-for-padding: could not infer tile sizes from launch body offset computations
```

Read the coefficient out of the map when the user is an `affine.apply` — evaluate at 1 and at 0 with every other input pinned to 0, which for an affine expression is exactly the coefficient — and make the hierarchy walk recursive instead of single-level.

## Testing

- `check-air-mlir` 525/525, including a new `AIRSplitLaunchForPadding` case that fails against the previous behaviour.
- All three examples in the tree carrying `air.actual_sizes` (`mnist_fc/argmax`, `mnist_fc/relu`, `mnist_fc/broadcast_bias_add`) compiled for npu2 with the old and new compiler: **byte-identical device IR** in all three.
- npu1 programming-examples sweep: 88 passed.
- `check-air-python` 39/39.

**`broadcast_bias_add` has not run on hardware.** It is npu2-only, so its lit is UNSUPPORTED on my npu1 box and cannot be the gate. The substitute is a comparison of generated code rather than results: both versions were compiled to ELF at the shipped 500x500 config and all 16 core LLVM IR files compared against the predecessor's. Each differs in exactly three ways, all classified — the two `vector.transfer_read`s are scheduled in the opposite order (with the SSA numbering following), three lock releases at the end of the loop are permuted among themselves with no acquire between them, and the `ModuleID` path. The arithmetic is the same `llvm.aie2p.ACC2048.accfloat.add.conf` with the matrix as lhs and the bias as rhs in both. The L1 buffers are deliberately allocated in the predecessor's order so the `aie.buffer` numbering matches and this comparison is possible at all. Worth an npu2 run before merge.