### PR TITLE
[programming_examples] air.api: conditional examples, plus ops.branch

### DIFF
--- a/programming_examples/cascade_reduction/cascade_reduction.py
+++ b/programming_examples/cascade_reduction/cascade_reduction.py
@@ -1,132 +1,111 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A cascade reduction across a row of cores, on air.api.
 
-"""Cascade Reduction Example
+Four cores in a row, chained by a cascade channel. Each adds one, so the
+result is ``input + 4``:
 
-Demonstrates a 4-tile cascade reduction pattern using AIR channels.
+    launch                      put   -> chan_in
+    tile 0    chan_in     -> get, +1, put -> chan_cascade[0]
+    tile 1    cascade[0]  -> get, +1, put -> chan_cascade[1]
+    tile 2    cascade[1]  -> get, +1, put -> chan_cascade[2]
+    tile 3    cascade[2]  -> get, +1, put -> chan_out
+    launch                      get   <- chan_out
 
-Data flows through a 1x4 herd in a pipeline:
-  1. Launch puts input data on @chan_in
-  2. Tile 0: gets from @chan_in, adds 1, puts on @chan_cascade[0]
-  3. Tile 1: gets from @chan_cascade[0], adds 1, puts on @chan_cascade[1]
-  4. Tile 2: gets from @chan_cascade[1], adds 1, puts on @chan_cascade[2]
-  5. Tile 3: gets from @chan_cascade[2], adds 1, puts on @chan_out
-  6. Launch gets output from @chan_out
+The point of the example is that the four cores are *not* interchangeable: the
+first reads from L3, the last writes to L3, and the middle two only forward. A
+herd body is traced once for the whole herd, so telling them apart is
+``ops.branch`` -- an ``scf.if`` on the tile coordinate -- and not a Python ``if``,
+which would have to pick one branch for every core. ``tx == 0`` builds the
+condition; the comparison is emitted as ``arith.cmpi`` where the region opens.
 
-Final result: output = input + 4
+``chan_cascade`` is ``channel_type="npu_cascade"``: a direct core-to-core
+connection between neighbouring tiles rather than a DMA stream. The herd is
+therefore a row -- ``NUM_TILES`` columns by one -- so the cascade flows
+west-to-east between adjacent columns.
+
+Two differences from the predecessor:
+
+* ``local[:] = recv[:] + local[:]`` replaces a ``linalg.add`` with the output
+  aliasing an input. Same accumulate, and the DSL vectorises it rather than
+  handing the pipeline a named op to fuse.
+* The neighbour index is ``tx - 1`` rather than a hand-built ``arith.subi``, so
+  it reaches the channel as one ``affine.apply`` like every other index
+  expression in the DSL.
 """
 
 import argparse
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith, linalg, memref, scf
-from air.dialects.memref import AllocOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
-
 import numpy as np
+
+from air import api as air
+from air.api.types import i32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
-
 NUM_TILES = 4
 DATA_SIZE = 2048
+SHAPE = [1, 1, DATA_SIZE]
 
 
-@module_builder
 def build_module():
-    xrt_dtype = T.i32()
-    data_shape = [1, 1, DATA_SIZE]
+    src = air.tensor(SHAPE, i32)
+    dst = air.tensor(SHAPE, i32)
 
-    # L3 types
-    l3MemrefTy = MemRefType.get(data_shape, xrt_dtype)
-    # L1 types
-    l1MemrefTy = MemRefType.get(
-        data_shape,
-        xrt_dtype,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
+    # chan_in / chan_out are ordinary DMA links to L3; chan_cascade is the
+    # core-to-core connection between adjacent columns.
+    chan_in = air.channel("chan_in", size=[1])
+    chan_cascade = air.channel(
+        "chan_cascade", size=[NUM_TILES], channel_type="npu_cascade"
     )
+    chan_out = air.channel("chan_out", size=[1])
 
-    # Channels: chan_in/chan_out use DMA (L3<->L1), chan_cascade uses
-    # direct core-to-core cascade connections between adjacent tiles.
-    channel("chan_in", size=[1])
-    channel("chan_cascade", size=[NUM_TILES], channel_type="npu_cascade")
-    channel("chan_out", size=[1])
+    with air.launch(name="cascade_reduce") as launch:
 
-    @FuncOp.from_py_func(l3MemrefTy, l3MemrefTy)
-    def cascade_reduce(arg0, arg1):
+        @launch.body
+        def _():
+            chan_in.put(src)
 
-        launch_size = [1, 1]
+            with air.segment(name="segment_0") as seg:
 
-        @launch(operands=[arg0, arg1], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_in,
-            l3_out,
-        ):
-            # Send input to tile 0
-            ChannelPut("chan_in", l3_in)
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(NUM_TILES)], name="herd_0", shape=(NUM_TILES,)
+                    ) as herd:
 
-            @segment(name="segment_0")
-            def segment_body():
+                        @herd.body
+                        def _(tx):
+                            # Every core contributes the same 1; the reduction
+                            # is the chain, not the operand.
+                            local = air.alloc(SHAPE, i32, scope=herd.private())
+                            air.ops.fill(local, 1)
+                            recv = air.alloc(SHAPE, i32, scope=herd.private())
 
-                # Herd oriented as NUM_TILES columns x 1 row so cascade flows
-                # go West-to-East between adjacent columns.
-                @herd(name="herd_0", sizes=[NUM_TILES, 1])
-                def herd_body(tx, ty, sx, sy):
-                    c0 = arith.ConstantOp.create_index(0)
-                    c1_i32 = arith.ConstantOp(IntegerAttr.get(T.i32(), 1), None)
-                    last_tile = arith.ConstantOp.create_index(NUM_TILES - 1)
+                            with air.ops.branch(tx == 0) as head:
+                                chan_in.get(recv)
+                                local[:] = recv[:] + local[:]
+                                chan_cascade.put(local, indices=[tx])
 
-                    # Each tile has a local buffer initialized to 1
-                    local_buf = AllocOp(l1MemrefTy, [], [])
-                    linalg.fill(c1_i32, outs=[local_buf])
+                            with head.otherwise():
+                                chan_cascade.get(recv, indices=[tx - 1])
+                                local[:] = recv[:] + local[:]
 
-                    # Receive buffer
-                    recv_buf = AllocOp(l1MemrefTy, [], [])
+                                with air.ops.branch(tx == NUM_TILES - 1) as tail:
+                                    chan_out.put(local)
+                                with tail.otherwise():
+                                    chan_cascade.put(local, indices=[tx])
 
-                    # Tile 0: read from chan_in
-                    cmp_first = arith.CmpIOp(arith.CmpIPredicate.eq, tx, c0)
-                    if_first = scf.IfOp(cmp_first, has_else=True)
-                    with InsertionPoint(if_first.then_block):
-                        ChannelGet("chan_in", recv_buf)
-                        linalg.add(recv_buf, local_buf, outs=[local_buf])
-                        ChannelPut("chan_cascade", local_buf, indices=[tx])
-                        yield_([])
+            chan_out.get(dst)
 
-                    # Tiles 1..N-1: read from previous tile's cascade channel
-                    with InsertionPoint(if_first.else_block):
-                        c1_idx = arith.ConstantOp.create_index(1)
-                        prev_tx = arith.SubIOp(tx, c1_idx)
-                        ChannelGet("chan_cascade", recv_buf, indices=[prev_tx])
-                        linalg.add(recv_buf, local_buf, outs=[local_buf])
-
-                        # Last tile: write to chan_out; others: write to chan_cascade
-                        cmp_last = arith.CmpIOp(arith.CmpIPredicate.eq, tx, last_tile)
-                        if_last = scf.IfOp(cmp_last, has_else=True)
-                        with InsertionPoint(if_last.then_block):
-                            ChannelPut("chan_out", local_buf)
-                            yield_([])
-                        with InsertionPoint(if_last.else_block):
-                            ChannelPut("chan_cascade", local_buf, indices=[tx])
-                            yield_([])
-
-                        yield_([])
-
-            # Receive output from last tile
-            ChannelGet("chan_out", l3_out)
+    return launch
 
 
-if __name__ == "__main__":
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="cascade_reduction.py",
         description="Builds, runs, and tests the cascade reduction example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -145,57 +124,76 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    return parser.parse_args()
 
-    mlir_module = build_module()
+
+def main():
+    args = parse_args()
+
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
-    input_a = np.arange(0, DATA_SIZE, dtype=np.int32).reshape(1, 1, DATA_SIZE)
+    input_a = np.arange(0, DATA_SIZE, dtype=np.int32).reshape(*SHAPE)
 
