### PR TITLE
[air-runner] Retire the ops an affine.if filters out, and diagnose work left unrun

### DIFF
--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -322,6 +322,7 @@ public:
                                              uint64_t time) {
 
     Graph &G = c.ctrl_g->g;
+    c.current_time = time;
 
     // Get candidate vertices to be pushed to wavefront
     std::vector<Graph::VertexId> next_vertex_set_candidates =
@@ -555,6 +556,60 @@ public:
             "never satisfy its dispatch condition; the most common cause is a "
             "channel whose put and get disagree on how many spatial instances "
             "they represent, so the pair can never be matched.");
+
+    // Reaching the terminator is necessary but not sufficient. A vertex that
+    // was never scheduled and never retired just sits in the graph: the run
+    // walks past it, the terminator is reached along some other path, and the
+    // latency reported is the latency of whatever happened to run. That is the
+    // same silently-wrong answer the check above exists to prevent, arriving by
+    // a different route, so account for the graph as well as the exit.
+    //
+    // "Never ran" means never started and no entry in the execution log --
+    // vertices are reset between loop iterations, so an unstarted vertex that
+    // ran in an earlier iteration is ordinary.
+    if (!diagnosticEmitted)
+      diagnoseVerticesThatNeverRan(launch);
+  }
+
+  // Report vertices that the simulation left untouched, deepest node first.
+  void diagnoseVerticesThatNeverRan(runnerNode &launch) {
+    // Aggregate across runner nodes: every core of a herd reports the same
+    // shape, and listing each separately buries the answer.
+    std::map<std::string, unsigned> offenders;
+    unsigned total = 0;
+    std::function<void(runnerNode &)> visit = [&](runnerNode &n) {
+      Graph &G = n.ctrl_g->g;
+      for (auto v : G.getVertices())
+        if (G[v].op && !G[v].is_started() && G[v].start_end_time_log.empty()) {
+          offenders[n.runner_node_type + " " + G[v].asyncEventName]++;
+          total++;
+        }
+      for (auto &sub : n.sub_runner_nodes)
+        visit(sub);
+    };
+    visit(launch);
+    if (!total)
+      return;
+
+    std::vector<std::pair<std::string, unsigned>> ranked(offenders.begin(),
+                                                         offenders.end());
+    llvm::sort(ranked, [](auto &a, auto &b) { return a.second > b.second; });
+    std::string detail;
+    unsigned shown = 0;
+    for (auto &o : ranked) {
+      if (shown++ == 6) {
+        detail += ", ...";
+        break;
+      }
+      detail +=
+          (shown > 1 ? ", " : "") + o.first + " x" + std::to_string(o.second);
+    }
+    launch.runner_assertion(
+        false, "simulation reached the launch terminator but left " +
+                   std::to_string(total) +
+                   " ops that never ran and were never retired, so the "
+                   "reported latency covers only part of the design: " +
+                   detail);
   }
 
 private:

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -571,7 +571,7 @@ public:
       diagnoseVerticesThatNeverRan(launch);
   }
 
-  // Report vertices that the simulation left untouched, deepest node first.
+  // Report vertices that the simulation left untouched, most numerous first.
   void diagnoseVerticesThatNeverRan(runnerNode &launch) {
     // Aggregate across runner nodes: every core of a herd reports the same
     // shape, and listing each separately buries the answer.

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -33,6 +33,9 @@ public:
   std::vector<Graph::VertexId> latent_wavefront_candidates;
   // Sub runner nodes to the current runner node
   std::vector<runnerNode> sub_runner_nodes;
+  // Simulation time as of the current scheduling step, for retiring ops that
+  // never enter the wavefront.
+  uint64_t current_time = 0;
   // Resource hierarchies which are allocated to this runner node
   std::vector<resourceHierarchy *> resource_hiers;
 
@@ -54,7 +57,8 @@ public:
     // Remove candidate vertices which are filtered out by an affine.if, if
     // showing cores
     if (this->sim_granularity == "core") {
-      this->removeOpsFilteredOutByAffineIf(next_vertex_set_candidates);
+      this->removeOpsFilteredOutByAffineIf(next_vertex_set_candidates,
+                                           this->current_time);
     }
 
     return next_vertex_set_candidates;
@@ -2065,23 +2069,43 @@ private:
     }
   }
 
