### PR TITLE
[air] Keep a sunk dealloc's dependences on the stand-in left in its place

### DIFF
--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -6552,11 +6552,27 @@ LogicalResult fuseAllocDeallocExecsIntoBlock(
   for (auto &[alloc, dealloc] : allocDeallocExecs) {
     SmallVector<air::ExecuteOp> execs({alloc});
     resolveDepFromAllocExec(alloc, block);
-    if (dealloc) {
-      resolveDepFromDeallocExec(dealloc, block);
+    if (dealloc)
       execs.push_back(dealloc);
-    }
+    // Leave the stand-ins behind before the deallocs are stripped, not after.
+    //
+    // resolveDepToExecs puts an air.wait_all where each exec used to be and
+    // points the exec's outside-the-block users at it; the wait_all inherits
+    // the exec's dependence list. resolveDepFromDeallocExec then erases the
+    // dependences that come from outside the block, because the dealloc is
+    // about to move inside it -- among them the enclosing loop's own token,
+    // which the dealloc cannot keep waiting on once it lives in that loop's
+    // body.
+    //
+    // Run the erasure first and the stand-in inherits nothing: an
+    // air.wait_all with no operands, ready the instant its region starts.
+    // Where the dealloc's token was the loop-carried value of an scf.for --
+    // it is the last thing to happen in an iteration, so it usually is -- the
+    // loop's yield stops depending on the body altogether, and the loop
+    // retires before a single transfer in it has completed.
     resolveDepToExecs(rewriter, execs, block);
+    if (dealloc)
+      resolveDepFromDeallocExec(dealloc, block);
     addDepToAllocUsersInBlock(alloc, block);
     if (dealloc) {
       addDepToDeallocInBlock(dealloc, alloc->getResult(1), block);

--- a/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_alloc_dealloc.mlir
+++ b/mlir/test/Transform/AIRDependencyScheduleOpt/fuse_alloc_dealloc.mlir
@@ -391,4 +391,51 @@ module {
     }
     return
   }
+
+// Check that the stand-in left where a sunk dealloc used to be keeps that
+// dealloc's dependences.
+//
+// The dealloc waits on the inner scf.for, and its token is what the outer
+// scf.for yields. Sinking the dealloc into the inner loop drops that
+// dependence from the dealloc itself -- it cannot wait on the loop it now
+// lives in -- so the air.wait_all standing in its place has to carry it
+// instead. An empty stand-in would leave the outer loop yielding a token that
+// does not depend on its own body.
+
+// CHECK-LABEL:   @func8
+// CHECK:   scf.for
+// CHECK:   %[[INNER:.*]] = scf.for
+// CHECK:   air.execute{{.*}}{
+// CHECK-NEXT:   memref.alloc()
+// CHECK-NEXT:   air.execute_terminator
+// CHECK-NEXT:   }
+// CHECK:   air.channel.get
+// CHECK:   air.execute{{.*}}{
+// CHECK-NEXT:   memref.dealloc
+// CHECK-NEXT:   }
+// CHECK:   }
+// CHECK:   %[[STANDIN:.*]] = air.wait_all async [%[[INNER]]]
+// CHECK:   scf.yield %[[STANDIN]]
+
+  func.func @func8() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %init = air.wait_all async
+    %0 = scf.for %arg0 = %c0 to %c2 step %c1 iter_args(%arg1 = %init) -> (!air.async.token) {
+      %async_token, %results = air.execute [%arg1] -> (memref<64xbf16, 2 : i32>) {
+        %alloc = memref.alloc() : memref<64xbf16, 2 : i32>
+        air.execute_terminator %alloc : memref<64xbf16, 2 : i32>
+      }
+      %inner = scf.for %arg2 = %c0 to %c2 step %c1 iter_args(%arg3 = %async_token) -> (!air.async.token) {
+        %get = air.channel.get async [%arg3] @channel_0[] (%results[] [] []) : (memref<64xbf16, 2 : i32>)
+        scf.yield %get : !air.async.token
+      }
+      %dealloc = air.execute [%inner] {
+        memref.dealloc %results : memref<64xbf16, 2 : i32>
+      }
+      scf.yield %dealloc : !air.async.token
+    }
+    return
+  }
 }

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -2,54 +2,32 @@
 // SPDX-License-Identifier: MIT
 //
 // REQUIRES: xrt
-// XFAIL: *
 // RUN: mkdir -p test_airrunner
 // RUN: cd test_airrunner
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile run 2>&1 | FileCheck %s
 //
-// This design does not currently simulate to completion, so the test is
-// expected to fail: air-runner reports the stall and exits non-zero, and no
-// latency line is printed.
+// This design used to stall. It was marked XFAIL and carried a note asking
+// whoever fixed it to pin the real latency rather than re-pin whatever the
+// runner printed, so: 774.592us, from a run that reaches the launch
+// terminator.
 //
-// Marked XFAIL rather than rewritten to assert the stall, so the signal points
-// the right way. An expectation that matches the error would go green now and
-// red the day someone fixes it. As an XFAIL it turns into an XPASS instead,
-// which is the prompt to drop this marker and pin the real latency.
+// For context on the number that was here before, 423.824us: that was the
+// point at which the simulation gave up, not a latency. air-runner runs until
+// no runner node can make progress, which is also what an unsatisfiable
+// dispatch condition looks like, so a stalled run and a finished one printed
+// the same line. The run stalled at 26489 cycles over 16 launch iterations,
+// and 26489 * 16 = 423824 ns.
 //