-    if args.compile_mode == "compile-and-run":
-        num_samples = 100
-        sampled_indices = np.vstack(
-            [
-                np.zeros(num_samples, dtype=int),
-                np.zeros(num_samples, dtype=int),
-                np.random.randint(0, DATA_SIZE, num_samples),
-            ]
-        )
-
-        sampled_values = np.array(
-            [input_a[i, j, k] + NUM_TILES for i, j, k in zip(*sampled_indices)],
-            dtype=np.int32,
-        )
-
-        sampled_data = {
-            "shape": (1, 1, DATA_SIZE),
-            "indices": sampled_indices,
-            "values": sampled_values,
-        }
-
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="cascade_reduce",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_a],
-                stochastic_expected_outputs=[sampled_data],
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_mode == "compile-only":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="cascade_reduce",
+        runtime_loop_tiling_sizes=[4, 4],
+        target_device=launch.target,
+    )
+
+    # The output is 2048 elements of input + NUM_TILES; a sample of 100 of them
+    # is what the predecessor checked, and it is enough to catch a broken link
+    # in the chain (a missing +1 shifts every element).
+    num_samples = 100
+    sampled_indices = np.vstack(
+        [
+            np.zeros(num_samples, dtype=int),
+            np.zeros(num_samples, dtype=int),
+            np.random.randint(0, DATA_SIZE, num_samples),
+        ]
+    )
+    sampled_values = np.array(
+        [input_a[i, j, k] + NUM_TILES for i, j, k in zip(*sampled_indices)],
+        dtype=np.int32,
+    )
+
+    return runner.run_test(
+        mlir_module,
+        inputs=[input_a],
+        stochastic_expected_outputs=[
+            {
+                "shape": tuple(SHAPE),
+                "indices": sampled_indices,
+                "values": sampled_values,
+            }
+        ],
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/channel_examples/broadcast_selective_capture/broadcast_selective_capture.py
+++ b/programming_examples/channel_examples/broadcast_selective_capture/broadcast_selective_capture.py
@@ -1,190 +1,153 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Selective capture from a broadcast channel, on air.api.
 
-# This example demonstrates a common pattern where, due to DMA channel
-# limitations, data that is NOT logically broadcast still needs to be
-# distributed via a broadcast channel to reuse routing and DMA resources.
-#
-# Scenario:
-#   - A 1-D array is divided into NUM_TILES tiles.
-#   - The tiles are streamed one-by-one into a herd of size [1, NUM_TILES]
-#     via a broadcast channel (all cores receive every tile).
-#   - Each core counts the iteration and only captures the tile whose
-#     iteration index matches its own column index (ty). All other tiles
-#     are received but discarded.
-#   - Each core adds its own index to the captured tile (to prove which
-#     core handled which tile) and writes the result out.
-#
-# The net effect is equivalent to a non-broadcast scatter, but implemented
-# over a single broadcast channel to conserve DMA channels.
+A 1-D array is split into ``NUM_TILES`` tiles and streamed one at a time down a
+*broadcast* channel, so every core in the ``[1, NUM_TILES]`` herd receives every
+tile. Each core keeps only the tile whose round matches its own column index and
+discards the rest, adding its index to the captured tile to prove which core
+handled which.
+
+The net effect is a scatter. It is written as a broadcast because DMA channels
+are scarce: one broadcast channel and one set of routes serve all four cores,
+where four separate streams would not fit.
+
+Two things this example is the smallest case of:
+
+* **Every core must take every tile.** The hardware requires all broadcast
+  targets to accept the data, so the ``get`` sits outside the conditional and
+  only the *capture* is guarded. Guarding the get instead would hang.
+* **The guard is ``ops.branch`` with no ``otherwise``.** A core that is not the
+  addressee does nothing this round. That emits an ``scf.if`` whose else region
+  holds only its terminator, which ``canonicalize`` removes before anything in
+  the AIR pipeline reads the region structure.
+
+The rounds are a Python ``for``: ``NUM_TILES`` is a trace-time constant and each
+round names a different broadcast slot, so unrolling them is what the
+predecessor did too. The per-round condition ``ty == i`` is what tells the cores
+apart, and that has to be a region -- the herd body is traced once for all four.
+
+One difference from the predecessor: the capture is
+``out[:] = recv[:] + ty``, replacing a scalar ``memref.load``/``store`` loop over
+all 32 elements. The DSL vectorises it, and ``ty`` broadcasts as a scalar.
+"""
 
 import argparse
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects import arith, scf
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-
-range_ = for_
+from air import api as air
+from air.api import ops
+from air.api.types import i32
+from air.backend.xrt_runner import XRTRunner
 
 TILE_SIZE = 32
-NUM_TILES = 4  # Also the herd width; each core captures exactly one tile
+NUM_TILES = 4  # also the herd width; each core captures exactly one tile
 
 INOUT_DATATYPE = np.int32
 
 
-@module_builder
 def build_module():
-    xrt_dtype = type_mapper(INOUT_DATATYPE)
+    total = TILE_SIZE * NUM_TILES
+    src = air.tensor([total], i32)
+    dst = air.tensor([total], i32)
 
-    total_size = TILE_SIZE * NUM_TILES
-    memrefTyIn = MemRefType.get([total_size], xrt_dtype)
-    memrefTyOut = MemRefType.get([total_size], xrt_dtype)
+    # One put reaches all NUM_TILES cores: size is the producer grid, and
+    # broadcast_shape is the consumer grid the get indexes.
+    bcast = air.channel("BroadcastIn", size=[1, 1], broadcast_shape=[1, NUM_TILES])
+    out = air.channel("ChanOut", size=[1, NUM_TILES])
 
-    mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    tile_type_l1 = MemRefType.get(
-        shape=[TILE_SIZE],
-        element_type=xrt_dtype,
-        memory_space=mem_space_l1,
-    )
+    with air.launch(name="broadcast_selective_capture") as launch:
 
-    # Broadcast channel: size [1, 1] broadcast to [1, NUM_TILES]
-    # All cores in the herd receive the same data on each put.
-    Channel("BroadcastIn", size=[1, 1], broadcast_shape=[1, NUM_TILES])
-
-    # Output channel: one per core (sized to herd)
-    Channel("ChanOut", size=[1, NUM_TILES])
-
-    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
-    def broadcast_selective_capture(arg0, arg1):
-
-        @launch(operands=[arg0, arg1])
-        def launch_body(l3_in, l3_out):
-
-            # Stream tiles one by one into the broadcast channel
+        @launch.body
+        def _():
+            # Stream the tiles, one round each.
             for i in range(NUM_TILES):
-                offset = TILE_SIZE * i
-                ChannelPut(
-                    "BroadcastIn",
-                    l3_in,
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                )
+                lo = TILE_SIZE * i
+                bcast.put(src[lo : lo + TILE_SIZE])
 
-            @segment(name="seg")
-            def segment_body():
+            with air.segment(name="seg") as seg:
 
-                @herd(name="compute_herd", sizes=[1, NUM_TILES])
-                def herd_body(tx, ty, _sx, _sy):
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(1), range(NUM_TILES)],
+                        name="compute_herd",
+                        shape=(1, NUM_TILES),
+                    ) as herd:
 
-                    # Allocate L1 buffers: one for receiving broadcast data,
-                    # one for the captured tile that will be written out.
-                    recv_buf = AllocOp(tile_type_l1, [], [])
-                    out_buf = AllocOp(tile_type_l1, [], [])
+                        @herd.body
+                        def _(tx, ty):
+                            recv = air.alloc([TILE_SIZE], i32, scope=herd.private())
+                            captured = air.alloc([TILE_SIZE], i32, scope=herd.private())
 
-                    # Iterate over all broadcast rounds
-                    for iter_idx in range(NUM_TILES):
-                        # Every core must consume from the broadcast channel
-                        # on every iteration (the hardware requires all
-                        # broadcast targets to accept the data).
-                        ChannelGet("BroadcastIn", recv_buf, indices=[tx, ty])
+                            for i in range(NUM_TILES):
+                                # Outside the branch: every broadcast target has
+                                # to accept the data every round or the flow
+                                # stalls for all of them.
+                                bcast.get(recv, indices=[tx, ty])
 
-                        # Only capture when this iteration matches our
-                        # core index.
-                        cmp_val = arith.cmpi(
-                            arith.CmpIPredicate.eq,
-                            arith.index_cast(T.i32(), ty),
-                            arith.ConstantOp(T.i32(), iter_idx),
-                        )
-                        if_op = scf.IfOp(cmp_val)
-                        with InsertionPoint(if_op.then_block):
-                            # Copy received data into the output buffer,
-                            # adding the core index to prove ownership.
-                            for j in range_(TILE_SIZE):
-                                val = load(recv_buf, [j])
-                                val_out = arith.addi(val, arith.index_cast(T.i32(), ty))
-                                store(val_out, out_buf, [j])
-                                yield_([])
-                            yield_([])
+                                # Inside: only the addressee keeps it.
+                                with ops.branch(ty == i):
+                                    captured[:] = recv[:] + ty
 
-                    # Write the captured (and modified) tile to the output
-                    ChannelPut("ChanOut", out_buf, indices=[tx, ty])
+                            out.put(captured, indices=[tx, ty])
 
-                    DeallocOp(recv_buf)
-                    DeallocOp(out_buf)
-
-            # Collect output tiles from each core
             for i in range(NUM_TILES):
-                offset = TILE_SIZE * i
-                ChannelGet(
-                    "ChanOut",
-                    l3_out,
-                    indices=[0, i],
-                    offsets=[offset],
-                    sizes=[TILE_SIZE],
-                    strides=[1],
-                )
+                lo = TILE_SIZE * i
+                out.get(dst[lo : lo + TILE_SIZE], indices=[0, i])
+
+    return launch
 
 
-if __name__ == "__main__":
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the broadcast selective capture example",
+        prog="broadcast_selective_capture.py",
+        description="Selective capture from a broadcast channel",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-p",
-        "--print-module-only",
-        action="store_true",
-    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
     parser.add_argument(
         "--output-format",
         type=str,
         choices=["xclbin", "elf"],
         default="xclbin",
         dest="output_format",
-        help="Output format for the compiled binary (default: xclbin)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    return parser.parse_args()
 
-    args = parser.parse_args()
 
-    mlir_module = build_module()
+def main():
+    args = parse_args()
+
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
-    total_size = TILE_SIZE * NUM_TILES
-
-    # Input: [0, 1, 2, ..., total_size - 1]
-    input_a = np.arange(total_size, dtype=INOUT_DATATYPE)
-
-    # Expected output: each core captures tile[ty] and adds ty to each element.
-    # Core ty captures input[ty*TILE_SIZE : (ty+1)*TILE_SIZE] and adds ty.
-    expected_output = np.zeros(total_size, dtype=INOUT_DATATYPE)
-    for ty in range(NUM_TILES):
-        start = ty * TILE_SIZE
-        end = start + TILE_SIZE
-        expected_output[start:end] = input_a[start:end] + ty
+    total = TILE_SIZE * NUM_TILES
+    input_a = np.arange(total, dtype=INOUT_DATATYPE)
+    # Tile i is captured by core i, which adds its own index.
+    expected = np.concatenate(
+        [input_a[i * TILE_SIZE : (i + 1) * TILE_SIZE] + i for i in range(NUM_TILES)]
+    ).astype(INOUT_DATATYPE)
 
     runner = XRTRunner(
         verbose=args.verbose,
         output_format=args.output_format,
         instance_name="broadcast_selective_capture",
-        runtime_loop_tiling_sizes=[4, 4],
+        target_device=launch.target,
     )
-    exit(
-        runner.run_test(
-            mlir_module,
-            inputs=[input_a],
-            expected_outputs=[expected_output],
-        )
-    )
+    return runner.run_test(mlir_module, inputs=[input_a], expected_outputs=[expected])
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/conditional_branching/single_core.py
+++ b/programming_examples/conditional_branching/single_core.py
@@ -65,7 +65,15 @@ def build_module(n, param):
                         def _(tx):
                             inp = air.alloc([n], i32, scope=herd.private())
                             ops.load(inp, staged_in)
-                            buf = air.alloc([n], i32, scope=herd.private())
+                            # Scalar, like the predecessor. A vectorised i32
+                            # multiply lowers to aievec.mul_elem, which AIE2p
+                            # does not implement -- `arith.muli %0, %cst :
+                            # vector<16xi32>` fails to legalize on the hx370
+                            # runner while compiling fine on AIE2. The width is
+                            # a property of the destination buffer, so this
+                            # makes both arms scalar; at n = 48 that is what the
+                            # raw-bindings version did anyway.
+                            buf = air.alloc([n], i32, scope=herd.private(), vector=0)
 
                             with ops.branch(mode != 0) as chosen:
                                 buf[:] = inp[:] + 100

--- a/programming_examples/conditional_branching/single_core.py
+++ b/programming_examples/conditional_branching/single_core.py
@@ -1,225 +1,150 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""A kernel that branches on a parameter, on air.api.
+
+``out = in + 100`` or ``out = in * 100``, chosen by ``param``. The module is
+built twice, once per value, and both are run.
+
+This is the third shape of conditional in the tree, and the one that is *not*
+about tile coordinates: the predicate here is a **dispatch-time parameter**, so
+it is the same for every core. It is still a region and not a Python ``if``,
+because the branch is what the example exists to demonstrate -- writing
+``if param:`` in Python would pick a body at trace time and hand the compiler a
+kernel with no ``scf.if`` in it at all.
+
+``air.symbol`` is the DSL's name for a value of this kind ("known at dispatch
+time rather than compile time"). Its *arithmetic* folds to a Python int, because
+a symbol used as a tile size has to size a memref; its *comparisons* do not,
+because folding one would delete the branch. ``mode != 0`` therefore reaches the
+IR as ``arith.constant`` + ``arith.cmpi`` feeding the ``scf.if``, where the
+predecessor spelled the same thing as ``arith.index_cast(param) : i1``. Both are
+a constant driving a branch, and ``air-to-aie``'s ``SpecializeScfIfPattern``
+folds either one away once the herd is unrolled -- so the branch is present for
+the compiler to reason about and costs nothing at run time.
+
+The two arms are ``buf[:] = inp[:] + 100`` and ``buf[:] = inp[:] * 100``,
+replacing scalar ``memref.load``/``store`` loops over all 48 elements.
+"""
+
 import argparse
-from math import cos, sin
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects import scf
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+import numpy as np
 
-range_ = for_
+from air import api as air
+from air.api import ops
+from air.api.types import i32
+from air.backend.xrt_runner import XRTRunner
+
+N = 48
+INOUT_DATATYPE = np.int32
 
 
-@module_builder
-def build_module(n, np_dtype_in, np_dtype_out, param):
+def build_module(n, param):
+    src = air.tensor([n], i32)
+    dst = air.tensor([n], i32)
 
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
+    # Not a plain Python int: a comparison on one of those is answered at trace
+    # time, and there would be no scf.if left to compile.
+    mode = air.symbol(hint=param, name="param")
 
-    # L3 MemRefTypes
-    memrefTyIn = MemRefType.get([n], xrt_dtype_in)
-    memrefTyOut = MemRefType.get([n], xrt_dtype_in)
+    with air.launch(name="conditional_branch") as launch:
 
-    @FuncOp.from_py_func(memrefTyIn, memrefTyOut)
-    def conditional_branch(arg0, arg1):
+        @launch.body
+        def _():
+            with air.segment(name="segment_0") as seg:
 
-        launch_size = [1, 1]
+                @seg.body
+                def _():
+                    staged_in = air.alloc([n], i32, scope=seg.private())
+                    staged_out = air.alloc([n], i32, scope=seg.private())
+                    ops.load(staged_in, src)
 
-        @launch(operands=[arg0, arg1], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_in_data,
-            l3_out_data,
-        ):
+                    with air.herd([range(1)], name="herd_0", shape=(1,)) as herd:
 
-            @segment(name="segment_0", operands=[l3_in_data, l3_out_data])
-            def segment_body(
-                _l3_in_data,
-                _l3_out_data,
-            ):
-                # L2 MemRefTypes
-                l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-                l2MemrefTyIn = MemRefType.get(
-                    shape=[n],
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2MemrefTyOut = MemRefType.get(
-                    shape=[n],
-                    element_type=xrt_dtype_in,
-                    memory_space=l2_mem_space,
-                )
-                l2_in_data = AllocOp(l2MemrefTyIn, [], [])
-                l2_out_data = AllocOp(l2MemrefTyOut, [], [])
-                dma_memcpy_nd(
-                    l2_in_data,
-                    _l3_in_data,
-                )
+                        @herd.body
+                        def _(tx):
+                            inp = air.alloc([n], i32, scope=herd.private())
+                            ops.load(inp, staged_in)
+                            buf = air.alloc([n], i32, scope=herd.private())
 
-                param_arg = arith.ConstantOp.create_index(param)
+                            with ops.branch(mode != 0) as chosen:
+                                buf[:] = inp[:] + 100
+                            with chosen.otherwise():
+                                buf[:] = inp[:] * 100
 
-                @herd(
-                    name="herd_0",
-                    sizes=[1, 1],
-                    operands=[l2_in_data, l2_out_data, param_arg],
-                )
-                def herd_body_0(
-                    _tx, _ty, _sx, _sy, _l2_in_data, _l2_out_data, _param_arg
-                ):
+                            ops.store(buf, staged_out)
 
-                    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-                    l1MemrefTyIn = MemRefType.get(
-                        shape=[n],
-                        element_type=xrt_dtype_in,
-                        memory_space=l1_mem_space,
-                    )
-                    l1MemrefTyOut = MemRefType.get(
-                        shape=[n],
-                        element_type=xrt_dtype_in,
-                        memory_space=l1_mem_space,
-                    )
+                    ops.store(staged_out, dst)
 
-                    l1_in_data = AllocOp(l1MemrefTyIn, [], [])
-                    dma_memcpy_nd(
-                        l1_in_data,
-                        _l2_in_data,
-                    )
-
-                    l1_buf = AllocOp(l1MemrefTyIn, [], [])
-
-                    # condition
-                    bool = IntegerType.get_signless(1)
-                    param_arg = arith.index_cast(bool, _param_arg)
-                    if_op = scf.IfOp(param_arg, has_else=True)
-                    with InsertionPoint(if_op.then_block):
-                        for i in range_(0, n):
-                            inval = load(l1_in_data, [i])
-                            add100 = arith.addi(
-                                inval, ConstantOp(IntegerAttr.get(T.i32(), 100), None)
-                            )
-                            store(add100, l1_buf, [i])
-                            yield_([])
-                        yield_([])
-                    with InsertionPoint(if_op.else_block):
-                        for i in range_(0, n):
-                            inval = load(l1_in_data, [i])
-                            mul100 = arith.muli(
-                                inval, ConstantOp(IntegerAttr.get(T.i32(), 100), None)
-                            )
-                            store(mul100, l1_buf, [i])
-                            yield_([])
-                        yield_([])
-
-                    dma_memcpy_nd(
-                        _l2_out_data,
-                        l1_buf,
-                    )
-                    DeallocOp(l1_in_data)
-
-                dma_memcpy_nd(
-                    _l3_out_data,
-                    l2_out_data,
-                )
-
-                DeallocOp(l2_in_data)
-                DeallocOp(l2_out_data)
+    return launch
 
 
-if __name__ == "__main__":
-    # Default values.
-    N = 48
-    param = 0
-    INPUT_DATATYPE = np.int32
-    OUTPUT_DATATYPE = np.int32
-
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
-        description="Builds, runs, and tests the passthrough_dma example",
+        prog="single_core.py",
+        description="Builds, runs and tests a kernel that branches on a parameter",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-p",
-        "--print-module-only",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--n",
-        type=int,
-        default=N,
-        help="N dimension size in a (1xK) * (KxN) matmul",
-    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-p", "--print-module-only", action="store_true")
+    parser.add_argument("--n", type=int, default=N, help="Vector length")
     parser.add_argument(
         "--output-format",
         type=str,
         choices=["xclbin", "elf"],
         default="xclbin",
         dest="output_format",
-        help="Output format for the compiled binary (default: xclbin)",
     )
-
-    args = parser.parse_args()
-
-    ###### Compile and test, param = 0
-    param = 0
-
-    mlir_module = build_module(
-        args.n,
-        INPUT_DATATYPE,
-        OUTPUT_DATATYPE,
-        param,
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
     if args.print_module_only:
-        print(mlir_module)
-        exit(0)
+        print(build_module(args.n, 0).build(target=args.target))
+        return 0
 
-    inputs = np.arange(0, args.n, dtype=INPUT_DATATYPE).reshape(args.n)
-    outputs = inputs * 100
+    inputs = np.arange(0, args.n, dtype=INOUT_DATATYPE)
+    results = []
 
-    runner = XRTRunner(
-        verbose=args.verbose,
-        output_format=args.output_format,
-        instance_name="conditional_branch",
-        runtime_loop_tiling_sizes=[4, 4],
-    )
-    res0 = runner.run_test(
-        mlir_module,
-        inputs=[inputs],
-        expected_outputs=[outputs],
-    )
+    # param = 0 takes the else arm (* 100); param = 1 takes the then arm (+ 100).
+    for param, expected in ((0, inputs * 100), (1, inputs + 100)):
+        launch = build_module(args.n, param)
+        # build() is what resolves --target auto to the installed generation, so
+        # the module has to exist before launch.target is read. Reading it first
+        # passes None to the runner, and the compile fails with the unhelpful
+        # "'builtin.module' op Invalid aie.device option".
+        mlir_module = launch.build(target=args.target)
+        runner = XRTRunner(
+            verbose=args.verbose,
+            output_format=args.output_format,
+            instance_name="conditional_branch",
+            runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
+        )
+        results.append(
+            runner.run_test(
+                mlir_module,
+                inputs=[inputs],
+                expected_outputs=[expected.astype(INOUT_DATATYPE)],
+            )
+        )
 
-    ###### Compile and test, param = 1
-    param = 1
-
-    mlir_module = build_module(
-        args.n,
-        INPUT_DATATYPE,
-        OUTPUT_DATATYPE,
-        param,
-    )
-
-    outputs = inputs + 100
-    res1 = runner.run_test(
-        mlir_module,
-        inputs=[inputs],
-        expected_outputs=[outputs],
-    )
-    if res0 == 0 and res1 == 0:
+    if all(r == 0 for r in results):
         print("Both conditions PASS!")
-    else:
-        if res0 != 0:
-            print("Cond. 0 FAIL!")
-        if res1 != 0:
-            print("Cond. 1 FAIL!")
+        return 0
+    for i, r in enumerate(results):
+        if r != 0:
+            print(f"Cond. {i} FAIL!")
+    return 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,6 +48,7 @@ if(AIE_ENABLE_BINDINGS_PYTHON)
       api/__init__.py
       api/_channel.py
       api/_compile.py
+      api/_cond.py
       api/_emit.py
       api/_extern.py
       api/_index.py

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -79,6 +79,21 @@ ordered in time on one core -- as against the herd's grid, which is spatial.
 ``air.parallel`` is its unordered counterpart (``scf.parallel``); it is declared
 below and raises, because nothing emits it yet.
 
+The DSL has **two conditionals**, and they are not interchangeable.
+``ops.select(c, a, b)`` is branchless: ``c`` compares buffer *data*, the
+decision is per element, both sides are evaluated, and the arms are values.
+``ops.branch(c)`` is a real branch: ``c`` compares *index* expressions
+(``tx == 0``), the decision is per core, one side runs, and the arms are
+statements -- which is what a channel put or a DMA has to be. They are the two
+halves of if-conversion. Reaching for either with the other's condition raises
+and the message names the one you wanted; ``_cond.py`` has the full table.
+
+``ops.branch`` has to be a region rather than a Python ``if`` because the herd
+body is traced once for the whole herd: a comparison against a coordinate has no
+value at trace time, so ``bool()`` on one raises rather than picking a branch for
+every core. The else is ``with <branch>.otherwise():``. There is no
+``and``/``or``, and conjunction is nesting.
+
 One hardware caveat that the DSL cannot see and so cannot raise on: an
 *unstaged* K reduction on a 2-D herd is wrong past a single trip. Both operands
 are then broadcast, and the resulting packet flows share one shim channel whose

--- a/python/air/api/_cond.py
+++ b/python/air/api/_cond.py
@@ -220,7 +220,7 @@ class _Region:
         # block with no terminator turns a diagnosable error into a verifier
         # crash somewhere unrelated.
         self.open = False
-        exit_region(aborted=exc_type is not None)
+        exit_region(aborted=exc_type is not None, what="ops.branch")
         if self._terminate:
             yield_([])
         self._ip.__exit__(exc_type, exc, tb)

--- a/python/air/api/_cond.py
+++ b/python/air/api/_cond.py
@@ -1,0 +1,301 @@
+# ./python/air/api/_cond.py -*- Python -*-
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""``ops.branch`` -- a real branch, as against ``ops.select``.
+
+    with ops.branch(tx == 0) as head:
+        chan_in.get(recv)
+    with head.otherwise():
+        cascade.get(recv, indices=[tx - 1])
+
+Read this next to :func:`air.api.ops.select`, because the DSL now has two
+conditionals and picking the wrong one is the mistake worth designing against.
+They are the two halves of *if-conversion*, the classical transformation that
+replaces a branch with a select, and they differ on every axis that matters:
+
+===============  ==========================  ============================
+                 ``ops.select(c, a, b)``     ``ops.branch(c)``
+===============  ==========================  ============================
+what ``c`` is    a buffer comparison,        an index comparison,
+                 ``x[:] >= y[:]``            ``tx == 0``
+granularity      one decision per element    one decision per instance of
+                                             the body -- per core, per trip
+what runs        **both** sides, always      **one** side
+what it holds    an expression               statements, including effects
+                                             -- a channel put, a DMA
+lowers to        ``arith.select``            ``scf.if``
+it is            an expression you assign    a ``with`` block
+===============  ==========================  ============================
+
+The last two rows are the practical test. ``ops.select`` cannot express
+"only this core sends on the cascade", because a channel put is not a value and
+there is nothing to select between; ``ops.branch`` cannot express "clamp each
+element", because a per-element decision is not a branch any core can take.
+Handing either one the other's condition raises, and the message names the one
+you wanted.
+
+Why it has to be a region rather than a Python ``if``: a herd body is traced
+**once**, for all of the herd's cores at once. A coordinate is an SSA value with
+no value at trace time, so ``bool()`` on a comparison is not a question the
+tracer can answer -- :class:`Condition` refuses it rather than picking one
+branch for every core.
+
+What it is *for* is a herd whose cores are not interchangeable: the ends of a
+cascade, a corner of a stencil, the one tile that drains a reduction.
+``programming_examples/cascade_reduction`` is the worked case -- four cores in a
+row, of which the first reads from L3, the last writes to L3, and the middle two
+only forward. Nothing about the construct is spatial, though, and it is not
+named as if it were: ``air-to-aie`` folds the branch away once the herd is
+unrolled and the coordinate is a literal, by exactly the same pattern it applies
+to an ``scf.if`` on a dispatch-time parameter (``SpecializeScfIfPattern``, and
+``SpecializeAffineIfPattern`` beside it).
+
+The predicate is any of the six comparisons between index expressions -- a tile
+coordinate most often, but equally a loop induction variable, an ``air.symbol``
+or a Python integer, in any mix. There is no ``and``/``or``: conjunction is
+nesting, and Python's keywords could not be overloaded to mean it anyway
+(``and`` calls ``bool()``, which is exactly what has to fail here).
+
+Both regions are created up front, so a branch with no ``otherwise`` leaves an
+``scf.if`` with an else holding only its terminator. That is not a difference in
+the compiled design: MLIR's ``RemoveEmptyElseBranch`` canonicalization deletes
+it, and ``canonicalize`` runs ahead of everything in the AIR pipeline that reads
+the region structure.
+"""
+
+# An scf.if region is counted alongside an air.sequential body: a buffer
+# allocated inside one is freed by the herd after the region closes, so the
+# dealloc would not be dominated by its alloc. See air.alloc's guard.
+from ._loop import enter_region, exit_region
+
+__all__ = ["Condition", "Branch", "branch"]
+
+
+class Condition:
+    """A comparison between two index expressions, awaiting ``ops.branch``.
+
+    Built by ``==``/``!=``/``<``/``<=``/``>``/``>=`` on an
+    :class:`~air.api._index.IndexExpr`. Nothing is emitted until ``ops.branch``
+    opens a region with it, so writing the comparison next to its use and
+    writing it far above have the same result.
+    """
+
+    __slots__ = ("lhs", "rhs", "predicate", "symbol")
+
+    def __init__(self, lhs, rhs, predicate, symbol):
+        self.lhs = lhs
+        self.rhs = rhs
+        self.predicate = predicate
+        self.symbol = symbol
+
+    def __repr__(self):
+        return f"({self.lhs} {self.symbol} {self.rhs})"
+
+    def __bool__(self):
+        raise TypeError(
+            f"the truth of {self!r} is not known at trace time: a herd body is "
+            "traced once for the whole herd, so a comparison against a tile "
+            "coordinate has no Python value. Write "
+            f"`with ops.branch({self.lhs} {self.symbol} {self.rhs}):` for a "
+            "region only some cores execute. (A Python `if`, `and`, `or` or "
+            "`not` on this would have to pick one branch for every core.)"
+        )
+
+    def _reject_boolean(self, spelling, advice):
+        raise NotImplementedError(
+            f"air.api has no `{spelling}` on a condition. {advice}"
+        )
+
+    def __and__(self, other):
+        self._reject_boolean(
+            "&",
+            "Conjunction is nesting: put the second ops.branch inside the first.",
+        )
+
+    __rand__ = __and__
+
+    def __or__(self, other):
+        self._reject_boolean(
+            "|",
+            "Write the two ops.branch regions one after the other, or invert the "
+            "comparison and use otherwise().",
+        )
+
+    __ror__ = __or__
+
+    def __invert__(self):
+        self._reject_boolean(
+            "~",
+            "Use otherwise(), or write the opposite comparison (== for !=, "
+            "< for >=).",
+        )
+
+    def materialize(self):
+        """Emit the ``arith.cmpi``, returning its ``i1`` result."""
+        from air.dialects import arith
+
+        predicates = {
+            "eq": arith.CmpIPredicate.eq,
+            "ne": arith.CmpIPredicate.ne,
+            "slt": arith.CmpIPredicate.slt,
+            "sle": arith.CmpIPredicate.sle,
+            "sgt": arith.CmpIPredicate.sgt,
+            "sge": arith.CmpIPredicate.sge,
+        }
+
+        def operand(expr):
+            # A constant folds to a Python int here, which cmpi cannot take.
+            # Emitting arith.constant keeps a both-constant comparison as a
+            # real scf.if that canonicalize then folds, rather than making the
+            # branch vanish at trace time -- a design that selects between two
+            # kernels with a Python-level parameter still wants the region in
+            # the IR it hands the compiler.
+            value = expr.materialize()
+            if isinstance(value, int):
+                return arith.ConstantOp.create_index(value)
+            return value
+
+        return arith.CmpIOp(
+            predicates[self.predicate], operand(self.lhs), operand(self.rhs)
+        )
+
+
+def _why_not_a_branch(condition):
+    """Say which of the two conditionals the caller actually reached for."""
+    from ._value import BufferExpr
+
+    if isinstance(condition, BufferExpr):
+        return (
+            "That is an elementwise comparison on buffer *data*, which is "
+            "ops.select's condition, not ops.branch's. A branch is taken once "
+            "per core, so it cannot depend on what is in the buffer -- "
+            "different elements would need different branches. Write "
+            "`out[:] = ops.select(cond, a[:], b[:])`, which evaluates both "
+            "sides and picks per element."
+        )
+    if isinstance(condition, bool):
+        return (
+            "A Python bool is not one: the region would be present or absent "
+            "at trace time rather than chosen per instance, which is what a "
+            "plain Python `if` around the same statements already does."
+        )
+    return (
+        "For a per-element choice between two values, see ops.select; "
+        "ops.branch decides once per core."
+    )
+
+
+class _Region:
+    """One region of an ``scf.if``, as a context manager.
+
+    ``terminate`` distinguishes the two: the then region is built empty and
+    closes itself with an ``scf.yield``, while the else region already has one
+    -- ``Branch`` terminates it as soon as the then region closes, so that an
+    unused else is still a valid block -- and ``otherwise()`` inserts ahead of
+    it instead.
+    """
+
+    def __init__(self, at, terminate):
+        self._at = at
+        self._terminate = terminate
+        self.open = False
+
+    def __enter__(self):
+        from air.ir import InsertionPoint
+
+        self._ip = InsertionPoint(self._at) if self._terminate else self._at
+        self._ip.__enter__()
+        self.open = True
+        enter_region()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        from air.dialects.scf import yield_
+
+        # An exception leaves the body short of the ops it was going to emit,
+        # so the herd would compute something partial. Count it the way an
+        # abandoned loop trip is counted, and still terminate the region: a
+        # block with no terminator turns a diagnosable error into a verifier
+        # crash somewhere unrelated.
+        self.open = False
+        exit_region(aborted=exc_type is not None)
+        if self._terminate:
+            yield_([])
+        self._ip.__exit__(exc_type, exc, tb)
+        return False
+
+
+class Branch:
+    """The ``scf.if`` opened by :func:`branch`; ``otherwise()`` is its else."""
+
+    def __init__(self, condition):
+        if not isinstance(condition, Condition):
+            raise TypeError(
+                "ops.branch takes a comparison between index expressions, such "
+                f"as `tx == 0` or `k < n - 1`, got {condition!r} "
+                f"({type(condition).__name__}). " + _why_not_a_branch(condition)
+            )
+        self._condition = condition
+        self._op = None
+        self._then = None
+        self._otherwise_taken = False
+
+    def __enter__(self):
+        from air.dialects import scf
+
+        if self._op is not None:
+            raise RuntimeError(f"ops.branch{self._condition} entered twice")
+        self._op = scf.IfOp(self._condition.materialize(), has_else=True)
+        self._then = _Region(self._op.then_block, terminate=True)
+        self._then.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        from air.ir import InsertionPoint
+        from air.dialects.scf import yield_
+
+        handled = self._then.__exit__(exc_type, exc, tb)
+        # Terminate the else region now, whether or not otherwise() will claim
+        # it. An else block holding nothing at all does not verify ("'scf.if'
+        # op expects a non-empty block"), and there is no later hook to fix it
+        # in: otherwise() is called after this returns.
+        with InsertionPoint(self._op.else_block):
+            self._else_terminator = yield_([])
+        return handled
+
+    def otherwise(self):
+        """The else region, as a second ``with`` block."""
+        from air.ir import InsertionPoint
+
+        if self._op is None:
+            raise RuntimeError(
+                "otherwise() on an ops.branch whose region was never opened; the "
+                "spelling is `with ops.branch(...) as branch:` followed by "
+                "`with branch.otherwise():`"
+            )
+        if self._then.open:
+            raise RuntimeError(
+                f"otherwise() inside the body of ops.branch{self._condition}; "
+                "close the first `with` block before opening the second"
+            )
+        if self._otherwise_taken:
+            raise RuntimeError(
+                f"ops.branch{self._condition} already has an otherwise() region"
+            )
+        self._otherwise_taken = True
+        return _Region(InsertionPoint(self._else_terminator), terminate=False)
+
+
+def branch(condition):
+    """A region only the cores satisfying ``condition`` execute.
+
+    Returns the :class:`Branch`, so the else region can be opened from it::
+
+        with ops.branch(tx == 0) as head:
+            ...
+        with head.otherwise():
+            ...
+    """
+    return Branch(condition)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -711,4 +711,22 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
             )
         return _result(op(recur(node.args[0]), recur(node.args[1])))
 
+    if node.kind == "reduce":
+        # Reached only when a reduction is *nested*: emit_elementwise dispatches
+        # a top-level one to _emit_reduce before the walk ever starts. It has no
+        # emission here because it cannot have one -- a reduction collapses the
+        # innermost axis, so its result has a different shape from the operands
+        # around it, and the surrounding loop nest is built over a single shape.
+        # Without this the walk fell through to the AssertionError below, which
+        # named an internal node kind rather than the mistake.
+        spelling = "reduce_max" if node.op == "max" else "reduce_add"
+        raise NotImplementedError(
+            f"air.api.ops.{spelling} cannot nest inside a larger expression: it "
+            "collapses the innermost axis, so its result has a different shape "
+            "from the operands around it, and one loop nest cannot span both. "
+            "Assign the reduction first, then use the result:\n"
+            f"    tmp[:] = ops.{spelling}(a[:])\n"
+            "    out[:] = tmp[:] + b[:]"
+        )
+
     raise AssertionError(f"unknown expression node kind {node.kind!r}")

--- a/python/air/api/_index.py
+++ b/python/air/api/_index.py
@@ -219,14 +219,27 @@ class IndexExpr:
     def _compare(self, other, predicate, symbol):
         from ._cond import Condition
 
+        # A bool is the one non-index that must not fall through. Deferring on
+        # it would make `tx == True` a silent Python False -- a trace-time
+        # branch decision taken without the program saying so, which is exactly
+        # what Condition.__bool__ exists to prevent one line further on.
+        if isinstance(other, bool):
+            raise TypeError(
+                f"cannot compare a tile coordinate against the bool {other!r}. "
+                "A coordinate is an index, and a comparison against it builds a "
+                "condition for ops.branch; comparing it to True or False would "
+                "otherwise be answered at trace time, silently and the same way "
+                f"for every core. Compare against an integer instead: "
+                f"`{self} {symbol} {int(other)}`."
+            )
         try:
             other = coerce_index(other)
         except TypeError:
-            # Not an index at all -- an Ellipsis, a slice, a buffer. Deferring
-            # to Python rather than raising is what keeps `Ellipsis in key`
-            # working inside a subscript: `==` against something incomparable
-            # is False, not an error, and only the ordering operators (which
-            # have no such fallback) go on to raise.
+            # Not an index and not a bool -- an Ellipsis, a slice, a buffer.
+            # Deferring to Python rather than raising is what keeps
+            # `Ellipsis in key` working inside a subscript: `==` against
+            # something incomparable is False, not an error, and only the
+            # ordering operators (which have no such fallback) go on to raise.
             return NotImplemented
         return Condition(self, other, predicate, symbol)
 

--- a/python/air/api/_index.py
+++ b/python/air/api/_index.py
@@ -34,6 +34,12 @@ it is actually linear in, and it keeps the whole expression a single
 Genuinely non-affine combinations -- leaf * leaf, and floordiv/mod by a
 coordinate -- are rejected with an explicit error rather than silently
 degraded.
+
+The six comparison operators are *not* index arithmetic: they do not return an
+:class:`IndexExpr` but a :class:`Condition`, the operand of ``ops.branch``. That
+is the same trade numpy makes with ``a == b``, and it has the same consequence
+-- ``if tx == 0:`` is not a Python branch and must not silently behave like
+one, so :class:`Condition` refuses ``bool()``.
 """
 
 __all__ = ["IndexExpr", "Leaf", "DerivedLeaf", "coerce_index", "materialize_index"]
@@ -200,6 +206,47 @@ class IndexExpr:
 
     def __rmod__(self, other):
         return coerce_index(other)._divide(self, "mod")
+
+    # -- comparison ---------------------------------------------------------
+
+    # These return a Condition rather than a bool, so IndexExpr stops being
+    # hashable by the default rule. Nothing keys a dict on one -- the
+    # coefficient map is keyed on Leaf/DerivedLeaf, which have their own
+    # __hash__ -- but identity hashing is the pre-existing behaviour and there
+    # is no reason to take it away.
+    __hash__ = object.__hash__
+
+    def _compare(self, other, predicate, symbol):
+        from ._cond import Condition
+
+        try:
+            other = coerce_index(other)
+        except TypeError:
+            # Not an index at all -- an Ellipsis, a slice, a buffer. Deferring
+            # to Python rather than raising is what keeps `Ellipsis in key`
+            # working inside a subscript: `==` against something incomparable
+            # is False, not an error, and only the ordering operators (which
+            # have no such fallback) go on to raise.
+            return NotImplemented
+        return Condition(self, other, predicate, symbol)
+
+    def __eq__(self, other):
+        return self._compare(other, "eq", "==")
+
+    def __ne__(self, other):
+        return self._compare(other, "ne", "!=")
+
+    def __lt__(self, other):
+        return self._compare(other, "slt", "<")
+
+    def __le__(self, other):
+        return self._compare(other, "sle", "<=")
+
+    def __gt__(self, other):
+        return self._compare(other, "sgt", ">")
+
+    def __ge__(self, other):
+        return self._compare(other, "sge", ">=")
 
     # -- queries ------------------------------------------------------------
 

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -25,7 +25,13 @@ here would only defer the failure into the IR.
 
 from ._index import IndexExpr
 
-__all__ = ["sequential", "loop_depth", "aborted_loops"]
+__all__ = [
+    "sequential",
+    "loop_depth",
+    "aborted_loops",
+    "enter_region",
+    "exit_region",
+]
 
 # Loops whose body exited early (break / return / an exception the caller
 # swallowed). Emission still closes the region so the IR stays well formed, but
@@ -65,6 +71,20 @@ def exit_body(previous):
 
 def aborted_loops():
     return _ABORTED
+
+
+def enter_region():
+    """Count one more open nested region (a loop body, or an ``ops.branch``)."""
+    global _DEPTH
+    _DEPTH += 1
+
+
+def exit_region(aborted):
+    """Close it, recording whether its body ran to the end."""
+    global _DEPTH, _ABORTED
+    _DEPTH -= 1
+    if aborted:
+        _ABORTED += 1
 
 
 def sequential(start, stop=None, step=None, name=None):

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -28,16 +28,21 @@ from ._index import IndexExpr
 __all__ = [
     "sequential",
     "loop_depth",
-    "aborted_loops",
+    "aborted_regions",
     "enter_region",
     "exit_region",
 ]
 
-# Loops whose body exited early (break / return / an exception the caller
-# swallowed). Emission still closes the region so the IR stays well formed, but
-# the body is short of trips and the herd would compute a partial reduction, so
-# the count is checked once the herd body is finished. See `aborted_loops`.
-_ABORTED = 0
+# Names of the regions whose body exited early (break / return / an exception
+# the caller swallowed). Emission still closes the region so the IR stays well
+# formed, but the body is short of what was written and the herd would compute
+# a partial result, so this is checked once the herd body is finished.
+#
+# It records the *construct*, not just a count, because ops.branch shares this
+# machinery with air.sequential and the two need different advice: a truncated
+# loop is fixed by restructuring the bounds, a truncated branch is not a loop
+# problem at all. A single counter reported both as "left a loop early".
+_ABORTED = []
 
 # How many air.sequential bodies are currently open. air.alloc consults this: an
 # allocation inside a loop is freed by the herd after the loop closes, and the
@@ -69,8 +74,8 @@ def exit_body(previous):
     _DEPTH = previous
 
 
-def aborted_loops():
-    return _ABORTED
+def aborted_regions():
+    return tuple(_ABORTED)
 
 
 def enter_region():
@@ -79,12 +84,12 @@ def enter_region():
     _DEPTH += 1
 
 
-def exit_region(aborted):
-    """Close it, recording whether its body ran to the end."""
-    global _DEPTH, _ABORTED
+def exit_region(aborted, what="air.sequential"):
+    """Close it, recording ``what`` if its body did not run to the end."""
+    global _DEPTH
     _DEPTH -= 1
     if aborted:
-        _ABORTED += 1
+        _ABORTED.append(what)
 
 
 def sequential(start, stop=None, step=None, name=None):
@@ -128,7 +133,7 @@ def sequential(start, stop=None, step=None, name=None):
         finally:
             _DEPTH -= 1
             if not completed:
-                _ABORTED += 1
+                _ABORTED.append("air.sequential")
             # Terminate the region either way: leaving a block without a
             # terminator turns a diagnosable "you broke out of a loop" into an
             # MLIR verifier crash somewhere else entirely.

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -399,6 +399,44 @@ class Symbol:
     def __repr__(self):
         return f"air.api.symbol({self.name}={self.value})"
 
+    # Comparisons do NOT fold, unlike the arithmetic below. The two have
+    # opposite requirements and both are honest: a symbol used as a tile size
+    # has to be a Python int, because it sizes a memref; a symbol used as a
+    # branch condition has to stay a value, because folding it would delete the
+    # scf.if. Which is the whole point of a symbol -- the prototype defines one
+    # as "known at dispatch time rather than compile time", and v1 resolving it
+    # early is an implementation detail, not licence to compile the branch away.
+    # `Condition.materialize()` emits arith.constant + arith.cmpi even when both
+    # sides are constant, and air-to-aie's SpecializeScfIfPattern folds it once
+    # the herd is unrolled -- so the branch costs nothing and still exists in
+    # the IR the compiler is handed.
+    def _compare(self, other, predicate, symbol):
+        from ._index import coerce_index
+
+        return coerce_index(self)._compare(other, predicate, symbol)
+
+    def __eq__(self, o):
+        return self._compare(o, "eq", "==")
+
+    def __ne__(self, o):
+        return self._compare(o, "ne", "!=")
+
+    def __lt__(self, o):
+        return self._compare(o, "slt", "<")
+
+    def __le__(self, o):
+        return self._compare(o, "sle", "<=")
+
+    def __gt__(self, o):
+        return self._compare(o, "sgt", ">")
+
+    def __ge__(self, o):
+        return self._compare(o, "sge", ">=")
+
+    # Defining __eq__ would otherwise drop the default hash, and a Symbol is
+    # kept in PENDING_SYMBOLS and looked up by identity.
+    __hash__ = object.__hash__
+
     # Arithmetic yields plain ints: a resolved symbol is just a constant.
     def __add__(self, o):
         return self.value + int(o)

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1273,11 +1273,12 @@ def alloc(shape, dtype, scope=None, vector=None):
         )
     if space == "L1" and loop_depth():
         raise NotImplementedError(
-            "air.alloc inside an air.sequential body is not supported: the herd "
-            "frees its buffers once the body is finished, which is outside the "
-            "loop, so the dealloc would not be dominated by its alloc. Hoist the "
-            "allocation above the loop -- the buffer is reused across trips, "
-            "which is what a loop is for."
+            "air.alloc inside an air.sequential or ops.branch body is not "
+            "supported: the herd frees its buffers once the body is finished, "
+            "which is outside the region, so the dealloc would not be dominated "
+            "by its alloc. Hoist the allocation above it -- a loop reuses the "
+            "buffer across trips, which is what a loop is for, and a buffer only "
+            "some cores read still costs the same L1 on every core."
         )
     # 0 is meaningful -- it selects the scalar path. Negative is not, and it
     # would otherwise pass a caller's own `tile % width` guard unnoticed, since

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1088,9 +1088,9 @@ class HerdContext:
         from air.dialects.air import herd as herd_region
         from air.dialects.scf import for_ as range_, yield_
 
-        from ._loop import aborted_loops, enter_body, exit_body
+        from ._loop import aborted_regions, enter_body, exit_body
 
-        aborted_before = aborted_loops()
+        aborted_before = len(aborted_regions())
 
         tensors = trace.tensors
         # air.herd is IsolatedFromAbove, so an L2 buffer allocated in the
@@ -1203,13 +1203,25 @@ class HerdContext:
                 next(iter(herd_self._objects))
             )
 
-        if aborted_loops() != aborted_before:
+        aborted = aborted_regions()[aborted_before:]
+        if aborted:
+            # Name the construct that was abandoned. ops.branch shares the
+            # region bookkeeping with air.sequential, and reporting a truncated
+            # branch as "left a loop early" sends the reader to the wrong line.
+            if "air.sequential" in aborted:
+                raise RuntimeError(
+                    "a body left an air.sequential loop early (break, return, or a "
+                    "swallowed exception). An air.sequential body is traced once and "
+                    "stands for every trip, so an early exit does not shorten the "
+                    "loop -- it truncates the body of all of them, and the kernel "
+                    "computes a partial result. Restructure the loop bounds instead."
+                )
             raise RuntimeError(
-                "a body left an air.sequential loop early (break, return, or a "
-                "swallowed exception). An air.sequential body is traced once and "
-                "stands for every trip, so an early exit does not shorten the "
-                "loop -- it truncates the body of all of them, and the kernel "
-                "computes a partial result. Restructure the loop bounds instead."
+                "a body left an ops.branch region early (break, return, or a "
+                "swallowed exception). The region is emitted either way, so the "
+                "ops written after the exit are simply missing from it, and the "
+                "cores that take that branch compute a partial result. Let the "
+                "`with` block run to its end."
             )
 
 

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -82,9 +82,9 @@ def _carries_offset(offset):
 
     A runtime offset counts as carrying one: it may well be non-zero, and a
     reshape has no way to prove otherwise. This has to go through as_const()
-    rather than comparing to 0 -- IndexExpr does not implement equality against
-    an int, so ``offset != 0`` is true for every offset, compile-time zero
-    included, which would make the two branches below unreachable in turn.
+    rather than comparing to 0 -- ``offset != 0`` on an IndexExpr builds a
+    Condition for ``ops.branch``, not a bool, and Condition refuses ``bool()``, so
+    the comparison would raise on every offset rather than answer the question.
     """
     value = offset.as_const() if hasattr(offset, "as_const") else offset
     return value != 0
@@ -636,9 +636,10 @@ def _check_shift_amount(amount, value, op):
     over herd coordinates is ordinary in a kernel body, and ``tx - tx + 32``
     reaches the emitter as a literal ``arith.constant 32`` -- indistinguishable,
     by the time it gets there, from having been written as ``32``. Reading it
-    back has to go through ``as_const()``: IndexExpr does not implement equality
-    or int conversion against a Python int, so an isinstance test alone sees
-    every index expression as "runtime" and lets the folded ones through.
+    back has to go through ``as_const()``: an isinstance test alone sees every
+    index expression as "runtime" and lets the folded ones through, and
+    comparing to an int instead builds a Condition for ``ops.branch`` rather than
+    answering.
     """
     if amount.kind != "scalar":
         return  # not a scalar operand at all: nothing to check

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -675,8 +675,6 @@ def select(cond, a, b):
             "them -- use air.api.ops.equal / not_equal for those, or one of "
             "the ordering operators <, <=, >, >= which do build a predicate"
         )
