### PR TITLE
[programming_examples] air.api: channel_3d_segment_unroll and rms_norm

### DIFF
--- a/programming_examples/channel_examples/channel_3d_segment_unroll/channel_3d_segment_unroll.py
+++ b/programming_examples/channel_examples/channel_3d_segment_unroll/channel_3d_segment_unroll.py
@@ -1,206 +1,154 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Two cascade columns per segment, stamped out by segment unroll, on air.api.
 
-"""Dual-Column Cascade Accumulate with Segment Unroll Example
+Sixteen L3 tiles are handed straight to sixteen cores -- no memtile, no
+broadcast -- and reduced along ``tx`` into four results::
 
-Demonstrates direct L3->L1 data distribution combined with cascade
-accumulation, stamped out to two physical copies via segment unroll.
+    output[seg, ty] = sum over tx of input[seg, tx, ty]
 
-Pattern:
-  1. The segment is unrolled with sizes=[NUM_SEGMENTS, 1], creating
-     NUM_SEGMENTS independent physical copies of the herd.
-  2. Each segment copy contains a [NUM_TILES, NUM_COLS] herd (4x2),
-     giving two cascade columns per segment.
-  3. Input data is distributed via a 3D channel [NUM_SEGMENTS, NUM_TILES, NUM_COLS].
-     Each core (segment_idx, tx, ty) gets its own unique tile from L3
-     directly to L1 (no memtile, no broadcast).
-  4. Within each segment, two independent cascade chains flow along tx:
-       Column ty: core (0,ty) -> (1,ty) -> (2,ty) -> (3,ty)
-  5. The bottom cores (tx=3) from all segments write accumulated results
-     to L3 via NUM_SEGMENTS * NUM_COLS = 4 shim DMA channels.
+Three iteration spaces are in play at once, and the example exists to show that
+they are three different things:
 
-Net effect per cascade column:
-  output[seg, ty] = sum_{tx=0}^{3} input[seg, tx, ty]
+* **``air.launch``** is gridless: the whole kernel runs once.
+* **``air.segment([range(NUM_SEGMENTS)])``** gives the *segment* an iteration
+  space of its own, which prints as ``unroll(...)``. Each point is a physical
+  copy of the segment body that ``air-to-aie`` lays out on its own columns, so
+  ``NUM_SEGMENTS`` is a replication factor, not a loop trip count.
+* **``air.herd([range(NUM_TILES), range(NUM_COLS)])``** is the 4x2 array of
+  cores inside each copy.
+
+The segment coordinate reaches the herd body by ordinary Python closure. The
+predecessor had to pass it as ``operands=[seg_x]`` because ``air.herd`` is
+``IsolatedFromAbove``; the DSL threads every enclosing coordinate in as an
+operand and rebinds it, so ``sx`` inside the herd body is the herd's own block
+argument. That is what makes ``chan_in.get(in_buf, indices=[sx, tx, ty])``
+legal: a 3-D channel index whose outermost component comes from a scope two
+levels up.
+
+The three roles along a cascade chain are the same head/middle/tail split as
+``cascade_reduction``, so they are the same nested ``ops.branch``. A herd body
+is traced once for all eight cores of a copy, so a Python ``if`` would pick one
+role for every one of them.
+
+Two differences from the predecessor:
+
+* ``acc[:] = in_buf[:]`` and ``acc[:] = in_buf[:] + acc[:]`` replace
+  ``linalg.copy`` and a ``linalg.add`` whose output aliases an input. Same
+  values; the DSL vectorises them rather than handing the pipeline named ops to
+  fuse.
+* The upstream neighbour is ``tx - 1`` rather than a hand-built ``arith.subi``,
+  so it reaches the channel as one ``affine.apply`` like every other index in
+  the DSL.
 """
 
 import argparse
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith, linalg, scf
-from air.dialects.memref import AllocOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
-
 import numpy as np
