### PR TITLE
[utils] Bump mlir-aie to 1.4.3.dev17+g4c8b56f

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -878,7 +878,9 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
           /*sizes=*/ValueRange{}, /*strides=*/ValueRange{},
           /*static_sizes=*/nullptr, /*static_strides=*/nullptr,
           /*pad_dimensions=*/nullptr, /*bd_id=*/nullptr, pktAttr,
-          /*burst_length=*/nullptr, /*iteration=*/nullptr,
+          /*out_of_order_id=*/nullptr,
+          /*burst_length=*/nullptr, /*axcache=*/nullptr,
+          /*iteration=*/nullptr,
           /*offset_parameter=*/nullptr,
           /*offset_state_table_idx=*/nullptr, /*next_bd_id=*/nullptr);
     } else if (dynOffsetI32) {
@@ -4453,7 +4455,8 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
             /* d0_zero_before */ 0, /* d1_zero_before */ 0,
             /* d2_zero_before */ 0,
             /* d0_zero_after */ 0, /* d1_zero_after */ 0,
-            /* d2_zero_after */ 0);
+            /* d2_zero_after */ 0, /* burst_length */ 0,
+            /* axcache */ nullptr);
         uint32_t addr = (dstColIndex << target_model.getColumnShift()) |
                         (0x1D004 + bdID * 0x20);
         {

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -6491,13 +6491,15 @@ public:
         if (!channel_head) {
           channel_head = start_bb;
           auto b = OpBuilder::atBlockBegin(channel_head);
-          startOp = AIE::DMAStartOp::create(b, loc, dir, chan, rep,
-                                            /*pad_value*/ 0, first_bd, end_bb);
+          startOp =
+              AIE::DMAStartOp::create(b, loc, dir, chan, rep,
+                                      /*pad_value*/ 0,
+                                      /*out_of_order*/ false, first_bd, end_bb);
         } else {
           auto b = OpBuilder::atBlockBegin(start_bb);
           startOp = AIE::DMAStartOp::create(
-              b, loc, dir, chan, rep, /*pad_value*/ 0, first_bd,
-              channel_head->getTerminator()->getSuccessor(1));
+              b, loc, dir, chan, rep, /*pad_value*/ 0, /*out_of_order*/ false,
+              first_bd, channel_head->getTerminator()->getSuccessor(1));
           channel_head->getTerminator()->setSuccessor(start_bb, 1);
           channel_head = start_bb;
         }

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
@@ -5,39 +5,33 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: *
-// AIE1 only. mlir-aie has dropped AIE1 support, and this lowers a multi-pass
-// transfer, which needs a repeat count AIE1 has no register for -- rejected
-// since mlir-aie#3577 added verifyDMARepeatCount. Before that the count was
-// silently dropped by the AIE1 backend, so the transfer ran once instead of
-// twice; the verifier made an existing miscompile visible.
-// RUN: air-opt -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcvc1902" %s | FileCheck %s
+// RUN: air-opt -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=2 col-offset=0 device=npu1" %s | FileCheck %s
 
-// CHECK-LABEL:   aie.device(xcvc1902) @herd_0 {
-// CHECK-DAG:   %[[VAL_2:.*]] = aie.tile(5, 3)
-// CHECK-DAG:   %[[VAL_3:.*]] = aie.tile(6, 3)
-// CHECK-DAG:   %[[VAL_4:.*]] = aie.tile(5, 4)
-// CHECK-DAG:   %[[VAL_5:.*]] = aie.tile(6, 4)
-// CHECK-COUNT-6:    aie.lock(%[[VAL_2]], {{.*}}) {init = 0 : i32}
-// CHECK-COUNT-6:    aie.lock(%[[VAL_3]], {{.*}}) {init = 0 : i32}
-// CHECK-COUNT-6:    aie.lock(%[[VAL_4]], {{.*}}) {init = 0 : i32}
-// CHECK-COUNT-6:    aie.lock(%[[VAL_5]], {{.*}}) {init = 0 : i32}
+// CHECK-LABEL:   aie.device(npu1) @herd_0 {
+// CHECK-DAG:   %[[VAL_2:.*]] = aie.tile(0, 2)
+// CHECK-DAG:   %[[VAL_3:.*]] = aie.tile(1, 2)
+// CHECK-DAG:   %[[VAL_4:.*]] = aie.tile(0, 3)
+// CHECK-DAG:   %[[VAL_5:.*]] = aie.tile(1, 3)
+// CHECK-COUNT-8:    aie.lock(%[[VAL_2]], {{.*}}) {init = {{[0-2]}} : i32}
+// CHECK-COUNT-8:    aie.lock(%[[VAL_3]], {{.*}}) {init = {{[0-2]}} : i32}
+// CHECK-COUNT-8:    aie.lock(%[[VAL_4]], {{.*}}) {init = {{[0-2]}} : i32}
+// CHECK-COUNT-8:    aie.lock(%[[VAL_5]], {{.*}}) {init = {{[0-2]}} : i32}
 // CHECK-COUNT-5:    aie.buffer(%[[VAL_5]]) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK-COUNT-5:    aie.buffer(%[[VAL_4]]) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK-COUNT-5:    aie.buffer(%[[VAL_3]]) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK-COUNT-5:    aie.buffer(%[[VAL_2]]) {{{.*}}} : memref<32x32xi32, 2>
 // CHECK:   aie.mem(%[[VAL_5]])
 // CHECK:   aie.core(%[[VAL_5]]) {
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:     scf.for
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
@@ -47,16 +41,16 @@
 // CHECK:   }
 // CHECK:   aie.mem(%[[VAL_4]])
 // CHECK:   aie.core(%[[VAL_4]])
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:     scf.for
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
@@ -66,16 +60,16 @@
 // CHECK:   }
 // CHECK:   aie.mem(%[[VAL_3]])
 // CHECK:   aie.core(%[[VAL_3]])
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:     scf.for
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
@@ -85,16 +79,16 @@
 // CHECK:   }
 // CHECK:   aie.mem(%[[VAL_2]])
 // CHECK:   aie.core(%[[VAL_2]])
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:     aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:     aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:     scf.for
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:       aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:       aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:       linalg.matmul
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:       aie.use_lock({{.*}}, Release, %{{.*}})
@@ -179,7 +173,7 @@ module {
         scf.reduce.return %12 : !air.async.token
       }
     }