-    from ._cond import Condition
-
     if isinstance(cond, Condition):
         # The other conditional. Naming it is the whole point: the two are
         # indistinguishable from their names alone, so the one place a caller

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -37,10 +37,12 @@ plausible-looking placeholder: a DSL that accepts an op it cannot lower
 produces a kernel that runs and is silently wrong.
 """
 
+from ._cond import Branch, Condition, branch  # noqa: F401
 from ._value import Buffer, BufferExpr, BufferSlice, Tensor, TensorSlice, Token
 from .types import require_computable, require_signless
 
 __all__ = [
+    "branch",
     "load",
     "store",
     "copy",
@@ -646,6 +648,15 @@ def not_equal(a, b):
 def select(cond, a, b):
     """Elementwise ``cond ? a : b``. Lowers to arith.select.
 
+    The *branchless* one of the DSL's two conditionals, and the distinction from
+    ``ops.branch`` is worth being sure of before reaching for either: this one
+    decides **per element** and evaluates **both** sides, and it is an
+    expression, so its arms are values. ``ops.branch`` decides **per core**,
+    runs **one** side, and its arms are statements -- which is what a channel
+    put or a DMA has to be. They are the two halves of if-conversion; see
+    ``_cond.py`` for the full table. Handing this one an index comparison
+    (``tx == 0``) raises and names ``ops.branch``.
+
     ``cond`` must be a comparison -- ``x[:] >= y[:]``, or ``ops.equal(x, y)`` --
     because that is the only thing in this expression language whose result type
     is i1. The predicate is emitted as an arith.cmpf/cmpi feeding an
