### PR TITLE
[programming_examples] Drop the llama decode's air.memtile_dma_channel_min pins

### DIFF
--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -3594,7 +3594,7 @@ def build_module():
                                         strides=[idx(1)],
                                     )
                             for c in range(N_ATTN_CU):
-                                _pk = ChannelPut(
+                                ChannelPut(
                                     "toK",
                                     akbs[c],
                                     indices=[idx(c)],
@@ -3602,7 +3602,7 @@ def build_module():
                                     sizes=[idx(KVPC_DH // 8), idx(16), idx(8)],
                                     strides=[idx(8), idx(KVPC_DH), idx(1)],
                                 )
-                                _pv = ChannelPut(
+                                ChannelPut(
                                     "toV",
                                     avbs[c],
                                     indices=[idx(c)],
@@ -3615,18 +3615,6 @@ def build_module():
                                         idx(1),
                                     ],
                                 )
-                                # col-3 KV: reserve memtile MM2S 0 (the q-broadcast
-                                # transits this memtile's switchbox; KV on MM2S 0
-                                # deadlocks the route). col 4 already has GLU/down on
-                                # MM2S 0, so its KV naturally lands on 1-4. Gate on
-                                # LOOPCLOSE to keep GREEN's layout/PASS unchanged.
-                                if ATTN_CU_LOC[c][0] == 3:
-                                    _pk.operation.attributes[
-                                        "air.memtile_dma_channel_min"
-                                    ] = IntegerAttr.get(T.i32(), 1)
-                                    _pv.operation.attributes[
-                                        "air.memtile_dma_channel_min"
-                                    ] = IntegerAttr.get(T.i32(), 1)
                             for c in range(N_ATTN_CU):
                                 DeallocOp(akbs[c])
                                 DeallocOp(avbs[c])
@@ -3689,7 +3677,7 @@ def build_module():
                                                 "inKV_V", _vbuf, indices=[idx(_gi)]
                                             )
                                             for _lc, _cc in enumerate(_cus):
-                                                _pk = ChannelPut(
+                                                ChannelPut(
                                                     "toK",
                                                     _kbuf,
                                                     indices=[idx(_cc)],
@@ -3705,7 +3693,7 @@ def build_module():
                                                     ],
                                                     strides=[idx(8), idx(_gw), idx(1)],
                                                 )
-                                                _pv = ChannelPut(
+                                                ChannelPut(
                                                     "toV",
                                                     _vbuf,
                                                     indices=[idx(_cc)],
@@ -3728,13 +3716,6 @@ def build_module():
                                                         idx(1),
                                                     ],
                                                 )
-                                                if col == 3:
-                                                    _pk.operation.attributes[
-                                                        "air.memtile_dma_channel_min"
-                                                    ] = IntegerAttr.get(T.i32(), 1)
-                                                    _pv.operation.attributes[
-                                                        "air.memtile_dma_channel_min"
-                                                    ] = IntegerAttr.get(T.i32(), 1)
                                             DeallocOp(_kbuf)
                                             DeallocOp(_vbuf)
                                             yield_([])
@@ -3750,7 +3731,7 @@ def build_module():
                                             IntegerAttr.get(T.i32(), col)
                                         )
                                         ChannelGet("inKV", kvb, indices=[idx(c)])
-                                        _pk = ChannelPut(
+                                        ChannelPut(
                                             "toK",
                                             kvb,
                                             indices=[idx(c)],
@@ -3758,7 +3739,7 @@ def build_module():
                                             sizes=[idx(KVPC_DH // 8), idx(16), idx(8)],
                                             strides=[idx(8), idx(KVPC_DH), idx(1)],
                                         )
-                                        _pv = ChannelPut(
+                                        ChannelPut(
                                             "toV",
                                             kvb,
                                             indices=[idx(c)],
@@ -3776,19 +3757,6 @@ def build_module():
                                                 idx(1),
                                             ],
                                         )
-                                        # MULTIBLK KV re-block: same col-3 switchbox collision
-                                        # as the on-chip path (KV on memtile MM2S 0 deadlocks
-                                        # in LOOPCLOSE - the o-proj feedback + q-broadcast
-                                        # transit col-3's switchbox). Reserve MM2S 0 by steering
-                                        # col-3 KV onto channels 1-4. (col 4 already lands on
-                                        # 1-4 via GLU/down; gate on LOOPCLOSE to keep GREEN.)
-                                        if col == 3:
-                                            _pk.operation.attributes[
-                                                "air.memtile_dma_channel_min"
-                                            ] = IntegerAttr.get(T.i32(), 1)
-                                            _pv.operation.attributes[
-                                                "air.memtile_dma_channel_min"
-                                            ] = IntegerAttr.get(T.i32(), 1)
                                         DeallocOp(kvb)
                                         yield_([])
 

--- a/utils/clone-mlir-aie.sh
+++ b/utils/clone-mlir-aie.sh
@@ -14,8 +14,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export HASH=4c8b56f5db25a9a89582bffed3ad933dea5b1d15
-WHEEL_VERSION=1.4.3.dev17+g4c8b56f
+export HASH=a2f8daf6d47d1a4dfba3e57d31d32a237eb9427f
+WHEEL_VERSION=1.4.3.dev19+ga2f8daf
 
 if [ x"$1" == x--get-wheel-version ]; then
   echo $WHEEL_VERSION


### PR DESCRIPTION
Removes the last four `air.memtile_dma_channel_min` pins in `fused_decode.py`, on the `toK`/`toV` puts for the col-3 attention CU. With them gone the design has **no hand-placed channel attributes left** — memtile DMA channel assignment is the compiler's to make. This completes the series started in #1884 (`air.shim_col`) and #1887 (the qwen half of this attribute).

## Why they were there

Not a cost-model gap — a router bug.

mlir-aie kept its pathfinder graph on `(tile, bundle, channel)` with no direction, so a single node stood for both a switchbox port's input side and its output side, and Dijkstra could chain two crossbar hops through it — turning a stream around inside one switchbox. Same-id packet fan-in is what surfaces it: same-id flows may not share a channel, so each extra source is pushed off the cheap direct entry until the aliased two-edge detour undercuts it. The emitted route then dead-ends and the flow is reported unroutable.

Pinning the channel floor moved the KV puts off the contended entry and hid it.

Fixed upstream in Xilinx/mlir-aie#3592.

The comment the pins carried was also wrong: it blamed the q-broadcast transiting col 3's switchbox, but that gather routes via **row 0** and never touches the col-3 memtile.

## The bump

`4c8b56f` → `a2f8daf` (`1.4.3.dev17` → `1.4.3.dev19`), two commits:

- `a2f8daf6d` [AIE] Give the pathfinder graph a port direction (#3592) — the fix this depends on
- `1e1eaf22a` [AIE2PS] Add VE3858 target model (#3593)

I verified the published wheel `mlir_aie-1.4.3.dev19+ga2f8daf` actually carries the fix rather than trusting the SHA: extracted its `aie-opt` and confirmed the llama pins-off design routes with 0 errors under it, where the previously-pinned build reports 1.

## Validation (NPU2)

- `llama32_1b_q4nx` `make verify` with the pins removed: **PASS 2/2**
- `qwen25_3b_q4` `make verify` (bump regression check, source untouched): **PASS 2/2**

The upstream router change itself was validated more broadly before landing: mlir-air `check-air-mlir` (513 passed), `check-air-python` (24), the XRT e2e suite on NPU2 (67 passed, 0 failed), and `check-programming-examples-peano` (223 passed, 0 failed).