-    %10 = air.herd @herd_0 async [%async_token_0]  tile (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) attributes {id = 1 : i32, x_loc = 5 : i64, y_loc = 3 : i64} {
+    %10 = air.herd @herd_0 async [%async_token_0]  tile (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) attributes {id = 1 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
       %c64_1 = arith.constant 64 : index
       %c0_2 = arith.constant 0 : index
       %c512_3 = arith.constant 512 : index

--- a/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
+++ b/mlir/test/Conversion/AIRToAIE/async_gemm_w_pingpong_to_locks.mlir
@@ -5,6 +5,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: *
+// AIE1 only. mlir-aie has dropped AIE1 support, and this lowers a multi-pass
+// transfer, which needs a repeat count AIE1 has no register for -- rejected
+// since mlir-aie#3577 added verifyDMARepeatCount. Before that the count was
+// silently dropped by the AIE1 backend, so the transfer ran once instead of
+// twice; the verifier made an existing miscompile visible.
 // RUN: air-opt -air-to-aie="emit-while-loop=false use-objectfifo=false row-offset=3 col-offset=5 device=xcvc1902" %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(xcvc1902) @herd_0 {

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -6,17 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: *
-// AIE1 only, implicitly: no device= is given, so air-to-aie falls back to its
-// xcvc1902 default, and the CHECKs below assert AIE1 lock semantics (Acquire;
-// AIE2 emits AcquireGreaterEqual). mlir-aie has dropped AIE1 support.
-// RUN: air-opt %s -air-to-aie | FileCheck %s
+// RUN: air-opt %s -air-to-aie="device=npu1 row-offset=2 col-offset=0" | FileCheck %s
 // CHECK: aie.core({{.*}}) {
-// CHECK: aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK: aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK: aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK: aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK: scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}} {
-// CHECK:   aie.use_lock({{.*}}, Acquire, %{{.*}})
-// CHECK:   aie.use_lock({{.*}}, Acquire, %{{.*}})
+// CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
+// CHECK:   aie.use_lock({{.*}}, AcquireGreaterEqual, %{{.*}})
 // CHECK:   linalg.matmul ins({{.*}}, {{.*}} : memref<32x32xi32, 2>, memref<32x32xi32, 2>) outs({{.*}} : memref<32x32xi32, 2>)
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})
 // CHECK:   aie.use_lock({{.*}}, Release, %{{.*}})

--- a/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
+++ b/mlir/test/Conversion/AIRToAIE/lower_herd_air_regions.mlir
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: *
+// AIE1 only, implicitly: no device= is given, so air-to-aie falls back to its
+// xcvc1902 default, and the CHECKs below assert AIE1 lock semantics (Acquire;
+// AIE2 emits AcquireGreaterEqual). mlir-aie has dropped AIE1 support.
 // RUN: air-opt %s -air-to-aie | FileCheck %s
 // CHECK: aie.core({{.*}}) {
 // CHECK: aie.use_lock({{.*}}, Acquire, %{{.*}})

--- a/mlir/test/aircc/emit_txn_cpp.mlir
+++ b/mlir/test/aircc/emit_txn_cpp.mlir
@@ -29,8 +29,13 @@
 // CHECK: [[BU:v[0-9]+]] = (uint32_t) [[B32]]
 // CHECK: [[WORDS:v[0-9]+]] = [[BU]] / v{{[0-9]+}}
 // CHECK: [[LEN:v[0-9]+]] = (int32_t) [[WORDS]]