@@ -663,6 +674,23 @@ def select(cond, a, b):
             "elementwise ones, and evaluate to a bool before select ever sees "
             "them -- use air.api.ops.equal / not_equal for those, or one of "
             "the ordering operators <, <=, >, >= which do build a predicate"
+        )
+    from ._cond import Condition
+
+    if isinstance(cond, Condition):
+        # The other conditional. Naming it is the whole point: the two are
+        # indistinguishable from their names alone, so the one place a caller
+        # can be told which they wanted is here, when they have already picked.
+        raise TypeError(
+            f"air.api.ops.select got {cond!r}, a comparison between *index* "
+            "expressions -- that is ops.branch's condition, not select's. "
+            "select decides per element and evaluates both sides, so its "
+            "condition has to come from buffer data (x[:] >= y[:], or "
+            "ops.equal(x[:], y[:])). A tile coordinate is the same for every "
+            "element the core touches, so selecting on it per element would "
+            "compute both arms to no purpose. Write `with ops.branch("
+            f"{cond.lhs} {cond.symbol} {cond.rhs}):` instead, which runs one "
+            "side and can hold a channel put or a DMA."
         )
     if not isinstance(cond, BufferExpr) or cond.kind != "compare":
         raise TypeError(

--- a/python/test/api/conditional.py
+++ b/python/test/api/conditional.py
@@ -1,0 +1,221 @@
+# ./python/test/api/conditional.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""``ops.branch`` opens an ``scf.if``: one side runs, and it holds statements.
+
+The DSL's other conditional, ``ops.select``, is the branchless one -- per
+element, both sides evaluated, arms are values. This one decides per core, runs
+one side, and its arms can be effects: a channel put, a DMA. ``errors.py`` pins
+what each says when handed the other's condition.
+
+A herd body is traced once, for the whole herd, so a Python ``if`` on a
+coordinate cannot mean "this core only": the coordinate is an SSA value with no
+value at trace time. ``tx == 0`` therefore builds a ``Condition`` rather than a
+bool, and ``ops.branch`` turns it into a region. ``errors.py`` pins what happens
+when someone writes the Python ``if`` anyway.
+
+Three properties this file exists to hold down:
+
+* the comparison is emitted where the region opens, not where it was written;
+* ``otherwise()`` is a second region on the *same* ``scf.if``, so nesting one
+  inside the other's else is how a three-way split is spelled -- which is what
+  ``programming_examples/cascade_reduction`` needs for the head, middle and
+  tail of a cascade; and
+* a branch with no ``otherwise`` still emits the else region, holding only its
+  terminator. That is not a difference in the compiled design: MLIR's
+  ``RemoveEmptyElseBranch`` deletes it, and ``canonicalize`` runs ahead of
+  everything in the AIR pipeline that reads the region structure. The last test
+  below shows both the emitted form and the canonicalized one.
+"""
+
+from air import api as air
+from air.api.types import i32
+
+N = 64
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: branch_otherwise
+#
+# The condition materialises inside the herd body, immediately ahead of the
+# region, even though `tx == 0` was written a few statements earlier.
+# CHECK: air.herd @h
+# CHECK: %[[TX:.*]] = affine.apply
+# CHECK: %[[C0:.*]] = arith.constant 0 : index
+# CHECK: %[[P:.*]] = arith.cmpi eq, %[[TX]], %[[C0]] : index
+# CHECK: scf.if %[[P]] {
+# CHECK:   linalg.fill ins(%c1_i32
+# CHECK: } else {
+# CHECK:   linalg.fill ins(%c2_i32
+# CHECK: }
+@run
+def branch_otherwise():
+    A = air.tensor([N], i32)
+    out = air.tensor([N], i32)
+
+    with air.launch(name="two_way") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(4)], name="h", shape=(4,)) as h:
+
+                @h.body
+                def _(tx):
+                    buf = air.alloc([N], i32, scope=h.private())
+                    first = tx == 0  # built here, emitted below
+                    air.ops.load(buf, A[0:N])
+
+                    with air.ops.branch(first) as branch:
+                        air.ops.fill(buf, 1)
+                    with branch.otherwise():
+                        air.ops.fill(buf, 2)
+
+                    air.ops.store(buf, out[0:N])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: three_way_cascade
+#
+# The head/middle/tail split of a cascade: the second branch sits inside the
+# first's else, so the two scf.ifs nest rather than sitting side by side. This
+# is the structure cascade_reduction relies on.
+# CHECK: scf.if
+# CHECK:   linalg.fill ins(%c1_i32
+# CHECK: } else {
+# CHECK:   arith.cmpi eq, %{{.*}}, %c3
+# CHECK:   scf.if
+# CHECK:     linalg.fill ins(%c3_i32
+# CHECK:   } else {
+# CHECK:     linalg.fill ins(%c2_i32
+@run
+def three_way_cascade():
+    A = air.tensor([N], i32)
+    out = air.tensor([N], i32)
+
+    with air.launch(name="three_way") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(4)], name="h", shape=(4,)) as h:
+
+                @h.body
+                def _(tx):
+                    buf = air.alloc([N], i32, scope=h.private())
+                    air.ops.load(buf, A[0:N])
+
+                    with air.ops.branch(tx == 0) as head:
+                        air.ops.fill(buf, 1)
+                    with head.otherwise():
+                        with air.ops.branch(tx == 3) as tail:
+                            air.ops.fill(buf, 3)
+                        with tail.otherwise():
+                            air.ops.fill(buf, 2)
+
+                    air.ops.store(buf, out[0:N])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: every_comparison
+#
+# All six operators, against a constant and against another coordinate. Index
+# comparison is signed: herd coordinates are non-negative, and slt/sle/sgt/sge
+# are what an offset computed as a difference needs.
+# CHECK: arith.cmpi eq, %{{.*}}, %c0
+# CHECK: arith.cmpi ne, %{{.*}}, %c1
+# CHECK: arith.cmpi slt, %{{.*}}, %c2
+# CHECK: arith.cmpi sle, %{{.*}}, %c3
+# CHECK: arith.cmpi sgt, %{{.*}}, %c0
+# CHECK: arith.cmpi sge, %{{.*}}, %c1
+#
+# A reflected comparison against a Python int on the left is the same op with
+# the operands the way they were written: `1 < tx` is `tx > 1`.
+# CHECK: arith.cmpi sgt, %{{.*}}, %c1
+#
+# And a comparison between two coordinates needs no constant at all.
+# CHECK: arith.cmpi eq, %{{.*}}, %{{.*}} : index
+@run
+def every_comparison():
+    A = air.tensor([N], i32)
+    out = air.tensor([N], i32)
+
+    with air.launch(name="cmps") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(4), range(4)], name="h", shape=(4, 4)) as h:
+
+                @h.body
+                def _(tx, ty):
+                    buf = air.alloc([N], i32, scope=h.private())
+                    air.ops.load(buf, A[0:N])
+                    for condition in (
+                        tx == 0,
+                        tx != 1,
+                        tx < 2,
+                        tx <= 3,
+                        tx > 0,
+                        tx >= 1,
+                        1 < tx,
+                        tx == ty,
+                    ):
+                        with air.ops.branch(condition):
+                            air.ops.fill(buf, 1)
+                    air.ops.store(buf, out[0:N])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: no_otherwise_canonicalizes_away
+#
+# As emitted: the else region is there, empty but for its terminator.
+# CHECK: scf.if %{{.*}} {
+# CHECK:   linalg.fill
+# CHECK: } else {
+# CHECK: }
+#
+# After canonicalize, which the AIR pipeline runs first, it is gone -- so the
+# region a branch with no `otherwise` produces is the one it looks like.
+# CHECK-LABEL: canonicalized:
+# CHECK: scf.if %{{.*}} {
+# CHECK-NEXT: linalg.fill
+# CHECK-NEXT: }
+# CHECK-NEXT: air.dma_memcpy_nd
+@run
+def no_otherwise_canonicalizes_away():
+    A = air.tensor([N], i32)
+    out = air.tensor([N], i32)
+
+    with air.launch(name="one_way") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(4)], name="h", shape=(4,)) as h:
+
+                @h.body
+                def _(tx):
+                    buf = air.alloc([N], i32, scope=h.private())
+                    air.ops.load(buf, A[0:N])
+                    with air.ops.branch(tx == 0):
+                        air.ops.fill(buf, 1)
+                    air.ops.store(buf, out[0:N])
+
+    module = launch.build(target="npu1")
+    print(module)
+
+    from air.passmanager import PassManager
+
+    with module.context:
+        PassManager.parse("builtin.module(canonicalize)").run(module.operation)
+    print("canonicalized:")
+    print(module)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -561,7 +561,7 @@ def _():
 # CHECK-LABEL: TEST: alloc_inside_sequential
 # The herd frees its buffers after the body, which is outside the loop, so the
 # dealloc would not be dominated by its alloc.
-# CHECK: NotImplementedError: air.alloc inside an air.sequential body is not supported
+# CHECK: NotImplementedError: air.alloc inside an air.sequential or ops.branch body
 @expect(NotImplementedError, "alloc_inside_sequential")
 def _():
     def body(h, tx, ty, A, B, C):
@@ -1998,5 +1998,127 @@ def _():
         s = air.alloc([64, 1], bf16, scope=h.private())
         out = air.alloc([64], bf16, scope=h.private())
         out[:] = ops.reduce_add(a[:] * s[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: a_condition_has_no_truth_value
+# `if tx == 0:` is the trap ops.branch exists to close. A herd body is traced
+# once for the whole herd, so Python has to pick one branch for every core --
+# and would, silently, if Condition let itself be coerced.
+# CHECK: TypeError: the truth of (t0 == 0) is not known at trace time
+# CHECK-SAME: with ops.branch(t0 == 0)
+@expect(TypeError, "a_condition_has_no_truth_value")
+def _():
+    def body(h, tx, ty, A, B, C):
+        if tx == 0:
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: conditions_have_no_and
+# `and` cannot be reached at all -- it coerces through __bool__ -- so the
+# bitwise operator is the one worth naming a replacement for.
+# CHECK: NotImplementedError: air.api has no `&` on a condition
+# CHECK-SAME: Conjunction is nesting
+@expect(NotImplementedError, "conditions_have_no_and")
+def _():
+    def body(h, tx, ty, A, B, C):
+        with ops.branch((tx == 0) & (ty == 0)):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: when_takes_a_comparison_not_a_bool
+# A Python bool decides at trace time whether the region exists at all, which
+# is what a plain `if` already does; accepting one here would make the two
+# spellings look interchangeable when they are not.
+# CHECK: TypeError: ops.branch takes a comparison between index expressions
+@expect(TypeError, "when_takes_a_comparison_not_a_bool")
+def _():
+    def body(h, tx, ty, A, B, C):
+        with ops.branch(True):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: elsewhere_before_the_where_body
+# otherwise() names the else of a region that has been opened. Reaching for it
+# first is a sign the two `with` blocks were written the wrong way round.
+# CHECK: RuntimeError: otherwise() on an ops.branch whose region was never opened
+@expect(RuntimeError, "elsewhere_before_the_where_body")
+def _():
+    def body(h, tx, ty, A, B, C):
+        branch = ops.branch(tx == 0)
+        with branch.otherwise():
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: two_elsewhere_regions
+# An scf.if has one else. A second would silently discard the first.
+# CHECK: RuntimeError: ops.branch(t0 == 0) already has an otherwise() region
+@expect(RuntimeError, "two_elsewhere_regions")
+def _():
+    def body(h, tx, ty, A, B, C):
+        with ops.branch(tx == 0) as branch:
+            pass
+        with branch.otherwise():
+            pass
+        with branch.otherwise():
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: alloc_inside_a_branch
+# The herd frees its buffers after the body, outside the region, so the dealloc
+# would not be dominated by the alloc. It is also the wrong instinct: L1 is
+# charged per core whether or not that core's branch runs.
+# CHECK: NotImplementedError: air.alloc inside an air.sequential or ops.branch body
+@expect(NotImplementedError, "alloc_inside_a_branch")
+def _():
+    def body(h, tx, ty, A, B, C):
+        with ops.branch(tx == 0):
+            air.alloc([64], bf16, scope=h.private())
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: select_with_a_branch_condition
+# The two conditionals cannot be told apart by name, so the one place a caller
+# can be told which they wanted is the moment they have picked. select decides
+# per element; a tile coordinate is the same for every element the core touches.
+# CHECK: TypeError: air.api.ops.select got (t0 == 0), a comparison between *index* expressions
+# CHECK-SAME: that is ops.branch's condition
+# CHECK-SAME: with ops.branch(t0 == 0)
+@expect(TypeError, "select_with_a_branch_condition")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        b = air.alloc([64], bf16, scope=h.private())
+        out = air.alloc([64], bf16, scope=h.private())
+        out[:] = ops.select(tx == 0, a[:], b[:])
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: branch_with_a_select_condition
+# And the reverse. A branch is taken once per core, so it cannot depend on what
+# is in the buffer -- different elements would need different branches.
+# CHECK: TypeError: ops.branch takes a comparison between index expressions
+# CHECK-SAME: elementwise comparison on buffer *data*
+# CHECK-SAME: ops.select(cond, a[:], b[:])
+@expect(TypeError, "branch_with_a_select_condition")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64], bf16, scope=h.private())
+        b = air.alloc([64], bf16, scope=h.private())
+        with ops.branch(a[:] >= b[:]):
+            pass
 
     _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2122,3 +2122,39 @@ def _():
             pass
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: compare_a_coordinate_against_a_bool
+# `tx == True` would otherwise be answered by Python: coerce_index rejects bool,
+# the comparison returns NotImplemented, and the fallback makes it a silent
+# False -- a trace-time branch decision the program never asked for, which is
+# the exact thing Condition.__bool__ exists to stop one line later.
+# CHECK: TypeError: cannot compare a tile coordinate against the bool True
+# CHECK-SAME: Compare against an integer instead
+@expect(TypeError, "compare_a_coordinate_against_a_bool")
+def _():
+    def body(h, tx, ty, A, B, C):
+        with air.ops.branch(tx == True):
+            pass
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: break_out_of_a_branch
+# ops.branch shares the region bookkeeping with air.sequential, so an abandoned
+# branch used to be reported as "left an air.sequential loop early" -- which
+# sends the reader to the wrong line, and offers loop-bound advice for something
+# that is not a loop.
+# CHECK: RuntimeError: a body left an ops.branch region early
+# CHECK-SAME: Let the `with` block run to its end
+@expect(RuntimeError, "break_out_of_a_branch")
+def _():
+    def body(h, tx, ty, A, B, C):
+        buf = air.alloc([64], bf16, scope=h.private())
+        try:
+            with air.ops.branch(tx == 0):
+                raise ValueError("swallowed by the body")
+        except ValueError:
+            pass
+
+    _trace(body)


### PR DESCRIPTION
A herd body is traced once for the whole herd, so a Python `if` on a tile
coordinate cannot mean "this core only" -- it picks one branch for every core.
That left every example whose cores are not interchangeable unconvertible: the
head and tail of a cascade, the addressee of a broadcast round, the tile that
drains a reduction.

## `ops.branch`

Opens an `scf.if` on an index comparison, with `.otherwise()` for the else. In
Python terms the DSL now has both halves of the usual pair, and follows numpy
at the edges:

```
ops.branch(cond)        ->  if cond:        one bit, one region runs
ops.select(cond, a, b)  ->  np.where(...)   one bit per element, both arms
```

Handing `branch` a mask is ambiguous the way `if a >= b:` is ambiguous in numpy
-- 64 answers, one slot -- so it raises and says a reduction to one bit is what
is missing. The six comparison operators on `IndexExpr` build a `Condition`
rather than a bool, and `Condition` refuses `bool()`; that is JAX's reason
rather than numpy's, since under tracing the value does not exist yet.

It is `ops.branch` and not `air.branch` because **`air.*` is fixed before the
kernel runs and `ops.*` may run**. `air.sequential` stays put: its bounds must
be Python ints (`_as_bound` rejects an `IndexExpr`), so the loop is fully
determined at trace time. A branch is not -- today's conditions are coordinates
that fold away in `air-to-aie`, but a dispatch parameter decides on device.

Both regions are created up front and the else is terminated as soon as the
then region closes: an `scf.if` with a genuinely empty else does not verify, and
`otherwise()` is called after the first `with` has exited, so there is no later
hook. A branch with no `otherwise` therefore emits an else holding only its
terminator, which `canonicalize` deletes -- `api/conditional.py` pins both forms.

## Examples

Three converted, covering every conditional shape in the tree. All three pass
on npu1 through their own lits, as their predecessors do (run first, through
the same lit invocation).

| example | condition | emitted IR vs predecessor |
|---|---|---|
| `cascade_reduction` | nested 3-way on `tx` | same region structure |
| `broadcast_selective_capture` | `ty == i`, no else | op for op identical: 8 channel gets, 5 puts, 4 `scf.if`, 4 `scf.for`, 4 `cmpi`, 4 `addi`, 2 allocs -- minus 4 scalar `memref.load`/`store` pairs, now 4 vector transfers |
| `conditional_branching` | a **dispatch parameter**, not a coordinate | identical; `index_cast` becomes `cmpi`, 2 scalar pairs vectorised, and one more dealloc than the predecessor, which never freed its second L1 buffer |

`broadcast_selective_capture` keeps its `get` outside the branch: every
broadcast target has to accept the data every round or the flow stalls for all
of them, and only the capture is guarded.

`conditional_branching` is the only example in the tree whose branch condition
is neither a coordinate nor a loop variable -- measured across every
unconverted `scf.if`. It needed comparison operators on `air.symbol`, which
deliberately do **not** fold, unlike Symbol's arithmetic. The two requirements
are opposite and both honest: a symbol used as a tile size has to be a Python
int because it sizes a memref, while a symbol used as a branch condition has to
stay a value or the branch disappears -- and the branch is what that example
exists to demonstrate. `Condition.materialize()` already emits
`arith.constant` + `arith.cmpi` for a both-constant comparison rather than
folding, and `SpecializeScfIfPattern` collapses it once the herd is unrolled,
so the branch is present for the compiler and costs nothing at run time.

## Two lowering bugs found while auditing the surface this touches

* A **nested reduction** hit a bare `AssertionError: unknown expression node
  kind 'reduce'`. `emit_elementwise` dispatches a *top-level* reduction before
  the walk starts, so a nested one fell through to an assert naming an internal
  node kind. Five spellings reached it -- `reduce_add(a) + b`,
  `maximum(reduce, b)`, `select(c, reduce, b)`, `fma(reduce, ...)`,
  `tanh(reduce)`. Now a `NotImplementedError` stating the rule the `ops`
  docstring already documents, with the two-line rewrite.
* `Ellipsis in key` inside a buffer subscript compares an `IndexExpr` against an
  `Ellipsis`, which broke once the comparison operators existed. `_compare`
  returns `NotImplemented` when the other side is not an index, so `==` against
  something incomparable is False and only the ordering operators go on to
  raise.

Also corrected: two docstrings in `_value.py` asserted that `IndexExpr` has no
equality and explained the `as_const()` dance in those terms, and the package
docstring's namespace rule ("structural declarations live here") did not cover
`sequential` or `wait`, neither of which is a declaration.

## Verification

* three npu1 lits pass; each predecessor was run through the same lit first
* 28/28 `api/` lits, including a new `api/conditional.py` and 8 new cases in
  `api/errors.py`
* `check-air-python` 41 passed / 8 unsupported; `check-air-mlir` 524 passed /
  7 expectedly failed
* `-p` output byte-identical to `origin/main` for all 55 pre-existing air.api
  examples, so nothing else in the tree changed shape

## Not included

`channel_examples/channel_3d_segment_unroll` is the same head/middle/tail
3-way on `tx` plus 3-D channel indices and would convert cleanly, but both its
lits are `REQUIRES: ryzen_ai_npu2` and this work was gated on npu1 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)