-  // Remove ops in affine.if which aren't running on this core
-  void
-  removeOpsFilteredOutByAffineIf(std::vector<Graph::VertexId> &candidates) {
+  // Retire ops in an affine.if branch which this core does not take.
+  //
+  // Such an op represents no work here, so it must not be scheduled. But
+  // dropping it from the candidate list is not enough: it stays unstarted
+  // forever, and every vertex that lists it as a dependence -- the branch's own
+  // terminator first, then the enclosing loop's scf.yield -- blocks on it for
+  // the rest of the run. In a broadcast design each core sits outside most of
+  // the branches, so most terminators never close and the enclosing loop never
+  // advances past its first iteration.
+  //
+  // Retire them with zero duration instead, and make their successors
+  // candidates, so the branch closes and the loop can advance.
+  void removeOpsFilteredOutByAffineIf(std::vector<Graph::VertexId> &candidates,
+                                      uint64_t time) {
     Graph &G = this->ctrl_g->g;
-    for (auto it = candidates.begin(); it != candidates.end(); ++it) {
-      auto op = G[*it].op;
-      if (op->getParentOfType<affine::AffineIfOp>()) {
-        std::vector<Operation *> affine_if_nest;
-        Operation *spatial_loop = nullptr;
-        getAffineIfNestAndSpatialLoopFromOp(op, affine_if_nest, spatial_loop);
-        if (!positionHitsAffineIfCondition(op, spatial_loop, affine_if_nest,
-                                           this->ctrl_g->position)) {
-          candidates.erase(it);
-          it--;
-        }
+    llvm::erase_if(candidates, [&](Graph::VertexId v) {
+      auto op = G[v].op;
+      if (!op || !op->getParentOfType<affine::AffineIfOp>())
+        return false;
+      std::vector<Operation *> affine_if_nest;
+      Operation *spatial_loop = nullptr;
+      getAffineIfNestAndSpatialLoopFromOp(op, affine_if_nest, spatial_loop);
+      if (positionHitsAffineIfCondition(op, spatial_loop, affine_if_nest,
+                                        this->ctrl_g->position))
+        return false;
+      if (!G[v].is_started()) {
+        G[v].start_time = time;
+        G[v].release_time = time;
+        G[v].end_time = time;
+        G[v].resources_released = true;
+        push_back_if_unique<Graph::VertexId>(this->processed_vertices, v);
+        for (auto adj_v : G.adjacentVertices(v))
+          push_back_if_unique<Graph::VertexId>(
+              this->latent_wavefront_candidates, adj_v);
       }
-    }
+      return true;
+    });
   }
 
 }; // runnerNode

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -2103,6 +2103,13 @@ private:
         for (auto adj_v : G.adjacentVertices(v))
           push_back_if_unique<Graph::VertexId>(
               this->latent_wavefront_candidates, adj_v);
+        // Drop it from the latent set as well. Latent candidates are copied
+        // into the candidate list on every scheduling step, so a filtered
+        // vertex left there is re-derived and re-filtered forever -- and in a
+        // broadcast design most vertices are filtered on most cores. Resetting
+        // the vertex for the next loop iteration puts it back, which is when
+        // it needs retiring again.
+        llvm::erase(this->latent_wavefront_candidates, v);
       }
       return true;
     });