-// It used to expect a line reading
-//   "Latency (single-iteration mode, estimated for 16 iterations): 423.824us".
-// That number was the point at which the simulation gave up. air-runner runs
-// until no runner node can make progress, which is also what an unsatisfiable
-// dispatch condition looks like, so a stalled run and a finished one used to
-// print the same thing. The run stalls at 26489 cycles and the test uses
-// single-iteration mode over 16 iterations: 26489 * 16 = 423824 ns, exactly
-// the figure above. It was the stall point, not a latency.
-//
-// What actually happens, on the 4x4 configuration this test uses: all sixteen
-// herds terminate, but the C write-back over @channel_10 completes one get out
-// of sixteen, no segment or launch terminator is ever reached, and the four
-// L3->L2 input channels are left with a put dispatched and no matching get.
-// So the number was "time to finish compute, with the output drain missing" --
-// an underestimate, which is why it looked plausible for so long.
-//
-// Notes for whoever picks this up:
-//   - It is not a scale problem. herd 1x1 stalls at 8057 cycles, 2x2 at 14201,
-//     4x4 at 26489. The 1x1 configuration is the smallest repro.
-//   - It is not the ping-pong transform. Dropping air-label-scf-for-to-ping-pong
-//     and air-ping-pong-transform from the pipeline still stalls, at 6362.
-//   - It is not simulation granularity. "herd" stalls identically to "core".
-//   - Nothing is ready-but-blocked at the stall: every unstarted op still has an
-//     incomplete predecessor, so this is an unsatisfiable dependency state
-//     rather than resource starvation.
-//   - test/airrunner/matmul, which builds its IR through the transform dialect
-//     instead of parsing the air.api example, reaches both terminators and is
-//     unaffected.
-//
-// Whether the generated IR is at fault or air-runner cannot model it is still
-// open. Restore a latency expectation once it simulates to completion; do not
-// just re-pin whatever number the runner prints.
+// The cause was in the compiler, not the runner. air-fuse-alloc-dealloc sinks
+// an alloc/dealloc pair into the innermost loop that uses the memref, and
+// leaves an air.wait_all where each one used to be for the benefit of users
+// outside that loop. It built those stand-ins after stripping the dealloc's
+// dependences rather than before, so they came out empty. Here the dealloc's
+// token was the herd's outer k-loop yield, which therefore stopped depending
+// on the loop body: the loop retired before a single get had run, the herd
+// consumed half the puts it should have, and the segment's remaining puts had
+// nothing left to match. See @func8 in
+// mlir/test/Transform/AIRDependencyScheduleOpt/fuse_alloc_dealloc.mlir.
 
-// Deliberately matches the line without its value: the old number was the
-// stall point, and the real one is not yet known.
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations):
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 774.592us


### PR DESCRIPTION
## The bug

`air-fuse-alloc-dealloc` sinks an alloc/dealloc pair into the innermost loop that uses the memref, and leaves an `air.wait_all` where each one used to be so that users outside the loop still have something to wait on. The stand-in inherits the exec's dependence list.

It was built *after* those dependences were stripped rather than before. `resolveDepFromDeallocExec` erases the dependences that come from outside the block — the dealloc is about to move inside it and cannot keep waiting on the loop it now lives in — so by the time `resolveDepToExecs` ran there was nothing left to inherit and the stand-in came out with no operands: an `air.wait_all` ready the instant its region starts.

Where the dealloc's token was the loop-carried value of an `scf.for` — and it usually is, since deallocating is the last thing an iteration does — the loop's yield stopped depending on the loop body altogether.

Before, on the herd's outer k-loop in the bf16 matmul:

```mlir
%26 = air.wait_all async
%27 = air.wait_all async
%28 = air.wait_all async [%26, %27]
scf.yield %28 : !air.async.token
```

After:

```mlir
%26 = air.wait_all async [%25]
%27 = air.wait_all async [%25]
%28 = air.wait_all async [%26, %27]
scf.yield %28 : !air.async.token
```

The fix is to create the stand-ins first and strip afterwards — a reorder of three calls.

## What it was breaking

`test/airrunner/matmul_bf16_vectorized`, which has been XFAIL. The herd's outer k-loop retired before a single `channel.get` in it had run, so the herd consumed half the puts it should have, and the segment's remaining puts sat dependency-ready with no get left to match them. The run gave up at 26489 cycles.

It now simulates to completion. The test drops its XFAIL and pins 774.592us. The 423.824us the test used to assert was never a latency: air-runner runs until no runner node can make progress, which is also what an unsatisfiable dispatch condition looks like, so a stalled run and a finished one printed the same line — 26489 × 16 launch iterations = 423824 ns.

Three claims in that test's preamble were wrong and are corrected: herd 1x1 completes rather than stalling (2x2 is the smallest configuration that reproduces), and while the ping-pong transform is indeed innocent, the pass immediately before it was not.

## Test

`@func8` in `fuse_alloc_dealloc.mlir`. The dealloc waits on an inner `scf.for` and its token is what the outer `scf.for` yields, so the stand-in has to carry the inner loop. Negative-controlled: with the reorder reverted, the CHECK finds an operand-less `air.wait_all` and the test fails.

The stall needs both K loops to have at least two trips, which is why it took a specific shape to surface:

| outer trips (`k / tile_k_l2`) | inner trips (`tile_k_l2 / tile_k_l1`) | result |
|---|---|---|
| 4 | 1 | completes |
| 1 | 2 | completes |
| 2 | 1 | completes |
| **2** | **2** | **stalls** |

## Checks

- `check-air-mlir` 520 passed / 7 expectedly failed / 0 failed
- `check-air-python` 36/36, `check-air-cpp` 1/1
- `test/airrunner/matmul` unchanged at 1127.23us
- `git clang-format origin/main` clean

Not verified on hardware: `programming_examples/matrix_multiplication/bf16` `make run4x4` fails the same way on clean `main` in my environment (aiecc selects chess, `chess-llvm-link` is not installed), so it could not serve as a before/after check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)