+
+from air import api as air
+from air.api import ops
+from air.api.types import i32
+from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
-
-NUM_TILES = 4  # Cascade depth (cores per column)
-NUM_COLS = 2  # Cascade columns per segment
-NUM_SEGMENTS = 2  # Segment unroll factor
+NUM_TILES = 4  # cascade depth (cores per column)
+NUM_COLS = 2  # cascade columns per segment
+NUM_SEGMENTS = 2  # segment unroll factor
 DATA_SIZE = 1024
 
 TOTAL_IN = NUM_SEGMENTS * NUM_TILES * NUM_COLS * DATA_SIZE  # 16384
 TOTAL_OUT = NUM_SEGMENTS * NUM_COLS * DATA_SIZE  # 4096
 
+INOUT_DATATYPE = np.int32
 
-@module_builder
+
 def build_module():
-    xrt_dtype = T.i32()
-    tile_shape = [DATA_SIZE]
+    src = air.tensor([TOTAL_IN], i32)
+    dst = air.tensor([TOTAL_OUT], i32)
 
-    # L3 types: flat arrays for input and output
-    l3MemrefTyIn = MemRefType.get([TOTAL_IN], xrt_dtype)
-    l3MemrefTyOut = MemRefType.get([TOTAL_OUT], xrt_dtype)
-
-    # L1 type: one tile per core
-    l1MemrefTy = MemRefType.get(
-        tile_shape,
-        xrt_dtype,
-        memory_space=IntegerAttr.get(T.i32(), MemorySpace.L1),
-    )
-
-    # 3D input channel: [NUM_SEGMENTS, NUM_TILES, NUM_COLS].
-    # Each core (seg, tx, ty) gets its own unique tile.
-    # Direct L3->L1 (no broadcast, no memtile).
-    Channel("chan_in", size=[NUM_SEGMENTS, NUM_TILES, NUM_COLS])
-
-    # Cascade channel: per-segment, two independent chains.
-    channel(
+    # One slot per core: L3 straight to L1, no staging and no broadcast.
+    chan_in = air.channel("chan_in", size=[NUM_SEGMENTS, NUM_TILES, NUM_COLS])
+    # The core-to-core links along each column.
+    chan_cascade = air.channel(
         "chan_cascade",
         size=[NUM_SEGMENTS, NUM_TILES, NUM_COLS],
         channel_type="npu_cascade",
     )
+    # One shim channel per finished column.
+    chan_out = air.channel("chan_out", size=[NUM_SEGMENTS, NUM_COLS])
 
-    # Output channel: one per cascade column across all segments.
-    Channel("chan_out", size=[NUM_SEGMENTS, NUM_COLS])
+    with air.launch(name="channel_3d_segment_unroll") as launch:
 
-    @FuncOp.from_py_func(l3MemrefTyIn, l3MemrefTyOut)
-    def channel_3d_segment_unroll(arg0, arg1):
-
-        launch_size = [1, 1]
-
-        @launch(operands=[arg0, arg1], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_in,
-            l3_out,
-        ):
-            # Distribute unique tiles to each core across all segments.
-            # Layout: core (seg, tx, ty) gets input at offset
-            # (seg * NUM_TILES * NUM_COLS + tx * NUM_COLS + ty) * DATA_SIZE.
+        @launch.body
+        def _():
+            # Unrolled at trace time: each put names a different channel slot,
+            # so there is nothing here for a loop to carry.
             for seg in range(NUM_SEGMENTS):
                 for tx in range(NUM_TILES):
                     for ty in range(NUM_COLS):
-                        offset = (
+                        lo = (
                             seg * NUM_TILES * NUM_COLS + tx * NUM_COLS + ty
                         ) * DATA_SIZE
-                        ChannelPut(
-                            "chan_in",
-                            l3_in,
-                            indices=[seg, tx, ty],
-                            offsets=[offset],
-                            sizes=[DATA_SIZE],
-                            strides=[1],
-                        )
+                        chan_in.put(src[lo : lo + DATA_SIZE], indices=[seg, tx, ty])
 
-            # Segment unroll: create NUM_SEGMENTS physical copies.
-            @segment(name="segment_0", sizes=[NUM_SEGMENTS, 1])
-            def segment_body(seg_x, seg_y, seg_sx, seg_sy):
+            with air.segment([range(NUM_SEGMENTS)], name="segment_0") as seg_ctx:
 
-                # Each segment contains a [NUM_TILES, NUM_COLS] herd.
-                # Cascade flows west-to-east (along tx) within each row (ty).
-                @herd(
-                    name="herd_0",
-                    sizes=[NUM_TILES, NUM_COLS],
-                    operands=[seg_x],
-                )
-                def herd_body(tx, ty, sx, sy, herd_seg_x):
-                    c0 = arith.ConstantOp.create_index(0)
-                    last_tile = arith.ConstantOp.create_index(NUM_TILES - 1)
+                @seg_ctx.body
+                def _(sx):
+                    with air.herd(
+                        [range(NUM_TILES), range(NUM_COLS)],
+                        name="herd_0",
+                        shape=(NUM_TILES, NUM_COLS),
+                    ) as herd:
 
-                    # Receive this core's unique input tile from L3
-                    in_buf = AllocOp(l1MemrefTy, [], [])
-                    ChannelGet("chan_in", in_buf, indices=[herd_seg_x, tx, ty])
+                        @herd.body
+                        def _(tx, ty):
+                            in_buf = air.alloc([DATA_SIZE], i32, scope=herd.private())
+                            chan_in.get(in_buf, indices=[sx, tx, ty])
 
-                    # Accumulation buffer
-                    acc_buf = AllocOp(l1MemrefTy, [], [])
+                            acc = air.alloc([DATA_SIZE], i32, scope=herd.private())
 
-                    # Core (tx=0, ty): first in cascade chain.
-                    cmp_first = arith.CmpIOp(arith.CmpIPredicate.eq, tx, c0)
-                    if_first = scf.IfOp(cmp_first, has_else=True)
-                    with InsertionPoint(if_first.then_block):
-                        linalg.copy(in_buf, outs=[acc_buf])
-                        ChannelPut(
-                            "chan_cascade",
-                            acc_buf,
-                            indices=[herd_seg_x, tx, ty],
-                        )
-                        yield_([])
+                            with ops.branch(tx == 0) as head:
+                                # Head of the chain: nothing upstream to add.
+                                acc[:] = in_buf[:]
+                                chan_cascade.put(acc, indices=[sx, tx, ty])
 
-                    # Cores (tx>0, ty): receive cascade, add input, pass along.
-                    with InsertionPoint(if_first.else_block):
-                        c1_idx = arith.ConstantOp.create_index(1)
-                        prev_tx = arith.SubIOp(tx, c1_idx)
+                            with head.otherwise():
+                                chan_cascade.get(acc, indices=[sx, tx - 1, ty])
+                                acc[:] = in_buf[:] + acc[:]
 
-                        ChannelGet(
-                            "chan_cascade",
-                            acc_buf,
-                            indices=[herd_seg_x, prev_tx, ty],
-                        )
+                                with ops.branch(tx == NUM_TILES - 1) as tail:
+                                    chan_out.put(acc, indices=[sx, ty])
+                                with tail.otherwise():
+                                    chan_cascade.put(acc, indices=[sx, tx, ty])
 
-                        linalg.add(in_buf, acc_buf, outs=[acc_buf])
-
-                        # Last core: write to output. Others: cascade forward.
-                        cmp_last = arith.CmpIOp(arith.CmpIPredicate.eq, tx, last_tile)
-                        if_last = scf.IfOp(cmp_last, has_else=True)
-                        with InsertionPoint(if_last.then_block):
-                            ChannelPut(
-                                "chan_out",
-                                acc_buf,
-                                indices=[herd_seg_x, ty],
-                            )
-                            yield_([])
-                        with InsertionPoint(if_last.else_block):
-                            ChannelPut(
-                                "chan_cascade",
-                                acc_buf,
-                                indices=[herd_seg_x, tx, ty],
-                            )
-                            yield_([])
-
-                        yield_([])
-
-            # Receive output from bottom core of each column in each segment.
-            # NUM_SEGMENTS * NUM_COLS = 4 shim DMA channels.
             for seg in range(NUM_SEGMENTS):
                 for ty in range(NUM_COLS):
-                    offset = (seg * NUM_COLS + ty) * DATA_SIZE
-                    ChannelGet(
-                        "chan_out",
-                        l3_out,
-                        indices=[seg, ty],
-                        offsets=[offset],
-                        sizes=[DATA_SIZE],
-                        strides=[1],
-                    )
+                    lo = (seg * NUM_COLS + ty) * DATA_SIZE
+                    chan_out.get(dst[lo : lo + DATA_SIZE], indices=[seg, ty])
+
+    return launch
 
 
-if __name__ == "__main__":
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="channel_3d_segment_unroll.py",
         description="Builds, runs, and tests the 3D channel with segment unroll example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
+    # Both lits are npu2-only, so on an npu1 box compiling is the whole gate
+    # this example can offer. cascade_reduction carries the same flag.
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        choices=["compile-only", "compile-and-run"],
+        dest="compile_mode",
+        default="compile-and-run",
+    )
     parser.add_argument(
         "--output-format",
         type=str,
@@ -208,22 +156,42 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    return parser.parse_args()
 
-    mlir_module = build_module()
+
+def main():
+    args = parse_args()
+
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
-    # Input: 16 unique tiles (2 segments × 4 rows × 2 cols), one per core.
-    # Layout: core (seg, tx, ty) gets
-    # input[(seg*NUM_TILES*NUM_COLS + tx*NUM_COLS + ty)*DATA_SIZE : ... + DATA_SIZE].
-    input_a = np.arange(0, TOTAL_IN, dtype=np.int32)
+    if args.compile_mode == "compile-only":
+        backend = XRTBackend(
+            verbose=args.verbose,
+            omit_while_true_loop=False,
+            output_format=args.output_format,
+            runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
+        )
+        backend.compile(mlir_module)
+        backend.unload()
+        return 0
 
-    # Expected output: per cascade column (seg, ty), sum of all tiles in that column.
-    # output[(seg*NUM_COLS+ty)*DATA_SIZE : ... + DATA_SIZE] =
-    #   sum_{tx=0}^{3} input_tile(seg, tx, ty)
-    expected_output = np.zeros(TOTAL_OUT, dtype=np.int32)
+    # Sixteen unique tiles, one per core: core (seg, tx, ty) reads the tile at
+    # (seg * NUM_TILES * NUM_COLS + tx * NUM_COLS + ty).
+    input_a = np.arange(0, TOTAL_IN, dtype=INOUT_DATATYPE)
+
+    expected_output = np.zeros(TOTAL_OUT, dtype=INOUT_DATATYPE)
     for seg in range(NUM_SEGMENTS):
         for ty in range(NUM_COLS):
             out_start = (seg * NUM_COLS + ty) * DATA_SIZE
@@ -239,11 +207,14 @@ if __name__ == "__main__":
         output_format=args.output_format,
         instance_name="channel_3d_segment_unroll",
         runtime_loop_tiling_sizes=[4, 4],
+        target_device=launch.target,
     )
-    exit(
-        runner.run_test(
-            mlir_module,
-            inputs=[input_a],
-            expected_outputs=[expected_output],
-        )
+    return runner.run_test(
+        mlir_module,
+        inputs=[input_a],
+        expected_outputs=[expected_output],
     )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/rms_norm/rms_norm.py
+++ b/programming_examples/rms_norm/rms_norm.py
@@ -1,162 +1,107 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""RMS normalisation of an [M, N] tile, on air.api.
 
-"""Vectorized RMS Normalization Example
+Row by row::
 
-Implements RMS normalization on a 2D input [M, N]:
-  1. rms  = sum(x^2, axis=-1) / N
-  2. rstd = 1 / sqrt(rms + eps)
-  3. y    = x * rstd
+    acc  = sum(x * x)            over the row
+    rstd = rsqrt(acc / N + eps)
+    y    = x * rstd
 
-Uses a single AIE tile with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.transfer_read/write with
-configurable VECTOR_SIZE (default 16 for AIE2).
+Three lines, and each is one line of DSL:
+
+    acc[:]  = ops.reduce_add(row[:] * row[:])
+    rstd[:] = ops.cast(ops.rsqrt(ops.cast(acc[:], f32) * (1 / N) + EPS), dtype)
+    out[:]  = row[:] * rstd[:]
+
+The last one is the interesting one. ``rstd`` is a ``[1, 1]`` buffer and ``row``
+is ``[1, N]``, so multiplying them is numpy broadcasting along the innermost
+axis: the DSL pins the broadcast axis at 0 and emits ``memref.load`` +
+``vector.broadcast`` inside the vector loop. The predecessor had to reduce to a
+scalar, build a ``vector.broadcast`` by hand and thread it through the second
+loop nest; here the shapes say it.
+
+``ops.reduce_add`` reads the whole innermost axis as one vector, which removes
+the predecessor's accumulator buffer entirely -- and with it the comment about
+writing the squared vector to a temporary and reading it back to break the
+``mulf``->``addf`` def-use chain that the aievec lowering rejected. There is no
+such chain left: the multiply feeds a ``vector.reduction``, not an add.
+
+Two things carried over deliberately:
+
+* **The reciprocal square root is computed in f32.** ``math.rsqrt`` on a scalar
+  ``bf16`` is not legalised by Peano, and AIE has no ``sqrt`` at all -- which is
+  why this is ``rsqrt`` and a multiply rather than ``sqrt`` and a divide. The
+  two ``ops.cast`` calls are that constraint, not a rounding preference. The
+  mean and the epsilon are now added in f32 as well, which is strictly more
+  accurate than the predecessor's bf16 arithmetic and well inside the tolerance
+  the test already used.
+* **The row loop is ``air.sequential``**, so it stays one ``scf.for`` over M
+  rather than unrolling M copies of the body at trace time.
 """
 
 import argparse
+
+import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith, math as math_dialect
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    reduction as vector_reduction,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
-
-range_ = for_
+from air.backend.xrt_runner import XRTRunner
 
 EPS = 1e-5
 
-
-@module_builder
-def build_module(M, N, np_dtype, vector_size=16):
-    xrt_dtype = type_mapper(np_dtype)
-    assert (
-        N % vector_size == 0
-    ), f"N ({N}) must be divisible by vector_size ({vector_size})"
-
-    vecTy = VectorType.get([vector_size], xrt_dtype)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    # L3 types
-    l3MemrefTy = MemRefType.get([M, N], xrt_dtype)
-
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1RowTy = MemRefType.get([N], xrt_dtype, memory_space=l1_mem_space)
-    l1VecTy = MemRefType.get([vector_size], xrt_dtype, memory_space=l1_mem_space)
-
-    @FuncOp.from_py_func(l3MemrefTy, l3MemrefTy)
-    def rms_norm(arg0, arg1):
-
-        @herd(name="herd_0", sizes=[1, 1], operands=[arg0, arg1])
-        def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_out):
-            l1_row = AllocOp(l1RowTy, [], [])
-            l1_out = AllocOp(l1RowTy, [], [])
-            # Vector accumulator buffer for reductions
-            l1_acc = AllocOp(l1VecTy, [], [])
-
-            c0 = arith.ConstantOp.create_index(0)
-            cst0 = arith.ConstantOp(xrt_dtype, 0.0)
-            n_f = arith.ConstantOp(xrt_dtype, float(N))
-            eps_f = arith.ConstantOp(xrt_dtype, EPS)
-
-            # Zero vector for initializing accumulator
-            v_zero = BroadcastOp(vecTy, cst0)
-
-            for row in range_(M):
-                # DMA: load one row from L3 to L1
-                dma_memcpy_nd(
-                    l1_row,
-                    l3_in,
-                    src_offsets=[row, 0],
-                    src_sizes=[1, N],
-                    src_strides=[N, 1],
-                )
-
-                # Step 1: Vectorized sum of x^2
-                # Initialize accumulator to zero
-                transfer_write(None, v_zero, l1_acc, [c0], identity_map, [True])
-                for j in range_(0, N, vector_size):
-                    sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                    sub_tmp = subview(l1_out.result, [j], [vector_size], [1])
-                    v_x = transfer_read(
-                        vecTy, sub_row, [c0], identity_map, cst0, [True]
-                    )
-                    v_sq = arith.mulf(v_x, v_x)
-                    # Write squared result to temp buffer and read back to
-                    # break the mulf->addf def-use chain. The aievec lowering
-                    # rejects addf when an operand is directly from mulf
-                    # (it defers to FMA matching which doesn't apply here).
-                    transfer_write(None, v_sq, sub_tmp, [c0], identity_map, [True])
-                    v_sq_rd = transfer_read(
-                        vecTy, sub_tmp, [c0], identity_map, cst0, [True]
-                    )
-                    v_acc = transfer_read(
-                        vecTy, l1_acc, [c0], identity_map, cst0, [True]
-                    )
-                    v_sum = arith.addf(v_acc, v_sq_rd)
-                    transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
-                    yield_([])
-
-                # Horizontal reduce accumulator vector to scalar
-                v_final = transfer_read(vecTy, l1_acc, [c0], identity_map, cst0, [True])
-                total_sum = vector_reduction(xrt_dtype, "add", v_final)
-                rms = arith.divf(total_sum, n_f)
-
-                # Step 2: rstd = rsqrt(rms + eps)
-                # Use math.rsqrt in f32 -- AIE supports rsqrt (not sqrt),
-                # and scalar bf16 rsqrt isn't legalized by Peano.
-                f32 = F32Type.get()
-                rms_eps = arith.addf(rms, eps_f)
-                rms_eps_f32 = arith.extf(f32, rms_eps)
-                rstd_f32 = math_dialect.rsqrt(rms_eps_f32)
-                rstd = arith.truncf(xrt_dtype, rstd_f32)
-
-                # Step 3: Vectorized normalize: y = x * rstd
-                v_rstd = BroadcastOp(vecTy, rstd)
-                for j in range_(0, N, vector_size):
-                    sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                    v_x = transfer_read(
-                        vecTy, sub_row, [c0], identity_map, cst0, [True]
-                    )
-                    v_normed = arith.mulf(v_x, v_rstd)
-                    sub_out = subview(l1_out.result, [j], [vector_size], [1])
-                    transfer_write(None, v_normed, sub_out, [c0], identity_map, [True])
-                    yield_([])
-
-                # DMA: write result row from L1 to L3
-                dma_memcpy_nd(
-                    l3_out,
-                    l1_out,
-                    dst_offsets=[row, 0],
-                    dst_sizes=[1, N],
-                    dst_strides=[N, 1],
-                )
-
-                yield_([])
-
-            DeallocOp(l1_row)
-            DeallocOp(l1_out)
-            DeallocOp(l1_acc)
+M_DEFAULT = 32
+N_DEFAULT = 64
+VECTOR_SIZE = 16
+INPUT_DATATYPE = bfloat16
 
 
-if __name__ == "__main__":
-    M_DEFAULT = 32
-    N_DEFAULT = 64
-    VECTOR_SIZE = 16
-    INPUT_DATATYPE = bfloat16
+def build_module(M, N, dtype=bf16, vector=VECTOR_SIZE):
+    if vector and N % vector:
+        raise ValueError(
+            f"N ({N}) must be a multiple of the vector width ({vector}): this "
+            "kernel has no partial vectors, so the last one would run past the "
+            "end of the row."
+        )
 
+    x = air.tensor([M, N], dtype)
+    y = air.tensor([M, N], dtype)
+
+    with air.launch(name="rms_norm") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="herd_0", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    # One row at a time. The leading 1 is what makes `rstd`
+                    # a [1, 1] that broadcasts along the row.
+                    row = air.alloc([1, N], dtype, scope=h.private(), vector=vector)
+                    out = air.alloc([1, N], dtype, scope=h.private(), vector=vector)
+                    acc = air.alloc([1, 1], dtype, scope=h.private(), vector=vector)
+                    rstd = air.alloc([1, 1], dtype, scope=h.private(), vector=vector)
+
+                    for r in air.sequential(M):
+                        ops.load(row, x[r : r + 1, :])
+
+                        acc[:] = ops.reduce_add(row[:] * row[:])
+                        rstd[:] = ops.cast(
+                            ops.rsqrt(ops.cast(acc[:], f32) * (1.0 / N) + EPS), dtype
+                        )
+
+                        out[:] = row[:] * rstd[:]
+                        ops.store(out, y[r : r + 1, :])
+
+    return launch
+
+
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="rms_norm.py",
         description="Builds, runs, and tests the RMS normalization example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -167,7 +112,8 @@ if __name__ == "__main__":
         "--vector-size",
         type=int,
         default=VECTOR_SIZE,
-        help="Vector size for SIMD operations",
+        dest="vector",
+        help="compute vector width in lanes; 0 forces a scalar loop",
     )
     parser.add_argument(
         "--compile-mode",
@@ -183,47 +129,62 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    return parser.parse_args()
 
-    mlir_module = build_module(args.M, args.N, INPUT_DATATYPE, args.vector_size)
+
+def main():
+    args = parse_args()
+
+    launch = build_module(args.M, args.N, bf16, args.vector)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
     np.random.seed(0)
     x_input = np.random.rand(args.M, args.N).astype(INPUT_DATATYPE)
 
-    # Reference: RMS normalization without weight/bias
-    eps = EPS
+    # Reference: RMS normalization without weight/bias.
     rms = np.sqrt(
-        np.mean(x_input.astype(np.float32) ** 2, axis=-1, keepdims=True) + eps
+        np.mean(x_input.astype(np.float32) ** 2, axis=-1, keepdims=True) + EPS
     )
     y_expected = (x_input / rms).astype(INPUT_DATATYPE)
 
-    if args.compile_mode == "compile-and-run":
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="rms_norm",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[x_input],
-                expected_outputs=[y_expected],
-                rtol=5e-2,
-                atol=5e-1,
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_mode == "compile-only":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="rms_norm",
+        runtime_loop_tiling_sizes=[4, 4],
+        target_device=launch.target,
+    )
+    return runner.run_test(
+        mlir_module,
+        inputs=[x_input],
+        expected_outputs=[y_expected],
+        rtol=5e-2,
+        atol=5e-1,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -203,6 +203,13 @@ def _check_region(node, dst, dtype, expected=None):
     the element type and nothing else.
     """
     expected = expected or f"destination is {dtype}"
+    # A nested reduction is diagnosed here rather than at emission, because the
+    # shape check below reaches it first and reports the collapsed axis as an
+    # operand that does not broadcast -- which is true, and says nothing about
+    # the actual mistake. `ops.cast(ops.reduce_add(row[:]), f32)` used to fail
+    # with "destination has shape (1, 1) but operand has shape (1, 64)".
+    if node.kind == "reduce":
+        raise _nested_reduction(node)
     if node.kind == "cast":
         source = node.args[0].element_dtype()
         _check_region(
@@ -231,6 +238,19 @@ def _check_region(node, dst, dtype, expected=None):
         return
     for arg in node.args:
         _check_region(arg, dst, dtype, expected)
+
+
+def _nested_reduction(node):
+    """The error for a reduction used anywhere but as the whole right-hand side."""
+    spelling = "reduce_max" if node.op == "max" else "reduce_add"
+    return NotImplementedError(
+        f"air.api.ops.{spelling} cannot nest inside a larger expression: it "
+        "collapses the innermost axis, so its result has a different shape "
+        "from the operands around it, and one loop nest cannot span both. "
+        "Assign the reduction first, then use the result:\n"
+        f"    tmp[:] = ops.{spelling}(a[:])\n"
+        "    out[:] = tmp[:] + b[:]"
+    )
 
 
 def _regions_in(node, dtype, out):
@@ -719,14 +739,6 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
         # around it, and the surrounding loop nest is built over a single shape.
         # Without this the walk fell through to the AssertionError below, which
         # named an internal node kind rather than the mistake.
-        spelling = "reduce_max" if node.op == "max" else "reduce_add"
-        raise NotImplementedError(
-            f"air.api.ops.{spelling} cannot nest inside a larger expression: it "
-            "collapses the innermost axis, so its result has a different shape "
-            "from the operands around it, and one loop nest cannot span both. "
-            "Assign the reduction first, then use the result:\n"
-            f"    tmp[:] = ops.{spelling}(a[:])\n"
-            "    out[:] = tmp[:] + b[:]"
-        )
+        raise _nested_reduction(node)
 
     raise AssertionError(f"unknown expression node kind {node.kind!r}")

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2164,3 +2164,22 @@ def _():
             pass
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: reduce_under_a_cast
+# The nesting message lives at emission, but the shape check runs first and
+# reaches the reduction on the way down -- so this used to fail with "destination
+# has shape (1, 1) but operand has shape (1, 64), which does not broadcast to
+# it". True, and silent about the actual mistake. Found converting rms_norm,
+# where casting the row sum to f32 before the rsqrt is the obvious first thing
+# to write.
+# CHECK: NotImplementedError: air.api.ops.reduce_add cannot nest inside a larger expression
+# CHECK-SAME: Assign the reduction first
+@expect(NotImplementedError, "reduce_under_a_cast")
+def _():
+    def body(h, tx, ty, A, B, C):
+        row = air.alloc([1, 64], bf16, scope=h.private())
+        acc = air.alloc([1, 1], f32, scope=h.private())
+        acc[:] = ops.cast(ops.reduce_add(row[:]), f32)
+
+    _trace(body)


### PR DESCRIPTION
Two more conversions onto `air.api`, plus one diagnostic fix that fell out of
writing the second.

### `channel_3d_segment_unroll`

Three iteration spaces at once, which is what the example is for: a gridless
`air.launch`, an `air.segment` with an `unroll(...)` grid of its own, and a 4x2
herd inside each copy. The segment coordinate reaches the herd body by ordinary
Python closure — the DSL threads every enclosing coordinate in as an operand and
rebinds it, where the predecessor passed `operands=[seg_x]` by hand. That is
what makes `chan_in.get(in_buf, indices=[sx, tx, ty])` legal: a 3-D channel
index whose outermost component comes from two scopes up.

The head/middle/tail split along each cascade column is the same nested
`ops.branch` as `cascade_reduction`.

### `rms_norm`

Three lines of DSL for the three lines of the algorithm. The one worth pointing
at is `out[:] = row[:] * rstd[:]`: `rstd` is `[1, 1]` and `row` is `[1, N]`, so
the multiply is numpy broadcasting along the innermost axis and the DSL emits
`memref.load` + `vector.broadcast` inside the vector loop. The predecessor
reduced to a scalar, built the `vector.broadcast` by hand and threaded it
through a second loop nest.

`ops.reduce_add` reads the whole innermost axis as one vector, which removes the
accumulator buffer — and with it the predecessor's workaround for the aievec
lowering rejecting `addf` fed directly by `mulf`. There is no such chain left:
the multiply feeds a `vector.reduction`.

The f32 round trip around the `rsqrt` is kept deliberately: scalar bf16
`math.rsqrt` is not legalized by Peano, and AIE has no `sqrt` at all. The mean
and the epsilon are now added in f32 as well, which is strictly more accurate
than the predecessor's bf16 arithmetic and well inside the tolerance the test
already used.

### `[air.api] Diagnose a reduction nested under a cast`

The "cannot nest inside a larger expression" message lives at emission, but the
shape check runs first and walks into the reduction on the way down, reporting
the collapsed axis as an operand that does not broadcast:

    destination has shape (1, 1) but operand has shape (1, 64), which does
    not broadcast to it

True, and silent about the mistake. Both paths now raise the same message. Found
writing `rms_norm`, where casting the row sum to f32 before the `rsqrt` is the
obvious first thing to write. A same-dtype cast folds away, so only a converting
one reaches this — which is what the new `errors.py` case uses.

### Gating

Both examples are `REQUIRES: ryzen_ai_npu2` and the dev box is Phoenix, so the
gate is compiling **both** versions for npu2 and diffing the generated AIE IR.

* `channel_3d_segment_unroll`: identical tiles, buffers, flows, cascade_flows,
  locks, DMA BDs and shim allocations, and a byte-identical `air.insts.bin`. The
  core bodies differ only because the predecessor's `linalg.copy` and
  `linalg.add` scalarize to `memref.load`/`store` loops while the DSL emits
  `vector<16xi32>`.
* `rms_norm`: byte-identical `air.insts.bin`; the DSL version double-buffers (8
  buffers vs 3, 4 dma_bds vs 2). The npu2-only lit is an inherited limit, not a
  new one — the predecessor also aborts `llc` on npu1 at the same core key.

A `--compile-mode compile-only` flag is added to `channel_3d_segment_unroll` to
make that gate reachable, matching `cascade_reduction`.

Also: 28/28 api lits, `check-air-python` 41, `check-air-mlir` 527 + 7 XFAIL, and
the byte-identical IR sweep 61/61 across every converted example (the emitter
change is a new error path only).

**Not gated locally: AIE2p.** Neither example can run on this box, and the
`aievec.mul_elem` limit that #1917 just tripped over is AIE2p-specific. The
hx370 runner is the first thing that will exercise either of these.
