### PR TITLE
[programming_examples] air.api: herd_dataflow, plus air.parallel

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -4577,6 +4577,12 @@ private:
   template <typename T>
   bool areConsistentMemoryAccessPattern(std::vector<T> a_vec,
                                         std::vector<T> b_vec) {
+    // a_vec[0] is the pattern every other op is compared against, so there is
+    // nothing to compare when it is empty -- and indexing it is out of bounds.
+    // A channel reaches here with no puts, or no gets, once an earlier fusion
+    // in this same pass has moved them onto another symbol.
+    if (a_vec.empty())
+      return false;
     Value memref = a_vec[0].getMemref();
     SmallVector<Value> offsets = air::getOffsetsAsValues(a_vec[0]);
     SmallVector<Value> sizes = air::getSizesAsValues(a_vec[0]);
@@ -5379,10 +5385,16 @@ private:
         getChannelGetOpThroughSymbol(chan_a);
     std::vector<air::ChannelGetOp> b_gets =
         getChannelGetOpThroughSymbol(chan_b);
-    if (!b_puts[0]->getParentOfType<air::HerdOp>()) {
+    // Each side is merged only when both channels have one to merge. A channel
+    // whose puts or gets have already been moved onto another symbol earlier
+    // in this pass reaches here with an empty list, and there is simply
+    // nothing to do for that half -- indexing it is out of bounds.
+    if (!a_puts.empty() && !b_puts.empty() &&
+        !b_puts[0]->getParentOfType<air::HerdOp>()) {
       mergeChannelOpsTemporally(a_puts[0], b_puts[0], mergeByLBOrUB);
     }
-    if (!b_gets[0]->getParentOfType<air::HerdOp>()) {
+    if (!a_gets.empty() && !b_gets.empty() &&
+        !b_gets[0]->getParentOfType<air::HerdOp>()) {
       mergeChannelOpsTemporally(a_gets[0], b_gets[0], mergeByLBOrUB);
     }
   }

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels_empty_endpoint_list.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_channels_empty_endpoint_list.mlir
@@ -1,0 +1,245 @@
+//===- fuse_channels_empty_endpoint_list.mlir ------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s -air-fuse-channels | FileCheck %s
+
+// A channel reaches the fusion helpers with no puts, or no gets, once an
+// earlier fusion in the same run has moved them onto another symbol. The
+// helpers read a_vec[0] as the pattern to compare against, and
+// a_puts[0]/b_puts[0]/a_gets[0]/b_gets[0] as the ops to merge, so an empty list
+// aborted the pass on
+//
+//   std::vector<xilinx::air::ChannelGetOp>::operator[]:
+//   Assertion '__n < this->size()' failed
+//
+// which without assertions is an out-of-bounds read instead. Both sites are hit
+// in turn: guarding only the first moves the abort to the second.
+//
+// This is the segment of herd_dataflow with its per-column staging written out
+// rather than left in an scf.forall -- three herds chained by channels, and a
+// memtile buffer fanned out to a row of cores with a constant bundle index per
+// column. The check is only that the pass completes and the pipeline is intact.
+
+// CHECK-LABEL: func.func @func1
+// CHECK: air.segment
+// CHECK: air.herd
+// CHECK: air.herd
+// CHECK: air.herd
+// CHECK: return
+
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0] -> (s0 * 256)>
+#map2 = affine_map<()[s0] -> (s0 * 256 + 64)>
+#map3 = affine_map<()[s0] -> (s0 * 256 + 128)>
+#map4 = affine_map<()[s0] -> (s0 * 256 + 192)>
+module {
+  air.channel @channel_0 []
+  air.channel @channel_1 []
+  air.channel @channel_2 []
+  air.channel @channel_3 []
+  air.channel @channel_4 []
+  air.channel @channel_5 []
+  air.channel @channel_6 []
+  air.channel @channel_7 []
+  air.channel @channel_8 []
+  air.channel @channel_9 []
+  air.channel @channel_10 []
+  air.channel @channel_11 []
+  func.func private @add_3_bf16(memref<64x64xbf16, 2 : i32>, memref<64x64xbf16, 2 : i32>) attributes {link_with = "extern_func.o", llvm.emit_c_interface}
+  air.channel @L2ToL1Chan1 [4, 1]
+  air.channel @L2ToL1Chan2 [4, 1]
+  air.channel @L1ToL1Chan1 [4, 1]
+  air.channel @L1ToL1Chan2 [4, 1] {channel_type = "npu_cascade"}
+  air.channel @L1ToL2Chan1 [4, 1]
+  func.func @func1(%arg0: memref<256x256xbf16>, %arg1: memref<256x256xbf16>, %arg2: memref<256x256xbf16>) {
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%arg3, %arg4) in (%arg5=%c4, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16> attributes {id = 1 : i32} {
+      %1 = affine.apply #map()[%arg3]
+      %2 = affine.apply #map1()[%arg4]
+      %3 = air.channel.put async  @channel_0[] (%arg7[%1, %2] [64, 64] [256, 1]) {id = 1 : i32} : (memref<256x256xbf16>)
+      %4 = air.channel.put async  @channel_1[] (%arg8[%1, %2] [64, 64] [256, 1]) {id = 2 : i32} : (memref<256x256xbf16>)
+      %5 = affine.apply #map2()[%arg4]
+      %6 = air.channel.put async  @channel_2[] (%arg7[%1, %5] [64, 64] [256, 1]) {id = 3 : i32} : (memref<256x256xbf16>)
+      %7 = air.channel.put async  @channel_3[] (%arg8[%1, %5] [64, 64] [256, 1]) {id = 4 : i32} : (memref<256x256xbf16>)
+      %8 = affine.apply #map3()[%arg4]
+      %9 = air.channel.put async  @channel_4[] (%arg7[%1, %8] [64, 64] [256, 1]) {id = 5 : i32} : (memref<256x256xbf16>)
+      %10 = air.channel.put async  @channel_5[] (%arg8[%1, %8] [64, 64] [256, 1]) {id = 6 : i32} : (memref<256x256xbf16>)
+      %11 = affine.apply #map4()[%arg4]
+      %12 = air.channel.put async  @channel_6[] (%arg7[%1, %11] [64, 64] [256, 1]) {id = 7 : i32} : (memref<256x256xbf16>)
+      %13 = air.channel.put async  @channel_7[] (%arg8[%1, %11] [64, 64] [256, 1]) {id = 8 : i32} : (memref<256x256xbf16>)
+      %14 = air.channel.get async  @channel_8[] (%arg9[%1, %2] [64, 64] [256, 1]) {id = 9 : i32} : (memref<256x256xbf16>)
+      %15 = air.channel.get async [%14]  @channel_9[] (%arg9[%1, %5] [64, 64] [256, 1]) {id = 10 : i32} : (memref<256x256xbf16>)
+      %16 = air.channel.get async [%15]  @channel_10[] (%arg9[%1, %8] [64, 64] [256, 1]) {id = 11 : i32} : (memref<256x256xbf16>)
+      %17 = air.channel.get async [%16]  @channel_11[] (%arg9[%1, %11] [64, 64] [256, 1]) {id = 12 : i32} : (memref<256x256xbf16>)
+      %18 = air.segment @segment_0 async  attributes {id = 2 : i32} {
+        %c4_0 = arith.constant 4 : index
+        %c3 = arith.constant 3 : index
+        %c2 = arith.constant 2 : index
+        %c1_1 = arith.constant 1 : index
+        %c0 = arith.constant 0 : index
+        %async_token, %results = air.execute -> (memref<64x256xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x256xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x256xbf16, 1 : i32>
+        }
+        %async_token_2, %results_3 = air.execute -> (memref<64x256xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x256xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x256xbf16, 1 : i32>
+        }
+        %async_token_4, %results_5 = air.execute -> (memref<64x256xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x256xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x256xbf16, 1 : i32>
+        }
+        %19 = air.channel.get async [%async_token]  @channel_0[] (%results[0, 0] [64, 64] [256, 1]) {id = 13 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %20 = air.channel.get async [%async_token_2]  @channel_1[] (%results_3[0, 0] [64, 64] [256, 1]) {id = 14 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %21 = air.channel.get async [%19]  @channel_2[] (%results[0, 64] [64, 64] [256, 1]) {id = 15 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %22 = air.channel.get async [%20]  @channel_3[] (%results_3[0, 64] [64, 64] [256, 1]) {id = 16 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %23 = air.channel.get async [%21]  @channel_4[] (%results[0, 128] [64, 64] [256, 1]) {id = 17 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %24 = air.channel.get async [%22]  @channel_5[] (%results_3[0, 128] [64, 64] [256, 1]) {id = 18 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %25 = air.channel.get async [%23]  @channel_6[] (%results[0, 192] [64, 64] [256, 1]) {id = 19 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %26 = air.channel.get async [%24]  @channel_7[] (%results_3[0, 192] [64, 64] [256, 1]) {id = 20 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %27 = air.channel.put async [%19]  @L2ToL1Chan1[%c0, %c0] (%results[0, 0] [64, 64] [256, 1]) {id = 21 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %28 = air.channel.put async [%20]  @L2ToL1Chan2[%c0, %c0] (%results_3[0, 0] [64, 64] [256, 1]) {id = 22 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %29 = air.channel.put async [%21]  @L2ToL1Chan1[%c1_1, %c0] (%results[0, 64] [64, 64] [256, 1]) {id = 23 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %30 = air.channel.put async [%22]  @L2ToL1Chan2[%c1_1, %c0] (%results_3[0, 64] [64, 64] [256, 1]) {id = 24 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %31 = air.channel.put async [%23]  @L2ToL1Chan1[%c2, %c0] (%results[0, 128] [64, 64] [256, 1]) {id = 25 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %32 = air.channel.put async [%24]  @L2ToL1Chan2[%c2, %c0] (%results_3[0, 128] [64, 64] [256, 1]) {id = 26 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %33 = air.channel.put async [%25]  @L2ToL1Chan1[%c3, %c0] (%results[0, 192] [64, 64] [256, 1]) {id = 27 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %34 = air.channel.put async [%26]  @L2ToL1Chan2[%c3, %c0] (%results_3[0, 192] [64, 64] [256, 1]) {id = 28 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %35 = air.herd @herd_0 async [%async_token_4]  tile (%arg10, %arg11) in (%arg12=%c4_0, %arg13=%c1_1) attributes {id = 3 : i32} {
+          %c16 = arith.constant 16 : index
+          %c1_9 = arith.constant 1 : index
+          %c64 = arith.constant 64 : index
+          %cst = arith.constant 0.000000e+00 : bf16
+          %c0_10 = arith.constant 0 : index
+          %async_token_11, %results_12 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %async_token_13, %results_14 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %async_token_15, %results_16 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %46 = air.channel.get async [%async_token_11]  @L2ToL1Chan1[%arg10, %c0_10] (%results_12[] [] []) {id = 29 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %47 = air.channel.get async [%async_token_13]  @L2ToL1Chan2[%arg10, %c0_10] (%results_14[] [] []) {id = 30 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %48 = air.wait_all async [%async_token_15, %46, %47] 
+          %49 = scf.for %arg14 = %c0_10 to %c64 step %c1_9 iter_args(%arg15 = %48) -> (!air.async.token) {
+            %51 = scf.for %arg16 = %c0_10 to %c64 step %c16 iter_args(%arg17 = %arg15) -> (!air.async.token) {
+              %async_token_20, %results_21 = air.execute [%arg17] -> (vector<16xbf16>) {
+                %54 = vector.transfer_read %results_12[%arg14, %arg16], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
+                air.execute_terminator %54 : vector<16xbf16>
+              }
+              %async_token_22, %results_23 = air.execute [%arg17] -> (vector<16xbf16>) {
+                %54 = vector.transfer_read %results_14[%arg14, %arg16], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
+                air.execute_terminator %54 : vector<16xbf16>
+              }
+              %52 = arith.addf %results_21, %results_23 : vector<16xbf16>
+              %async_token_24 = air.execute [%arg17] {
+                vector.transfer_write %52, %results_16[%arg14, %arg16] {in_bounds = [true]} : vector<16xbf16>, memref<64x64xbf16, 2 : i32>
+              }
+              %53 = air.wait_all async [%async_token_20, %async_token_22, %async_token_24] 
+              scf.yield %53 : !air.async.token
+            }
+            scf.yield %51 : !air.async.token
+          }
+          %async_token_17 = air.execute [%49] {
+            memref.dealloc %results_14 : memref<64x64xbf16, 2 : i32>
+          }
+          %async_token_18 = air.execute [%49] {
+            memref.dealloc %results_12 : memref<64x64xbf16, 2 : i32>
+          }
+          %50 = air.channel.put async [%49]  @L1ToL1Chan1[%arg10, %c0_10] (%results_16[] [] []) {id = 31 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %async_token_19 = air.execute [%50] {
+            memref.dealloc %results_16 : memref<64x64xbf16, 2 : i32>
+          }
+        }
+        %36 = air.herd @herd_1 async [%35]  tile (%arg10, %arg11) in (%arg12=%c4_0, %arg13=%c1_1) attributes {id = 4 : i32} {
+          %c16 = arith.constant 16 : index
+          %c1_9 = arith.constant 1 : index
+          %c64 = arith.constant 64 : index
+          %cst = arith.constant 0.000000e+00 : bf16
+          %c0_10 = arith.constant 0 : index
+          %async_token_11, %results_12 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %async_token_13, %results_14 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %46 = air.channel.get async [%async_token_11]  @L1ToL1Chan1[%arg10, %c0_10] (%results_12[] [] []) {id = 32 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %47 = air.wait_all async [%async_token_13, %46] 
+          %48 = scf.for %arg14 = %c0_10 to %c64 step %c1_9 iter_args(%arg15 = %47) -> (!air.async.token) {
+            %50 = scf.for %arg16 = %c0_10 to %c64 step %c16 iter_args(%arg17 = %arg15) -> (!air.async.token) {
+              %async_token_17, %results_18 = air.execute [%arg17] -> (vector<16xbf16>) {
+                %52 = vector.transfer_read %results_12[%arg14, %arg16], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
+                air.execute_terminator %52 : vector<16xbf16>
+              }
+              %async_token_19 = air.execute [%arg17] {
+                vector.transfer_write %results_18, %results_14[%arg14, %arg16] {in_bounds = [true]} : vector<16xbf16>, memref<64x64xbf16, 2 : i32>
+              }
+              %51 = air.wait_all async [%async_token_17, %async_token_19] 
+              scf.yield %51 : !air.async.token
+            }
+            scf.yield %50 : !air.async.token
+          }
+          %async_token_15 = air.execute [%48] {
+            memref.dealloc %results_12 : memref<64x64xbf16, 2 : i32>
+          }
+          %49 = air.channel.put async [%48]  @L1ToL1Chan2[%arg10, %c0_10] (%results_14[] [] []) {id = 33 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %async_token_16 = air.execute [%49] {
+            memref.dealloc %results_14 : memref<64x64xbf16, 2 : i32>
+          }
+        }
+        %37 = air.herd @herd_2 async [%36]  tile (%arg10, %arg11) in (%arg12=%c4_0, %arg13=%c1_1) attributes {id = 5 : i32, link_with = "extern_func.o"} {
+          %c0_9 = arith.constant 0 : index
+          %async_token_10, %results_11 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %async_token_12, %results_13 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %46 = air.channel.get async [%async_token_10]  @L1ToL1Chan2[%arg10, %c0_9] (%results_11[] [] []) {id = 34 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %async_token_14 = air.execute [%46, %async_token_12] {
+            func.call @add_3_bf16(%results_11, %results_13) : (memref<64x64xbf16, 2 : i32>, memref<64x64xbf16, 2 : i32>) -> ()
+          }
+          %async_token_15 = air.execute [%async_token_14] {
+            memref.dealloc %results_11 : memref<64x64xbf16, 2 : i32>
+          }
+          %47 = air.channel.put async [%async_token_14]  @L1ToL2Chan1[%arg10, %c0_9] (%results_13[] [] []) {id = 35 : i32} : (memref<64x64xbf16, 2 : i32>)
+          %async_token_16 = air.execute [%47] {
+            memref.dealloc %results_13 : memref<64x64xbf16, 2 : i32>
+          }
+        }
+        %async_token_6 = air.execute [%34, %32, %30, %28] {
+          memref.dealloc %results_3 : memref<64x256xbf16, 1 : i32>
+        }
+        %async_token_7 = air.execute [%33, %31, %29, %27] {
+          memref.dealloc %results : memref<64x256xbf16, 1 : i32>
+        }
+        %38 = air.channel.get async [%37]  @L1ToL2Chan1[%c0, %c0] (%results_5[0, 0] [64, 64] [256, 1]) {id = 36 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %39 = air.channel.put async [%38]  @channel_8[] (%results_5[0, 0] [64, 64] [256, 1]) {id = 37 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %40 = air.channel.get async [%37]  @L1ToL2Chan1[%c1_1, %c0] (%results_5[0, 64] [64, 64] [256, 1]) {id = 38 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %41 = air.channel.put async [%38, %40]  @channel_9[] (%results_5[0, 64] [64, 64] [256, 1]) {id = 39 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %42 = air.channel.get async [%37]  @L1ToL2Chan1[%c2, %c0] (%results_5[0, 128] [64, 64] [256, 1]) {id = 40 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %43 = air.channel.put async [%38, %40, %42]  @channel_10[] (%results_5[0, 128] [64, 64] [256, 1]) {id = 41 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %44 = air.channel.get async [%37]  @L1ToL2Chan1[%c3, %c0] (%results_5[0, 192] [64, 64] [256, 1]) {id = 42 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %45 = air.channel.put async [%38, %40, %42, %44]  @channel_11[] (%results_5[0, 192] [64, 64] [256, 1]) {id = 43 : i32} : (memref<64x256xbf16, 1 : i32>)
+        %async_token_8 = air.execute [%45, %43, %41, %39] {
+          memref.dealloc %results_5 : memref<64x256xbf16, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}

--- a/programming_examples/herd_dataflow/air.mlir
+++ b/programming_examples/herd_dataflow/air.mlir
@@ -1,144 +1,133 @@
-
-#map = affine_map<()[s0] -> (s0 * 96)>
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 64)>
+#map2 = affine_map<()[s0] -> (s0)>
 module {
-  // External function for the final compute stage
   func.func private @add_3_bf16(memref<64x64xbf16, 2 : i32>, memref<64x64xbf16, 2 : i32>) attributes {link_with = "extern_func.o", llvm.emit_c_interface}
-
-  // AIR channels model hardware FIFOs for inter-stage communication
-  air.channel @L2ToL1Chan1 [4, 1]         // L2 to L1, input A; default channel_type is "npu_dma_stream", representing data movement performed using DMA streaming interconnects
-  air.channel @L2ToL1Chan2 [4, 1]         // L2 to L1, input B
-  air.channel @L1ToL1Chan1 [4, 1]         // Between herd_0 and herd_1
-  air.channel @L1ToL1Chan2 [4, 1] {channel_type = "npu_cascade"} // Between herd_1 and herd_2; channel_type="npu_cascade" means this channel is expected to map to cascade connections (peer-to-peer communication between compute tiles)
-  air.channel @L1ToL2Chan1 [4, 1]         // Output from herd_2 to L2
-
-  // Top-level function: runtime dispatch over a 4x1 iteration space (not necessarily hardware parallelism)
+  air.channel @L2ToL1Chan1 [4, 1]
+  air.channel @L2ToL1Chan2 [4, 1]
+  air.channel @L1ToL1Chan1 [4, 1]
+  air.channel @L1ToL1Chan2 [4, 1] {channel_type = "npu_cascade"}
+  air.channel @L1ToL2Chan1 [4, 1]
   func.func @func1(%arg0: memref<256x256xbf16>, %arg1: memref<256x256xbf16>, %arg2: memref<256x256xbf16>) {
-    %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index
-    // air.launch: runtime dispatch over a 4x1 iteration space (may be sequential or parallel depending on runtime)
-    air.launch (%arg5, %arg6) in (%arg7=%c4, %arg8=%c1) args(%arg9=%arg0, %arg10=%arg1, %arg11=%arg2) : memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16> {
-      %c0 = arith.constant 0 : index
-      %c1_0 = arith.constant 1 : index
-      %c4_0 = arith.constant 4 : index
-      %c64 = arith.constant 64 : index
-      %c256 = arith.constant 256 : index
-      // Each segment is a program mapped to a hardware tile of resources, including the L1 and L2 memories and compute cores
-      air.segment @seg args(%arg51=%arg5, %arg61=%arg6, %arg91=%arg9, %arg101=%arg10, %arg111=%arg11) : index, index, memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16> {
-        // Allocate L2 buffers for tile-local computation (memory space 1 = L2)
+    %c1 = arith.constant 1 : index
+    air.launch (%arg3, %arg4) in (%arg5=%c4, %arg6=%c1) args(%arg7=%arg0, %arg8=%arg1, %arg9=%arg2) : memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16> {
+      air.segment @segment_0  args(%arg10=%arg3, %arg11=%arg4, %arg12=%arg7, %arg13=%arg8, %arg14=%arg9) : index, index, memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16> {
+        %alloc = memref.alloc() : memref<64x256xbf16, 1 : i32>
+        %alloc_0 = memref.alloc() : memref<64x256xbf16, 1 : i32>
         %alloc_1 = memref.alloc() : memref<64x256xbf16, 1 : i32>
-        %alloc_2 = memref.alloc() : memref<64x256xbf16, 1 : i32>
-        %alloc_3 = memref.alloc() : memref<64x256xbf16, 1 : i32>
-
-        %c0_2 = arith.constant 0 : index
-        %c1_1 = arith.constant 1 : index
-        %c2_1 = arith.constant 2 : index
-        %c3_1 = arith.constant 3 : index
-        %c4_1 = arith.constant 4 : index
-        %c64_1 = arith.constant 64 : index
-        %c256_1 = arith.constant 256 : index
-
-        %pid_x_offset = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%arg51]
-        // Stage 1: DMA from L2 to L1 for both inputs, in parallel for each sub-tile
-        // This parallel loop partitions the DMA transfers so that each iteration moves a unique tile's data from L2 to its corresponding L1 buffer.
-        // air.dma_memcpy_nd represents a full memcpy, expected to be mapped to hardware DMAs, specifying both source and destination.
-        scf.parallel (%par1) = (%c0_2) to (%c4_1) step (%c1_1) {
-          %apply = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%par1]
-          air.dma_memcpy_nd (%alloc_1[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1], %arg91[%pid_x_offset, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<64x256xbf16, 1 : i32>, memref<256x256xbf16>)
-          air.dma_memcpy_nd (%alloc_2[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1], %arg101[%pid_x_offset, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<64x256xbf16, 1 : i32>, memref<256x256xbf16>)
+        scf.forall (%arg15) in (4) {
+          %0 = affine.apply #map()[%arg15]
+          %1 = affine.apply #map()[%arg10]
+          %2 = affine.apply #map1()[%arg11, %arg15]
+          air.dma_memcpy_nd (%alloc[0, %0] [64, 64] [256, 1], %arg12[%1, %2] [64, 64] [256, 1]) : (memref<64x256xbf16, 1 : i32>, memref<256x256xbf16>)
+          %3 = affine.apply #map()[%arg15]
+          %4 = affine.apply #map()[%arg10]
+          %5 = affine.apply #map1()[%arg11, %arg15]
+          air.dma_memcpy_nd (%alloc_0[0, %3] [64, 64] [256, 1], %arg13[%4, %5] [64, 64] [256, 1]) : (memref<64x256xbf16, 1 : i32>, memref<256x256xbf16>)
         }
-        // Stage 2: Send L1 buffers to next stage via AIR channels
-        // This parallel loop partitions the channel put operations, so each iteration sends a specific tile's L1 buffer to its corresponding downstream channel.
-        // air.channel.put represents a "half DMA" operation, expected to be mapped to hardware DMAs but only specifies the source (put) end.
-        scf.parallel (%par1) = (%c0_2) to (%c4_1) step (%c1_1) {
-          %apply = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%par1]
-          air.channel.put  @L2ToL1Chan1[%par1, %c0_2] (%alloc_1[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<64x256xbf16, 1 : i32>)
-          air.channel.put  @L2ToL1Chan2[%par1, %c0_2] (%alloc_2[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<64x256xbf16, 1 : i32>)
+        scf.forall (%arg15) in (4) {
+          %0 = affine.apply #map()[%arg15]
+          %1 = affine.apply #map2()[%arg15]
+          %c0 = arith.constant 0 : index
+          air.channel.put  @L2ToL1Chan1[%1, %c0] (%alloc[0, %0] [64, 64] [256, 1]) : (memref<64x256xbf16, 1 : i32>)
+          %2 = affine.apply #map()[%arg15]
+          %3 = affine.apply #map2()[%arg15]
+          %c0_8 = arith.constant 0 : index
+          air.channel.put  @L2ToL1Chan2[%3, %c0_8] (%alloc_0[0, %2] [64, 64] [256, 1]) : (memref<64x256xbf16, 1 : i32>)
         }
-        
-        // Stage 3: First compute herd (herd_0): 4x1 shape. Each of the 4 tiles asynchronously receives two input tiles via channels, performs vector addition, and sends the result to the next stage.
-        air.herd @herd_0  tile (%arg22, %arg23) in (%arg24=%c4_1, %arg25=%c1_1) {
-          %alloc_a = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          %alloc_b = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          %alloc_c = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          // Receive input tiles from previous stage via channels
-          air.channel.get  @L2ToL1Chan1[%arg22, %arg23] (%alloc_a[] [] []) : (memref<64x64xbf16, 2 : i32>)
-          air.channel.get  @L2ToL1Chan2[%arg22, %arg23] (%alloc_b[] [] []) : (memref<64x64xbf16, 2 : i32>)
-          %c0_3 = arith.constant 0 : index
-          %c1_3 = arith.constant 1 : index
-          %c64_3 = arith.constant 64 : index
-          %c16_3 = arith.constant 16 : index
-          
-          // Vectorized tile-wise addition: C = A + B
-          // This is the first form of kernel coding in this example: MLIR vector dialect is used to represent vector loads, stores, and computation.
-          // The vectorized code here maps directly to hardware vector intrinsics.
-          scf.for %arg29 = %c0_3 to %c64_3 step %c1_3 {
-            %subview = memref.subview %alloc_a[%arg29, 0] [1, 64] [1, 1] : memref<64x64xbf16, 2 : i32> to memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-            %subview_10 = memref.subview %alloc_b[%arg29, 0] [1, 64] [1, 1] : memref<64x64xbf16, 2 : i32> to memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-            %subview_11 = memref.subview %alloc_c[%arg29, 0] [1, 64] [1, 1] : memref<64x64xbf16, 2 : i32> to memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-            scf.for %arg30 = %c0_3 to %c64_3 step %c16_3 {
-              %subview_12 = memref.subview %subview[0, %arg30] [1, 16] [1, 1] : memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32> to memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-              %subview_13 = memref.subview %subview_10[0, %arg30] [1, 16] [1, 1] : memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32> to memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-              %subview_14 = memref.subview %subview_11[0, %arg30] [1, 16] [1, 1] : memref<1x64xbf16, strided<[64, 1], offset: ?>, 2 : i32> to memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32>
-              %collapse_shape_a = memref.collapse_shape %subview_12 [[0, 1]] : memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32> into memref<16xbf16, strided<[1], offset: ?>, 2 : i32>
-              %collapse_shape_b = memref.collapse_shape %subview_13 [[0, 1]] : memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32> into memref<16xbf16, strided<[1], offset: ?>, 2 : i32>
-              %collapse_shape_c = memref.collapse_shape %subview_14 [[0, 1]] : memref<1x16xbf16, strided<[64, 1], offset: ?>, 2 : i32> into memref<16xbf16, strided<[1], offset: ?>, 2 : i32>
-              %poison = ub.poison : bf16
-              %3 = vector.transfer_read %collapse_shape_a[%c0_3], %poison {in_bounds = [true]} : memref<16xbf16, strided<[1], offset: ?>, 2 : i32>, vector<16xbf16>
-              %4 = vector.transfer_read %collapse_shape_b[%c0_3], %poison {in_bounds = [true]} : memref<16xbf16, strided<[1], offset: ?>, 2 : i32>, vector<16xbf16>
+        %c4_2 = arith.constant 4 : index
+        %c1_3 = arith.constant 1 : index
+        air.herd @herd_0  tile (%arg15, %arg16) in (%arg17=%c4_2, %arg18=%c1_3) args(%arg19=%arg10, %arg20=%arg11, %arg21=%arg12, %arg22=%arg13, %arg23=%arg14, %arg24=%alloc, %arg25=%alloc_0, %arg26=%alloc_1) : index, index, memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32> {
+          %alloc_8 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %alloc_9 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %alloc_10 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %0 = affine.apply #map2()[%arg15]
+          %c0 = arith.constant 0 : index
+          air.channel.get  @L2ToL1Chan1[%0, %c0] (%alloc_8[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          %1 = affine.apply #map2()[%arg15]
+          %c0_11 = arith.constant 0 : index
+          air.channel.get  @L2ToL1Chan2[%1, %c0_11] (%alloc_9[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          %cst = arith.constant 0.000000e+00 : bf16
+          %c0_12 = arith.constant 0 : index
+          %c64 = arith.constant 64 : index
+          %c1_13 = arith.constant 1 : index
+          scf.for %arg27 = %c0_12 to %c64 step %c1_13 {
+            %c0_15 = arith.constant 0 : index
+            %c64_16 = arith.constant 64 : index
+            %c16 = arith.constant 16 : index
+            scf.for %arg28 = %c0_15 to %c64_16 step %c16 {
+              %3 = vector.transfer_read %alloc_8[%arg27, %arg28], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
+              %4 = vector.transfer_read %alloc_9[%arg27, %arg28], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
               %5 = arith.addf %3, %4 : vector<16xbf16>
-              vector.transfer_write %5, %collapse_shape_c[%c0_3] {in_bounds = [true]} : vector<16xbf16>, memref<16xbf16, strided<[1], offset: ?>, 2 : i32>
+              vector.transfer_write %5, %alloc_10[%arg27, %arg28] {in_bounds = [true]} : vector<16xbf16>, memref<64x64xbf16, 2 : i32>
             }
           }
-          // Send result to next herd via channel
-          air.channel.put  @L1ToL1Chan1[%arg22, %arg23] (%alloc_c[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          memref.dealloc %alloc_9 : memref<64x64xbf16, 2 : i32>
+          memref.dealloc %alloc_8 : memref<64x64xbf16, 2 : i32>
+          %2 = affine.apply #map2()[%arg15]
+          %c0_14 = arith.constant 0 : index
+          air.channel.put  @L1ToL1Chan1[%2, %c0_14] (%alloc_10[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          memref.dealloc %alloc_10 : memref<64x64xbf16, 2 : i32>
         }
-        // Stage 4: Second herd (herd_1): 4x1 shape. Each of the 4 tiles asynchronously receives a tile via channel, copies its contents, and sends it to the next stage.
-        air.herd @herd_1  tile (%arg22, %arg23) in (%arg24=%c4_1, %arg25=%c1_1) {
-          %alloc_a = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          %alloc_c = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          // Receive from previous herd via channel
-          air.channel.get  @L1ToL1Chan1[%arg22, %arg23] (%alloc_a[] [] []) : (memref<64x64xbf16, 2 : i32>)
-          %c0_3 = arith.constant 0 : index
-          %c1_3 = arith.constant 1 : index
-          %c64_3 = arith.constant 64 : index
-          // Second form of kernel writing: using the memref dialect to represent scalar load and store of individual data.
-          // This maps to scalar memory operations on the hardware.
-          scf.for %arg29 = %c0_3 to %c64_3 step %c1_3 {
-            scf.for %arg30 = %c0_3 to %c64_3 step %c1_3 {
-              %0 = memref.load %alloc_a[%arg29, %arg30] : memref<64x64xbf16, 2 : i32>
-              memref.store %0, %alloc_c[%arg29, %arg30] : memref<64x64xbf16, 2 : i32>
+        %c4_4 = arith.constant 4 : index
+        %c1_5 = arith.constant 1 : index
+        air.herd @herd_1  tile (%arg15, %arg16) in (%arg17=%c4_4, %arg18=%c1_5) args(%arg19=%arg10, %arg20=%arg11, %arg21=%arg12, %arg22=%arg13, %arg23=%arg14, %arg24=%alloc, %arg25=%alloc_0, %arg26=%alloc_1) : index, index, memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32> {
+          %alloc_8 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %alloc_9 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %0 = affine.apply #map2()[%arg15]
+          %c0 = arith.constant 0 : index
+          air.channel.get  @L1ToL1Chan1[%0, %c0] (%alloc_8[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          %cst = arith.constant 0.000000e+00 : bf16
+          %c0_10 = arith.constant 0 : index
+          %c64 = arith.constant 64 : index
+          %c1_11 = arith.constant 1 : index
+          scf.for %arg27 = %c0_10 to %c64 step %c1_11 {
+            %c0_13 = arith.constant 0 : index
+            %c64_14 = arith.constant 64 : index
+            %c16 = arith.constant 16 : index
+            scf.for %arg28 = %c0_13 to %c64_14 step %c16 {
+              %2 = vector.transfer_read %alloc_8[%arg27, %arg28], %cst {in_bounds = [true]} : memref<64x64xbf16, 2 : i32>, vector<16xbf16>
+              vector.transfer_write %2, %alloc_9[%arg27, %arg28] {in_bounds = [true]} : vector<16xbf16>, memref<64x64xbf16, 2 : i32>
             }
           }
-          // Send to next herd via channel (cascade type)
-          // This channel.put sends the output of herd_1 to herd_2 using the cascade interconnect, enabling direct peer-to-peer transfer between adjacent tiles.
-          air.channel.put  @L1ToL1Chan2[%arg22, %arg23] (%alloc_c[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          memref.dealloc %alloc_8 : memref<64x64xbf16, 2 : i32>
+          %1 = affine.apply #map2()[%arg15]
+          %c0_12 = arith.constant 0 : index
+          air.channel.put  @L1ToL1Chan2[%1, %c0_12] (%alloc_9[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          memref.dealloc %alloc_9 : memref<64x64xbf16, 2 : i32>
         }
-        // Stage 5: Third herd (herd_2): 4x1 shape. Each of the 4 tiles asynchronously receives a tile via channel, calls an external function for further computation, and sends the result to the output channel.
-        air.herd @herd_2  tile (%arg22, %arg23) in (%arg24=%c4_1, %arg25=%c1_1) attributes {link_with = "extern_func.o"} {
-          %alloc_a = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          %alloc_c = memref.alloc() : memref<64x64xbf16, 2 : i32> // L1 memory (memory space 2)
-          // Receive from previous herd via channel
-          // This channel.get receives input from herd_1 via the cascade interconnect, providing low-latency data movement into herd_2 from its neighbor tile.
-          air.channel.get  @L1ToL1Chan2[%arg22, %arg23] (%alloc_a[] [] []) : (memref<64x64xbf16, 2 : i32>)
-          %c0_3 = arith.constant 0 : index
-          %c1_3 = arith.constant 1 : index
-          %c64_3 = arith.constant 64 : index
-          // Third form of kernel coding: function call to an external kernel.
-          // The link_with attribute in the herd specifies which object file to link, containing the implementation of the function.
-          func.call @add_3_bf16(%alloc_a, %alloc_c) : (memref<64x64xbf16, 2 : i32>, memref<64x64xbf16, 2 : i32>) -> ()
-          // Send result back to L2 via channel
-          air.channel.put  @L1ToL2Chan1[%arg22, %arg23] (%alloc_c[] [] []) : (memref<64x64xbf16, 2 : i32>)
+        %c4_6 = arith.constant 4 : index
+        %c1_7 = arith.constant 1 : index
+        air.herd @herd_2  tile (%arg15, %arg16) in (%arg17=%c4_6, %arg18=%c1_7) args(%arg19=%arg10, %arg20=%arg11, %arg21=%arg12, %arg22=%arg13, %arg23=%arg14, %arg24=%alloc, %arg25=%alloc_0, %arg26=%alloc_1) : index, index, memref<256x256xbf16>, memref<256x256xbf16>, memref<256x256xbf16>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32>, memref<64x256xbf16, 1 : i32> attributes {link_with = "extern_func.o"} {
+          %alloc_8 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %alloc_9 = memref.alloc() : memref<64x64xbf16, 2 : i32>
+          %0 = affine.apply #map2()[%arg15]
+          %c0 = arith.constant 0 : index
+          air.channel.get  @L1ToL1Chan2[%0, %c0] (%alloc_8[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          func.call @add_3_bf16(%alloc_8, %alloc_9) : (memref<64x64xbf16, 2 : i32>, memref<64x64xbf16, 2 : i32>) -> ()
+          memref.dealloc %alloc_8 : memref<64x64xbf16, 2 : i32>
+          %1 = affine.apply #map2()[%arg15]
+          %c0_10 = arith.constant 0 : index
+          air.channel.put  @L1ToL2Chan1[%1, %c0_10] (%alloc_9[] [] []) : (memref<64x64xbf16, 2 : i32>)
+          memref.dealloc %alloc_9 : memref<64x64xbf16, 2 : i32>
         }
-        // Stage 6: Gather results from all tiles and DMA back to L2
-        // This parallel loop partitions the result collection and DMA, so each iteration gathers a tile's output from its channel and writes it back to its region in L2.
-        scf.parallel (%par1) = (%c0_2) to (%c4_1) step (%c1_1) {
-          %apply = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%par1]
-          // air.channel.get represents a "half DMA" operation, expected to be mapped to hardware DMAs but only specifies the destination (get) end.
-          air.channel.get  @L1ToL2Chan1[%par1, %c0_2] (%alloc_3[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<64x256xbf16, 1 : i32>) // L2 memory (memory space 1)
-          air.dma_memcpy_nd (%arg111[%pid_x_offset, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1], %alloc_3[%c0_2, %apply] [%c64_1, %c64_1] [%c256_1, %c1_1]) : (memref<256x256xbf16>, memref<64x256xbf16, 1 : i32>)
+        memref.dealloc %alloc_0 : memref<64x256xbf16, 1 : i32>
+        memref.dealloc %alloc : memref<64x256xbf16, 1 : i32>
+        scf.forall (%arg15) in (4) {
+          %0 = affine.apply #map()[%arg15]
+          %1 = affine.apply #map2()[%arg15]
+          %c0 = arith.constant 0 : index
+          air.channel.get  @L1ToL2Chan1[%1, %c0] (%alloc_1[0, %0] [64, 64] [256, 1]) : (memref<64x256xbf16, 1 : i32>)
+          %2 = affine.apply #map()[%arg15]
+          %3 = affine.apply #map()[%arg10]
+          %4 = affine.apply #map1()[%arg11, %arg15]
+          air.dma_memcpy_nd (%arg14[%3, %4] [64, 64] [256, 1], %alloc_1[0, %2] [64, 64] [256, 1]) : (memref<256x256xbf16>, memref<64x256xbf16, 1 : i32>)
         }
+        memref.dealloc %alloc_1 : memref<64x256xbf16, 1 : i32>
       }
     }
     return
   }
 }
+

--- a/programming_examples/herd_dataflow/run.py
+++ b/programming_examples/herd_dataflow/run.py
@@ -1,41 +1,171 @@
-# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A three-herd pipeline wired with channels, on air.api.
 
-"""AIR Herd Dataflow Example
+Each stage is a separate herd of NUM_COLUMNS cores, and a tile flows through
+all three without ever going back to L2:
 
-This script demonstrates building and running a dataflow module using AIR and MLIR constructs.
+    herd_0    a, b from L2        c = a + b        -> L1ToL1Chan1
+    herd_1    a from herd_0       c = a            -> L1ToL1Chan2  (cascade)
+    herd_2    a from herd_1       add_3_bf16(a,c)  -> L1ToL2Chan1
+
+    output = input_a + input_b + 3
+
+The middle link is ``channel_type="npu_cascade"``: a direct core-to-core
+connection between neighbouring tiles rather than a DMA stream. The two ends of
+it are two different herds, which is the point of the example -- a channel is a
+module-level symbol, so a herd finds what another herd sent by name alone, with
+nothing threaded through the segment.
+
+Three differences from the predecessor worth naming:
+
+* ``c[:] = a[:] + b[:]`` and ``c[:] = a[:]`` replace, respectively, a
+  doubly-nested loop building each 16-element strip out of two
+  ``memref.subview``s and a ``memref.collapse_shape``, and a scalar
+  ``memref.load``/``memref.store`` loop over all 4096 elements. The copy in
+  herd_1 is now vectorised at the same 16 lanes as the add, where the
+  predecessor moved one element per iteration.
+* The per-column L2 staging is a Python ``for`` rather than an ``scf.forall``
+  with two hand-built ``AffineMap``s per iteration. Both end up as
+  NUM_COLUMNS independent transfers; writing it out is what lets the offsets be
+  plain arithmetic on the loop variable.
+* The tile origin comes from the launch coordinates directly, instead of
+  ``affine_apply``-ing ``mul_m_l2_map`` and ``mul_n_l2_map`` to them and
+  threading the results down.
+
+``air.mlir``, which ``--mlir-source file`` parses instead of building, was
+regenerated from this builder so the two sources stay the same design. It is
+only valid at the default M=N=256.
 """
 
 import argparse
+import os
+
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api.types import bf16
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-import air
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import memref, vector, arith, scf
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store, subview
-from air.backend.xrt_runner import XRTRunner
-from ml_dtypes import bfloat16
-
-# Constants for buffer sizes and loop bounds
-L1_BUFFER_SIZE_M = 64
-L2_BUFFER_SIZE_M = L1_BUFFER_SIZE_M
-# Number of columns used in the hardware array
+# One core's tile, and the number of cores each herd spans.
+L1_M = 64
+L1_N = 64
 NUM_COLUMNS = 4
-L1_BUFFER_SIZE_N = 64
-L2_BUFFER_SIZE_N = L1_BUFFER_SIZE_N * NUM_COLUMNS
-# Stride (step size) in the column dimension for channel and DMA operations; 1 means data is contiguous in memory
-CHANNEL_STRIDE = 1
-# Number of elements processed in a single vector operation (matches hardware vector width)
-VECTOR_SIZE = 16
+# The L2 staging buffer holds one row of tiles: every column's tile side by side.
+L2_M = L1_M
+L2_N = L1_N * NUM_COLUMNS
 
-range_ = for_
+KERNEL_OBJ_NAME = "extern_func.o"
+
+
+def build_module(m, n):
+    assert m % L2_M == 0, f"m={m} is not a multiple of {L2_M}"
+    assert n % L2_N == 0, f"n={n} is not a multiple of {L2_N}"
+
+    A = air.tensor([m, n], bf16)
+    B = air.tensor([m, n], bf16)
+    C = air.tensor([m, n], bf16)
+
+    # Named links between the stages. L1ToL1Chan2 is the cascade: a
+    # point-to-point connection between neighbouring compute tiles, not a DMA
+    # stream, which is what the middle stage exists to exercise.
+    l2_to_l1_a = air.channel("L2ToL1Chan1", size=[NUM_COLUMNS, 1])
+    l2_to_l1_b = air.channel("L2ToL1Chan2", size=[NUM_COLUMNS, 1])
+    stage0_to_1 = air.channel("L1ToL1Chan1", size=[NUM_COLUMNS, 1])
+    stage1_to_2 = air.channel(
+        "L1ToL1Chan2", size=[NUM_COLUMNS, 1], channel_type="npu_cascade"
+    )
+    l1_to_l2 = air.channel("L1ToL2Chan1", size=[NUM_COLUMNS, 1])
+
+    add_3 = air.extern("add_3_bf16", link_with=KERNEL_OBJ_NAME)
+
+    with air.launch([range(m // L2_M), range(n // L2_N)], name="func1") as launch:
+
+        @launch.body
+        def _(ix, iy):
+            r0, c0 = ix * L2_M, iy * L2_N
+
+            with air.segment() as seg:
+
+                @seg.body
+                def _():
+                    l2_a = air.alloc([L2_M, L2_N], bf16, scope=seg.private())
+                    l2_b = air.alloc([L2_M, L2_N], bf16, scope=seg.private())
+                    l2_c = air.alloc([L2_M, L2_N], bf16, scope=seg.private())
+
+                    # L3 -> L2, then memtile -> cores, a column at a time.
+                    # air.parallel, not a Python loop: the trips share one set
+                    # of buffer descriptors, and the trip index is a channel
+                    # bundle slot, which a temporal loop may not supply.
+                    for col in air.parallel(NUM_COLUMNS):
+                        lo, hi = col * L1_N, col * L1_N + L1_N
+                        air.ops.load(
+                            l2_a[:, lo:hi], A[r0 : r0 + L2_M, c0 + lo : c0 + hi]
+                        )
+                        air.ops.load(
+                            l2_b[:, lo:hi], B[r0 : r0 + L2_M, c0 + lo : c0 + hi]
+                        )
+
+                    for col in air.parallel(NUM_COLUMNS):
+                        lo, hi = col * L1_N, col * L1_N + L1_N
+                        l2_to_l1_a.put(l2_a[:, lo:hi], indices=[col, 0])
+                        l2_to_l1_b.put(l2_b[:, lo:hi], indices=[col, 0])
+
+                    # Stage 1: add.
+                    with air.herd(
+                        [range(NUM_COLUMNS)], name="herd_0", shape=(NUM_COLUMNS,)
+                    ) as h0:
+
+                        @h0.body
+                        def _(tx):
+                            a = air.alloc([L1_M, L1_N], bf16, scope=h0.private())
+                            b = air.alloc([L1_M, L1_N], bf16, scope=h0.private())
+                            c = air.alloc([L1_M, L1_N], bf16, scope=h0.private())
+                            l2_to_l1_a.get(a, indices=[tx, 0])
+                            l2_to_l1_b.get(b, indices=[tx, 0])
+                            c[:] = a[:] + b[:]
+                            stage0_to_1.put(c, indices=[tx, 0])
+
+                    # Stage 2: copy, and hand it over the cascade.
+                    with air.herd(
+                        [range(NUM_COLUMNS)], name="herd_1", shape=(NUM_COLUMNS,)
+                    ) as h1:
+
+                        @h1.body
+                        def _(tx):
+                            a = air.alloc([L1_M, L1_N], bf16, scope=h1.private())
+                            c = air.alloc([L1_M, L1_N], bf16, scope=h1.private())
+                            stage0_to_1.get(a, indices=[tx, 0])
+                            c[:] = a[:]
+                            stage1_to_2.put(c, indices=[tx, 0])
+
+                    # Stage 3: the hand-written kernel, c = a + 3.
+                    with air.herd(
+                        [range(NUM_COLUMNS)],
+                        name="herd_2",
+                        shape=(NUM_COLUMNS,),
+                        link_with=KERNEL_OBJ_NAME,
+                    ) as h2:
+
+                        @h2.body
+                        def _(tx):
+                            a = air.alloc([L1_M, L1_N], bf16, scope=h2.private())
+                            c = air.alloc([L1_M, L1_N], bf16, scope=h2.private())
+                            stage1_to_2.get(a, indices=[tx, 0])
+                            add_3(a, c)
+                            l1_to_l2.put(c, indices=[tx, 0])
+
+                    for col in air.parallel(NUM_COLUMNS):
+                        lo, hi = col * L1_N, col * L1_N + L1_N
+                        l1_to_l2.get(l2_c[:, lo:hi], indices=[col, 0])
+                        air.ops.store(
+                            l2_c[:, lo:hi], C[r0 : r0 + L2_M, c0 + lo : c0 + hi]
+                        )
+
+    return launch
 
 
 def parse_args():
@@ -59,7 +189,9 @@ def parse_args():
         "--mlir-source",
         choices=["python", "file"],
         default="python",
-        help="How to obtain the MLIR module: 'python' (build with Python bindings) or 'file' (load and parse air.mlir; NOTE: air.mlir is only valid for M=N=256)",
+        help="How to obtain the MLIR module: 'python' (build with air.api) or "
+        "'file' (load and parse air.mlir; NOTE: air.mlir is only valid for "
+        "M=N=256)",
     )
     parser.add_argument(
         "--output-format",
@@ -69,400 +201,53 @@ def parse_args():
         dest="output_format",
         help="Output format for the compiled binary (default: xclbin)",
     )
-    args = parser.parse_args()
-    return args
-
-
-@module_builder
-def build_module(M_SIZE, N_SIZE):
-    """
-    Build the AIR dataflow module with memory allocation, channel setup, and computation kernels.
-
-    Returns:
-        The constructed MLIR module.
-    """
-
-    # External function for the final compute stage (herd_2)
-    # This function will be linked from "extern_func.o" and called in herd_2 for further computation.
-    input_type = bfloat16
-    output_type = bfloat16
-    index_type = IndexType.get()
-    bf16 = air.ir.Type.parse("bf16")
-    memrefMxN = MemRefType.get((M_SIZE, N_SIZE), bf16)
-    memrefL1xN_l2 = MemRefType.get(
-        (L1_BUFFER_SIZE_M, L2_BUFFER_SIZE_N), bf16, memory_space=Attribute.parse("1")
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
-    memrefL1xL1_l1 = MemRefType.get(
-        (L1_BUFFER_SIZE_M, L1_BUFFER_SIZE_N), bf16, memory_space=Attribute.parse("2")
-    )
-
-    add_3_bf16_ty = FunctionType.get([memrefL1xL1_l1, memrefL1xL1_l1], [])
-    add_3_func = FuncOp("add_3_bf16", add_3_bf16_ty, visibility="private")
-    add_3_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-    add_3_func.attributes["link_with"] = StringAttr.get("extern_func.o")
-
-    # AIR channels model hardware FIFOs for inter-stage communication
-    # Default channel_type is "npu_dma_stream", representing data movement performed using DMA streaming interconnects
-    channel("L2ToL1Chan1", size=[NUM_COLUMNS, 1])  # L2 to L1, input A
-    channel("L2ToL1Chan2", size=[NUM_COLUMNS, 1])  # L2 to L1, input B
-    channel("L1ToL1Chan1", size=[NUM_COLUMNS, 1])  # Between herd_0 and herd_1
-    channel(
-        "L1ToL1Chan2", size=[NUM_COLUMNS, 1], channel_type="npu_cascade"
-    )  # Between herd_1 and herd_2; channel_type="npu_cascade" means peer-to-peer communication between compute tiles
-    channel("L1ToL2Chan1", size=[NUM_COLUMNS, 1])  # Output from herd_2 to L2
-
-    @FuncOp.from_py_func(memrefMxN, memrefMxN, memrefMxN)
-    def func1(arg0, arg1, arg2):
-        """
-        Top-level function: runtime dispatch over a "launch" iteration space (not necessarily hardware parallelism).
-        Compute the three-stage dataflow using vector addition, copy, and external function call kernels.
-
-        Args:
-            arg0, arg1, arg2: Input and output memory references.
-
-        Returns:
-            None. Operates via side effects on MLIR memory references.
-        """
-        launch_x_size = ConstantOp(index_type, M_SIZE // L1_BUFFER_SIZE_M)
-        launch_y_size = ConstantOp(index_type, N_SIZE // L2_BUFFER_SIZE_N)
-
-        # air.launch: runtime dispatch over a "launch" iteration space (may be sequential or parallel depending on runtime)
-        @launch(operands=[arg0, arg1, arg2], sizes=[launch_x_size, launch_y_size])
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_a, l3_b, l3_c
-        ):
-
-            # Each segment is a program mapped to a hardware tile of resources, including the L1 and L2 memories and compute cores
-            @segment(operands=[launch_ivx, launch_ivy, l3_a, l3_b, l3_c])
-            def segment_body(lau_ivx, lau_ivy, seg_a, seg_b, seg_c):
-                c0 = ConstantOp(index_type, 0)
-                c1 = ConstantOp(index_type, 1)
-                cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-                cML2 = ConstantOp(index_type, L2_BUFFER_SIZE_M)
-                cNL2 = ConstantOp(index_type, L2_BUFFER_SIZE_N)
-                cM = ConstantOp(index_type, M_SIZE)
-                cN = ConstantOp(index_type, N_SIZE)
-                # Allocate L2 buffers for tile-local computation (memory space 1 = L2)
-                alloc_1 = AllocOp(memrefL1xN_l2, [], [])
-                alloc_2 = AllocOp(memrefL1xN_l2, [], [])
-                alloc_3 = AllocOp(memrefL1xN_l2, [], [])
-
-                mul_m_l2_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(L2_BUFFER_SIZE_M),
-                        )
-                    ],
-                )
-                mul_n_l2_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(L2_BUFFER_SIZE_N),
-                        )
-                    ],
-                )
-                mul_n_l1_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(L1_BUFFER_SIZE_M),
-                        )
-                    ],
-                )
-                pid_x_offset = affine_apply(mul_m_l2_map, [lau_ivx])
-                pid_y_offset = affine_apply(mul_n_l2_map, [lau_ivy])
-
-                mac_n_l2_map = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(L1_BUFFER_SIZE_N),
-                            ),
-                            AffineSymbolExpr.get(1),
-                        )
-                    ],
-                )
-                # Stage 1: DMA from L2 to L1 for both inputs, in parallel for each sub-tile
-                par_1 = scf.ForallOp(
-                    lower_bounds=[c0], upper_bounds=[NUM_COLUMNS], steps=[c1]
-                )
-                with InsertionPoint(par_1.body):
-                    apply_l1 = affine_apply(
-                        mul_n_l1_map, [par_1.induction_variables[0]]
-                    )
-                    apply_l2 = affine_apply(
-                        mac_n_l2_map, [par_1.induction_variables[0], pid_y_offset]
-                    )
-                    dma_memcpy_nd(
-                        alloc_1.result,
-                        seg_a,
-                        dst_offsets=[c0, apply_l1],
-                        dst_sizes=[cML1, cNL1],
-                        dst_strides=[cNL2, c1],
-                        src_offsets=[pid_x_offset, apply_l2],
-                        src_sizes=[cML1, cNL1],
-                        src_strides=[cN, c1],
-                    ),
-                    dma_memcpy_nd(
-                        alloc_2.result,
-                        seg_b,
-                        dst_offsets=[c0, apply_l1],
-                        dst_sizes=[cML1, cNL1],
-                        dst_strides=[cNL2, c1],
-                        src_offsets=[pid_x_offset, apply_l2],
-                        src_sizes=[cML1, cNL1],
-                        src_strides=[cN, c1],
-                    )
-                    scf.InParallelOp()
-
-                # Stage 2: Send L1 buffers to next stage via AIR channels
-                par_2 = scf.ForallOp(
-                    lower_bounds=[c0], upper_bounds=[NUM_COLUMNS], steps=[c1]
-                )
-                with InsertionPoint(par_2.body):
-                    apply = affine_apply(mul_n_l1_map, [par_2.induction_variables[0]])
-                    ChannelPut(
-                        "L2ToL1Chan1",
-                        alloc_1.result,
-                        indices=[par_2.induction_variables[0], c0],
-                        offsets=[c0, apply],
-                        sizes=[cML1, cNL1],
-                        strides=[cNL2, c1],
-                    ),
-                    ChannelPut(
-                        "L2ToL1Chan2",
-                        alloc_2.result,
-                        indices=[par_2.induction_variables[0], c0],
-                        offsets=[c0, apply],
-                        sizes=[cML1, cNL1],
-                        strides=[cNL2, c1],
-                    ),
-                    scf.InParallelOp()
-
-                # Stage 3: First compute herd (herd_0): NUM_COLUMNS x 1 shape. Each of the NUM_COLUMNS tiles asynchronously receives two input tiles via channels, performs vector addition, and sends the result to the next stage.
-                @herd(name="herd_0", sizes=[NUM_COLUMNS, c1], operands=[])
-                def herd0_body(h0_x, h0_y, h0_x_size, h0_y_size):
-                    alloc_a = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    alloc_b = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    alloc_c = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    ChannelGet("L2ToL1Chan1", alloc_a.result, indices=[h0_x, h0_y])
-                    ChannelGet("L2ToL1Chan2", alloc_b.result, indices=[h0_x, h0_y])
-                    c0 = ConstantOp(index_type, 0)
-                    c1 = ConstantOp(index_type, 1)
-                    c16 = ConstantOp(index_type, VECTOR_SIZE)
-                    cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                    cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-                    for i in range_(c0, cML1, c1):
-                        sub_a = memref.subview(
-                            alloc_a.result,
-                            [i, 0],
-                            [1, L1_BUFFER_SIZE_M],
-                            [1, 1],
-                        )
-                        sub_b = memref.subview(
-                            alloc_b.result,
-                            [i, 0],
-                            [1, L1_BUFFER_SIZE_M],
-                            [1, 1],
-                        )
-                        sub_c = memref.subview(
-                            alloc_c.result,
-                            [i, 0],
-                            [1, L1_BUFFER_SIZE_M],
-                            [1, 1],
-                        )
-                        for j in range_(c0, cNL1, c16):
-                            sub_a_16 = memref.subview(
-                                sub_a,
-                                [0, j],
-                                [1, VECTOR_SIZE],
-                                [1, 1],
-                            )
-                            sub_b_16 = memref.subview(
-                                sub_b,
-                                [0, j],
-                                [1, VECTOR_SIZE],
-                                [1, 1],
-                            )
-                            sub_c_16 = memref.subview(
-                                sub_c,
-                                [0, j],
-                                [1, VECTOR_SIZE],
-                                [1, 1],
-                            )
-                            layout = StridedLayoutAttr.get(
-                                ShapedType.get_dynamic_size(),
-                                [
-                                    1,
-                                ],
-                            )
-                            collapsed_type = MemRefType.get(
-                                (VECTOR_SIZE,),
-                                bf16,
-                                memory_space=Attribute.parse("2"),
-                                layout=layout,
-                            )
-                            collapse_dims = [[0, 1]]
-                            collapse_a = memref.collapse_shape(
-                                collapsed_type, sub_a_16, collapse_dims
-                            )
-                            collapse_b = memref.collapse_shape(
-                                collapsed_type, sub_b_16, collapse_dims
-                            )
-                            collapse_c = memref.collapse_shape(
-                                collapsed_type, sub_c_16, collapse_dims
-                            )
-                            cst0 = arith.ConstantOp(bf16, 0.0)
-                            v_a = vector.transfer_read(
-                                VectorType.get([VECTOR_SIZE], bf16),
-                                collapse_a,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                cst0,
-                                [True],
-                            )
-                            v_b = vector.TransferReadOp(
-                                VectorType.get([VECTOR_SIZE], bf16),
-                                collapse_b,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                cst0,
-                                [True],
-                            )
-                            v_c = arith.AddFOp(v_a, v_b)
-                            vector.transfer_write(
-                                None,
-                                v_c,
-                                collapse_c,
-                                [c0],
-                                AffineMapAttr.get(AffineMap.get_identity(1)),
-                                [True],
-                            )
-                            yield_([])
-                        yield_([])
-                    ChannelPut("L1ToL1Chan1", alloc_c.result, indices=[h0_x, h0_y])
-
-                # Stage 4: Second herd (herd_1): NUM_COLUMNS x 1 shape. Each of the NUM_COLUMNS tiles asynchronously receives a tile via channel, copies its contents, and sends it to the next stage.
-                @herd(name="herd_1", sizes=[NUM_COLUMNS, c1], operands=[])
-                def herd1_body(h1_x, h1_y, h1_x_size, h1_y_size):
-                    c0 = ConstantOp(index_type, 0)
-                    c1 = ConstantOp(index_type, 1)
-                    cML1 = ConstantOp(index_type, L1_BUFFER_SIZE_M)
-                    cNL1 = ConstantOp(index_type, L1_BUFFER_SIZE_N)
-                    alloc_a = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    alloc_c = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    ChannelGet("L1ToL1Chan1", alloc_a.result, indices=[h1_x, h1_y])
-                    for i in range_(c0, cML1, c1):
-                        for j in range_(c0, cNL1, c1):
-                            store(load(alloc_a.result, [i, j]), alloc_c.result, [i, j])
-                            yield_([])
-                        yield_([])
-                    ChannelPut("L1ToL1Chan2", alloc_c.result, indices=[h1_x, h1_y])
-
-                # Stage 5: Third herd (herd_2): NUM_COLUMNS x 1 shape. Each of the NUM_COLUMNS tiles asynchronously receives a tile via channel, calls an external function for further computation, and sends the result to the output channel.
-                @herd(name="herd_2", sizes=[NUM_COLUMNS, c1], operands=[])
-                def herd2_body(h2_x, h2_y, h2_x_size, h2_y_size):
-                    alloc_a = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    alloc_c = AllocOp(
-                        memrefL1xL1_l1, [], []
-                    )  # L1 memory (memory space 2)
-                    ChannelGet("L1ToL1Chan2", alloc_a.result, indices=[h2_x, h2_y])
-                    CallOp(add_3_func, [alloc_a.result, alloc_c.result])
-                    ChannelPut("L1ToL2Chan1", alloc_c.result, indices=[h2_x, h2_y])
-
-                herd2_body.attributes["link_with"] = StringAttr.get("extern_func.o")
-
-                # Stage 6: Gather results from all tiles and DMA back to L2
-                par_3 = scf.ForallOp(
-                    lower_bounds=[c0], upper_bounds=[NUM_COLUMNS], steps=[c1]
-                )
-                with InsertionPoint(par_3.body):
-                    apply_l1 = affine_apply(
-                        mul_n_l1_map, [par_3.induction_variables[0]]
-                    )
-                    apply_l2 = affine_apply(
-                        mac_n_l2_map, [par_3.induction_variables[0], pid_y_offset]
-                    )
-                    ChannelGet(
-                        "L1ToL2Chan1",
-                        alloc_3.result,
-                        indices=[par_3.induction_variables[0], c0],
-                        offsets=[c0, apply_l1],
-                        sizes=[cML1, cNL1],
-                        strides=[cNL2, c1],
-                    ),
-                    dma_memcpy_nd(
-                        seg_c,
-                        alloc_3.result,
-                        dst_offsets=[pid_x_offset, apply_l2],
-                        dst_sizes=[cML1, cNL1],
-                        dst_strides=[cN, c1],
-                        src_offsets=[c0, apply_l1],
-                        src_sizes=[cML1, cNL1],
-                        src_strides=[cNL2, c1],
-                    )
-                    scf.InParallelOp()
+    return parser.parse_args()
 
 
 def main():
-    """Main entry point for running the AIR Herd Dataflow example."""
     args = parse_args()
     M_SIZE = args.m_size
     N_SIZE = args.n_size
 
-    # Obtain the MLIR module either by building with Python or loading from file
+    # Either build the module here or parse the one checked in beside this
+    # script. The file is the same design; it is regenerated from the builder.
+    target = None
     if args.mlir_source == "python":
-        mlir_module = build_module(M_SIZE, N_SIZE)
+        launch = build_module(M_SIZE, N_SIZE)
+        mlir_module = launch.build(target=args.target)
+        target = launch.target
     else:
-        import os
+        import air.ir
+        from air.ir import Module
 
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        mlir_path = os.path.join(script_dir, "air.mlir")
-        with open(mlir_path, "r") as f:
+        with open(os.path.join(script_dir, "air.mlir"), "r") as f:
             mlir_text = f.read()
         mlir_module = Module.parse(mlir_text, context=air.ir.Context())
 
     if args.print_ir:
-        # Print the MLIR IR and exit
         print(str(mlir_module))
         return
 
-    # Prepare input and expected output data
     A = np.random.rand(M_SIZE, N_SIZE).astype(bfloat16)
     B = np.random.rand(M_SIZE, N_SIZE).astype(bfloat16)
     C = (A + B + 3.0).astype(bfloat16)
 
-    # Run the module using XRTRunner
     runner = XRTRunner(
         omit_while_true_loop=False,
         verbose=False,
         runtime_loop_tiling_sizes=[2, 2],
         output_format=args.output_format,
         instance_name="func1",
+        report_precision=True,
+        **({"target_device": target} if target else {}),
     )
     exit(
         runner.run_test(

--- a/programming_examples/herd_dataflow/run.py
+++ b/programming_examples/herd_dataflow/run.py
@@ -25,10 +25,12 @@ Three differences from the predecessor worth naming:
   ``memref.load``/``memref.store`` loop over all 4096 elements. The copy in
   herd_1 is now vectorised at the same 16 lanes as the add, where the
   predecessor moved one element per iteration.
-* The per-column L2 staging is a Python ``for`` rather than an ``scf.forall``
-  with two hand-built ``AffineMap``s per iteration. Both end up as
-  NUM_COLUMNS independent transfers; writing it out is what lets the offsets be
-  plain arithmetic on the loop variable.
+* The per-column L2 staging is ``air.parallel``, which emits the same
+  ``scf.forall`` the predecessor built by hand -- minus the two ``AffineMap``s
+  per iteration, since the offsets are plain arithmetic on the loop variable.
+  It is deliberately *not* a Python ``for``: that unrolls, and four independent
+  shim DMAs is a different design from one fan-out sharing a set of buffer
+  descriptors. It does not fit on npu1 at all.
 * The tile origin comes from the launch coordinates directly, instead of
   ``affine_apply``-ing ``mul_m_l2_map`` and ``mul_n_l2_map`` to them and
   threading the results down.

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -76,8 +76,13 @@ what makes each core's slab well defined. Zero it with ``ops.fill(acc, 0.0)``.
 
 ``air.sequential`` is named for what ``scf.for`` guarantees -- its trips are
 ordered in time on one core -- as against the herd's grid, which is spatial.
-``air.parallel`` is its unordered counterpart (``scf.parallel``); it is declared
-below and raises, because nothing emits it yet.
+``air.parallel`` is its unordered counterpart, and the two are not
+interchangeable at segment scope. Staging that fans a memtile buffer out to a
+row of cores has to be parallel twice over: the trip index names one slot of a
+channel bundle, which ``air-place-herds`` refuses to take from a temporal loop,
+and the trips share one set of buffer descriptors, so writing them out as a
+Python ``for`` turns one fan-out into that many independent DMAs. See
+``herd_dataflow``, where the unrolled form does not fit on npu1 at all.
 
 One hardware caveat that the DSL cannot see and so cannot raise on: an
 *unstaged* K reduction on a 2-D herd is wrong past a single trip. Both operands
@@ -91,7 +96,7 @@ from . import ops
 from ._channel import Channel, channel
 from ._compile import CompiledKernel, LaunchContext, compile, launch
 from ._extern import ExternKernel, extern
-from ._loop import sequential
+from ._loop import parallel, sequential
 from ._trace import (
     HerdContext,
     Scope,
@@ -173,15 +178,6 @@ def _unimplemented(name, needs):
 # Names from the wider API proposal that this version does not lower. They are
 # present, and they raise -- an accepted-but-ignored capability gate is worse
 # than an absent one, because the kernel still compiles and still runs.
-# The unordered counterpart of air.sequential: an scf.parallel inside a herd
-# body, whose trips carry no ordering guarantee. Named here so that reaching for
-# it fails at the call site with this explanation rather than as an
-# AttributeError, and so the name cannot later be attached to the herd grid --
-# air.herd emits air.herd directly, and an scf.parallel reaches the spatial
-# hierarchy only when a conversion pass selects it, which in general it does not.
-parallel = _unimplemented(
-    "parallel", "scf.parallel emission; use air.sequential for an ordered loop"
-)
 BlockType = _unimplemented("BlockType", "block floating-point types")
 Field = _unimplemented("Field", "block floating-point types")
 Scratchpad = _unimplemented("Scratchpad", "fabric property gating")

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -25,7 +25,7 @@ here would only defer the failure into the IR.
 
 from ._index import IndexExpr
 
-__all__ = ["sequential", "loop_depth", "aborted_loops"]
+__all__ = ["sequential", "parallel", "loop_depth", "aborted_loops"]
 
 # Loops whose body exited early (break / return / an exception the caller
 # swallowed). Emission still closes the region so the IR stays well formed, but
@@ -115,10 +115,77 @@ def sequential(start, stop=None, step=None, name=None):
             yield_([])
 
 
-def _as_bound(value, which):
+def parallel(start, stop=None, step=None, name=None):
+    """An unordered ``scf.forall`` over ``[start, stop)`` in strides of ``step``.
+
+    The counterpart of :func:`sequential`, and not interchangeable with it. Two
+    things follow from the trips being unordered rather than merely unrolled,
+    and both are load-bearing where staging fans a memtile buffer out to a row
+    of cores:
+
+    * **The induction variable may index a channel bundle.** A bundled put is
+      one slot of a spatial fan-out, so the index has to name a destination, not
+      a point in time; ``air-place-herds`` refuses a temporal one outright --
+      *"channel bundle indices must not be temporal scf.for induction
+      variables"*.
+    * **The trips share one set of buffer descriptors.** Writing the same
+      transfers out as a Python ``for`` unrolls them into that many independent
+      DMAs, which is not the same design: herd_dataflow's four per-column L3
+      reads fit on npu1 inside this loop and do not fit unrolled -- *"no
+      ShimNOCTile has sufficient DMA capacity"*.
+
+    Emitted as ``scf.forall``; the pipeline's ``scf-forall-to-parallel`` turns
+    it into the ``scf.parallel`` that the hand-written examples spell directly.
+    """
+    global _ABORTED, _DEPTH
+
+    if stop is None:
+        start, stop = 0, start
+    if step is None:
+        step = 1
+
+    lo, hi, st = (
+        _as_bound(v, n, "parallel")
+        for v, n in ((start, "start"), (stop, "stop"), (step, "step"))
+    )
+    if st <= 0:
+        raise ValueError(f"air.parallel needs a positive step, got {st}")
+    if hi < lo:
+        raise ValueError(
+            f"air.parallel({lo}, {hi}) counts backwards; stop must be >= start"
+        )
+    if (hi - lo) % st:
+        raise ValueError(
+            f"air.parallel({lo}, {hi}, {st}) does not tile its extent exactly: "
+            f"{(hi - lo) // st} steps of {st} span {((hi - lo) // st) * st}, past "
+            f"the extent of {hi - lo}. air.api has no partial trips, so the last "
+            "one would run off the end of whatever it indexes."
+        )
+
+    from air.ir import InsertionPoint
+    from air.dialects.scf import ForallOp, InParallelOp
+
+    op = ForallOp(lower_bounds=[lo], upper_bounds=[hi], steps=[st])
+    _DEPTH += 1
+    completed = False
+    try:
+        with InsertionPoint(op.body):
+            yield IndexExpr.leaf(op.induction_variables[0], name or "p")
+            completed = True
+            # scf.forall's terminator, emitted inside the body region.
+            InParallelOp()
+    finally:
+        _DEPTH -= 1
+        if not completed:
+            _ABORTED += 1
+            with InsertionPoint(op.body):
+                InParallelOp()
+
+
+def _as_bound(value, which, what="sequential"):
     if isinstance(value, bool) or not hasattr(value, "__index__"):
         raise TypeError(
-            f"air.sequential({which}=...) takes a Python integer (or an air.symbol), "
+            f"air.{what}({which}=...) takes a Python integer (or an air.symbol), "
             f"got {type(value).__name__} {value!r}. Loop bounds are resolved at "
             "trace time; a bound computed from a tile coordinate is not supported."
         )

--- a/python/test/api/channel.py
+++ b/python/test/api/channel.py
@@ -369,3 +369,56 @@ def a_computed_offset_cannot_follow_the_segment():
         print(f"RuntimeError: {e}")
     else:
         print("ERROR: no exception raised")
+
+
+# CHECK-LABEL: TEST: a_parallel_loop_indexes_a_channel_bundle
+# Staging that fans a memtile buffer out to a row of cores has to be parallel
+# twice over, and air.sequential is wrong on both counts. The trip index names
+# one slot of the bundle, which air-place-herds refuses to take from a temporal
+# loop ("channel bundle indices must not be temporal scf.for induction
+# variables"); and the trips share one set of buffer descriptors, where a Python
+# `for` would unroll into that many independent DMAs.
+#
+# Emitted as scf.forall, which the pipeline's scf-forall-to-parallel turns into
+# the scf.parallel the hand-written examples spell directly. One put, inside the
+# loop -- not four.
+# CHECK: scf.forall (%[[COL:.*]]) in (4) {
+# CHECK: air.channel.put @fan[%{{.*}}, %{{.*}}] (%{{.*}}[0, %{{.*}}] [8, 8] [32, 1])
+# CHECK: air.herd @h
+# CHECK: air.channel.get @fan[%{{.*}}, %{{.*}}]
+@run
+def a_parallel_loop_indexes_a_channel_bundle():
+    A = air.tensor([8, 32], i32)
+    Out = air.tensor([8, 32], i32)
+    fan = air.channel("fan", size=[4, 1])
+    back = air.channel("back", size=[4, 1])
+
+    with air.launch(name="fanout") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    staged = air.alloc([8, 32], i32, scope=seg.private())
+                    air.ops.load(staged, A)
+
+                    for col in air.parallel(4):
+                        lo = col * 8
+                        fan.put(staged[:, lo : lo + 8], indices=[col, 0])
+
+                    with air.herd([range(4)], name="h", shape=(4,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            tile = air.alloc([8, 8], i32, scope=h.private())
+                            fan.get(tile, indices=[tx, 0])
+                            back.put(tile, indices=[tx, 0])
+
+                    for col in air.parallel(4):
+                        lo = col * 8
+                        back.get(staged[:, lo : lo + 8], indices=[col, 0])
+                    air.ops.store(staged, Out)
+
+    print(launch.mlir())

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -599,13 +599,19 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: parallel_unimplemented
-# The unordered counterpart of air.sequential. Declared so that reaching for it
-# says what it would be, rather than raising AttributeError.
-# CHECK: NotImplementedError: air.api.parallel is not implemented yet
-@expect(NotImplementedError, "parallel_unimplemented")
+# CHECK-LABEL: TEST: a_parallel_loop_must_tile_its_extent
+# The same rule air.sequential applies, for the same reason: there are no
+# partial trips, so a step that does not divide the extent would send the last
+# one off the end of whatever it indexes. Worth pinning separately because the
+# trips of a parallel loop are slots of a spatial fan-out -- overrunning is a
+# put addressed to a destination that does not exist, not a short read.
+# CHECK: ValueError: air.parallel(0, 64, 24) does not tile its extent exactly
+@expect(ValueError, "a_parallel_loop_must_tile_its_extent")
 def _():
-    air.parallel(0, 64, 16)
+    # Generators are lazy: the bounds are checked when the first trip is
+    # requested, so the loop has to actually be entered.
+    for _ in air.parallel(0, 64, 24):
+        pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`herd_dataflow` onto `air.api`, the DSL surface it turned out to need, and a compiler crash found on the way.

## `air.parallel`

`air.parallel` was a stub that raised, on the reasoning that *"an `scf.parallel` reaches the spatial hierarchy only when a conversion pass selects it, which in general it does not"*. That is true of a herd grid and wrong at segment scope, where staging fans a memtile buffer out to a row of cores. Two things make that loop parallel rather than merely repeated, and `air.sequential` supplies neither:

- **The trip index names one slot of a channel bundle.** `air-place-herds` refuses to take that from a temporal loop — *"channel bundle indices must not be temporal scf.for induction variables"*.
- **The trips share one set of buffer descriptors.** Writing them out as a Python `for` unrolls into that many independent DMAs, which is a different design: herd_dataflow's four per-column L3 reads fit on npu1 inside the loop and do not fit unrolled, with *"no ShimNOCTile has sufficient DMA capacity for 0 input/2 output channels"*.

This is not a judgement call about style — the example's own checked-in `air.mlir`, which three of its six lits parse via `--mlir-source file`, has read `scf.parallel` with the loop IV as the bundle index all along:

```mlir
scf.parallel (%par1) = (%c0) to (%c4) step (%c1) {
  air.dma_memcpy_nd (%alloc_1[%c0, %apply] ...)
  air.channel.put @L2ToL1Chan1[%par1, %c0] (...)
}
```

`air.parallel` emits `scf.forall`, which the pipeline's `scf-forall-to-parallel` turns into exactly that. Bounds validation mirrors `air.sequential`. `errors.py` loses the case pinning the old `NotImplementedError` and gains one for a step that does not tile the extent — overrunning matters more here, because the trips are fan-out slots and the last one would address a destination that does not exist.

## The conversion

Three herds and a tile that flows through all of them without going back to L2: `herd_0` adds, `herd_1` copies and hands the result over a cascade channel, `herd_2` calls the hand-written `add_3_bf16`. A channel is a module-level symbol, so each stage finds what the previous one sent by name, with nothing threaded through the segment.

Both compute bodies are one line. `c[:] = a[:] + b[:]` replaces a doubly-nested loop building every 16-element strip out of two `memref.subview`s and a `memref.collapse_shape`; `c[:] = a[:]` replaces a scalar `memref.load`/`memref.store` loop over all 4096 elements, and is now vectorised at the same 16 lanes as the add.

`air.mlir` is regenerated from this builder, so `--mlir-source file` parses the same design the Python path builds. It is target-independent — npu1 and npu2 print identically — which is what lets one file serve both generations' lits. Against the predecessor's, the segment holds the same three `scf.parallel` loops and the same one put and one get per channel across all five channels.

## `air-fuse-channels`: do not index an empty put/get list

`AIRFuseChannels` reads `a_vec[0]` as the access pattern every other op is compared against, and `a_puts[0]`/`b_puts[0]`/`a_gets[0]`/`b_gets[0]` as the ops to merge, in all four cases without checking the list is non-empty. A channel reaches these with no puts, or no gets, once an earlier fusion in the same run has moved them onto another symbol, and the pass aborts on

```
std::vector<xilinx::air::ChannelGetOp>::operator[]: Assertion '__n < this->size()' failed
```

which in a build without assertions is an out-of-bounds read instead. Both sites are hit in turn — guarding only the first moves the abort to the second.

Reached from valid input: a segment that stages a row of tiles into one memtile buffer and puts each column's slice on a bundled channel with a constant index. That is what a plain Python loop produces in air.api, and while herd_dataflow is better written with `air.parallel`, nothing rejects the unrolled spelling, so the crash is reachable. The new test is the IR that form reaches this pass with; it aborts the pass without the fix.

## Testing

- Both npu1 `herd_dataflow` lits pass — python source and file source. The four npu2 lits are UNSUPPORTED on my box.
- `check-air-mlir` 525/525 (new `air-fuse-channels` case fails against the previous behaviour), `check-air-python` 40/40, `api/` suite 27/27.
- npu1 programming-examples sweep: 88 passed.
- 46 air.api examples emit byte-identical IR.