--- a/mlir/test/Util/Runner/core_runners/affine_if_filtered_ops_retire.mlir
+++ b/mlir/test/Util/Runner/core_runners/affine_if_filtered_ops_retire.mlir
@@ -1,0 +1,64 @@
+//===- affine_if_filtered_ops_retire.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/../arch.json -g core | FileCheck %s
+
+// A broadcast pair guarded by affine.if, simulated per core.
+//
+// Each core takes exactly one side of the branch, so at core granularity the
+// other side is filtered out of scheduling. Filtered ops have to be retired,
+// not merely skipped: an op left unstarted blocks every vertex that lists it
+// as a dependence, starting with its own branch terminator.
+//
+// The assertion here is not the cycle count -- retiring costs no time, so the
+// count is the same either way. It is that the run leaves nothing behind.
+// air-runner fails a run that reaches the launch terminator with ops that
+// never ran and were never retired, so reaching this CHECK at all is the test:
+// without the retirement each of the four cores strands its unselected branch
+// and the run is diagnosed instead of reporting a latency.
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: Latency (all-iterations mode): 0.097us
+
+#set = affine_set<()[s0, s1] : (s0 == 0, s1 >= 0, -s1 + 1 >= 0)>
+module {
+  air.channel @row0 [1, 1] {broadcast_shape = [1, 2]}
+  air.channel @row1 [1, 1] {broadcast_shape = [1, 2]}
+  func.func @test() {
+    %0 = air.launch async () in () attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 2 : i64, y_loc = 0 : i64, y_size = 2 : i64} {
+        %c2 = arith.constant 2 : index
+        %async_token, %results = air.execute -> (memref<64x64xbf16, 1 : i32>) {
+          %alloc = memref.alloc() : memref<64x64xbf16, 1 : i32>
+          air.execute_terminator %alloc : memref<64x64xbf16, 1 : i32>
+        }
+        %2 = air.channel.put async [%async_token] @row0[] (%results[] [] []) {id = 1 : i32} : (memref<64x64xbf16, 1 : i32>)
+        %3 = air.channel.put async [%async_token] @row1[] (%results[] [] []) {id = 2 : i32} : (memref<64x64xbf16, 1 : i32>)
+        %4 = air.herd @herd_0 async [%async_token] tile (%arg0, %arg1) in (%arg2=%c2, %arg3=%c2) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %async_token_0, %results_1 = air.execute -> (memref<64x64xbf16, 2 : i32>) {
+            %alloc = memref.alloc() : memref<64x64xbf16, 2 : i32>
+            air.execute_terminator %alloc : memref<64x64xbf16, 2 : i32>
+          }
+          %5 = affine.if #set()[%arg0, %arg1] -> !air.async.token {
+            %6 = air.channel.get async [%async_token_0] @row0[%arg0, %arg1] (%results_1[] [] []) {id = 3 : i32} : (memref<64x64xbf16, 2 : i32>)
+            affine.yield %6 : !air.async.token
+          } else {
+            %6 = air.channel.get async [%async_token_0] @row1[%arg0, %arg1] (%results_1[] [] []) {id = 4 : i32} : (memref<64x64xbf16, 2 : i32>)
+            affine.yield %6 : !air.async.token
+          }
+          %async_token_2 = air.execute [%5] {
+            memref.dealloc %results_1 : memref<64x64xbf16, 2 : i32>
+          }
+        }
+        %async_token_3 = air.execute [%4, %2, %3] {
+          memref.dealloc %results : memref<64x64xbf16, 1 : i32>
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Two related changes to `air-runner`, found while root-causing the `test/airrunner/matmul_bf16_vectorized` stall (fixed separately in #1914 — this PR is independent of it and sits on plain `main`).

## Retire filtered ops instead of dropping them

At core granularity `removeOpsFilteredOutByAffineIf` drops the candidate vertices whose `affine.if` condition does not cover this core. Dropping them from the candidate list is right — they represent no work here — but they were never marked done either. They sat unstarted for the whole run, and every vertex listing one as a dependence blocked on it: the branch's own terminator first, then anything waiting on that. In a broadcast design each core is outside most of the branches, so most terminators never closed.

They are now retired with zero duration — `start = end = now`, pushed to `processed_vertices`, successors made latent candidates — so the branch closes.

The loop also erased mid-iteration with `candidates.erase(it); it--`, which is undefined when `it == begin()`. Rewritten with `llvm::erase_if`.

## Diagnose a run that finished with work left unrun

Nothing detected any of the above, which is the more important half.

Reaching the launch terminator is necessary but not sufficient. A vertex that is never scheduled and never retired just sits in the graph: the run reaches the exit along some other path and the latency printed is the latency of whatever happened to run. That is the same silently-wrong answer the existing stall assertion exists to prevent, arriving by a different route — so this accounts for the graph as well as the exit.

"Never ran" means never started **and** no entry in the execution log. Vertices are reset between loop iterations, so an unstarted vertex that ran in an earlier iteration is ordinary and is not reported. (Getting this wrong is why an earlier draft of the census appeared to show un-simulated `linalg` ops that were in fact running fine.)

```
Error: simulation reached the launch terminator but left 128 ops that never ran
and were never retired, so the reported latency covers only part of the design:
herd AffineIfYieldOp x60, herd AffineIfOp x20,
herd ChannelGetOp@channel_0(L1<--L2) x12, ...
```

## Negative control

Five existing tests are the control. With the diagnostic and without the retirement they fail, having left this much unrun:

| test | ops never run |
|---|---|
| `core_runners/channel_broadcast.mlir` | 128 |
| `core_runners/core_to_core_ping_pong.mlir` | 80 |
| `core_runners/one_by_four_herd_dataflow.mlir` | 44 |
| `core_runners/two_by_two_herd_dataflow.mlir` | 8 |
| `core_runners/two_herds_per_core_mode.mlir` | 4 |

With both changes they report zero. **Every latency in the suite is unchanged** — the retired ops are the branches a core does not take, so they carry no time. `test/airrunner/matmul_bf16_vectorized` goes from 512 ops unrun to none, also without moving its latency.

## Checks

- `check-air-mlir` 520 passed / 7 expectedly failed / 0 failed
- `check-air-python` 36/36, `check-air-cpp` 1/1
- `git clang-format origin/main` clean
- All 34 runner tests swept for never-run vertices before and after: 5 non-zero → 0, rest already 0

## Considered and rejected

A stronger invariant — *a block terminator may not run before its block's ops complete* — would also have fixed the ordering hazard where an `scf.yield` runs before its `scf.for` entry and the loop's trip counts are therefore never registered. It is the wrong rule for this model: it suppresses cross-iteration overlap, moving `multi_token_loop.mlir` from 69.346us to 71.642us. Software pipelining across iterations is the thing that test exists to measure, so that is a regression, not a fix. Not included.

The narrow version of that guard — a yield may not run before its loop's entry vertex — is correct but has no observable effect on any design available, including hand-written IR built specifically to provoke it, so it is not included either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)