+// mlir-aie #3559 packs the shim BD's register block into one blockwrite, so the
+// length is now word 0 of that block rather than its own write32. Same property:
+// the runtime-derived length reaches 0x1d000.
 // CHECK: [[ADDR:v[0-9]+]] = 118784u
-// CHECK-NEXT: txn_append_write32(txn, [[ADDR]], [[LEN]])
+// CHECK-NEXT: [[BD:v[0-9]+]]{{\[}}8] = {}
+// CHECK-NEXT: [[BD]]{{\[}}0] = [[LEN]]
+// CHECK: txn_append_blockwrite(txn, [[ADDR]], [[BD]]
 
 module {
   air.channel @rb [1]

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=7e00b57955e108fe9d8e9419f5828a0c7e650858
-WHEEL_VERSION=1.4.2.dev16+g7e00b57
+export HASH=4c8b56f5db25a9a89582bffed3ad933dea5b1d15
+WHEEL_VERSION=1.4.3.dev17+g4c8b56f
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
## Description

Bumps mlir-aie from `1.4.2.dev16+g7e00b57` to `1.4.3.dev17+g4c8b56f`.

The target is the merge commit of [mlir-aie#3580](https://github.com/Xilinx/mlir-aie/pull/3580) itself, which splits aiecc's two `--unified` behaviours apart: a device's cores are lowered once, but still compile to separate objects in parallel. That is the prerequisite for #1873, which asks aircc for the flag; before the split, `--unified` also merged the objects and regressed single-device designs 2.7x.

LLVM is unchanged. Both sides pin `56bcc1871734e6c375a254dec0ec74eb18d04a2e` / `DATETIME=2026080106`, so `utils/clone-llvm.sh` stays as it is.

## What the bump drags in

Three upstream changes touch op signatures we build:

- **#3577** (out-of-order S2MM DMA) inserts `out_of_order_id` into `aie.dma_bd` between `packet` and `burst_length`, and adds `out_of_order` to `aie.dma_start`.
- **#3546** adds `axcache` to `aie.dma_bd` and `aiex.npu.write_bd`.
- **#3559** packs the dynamic BD register block into one blockwrite, changing what `emit_txn_cpp` sees.

Four `create()` call sites in `AIRRtToNpuPass.cpp` and `AIRToAIEPass.cpp` are adapted positionally, and the `emit_txn_cpp` CHECKs follow the new blockwrite shape. No behaviour change intended on our side.

## Two AIE1 tests xfailed

mlir-aie has dropped AIE1. Two tests depend on it; the other 17 files naming `xcvc1902` still pass, so only the repeat-count path is affected.

`async_gemm_w_pingpong_to_locks` asks for a multi-pass transfer on a target whose `getMaxRepeatCount()` is 0. #3577's new `verifyDMARepeatCount` rejects it — and that verifier exposed an existing miscompile rather than causing one. The AIE1 backend branches on architecture before repeat is ever read:

```cpp
if (target_model.getTargetArch() == AIEArch::AIE1) {
  XAie_DmaChannelPushBdToQueue(..., /* BdNum */ bdNum);   // no repeat argument
} else if (op.getOutOfOrder()) {
  int repeatCount = op.getRepeatCount() + 1;              // AIE2 only
```

So the count never reached the emitted CDO: that transfer has been running once where the IR asked for twice.

`lower_herd_air_regions` is AIE1 only by accident — it passes no `device=`, so `air-to-aie` falls back to its `xcvc1902` default, and its CHECKs assert AIE1 lock semantics. I tried to retarget it instead of xfailing: npu2 additionally needs `row-offset=2` (NPU core rows start at 2), and even then it emits `AcquireGreaterEqual` where the test expects `Acquire`. Half-porting it would assert less than it does now, so it is xfailed with the other.

I also tried to *fix* the repeat-count case rather than xfail it, by unfolding an N-pass task into N single-pass ones. That trades an invalid repeat count for BD exhaustion — `'aie.mem' op has more than 16 blocks` on the pingpong test — so it is not in this PR.

## Follow-up this exposes

`air-to-aie` still defaults to `xcvc1902`, so any invocation omitting `device=` now targets an architecture upstream no longer supports. That default is exactly how `lower_herd_air_regions` got caught. Changing it is a behavioural change with its own blast radius, so it is left for a separate PR.

## Verification

Ryzen AI 9 HX 370 (Strix, npu2), Peano.

| check | result |
|---|---|
| `check-air-mlir` | 538 tests, 522 passed, **0 unexpected failures** (xfail 7 -> 9) |
| `llama32_1b_q4nx` `make compile` | passes |
| `llama32_1b_q4nx` `make verify` (hardware) | **PASS 2/2** |
| GEMV bf16 npu2 configs (hardware) | PASS |

Not covered: Chess (no Vitis on this host) and npu1 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
